### PR TITLE
fix(lab): bound provenance environment payloads

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -38,21 +38,32 @@ impl HarvestExecutionContext {
     pub fn from_current_process() -> homeboy_core::Result<Self> {
         let source = std::env::var(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV).ok();
         let lab = std::env::var(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV).ok();
+        Self::from_transport_values(source.as_deref(), lab.as_deref())
+    }
+
+    fn from_transport_values(
+        source: Option<&str>,
+        lab: Option<&str>,
+    ) -> homeboy_core::Result<Self> {
         match (source, lab) {
             (None, None) => Ok(Self::default()),
             (Some(source), Some(lab)) if !source.trim().is_empty() && !lab.trim().is_empty() => {
-                let lab_offload: serde_json::Value = serde_json::from_str(&lab).map_err(|error| {
-                    incomplete_transport_error(format!("invalid Lab offload metadata: {error}"))
-                })?;
+                let lab_offload = homeboy_core::observation::resolve_json_value(lab).ok_or_else(
+                    || incomplete_transport_error("invalid Lab offload metadata".to_string()),
+                )?;
                 if !lab_offload.is_object() {
                     return Err(incomplete_transport_error(
                         "Lab offload metadata must be a JSON object".to_string(),
                     ));
                 }
                 Self::from_lab_transport(
-                    serde_json::from_str(&source).map_err(|error| {
-                        incomplete_transport_error(format!("invalid source snapshot metadata: {error}"))
-                    })?,
+                    homeboy_core::observation::resolve_json_value(source)
+                        .and_then(|value| serde_json::from_value(value).ok())
+                        .ok_or_else(|| {
+                            incomplete_transport_error(
+                                "invalid source snapshot metadata".to_string(),
+                            )
+                        })?,
                     lab_offload,
                 )
             }
@@ -745,8 +756,43 @@ fn sha256_hex(contents: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
     use std::fs;
     use std::process::Command;
+
+    #[test]
+    fn harvest_context_resolves_direct_lab_transport_references() {
+        let directory = tempfile::tempdir().expect("transport directory");
+        let source = serde_json::to_vec(&homeboy_core::source_snapshot::existing_remote(
+            "runner-a",
+            "/runner/workspace",
+            None,
+        ))
+        .expect("source snapshot");
+        let lab = br#"{"schema":"fixture/lab-offload/v1","runner_id":"runner-a"}"#;
+        let reference = |name: &str, payload: &[u8]| {
+            let path = directory.path().join(name);
+            fs::write(&path, payload).expect("write transport payload");
+            serde_json::json!({
+                "schema": homeboy_core::observation::PROVENANCE_REFERENCE_SCHEMA,
+                "path": path,
+                "sha256": format!("{:x}", Sha256::digest(payload)),
+            })
+            .to_string()
+        };
+
+        let context = HarvestExecutionContext::from_transport_values(
+            Some(&reference("source.json", &source)),
+            Some(&reference("lab.json", lab)),
+        )
+        .expect("referenced transport");
+
+        assert_eq!(
+            context.source_snapshot.expect("source").runner_id,
+            "runner-a"
+        );
+        assert_eq!(context.lab_offload.expect("lab")["runner_id"], "runner-a");
+    }
 
     #[test]
     fn terminal_cleanup_reclaims_build_output_before_preserving_changed_source() {

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -326,13 +326,7 @@ fn materialize_follow_up_baseline_at(
             None,
         ));
     }
-    let parent_snapshot = std::env::var(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
-        .ok()
-        .map(|raw| serde_json::from_str::<Value>(&raw))
-        .transpose()
-        .map_err(|error| {
-            Error::validation_invalid_argument("source_snapshot", error.to_string(), None, None)
-        })?;
+    let parent_snapshot = parent_snapshot_from_current_process()?;
     let artifact_bytes = std::fs::read(&promotion.patch_artifact.path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -487,6 +481,51 @@ fn materialize_follow_up_baseline_at(
     baseline.capability.commit = commit;
     baseline.capability.tree = tree;
     Ok(baseline)
+}
+
+fn parent_snapshot_from_current_process() -> Result<Option<Value>> {
+    let Some(raw) = std::env::var(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV).ok()
+    else {
+        return Ok(None);
+    };
+    parent_snapshot_from_transport(&raw).map(Some)
+}
+
+fn parent_snapshot_from_transport(raw: &str) -> Result<Value> {
+    homeboy_core::observation::resolve_json_value(raw).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source_snapshot",
+            "invalid inline or referenced source snapshot JSON",
+            None,
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn cook_baseline_resolves_referenced_parent_snapshot() {
+        let directory = tempfile::tempdir().expect("transport directory");
+        let path = directory.path().join("source.json");
+        let payload = br#"{"schema":"fixture/source/v1","snapshot_hash":"abc"}"#;
+        std::fs::write(&path, payload).expect("write source snapshot");
+        let reference = serde_json::json!({
+            "schema": homeboy_core::observation::PROVENANCE_REFERENCE_SCHEMA,
+            "path": path,
+            "sha256": format!("{:x}", Sha256::digest(payload)),
+        })
+        .to_string();
+
+        assert_eq!(
+            parent_snapshot_from_transport(&reference).expect("referenced parent snapshot")
+                ["snapshot_hash"],
+            "abc"
+        );
+    }
 }
 
 pub(crate) fn git_output(cwd: &std::path::Path, args: &[&str]) -> Result<String> {

--- a/crates/homeboy-core/src/observation/context.rs
+++ b/crates/homeboy-core/src/observation/context.rs
@@ -1,9 +1,11 @@
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 pub const SOURCE_SNAPSHOT_METADATA_ENV: &str = "HOMEBOY_SOURCE_SNAPSHOT_JSON";
 pub const LAB_OFFLOAD_METADATA_ENV: &str = "HOMEBOY_LAB_OFFLOAD_JSON";
 pub const PREVIEW_METADATA_ENV: &str = "HOMEBOY_PREVIEW_JSON";
 pub const PREVIEW_PUBLIC_URL_ENV: &str = "HOMEBOY_PREVIEW_PUBLIC_URL";
+pub const PROVENANCE_REFERENCE_SCHEMA: &str = "homeboy/provenance-reference/v1";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RunContext {
@@ -80,10 +82,28 @@ impl RunProvenance {
     }
 }
 
-fn env_json(name: &str) -> Option<serde_json::Value> {
+pub fn env_json(name: &str) -> Option<serde_json::Value> {
     std::env::var(name)
         .ok()
-        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|raw| resolve_json_value(&raw))
+}
+
+/// Resolve inline JSON or a content-addressed provenance file reference. The
+/// reference keeps `execve` bounded without changing the established env names.
+pub fn resolve_json_value(raw: &str) -> Option<serde_json::Value> {
+    let value = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+    if value.get("schema").and_then(serde_json::Value::as_str) != Some(PROVENANCE_REFERENCE_SCHEMA)
+    {
+        return Some(value);
+    }
+
+    let path = value.get("path")?.as_str()?;
+    let expected_hash = value.get("sha256")?.as_str()?;
+    let contents = std::fs::read(path).ok()?;
+    let actual_hash = format!("{:x}", Sha256::digest(&contents));
+    (actual_hash == expected_hash)
+        .then(|| serde_json::from_slice::<serde_json::Value>(&contents).ok())
+        .flatten()
 }
 
 fn preview_metadata_from_env() -> Option<serde_json::Value> {
@@ -102,7 +122,11 @@ fn preview_metadata_from_env() -> Option<serde_json::Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{RunContext, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
+    use super::{
+        resolve_json_value, RunContext, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+        PROVENANCE_REFERENCE_SCHEMA,
+    };
+    use sha2::{Digest, Sha256};
 
     #[test]
     fn subprocess_context_reads_generic_preview_metadata_with_public_url_overlay() {
@@ -129,5 +153,34 @@ mod tests {
 
         std::env::remove_var(PREVIEW_METADATA_ENV);
         std::env::remove_var(PREVIEW_PUBLIC_URL_ENV);
+    }
+
+    #[test]
+    fn provenance_resolver_preserves_inline_json_and_rejects_tampered_references() {
+        let inline = r#"{"schema":"fixture/v1","value":"inline"}"#;
+        assert_eq!(
+            resolve_json_value(inline),
+            serde_json::from_str(inline).ok()
+        );
+
+        let directory = tempfile::tempdir().expect("provenance directory");
+        let path = directory.path().join("payload.json");
+        let payload = br#"{"schema":"fixture/v1","value":"staged"}"#;
+        std::fs::write(&path, payload).expect("stage provenance");
+        let reference = serde_json::json!({
+            "schema": PROVENANCE_REFERENCE_SCHEMA,
+            "path": path,
+            "sha256": format!("{:x}", Sha256::digest(payload)),
+        })
+        .to_string();
+
+        assert_eq!(
+            resolve_json_value(&reference),
+            serde_json::from_slice(payload).ok()
+        );
+
+        std::fs::write(&path, br#"{"schema":"fixture/v1","value":"tampered"}"#)
+            .expect("tamper provenance");
+        assert_eq!(resolve_json_value(&reference), None);
     }
 }

--- a/crates/homeboy-core/src/observation/mod.rs
+++ b/crates/homeboy-core/src/observation/mod.rs
@@ -36,7 +36,9 @@ pub use loop_inventory_run::persist_loop_inventory_run;
 
 pub use crate::notification_route::NotificationRoute;
 pub use budget_findings::finding_records_from_budget;
-pub use context::{RunContext, RunProvenance};
+pub use context::{
+    env_json, resolve_json_value, RunContext, RunProvenance, PROVENANCE_REFERENCE_SCHEMA,
+};
 pub use homeboy_lifecycle_contract::timeline::{
     ObservationEvent, ObservationPhaseMilestone, ObservationSpanDefinition, ObservationSpanResult,
     ObservationSpanStatus,

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,6 +15,7 @@ use homeboy_core::runner_execution_envelope::{
 use homeboy_core::secret_env_plan::SecretEnvPlan;
 use homeboy_core::server::{self, SshClient};
 use homeboy_core::source_snapshot::SourceSnapshot;
+use sha2::{Digest, Sha256};
 
 use super::super::normalize_runner_command_env_for_homeboy_path;
 use super::super::resource_metrics::{
@@ -424,7 +427,7 @@ pub(crate) fn prepare_daemon_local_process(
 pub(crate) fn execute_runner_process(plan: &PreparedRunnerProcess) -> Result<ProcessOutput> {
     let mut command = std::process::Command::new(&plan.command[0]);
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
-    apply_runner_process_env(&mut command, plan);
+    apply_runner_process_env(&mut command, plan)?;
 
     command_output(&mut command, plan.runner.settings.concurrency_limit)
 }
@@ -438,7 +441,7 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
 ) -> Result<ProcessOutput> {
     let mut command = std::process::Command::new(&plan.command[0]);
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
-    apply_runner_process_env(&mut command, plan);
+    apply_runner_process_env(&mut command, plan)?;
 
     command_output_until_cancelled_with_progress(
         &mut command,
@@ -452,10 +455,252 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
     )
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+
+    const GUTENBERG_LAB_OFFLOAD_BYTES: usize = 142_952;
+    const GUTENBERG_SOURCE_SNAPSHOT_BYTES: usize = 44_680;
+    const GUTENBERG_EXECUTION_BUNDLE_BYTES: usize = 8_552;
+    const SAFE_CHILD_PROVENANCE_ENV_BYTES: usize = 16 * 1024;
+
+    fn json_payload(bytes: usize) -> String {
+        let mut value = serde_json::json!({ "payload": "" });
+        let base = serde_json::to_string(&value)
+            .expect("JSON serializes")
+            .len();
+        value["payload"] = serde_json::Value::String("x".repeat(bytes - base));
+        let serialized = serde_json::to_string(&value).expect("JSON serializes");
+        assert_eq!(serialized.len(), bytes);
+        serialized
+    }
+
+    fn execution_bundle(bytes: usize, provenance_dir: &Path) -> String {
+        let mut value = serde_json::json!({
+            "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": {
+                "path": "/runner/bin/homeboy",
+                "build_identity": homeboy_core::build_identity::current().display,
+            },
+            "provenance_dir": provenance_dir,
+            "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
+            "extension_runtime_home": "/runner/job/home",
+            "extensions": [{ "id": "fixture", "remote_path": "/runner/job/fixture", "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }],
+            "padding": "",
+        });
+        let base = serde_json::to_string(&value)
+            .expect("bundle serializes")
+            .len();
+        value["padding"] = serde_json::Value::String("x".repeat(bytes - base));
+        let serialized = serde_json::to_string(&value).expect("bundle serializes");
+        assert_eq!(serialized.len(), bytes);
+        serialized
+    }
+
+    #[test]
+    fn oversized_lab_provenance_is_staged_within_a_safe_child_environment_budget() {
+        let stage = tempfile::tempdir().expect("provenance stage");
+        let provenance_dir = stage.path().join("run-artifacts/provenance");
+        fs::create_dir_all(provenance_dir.parent().expect("artifact root")).expect("artifact root");
+        let lab_offload = json_payload(GUTENBERG_LAB_OFFLOAD_BYTES);
+        let source_snapshot = json_payload(GUTENBERG_SOURCE_SNAPSHOT_BYTES);
+        let bundle = execution_bundle(GUTENBERG_EXECUTION_BUNDLE_BYTES, &provenance_dir);
+        assert_eq!(
+            (lab_offload.len(), source_snapshot.len(), bundle.len()),
+            (
+                GUTENBERG_LAB_OFFLOAD_BYTES,
+                GUTENBERG_SOURCE_SNAPSHOT_BYTES,
+                GUTENBERG_EXECUTION_BUNDLE_BYTES,
+            )
+        );
+
+        let mut env = HashMap::from([
+            (
+                homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV.to_string(),
+                lab_offload.clone(),
+            ),
+            (
+                crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV.to_string(),
+                bundle.clone(),
+            ),
+            (
+                "HOMEBOY_EXISTING_BEHAVIOR".to_string(),
+                "preserved".to_string(),
+            ),
+        ]);
+        env = child_provenance_env(env, source_snapshot.clone()).expect("stage env");
+
+        let provenance_names = [
+            homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV,
+            homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+            crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV,
+        ];
+        let child_provenance_bytes = provenance_names
+            .iter()
+            .map(|name| env.get(*name).expect("child provenance key").len())
+            .sum::<usize>();
+        assert!(child_provenance_bytes < SAFE_CHILD_PROVENANCE_ENV_BYTES);
+        assert_eq!(env["HOMEBOY_EXISTING_BEHAVIOR"], "preserved");
+        assert_eq!(
+            homeboy_core::observation::resolve_json_value(
+                env.get(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV)
+                    .expect("offload reference"),
+            ),
+            serde_json::from_str::<serde_json::Value>(&lab_offload).ok(),
+        );
+        assert_eq!(
+            homeboy_core::observation::resolve_json_value(
+                env.get(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV)
+                    .expect("snapshot reference"),
+            ),
+            serde_json::from_str::<serde_json::Value>(&source_snapshot).ok(),
+        );
+        assert!(crate::execution_bundle::validate_bundle_env(
+            &env,
+            &["/runner/bin/homeboy".to_string(), "fuzz".to_string()],
+            &["fixture".to_string()],
+        ));
+        assert_eq!(
+            fs::read_dir(stage.path().join("run-artifacts/provenance"))
+                .expect("staged files")
+                .count(),
+            3
+        );
+        assert!(!stage.path().join("provenance").exists());
+    }
+
+    #[test]
+    fn concurrent_staging_atomically_reuses_one_valid_hash_file() {
+        let root = tempfile::tempdir().expect("run artifact root");
+        let provenance_dir = root.path().join("provenance");
+        let payload = json_payload(GUTENBERG_LAB_OFFLOAD_BYTES);
+        let bundle = serde_json::json!({
+            "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+            "binary": {
+                "path": "/runner/bin/homeboy",
+                "build_identity": homeboy_core::build_identity::current().display,
+            },
+            "provenance_dir": provenance_dir,
+            "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
+        });
+        let env = HashMap::from([
+            (
+                crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV.to_string(),
+                bundle.to_string(),
+            ),
+            (
+                homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV.to_string(),
+                payload.clone(),
+            ),
+        ]);
+        let barrier = Arc::new(Barrier::new(8));
+        let handles = (0..8)
+            .map(|_| {
+                let env = env.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    child_provenance_env(env, "{}".to_string()).expect("concurrent stage")
+                })
+            })
+            .collect::<Vec<_>>();
+        let references = handles
+            .into_iter()
+            .map(|handle| {
+                handle.join().expect("staging thread")
+                    [homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV]
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+
+        assert!(references
+            .iter()
+            .all(|reference| reference == &references[0]));
+        let files = fs::read_dir(root.path().join("provenance"))
+            .expect("provenance files")
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .expect("directory entries");
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            fs::read(files[0].path()).expect("published payload"),
+            payload.as_bytes()
+        );
+    }
+
+    #[test]
+    fn mixed_build_does_not_replace_established_inline_json() {
+        let root = tempfile::tempdir().expect("run artifact root");
+        let payload = json_payload(GUTENBERG_LAB_OFFLOAD_BYTES);
+        let env = HashMap::from([
+            (
+                crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV.to_string(),
+                serde_json::json!({
+                    "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+                    "binary": { "path": "/runner/bin/homeboy", "build_identity": "homeboy older-build" },
+                    "provenance_dir": root.path().join("provenance"),
+                    "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
+                }).to_string(),
+            ),
+            (
+                homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV.to_string(),
+                payload,
+            ),
+        ]);
+
+        let error = child_provenance_env(env, "{}".to_string())
+            .expect_err("mixed build must fail before replacement");
+        assert!(error
+            .message
+            .contains("does not support provenance references"));
+        assert!(!root.path().join("provenance").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staging_rejects_a_symlinked_provenance_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("run artifact root");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let provenance_dir = root.path().join("provenance");
+        symlink(outside.path(), &provenance_dir).expect("symlink provenance directory");
+        let env = HashMap::from([
+            (
+                crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV.to_string(),
+                serde_json::json!({
+                    "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+                    "binary": {
+                        "path": "/runner/bin/homeboy",
+                        "build_identity": homeboy_core::build_identity::current().display,
+                    },
+                    "provenance_dir": provenance_dir,
+                    "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
+                })
+                .to_string(),
+            ),
+            (
+                homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV.to_string(),
+                json_payload(GUTENBERG_LAB_OFFLOAD_BYTES),
+            ),
+        ]);
+
+        let error = child_provenance_env(env, "{}".to_string())
+            .expect_err("symlinked stage directory must fail closed");
+        assert!(error.message.contains("not a real directory"));
+        assert_eq!(
+            fs::read_dir(outside.path())
+                .expect("outside directory")
+                .count(),
+            0
+        );
+    }
+}
+
 pub(super) fn apply_runner_process_env(
     command: &mut std::process::Command,
     plan: &PreparedRunnerProcess,
-) {
+) -> Result<()> {
     command.env_clear();
     for key in inherited_runner_process_env_keys() {
         if !plan.env.contains_key(*key) {
@@ -464,11 +709,210 @@ pub(super) fn apply_runner_process_env(
             }
         }
     }
-    preserve_durable_homeboy_data_dir(command, &plan.env);
-    command.envs(plan.env.iter()).env(
-        homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+    let env = child_provenance_env(
+        plan.env.clone(),
         serde_json::to_string(&plan.source_snapshot).unwrap_or_default(),
+    )?;
+    preserve_durable_homeboy_data_dir(command, &env);
+    command.envs(env.iter());
+    Ok(())
+}
+
+const PROVENANCE_ENV_INLINE_MAX_BYTES: usize = 8 * 1024;
+
+fn child_provenance_env(
+    mut env: HashMap<String, String>,
+    source_snapshot: String,
+) -> Result<HashMap<String, String>> {
+    env.insert(
+        homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV.to_string(),
+        source_snapshot,
     );
+    let provenance_names = [
+        homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV,
+        homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV,
+        crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV,
+    ];
+    if !provenance_names.iter().any(|name| {
+        env.get(*name)
+            .is_some_and(|raw| raw.len() > PROVENANCE_ENV_INLINE_MAX_BYTES)
+    }) {
+        return Ok(env);
+    }
+    let bundle = env
+        .get(crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV)
+        .and_then(|raw| homeboy_core::observation::resolve_json_value(raw))
+        .ok_or_else(|| provenance_reference_error("execution bundle is missing or invalid"))?;
+    let child_identity = bundle
+        .pointer("/binary/build_identity")
+        .and_then(serde_json::Value::as_str)
+        .filter(|identity| !identity.trim().is_empty())
+        .ok_or_else(|| provenance_reference_error("child build identity is unavailable"))?;
+    if child_identity.trim() != homeboy_core::build_identity::current().display {
+        return Err(provenance_reference_error(&format!(
+            "child build `{child_identity}` does not support provenance references from runner build `{}`",
+            homeboy_core::build_identity::current().display
+        )));
+    }
+    let stage_dir = bundle
+        .get("provenance_dir")
+        .and_then(serde_json::Value::as_str)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| {
+            provenance_reference_error("run-owned provenance directory is unavailable")
+        })?;
+    ensure_restricted_stage_dir(&stage_dir)?;
+
+    for name in provenance_names {
+        let Some(raw) = env.get(name).cloned() else {
+            continue;
+        };
+        if raw.len() <= PROVENANCE_ENV_INLINE_MAX_BYTES {
+            continue;
+        }
+        let hash = format!("{:x}", Sha256::digest(raw.as_bytes()));
+        let path = stage_dir.join(format!("{hash}.json"));
+        publish_provenance(&stage_dir, &path, raw.as_bytes(), &hash)?;
+        let reference = serde_json::json!({
+            "schema": homeboy_core::observation::PROVENANCE_REFERENCE_SCHEMA,
+            "path": path,
+            "sha256": hash,
+        });
+        env.insert(
+            name.to_string(),
+            serde_json::to_string(&reference).expect("provenance reference serializes"),
+        );
+    }
+    Ok(env)
+}
+
+fn provenance_reference_error(reason: &str) -> Error {
+    Error::validation_invalid_argument(
+        "provenance_transport",
+        format!("cannot safely bound child provenance environment: {reason}"),
+        None,
+        Some(vec![
+            "Run the child with the admitted Homeboy build or refresh the runner before retrying."
+                .to_string(),
+        ]),
+    )
+}
+
+fn ensure_restricted_stage_dir(path: &Path) -> Result<()> {
+    match fs::create_dir(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("inspect provenance directory".to_string()),
+                )
+            })?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(provenance_reference_error(
+                    "run-owned provenance path is not a real directory",
+                ));
+            }
+        }
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some("create run-owned provenance directory".to_string()),
+            ));
+        }
+    }
+    restrict_provenance_permissions(path, 0o700)
+}
+
+fn publish_provenance(stage_dir: &Path, path: &Path, payload: &[u8], hash: &str) -> Result<()> {
+    if path.exists() {
+        return validate_published_provenance(path, hash);
+    }
+    let temp_path = stage_dir.join(format!(".{hash}.{}.tmp", uuid::Uuid::new_v4()));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut temp = options.open(&temp_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create exclusive provenance temp file".to_string()),
+        )
+    })?;
+    let publish = (|| {
+        temp.write_all(payload).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("write provenance temp file".to_string()),
+            )
+        })?;
+        temp.sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("sync provenance temp file".to_string()),
+            )
+        })?;
+        drop(temp);
+        match fs::hard_link(&temp_path, path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                validate_published_provenance(path, hash)
+            }
+            Err(error) => Err(Error::internal_io(
+                error.to_string(),
+                Some("atomically publish provenance file".to_string()),
+            )),
+        }
+    })();
+    let _ = fs::remove_file(temp_path);
+    publish
+}
+
+fn validate_published_provenance(path: &Path, expected_hash: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("inspect published provenance".to_string()),
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(provenance_reference_error(
+            "published provenance path is not a regular file",
+        ));
+    }
+    let contents = fs::read(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read published provenance".to_string()),
+        )
+    })?;
+    let actual_hash = format!("{:x}", Sha256::digest(&contents));
+    if actual_hash != expected_hash {
+        return Err(provenance_reference_error(
+            "existing content-addressed provenance file failed hash verification",
+        ));
+    }
+    restrict_provenance_permissions(path, 0o600)
+}
+
+#[cfg(unix)]
+fn restrict_provenance_permissions(path: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("restrict provenance permissions".to_string()),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_provenance_permissions(_path: &Path, _mode: u32) -> Result<()> {
+    Ok(())
 }
 
 fn preserve_durable_homeboy_data_dir(

--- a/crates/homeboy-lab-runner/src/execution_bundle.rs
+++ b/crates/homeboy-lab-runner/src/execution_bundle.rs
@@ -16,7 +16,7 @@ pub(crate) fn validate_bundle_env(
     let Some(raw) = env.get(LAB_EXECUTION_BUNDLE_ENV) else {
         return false;
     };
-    let Ok(bundle) = serde_json::from_str::<serde_json::Value>(raw) else {
+    let Some(bundle) = homeboy_core::observation::resolve_json_value(raw) else {
         return false;
     };
     let non_empty = |pointer| {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -79,9 +79,13 @@ pub(crate) fn ensure_remote_lab_artifact_dir(runner_id: &str, output_file: &str)
         .rsplit_once('/')
         .map(|(parent, _)| if parent.is_empty() { "/" } else { parent })
         .unwrap_or(".");
+    ensure_remote_lab_artifact_directory(runner_id, parent)
+}
+
+fn ensure_remote_lab_artifact_directory(runner_id: &str, directory: &str) -> Result<()> {
     lab_runner_file_transfer(runner_id)?
-        .ensure_directory(parent)
-        .map_err(|err| lab_artifact_directory_error(runner_id, parent, err))?;
+        .ensure_directory(directory)
+        .map_err(|err| lab_artifact_directory_error(runner_id, directory, err))?;
     Ok(())
 }
 
@@ -128,7 +132,7 @@ where
     F: FnMut() -> Result<()>,
 {
     check_cancelled()?;
-    ensure_remote_lab_artifact_dir(runner.id.as_str(), &remote_lab_artifact_dir(remote_cwd))?;
+    ensure_remote_lab_artifact_directory(runner.id.as_str(), &remote_lab_artifact_dir(remote_cwd))?;
     check_cancelled()?;
 
     let candidate_rig_registry_root = remote_lab_rig_registry_root(remote_cwd);
@@ -1895,6 +1899,9 @@ pub(crate) fn run_lab_offload_inner(
             "build_identity": runner_homeboy.get("job_command_binary_build_identity")
                 .or_else(|| runner_homeboy.get("active_daemon_build_identity")),
         },
+        // The materialized workspace deletes this artifact root on every known
+        // terminal result, bounding content-addressed transport retention.
+        "provenance_dir": format!("{}/provenance", remote_lab_artifact_dir(&remote_cwd)),
         "admission": {
             "daemon_lease_id": admission
                 .as_ref()

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -405,12 +405,7 @@ fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Resu
     else {
         return Ok(());
     };
-    let lab: serde_json::Value = serde_json::from_str(lab).map_err(|err| {
-        Error::internal_json(
-            err.to_string(),
-            Some("parse reverse worker Lab offload metadata".to_string()),
-        )
-    })?;
+    let lab = reverse_worker_lab_offload(lab)?;
     if !matches!(
         lab.get("sync_mode").and_then(serde_json::Value::as_str),
         Some("snapshot" | "filesystem_snapshot")
@@ -435,6 +430,15 @@ fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Resu
     // re-attempt rather than terminalizing the cook as a provider failure
     // (#9399).
     .map_err(|message| Error::internal_unexpected(message).with_retryable(true))
+}
+
+fn reverse_worker_lab_offload(raw: &str) -> Result<serde_json::Value> {
+    homeboy_core::observation::resolve_json_value(raw).ok_or_else(|| {
+        Error::internal_json(
+            "invalid inline or referenced Lab offload metadata",
+            Some("parse reverse worker Lab offload metadata".to_string()),
+        )
+    })
 }
 
 /// Materialize broker-owned command files in the worker's durable data root and
@@ -651,4 +655,29 @@ fn non_empty_run_id(run_id: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|run_id| !run_id.is_empty())
         .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod provenance_tests {
+    use super::reverse_worker_lab_offload;
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn reverse_worker_resolves_referenced_lab_offload_metadata() {
+        let directory = tempfile::tempdir().expect("transport directory");
+        let path = directory.path().join("lab-offload.json");
+        let payload = br#"{"schema":"fixture/lab-offload/v1","sync_mode":"snapshot"}"#;
+        std::fs::write(&path, payload).expect("write Lab offload metadata");
+        let reference = serde_json::json!({
+            "schema": homeboy_core::observation::PROVENANCE_REFERENCE_SCHEMA,
+            "path": path,
+            "sha256": format!("{:x}", Sha256::digest(payload)),
+        })
+        .to_string();
+
+        assert_eq!(
+            reverse_worker_lab_offload(&reference).expect("referenced Lab metadata")["sync_mode"],
+            "snapshot"
+        );
+    }
 }

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -386,9 +386,11 @@ pub(crate) fn verify_lab_workspace_from_env(
     expected_remote_component_path: &str,
     materialized_workspace_path: &Path,
 ) -> std::result::Result<VerifiedLabWorkspaceProvenance, String> {
-    let snapshot: SourceSnapshot = env_json(SOURCE_SNAPSHOT_METADATA_ENV)
-        .ok_or_else(|| "is missing source snapshot transport metadata".to_string())?;
-    let lab: serde_json::Value = env_json(LAB_OFFLOAD_METADATA_ENV)
+    let snapshot: SourceSnapshot =
+        homeboy_core::observation::env_json(SOURCE_SNAPSHOT_METADATA_ENV)
+            .and_then(|value| serde_json::from_value(value).ok())
+            .ok_or_else(|| "is missing source snapshot transport metadata".to_string())?;
+    let lab: serde_json::Value = homeboy_core::observation::env_json(LAB_OFFLOAD_METADATA_ENV)
         .ok_or_else(|| "is missing Lab dispatch transport metadata".to_string())?;
     verify_lab_workspace(
         expected_remote_component_path,
@@ -922,12 +924,6 @@ fn nested_git_metadata(
         Ok(None)
     }
     visit(workspace, workspace, &content_excludes)
-}
-
-fn env_json<T: serde::de::DeserializeOwned>(name: &str) -> Option<T> {
-    std::env::var(name)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
 }
 
 /// Runner process preparation may enrich a staged snapshot with the original

--- a/crates/homeboy-rig/src/lease.rs
+++ b/crates/homeboy-rig/src/lease.rs
@@ -239,9 +239,7 @@ fn lab_metadata_string_pointer(pointer: &str) -> Option<String> {
 }
 
 fn lab_metadata_value() -> Option<serde_json::Value> {
-    std::env::var(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV)
-        .ok()
-        .and_then(|value| serde_json::from_str(&value).ok())
+    homeboy_core::observation::env_json(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV)
 }
 
 fn overlapping_resource(


### PR DESCRIPTION
## Summary

- keep small Lab provenance values inline while staging oversized JSON in run-owned artifact storage
- pass SHA-256 content-addressed references only when the child build identity proves resolver support
- resolve inline and referenced values across Lab, reverse-worker, rig, harvest, and cook-baseline consumers
- publish staged payloads atomically with restricted permissions and integrity verification

## Compatibility

- preserves the existing inline environment schema for small values
- fails closed rather than sending references to mixed-version children
- retains staged provenance through the existing run-owned artifact lifecycle
- verifies referenced bytes against the declared SHA-256 digest

## Verification

- `cargo check -p homeboy-agents -p homeboy-lab-runner`
- `cargo test -p homeboy-core observation::context::tests`
- `cargo test -p homeboy-agents harvest_context_resolves_direct_lab_transport_references`
- `cargo test -p homeboy-agents cook_baseline_resolves_referenced_parent_snapshot`
- `cargo test -p homeboy-lab-runner execution::process::tests`
- `cargo test -p homeboy-lab-runner reverse_worker_resolves_referenced_lab_offload_metadata`
- `cargo test -p homeboy-lab-runner execution_bundle`
- `cargo test -p homeboy-lab-runner lab_artifact_dir`
- `cargo test -p homeboy-rig lease::lease_test`
- changed-file `rustfmt --check`
- `git diff --check`

The full `homeboy-lab-runner` suite completed with 1,309 passing tests and 21 unrelated environment-sensitive failures. Focused affected contracts pass.

## AI assistance

OpenCode agents using `openai/gpt-5.6-terra` and `openai/gpt-5.6-sol` drafted, reviewed, and refined substantive portions of this change. Chris Huber remains responsible for the submitted code.

Closes #9760