### PR TITLE
Downgrade stale-heartbeat running rows from activity active totals (#9743)

### DIFF
--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -28,10 +28,17 @@ pub use model::*;
 
 // Re-exported at module scope so the source-provider submodules can pull the
 // shared helpers and collector through `use super::*` (#9794).
-pub(crate) use action_helpers::{action, metadata_string, ms_to_rfc3339};
+pub(crate) use action_helpers::{action, metadata_string, ms_to_rfc3339, parse_ts};
 pub(crate) use collector::ActivityCollector;
 
 pub const ACTIVITY_REPORT_SCHEMA: &str = "homeboy/activity-report/v1";
+
+/// A `Running` activity row whose last heartbeat/update is older than this many
+/// minutes is treated as an unverified stale projection rather than active
+/// running work. Old observation rows (runner executions and Cooks from hours or
+/// days earlier) whose processes are gone must not inflate the `active`/`running`
+/// totals that operators rely on for cleanup and workload decisions (#9743).
+const RUNNING_HEARTBEAT_STALE_MINUTES: i64 = 30;
 
 pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityReport> {
     let mut collector = ActivityCollector::default();
@@ -111,7 +118,44 @@ fn resolve_item<'a>(items: &'a [ActivityItem], id: &str) -> Option<&'a ActivityI
     })
 }
 
-fn report_from_items(items: Vec<ActivityItem>, command: &'static str) -> ActivityReport {
+/// Downgrade `Running` rows whose heartbeat is stale to `Stale` so `active`
+/// totals reflect only fresh, verifiable work. A row is considered stale when
+/// its last heartbeat (`updated_at`) is older than
+/// [`RUNNING_HEARTBEAT_STALE_MINUTES`]. A row with a fresh heartbeat — or one
+/// with no `updated_at` heartbeat at all, whose liveness cannot be disproven
+/// from a timestamp alone — is left untouched. Each downgraded row is annotated
+/// with the exact reconcile command so operators can converge or inspect it
+/// (#9743).
+fn reclassify_stale_running(items: &mut [ActivityItem]) {
+    let now = chrono::Utc::now();
+    for item in items.iter_mut() {
+        if item.state != ActivityState::Running {
+            continue;
+        }
+        let Some(heartbeat) = item.updated_at.as_deref().and_then(parse_ts) else {
+            continue;
+        };
+        let age_minutes = (now - heartbeat).num_minutes();
+        if age_minutes < RUNNING_HEARTBEAT_STALE_MINUTES {
+            continue;
+        }
+        item.state = ActivityState::Stale;
+        let reconcile = action(
+            "reconcile stale activity",
+            "homeboy agent-task active --reconcile",
+        );
+        if !item
+            .next_actions
+            .iter()
+            .any(|existing| existing.command == reconcile.command)
+        {
+            item.next_actions.push(reconcile);
+        }
+    }
+}
+
+fn report_from_items(mut items: Vec<ActivityItem>, command: &'static str) -> ActivityReport {
+    reclassify_stale_running(&mut items);
     let counts = counts_for_items(&items);
     let next_actions = items
         .iter()
@@ -319,6 +363,39 @@ mod tests {
         assert!(resolve_item(&items, "agent-1").is_some());
         assert!(resolve_item(&items, "job-1").is_some());
         assert!(resolve_item(&items, "missing").is_none());
+    }
+
+    #[test]
+    fn stale_heartbeat_running_rows_are_reclassified_and_not_counted_active() {
+        let now = chrono::Utc::now();
+        let fresh_ts = now.to_rfc3339();
+        let stale_ts = (now - chrono::Duration::hours(6)).to_rfc3339();
+
+        let mut fresh = item("fresh-running", ActivityState::Running);
+        fresh.updated_at = Some(fresh_ts);
+        let mut stale = item("stale-running", ActivityState::Running);
+        stale.updated_at = Some(stale_ts);
+        // No heartbeat at all: liveness cannot be disproven from a timestamp, so
+        // it is left as Running (not reclassified).
+        let no_heartbeat = item("no-heartbeat-running", ActivityState::Running);
+
+        let report = report_from_items(vec![fresh, stale, no_heartbeat], "homeboy activity");
+
+        // Fresh + heartbeat-less stay running; the stale-heartbeat row moves to stale.
+        assert_eq!(report.counts.running, 2);
+        assert_eq!(report.counts.stale, 1);
+        assert_eq!(report.counts.active, 2);
+
+        let reclassified = report
+            .items
+            .iter()
+            .find(|item| item.id == "stale-running")
+            .expect("stale row present");
+        assert_eq!(reclassified.state, ActivityState::Stale);
+        assert!(reclassified
+            .next_actions
+            .iter()
+            .any(|action| action.command == "homeboy agent-task active --reconcile"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #9743 (bounded first cut). Same class of bug as #9718 (dead-owner runs classified active), applied to the `homeboy activity` surface.

## Problem
`homeboy activity` counted old observation projections as active running work even when the underlying processes were gone:

```
activity: total=20 active=20 running=20 queued=0 failed=0 stale=0
```

Process inspection found no matching commands for most rows (runner executions from hours earlier, a Cook from the previous day). The stale rows forced manual `ps`/`pgrep`/status spelunking before any cleanup decision, and obscured the one genuinely active Cook.

## Root cause
`counts_for_items` tallied purely off each item's declared `state` with **no freshness check** — a `Running` row was counted `active`/`running` regardless of how old its last heartbeat was.

## Fix
`reclassify_stale_running()` runs in the single report-assembly funnel (`report_from_items`): a `Running` row whose last heartbeat (`updated_at`) is older than `RUNNING_HEARTBEAT_STALE_MINUTES` (30) is downgraded to `Stale` before counting, so `active`/`running` reflect only fresh work. Each downgraded row is annotated with the exact `homeboy agent-task active --reconcile` command.

**Conservative by design:**
- Fresh heartbeat → untouched (stays `Running`).
- No `updated_at` heartbeat at all → untouched (liveness can't be disproven from a timestamp alone; not guessed from `created_at`).
- Only a *present-but-stale* heartbeat is downgraded.

Stays generic in `homeboy-core` — timestamp-only, no process-probe or agent-task coupling.

## Acceptance criteria coverage
- ✅ `active` totals count only fresh liveness (stale-heartbeat rows excluded)
- ✅ Stale rows move to `stale` with an exact reconcile command
- ✅ Deterministic test covering stale heartbeat, fresh heartbeat, and missing heartbeat

## Not included (intentionally — the larger part of #9743)
Full liveness reconciliation against **runner daemon job state and process identity** (owner PID / lease probes, terminal-runner-job cross-checks) is a bigger, cross-subsystem change that would couple more state into the activity collector. This PR delivers the deterministic, generic heartbeat-freshness slice — the one that actually stops hours/days-old rows from inflating `active` — as a safe first cut. Process/lease/runner-job reconciliation can follow.

## Verification
- `cargo fmt -p homeboy-core --check` clean
- `cargo check -p homeboy-core --lib --tests` exit 0
- Full test run deferred to CI per this VPS's no-heavy-local-build rule

Diff: +79/-2, 1 file.