### PR TITLE
fix(lab): admit handoff when daemon identity is unavailable

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -275,7 +275,12 @@ impl LabStagingRecipe {
 struct LabHandoffHomeboyIdentity {
     requested_build_identity: String,
     configured_command_build_identity: String,
-    daemon_build_identity: String,
+    /// The daemon (session) build identity is advisory pre-dispatch evidence and
+    /// is legitimately absent when a controller-owned handoff runs before any
+    /// daemon has attached. Admission authority rests on the command binary
+    /// identity; an unreported daemon does not block the handoff.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    daemon_build_identity: Option<String>,
     /// This is populated only when the command execution itself reports it.
     /// Session and configured-binary identities are pre-dispatch evidence.
     executed_command_build_identity: Option<String>,
@@ -297,6 +302,30 @@ fn canonical_homeboy_identity(identity: &str) -> &str {
         .trim()
         .strip_prefix("homeboy ")
         .unwrap_or(identity.trim())
+}
+
+/// Decide whether a Lab handoff may proceed given the runner's command-binary
+/// (`configured`) and daemon (session) build identities against the immutably
+/// `requested` build.
+///
+/// The command binary is authoritative: it must positively match `requested`,
+/// so a stale/mismatched binary fails closed (the intent of #9626). The daemon
+/// identity is advisory — it is legitimately unreported (`None`) when a
+/// controller-owned handoff runs before any daemon has attached (e.g. the
+/// in-process reverse-cook path). An absent daemon identity must NOT block
+/// admission; only a daemon that is present AND positively disagrees with
+/// `requested` indicates a stale runtime worth refusing.
+fn handoff_identities_match(
+    requested: &str,
+    configured: Option<&str>,
+    daemon: Option<&str>,
+) -> bool {
+    let requested = canonical_homeboy_identity(requested);
+    let command_matches =
+        configured.is_some_and(|identity| canonical_homeboy_identity(identity) == requested);
+    let daemon_disagrees =
+        daemon.is_some_and(|identity| canonical_homeboy_identity(identity) != requested);
+    command_matches && !daemon_disagrees
 }
 
 fn handoff_build_reference(identity: &str) -> String {
@@ -1574,14 +1603,7 @@ impl ProductionLabStagingOperations {
             .session
             .as_ref()
             .and_then(|session| session.homeboy_build_identity.clone());
-        let identities_match = |configured: Option<&str>, daemon: Option<&str>| {
-            configured.is_some_and(|identity| {
-                canonical_homeboy_identity(identity) == canonical_homeboy_identity(requested)
-            }) && daemon.is_some_and(|identity| {
-                canonical_homeboy_identity(identity) == canonical_homeboy_identity(requested)
-            })
-        };
-        if !identities_match(configured.as_deref(), daemon.as_deref())
+        if !handoff_identities_match(requested, configured.as_deref(), daemon.as_deref())
             && automatic_handoff_convergence_allowed(&runner)
             && status.active_jobs.is_empty()
             && status.active_job_state == crate::RunnerActiveJobState::Available
@@ -1616,7 +1638,7 @@ impl ProductionLabStagingOperations {
             .as_ref()
             .and_then(|session| session.homeboy_build_identity.clone());
         let configured = crate::configured_runner_homeboy_build_identity(&runner, &command)?;
-        if !identities_match(configured.as_deref(), daemon.as_deref()) {
+        if !handoff_identities_match(requested, configured.as_deref(), daemon.as_deref()) {
             return Err(handoff_identity_error(
                 &request.recipe.runner_id,
                 requested,
@@ -1629,7 +1651,7 @@ impl ProductionLabStagingOperations {
             configured_command_build_identity: configured
                 .clone()
                 .expect("checked configured identity"),
-            daemon_build_identity: daemon.expect("checked daemon identity"),
+            daemon_build_identity: daemon,
             executed_command_build_identity: None,
         }))
     }
@@ -3797,7 +3819,7 @@ mod tests {
         let identity = LabHandoffHomeboyIdentity {
             requested_build_identity: "homeboy 1.2.3+required".to_string(),
             configured_command_build_identity: "homeboy 1.2.3+required".to_string(),
-            daemon_build_identity: "homeboy 1.2.3+required".to_string(),
+            daemon_build_identity: Some("homeboy 1.2.3+required".to_string()),
             executed_command_build_identity: None,
         };
 
@@ -3890,6 +3912,46 @@ mod tests {
             error.details["homeboy_handoff_identity"]["executed_command_build_identity"],
             serde_json::Value::Null
         );
+    }
+
+    #[test]
+    fn handoff_admitted_when_command_matches_and_daemon_identity_unavailable() {
+        // Regression for #9626: a controller-owned handoff (e.g. the in-process
+        // reverse-cook path) runs before any daemon has attached, so the daemon
+        // build identity is legitimately unreported. Admission must still proceed
+        // as long as the command binary positively matches the required build.
+        assert!(handoff_identities_match(
+            "homeboy 1.2.3+required",
+            Some("homeboy 1.2.3+required"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn handoff_refused_when_command_binary_is_stale_even_if_daemon_absent() {
+        // The command binary remains authoritative: a stale/mismatched binary
+        // fails closed regardless of daemon availability (#9626 intent).
+        assert!(!handoff_identities_match(
+            "homeboy 1.2.3+required",
+            Some("homeboy 1.2.2+stale"),
+            None,
+        ));
+        assert!(!handoff_identities_match(
+            "homeboy 1.2.3+required",
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn handoff_refused_when_daemon_positively_disagrees() {
+        // A daemon that is present AND reports a different build indicates a
+        // stale runtime worth refusing, even if the command binary matches.
+        assert!(!handoff_identities_match(
+            "homeboy 1.2.3+required",
+            Some("homeboy 1.2.3+required"),
+            Some("homeboy 1.2.2+stale"),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes a regression on `main` introduced by #9626 (`fix(lab): fail closed on stale command binaries`). The failing CI test is `detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once` (`tests/reverse_cook_queue_acceptance.rs`), which now blocks the Test gate + Release Quality Policy.

## Root cause
#9626's new admission guard (`identities_match` in `lab_staging_controller.rs`) required **both** the runner command binary **and** the daemon (session) to positively report a build identity matching the immutably `requested` build:

```rust
configured.is_some_and(... == requested) && daemon.is_some_and(... == requested)
```

But a **controller-owned handoff** — the in-process reverse-cook path — runs *before any daemon has attached*, so the daemon build identity is legitimately unreported (`None`). The guard then refused admission even though the command binary matched the required build byte-for-byte:

```
Lab handoff refused runner `lab` before workspace materialization because
required Homeboy build `homeboy 0.308.0+c3f2bd7cd0e8` does not match the
selected runner command identity `homeboy 0.308.0+c3f2bd7cd0e8`
or active daemon identity `unavailable`
```

(Note the required build and selected runner identity are identical — the only reason for refusal was `daemon: unavailable`.) The controller therefore never staged/enqueued the reverse job and the test timed out.

## Fix
Make the **command binary the sole admission authority**:
- It must positively match `requested`, so a stale/mismatched binary still fails closed (preserving #9626's intent).
- The daemon identity is now **advisory**: an absent daemon no longer blocks admission; only a daemon that is **present AND positively disagrees** with the required build is refused.
- `daemon_build_identity` on `LabHandoffHomeboyIdentity` becomes `Option<String>` to honestly represent the unreported case (serialized with `skip_serializing_if`).
- Matching logic extracted into a testable free function `handoff_identities_match`.

## Tests
Added three unit tests covering the decision matrix (all pass locally, `40 passed; 0 failed`):
- `handoff_admitted_when_command_matches_and_daemon_identity_unavailable` — the exact failing scenario
- `handoff_refused_when_command_binary_is_stale_even_if_daemon_absent` — preserves #9626 stale-binary protection
- `handoff_refused_when_daemon_positively_disagrees` — a present, mismatched daemon still fails closed

Single-file change (`crates/homeboy-lab-runner/src/lab_staging_controller.rs`).