### PR TITLE
Resume historical candidate adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -318,65 +318,71 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
         adoption.replace_interrupted,
     )?;
     let gate_run_id = record.run_id.clone();
-    let promotion = crate::agent_task_promotion::with_gate_supervision(
-        crate::agent_task_gate::GateSupervision {
-            timeout: options.gates.gate_timeout(),
-            heartbeat_interval: options.gates.gate_heartbeat_interval(),
-            on_spawn: Arc::new({
-                let run_id = gate_run_id.clone();
-                move |pid, command| {
-                    agent_task_lifecycle::start_candidate_adoption_gate(
-                        &run_id,
-                        command,
-                        pid,
-                        options.gates.gate_timeout_seconds,
-                    )
-                }
-            }),
-            on_heartbeat: Arc::new({
-                let run_id = gate_run_id.clone();
-                move |tail| agent_task_lifecycle::heartbeat_candidate_adoption_gate(&run_id, tail)
-            }),
-            is_cancelled: Arc::new(move || {
-                agent_task_lifecycle::candidate_adoption_cancel_requested(&gate_run_id)
-                    .unwrap_or(false)
-            }),
-        },
-        || {
-            promote_with_checkpoint(
-                AgentTaskPromotionOptions {
-                    source,
-                    source_run_id: Some(record.run_id.clone()),
-                    source_path,
-                    source_worktree_path: options.source_worktree_path.clone(),
-                    base_ref: Some(options.base.clone()),
-                    task_base_sha: options.task_base_sha.clone(),
-                    candidate_ref: Some(candidate_sha.clone()),
-                    to_worktree: options.to_worktree.clone(),
-                    task_id: None,
-                    artifact_id: None,
-                    dry_run: false,
-                    gates: options.gates.clone(),
-                    provider_command: options.provider_command.clone(),
-                    provider_invocation: options.provider_invocation.clone(),
-                },
-                |checkpoint| {
-                    let checkpoint = serde_json::to_value(checkpoint).map_err(|error| {
-                        Error::internal_json(
-                            error.to_string(),
-                            Some("serialize adopted candidate checkpoint".to_string()),
+    let promotion = match reusable_applied_adoption_promotion(&record, &candidate_sha) {
+        Some(promotion) => promotion,
+        None => crate::agent_task_promotion::with_gate_supervision(
+            crate::agent_task_gate::GateSupervision {
+                timeout: options.gates.gate_timeout(),
+                heartbeat_interval: options.gates.gate_heartbeat_interval(),
+                on_spawn: Arc::new({
+                    let run_id = gate_run_id.clone();
+                    move |pid, command| {
+                        agent_task_lifecycle::start_candidate_adoption_gate(
+                            &run_id,
+                            command,
+                            pid,
+                            options.gates.gate_timeout_seconds,
                         )
-                    })?;
-                    agent_task_lifecycle::checkpoint_candidate_adoption(
-                        &record.run_id,
-                        "post_apply_verification",
-                        &gate_identity,
-                    )?;
-                    agent_task_lifecycle::record_promotion(&record.run_id, checkpoint).map(|_| ())
-                },
-            )
-        },
-    );
+                    }
+                }),
+                on_heartbeat: Arc::new({
+                    let run_id = gate_run_id.clone();
+                    move |tail| {
+                        agent_task_lifecycle::heartbeat_candidate_adoption_gate(&run_id, tail)
+                    }
+                }),
+                is_cancelled: Arc::new(move || {
+                    agent_task_lifecycle::candidate_adoption_cancel_requested(&gate_run_id)
+                        .unwrap_or(false)
+                }),
+            },
+            || {
+                promote_with_checkpoint(
+                    AgentTaskPromotionOptions {
+                        source,
+                        source_run_id: Some(record.run_id.clone()),
+                        source_path,
+                        source_worktree_path: options.source_worktree_path.clone(),
+                        base_ref: Some(options.base.clone()),
+                        task_base_sha: options.task_base_sha.clone(),
+                        candidate_ref: Some(candidate_sha.clone()),
+                        to_worktree: options.to_worktree.clone(),
+                        task_id: None,
+                        artifact_id: None,
+                        dry_run: false,
+                        gates: options.gates.clone(),
+                        provider_command: options.provider_command.clone(),
+                        provider_invocation: options.provider_invocation.clone(),
+                    },
+                    |checkpoint| {
+                        let checkpoint = serde_json::to_value(checkpoint).map_err(|error| {
+                            Error::internal_json(
+                                error.to_string(),
+                                Some("serialize adopted candidate checkpoint".to_string()),
+                            )
+                        })?;
+                        agent_task_lifecycle::checkpoint_candidate_adoption(
+                            &record.run_id,
+                            "post_apply_verification",
+                            &gate_identity,
+                        )?;
+                        agent_task_lifecycle::record_promotion(&record.run_id, checkpoint)
+                            .map(|_| ())
+                    },
+                )
+            },
+        ),
+    };
     let mut promotion = match promotion {
         Ok(promotion) => promotion,
         Err(error) => {
@@ -644,6 +650,64 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
         exit_code,
         Some(record.run_id.as_str()),
     ))
+}
+
+fn reusable_applied_adoption_promotion(
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+    candidate_sha: &str,
+) -> Option<Result<AgentTaskPromotionReport>> {
+    let promotion = match persisted_promotion_for_attempt(&record.run_id) {
+        Ok(Some(promotion))
+            if promotion.status
+                == crate::agent_task_promotion::AgentTaskPromotionStatus::Applied =>
+        {
+            promotion
+        }
+        Ok(_) => return None,
+        Err(error) => return Some(Err(error)),
+    };
+    if record
+        .candidate_adoption
+        .as_ref()
+        .is_none_or(|adoption| adoption.candidate_sha != candidate_sha)
+    {
+        return None;
+    }
+    let Some(worktree_path) = promotion.target.path.as_deref() else {
+        return Some(Err(Error::validation_invalid_argument(
+            "latest_promotion.target.path",
+            "applied candidate adoption has no controller-recorded destination path",
+            Some(record.run_id.clone()),
+            None,
+        )));
+    };
+    let baseline = promotion.provenance.get("gate_feedback_baseline").cloned();
+    let Some(mut baseline) = baseline else {
+        return Some(Err(Error::validation_invalid_argument(
+            "latest_promotion",
+            "applied candidate adoption has no authenticated gate-feedback baseline",
+            Some(record.run_id.clone()),
+            None,
+        )));
+    };
+    // The checkpoint records the complete candidate diff; bind it to the exact
+    // promoted artifact before handing it to the shared dirty-destination check.
+    baseline["patch_artifact"] = match serde_json::to_value(&promotion.patch_artifact) {
+        Ok(artifact) => artifact,
+        Err(error) => {
+            return Some(Err(Error::internal_json(
+                error.to_string(),
+                Some("serialize persisted promotion artifact baseline".to_string()),
+            )));
+        }
+    };
+    Some(
+        crate::agent_task_candidate_baseline::validate_gate_feedback_candidate_baseline(
+            std::path::Path::new(worktree_path),
+            &baseline,
+        )
+        .map(|_| promotion),
+    )
 }
 
 /// Candidate adoption can prove that an otherwise-red broad command is

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -180,7 +180,7 @@ pub(crate) fn persisted_promotion_for_attempt(
     let Some(value) = record.metadata.get("latest_promotion") else {
         return Ok(None);
     };
-    let promotion: AgentTaskPromotionReport =
+    let mut promotion: AgentTaskPromotionReport =
         serde_json::from_value(value.clone()).map_err(|error| {
             Error::validation_invalid_argument(
                 "latest_promotion",
@@ -189,6 +189,9 @@ pub(crate) fn persisted_promotion_for_attempt(
                 None,
             )
         })?;
+    // `status` resolves a Cook alias to its immutable latest attempt. Validate
+    // against that concrete owner so aliases and exact durable IDs share the
+    // same persisted-promotion contract.
     if promotion.source.run_id.as_deref() != Some(record.run_id.as_str()) {
         let mut error = Error::validation_invalid_argument(
             "latest_promotion.source.run_id",
@@ -201,7 +204,97 @@ pub(crate) fn persisted_promotion_for_attempt(
         error.details["promotion_run_id"] = serde_json::json!(promotion.source.run_id);
         return Err(error);
     }
+    restore_gate_feedback_baseline(&record, &mut promotion)?;
     Ok(Some(promotion))
+}
+
+/// Older applied reports lost the post-apply baseline when the final gate
+/// report replaced its checkpoint. Recover it only from one controller-owned
+/// checkpoint for this exact promotion; any conflicting or incomplete evidence
+/// leaves the destination unavailable for dirty-worktree reuse.
+fn restore_gate_feedback_baseline(
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+    promotion: &mut AgentTaskPromotionReport,
+) -> Result<()> {
+    if promotion
+        .provenance
+        .pointer("/gate_feedback_baseline/current_diff")
+        .and_then(Value::as_str)
+        .is_some_and(|diff| !diff.trim().is_empty())
+    {
+        return Ok(());
+    }
+    let Some(events) = record.metadata.get("promotions").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    let mut baselines = events
+        .iter()
+        .filter(|event| promotion_checkpoint_matches(promotion, event))
+        .filter_map(|event| {
+            event
+                .pointer("/provenance/gate_feedback_baseline")
+                .filter(|baseline| {
+                    baseline.get("schema").and_then(Value::as_str)
+                        == Some("homeboy/agent-task-gate-feedback-baseline/v1")
+                        && baseline
+                            .get("current_diff")
+                            .and_then(Value::as_str)
+                            .is_some_and(|diff| !diff.trim().is_empty())
+                })
+                .cloned()
+        })
+        .collect::<Vec<_>>();
+    baselines.dedup();
+    match baselines.len() {
+        0 => Ok(()),
+        1 => {
+            promotion.provenance["gate_feedback_baseline"] = baselines.remove(0);
+            Ok(())
+        }
+        _ => Err(Error::validation_invalid_argument(
+            "latest_promotion",
+            "persisted promotion has ambiguous controller checkpoint gate-feedback baselines",
+            Some(record.run_id.clone()),
+            None,
+        )),
+    }
+}
+
+fn promotion_checkpoint_matches(promotion: &AgentTaskPromotionReport, checkpoint: &Value) -> bool {
+    checkpoint.get("status").and_then(Value::as_str) == Some("verification_pending")
+        && checkpoint.pointer("/provenance/post_apply") == Some(&Value::Bool(true))
+        && checkpoint.pointer("/source/run_id").and_then(Value::as_str)
+            == promotion.source.run_id.as_deref()
+        && checkpoint
+            .pointer("/source/task_id")
+            .and_then(Value::as_str)
+            == Some(promotion.source.task_id.as_str())
+        && checkpoint.get("to_worktree").and_then(Value::as_str)
+            == Some(promotion.to_worktree.as_str())
+        && checkpoint
+            .pointer("/target/worktree")
+            .and_then(Value::as_str)
+            == Some(promotion.target.worktree.as_str())
+        && checkpoint.pointer("/target/path")
+            == promotion
+                .target
+                .path
+                .as_ref()
+                .map(|path| Value::String(path.clone()))
+                .as_ref()
+        && checkpoint
+            .pointer("/patch_artifact/id")
+            .and_then(Value::as_str)
+            == Some(promotion.patch_artifact.id.as_str())
+        && checkpoint
+            .pointer("/patch_artifact/kind")
+            .and_then(Value::as_str)
+            == Some(promotion.patch_artifact.kind.as_str())
+        && checkpoint
+            .pointer("/patch_artifact/sha256")
+            .and_then(Value::as_str)
+            == promotion.patch_artifact.sha256.as_deref()
+        && checkpoint.pointer("/provenance/candidate") == promotion.provenance.get("candidate")
 }
 
 pub(crate) fn attempt_needs_execution(run_id: &str) -> bool {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3339,6 +3339,47 @@ fn restarted_cook_alias_and_exact_id_reuse_the_same_persisted_promotion() {
 }
 
 #[test]
+fn historical_applied_promotion_restores_only_its_exact_checkpoint_baseline() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let plan = AgentTaskPlan::new("cook-historical-baseline", Vec::new());
+        let run_id = "cook-historical-baseline-attempt-1";
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt("cook-historical-baseline", 1, run_id).unwrap();
+        let candidate = serde_json::json!({"kind":"git","fingerprint":{"head":"abc"}});
+        let checkpoint = serde_json::json!({
+            "schema":"homeboy/agent-task-promotion-report/v1",
+            "status":"verification_pending",
+            "source":{"kind":"aggregate","task_id":"task","run_id":run_id},
+            "to_worktree":"fixture@target",
+            "target":{"worktree":"fixture@target","path":"/fixture/target"},
+            "patch_artifact":{"id":"patch","kind":"patch","path":"/fixture/patch","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+            "provenance":{"post_apply":true,"candidate":candidate,"gate_feedback_baseline":{"schema":"homeboy/agent-task-gate-feedback-baseline/v1","current_diff":"diff --git a/a b/a\n"}},
+            "operator_notification":{"status":"blocked","message":"pending"}
+        });
+        let applied = serde_json::json!({
+            "schema":"homeboy/agent-task-promotion-report/v1",
+            "status":"applied",
+            "source":{"kind":"aggregate","task_id":"task","run_id":run_id},
+            "to_worktree":"fixture@target",
+            "target":{"worktree":"fixture@target","path":"/fixture/target"},
+            "patch_artifact":{"id":"patch","kind":"patch","path":"/fixture/patch","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+            "provenance":{"candidate":candidate},
+            "operator_notification":{"status":"completed","message":"applied"}
+        });
+        agent_task_lifecycle::record_promotion(run_id, checkpoint).unwrap();
+        agent_task_lifecycle::record_promotion(run_id, applied).unwrap();
+
+        let restored = persisted_promotion_for_attempt("cook-historical-baseline")
+            .unwrap()
+            .expect("alias resolves historical attempt");
+        assert_eq!(
+            restored.provenance["gate_feedback_baseline"]["current_diff"],
+            "diff --git a/a b/a\n"
+        );
+    });
+}
+
+#[test]
 fn persisted_promotion_from_another_attempt_is_rejected() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-persisted";


### PR DESCRIPTION
## Summary

- reuse an already-applied adoption promotion when its immutable candidate and controller-recorded destination still match
- restore historical gate-feedback baselines only from an exact verification-pending checkpoint owned by the same promotion
- validate the complete current destination tree against the authenticated patch before re-entering review remediation
- resolve Cook aliases against their immutable attempt IDs while preserving fail-closed ownership diagnostics

Closes #9575.

## Verification

- `cargo test -p homeboy-agents historical_applied_promotion_restores_only_its_exact_checkpoint_baseline -- --test-threads=1`
- `cargo test -p homeboy-agents persisted_promotion -- --test-threads=1`
- `cargo test -p homeboy-agents historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_replay -- --test-threads=1`
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`

## AI Assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** Integrating the preserved repair with the merged durable-promotion resume contract, resolving the overlapping source change, and running verification. Chris Huber remains responsible for every line.