### PR TITLE
Revert #9857 to restore green main (reverse-cook controller regression)

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -108,9 +108,6 @@ enum DaemonCommand {
         /// Local bind address. Defaults to an OS-selected loopback port.
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
-        /// Startup ownership token forwarded by the daemon supervisor.
-        #[arg(long, hide = true)]
-        startup_token: Option<String>,
     },
     /// Supervise one daemon child and persist its termination evidence.
     #[command(hide = true)]
@@ -245,20 +242,7 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             DaemonOutput::RecoverMissingLeaseState(daemon::recover_missing_lease_state(&lease_id, recorded_pid, &recorded_endpoint, confirm_pid_dead, confirm_control_plane_lost, &addr)?),
             0,
         )),
-        DaemonCommand::Serve { addr, startup_token } => {
-            if let Some(startup_token) = startup_token {
-                let inherited = std::env::var(daemon::DAEMON_STARTUP_TOKEN_ENV).ok();
-                if inherited.as_deref() != Some(startup_token.as_str()) {
-                    return Err(Error::validation_invalid_argument(
-                        "startup_token",
-                        "daemon serve startup token does not match its inherited supervisor token",
-                        None,
-                        None,
-                    ));
-                }
-            }
-            serve(&addr)
-        }
+        DaemonCommand::Serve { addr } => serve(&addr),
         DaemonCommand::Supervise { addr, startup_token } => {
             daemon::supervise(&addr, &startup_token)?;
             Ok((DaemonOutput::Serve(DaemonStartResult { pid: std::process::id(), address: addr, state_path: String::new(), lease_id: String::new() }), 0))

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -5,7 +5,6 @@
 //! artifact fetch, and filesystem persistence live here so the orchestration is
 //! testable and reusable outside the CLI.
 
-use std::fs::{self, OpenOptions};
 use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -117,26 +116,6 @@ fn bounded_redacted(bytes: &[u8]) -> Option<String> {
         text.push_str("\n[truncated]");
     }
     Some(crate::redaction::redact_string(&text))
-}
-
-fn startup_timeout_error(
-    pid: u32,
-    state_path: &Path,
-    child: String,
-    observed_state: Option<serde_json::Value>,
-    stderr: Option<String>,
-) -> Error {
-    let mut error = Error::internal_unexpected(format!(
-        "daemon process {} did not publish matching startup token before timeout",
-        pid
-    ));
-    error.details["daemon_startup"] = serde_json::json!({
-        "child": child,
-        "state_path": state_path,
-        "observed_state": observed_state,
-        "stderr": stderr,
-    });
-    error
 }
 
 #[cfg(unix)]
@@ -1762,26 +1741,6 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
             Some("resolve current executable".to_string()),
         )
     })?;
-    let state_path = crate::paths::daemon_state_file()?;
-    let startup_stderr_path = state_path.with_extension(format!("startup-{startup_token}.stderr"));
-    if let Some(parent) = startup_stderr_path.parent() {
-        fs::create_dir_all(parent).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("create daemon startup directory".to_string()),
-            )
-        })?;
-    }
-    let startup_stderr = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&startup_stderr_path)
-        .map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("create daemon startup stderr".to_string()),
-            )
-        })?;
     let mut command = Command::new(exe);
     command
         .args([
@@ -1795,9 +1754,9 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
         .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::from(startup_stderr));
+        .stderr(Stdio::null());
     detach_from_launcher_session(&mut command);
-    let mut child = command
+    let child = command
         .spawn()
         .map_err(|e| Error::internal_io(e.to_string(), Some("spawn daemon".to_string())))?;
     let pid = child.id();
@@ -1805,51 +1764,30 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         let status = read_status()?;
-        if let Some(state) = status.state.as_ref() {
+        if let Some(state) = status.state {
             if state.pid == pid && state.startup_token == startup_token {
-                let _ = fs::remove_file(&startup_stderr_path);
                 return Ok(DaemonStartResult {
                     pid,
-                    address: state.address.clone(),
-                    state_path: state.state_path.clone(),
-                    lease_id: state.lease_id.clone(),
+                    address: state.address,
+                    state_path: state.state_path,
+                    lease_id: state.lease_id,
                 });
             }
             if status.running {
-                let _ = fs::remove_file(&startup_stderr_path);
                 return Ok(DaemonStartResult {
                     pid: state.pid,
-                    address: state.address.clone(),
-                    state_path: state.state_path.clone(),
-                    lease_id: state.lease_id.clone(),
+                    address: state.address,
+                    state_path: state.state_path,
+                    lease_id: state.lease_id,
                 });
             }
         }
 
         if Instant::now() >= deadline {
-            let stderr = fs::read(&startup_stderr_path)
-                .ok()
-                .and_then(|bytes| bounded_redacted(&bytes));
-            let child_state = child
-                .try_wait()
-                .ok()
-                .flatten()
-                .map(|status| format!("exited: {status}"))
-                .unwrap_or_else(|| "running".to_string());
-            let observed_state = status.state.as_ref().map(|state| {
-                serde_json::json!({
-                    "pid": state.pid,
-                    "startup_token_matches": state.startup_token == startup_token,
-                    "state_path": state.state_path,
-                })
-            });
-            return Err(startup_timeout_error(
-                pid,
-                &state_path,
-                child_state,
-                observed_state,
-                stderr,
-            ));
+            return Err(Error::internal_unexpected(format!(
+                "daemon process {} did not publish matching startup token before timeout",
+                pid
+            )));
         }
 
         thread::sleep(Duration::from_millis(50));

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -150,7 +150,7 @@ pub(crate) fn controller_job_runtime_count() -> usize {
 }
 
 pub(crate) const DAEMON_LEASE_SCHEMA: &str = "homeboy.daemon.session_lease.v1";
-pub const DAEMON_STARTUP_TOKEN_ENV: &str = "HOMEBOY_DAEMON_STARTUP_TOKEN";
+pub(super) const DAEMON_STARTUP_TOKEN_ENV: &str = "HOMEBOY_DAEMON_STARTUP_TOKEN";
 const RUNTIME_PATH_FILE_LIMIT: usize = 2_000;
 const RUNTIME_PATH_SUFFIXES: &[&str] = &["_COMPONENT_PATH", "_PROVIDER_PATH", "_RUNTIME_PATH"];
 pub(super) const FORCE_STOP_WAIT: Duration = Duration::from_secs(5);

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -46,12 +46,9 @@ use homeboy_core::server::{is_transient_ssh_error, CommandOutput};
 
 mod snapshots;
 use snapshots::workspace_snapshot_for_lease;
-use snapshots::workspace_snapshots_matching_hint;
-pub use snapshots::{list_workspaces, workspace_snapshots};
 #[cfg(test)]
-pub(crate) use snapshots::{
-    workspace_snapshot_scan_command, workspace_snapshot_scan_command_with_hint,
-};
+pub(crate) use snapshots::workspace_snapshot_scan_command;
+pub use snapshots::{list_workspaces, workspace_snapshots};
 
 pub(crate) const WORKSPACE_METADATA_FILE: &str = ".homeboy/runner-workspace.json";
 const MIN_RUNNER_WORKSPACE_FREE_BYTES: u64 = 1024 * 1024 * 1024;
@@ -773,13 +770,12 @@ pub fn hydrate_prepared_workspace_source_snapshot(
     if !remote_path.starts_with(&prepared_root) {
         return Ok(());
     }
-    let (snapshots, _) = workspace_snapshots_matching_hint(
+    let (snapshots, _) = workspace_snapshots(
         runner_id,
         RunnerWorkspaceSnapshotFilters {
             limit: usize::MAX,
             ..Default::default()
         },
-        remote_path,
     )?;
     let Some(snapshot) = snapshots
         .snapshots
@@ -822,13 +818,12 @@ pub fn reuse_compatible_snapshot_workspace(
         return Ok(None);
     }
 
-    let (snapshots, _) = workspace_snapshots_matching_hint(
+    let (snapshots, _) = workspace_snapshots(
         runner_id,
         RunnerWorkspaceSnapshotFilters {
             limit: usize::MAX,
             ..Default::default()
         },
-        &source_commit,
     )?;
     let local_path_string = local_path.display().to_string();
     let Some(snapshot) = snapshots.snapshots.into_iter().find(|snapshot| {
@@ -936,14 +931,12 @@ fn compatible_incremental_snapshot(
     excludes: &[String],
     controller_manifest: &super::snapshot::WorkspaceContentManifest,
 ) -> Result<Option<(RunnerWorkspaceSnapshotEntry, SnapshotManifestDelta)>> {
-    let repo_hint = workspace_repo_from_path(&local_path.display().to_string());
-    let (snapshots, _) = workspace_snapshots_matching_hint(
+    let (snapshots, _) = workspace_snapshots(
         &runner.id,
         RunnerWorkspaceSnapshotFilters {
             limit: usize::MAX,
             ..Default::default()
         },
-        &repo_hint,
     )?;
     let local_path = local_path.display().to_string();
     Ok(snapshots.snapshots.into_iter().find_map(|snapshot| {

--- a/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/snapshots.rs
@@ -71,22 +71,6 @@ pub fn workspace_snapshots(
     runner_id: &str,
     filters: RunnerWorkspaceSnapshotFilters,
 ) -> Result<(RunnerWorkspaceSnapshotsOutput, i32)> {
-    workspace_snapshots_with_hint(runner_id, filters, None)
-}
-
-pub(crate) fn workspace_snapshots_matching_hint(
-    runner_id: &str,
-    filters: RunnerWorkspaceSnapshotFilters,
-    hint: &str,
-) -> Result<(RunnerWorkspaceSnapshotsOutput, i32)> {
-    workspace_snapshots_with_hint(runner_id, filters, Some(hint))
-}
-
-fn workspace_snapshots_with_hint(
-    runner_id: &str,
-    filters: RunnerWorkspaceSnapshotFilters,
-    hint: Option<&str>,
-) -> Result<(RunnerWorkspaceSnapshotsOutput, i32)> {
     let runner = load(runner_id)?;
     let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -103,7 +87,7 @@ fn workspace_snapshots_with_hint(
     let limit = filters.limit.max(1);
     let (mut snapshots, skipped_invalid_metadata) = match runner.kind {
         RunnerKind::Local => workspace_snapshots_local(Path::new(&lab_workspaces_root))?,
-        RunnerKind::Ssh => workspace_snapshots_ssh(&runner, &lab_workspaces_root, hint)?,
+        RunnerKind::Ssh => workspace_snapshots_ssh(&runner, &lab_workspaces_root)?,
     };
     snapshots.retain(|snapshot| workspace_snapshot_matches(snapshot, &filters));
     snapshots.sort_by(|a, b| {
@@ -282,14 +266,13 @@ fn workspace_snapshots_local(
 fn workspace_snapshots_ssh(
     runner: &super::super::super::Runner,
     root: &str,
-    hint: Option<&str>,
 ) -> Result<(
     Vec<RunnerWorkspaceSnapshotEntry>,
     Vec<RunnerWorkspaceSnapshotInvalidMetadata>,
 )> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
-    let command = workspace_snapshot_scan_command_with_hint(root, hint);
+    let command = workspace_snapshot_scan_command(root);
     let output = client.execute(&command);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
@@ -299,14 +282,22 @@ fn workspace_snapshots_ssh(
     }
     let mut snapshots = Vec::new();
     let mut skipped_invalid_metadata = Vec::new();
-    for record in output.stdout.split_terminator('\u{1e}') {
-        let Some((source, content)) = record.split_once('\t') else {
+    for line in output.stdout.lines() {
+        let parts = line.splitn(2, '\t').collect::<Vec<_>>();
+        if parts.len() != 2 {
+            continue;
+        }
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(parts[1])
+            .map_err(|error| invalid_workspace_metadata(parts[0], error));
+        let Ok(decoded) = decoded else {
+            skipped_invalid_metadata.push(decoded.expect_err("base64 decode failed"));
             continue;
         };
-        let metadata: RunnerWorkspaceMetadata = match serde_json::from_str(content) {
+        let metadata: RunnerWorkspaceMetadata = match serde_json::from_slice(&decoded) {
             Ok(metadata) => metadata,
             Err(error) => {
-                skipped_invalid_metadata.push(invalid_workspace_metadata(source, error));
+                skipped_invalid_metadata.push(invalid_workspace_metadata(parts[0], error));
                 continue;
             }
         };
@@ -406,24 +397,13 @@ fn invalid_workspace_metadata(
 }
 
 pub(crate) fn workspace_snapshot_scan_command(root: &str) -> String {
-    workspace_snapshot_scan_command_with_hint(root, None)
-}
-
-pub(crate) fn workspace_snapshot_scan_command_with_hint(root: &str, hint: Option<&str>) -> String {
-    // Stream metadata in batched awk processes instead of launching base64/tr
-    // for every workspace. `find` may report a child removed during promotion,
-    // so only disappearance of the snapshot root makes the scan fail.
+    // Promotion replaces a temporary child atomically. `find` reports a
+    // disappeared child as an error even though the snapshot root remains
+    // valid, so read each candidate defensively and verify the root afterwards.
     format!(
-        "root={root}; meta_rel={meta}; if [ -d \"$root\" ]; then find \"$root\" -mindepth 3 -maxdepth 3 -type f -path \"*/$meta_rel\" -exec awk -v suffix=\"/$meta_rel\" -v needle={needle} 'BEGIN {{ for (i = 1; i < ARGC; i++) {{ file = ARGV[i]; content = \"\"; while ((status = (getline line < file)) > 0) content = content line ORS; close(file); if (status < 0) continue; if (needle == \"\" || index(content, needle) > 0) {{ dir = substr(file, 1, length(file) - length(suffix)); printf \"%s\\t%s%c\", dir, content, 30 }} }} }}' {{}} + >/dev/stdout 2>/dev/null || true; [ -d \"$root\" ] || {{ printf '%s\\n' \"runner workspace snapshot root disappeared during scan: $root\" >&2; exit 1; }}; fi",
+        "root={root}; meta_rel={meta}; if [ -d \"$root\" ]; then for dir in \"$root\"/*; do [ -d \"$dir\" ] || continue; meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; encoded=$(base64 < \"$meta\" 2>/dev/null) || continue; encoded=$(printf '%s' \"$encoded\" | tr -d '\\n'); printf \"%s\\t%s\\n\" \"$dir\" \"$encoded\"; done; [ -d \"$root\" ] || {{ printf '%s\\n' \"runner workspace snapshot root disappeared during scan: $root\" >&2; exit 1; }}; fi",
         root = shell::quote_arg(root),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
-        needle = shell::quote_arg(
-            &hint
-                .map(serde_json::to_string)
-                .transpose()
-                .expect("serialize workspace snapshot hint")
-                .unwrap_or_default()
-        ),
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -5,7 +5,7 @@ use super::git;
 use crate::workspace::snapshot::{incremental_prepare_command_fits, snapshot_manifest_delta};
 use crate::workspace::sync::{
     reuse_compatible_snapshot_workspace, sync_workspace, workspace_snapshot_scan_command,
-    workspace_snapshot_scan_command_with_hint, workspace_snapshots,
+    workspace_snapshots,
 };
 use crate::workspace::types::{
     RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
@@ -28,8 +28,8 @@ fn workspace_snapshot_scan_skips_a_child_removed_during_atomic_promotion() {
         r#"{"schema":"homeboy/runner-workspace/v1"}"#,
     )
     .expect("temporary metadata");
-    let shim_root = tempfile::tempdir().expect("find shim root");
-    let shim = shim_root.path().join("find");
+    let shim_root = tempfile::tempdir().expect("base64 shim root");
+    let shim = shim_root.path().join("base64");
     fs::write(
         &shim,
         format!(
@@ -37,7 +37,7 @@ fn workspace_snapshot_scan_skips_a_child_removed_during_atomic_promotion() {
             shell_quote(temporary.as_path())
         ),
     )
-    .expect("find shim");
+    .expect("base64 shim");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -82,8 +82,8 @@ fn workspace_snapshot_scan_fails_when_its_root_disappears() {
     let workspace = root.path().join("workspace");
     fs::create_dir_all(workspace.join(".homeboy")).expect("workspace");
     fs::write(workspace.join(".homeboy/runner-workspace.json"), "{}").expect("workspace metadata");
-    let shim_root = tempfile::tempdir().expect("find shim root");
-    let shim = shim_root.path().join("find");
+    let shim_root = tempfile::tempdir().expect("base64 shim root");
+    let shim = shim_root.path().join("base64");
     fs::write(
         &shim,
         format!(
@@ -91,7 +91,7 @@ fn workspace_snapshot_scan_fails_when_its_root_disappears() {
             shell_quote(root.path())
         ),
     )
-    .expect("find shim");
+    .expect("base64 shim");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -114,65 +114,6 @@ fn workspace_snapshot_scan_fails_when_its_root_disappears() {
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr)
         .contains("runner workspace snapshot root disappeared during scan"));
-}
-
-#[test]
-fn workspace_snapshot_scan_hint_streams_only_matching_metadata() {
-    let root = tempfile::tempdir().expect("workspace root");
-    for (name, commit) in [("matching", "commit-a"), ("unrelated", "commit-b")] {
-        let metadata = root
-            .path()
-            .join(name)
-            .join(".homeboy/runner-workspace.json");
-        fs::create_dir_all(metadata.parent().expect("metadata parent")).expect("workspace");
-        fs::write(
-            metadata,
-            format!(r#"{{"schema":"homeboy/runner-workspace/v1","source_commit":"{commit}"}}"#),
-        )
-        .expect("workspace metadata");
-    }
-
-    let output = std::process::Command::new("sh")
-        .args([
-            "-c",
-            &workspace_snapshot_scan_command_with_hint(
-                &root.path().display().to_string(),
-                Some("commit-a"),
-            ),
-        ])
-        .output()
-        .expect("run hinted snapshot scan");
-    let stdout = String::from_utf8(output.stdout).expect("UTF-8 scan output");
-
-    assert!(output.status.success());
-    assert!(stdout.contains("matching"));
-    assert!(stdout.contains("commit-a"));
-    assert!(!stdout.contains("unrelated"));
-    assert!(!stdout.contains("commit-b"));
-}
-
-#[test]
-fn workspace_snapshot_scan_streams_empty_metadata_for_validation() {
-    let root = tempfile::tempdir().expect("workspace root");
-    let metadata = root
-        .path()
-        .join("empty")
-        .join(".homeboy/runner-workspace.json");
-    fs::create_dir_all(metadata.parent().expect("metadata parent")).expect("workspace");
-    fs::write(&metadata, "").expect("empty workspace metadata");
-
-    let output = std::process::Command::new("sh")
-        .args([
-            "-c",
-            &workspace_snapshot_scan_command(&root.path().display().to_string()),
-        ])
-        .output()
-        .expect("run snapshot scan");
-    let stdout = String::from_utf8(output.stdout).expect("UTF-8 scan output");
-
-    assert!(output.status.success());
-    assert!(stdout.contains("empty"));
-    assert!(stdout.contains('\u{1e}'));
 }
 
 fn shell_quote(path: &std::path::Path) -> String {

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -8,7 +8,7 @@ use std::{os::unix::process::CommandExt, process::Command};
 use super::{
     artifact_content_url, ensure_running_with_operations, fetch_artifact_to_path,
     reconcile_dead_lease_and_ensure_running_with_operations,
-    reconcile_leaseless_orphan_store_with_operations, startup_timeout_error,
+    reconcile_leaseless_orphan_store_with_operations,
 };
 use crate::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::build_identity::BuildIdentity;
@@ -17,39 +17,6 @@ use crate::daemon::{
     DaemonTerminationClassification, DaemonTerminationEvidence,
 };
 use crate::test_support::with_isolated_home;
-
-#[test]
-fn startup_timeout_diagnostic_captures_exit_state_lease_location_and_stderr() {
-    let error = startup_timeout_error(
-        42,
-        std::path::Path::new("/tmp/homeboy/daemon/state.json"),
-        "exited: exit status: 1".to_string(),
-        Some(serde_json::json!({
-            "pid": 7,
-            "startup_token_matches": false,
-            "state_path": "/other/homeboy/daemon/state.json",
-        })),
-        Some("daemon owner lock is held".to_string()),
-    );
-
-    assert!(error.message.contains("42"));
-    assert_eq!(
-        error.details["daemon_startup"]["child"],
-        "exited: exit status: 1"
-    );
-    assert_eq!(
-        error.details["daemon_startup"]["state_path"],
-        "/tmp/homeboy/daemon/state.json"
-    );
-    assert_eq!(
-        error.details["daemon_startup"]["observed_state"]["startup_token_matches"],
-        false
-    );
-    assert_eq!(
-        error.details["daemon_startup"]["stderr"],
-        "daemon owner lock is held"
-    );
-}
 
 #[cfg(unix)]
 #[test]


### PR DESCRIPTION
## Summary
Reverts the two commits merged in #9857 (`7a57f9731 fix(daemon): diagnose replacement startup publication` and `98bd2818e fix(lab): bound workspace snapshot scans`) to get `main` back to green. Both reverts apply cleanly and restore the exact file state of the last green release (#9851 / v0.310.3 baseline).

## Why
`main` has been red since #9857. The failing test is the full-suite integration test:

```
tests/reverse_cook_queue_acceptance.rs
detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once ... FAILED
panicked at tests/reverse_cook_queue_acceptance.rs:332:13: controller did not project terminal broker result
```

The detached reverse-cook parent run hangs in `running` until the 30s reconcile timeout because the controller daemon never projects the terminal broker result (`stale_reason: runner_disconnected`, `runner_job_status: null`, looping `runner is not connected to a daemon` evidence-refresh warnings).

## Root-cause isolation (CI archaeology)
- **#9851** (branch `fix/9849-private-attachment-staging`): its own PR CI ran the **full** suite and this test **passed** (`... ok`).
- **#9857** (same branch, re-merged with 2 additional commits): its own PR CI already showed this test **`FAILED`** (405s timeout) — but the run was reported green and merged anyway (the full-suite failure was not enforced on that run).
- Everything merged afterward (#9852, #9859) inherited the break. #9859 (`recover terminal Lab aggregates`) was a red herring — a focused unit test confirmed its aggregate-recovery logic correctly recovers the reverse-cook embedded lifecycle event; the break is in the controller-daemon reconcile/spawn path, not aggregate projection.

The two new commits in #9857 are the delta between green (#9851) and red (#9857):
- `98bd2818e` (bound workspace snapshot scans) is **SSH-runner only**; the fixture uses a **Local** runner, so it is not the trigger (reverted here for a clean full-PR revert; it is harmless to the fixture either way).
- `7a57f9731` (daemon replacement startup diagnostics) touches the controller daemon spawn/replacement path that the detached-staging controller relies on — the actual regression.

## Follow-up
The #9857 work (startup-publication diagnostics + SSH snapshot-scan bounding) should be reopened on a fresh branch and re-landed **with the `reverse_cook_queue_acceptance` integration test enforced** so the reverse-cook controller-daemon path can't regress silently again.

## AI assistance
Investigated and reverted with OpenCode (chubes-bot). Root cause isolated by downloading and diffing the per-PR CI observation artifacts for #9851 vs #9857. Chris Huber remains responsible for the change.