### PR TITLE
fix(lab): scope provenance identity requirement

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -479,10 +479,10 @@ mod tests {
     fn execution_bundle(bytes: usize, provenance_dir: &Path) -> String {
         let mut value = serde_json::json!({
             "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
-            "binary": {
-                "path": "/runner/bin/homeboy",
-                "build_identity": homeboy_core::build_identity::current().display,
-            },
+            "binary": crate::execution_bundle::binary(
+                "/runner/bin/homeboy",
+                Some(homeboy_core::build_identity::current().display.as_str()),
+            ),
             "provenance_dir": provenance_dir,
             "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
             "extension_runtime_home": "/runner/job/home",
@@ -653,6 +653,34 @@ mod tests {
         assert!(error
             .message
             .contains("does not support provenance references"));
+        assert!(!root.path().join("provenance").exists());
+    }
+
+    #[test]
+    fn missing_verified_build_identity_does_not_replace_oversized_json() {
+        let root = tempfile::tempdir().expect("run artifact root");
+        let env = HashMap::from([
+            (
+                crate::execution_bundle::LAB_EXECUTION_BUNDLE_ENV.to_string(),
+                serde_json::json!({
+                    "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
+                    "binary": crate::execution_bundle::binary("/runner/bin/homeboy", None),
+                    "provenance_dir": root.path().join("provenance"),
+                    "admission": { "daemon_lease_id": "lease", "reservation_job_id": "job" },
+                })
+                .to_string(),
+            ),
+            (
+                homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV.to_string(),
+                json_payload(GUTENBERG_LAB_OFFLOAD_BYTES),
+            ),
+        ]);
+
+        let error = child_provenance_env(env, "{}".to_string())
+            .expect_err("missing verified identity must fail before replacement");
+        assert!(error
+            .message
+            .contains("child build identity is unavailable"));
         assert!(!root.path().join("provenance").exists());
     }
 

--- a/crates/homeboy-lab-runner/src/execution_bundle.rs
+++ b/crates/homeboy-lab-runner/src/execution_bundle.rs
@@ -5,6 +5,13 @@ use std::collections::HashMap;
 pub(crate) const LAB_EXECUTION_BUNDLE_ENV: &str = "HOMEBOY_LAB_EXECUTION_BUNDLE";
 pub(crate) const LAB_EXECUTION_BUNDLE_SCHEMA: &str = "homeboy/lab-execution-bundle/v1";
 
+pub(crate) fn binary(path: &str, verified_build_identity: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "path": path,
+        "build_identity": verified_build_identity,
+    })
+}
+
 /// Validate the authority passed to the runner process. This is deliberately
 /// stricter than checking for an environment key: only a complete bundle can
 /// replace runner-global extension resolution.
@@ -77,6 +84,14 @@ pub(crate) fn bundle_env(bundle: &serde_json::Value) -> HashMap<String, String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn binary_uses_the_verified_configured_identity_without_status_fallbacks() {
+        let binary = binary("/runner/bin/homeboy", Some("homeboy 1.2.3+abc123"));
+
+        assert_eq!(binary["path"], "/runner/bin/homeboy");
+        assert_eq!(binary["build_identity"], "homeboy 1.2.3+abc123");
+    }
 
     #[test]
     fn bundle_requires_matching_command_admission_and_private_extension_snapshot() {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1892,17 +1892,12 @@ pub(crate) fn run_lab_offload_inner(
             return Err(error);
         }
     };
-    let execution_bundle_build_identity = verified_execution_bundle_build_identity(
-        configured_build_identity.as_deref(),
-        runner_id,
-        homeboy_path,
-    )?;
     lab_metadata["execution_bundle"] = serde_json::json!({
         "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
-        "binary": {
-            "path": homeboy_path,
-            "build_identity": execution_bundle_build_identity,
-        },
+        "binary": crate::execution_bundle::binary(
+            homeboy_path,
+            configured_build_identity.as_deref(),
+        ),
         // The materialized workspace deletes this artifact root on every known
         // terminal result, bounding content-addressed transport retention.
         "provenance_dir": format!("{}/provenance", remote_lab_artifact_dir(&remote_cwd)),
@@ -2295,28 +2290,6 @@ fn artifact_name_or_kind_is_fuzz_result(value: &str) -> bool {
     )
 }
 
-fn verified_execution_bundle_build_identity<'a>(
-    configured_build_identity: Option<&'a str>,
-    runner_id: &str,
-    homeboy_path: &str,
-) -> Result<&'a str> {
-    configured_build_identity
-        .map(str::trim)
-        .filter(|identity| !identity.is_empty())
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "runner_homeboy_build_identity",
-                format!(
-                    "Lab offload cannot bind the execution bundle to configured runner binary `{homeboy_path}` because its immutable build identity is unavailable"
-                ),
-                None,
-                Some(vec![format!(
-                    "Run `{homeboy_path} self identity` on runner `{runner_id}`, then refresh and reconnect the runner before retrying."
-                )]),
-            )
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2324,46 +2297,6 @@ mod tests {
         RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning, RunnerTunnelMode,
     };
     use std::sync::{Arc, Barrier, Mutex};
-
-    #[test]
-    fn execution_bundle_uses_verified_configured_binary_identity() {
-        let configured_build_identity = Some("homeboy 0.310.0+verified".to_string());
-        let runner_homeboy = serde_json::json!({
-            "job_command_binary_build_identity": null,
-            "active_daemon_build_identity": "homeboy 0.310.0+verified",
-        });
-
-        let identity = verified_execution_bundle_build_identity(
-            configured_build_identity.as_deref(),
-            "homeboy-lab",
-            "/runner/bin/homeboy",
-        )
-        .expect("verified configured identity");
-        let bundle = serde_json::json!({
-            "binary": {
-                "path": "/runner/bin/homeboy",
-                "build_identity": identity,
-            },
-        });
-
-        assert!(runner_homeboy["job_command_binary_build_identity"].is_null());
-        assert_eq!(
-            bundle["binary"]["build_identity"],
-            "homeboy 0.310.0+verified"
-        );
-    }
-
-    #[test]
-    fn execution_bundle_rejects_unavailable_configured_binary_identity() {
-        let error =
-            verified_execution_bundle_build_identity(None, "homeboy-lab", "/runner/bin/homeboy")
-                .expect_err("missing configured identity must fail closed");
-
-        assert_eq!(error.code.as_str(), "validation.invalid_argument");
-        assert!(error
-            .message
-            .contains("immutable build identity is unavailable"));
-    }
 
     #[test]
     fn concurrent_same_id_rigs_dispatch_from_their_admitted_registry_after_promotion() {


### PR DESCRIPTION
## Summary
- preserve verified configured build identity in the execution bundle without reading nullable runner status fields
- require that identity only when oversized provenance must switch from inline JSON to reference transport
- preserve existing small inline provenance compatibility while keeping missing and mixed identity reference staging fail-closed

Follow-up to #9837 and #9836.

## Verification
- `cargo test -p homeboy-lab-runner execution_bundle` (6 passed)
- `cargo test -p homeboy-lab-runner execution::process::tests` (5 passed)
- `cargo check -p homeboy-lab-runner`
- changed-file `rustfmt`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6-sol was used through OpenCode to analyze the provenance transport failure, draft the scoped implementation and tests, and resolve the rebase against v0.310.2. Chris Huber reviewed and remains responsible for the change.