### PR TITLE
Expand fuzz profiles in campaigns

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/planning.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/planning.rs
@@ -22,7 +22,7 @@ use super::types_extra::{
 };
 use super::workloads::{
     build_target_inventory, fuzz_workloads, load_rig, resolve_component_id, resolve_fuzz_context,
-    resolve_profile_workload_id, select_workload,
+    resolve_profile_workload_id, resolve_profile_workload_ids, select_workload,
 };
 use homeboy_extension::ExtensionCapability;
 
@@ -141,6 +141,23 @@ pub(super) fn run_campaign(
             None,
             None,
         ));
+    }
+    if let Some(profile) = args.run.profile.take() {
+        if args.run.workload_id.is_some() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "profile",
+                "--profile and --workload cannot be combined; pass one workload selector",
+                Some(profile),
+                None,
+            ));
+        }
+        let rig_context = load_rig(args.run.rig.as_deref(), &args.run.setting_args)?;
+        let workload_ids = resolve_profile_workload_ids(
+            rig_context.as_ref().map(|context| &context.spec),
+            &profile,
+        )?;
+        args.run.workload_id = workload_ids.first().cloned();
+        args.campaign_workloads.extend(workload_ids);
     }
     args.execute = args.execute || !args.dry_run;
     let plan_output = run_plan(args.clone())?;

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -673,6 +673,80 @@ fn fuzz_run_campaign_dry_run_emits_structured_dispatch_records() {
 }
 
 #[test]
+fn fuzz_run_campaign_expands_multi_workload_rig_profile() {
+    with_isolated_home(|home| {
+        let extension_dir = home.path().join(".config/homeboy/extensions/generic");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("generic.json"),
+            serde_json::json!({
+                "name": "generic",
+                "version": "0.0.0",
+                "fuzz": {
+                    "workloads": [
+                        { "id": "api-fuzz" },
+                        { "id": "db-fuzz" }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        let component = tempfile::tempdir().expect("component dir");
+        fs::write(
+            component.path().join("homeboy.json"),
+            serde_json::json!({
+                "id": "component-a",
+                "extensions": { "generic": { "settings": {} } }
+            })
+            .to_string(),
+        )
+        .expect("component config");
+        let rig_dir = home.path().join(".config/homeboy/rigs");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("profile-rig.json"),
+            serde_json::json!({
+                "id": "profile-rig",
+                "components": {
+                    "component-a": {
+                        "path": component.path(),
+                        "extensions": { "generic": { "settings": {} } }
+                    }
+                },
+                "fuzz_profiles": {
+                    "full-surface": ["api-fuzz", "db-fuzz"]
+                }
+            })
+            .to_string(),
+        )
+        .expect("rig manifest");
+
+        let mut args = planner_args();
+        args.run.comp.path = Some(component.path().to_string_lossy().to_string());
+        args.run.comp.component = Some("component-a".to_string());
+        args.run.rig = Some("profile-rig".to_string());
+        args.run.workload_id = None;
+        args.run.profile = Some("full-surface".to_string());
+        args.request_id = Some("campaign-profile".to_string());
+        args.lab_runner = Some("homeboy-lab".to_string());
+        args.dry_run = true;
+
+        let (output, exit_code) = run_campaign(args).expect("profile campaign");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.dispatch_records.len(), 2);
+        assert_eq!(output.dispatch_records[0].workload_id, "api-fuzz");
+        assert_eq!(output.dispatch_records[1].workload_id, "db-fuzz");
+        assert!(output.dispatch_records.iter().all(|record| {
+            record.lab_runner.as_deref() == Some("homeboy-lab")
+                && !record.command.iter().any(|arg| arg == "--profile")
+                && record.command.iter().any(|arg| arg == "--workload")
+        }));
+    });
+}
+
+#[test]
 fn fuzz_plan_operation_filter_limits_inventory_selection() {
     let mut args = planner_args();
     args.run.isolation = FuzzIsolationArg::Isolated;

--- a/crates/homeboy-cli/src/commands/fuzz/workloads.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/workloads.rs
@@ -166,6 +166,30 @@ pub(super) fn resolve_profile_workload_id(
     let Some(profile) = profile else {
         return Ok(explicit_workload_id.map(str::to_string));
     };
+    let workload_ids = resolve_profile_workload_ids(rig_spec, profile)?;
+    if workload_ids.len() != 1 {
+        let spec = rig_spec.expect("profile resolution requires a rig");
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "profile",
+            format!(
+                "fuzz profile '{}' in rig '{}' resolves to {} workloads; `homeboy fuzz run` requires exactly one workload",
+                profile,
+                spec.id,
+                workload_ids.len()
+            ),
+            Some(profile.to_string()),
+            Some(workload_ids.clone()),
+        )
+        .with_hint("Select one workload with `--workload <id>` or use a campaign command for multi-workload profiles."));
+    }
+
+    Ok(workload_ids.first().cloned())
+}
+
+pub(super) fn resolve_profile_workload_ids(
+    rig_spec: Option<&RigSpec>,
+    profile: &str,
+) -> homeboy::core::Result<Vec<String>> {
     let Some(spec) = rig_spec else {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "profile",
@@ -191,22 +215,7 @@ pub(super) fn resolve_profile_workload_id(
             spec.id
         )));
     };
-    if workload_ids.len() != 1 {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "profile",
-            format!(
-                "fuzz profile '{}' in rig '{}' resolves to {} workloads; `homeboy fuzz run` requires exactly one workload",
-                profile,
-                spec.id,
-                workload_ids.len()
-            ),
-            Some(profile.to_string()),
-            Some(workload_ids.clone()),
-        )
-        .with_hint("Select one workload with `--workload <id>` or use a campaign command for multi-workload profiles."));
-    }
-
-    Ok(workload_ids.first().cloned())
+    Ok(workload_ids.clone())
 }
 
 fn rig_component_path(spec: &RigSpec, component_id: &str) -> Option<String> {


### PR DESCRIPTION
## Summary

- expand rig `fuzz_profiles` into concrete `run-campaign` workload entries
- clear the parent profile while preserving single-workload `fuzz run` validation
- keep explicit campaign manifest/workload behavior unchanged

Closes #9820.

## Verification

- `cargo test -p homeboy-cli fuzz_run_campaign` (3 passed)
- `cargo test -p homeboy-cli resolve_profile_workload` (2 passed)
- `cargo build --bin homeboy`
- Real Jetpack `full-surface` dry-run emitted 14 entries, all pinned to `homeboy-lab`, each with one concrete `--workload`, and none with `--profile`.
- Downstream: https://github.com/chubes4/homeboy-rigs/issues/695
- Source report: https://a8c.zendesk.com/agent/tickets/11206186

## AI assistance

Substantive implementation and regression tests were drafted and reviewed with OpenCode using `openai/gpt-5.6-sol`. The change was verified against the real Jetpack 14-workload campaign contract before commit. Chris remains responsible for every line.
