### PR TITLE
fix(review): capture child output in summary mode instead of streaming

### DIFF
--- a/crates/homeboy-extension/src/lint/mod.rs
+++ b/crates/homeboy-extension/src/lint/mod.rs
@@ -54,6 +54,10 @@ pub fn build_lint_runner(
         .settings(&string_settings)
         .settings_json(&json_settings)
         .with_run_dir(run_dir)
+        // Summary mode captures the lint/clippy stream into evidence rather than
+        // tee-ing the full warning output to the terminal, so `--summary` renders
+        // only the compact findings envelope on large repositories (#9845).
+        .passthrough(!summary)
         .env_if(summary, "HOMEBOY_SUMMARY_MODE", "1")
         .env_opt("HOMEBOY_LINT_FILE", &file.map(str::to_string))
         .env_opt("HOMEBOY_LINT_GLOB", &glob.map(str::to_string))

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -198,6 +198,14 @@ impl ExtensionRunner {
         self
     }
 
+    /// Whether this runner streams child output to the terminal. Summary-mode
+    /// callers disable passthrough so large child streams are captured to
+    /// evidence rather than flooding the terminal (#9845).
+    #[cfg(test)]
+    pub(crate) fn is_passthrough(&self) -> bool {
+        self.passthrough
+    }
+
     /// Stream stderr without streaming stdout. Useful for commands that emit
     /// live human progress while the parent process owns stdout JSON.
     pub(crate) fn stderr_passthrough(mut self, stderr_passthrough: bool) -> Self {
@@ -683,6 +691,24 @@ mod tests {
         let runner = ExtensionRunner::for_context(context()).stderr_passthrough(true);
 
         assert!(runner.stderr_passthrough);
+    }
+
+    #[test]
+    fn passthrough_defaults_on_and_summary_mode_disables_it() {
+        // The runner streams child output to the terminal by default, but
+        // summary-mode callers pass `passthrough(false)` so large child streams
+        // are captured to evidence instead of flooding the terminal (#9845).
+        let default_runner = ExtensionRunner::for_context(context());
+        assert!(
+            default_runner.is_passthrough(),
+            "passthrough is on by default so non-summary runs still stream live output"
+        );
+
+        let summary_runner = ExtensionRunner::for_context(context()).passthrough(false);
+        assert!(
+            !summary_runner.is_passthrough(),
+            "summary mode must disable passthrough so the child stream is captured, not streamed"
+        );
     }
 
     #[test]

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -259,6 +259,12 @@ fn run_main_test_workflow_inner(
         .ci_env
         .iter()
         .fold(runner, |runner, (key, value)| runner.env(key, value));
+    // In summary mode, capture the child's stdout/stderr into run evidence
+    // instead of tee-ing the full compiler/test stream to the terminal. The
+    // output is still persisted to artifacts below and a bounded failure tail
+    // is surfaced by the summary, so `--summary` stays actionable on large
+    // repositories instead of overflowing the caller's display limit (#9845).
+    let runner = runner.passthrough(!args.json_summary);
     let passthrough_args = normalize_test_passthrough_args(component, &args.passthrough_args)?;
     let mut progress = ValidationProgressRecorder::new(
         run_dir,


### PR DESCRIPTION
## Summary
`homeboy review --summary` (and `test`/`lint --json-summary`) tee'd the **full** child compiler/test/clippy stream to the terminal *and* captured it. On a large Rust review this emitted tens of thousands of bytes of warnings + test logs before the compact envelope, overflowed the agent tool display limit, and pushed the actionable result into a separate truncation artifact — defeating the compact flag (#9845).

## Root cause
The runner already supported a capture-only stream mode (`ExtensionRunner`'s `passthrough` builder — `StreamMode::Capture` vs `Passthrough`/tee in `local_exec.rs`), already persists full stdout/stderr to run-dir artifacts, and already renders a **bounded, redacted failure tail** (`RAW_OUTPUT_TAIL_LINES` in `test/run.rs`). It just always left passthrough on.

## Change
Gate passthrough on summary mode:
- test runner: `.passthrough(!args.json_summary)`
- lint runner (`build_lint_runner`): `.passthrough(!summary)`, alongside the existing `HOMEBOY_SUMMARY_MODE` signal.

Summary mode now renders only the structured envelope (stage progress, counts, and — on failure — the existing bounded tail). Full live streaming stays the default for non-summary runs, and full output stays in persisted artifacts.

## Acceptance criteria
- [x] `--summary` does not stream unbounded child stdout/stderr (passthrough off → `StreamMode::Capture`).
- [x] On failure, render a bounded relevant tail (existing `RAW_OUTPUT_TAIL_LINES`, redacted).
- [x] Full raw output preserved in run-dir artifacts (unchanged).
- [x] Explicit non-summary run keeps live streaming (passthrough defaults on).
- [x] Documented byte/line bound applies to the summary tail (existing line bound).

## Testing
- `homeboy-extension --lib runner::tests::passthrough_defaults_on_and_summary_mode_disables_it` — passes (default on; summary disables).
- `cargo check -p homeboy-extension --lib` — clean (test-only accessor gated behind `#[cfg(test)]`).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the tee-vs-capture stream seam from `review --summary` down to `local_exec` StreamMode, gating passthrough on summary mode, and coverage.

Refs #9845