### PR TITLE
Resume legacy candidate adoption budget failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -154,6 +154,9 @@ pub fn start_candidate_adoption_with_policy(
                 conflict = true;
                 return false;
             }
+            if replacement.is_none() && existing.state == "failed" {
+                replacement = Some(existing.clone());
+            }
         }
         if let Some(replacement) = replacement {
             let metadata = record.ensure_metadata_object();

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -61,6 +61,22 @@ fn persist_adoption_terminal_result(run_id: &str, report: &AgentTaskCookReport) 
     )
 }
 
+fn legacy_adoption_budget_failure(
+    recipe: &super::AgentTaskCookRecipe,
+    source_run_id: &str,
+    result: Option<&Value>,
+) -> bool {
+    result.is_some_and(|result| result["status"] == "execution_budget_exhausted")
+        && !recipe.attempts.iter().any(|attempt| {
+            attempt.plan.tasks.iter().any(|task| {
+                task.inputs["cook_loop"]["artifact_provenance"]["source_run_id"].as_str()
+                    == Some(source_run_id)
+                    && task.inputs["cook_loop"]["execution_budget_authority"]["kind"]
+                        == "candidate_adoption_review"
+            })
+        })
+}
+
 /// Read the AI-authored review form off an adopted candidate's terminal
 /// outcome. The candidate was produced by an earlier cook attempt, so any form
 /// the original agent emitted is recorded on its aggregate. Absent/invalid here
@@ -234,12 +250,19 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
     } else {
         options.gates.verify.join(" && ")
     };
+    let persisted_adoption_result = record
+        .candidate_adoption
+        .as_ref()
+        .and_then(|adoption| adoption.result.as_ref());
     if !options.gates.rerun_completed_gates
         && record.candidate_adoption.as_ref().is_some_and(|adoption| {
             adoption.candidate_sha == candidate_sha
                 && adoption.ai_model == adoption_ai_model
                 && (adoption.state == "completed" || adoption.result.is_some())
         })
+        // Pre-authority budget failures may enter the repaired path once. The
+        // failed attempt is archived when the new adoption starts.
+        && !legacy_adoption_budget_failure(&recipe, &run_id, persisted_adoption_result)
     {
         if let Some(result) = record
             .candidate_adoption

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2717,6 +2717,55 @@ fn adoption_review_uses_one_bounded_execution_after_the_source_budget_is_consume
 }
 
 #[test]
+fn legacy_adoption_budget_failure_reenters_once_through_review_authority() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let fixture = CandidateAdoptionFixture::new("cook-9847-legacy-budget", 2, 0, true, None);
+        agent_task_lifecycle::start_candidate_adoption(
+            &fixture.run_id,
+            &fixture.candidate,
+            "openai/gpt-5.6-terra",
+            "historical gate",
+        )
+        .unwrap();
+        agent_task_lifecycle::finish_candidate_adoption(
+            &fixture.run_id,
+            Some("candidate remediation budget exhausted".to_string()),
+        )
+        .unwrap();
+        agent_task_lifecycle::record_candidate_adoption_result(
+            &fixture.run_id,
+            serde_json::json!({
+                "status": "execution_budget_exhausted",
+                "stop_reason": "provider execution stopped because max_provider_executions was exhausted",
+            }),
+        )
+        .unwrap();
+        let mut backend = CaptureBackend::default();
+
+        let result = fixture
+            .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
+            .expect("legacy budget failure re-enters through repaired review authority");
+
+        assert_eq!(result.value.status, "green_no_finalize");
+        let follow_up = result.value.latest_run_id.as_deref().unwrap();
+        let follow_up_plan = agent_task_lifecycle::load_plan(follow_up).unwrap();
+        assert_eq!(
+            follow_up_plan.tasks[0].inputs["cook_loop"]["execution_budget_authority"]["kind"],
+            "candidate_adoption_review"
+        );
+        let record = agent_task_lifecycle::status(&fixture.run_id).unwrap();
+        let replacements = record.metadata["candidate_adoption_replacements"]
+            .as_array()
+            .expect("legacy terminal adoption retained for audit");
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(
+            replacements[0]["result"]["status"],
+            "execution_budget_exhausted"
+        );
+    });
+}
+
+#[test]
 fn adoption_review_allowance_is_terminal_and_replay_does_not_dispatch() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let fixture = CandidateAdoptionFixture::new("cook-9575-budget", 2, 0, true, None);


### PR DESCRIPTION
## Summary
- let pre-authority candidate-adoption `execution_budget_exhausted` records enter the repaired review-budget path once
- distinguish legacy failures from post-#9831 terminal results using durable `candidate_adoption_review` authority provenance
- archive replaced failed adoption attempts before re-entry and cover the #9480 lifecycle shape

Closes #9847

## Verification
- `cargo test -p homeboy-agents adoption_ -- --test-threads=1`: 34 passed, 1 unrelated process-group cancellation timing test failed
- `cargo test -p homeboy-agents candidate_adoption_cancellation_persists_request_before_group_termination -- --test-threads=1`: failed in isolation on the same existing process-group liveness race; retries stopped after two failures
- Earlier pre-rebase run of the same adoption filter: 35 passed
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## Runtime evidence
- #9480 exact adoption re-entry on #9831 safely replayed the legacy terminal result with zero new attempts or side effects
- controller and `homeboy-lab` were both active at exact #9831 merge `ead25caab0a8`

## AI assistance
Substantive implementation, regression tests, and runtime diagnosis were drafted with OpenAI GPT-5.6 Sol through OpenCode. Chris Huber directed the repair, reviewed the diff, and remains responsible for the change.