### PR TITLE
Make changed-file mismatch finalization error self-diagnosing (#9870)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -78,11 +78,10 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
             validate_durable_publication_eligibility(&lifecycle, &gate_proof.promotion)?;
         durable_changed_files = normalize_changed_files(&gate_proof.promotion.changed_files);
         if normalize_changed_files(&options.changed_files) != durable_changed_files {
-            return Err(Error::validation_invalid_argument(
-                "changed-file",
-                "caller changed files must exactly match the persisted promotion report before finalization",
-                None,
-                None,
+            return Err(changed_files_mismatch_error(
+                &options.run_id,
+                &options.changed_files,
+                &gate_proof.promotion.changed_files,
             ));
         }
         options.normalized_gate_results = gate_proof.promotion.gate_results;
@@ -304,11 +303,83 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     ))
 }
 
-fn normalize_changed_files(changed_files: &[String]) -> Vec<String> {
+pub(crate) fn normalize_changed_files(changed_files: &[String]) -> Vec<String> {
     let mut normalized = changed_files.to_vec();
     normalized.sort();
     normalized.dedup();
     normalized
+}
+
+/// Maximum number of individual paths listed in a changed-file mismatch
+/// diagnostic before the remainder is summarized as an omitted count. Keeps the
+/// fail-closed error bounded on large divergences while still naming the paths
+/// an operator needs to resolve the common small cases (#9870).
+const CHANGED_FILE_DIAGNOSTIC_PATH_LIMIT: usize = 20;
+
+/// Build a self-diagnosing changed-file mismatch error for finalization.
+///
+/// Instead of only stating the invariant, this reports the expected/actual
+/// counts, the paths `missing_from_caller` (expected but not supplied) and
+/// `unexpected_from_caller` (supplied but not expected), each bounded with an
+/// omitted count, and an exact inspection command for the full sets. This makes
+/// the fail-closed error self-diagnosing regardless of whether the root cause is
+/// a caller typo, a stale promotion scope, or genuine Git candidate divergence
+/// (#9870).
+pub(crate) fn changed_files_mismatch_error(
+    run_id: &str,
+    caller_changed_files: &[String],
+    expected_changed_files: &[String],
+) -> Error {
+    let caller = normalize_changed_files(caller_changed_files);
+    let expected = normalize_changed_files(expected_changed_files);
+    let missing_from_caller: Vec<String> = expected
+        .iter()
+        .filter(|path| !caller.contains(*path))
+        .cloned()
+        .collect();
+    let unexpected_from_caller: Vec<String> = caller
+        .iter()
+        .filter(|path| !expected.contains(*path))
+        .cloned()
+        .collect();
+
+    let problem = format!(
+        "caller changed files must exactly match the persisted promotion report before \
+         finalization. expected_count={} actual_count={}; missing_from_caller={}; \
+         unexpected_from_caller={}. Inspect the full recorded set with \
+         `homeboy agent-task status {run_id} --full` (promotion.changed_files). A caller \
+         typo lists an unexpected path; a stale promotion scope inflates the expected set \
+         beyond the current PR diff (see #9706 for adoption scope).",
+        expected.len(),
+        caller.len(),
+        bounded_path_summary(&missing_from_caller),
+        bounded_path_summary(&unexpected_from_caller),
+    );
+
+    Error::validation_invalid_argument("changed-file", problem, None, None)
+}
+
+/// Render a bounded, human-readable summary of a path set: up to
+/// [`CHANGED_FILE_DIAGNOSTIC_PATH_LIMIT`] paths followed by an omitted count.
+fn bounded_path_summary(paths: &[String]) -> String {
+    if paths.is_empty() {
+        return "[]".to_string();
+    }
+    let shown: Vec<&String> = paths
+        .iter()
+        .take(CHANGED_FILE_DIAGNOSTIC_PATH_LIMIT)
+        .collect();
+    let omitted = paths.len().saturating_sub(shown.len());
+    let joined = shown
+        .iter()
+        .map(|path| path.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if omitted > 0 {
+        format!("[{joined}, +{omitted} more]")
+    } else {
+        format!("[{joined}]")
+    }
 }
 
 fn validate_gate_proof_binding(

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -1031,14 +1031,13 @@ pub(super) fn validate_real_candidate_fingerprint(
             None,
         ));
     }
-    if normalize_changed_files(&options.changed_files)
-        != normalize_changed_files(&promotion.changed_files)
+    if super::normalize_changed_files(&options.changed_files)
+        != super::normalize_changed_files(&promotion.changed_files)
     {
-        return Err(Error::validation_invalid_argument(
-            "changed-file",
-            "caller changed files must exactly match the persisted promotion report before finalization",
-            None,
-            None,
+        return Err(super::changed_files_mismatch_error(
+            &options.run_id,
+            &options.changed_files,
+            &promotion.changed_files,
         ));
     }
     validate_candidate_fingerprint(options, &expected)
@@ -1093,13 +1092,6 @@ fn committed_candidate_matches(
     }
     let tree = git_output(&options.path, &["rev-parse", "HEAD^{tree}"])?;
     Ok(tree.trim() == fingerprint.tree)
-}
-
-fn normalize_changed_files(changed_files: &[String]) -> Vec<String> {
-    let mut normalized = changed_files.to_vec();
-    normalized.sort();
-    normalized.dedup();
-    normalized
 }
 
 fn deserialize_persisted_value<T: DeserializeOwned>(

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -1999,3 +1999,59 @@ fn options() -> AgentTaskPrFinalizationOptions {
         ],
     }
 }
+
+#[test]
+fn changed_files_mismatch_error_reports_missing_and_unexpected_paths() {
+    // Caller supplied a file the promotion did not, and omitted one it did:
+    // both divergences must be named, with accurate counts.
+    let expected = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+    let caller = vec!["src/a.rs".to_string(), "src/typo.rs".to_string()];
+
+    let error = changed_files_mismatch_error("agent-task-1", &caller, &expected);
+    let message = error.message;
+
+    assert!(message.contains("expected_count=2"), "{message}");
+    assert!(message.contains("actual_count=2"), "{message}");
+    assert!(
+        message.contains("missing_from_caller=[src/b.rs]"),
+        "{message}"
+    );
+    assert!(
+        message.contains("unexpected_from_caller=[src/typo.rs]"),
+        "{message}"
+    );
+    assert!(
+        message.contains("homeboy agent-task status agent-task-1 --full"),
+        "{message}"
+    );
+}
+
+#[test]
+fn changed_files_mismatch_error_flags_stale_base_inflated_promotion() {
+    // Stale-base attribution inflates the expected set well beyond the caller's
+    // current PR diff; every extra expected path shows as missing_from_caller.
+    let caller = vec!["src/a.rs".to_string()];
+    let expected: Vec<String> = (0..6).map(|index| format!("stale/f{index}.rs")).collect();
+
+    let error = changed_files_mismatch_error("agent-task-2", &caller, &expected);
+    let message = error.message;
+
+    assert!(message.contains("expected_count=6"), "{message}");
+    assert!(message.contains("actual_count=1"), "{message}");
+    assert!(message.contains("unexpected_from_caller=[]"), "{message}");
+    // The stale base paths are all reported as missing from the caller.
+    assert!(message.contains("stale/f0.rs"), "{message}");
+}
+
+#[test]
+fn changed_files_mismatch_error_bounds_large_path_sets() {
+    let caller: Vec<String> = Vec::new();
+    let expected: Vec<String> = (0..30).map(|index| format!("dir/f{index:02}.rs")).collect();
+
+    let error = changed_files_mismatch_error("agent-task-3", &caller, &expected);
+    let message = error.message;
+
+    assert!(message.contains("expected_count=30"), "{message}");
+    // Only the bounded prefix is listed, with an explicit omitted count.
+    assert!(message.contains("+10 more"), "{message}");
+}


### PR DESCRIPTION
Fixes #9870. Builds on the changed-file parsing from #9742.

## Problem
`finalize-pr` fails closed when caller changed files differ from the persisted promotion report, but the error only stated the invariant:

```
Invalid argument changed-file: caller changed files must exactly match the persisted promotion report before finalization
```

It named neither the expected nor the supplied set. During a real recovery (a 6-file current-main PR diff vs a candidate-adoption bug that persisted 15 stale-base files), diagnosing the mismatch required `agent-task status --full` — ~3,000 lines of repeated promotion history, runner events, and diffs — before the 15-file stale-base attribution was visible.

## Fix
`changed_files_mismatch_error()` now reports, inline in the fail-closed error:
- `expected_count` / `actual_count`
- `missing_from_caller` — expected but not supplied
- `unexpected_from_caller` — supplied but not expected
- each path set **bounded** to `CHANGED_FILE_DIAGNOSTIC_PATH_LIMIT` (20) with an explicit `+N more` omitted count
- the exact `homeboy agent-task status <run> --full` inspection command for the complete sets
- a hint distinguishing a caller typo (an unexpected path) from a stale promotion scope (inflated expected set — points at #9706 for the adoption-scope root cause)

Applied at **both** fail-closed finalization sites (durable publication eligibility in `agent_task_finalization.rs`, and real candidate fingerprint validation in `backend.rs`).

Also deduplicates the two per-module `normalize_changed_files` copies onto the parent module's `pub(crate)` helper.

## Acceptance criteria coverage
- ✅ Bounded `expected_count`, `actual_count`, `missing_from_caller`, `unexpected_from_caller`
- ✅ One exact compact inspection command for the complete sets
- ✅ Large path sets bounded with omitted counts
- ✅ Distinguishes caller typo vs stale promotion scope (diagnostic hint)
- ✅ Tests for missing path, unexpected path, stale-base inflated promotion, and large-set bounding

## Not included (owned elsewhere, noted in the issue)
- The adoption-scope root cause that *produces* the stale 15-file set is #9706.
- `latest_promotion` identity/status and base/candidate range in the error would require threading more promotion context through both call sites; the inspection command already resolves the full identity. Left as a follow-up so this stays a bounded, behavior-preserving diagnostic enrichment.

## Verification
- `cargo fmt -p homeboy-agents --check` clean
- `cargo check -p homeboy-agents --lib --tests` exit 0
- Full test run deferred to CI per this VPS's no-heavy-local-build rule

Diff: +139/-20, 3 files.