### PR TITLE
Replay terminal evidence across runtime retention boundaries

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -285,6 +285,59 @@ fn project_terminal_runner_lifecycle_event(
     crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &event.aggregate)
 }
 
+pub(crate) fn project_persisted_terminal_runner_events(
+    record: &mut AgentTaskRunRecord,
+) -> Result<bool> {
+    let terminal_status = record
+        .metadata
+        .get("runner_job_status")
+        .and_then(Value::as_str)
+        .is_some_and(|status| matches!(status, "succeeded" | "failed" | "cancelled"));
+    if !terminal_status {
+        return Ok(false);
+    }
+    let Some(runner_job_id) = record.runner_job_id() else {
+        return Ok(false);
+    };
+    let Some(events) = record
+        .metadata
+        .get("runner_job_events")
+        .cloned()
+        .and_then(|events| {
+            serde_json::from_value::<Vec<homeboy_core::api_jobs::JobEvent>>(events).ok()
+        })
+        .filter(|events| {
+            !events.is_empty()
+                && events
+                    .iter()
+                    .all(|event| event.job_id.to_string() == runner_job_id)
+        })
+    else {
+        return Ok(false);
+    };
+    let Some(event) = crate::agent_task_lifecycle::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_persisted_job_events(
+        &events,
+        record.runner_id().unwrap_or_default(),
+        runner_job_id,
+        &record.run_id,
+    )? else {
+        return Ok(false);
+    };
+    validate_terminal_child_event_identity(record, &event)?;
+    let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
+    let aggregate_path = store::aggregate_path(&record.run_id)
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "aggregate.json".to_string());
+    apply_aggregate_to_record(record, &projection_plan, &event.aggregate, aggregate_path);
+    record.ensure_metadata_object().insert(
+        "terminal_transport_recovery".to_string(),
+        json!("persisted_runner_job_events"),
+    );
+    store::write_aggregate_and_record(record, &event.aggregate)?;
+    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &event.aggregate)?;
+    Ok(true)
+}
+
 fn preserve_terminal_runner_identity(
     record: &mut AgentTaskRunRecord,
     event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
@@ -418,6 +471,22 @@ fn validate_terminal_child_identity(
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
     event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
 ) -> Result<()> {
+    validate_terminal_child_event_identity(record, event)?;
+    if snapshot.job.id.to_string() == record.runner_job_id().unwrap_or_default() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "runner_lifecycle_identity",
+        "terminal runner child lifecycle event does not match its controller run, persisted run, runner, and job identity",
+        Some(record.run_id.clone()),
+        None,
+    ))
+}
+
+fn validate_terminal_child_event_identity(
+    record: &AgentTaskRunRecord,
+    event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
+) -> Result<()> {
     // Canonical run/runner/job identity the controller expects, and the identity
     // the terminal event carries (built from its *persisted* run id). Comparing
     // via the shared `RunnerJobIdentity` keeps the runner/job/run tuple check in
@@ -433,11 +502,9 @@ fn validate_terminal_child_identity(
         event.identity.runner_job_id.clone(),
     );
     // Beyond the run/runner/job tuple, the terminal event must also agree on the
-    // raw transport run id (not just the persisted run id) and the snapshot's
-    // own job id, so the whole child projection provably belongs to this run.
+    // raw transport run id (not just the persisted run id).
     if expected.matches(&event_identity)
         && event.identity.run_id.as_deref() == Some(record.run_id.as_str())
-        && snapshot.job.id.to_string() == expected.runner_job_id
     {
         return Ok(());
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -123,6 +123,9 @@ pub fn recover_terminal_transport_proxy_evidence(run_id: &str) -> Result<bool> {
     ) else {
         return Ok(false);
     };
+    if super::lifecycle_runner_projection::project_persisted_terminal_runner_events(&mut record)? {
+        return Ok(true);
+    }
     let snapshot = super::runner_continuation::with_runner_continuation(|p| {
         p.runner_job_log_snapshot(&runner_id, &runner_job_id)
     })?;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -102,10 +102,18 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
 /// job snapshot and cannot dispatch or resume provider work.
 pub fn recover_terminal_transport_proxy_evidence(run_id: &str) -> Result<bool> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
-    homeboy_core::controller_runtime::validate_for_mutation(
-        &record.metadata,
-        &homeboy_core::build_identity::current().display,
-    )?;
+    let runtime = record
+        .metadata
+        .get(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "controller_runtime",
+                "durable run has no controller runtime pin",
+                Some(record.run_id.clone()),
+                None,
+            )
+        })?;
+    homeboy_core::controller_runtime::validate(runtime)?;
     if !record.state.is_terminal() || !is_authenticated_transport_recovery_record(&record) {
         return Ok(false);
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -962,8 +962,13 @@ fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
             })),
             "stderr": "",
         }));
+        rewrite_record_for_test(run_id, |record| {
+            record.metadata["runner_job_status"] = json!("succeeded");
+            record.metadata["runner_job_events"] = json!(&snapshot.events);
+        })
+        .expect("persist historical daemon events");
         let _provider = RunnerContinuationTestGuard::install(Box::new(TerminalSnapshotProvider {
-            snapshot: Mutex::new(Some(snapshot)),
+            snapshot: Mutex::new(None),
         }));
 
         assert!(recover_terminal_transport_proxy_evidence(run_id)
@@ -1058,8 +1063,13 @@ fn terminal_transport_recovery_accepts_a_verified_older_controller_pin() {
             }).to_string(),
             "stderr": "",
         }));
+        rewrite_record_for_test(run_id, |record| {
+            record.metadata["runner_job_status"] = json!("succeeded");
+            record.metadata["runner_job_events"] = json!(&snapshot.events);
+        })
+        .expect("persist older controller daemon events");
         let _provider = RunnerContinuationTestGuard::install(Box::new(TerminalSnapshotProvider {
-            snapshot: Mutex::new(Some(snapshot)),
+            snapshot: Mutex::new(None),
         }));
 
         assert!(recover_terminal_transport_proxy_evidence(run_id)

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -987,6 +987,94 @@ fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
 }
 
 #[test]
+fn terminal_transport_recovery_accepts_a_verified_older_controller_pin() {
+    with_isolated_home(|_| {
+        let run_id = "terminal-recovery-older-controller";
+        let runner_job_id = "00000000-0000-0000-0000-000000000123";
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--record-run-id".to_string(),
+            run_id.to_string(),
+        ];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id,
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("accepted Lab handoff");
+        apply_runner_job_terminal_state(
+            &mut record,
+            homeboy_core::api_jobs::JobStatus::Succeeded,
+            &[],
+        );
+        let temporary = tempfile::tempdir().expect("temporary controller directory");
+        let pinned = temporary.path().join("older-homeboy");
+        let identity = "homeboy verified-older-controller";
+        let digest = fake_controller_artifact(&pinned, identity, "older controller");
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            ["originating"]["build_identity"] = json!(identity);
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            ["current"] = json!(identity);
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            ["executed"] = json!(identity);
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            ["requested"] = json!(identity);
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            ["originating"]["executable"] = json!(&pinned);
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            ["originating"]["pinned_executable"] = json!(&pinned);
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            ["originating"]["sha256"] = json!(digest);
+        store::write_record(&record).expect("older controller projection");
+
+        let mut lossy = succeeded_aggregate(&test_plan());
+        lossy.outcomes.clear();
+        store::write_aggregate(run_id, &lossy).expect("lossy aggregate");
+        let compact = json!({
+            "schema": "homeboy/agent-task-aggregate/v1",
+            "view": "summary",
+            "plan_id": "plan-a",
+            "status": "succeeded",
+            "totals": { "skipped": 0, "succeeded": 1, "failed": 0 },
+            "tasks": [{ "task_id": "task-a", "status": "succeeded" }],
+            "tasks_omitted": 0,
+            "run_id": run_id,
+        });
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.events[0].kind = JobEventKind::Result;
+        snapshot.events[0].data = Some(json!({
+            "exit_code": 0,
+            "command": command,
+            "stdout": json!({
+                "schema": "homeboy/command-result/v3",
+                "command": "agent-task",
+                "success": true,
+                "exit_code": 0,
+                "data": compact,
+            }).to_string(),
+            "stderr": "",
+        }));
+        let _provider = RunnerContinuationTestGuard::install(Box::new(TerminalSnapshotProvider {
+            snapshot: Mutex::new(Some(snapshot)),
+        }));
+
+        assert!(recover_terminal_transport_proxy_evidence(run_id)
+            .expect("current controller replays verified historical evidence"));
+        assert_eq!(
+            store::read_aggregate(run_id)
+                .expect("recovered aggregate")
+                .outcomes
+                .len(),
+            1
+        );
+    });
+}
+
+#[test]
 fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -526,6 +526,14 @@ fn delegate_agent_task_lifecycle_to_pinned_runtime(
     let run_id = match &cli.command {
         Commands::AgentTask(agent_task) => match &agent_task.command {
             crate::commands::agent_task::AgentTaskCommand::Run(args) => Some(&args.run_id),
+            crate::commands::agent_task::AgentTaskCommand::Resume(args)
+                if args.bridge
+                    && crate::agents::agent_tasks::service::terminal_transport_recovery_required(
+                        &args.run_id,
+                    ) =>
+            {
+                None
+            }
             crate::commands::agent_task::AgentTaskCommand::Resume(args) => Some(&args.run_id),
             _ => None,
         },


### PR DESCRIPTION
Closes #9773.

## Summary

- replay terminal, lossy bridge evidence through the current runtime while validating the immutable originating controller pin
- recover authenticated terminal runner results from retained daemon events when the runner API retention window has expired
- require terminal status, accepted handoff, matching event job IDs, and matching run, runner, and job identity before projection

## Live evidence

- recovered run cook-ssi-510-after-9849-v5-attempt-1-4f0b66a4 from its historical 0.310.2 controller pin
- recovered runner job fc3215cb-e657-485b-9887-96deaf0d5c5a after its live runner endpoint returned 404
- materialized the exact 12,704-byte patch with SHA-256 b86157f2c3735b453880c486455b263dfdbd8e77541cb5846b89754065fc9d9a

## Tests

- cargo test -p homeboy-agents terminal_transport_recovery -- --test-threads=1
- cargo check -p homeboy-cli

## AI assistance

OpenCode using OpenAI openai/gpt-5.6-sol implemented and verified the runtime-pin and retained-event recovery paths against persisted runner evidence. Chris Huber remains responsible for the change.