### PR TITLE
feat(agent-task): surface in-flight provider execution for local cooks

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -725,8 +725,9 @@ pub fn reserve_provider_execution(
     let execution_key = format!("{}:{attempt}", task.task_id);
     let mut reservation = ProviderExecutionReservation::AlreadyReserved;
     store::mutate_record(&run_id, |record| {
-        let metadata = record.ensure_metadata_object();
+        let started_at = now_timestamp();
         let consumed = {
+            let metadata = record.ensure_metadata_object();
             let executions = metadata
                 .entry("provider_executions".to_string())
                 .or_insert_with(|| json!([]))
@@ -745,11 +746,23 @@ pub fn reserve_provider_execution(
                 "backend": task.executor.backend,
                 "model": task.executor.model(),
                 "state": "running",
-                "started_at": now_timestamp(),
+                "started_at": started_at.clone(),
             }));
-            executions.len()
+            let consumed = executions.len();
+            metadata.insert("provider_executions_consumed".to_string(), json!(consumed));
+            consumed
         };
-        metadata.insert("provider_executions_consumed".to_string(), json!(consumed));
+        let _ = consumed;
+        // Advance the heartbeat to provider-execution start for a local
+        // (in-process) cook. Before this, a local cook left the heartbeat frozen
+        // at submission time for the entire provider run, so operators could not
+        // distinguish active execution from a hung preflight (#8396). Restrict
+        // this to non-runner-backed runs: a runner-backed run's owner PID and
+        // heartbeat are owned by the runner, not the controller reserving here.
+        if !record.is_runner_backed() {
+            record.updated_at = Some(started_at);
+            update_lifecycle_heartbeat(record);
+        }
         reservation = ProviderExecutionReservation::Acquired;
         true
     })?;

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -289,6 +289,41 @@ fn provider_execution_reservation_is_exactly_once_and_terminal() {
 }
 
 #[test]
+fn local_reservation_advances_heartbeat_to_execution_start() {
+    // A local (in-process) cook must advance its heartbeat when the provider
+    // execution is reserved, so `status`/`activity` can distinguish an active
+    // provider from a hung preflight instead of showing the submission-time
+    // heartbeat for the whole run (#8396).
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        agent_task_lifecycle::submit_plan(&plan, Some("local-heartbeat")).expect("run submitted");
+        let task = &plan.tasks[0];
+
+        agent_task_lifecycle::reserve_provider_execution("local-heartbeat", task, 1)
+            .expect("reservation acquired");
+
+        let record = lifecycle_status("local-heartbeat").expect("durable record");
+        let started_at = record.metadata["provider_executions"][0]["started_at"]
+            .as_str()
+            .expect("running execution start recorded");
+        let heartbeat = record
+            .lifecycle
+            .heartbeat
+            .as_ref()
+            .expect("heartbeat advanced on reservation");
+        assert_eq!(
+            heartbeat.last_seen_at, started_at,
+            "heartbeat should advance to provider-execution start for a local cook"
+        );
+        assert_eq!(
+            heartbeat.owner_pid,
+            Some(std::process::id()),
+            "a local cook's owner PID is the reserving process"
+        );
+    });
+}
+
+#[test]
 fn concurrent_schedulers_dispatch_one_reserved_provider_execution() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1465,15 +1465,28 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
         .and_then(Value::as_str)
         == Some("waiting_for_capacity");
 
+    // A local cook runs the provider in an in-process thread, so it has neither
+    // provider handles nor a runner job id. `reserve_provider_execution` still
+    // durably records the running attempt (backend, model, started_at) before
+    // the scheduler blocks on the backend, so surface that as authoritative
+    // in-flight provider evidence instead of reporting the boundary absent
+    // while the provider is actively working (#8396).
+    let active_provider_executions = running_provider_executions(metadata);
+    let has_active_provider_execution = !active_provider_executions.is_empty();
+    let provider_boundary_recorded =
+        provider_handle_count > 0 || runner_job_id.is_some() || has_active_provider_execution;
+
     json!({
         "status": if terminal { "terminal" } else if stale { "stale" } else if waiting_for_capacity { "waiting_for_capacity" } else { "active" },
         "heartbeat_last_seen_at": record.pointer("/lifecycle/heartbeat/last_seen_at"),
         "runner_job_status": metadata.get("runner_job_status"),
         "runner_job_last_seen_at": metadata.get("runner_job_last_seen_at"),
         "provider_boundary": {
-            "status": if provider_handle_count > 0 || runner_job_id.is_some() { "recorded" } else { "absent" },
+            "status": if provider_boundary_recorded { "recorded" } else { "absent" },
             "provider_handle_count": provider_handle_count,
             "runner_job_id": runner_job_id,
+            "active_execution_count": active_provider_executions.len(),
+            "active_executions": active_provider_executions,
         },
         "stale_reason": metadata.get("stale_running_reason"),
         "runner_queue": metadata.get("runner_queue"),
@@ -1487,6 +1500,36 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
             "homeboy agent-task status <run-id> --full".to_string()
         },
     })
+}
+
+/// Project the durable `provider_executions` metadata into a compact list of the
+/// attempts that are still `running`. These are written by
+/// `reserve_provider_execution` before the scheduler blocks on the backend and
+/// cleared to a terminal state by `record_provider_execution_terminal`, so a
+/// running entry is authoritative evidence that a provider is executing right
+/// now — the only in-flight signal a local (in-process) cook has (#8396).
+fn running_provider_executions(metadata: &Value) -> Vec<Value> {
+    metadata
+        .get("provider_executions")
+        .and_then(Value::as_array)
+        .map(|executions| {
+            executions
+                .iter()
+                .filter(|execution| {
+                    execution.get("state").and_then(Value::as_str) == Some("running")
+                })
+                .map(|execution| {
+                    json!({
+                        "task_id": execution.get("task_id"),
+                        "attempt": execution.get("attempt"),
+                        "backend": execution.get("backend"),
+                        "model": execution.get("model"),
+                        "started_at": execution.get("started_at"),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn execution_location(record: &Value) -> Value {
@@ -2110,6 +2153,85 @@ mod tests {
             accepted_handoff["liveness"]["provider_boundary"]["runner_job_id"],
             "accepted-daemon-job"
         );
+    }
+
+    #[test]
+    fn local_cook_surfaces_in_flight_provider_execution() {
+        // A local cook has no provider handles and no runner job id, but
+        // `reserve_provider_execution` durably records the running attempt
+        // before the backend blocks. The liveness projection must report the
+        // provider boundary as recorded (not absent) and expose the running
+        // execution's backend, model, and start time so operators can tell an
+        // active provider from a hung preflight (#8396).
+        let local_running = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-local-1",
+                "state": "running",
+                "tasks": [],
+                "provider_handles": [],
+                "lifecycle": { "heartbeat": { "last_seen_at": "2026-07-16T00:00:00Z" } },
+                "metadata": {
+                    "provider_executions_consumed": 1,
+                    "provider_executions": [{
+                        "key": "cook:1",
+                        "task_id": "cook",
+                        "attempt": 1,
+                        "backend": "opencode",
+                        "model": "openai/gpt-5.6-sol",
+                        "state": "running",
+                        "started_at": "2026-07-16T00:00:00Z"
+                    }]
+                }
+            }),
+            "agent-task-local-1",
+        );
+        let boundary = &local_running["liveness"]["provider_boundary"];
+        assert_eq!(boundary["status"], "recorded");
+        assert_eq!(boundary["provider_handle_count"], 0);
+        assert!(boundary["runner_job_id"].is_null());
+        assert_eq!(boundary["active_execution_count"], 1);
+        assert_eq!(boundary["active_executions"][0]["backend"], "opencode");
+        assert_eq!(
+            boundary["active_executions"][0]["model"],
+            "openai/gpt-5.6-sol"
+        );
+        assert_eq!(boundary["active_executions"][0]["task_id"], "cook");
+        assert_eq!(
+            boundary["active_executions"][0]["started_at"],
+            "2026-07-16T00:00:00Z"
+        );
+        assert_eq!(local_running["execution_location"], "local");
+    }
+
+    #[test]
+    fn terminal_provider_execution_is_not_surfaced_as_active() {
+        // Once the provider execution reaches a terminal state, it must no
+        // longer count as in-flight. A local run with only completed executions
+        // and no other liveness evidence reports the boundary as absent (#8396).
+        let completed = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-local-2",
+                "state": "running",
+                "tasks": [],
+                "provider_handles": [],
+                "metadata": {
+                    "provider_executions": [{
+                        "key": "cook:1",
+                        "task_id": "cook",
+                        "attempt": 1,
+                        "backend": "opencode",
+                        "state": "succeeded",
+                        "started_at": "2026-07-16T00:00:00Z",
+                        "finished_at": "2026-07-16T00:03:00Z"
+                    }]
+                }
+            }),
+            "agent-task-local-2",
+        );
+        let boundary = &completed["liveness"]["provider_boundary"];
+        assert_eq!(boundary["status"], "absent");
+        assert_eq!(boundary["active_execution_count"], 0);
+        assert!(boundary["active_executions"].as_array().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- A local `agent-task cook` runs the provider in an **in-process thread**, so it has no provider handles and no runner job id. `status --full` reported `provider_boundary.status: absent` with a heartbeat **frozen at submission time** for the whole run — operators could not tell an actively-executing provider from a hung preflight (#8396).
- The durable signal already exists but wasn't projected: `reserve_provider_execution` writes a `provider_executions` entry (backend, model, started_at, `state: running`) *before* the scheduler blocks on the backend, and `record_provider_execution_terminal` clears it on completion. This surfaces it.

## Changes
**Projection (`liveness_summary` in `agent_task/status.rs`):**
- Reads running `provider_executions` and reports the provider boundary as `recorded` (not `absent`) when one is in flight.
- Adds `active_execution_count` and an `active_executions` list carrying `task_id`, `attempt`, `backend`, `model`, `started_at`.
- A run whose executions are all terminal (and has no other liveness) stays `absent`.

**Heartbeat (`reserve_provider_execution` in `lifecycle_ops.rs`):**
- Advances the lifecycle heartbeat to provider-execution start and stamps the local owner PID, so `status`/`logs`/`activity` show advancing liveness during execution.
- **Guarded to non-runner-backed runs only** — a runner-backed run's heartbeat and owner PID belong to the runner, not the controller reserving here. Zero Lab-path behavior change.

## Testing
- `homeboy-cli --lib agent_task::status` — 12 passed, incl. 2 new: local running cook surfaces the boundary as `recorded` with backend/model/started_at; terminal-only executions stay `absent`.
- `homeboy-agents --lib` reservation tests — new `local_reservation_advances_heartbeat_to_execution_start` passes; existing exactly-once/concurrent reservation tests still pass.
- 5 `agent_task_service::tests` (discovery/reconcile/materialize) fail **identically on pristine origin/main** in this sandbox — they depend on real-PID liveness / process-global state that the local env doesn't reproduce (tracked by #9774). Verified by reverting the 3 files to `origin/main` and observing the same `Active` vs `Stale` failure. Not caused or worsened by this change; CI runs them in a clean environment.

## Scope
Advances the local-cook visibility item on the #9181 readiness checklist. Does not implement the advancing *progress-event stream* (bounded heartbeat events emitted mid-execution by the provider) — the reservation-time heartbeat + `started_at` give operators the running/started signal; a periodic progress emitter is a larger follow-up.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the local-cook execution/projection seam, surfacing the durable provider-execution signal, guarding the heartbeat change off the runner path, and coverage.

Refs #8396, #9181