### PR TITLE
Preserve cleanup artifact follow-up scope

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1410,10 +1410,16 @@ pub(crate) fn render_artifact_cleanup_summary(payload: &Value) -> Option<String>
     let next = if mode == "apply" {
         format!("homeboy cleanup artifacts --path {}", quote_arg(root))
     } else {
-        format!(
-            "homeboy cleanup artifacts --path {} --apply",
-            quote_arg(root)
-        )
+        payload
+            .get("next_command")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| {
+                format!(
+                    "homeboy cleanup artifacts --path {} --apply",
+                    quote_arg(root)
+                )
+            })
     };
     lines.push(format!("Next safe command: {next}"));
     lines.push(String::new());
@@ -2032,6 +2038,7 @@ mod tests {
             "applied_count": 0,
             "estimated_bytes": 1572864,
             "reclaimed_bytes": 0,
+            "next_command": "homeboy cleanup artifacts --path '/tmp/homeboy repo' --temp-root /tmp/review --sort size --limit 7 --merged-only --apply",
             "candidates": [],
             "skipped": [
                 { "reason": "artifact path contains tracked or staged source changes" },
@@ -2052,7 +2059,7 @@ mod tests {
             summary.contains("  - artifact path contains tracked or staged source changes: 2\n")
         );
         assert!(summary.contains(
-            "Next safe command: homeboy cleanup artifacts --path '/tmp/homeboy repo' --apply\n"
+            "Next safe command: homeboy cleanup artifacts --path '/tmp/homeboy repo' --temp-root /tmp/review --sort size --limit 7 --merged-only --apply\n"
         ));
     }
 

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -89,6 +89,8 @@ pub struct ArtifactCleanupOutput {
     pub remaining_count: usize,
     pub estimated_bytes: u64,
     pub reclaimed_bytes: u64,
+    /// Replays the reviewed cleanup scope with mutation explicitly enabled.
+    pub next_command: String,
     pub summary: ArtifactCleanupSummary,
     pub candidates: Vec<ArtifactCleanupCandidate>,
     pub skipped: Vec<ArtifactCleanupSkipped>,
@@ -305,12 +307,41 @@ fn cleanup_artifacts_in_worktrees(
         remaining_count,
         estimated_bytes,
         reclaimed_bytes,
+        next_command: artifact_cleanup_apply_command(options),
         summary,
         candidates,
         skipped,
         applied,
         failed,
     })
+}
+
+fn artifact_cleanup_apply_command(options: &ArtifactCleanupOptions) -> String {
+    use crate::engine::shell::quote_arg;
+
+    let mut command = "homeboy cleanup artifacts".to_string();
+    if options.self_artifacts {
+        command.push_str(" --self");
+    } else if let Some(path) = &options.path {
+        command.push_str(&format!(" --path {}", quote_arg(&path.to_string_lossy())));
+    }
+    for temp_root in &options.temp_roots {
+        command.push_str(&format!(
+            " --temp-root {}",
+            quote_arg(&temp_root.to_string_lossy())
+        ));
+    }
+    if options.sort == ArtifactCleanupSort::Size {
+        command.push_str(" --sort size");
+    }
+    if let Some(limit) = options.limit {
+        command.push_str(&format!(" --limit {limit}"));
+    }
+    if options.merged_only {
+        command.push_str(" --merged-only");
+    }
+    command.push_str(" --apply");
+    command
 }
 
 pub fn cleanup_resources_from_config(
@@ -1939,6 +1970,36 @@ mod tests {
 
         assert!(output.applied_count >= 1, "merged target must be reclaimed");
         assert!(!repo.path().join("target").exists());
+    }
+
+    #[test]
+    fn artifact_cleanup_preview_apply_command_preserves_reviewed_scope() {
+        let options = ArtifactCleanupOptions {
+            path: Some(PathBuf::from("/tmp/review scope")),
+            apply: false,
+            self_artifacts: false,
+            temp_roots: vec![
+                PathBuf::from("/tmp/first root"),
+                PathBuf::from("/tmp/second"),
+            ],
+            sort: ArtifactCleanupSort::Size,
+            limit: Some(7),
+            merged_only: true,
+        };
+
+        assert_eq!(
+            artifact_cleanup_apply_command(&options),
+            "homeboy cleanup artifacts --path '/tmp/review scope' --temp-root '/tmp/first root' --temp-root /tmp/second --sort size --limit 7 --merged-only --apply"
+        );
+
+        assert_eq!(
+            artifact_cleanup_apply_command(&ArtifactCleanupOptions {
+                path: None,
+                self_artifacts: true,
+                ..options
+            }),
+            "homeboy cleanup artifacts --self --temp-root '/tmp/first root' --temp-root /tmp/second --sort size --limit 7 --merged-only --apply"
+        );
     }
 
     fn git_repo() -> TempDir {


### PR DESCRIPTION
## Summary
Preserve a reviewed artifact-cleanup scope when presenting the follow-up apply command, preventing users from accidentally applying a broader cleanup than the preview.

## What changed
- Added next\_command to artifact cleanup output with the scoped apply command.
- Reconstruct the apply command from path/self mode, temp roots, sort, limit, and merged-only options.
- Render the supplied scoped command in the CLI cleanup summary.
- Added coverage for command construction and summary rendering.

## How to test
1. Run `cargo test -p homeboy-cli cleanup_artifacts_`; expect All cleanup CLI scope-preservation tests pass..
2. Run `cargo test -p homeboy-core artifact_cleanup_`; expect All cleanup core apply-command tests pass..

## Compatibility
Additive output-field change. Existing cleanup behavior is unchanged; previews now provide a safer, more precise apply command.

## Evidence
- Base advanced after verification: verified main at 97ae1cd91203501f69913e14b5b4eabe6a0c961e; publication observed 3b5b5df624df355de1557843b65ddc45729ed743. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from artifact\_refs\[0\]: https://github.com/Extra-Chill/homeboy-extensions/pull/2393
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9480
- Verified finalization base: main at 97ae1cd91203501f69913e14b5b4eabe6a0c961e
- cleanup-cli: passed (cargo test -p homeboy-cli cleanup\_artifacts\_) (Passed)
- cleanup-core: passed (cargo test -p homeboy-core artifact\_cleanup\_) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Inspected the promoted baseline commit and its tests to accurately capture the completed behavior without modifying the worktree, then produced reviewer-facing context focused on scope preservation and compatibility.

## Source relationships
- Closes #9480
