### PR TITLE
Report skipped runner convergence instead of false success (#9842)

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -262,6 +262,12 @@ pub fn run_upgrade_with_method(
                 &runners_skipped,
                 Some(previous_version.as_str()),
             );
+            let runner_disposition = runner_convergence_disposition(
+                skip_runners,
+                &runners_updated,
+                &runners_skipped,
+                Some(previous_version.as_str()),
+            );
             return Ok(UpgradeResult {
                 command: "upgrade".to_string(),
                 install_method,
@@ -272,11 +278,21 @@ pub fn run_upgrade_with_method(
                 source_revision: None,
                 upgraded: false,
                 partial,
-                message: if partial {
-                    "PARTIAL: controller is already current, but configured runners did not converge"
-                        .to_string()
-                } else {
-                    "Already at latest version; configured runners converged".to_string()
+                runner_convergence: Some(runner_disposition),
+                message: match runner_disposition {
+                    RunnerConvergenceDisposition::Partial => {
+                        "PARTIAL: controller is already current, but configured runners did not converge"
+                            .to_string()
+                    }
+                    RunnerConvergenceDisposition::Skipped => {
+                        "Already at latest version; runner convergence skipped".to_string()
+                    }
+                    RunnerConvergenceDisposition::NoRunnersConfigured => {
+                        "Already at latest version; no configured runners".to_string()
+                    }
+                    RunnerConvergenceDisposition::Converged => {
+                        "Already at latest version; configured runners converged".to_string()
+                    }
                 },
                 restart_required: false,
                 extensions_unrefreshed: warn_unrefreshed_symlinked_extensions(&extensions_updated),
@@ -344,6 +360,13 @@ pub fn run_upgrade_with_method(
     let (services_restarted, services_pending_restart) =
         restart_resident_services_after_swap(success, skip_services);
 
+    let runner_disposition = runner_convergence_disposition(
+        skip_runners,
+        &runners_updated,
+        &runners_skipped,
+        new_version.as_deref(),
+    );
+
     Ok(UpgradeResult {
         command: "upgrade".to_string(),
         install_method,
@@ -358,10 +381,12 @@ pub fn run_upgrade_with_method(
             &runners_skipped,
             new_version.as_deref(),
         ),
+        runner_convergence: Some(runner_disposition),
         message: upgrade_message(
             success,
             new_version.as_deref(),
             new_build_identity.as_deref(),
+            runner_disposition,
             &runners_updated,
             &runners_skipped,
         ),
@@ -395,6 +420,8 @@ fn source_upgrade_noop_result(
         source_revision: None,
         upgraded: false,
         partial: false,
+        // No upgrade occurred, so there is no runner-convergence claim to make.
+        runner_convergence: None,
         message: decision.no_op_message(),
         restart_required: false,
         extensions_updated: Vec::new(),
@@ -475,6 +502,13 @@ fn run_targeted_runner_upgrade(
             &runners_skipped,
             Some(previous_version.as_str()),
         ),
+        // Targeted runner upgrade always attempts convergence (never skipped).
+        runner_convergence: Some(runner_convergence_disposition(
+            false,
+            &runners_updated,
+            &runners_skipped,
+            Some(previous_version.as_str()),
+        )),
         message: targeted_runner_message(
             source_checkout.is_some(),
             &previous_version,
@@ -505,10 +539,34 @@ fn runner_convergence_failed(
     })
 }
 
+/// Classify runner convergence from intent (`--skip-runners`) and evidence.
+///
+/// Distinguishes an explicit skip, zero configured runners, verified
+/// convergence, and partial convergence, so the rendered message and structured
+/// output never claim convergence that was not actually verified (#9842).
+fn runner_convergence_disposition(
+    runners_skipped_by_flag: bool,
+    updated: &[RunnerUpgradeEntry],
+    skipped: &[RunnerUpgradeEntry],
+    controller_version: Option<&str>,
+) -> RunnerConvergenceDisposition {
+    if runners_skipped_by_flag {
+        return RunnerConvergenceDisposition::Skipped;
+    }
+    if runner_convergence_failed(updated, skipped, controller_version) {
+        return RunnerConvergenceDisposition::Partial;
+    }
+    if updated.is_empty() && skipped.is_empty() {
+        return RunnerConvergenceDisposition::NoRunnersConfigured;
+    }
+    RunnerConvergenceDisposition::Converged
+}
+
 fn upgrade_message(
     success: bool,
     new_version: Option<&str>,
     new_build_identity: Option<&str>,
+    disposition: RunnerConvergenceDisposition,
     updated: &[RunnerUpgradeEntry],
     skipped: &[RunnerUpgradeEntry],
 ) -> String {
@@ -516,14 +574,22 @@ fn upgrade_message(
     let identity = new_build_identity
         .map(|identity| format!(" ({identity})"))
         .unwrap_or_default();
-    if runner_convergence_failed(updated, skipped, new_version) {
+    if disposition == RunnerConvergenceDisposition::Partial {
         return format!(
             "PARTIAL: controller upgraded to {controller}{identity}, but {} selected configured runner(s) did not converge",
             updated.len() + skipped.len()
         );
     }
     if success {
-        format!("Controller upgraded to {controller}{identity}; configured runners converged")
+        // Report the runner disposition honestly: an explicit skip is never
+        // rendered as convergence, and a fleet with no configured runners is
+        // distinguished from a verified convergence (#9842).
+        let runner_clause = match disposition {
+            RunnerConvergenceDisposition::Skipped => "runner convergence skipped",
+            RunnerConvergenceDisposition::NoRunnersConfigured => "no configured runners",
+            _ => "configured runners converged",
+        };
+        format!("Controller upgraded to {controller}{identity}; {runner_clause}")
     } else if new_version.is_some() {
         format!("Upgrade command completed but active controller is still {controller}")
     } else {
@@ -1821,8 +1887,47 @@ mod convergence_tests {
             &[],
             Some("0.304.0")
         ));
-        assert!(upgrade_message(true, Some("0.304.0"), None, &[runner], &[])
-            .starts_with("PARTIAL: controller upgraded to 0.304.0"));
+        let disposition =
+            runner_convergence_disposition(false, &[runner.clone()], &[], Some("0.304.0"));
+        assert_eq!(disposition, RunnerConvergenceDisposition::Partial);
+        assert!(
+            upgrade_message(true, Some("0.304.0"), None, disposition, &[runner], &[])
+                .starts_with("PARTIAL: controller upgraded to 0.304.0")
+        );
+    }
+
+    #[test]
+    fn skip_runners_reports_skipped_not_converged() {
+        // #9842: --skip-runners must never claim convergence.
+        let disposition = runner_convergence_disposition(true, &[], &[], Some("0.310.0"));
+        assert_eq!(disposition, RunnerConvergenceDisposition::Skipped);
+        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[], &[]);
+        assert!(message.contains("runner convergence skipped"), "{message}");
+        assert!(!message.contains("converged"), "{message}");
+    }
+
+    #[test]
+    fn no_configured_runners_is_distinct_from_converged() {
+        let disposition = runner_convergence_disposition(false, &[], &[], Some("0.310.0"));
+        assert_eq!(
+            disposition,
+            RunnerConvergenceDisposition::NoRunnersConfigured
+        );
+        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[], &[]);
+        assert!(message.contains("no configured runners"), "{message}");
+    }
+
+    #[test]
+    fn converged_runners_still_report_convergence() {
+        let runner = runner("0.301.2", "0.310.0", true);
+        let disposition =
+            runner_convergence_disposition(false, &[runner.clone()], &[], Some("0.310.0"));
+        assert_eq!(disposition, RunnerConvergenceDisposition::Converged);
+        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[runner], &[]);
+        assert!(
+            message.contains("configured runners converged"),
+            "{message}"
+        );
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -42,6 +42,23 @@ impl<'de> Deserialize<'de> for InstallMethod {
     }
 }
 
+/// Disposition of runner convergence for an upgrade, so structured output
+/// records intent and outcome rather than leaving consumers to infer it from
+/// empty runner arrays (#9842).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerConvergenceDisposition {
+    /// Runner convergence was explicitly skipped (e.g. `--skip-runners`); no
+    /// runner state was collected or claimed.
+    Skipped,
+    /// No runners are configured, so there was nothing to converge.
+    NoRunnersConfigured,
+    /// Every selected configured runner converged to the controller build.
+    Converged,
+    /// One or more selected runners did not converge.
+    Partial,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 
 pub struct VersionCheck {
@@ -73,6 +90,11 @@ pub struct UpgradeResult {
     /// their current payload shape; accepted when reading persisted responses.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub partial: bool,
+    /// Explicit runner-convergence disposition (skipped / none configured /
+    /// converged / partial), so consumers never infer convergence from empty
+    /// runner arrays. Omitted for older persisted responses (#9842).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_convergence: Option<RunnerConvergenceDisposition>,
     pub message: String,
     pub restart_required: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
Fixes #9842.

## Problem
`homeboy upgrade --skip-runners` reported that configured runners **converged** even though convergence was explicitly skipped and no runner evidence was collected:

```
Controller upgraded to 0.310.0 (homeboy 0.310.0+d0230e01e528); configured runners converged
```

The runner actually remained on a different build and still required an explicit refresh.

## Root cause
`upgrade_message()` only received `success` plus empty `updated`/`skipped` runner arrays. With `--skip-runners`, the empty arrays made `runner_convergence_failed()` return false, so the generic success branch claimed convergence. The function never received whether runner convergence was **requested**.

## Fix
- New `RunnerConvergenceDisposition` — `Skipped` / `NoRunnersConfigured` / `Converged` / `Partial` — computed from `--skip-runners` intent **plus** the collected runner evidence.
- Threaded into `upgrade_message()`: `--skip-runners` now renders `runner convergence skipped`, and a fleet with no configured runners renders `no configured runners`, distinct from a verified `configured runners converged`.
- Recorded on `UpgradeResult` (`runner_convergence`) so structured output carries the disposition rather than leaving consumers to infer it from empty arrays.
- Both the main upgrade path **and** the already-current path (which had the same false "converged" claim) are fixed.

## Acceptance criteria coverage
- ✅ Runner-convergence intent included in result rendering
- ✅ `--skip-runners` reports `runner convergence skipped` and claims no runner state
- ✅ Distinguishes zero configured runners, verified converged, partial, and explicitly skipped
- ✅ Structured output records the disposition, not only empty arrays
- ✅ Tests for skipped, no-runners, converged, and partial dispositions

## Verification
- `cargo fmt -p homeboy-upgrade --check` clean
- `cargo check -p homeboy-upgrade --lib --tests` exit 0
- Full test run deferred to CI per this VPS's no-heavy-local-build rule

Diff: +136/-9, 2 files.