### PR TITLE
Fix runner refresh verification across Lab boundary

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -431,7 +431,13 @@ pub fn refresh_homeboy_binary(
                     options.allow_downgrade,
                     &promotion_authorities,
                     |older, newer| {
-                        runner_commits_are_ancestral(&plan, older, newer, disconnected_ssh)
+                        runner_commits_are_ancestral(
+                            &plan,
+                            older,
+                            newer,
+                            disconnected_ssh,
+                            &connection_status,
+                        )
                     },
                 )?;
                 Ok((
@@ -458,7 +464,15 @@ pub fn refresh_homeboy_binary(
                 &identity,
                 options.allow_downgrade,
                 &promotion_authorities,
-                |older, newer| runner_commits_are_ancestral(&plan, older, newer, disconnected_ssh),
+                |older, newer| {
+                    runner_commits_are_ancestral(
+                        &plan,
+                        older,
+                        newer,
+                        disconnected_ssh,
+                        &connection_status,
+                    )
+                },
             )?;
             let updated_fields =
                 promote_verified_runner_binary(&plan.runner_id, &plan.binary_path)?;
@@ -1251,6 +1265,26 @@ fn runner_commits_are_ancestral(
     older: &str,
     newer: &str,
     disconnected_ssh: bool,
+    status_snapshot: &super::RunnerStatusReport,
+) -> Result<bool> {
+    runner_commits_are_ancestral_with(
+        plan,
+        older,
+        newer,
+        disconnected_ssh,
+        |runner_id, options| {
+            exec_with_status_snapshot(runner_id, options, Some(status_snapshot.clone()))
+                .map(|(_, exit_code)| exit_code)
+        },
+    )
+}
+
+fn runner_commits_are_ancestral_with(
+    plan: &HomeboyBinaryRefreshPlan,
+    older: &str,
+    newer: &str,
+    disconnected_ssh: bool,
+    mut exec_runner: impl FnMut(&str, RunnerExecOptions) -> Result<i32>,
 ) -> Result<bool> {
     let repository = plan.target_dir.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -1260,7 +1294,7 @@ fn runner_commits_are_ancestral(
             None,
         )
     })?;
-    let (_, exit_code) = exec(
+    let exit_code = exec_runner(
         &plan.runner_id,
         refresh_ancestry_execution_options(repository, older, newer, disconnected_ssh),
     )?;

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -16,6 +16,54 @@ fn fixture_commits_are_ancestral(repository: &Path, older: &str, newer: &str) ->
     Ok(status.success())
 }
 
+fn linear_commit_fixture() -> (tempfile::TempDir, String, String) {
+    let fixture = tempfile::tempdir().expect("git fixture");
+    for args in [
+        vec!["init", "--quiet"],
+        vec!["config", "user.email", "homeboy@example.test"],
+        vec!["config", "user.name", "Homeboy Test"],
+    ] {
+        assert!(Command::new("git")
+            .args(args)
+            .current_dir(fixture.path())
+            .status()
+            .expect("git")
+            .success());
+    }
+    let revision = || {
+        String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(fixture.path())
+                .output()
+                .expect("revision")
+                .stdout,
+        )
+        .expect("utf8")
+        .trim()
+        .to_string()
+    };
+    std::fs::write(fixture.path().join("release"), "old\n").expect("old release");
+    for args in [vec!["add", "."], vec!["commit", "-m", "old"]] {
+        assert!(Command::new("git")
+            .args(args)
+            .current_dir(fixture.path())
+            .status()
+            .expect("commit old")
+            .success());
+    }
+    let old = revision();
+    std::fs::write(fixture.path().join("release"), "new\n").expect("new release");
+    assert!(Command::new("git")
+        .args(["commit", "-am", "new"])
+        .current_dir(fixture.path())
+        .status()
+        .expect("commit new")
+        .success());
+    let new = revision();
+    (fixture, old, new)
+}
+
 #[test]
 fn routine_reconnect_refuses_to_interrupt_an_admitted_lab_offload() {
     let admission = active_admission("0b77251a-b6a7-42a6-91a3-e49ff5f57c16");
@@ -1348,6 +1396,112 @@ fn refresh_ancestry_exit_status_requires_authoritative_git_result() {
     let error = classify_refresh_ancestry_exit(&plan, 128)
         .expect_err("git comparison errors are not ancestry evidence");
     assert_eq!(error.details["field"], "allow_downgrade");
+}
+
+#[test]
+fn remote_forward_upgrade_uses_runner_owned_ancestry_evidence() {
+    let (fixture, old, new) = linear_commit_fixture();
+    let runner_repository = "/runner-only/homeboy";
+    assert!(!Path::new(runner_repository).exists());
+    let plan = HomeboyBinaryRefreshPlan {
+        runner_id: "lab".to_string(),
+        mode: "materialize".to_string(),
+        source: None,
+        git_ref: Some("main".to_string()),
+        target_dir: Some(runner_repository.to_string()),
+        binary_path: format!("{runner_repository}/target/release/homeboy"),
+        script: String::new(),
+        reconnect: true,
+        followup_commands: Vec::new(),
+    };
+    let mut probes = 0;
+
+    let accepted = validate_refresh_promotion(
+        &plan,
+        &serde_json::json!({"data":{"git_commit":new}}),
+        false,
+        &RefreshPromotionAuthorities {
+            controller: None,
+            active_daemon: Some(old),
+            configured_selected: None,
+        },
+        |older, newer| {
+            runner_commits_are_ancestral_with(
+                &plan,
+                older,
+                newer,
+                false,
+                |runner_id, mut options| {
+                    probes += 1;
+                    assert_eq!(runner_id, "lab");
+                    assert_eq!(options.command[2], runner_repository);
+                    options.command[2] = fixture.path().display().to_string();
+                    Ok(Command::new(&options.command[0])
+                        .args(&options.command[1..])
+                        .status()
+                        .expect("runner ancestry probe")
+                        .code()
+                        .expect("git exit code"))
+                },
+            )
+        },
+    )
+    .expect("forward upgrade is accepted");
+
+    assert!(accepted.is_none());
+    assert_eq!(probes, 1);
+}
+
+#[test]
+fn remote_true_downgrade_is_still_refused_from_runner_owned_evidence() {
+    let (fixture, old, new) = linear_commit_fixture();
+    let runner_repository = "/runner-only/homeboy";
+    assert!(!Path::new(runner_repository).exists());
+    let plan = HomeboyBinaryRefreshPlan {
+        runner_id: "lab".to_string(),
+        mode: "materialize".to_string(),
+        source: None,
+        git_ref: Some("old".to_string()),
+        target_dir: Some(runner_repository.to_string()),
+        binary_path: format!("{runner_repository}/target/release/homeboy"),
+        script: String::new(),
+        reconnect: true,
+        followup_commands: Vec::new(),
+    };
+
+    let denied = validate_refresh_promotion(
+        &plan,
+        &serde_json::json!({"data":{"git_commit":old}}),
+        false,
+        &RefreshPromotionAuthorities {
+            controller: None,
+            active_daemon: Some(new),
+            configured_selected: None,
+        },
+        |older, newer| {
+            runner_commits_are_ancestral_with(
+                &plan,
+                older,
+                newer,
+                false,
+                |runner_id, mut options| {
+                    assert_eq!(runner_id, "lab");
+                    assert_eq!(options.command[2], runner_repository);
+                    options.command[2] = fixture.path().display().to_string();
+                    Ok(Command::new(&options.command[0])
+                        .args(&options.command[1..])
+                        .status()
+                        .expect("runner ancestry probe")
+                        .code()
+                        .expect("git exit code"))
+                },
+            )
+        },
+    )
+    .expect_err("true downgrade remains refused");
+
+    assert_eq!(denied.details["field"], "allow_downgrade");
+    assert!(denied.message.contains("refusing Homeboy runner downgrade"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Execute refresh ancestry verification through the captured runner transport so controller-local fallback cannot dereference runner-only paths.

## What changed
- Pass the current RunnerStatusReport into refresh ancestry probes and add deterministic forward-upgrade and downgrade coverage.

## How to test
1. Run `cargo nextest run --profile quick -p homeboy-lab-runner --lib homeboy_refresh`; expect 68 refresh tests pass, including runner-owned forward upgrade and true downgrade refusal..

## Compatibility
Preserves existing refresh output and rollback safety; only the execution location of the existing git ancestry probe changes.

## Evidence
- Base advanced after verification: verified main at 783038bfdede39a65fb1381cd69f68961b4a1d58; publication observed 6ec8118edf7ae195beef47b0e288ff9c7acca520. Candidate ancestry was validated against the verified snapshot.
- CI expected: Homeboy CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9810
- Verified finalization base: main at 783038bfdede39a65fb1381cd69f68961b4a1d58
- fmt: passed (Passed)
- refresh-tests: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced the controller/runner execution boundary, drafted the scoped status-snapshot transport binding and regression tests, and assisted with test interpretation; Chris reviewed and narrowed the promoted patch.

## Source relationships
- Closes #9810
- Relates to #9829
