### PR TITLE
Give candidate adoption a bounded review budget

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -565,6 +565,12 @@ pub(crate) enum CookFollowUpDispatch {
     PolicyFailure { reason: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CookFollowUpBudgetScope {
+    Cook,
+    CandidateAdoptionReview,
+}
+
 /// Append and dispatch one remediation attempt from an authenticated promoted
 /// candidate. Both ordinary Cook feedback and external candidate adoption use
 /// this boundary so their budget, provenance, and baseline authority match.
@@ -579,6 +585,7 @@ pub(crate) fn dispatch_cook_follow_up<E>(
     promotion: &AgentTaskPromotionReport,
     mut follow_up_request: crate::agent_task::AgentTaskRequest,
     known_same_executor: bool,
+    budget_scope: CookFollowUpBudgetScope,
     budget_limit: &AgentTaskExecutionBudget,
     budget_used: ExecutionBudgetUsage,
     remediation_category_usage: &mut ExecutionBudgetUsage,
@@ -603,7 +610,16 @@ where
                 && retryable_provider_discovery_failure(&recipe_attempt.run_id)
         })
         .cloned();
-    let mut durable_budget_used = budget_used;
+    // The review plan itself permits one execution. The owning dispatch budget
+    // also permits one replay when executor startup cannot discover a provider.
+    let candidate_adoption_review_budget = AgentTaskExecutionBudget::new(2, 1, 0);
+    let (budget_limit, mut durable_budget_used) = match budget_scope {
+        CookFollowUpBudgetScope::Cook => (budget_limit, budget_used),
+        CookFollowUpBudgetScope::CandidateAdoptionReview => (
+            &candidate_adoption_review_budget,
+            ExecutionBudgetUsage::default(),
+        ),
+    };
     for recipe_attempt in related_attempts.clone() {
         if let Ok(aggregate) = agent_task_lifecycle::read_aggregate(&recipe_attempt.run_id) {
             durable_budget_used.add(execution_budget_usage(&aggregate));
@@ -668,6 +684,15 @@ where
         "source_task_id": promotion.source.task_id,
         "source_patch_artifact_sha256": promotion.patch_artifact.sha256,
     });
+    if budget_scope == CookFollowUpBudgetScope::CandidateAdoptionReview {
+        follow_up_request.inputs["cook_loop"]["execution_budget_authority"] = serde_json::json!({
+            "kind": "candidate_adoption_review",
+            "max_provider_executions": 2,
+            "max_same_provider_retries": 1,
+            "max_provider_rotations": 0,
+            "review_plan_provider_executions": 1,
+        });
+    }
     let (next_attempt, next_run_id, mut follow_up_plan, replaced_run_id) = match replay {
         Some(recipe_attempt) => (
             recipe_attempt.attempt,
@@ -1513,6 +1538,7 @@ where
                     &promotion,
                     follow_up_request,
                     false,
+                    CookFollowUpBudgetScope::Cook,
                     budget_limit,
                     budget_used,
                     &mut remediation_category_usage,

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -36,7 +36,7 @@ use homeboy_core::{Error, Result};
 use super::cook::{
     dispatch_cook_follow_up, gate_feedback_current_diff, AgentTaskCandidateAdoptionOptions,
     AgentTaskCookAttemptDispatcher, AgentTaskCookAttemptReport, AgentTaskCookReport,
-    CookFollowUpDispatch,
+    CookFollowUpBudgetScope, CookFollowUpDispatch,
 };
 use super::cook_promotion::{
     cook_report, finalize_or_load_cook_pr_with_backend, persisted_promotion_for_attempt,
@@ -519,6 +519,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
             &promotion,
             follow_up_request,
             true,
+            CookFollowUpBudgetScope::CandidateAdoptionReview,
             &budget,
             super::cook_budget::execution_budget_usage(&aggregate),
             &mut remediation_usage,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1192,6 +1192,24 @@ impl CandidateAdoptionFixture {
         no_finalize: bool,
         dispatcher: Option<Arc<dyn AgentTaskCookAttemptDispatcher>>,
     ) -> Self {
+        Self::new_with_execution_budget(
+            cook_id,
+            max_attempts,
+            max_attempts,
+            max_same_provider_retries,
+            no_finalize,
+            dispatcher,
+        )
+    }
+
+    fn new_with_execution_budget(
+        cook_id: &str,
+        max_attempts: u32,
+        max_provider_executions: u32,
+        max_same_provider_retries: u32,
+        no_finalize: bool,
+        dispatcher: Option<Arc<dyn AgentTaskCookAttemptDispatcher>>,
+    ) -> Self {
         let temp = tempfile::tempdir().expect("temporary adoption repositories");
         let source = temp.path().join("source");
         let target = temp.path().join("target");
@@ -1262,7 +1280,7 @@ impl CandidateAdoptionFixture {
         options.max_attempts = max_attempts;
         options.initial_plan.options.execution_budget =
             crate::agent_task_scheduler::AgentTaskExecutionBudget::new(
-                max_attempts,
+                max_provider_executions,
                 max_same_provider_retries,
                 0,
             );
@@ -2635,14 +2653,78 @@ fn pre_provider_adoption_retries_only_the_missing_form_binds_model_and_reaches_r
 }
 
 #[test]
-fn adoption_budget_failure_is_terminal_non_green_and_replay_does_not_dispatch() {
+fn adoption_review_uses_one_bounded_execution_after_the_source_budget_is_consumed() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let fixture = CandidateAdoptionFixture::new_with_execution_budget(
+            "cook-9575-consumed-source-budget",
+            2,
+            1,
+            0,
+            false,
+            None,
+        );
+        let mut aggregate = agent_task_lifecycle::read_aggregate(&fixture.run_id).unwrap();
+        aggregate
+            .events
+            .push(crate::agent_task_scheduler::AgentTaskProgressEvent {
+                task_id: "cook-homeboy".to_string(),
+                state: AgentTaskState::Running,
+                attempt: 1,
+                message: Some("historical provider execution".to_string()),
+            });
+        let aggregate_path = agent_task_lifecycle::status(&fixture.run_id)
+            .unwrap()
+            .aggregate_path
+            .expect("fixture aggregate path");
+        std::fs::write(
+            aggregate_path,
+            serde_json::to_vec_pretty(&aggregate).unwrap(),
+        )
+        .unwrap();
+        let mut backend = CaptureBackend {
+            hydrate_run_id: Some(fixture.run_id.clone()),
+            ..Default::default()
+        };
+
+        let result = fixture
+            .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
+            .expect("adoption review has a separate bounded execution allowance");
+
+        assert_eq!(result.value.status, "review_ready");
+        let follow_up_plan = agent_task_lifecycle::load_plan(
+            result
+                .value
+                .latest_run_id
+                .as_deref()
+                .expect("follow-up run id"),
+        )
+        .unwrap();
+        assert_eq!(
+            follow_up_plan.tasks[0].inputs["cook_loop"]["execution_budget_authority"]["kind"],
+            "candidate_adoption_review"
+        );
+        assert_eq!(
+            follow_up_plan.tasks[0].inputs["cook_loop"]["execution_budget_authority"]
+                ["max_provider_executions"],
+            2
+        );
+        assert_eq!(
+            follow_up_plan.options.execution_budget,
+            crate::agent_task_scheduler::AgentTaskExecutionBudget::new(1, 0, 0)
+        );
+        assert!(backend.committed && backend.pushed && backend.created);
+    });
+}
+
+#[test]
+fn adoption_review_allowance_is_terminal_and_replay_does_not_dispatch() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let fixture = CandidateAdoptionFixture::new("cook-9575-budget", 2, 0, true, None);
         let mut backend = CaptureBackend::default();
 
         let first = fixture
             .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
-            .expect("budget exhaustion returns a durable report");
+            .expect("adoption review consumes its bounded allowance");
         let replay = fixture
             .adopt(
                 |_| panic!("terminal adoption must not reconstruct a dispatcher"),
@@ -2651,19 +2733,19 @@ fn adoption_budget_failure_is_terminal_non_green_and_replay_does_not_dispatch() 
             )
             .expect("identical adoption replays its terminal result");
 
-        assert_eq!(first.exit_code, 1);
-        assert_eq!(first.value.status, "execution_budget_exhausted");
-        assert_eq!(replay.exit_code, 1);
-        assert_eq!(replay.value.status, "execution_budget_exhausted");
-        assert_ne!(replay.value.status, "green_no_finalize");
+        assert_eq!(first.exit_code, 0);
+        assert_eq!(first.value.status, "green_no_finalize");
+        assert_eq!(replay.exit_code, 0);
+        assert_eq!(replay.value.status, "green_no_finalize");
         assert!(!backend.created);
         let record = agent_task_lifecycle::status(&fixture.run_id).unwrap();
-        assert_eq!(record.candidate_adoption.unwrap().state, "failed");
-        assert!(agent_task_lifecycle::cook_index(&fixture.cook_id)
+        assert_eq!(record.candidate_adoption.unwrap().state, "completed");
+        let attempts = agent_task_lifecycle::cook_index(&fixture.cook_id)
             .unwrap()
-            .attempts
-            .iter()
-            .all(|attempt| attempt.run_id == fixture.run_id));
+            .attempts;
+        assert_eq!(attempts.len(), 2);
+        assert_eq!(attempts[0].run_id, fixture.run_id);
+        assert_eq!(attempts[1].run_id, first.value.latest_run_id.unwrap());
     });
 }
 
@@ -2804,7 +2886,7 @@ fn adoption_replays_provider_discovery_failure_in_the_same_recipe_attempt() {
 }
 
 #[test]
-fn repeated_provider_discovery_failures_exhaust_the_execution_budget() {
+fn repeated_provider_discovery_failures_exhaust_the_adoption_review_allowance() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let dispatcher = Arc::new(ProviderDiscoveryReplayDispatcher {
             dispatches: AtomicUsize::new(0),


### PR DESCRIPTION
## Summary
- give explicit historical candidate-adoption review its own bounded dispatch authority instead of inheriting consumed Cook usage
- preserve the materialized review plan at one provider execution while permitting one provider-discovery recovery at the owning dispatch boundary
- persist the candidate-adoption budget authority and cover consumed-source-budget, replay, recovery, and exhaustion behavior

Closes #9575

## Verification
- `cargo test -p homeboy-agents adoption_ -- --test-threads=1`: 33 passed; one unrelated process-group cancellation timing test flaked in the suite
- `cargo test -p homeboy-agents candidate_adoption_cancellation_persists_request_before_group_termination -- --test-threads=1`: passed in isolation
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
Substantive implementation and regression tests were drafted with OpenAI GPT-5.6 Sol through OpenCode. Chris Huber directed the repair, reviewed the diff, and remains responsible for the change.