### PR TITLE
Terminalize agent-task runs whose owner process is dead (#9718)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -465,7 +465,7 @@ impl AgentTaskRunRecord {
         RunExecutionState::from(self.state) == self.lifecycle.execution.state
     }
 
-    fn has_fresh_update(&self) -> bool {
+    pub(crate) fn has_fresh_update(&self) -> bool {
         self.updated_at
             .as_deref()
             .and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok())

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -319,6 +319,19 @@ fn classify_liveness(
         return AgentTaskLiveness::Stale;
     }
 
+    // A record can carry a stale-running condition that has not yet been
+    // annotated onto its metadata (annotation happens on the `status` path, not
+    // at rest). Detect a dead owner process directly here so discovery agrees
+    // with `status` and `reconcile_stale_active_runs` actually terminalizes the
+    // ghost `running` record instead of classifying it Active because the
+    // owner_pid is merely PRESENT (#9718). A runner-backed job with a fresh
+    // heartbeat is authoritative liveness and is deliberately left alone.
+    let owner_process_dead = record.owner_pid().is_some() && !record.owner_process_is_running();
+    let runner_backed_and_fresh = record.runner_job_id().is_some() && record.has_fresh_update();
+    if owner_process_dead && !runner_backed_and_fresh {
+        return AgentTaskLiveness::Stale;
+    }
+
     let stale_by_age =
         last_update_age_minutes.is_some_and(|age| age >= STALE_UPDATE_THRESHOLD_MINUTES);
 

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -886,6 +886,45 @@ fn reconcile_cancels_stale_running_record_without_manual_edit() {
 }
 
 #[test]
+fn dead_owner_process_run_is_classified_stale_and_reconciled() {
+    // Regression for #9718: a `running` record whose owner process is dead but
+    // whose `runner_pid` is merely PRESENT (and heartbeat not yet age-stale)
+    // was classified Active by discovery and so was never terminalized by
+    // `active --reconcile`. It must now classify Stale and reconcile to
+    // Cancelled without a manual `cancel`.
+    with_isolated_home(|_| {
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-dead-owner"))
+            .expect("submitted");
+        agent_task_lifecycle::rewrite_record_for_test("run-dead-owner", |record| {
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
+            record.tasks[0].state = AgentTaskState::Running;
+            // Fresh update timestamp + a present-but-dead owner pid, and NO
+            // runner job (local controller-owned run). A very large PID is not
+            // a live process on this host.
+            record.metadata = serde_json::json!({
+                "runner_pid": u32::MAX,
+            });
+        })
+        .expect("dead-owner record stored");
+
+        let report = discover_runs(AgentTaskDiscoveryFilter::Active).expect("active listed");
+        let ghost = report
+            .runs
+            .iter()
+            .find(|run| run.run_id == "run-dead-owner")
+            .expect("ghost listed");
+        assert_eq!(ghost.liveness, Some(AgentTaskLiveness::Stale));
+
+        let reconciled = reconcile_stale_active_runs(false).expect("reconciled");
+        assert_eq!(reconciled.reconciled, 1);
+        assert_eq!(reconciled.failed, 0);
+
+        let record = lifecycle_status("run-dead-owner").expect("status");
+        assert_eq!(record.state, AgentTaskRunState::Cancelled);
+    });
+}
+
+#[test]
 fn discovery_latest_returns_only_newest_run() {
     with_isolated_home(|_| {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-latest-a"))


### PR DESCRIPTION
Fixes #9718. (I filed this after hitting a ghost `running` record while cooking this session.)

## Problem
A run could remain in state `running` for hours with **no live owner process**, yet `agent-task active --reconcile` and `reconcile-records` would NOT terminalize it — only an explicit `agent-task cancel <id>` cleared it. Ghost `running` records accumulate and pollute `agent-task list`/`active` and any completion/notification logic keyed off running state.

## Root cause
`reconcile_stale_active_runs` already cancels **reconcilable** runs (Stale/Suspect/Unreconciled) — the mechanism was fine. The gap was in **classification**: `discovery::classify_liveness` only consulted:
1. the `stale_running` metadata **flag** — which is set on the `status` path (`annotate_stale_running`), not at rest, so a freshly-read record doesn't carry it; and
2. `stale_by_age` / owner-signal **presence**.

A local controller-owned run whose `runner_pid` was **present but dead**, with a heartbeat not yet past the age threshold, fell into `(stale_by_age=false, has_owner_signal=true)` → classified **`Active`**, because nothing verified the owner process was actually alive. So it was never a reconcile candidate. This is why `status` (which annotates) showed `liveness: stale` while `active --reconcile` (which uses discovery) treated it as active — a classification divergence.

## Fix
In `classify_liveness`, detect a dead owner process **directly** — `owner_pid` present AND `!pid_is_running` — and classify `Stale`, mirroring `annotate_stale_running`'s own logic. A runner-backed job with a fresh heartbeat is authoritative live evidence and is deliberately left untouched, so in-flight Lab/detached runs are never wrongly terminalized. This makes discovery agree with status, so `reconcile_stale_active_runs` converges the ghost to `Cancelled`.

`has_fresh_update` widened from module-private to `pub(crate)` for the cross-module check.

## Safety
- Runner-backed + fresh heartbeat → untouched (stays running).
- Live local owner process → `owner_process_dead` is false → still `Active`.
- No owner pid and no runner → still `Unreconciled` (unchanged).
- Only a **present-but-dead** owner pid newly classifies `Stale`.

## Tests
Added `dead_owner_process_run_is_classified_stale_and_reconciled`: a running record with a dead present `runner_pid` and no runner job classifies `Stale` and reconciles to `Cancelled` — the exact #9718 ghost scenario.

## Verification
- `cargo fmt -p homeboy-agents --check` clean
- `cargo check -p homeboy-agents --lib --tests` exit 0
- Full test run deferred to CI per this VPS's no-heavy-local-build rule

Diff: +53/-1, 3 files.