### PR TITLE
feat(agent-task): add durable exactly-once cook operation claims (primitive)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -43,6 +43,7 @@ mod lifecycle_ops;
 mod lifecycle_record_ops;
 mod lifecycle_runner_projection;
 mod lifecycle_transport_proxy;
+mod operation_claims;
 mod private_attachment;
 mod records;
 pub mod runner_continuation;
@@ -58,6 +59,7 @@ pub use lifecycle_ops::*;
 pub use lifecycle_record_ops::cook_attempt_run_id;
 pub use lifecycle_runner_projection::*;
 pub use lifecycle_transport_proxy::*;
+pub use operation_claims::*;
 pub use private_attachment::*;
 pub use records::*;
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -1,0 +1,256 @@
+//! Durable exactly-once cook side-effect operation claims.
+//!
+//! Cook continuation persists enough intent to resume after a reconciled
+//! attempt, but the external side effects it drives — promotion, retry
+//! dispatch, and PR finalization — record their result only *after* the effect
+//! completes. A controller crash in the window between "external effect
+//! executed" and "result durably recorded" can repeat the effect on restart
+//! (double push, duplicate PR, re-dispatched retry) (#8357).
+//!
+//! This module provides the lifecycle-owned durable operation claim the cook
+//! side-effect boundary reserves *before* performing an external effect. A claim
+//! is keyed by `(run_id, operation_key)` where `operation_key` covers the
+//! promotion report identity, retry run id, or finalization candidate
+//! fingerprint. Its states are:
+//!
+//! - `pending`/`running` — leased: an in-flight effect owns the claim. A second
+//!   controller pass observes [`ClaimOutcome::LeaseHeld`] and must reconcile the
+//!   lease (via Git/PR lookup) rather than blindly repeating the effect.
+//! - `completed` — an immutable result the operation produced. A resumed
+//!   controller observes [`ClaimOutcome::AlreadyCompleted`] and returns the
+//!   recorded result without re-running the effect.
+//!
+//! The claim is written through the same atomic [`store::mutate_record`]
+//! read-modify-write used by the rest of the lifecycle, so concurrent
+//! controller passes converge on one owner. The primitive is deliberately
+//! generic and product/framework agnostic: callers supply the operation key and
+//! the completed result value; this module owns only claim identity and
+//! lifecycle.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use super::*;
+
+/// Metadata key under which the durable operation-claim ledger is stored on a
+/// run record. Each entry is keyed by its `operation_key`.
+const OPERATION_CLAIMS_KEY: &str = "cook_operation_claims";
+
+/// Result of attempting to claim a cook side-effect operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimOutcome {
+    /// This pass acquired a fresh lease and must perform the external effect,
+    /// then call [`complete_cook_operation`].
+    Acquired,
+    /// A prior pass already completed this operation. The immutable recorded
+    /// result is returned; the caller must not repeat the effect.
+    AlreadyCompleted(Value),
+    /// A concurrent (or interrupted) pass holds a still-fresh lease. The caller
+    /// must not perform the effect; it should wait or reconcile the lease.
+    LeaseHeld,
+}
+
+/// State of a single durable operation claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimState {
+    /// Leased and in flight (no result recorded yet).
+    Running,
+    /// Completed with an immutable recorded result.
+    Completed,
+}
+
+/// A durable operation claim projected for reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationClaim {
+    pub operation_key: String,
+    pub state: ClaimState,
+    pub leased_at: String,
+    pub lease_deadline: Option<String>,
+    pub result: Option<Value>,
+}
+
+/// Reserve a cook side-effect operation before an external effect.
+///
+/// Writes a durable `running` lease keyed by `operation_key` when none exists,
+/// returning [`ClaimOutcome::Acquired`]. If the operation already completed, the
+/// recorded result is returned via [`ClaimOutcome::AlreadyCompleted`] and no
+/// lease is taken. If a still-fresh lease is held by another pass,
+/// [`ClaimOutcome::LeaseHeld`] is returned. A lease whose deadline has elapsed
+/// is reclaimable and is re-leased to this pass (the caller is expected to
+/// reconcile any partially-applied external effect via Git/PR lookup first).
+pub fn claim_cook_operation(
+    run_id: &str,
+    operation_key: &str,
+    lease: Duration,
+) -> Result<ClaimOutcome> {
+    let run_id = sanitize_run_id(run_id);
+    let now = now_timestamp();
+    let lease_deadline = timestamp_after(&now, lease);
+    let mut outcome = ClaimOutcome::LeaseHeld;
+    store::mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let claims = metadata
+            .entry(OPERATION_CLAIMS_KEY.to_string())
+            .or_insert_with(|| json!([]));
+        if !claims.is_array() {
+            *claims = json!([]);
+        }
+        let claims = claims.as_array_mut().expect("operation claims array");
+
+        if let Some(existing) = claims
+            .iter()
+            .find(|claim| claim["operation_key"] == json!(operation_key))
+        {
+            // A completed claim is immutable: return its recorded result.
+            if existing["state"] == json!("completed") {
+                outcome = ClaimOutcome::AlreadyCompleted(
+                    existing.get("result").cloned().unwrap_or(Value::Null),
+                );
+                return false;
+            }
+            // A still-fresh lease is owned by another pass.
+            if !lease_is_expired(existing, &now) {
+                outcome = ClaimOutcome::LeaseHeld;
+                return false;
+            }
+            // Expired lease: reclaim it for this pass.
+        }
+
+        let claim = json!({
+            "operation_key": operation_key,
+            "state": "running",
+            "leased_at": now,
+            "lease_deadline": lease_deadline,
+        });
+        // Replace an expired lease in place, or append a new one.
+        if let Some(slot) = claims
+            .iter_mut()
+            .find(|claim| claim["operation_key"] == json!(operation_key))
+        {
+            *slot = claim;
+        } else {
+            claims.push(claim);
+        }
+        record.updated_at = Some(now.clone());
+        outcome = ClaimOutcome::Acquired;
+        true
+    })?;
+    Ok(outcome)
+}
+
+/// Record the immutable result of a completed cook side-effect operation.
+///
+/// Transitions the `(run_id, operation_key)` claim to `completed` and stores the
+/// result. Idempotent: completing an already-completed claim leaves the first
+/// recorded result intact. Returns an error if no claim was ever reserved (a
+/// terminal result without its durable lease is a lifecycle invariant break,
+/// mirroring [`record_provider_execution_terminal`]).
+pub fn complete_cook_operation(run_id: &str, operation_key: &str, result: Value) -> Result<()> {
+    let run_id = sanitize_run_id(run_id);
+    let now = now_timestamp();
+    let mut found = false;
+    store::mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let Some(claims) = metadata
+            .get_mut(OPERATION_CLAIMS_KEY)
+            .and_then(Value::as_array_mut)
+        else {
+            return false;
+        };
+        let Some(claim) = claims
+            .iter_mut()
+            .find(|claim| claim["operation_key"] == json!(operation_key))
+        else {
+            return false;
+        };
+        found = true;
+        // Completed results are immutable: the first result wins.
+        if claim["state"] == json!("completed") {
+            return false;
+        }
+        claim["state"] = json!("completed");
+        claim["completed_at"] = json!(now);
+        claim["result"] = result.clone();
+        record.updated_at = Some(now.clone());
+        true
+    })?;
+    if !found {
+        return Err(Error::internal_unexpected(
+            "cook operation completed without its durable claim; reserve the operation before performing its side effect",
+        ));
+    }
+    Ok(())
+}
+
+/// Read a single operation claim for reconciliation, if present.
+pub fn operation_claim(run_id: &str, operation_key: &str) -> Result<Option<OperationClaim>> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::read_record(&run_id)?;
+    Ok(record
+        .metadata
+        .get(OPERATION_CLAIMS_KEY)
+        .and_then(Value::as_array)
+        .and_then(|claims| {
+            claims
+                .iter()
+                .find(|claim| claim["operation_key"] == json!(operation_key))
+        })
+        .and_then(project_claim))
+}
+
+/// Whether the `(run_id, operation_key)` operation has a still-fresh in-flight
+/// lease that another controller pass owns. Callers use this to decide between
+/// waiting and reconciling an interrupted effect via Git/PR lookup.
+pub fn operation_lease_is_active(run_id: &str, operation_key: &str) -> Result<bool> {
+    let now = now_timestamp();
+    Ok(
+        operation_claim(run_id, operation_key)?.is_some_and(|claim| {
+            claim.state == ClaimState::Running
+                && claim
+                    .lease_deadline
+                    .as_deref()
+                    .is_none_or(|deadline| deadline > now.as_str())
+        }),
+    )
+}
+
+fn project_claim(claim: &Value) -> Option<OperationClaim> {
+    let operation_key = claim.get("operation_key")?.as_str()?.to_string();
+    let state = match claim.get("state").and_then(Value::as_str)? {
+        "completed" => ClaimState::Completed,
+        _ => ClaimState::Running,
+    };
+    Some(OperationClaim {
+        operation_key,
+        state,
+        leased_at: claim
+            .get("leased_at")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        lease_deadline: claim
+            .get("lease_deadline")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        result: claim.get("result").cloned(),
+    })
+}
+
+/// A leased claim is expired when its deadline has elapsed relative to `now`. A
+/// claim without a deadline never expires on its own (it must be completed or
+/// explicitly reconciled).
+fn lease_is_expired(claim: &Value, now: &str) -> bool {
+    claim
+        .get("lease_deadline")
+        .and_then(Value::as_str)
+        .is_some_and(|deadline| deadline <= now)
+}
+
+/// RFC3339 timestamp `lease` after `base`. Falls back to `base` when the base is
+/// unparseable so a claim is never handed an earlier-than-now deadline.
+fn timestamp_after(base: &str, lease: Duration) -> Option<String> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(base).ok()?;
+    let deadline = parsed + chrono::Duration::from_std(lease).ok()?;
+    Some(deadline.to_rfc3339())
+}

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -380,6 +380,7 @@ pub(super) fn succeeded_aggregate(plan: &AgentTaskPlan) -> AgentTaskAggregate {
 }
 
 mod handoff_and_proxy;
+mod operation_claims;
 mod private_attachment;
 mod status_and_recovery;
 mod submit_and_persist;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/operation_claims.rs
@@ -1,0 +1,144 @@
+//! Split partition of agent_task_lifecycle tests (see mod.rs for shared setup).
+//!
+//! Durable exactly-once cook side-effect operation claims (#8357). These use
+//! injected result values and never perform real Git/GitHub mutations, so the
+//! primitive's crash/restart contract is deterministic (AC#7).
+#![cfg(test)]
+
+use std::time::Duration;
+
+use serde_json::json;
+
+use super::*;
+use crate::agent_task_lifecycle::{
+    claim_cook_operation, complete_cook_operation, operation_claim, operation_lease_is_active,
+    ClaimOutcome, ClaimState,
+};
+use homeboy_core::test_support::with_isolated_home;
+
+const LEASE: Duration = Duration::from_secs(300);
+
+fn seed_run(run_id: &str) {
+    submit_plan(&test_plan(), Some(run_id)).expect("seed run");
+}
+
+#[test]
+fn first_claim_is_acquired_and_second_pass_sees_lease_held() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-1");
+        assert_eq!(
+            claim_cook_operation("op-claim-1", "promote:abc", LEASE).expect("first claim"),
+            ClaimOutcome::Acquired
+        );
+        // A concurrent pass with a still-fresh lease must not repeat the effect.
+        assert_eq!(
+            claim_cook_operation("op-claim-1", "promote:abc", LEASE)
+                .expect("second observes lease"),
+            ClaimOutcome::LeaseHeld
+        );
+    });
+}
+
+#[test]
+fn completed_operation_returns_immutable_result_without_release() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-2");
+        claim_cook_operation("op-claim-2", "finalize:xyz", LEASE).expect("claim");
+        complete_cook_operation("op-claim-2", "finalize:xyz", json!({"pr": 42})).expect("complete");
+
+        // A resumed controller gets the recorded result, never a fresh lease.
+        match claim_cook_operation("op-claim-2", "finalize:xyz", LEASE).expect("resume") {
+            ClaimOutcome::AlreadyCompleted(result) => assert_eq!(result, json!({"pr": 42})),
+            other => panic!("expected AlreadyCompleted, got {other:?}"),
+        }
+    });
+}
+
+#[test]
+fn completing_twice_keeps_the_first_result() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-3");
+        claim_cook_operation("op-claim-3", "retry:run-2", LEASE).expect("claim");
+        complete_cook_operation("op-claim-3", "retry:run-2", json!({"attempt": 2}))
+            .expect("first complete");
+        complete_cook_operation("op-claim-3", "retry:run-2", json!({"attempt": 999}))
+            .expect("second complete is a no-op");
+
+        let claim = operation_claim("op-claim-3", "retry:run-2")
+            .expect("read")
+            .expect("claim present");
+        assert_eq!(claim.state, ClaimState::Completed);
+        assert_eq!(claim.result, Some(json!({"attempt": 2})));
+    });
+}
+
+#[test]
+fn expired_lease_is_reclaimable_by_a_new_pass() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-4");
+        // A zero-length lease is immediately expired, modelling a crashed
+        // controller whose lease elapsed before it recorded a result.
+        assert_eq!(
+            claim_cook_operation("op-claim-4", "promote:def", Duration::from_secs(0))
+                .expect("first claim"),
+            ClaimOutcome::Acquired
+        );
+        // The next pass finds the expired lease and reclaims it.
+        assert_eq!(
+            claim_cook_operation("op-claim-4", "promote:def", LEASE).expect("reclaim"),
+            ClaimOutcome::Acquired
+        );
+    });
+}
+
+#[test]
+fn distinct_operation_keys_are_independent() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-5");
+        assert_eq!(
+            claim_cook_operation("op-claim-5", "promote:a", LEASE).expect("promote"),
+            ClaimOutcome::Acquired
+        );
+        // A different operation on the same run gets its own fresh lease.
+        assert_eq!(
+            claim_cook_operation("op-claim-5", "finalize:a", LEASE).expect("finalize"),
+            ClaimOutcome::Acquired
+        );
+    });
+}
+
+#[test]
+fn completing_without_a_claim_is_an_invariant_error() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-6");
+        let error = complete_cook_operation("op-claim-6", "never-claimed", json!({}))
+            .expect_err("terminal without claim must error");
+        assert!(error.message.contains("without its durable claim"));
+    });
+}
+
+#[test]
+fn active_lease_is_reported_until_completion() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-7");
+        claim_cook_operation("op-claim-7", "promote:live", LEASE).expect("claim");
+        assert!(operation_lease_is_active("op-claim-7", "promote:live").expect("active"));
+
+        complete_cook_operation("op-claim-7", "promote:live", json!({})).expect("complete");
+        assert!(
+            !operation_lease_is_active("op-claim-7", "promote:live").expect("inactive"),
+            "a completed operation no longer holds an active lease"
+        );
+    });
+}
+
+#[test]
+fn unknown_operation_has_no_claim_or_active_lease() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-8");
+        assert!(operation_claim("op-claim-8", "absent")
+            .expect("read")
+            .is_none());
+        assert!(!operation_lease_is_active("op-claim-8", "absent").expect("inactive"));
+    });
+}


### PR DESCRIPTION
## Summary
Cook side effects — **promotion, retry dispatch, PR finalization** — record their result only *after* the external effect completes. A controller crash in the window between "effect executed" and "result durably recorded" repeats the effect on restart: double push, duplicate PR, re-dispatched retry (#8357).

This PR lands the **owning-layer primitive** the issue calls for — a lifecycle-owned durable operation-claim ledger reserved *before* an external effect — as slice 1 of the exactly-once work. It generalizes the already-proven `reserve_provider_execution` claim pattern.

## API (`agent_task_lifecycle::operation_claims`)
- `claim_cook_operation(run_id, operation_key, lease) -> ClaimOutcome`
  - `Acquired` — fresh lease taken; caller performs the effect, then completes.
  - `LeaseHeld` — a still-fresh lease is owned by another/interrupted pass; caller must not repeat the effect.
  - `AlreadyCompleted(result)` — immutable recorded result returned; effect is not repeated.
  - An **expired** lease is reclaimable, so a crashed controller's operation can be reconciled (via Git/PR lookup) and retried.
- `complete_cook_operation(run_id, operation_key, result)` — records an immutable result (first result wins). A terminal without a prior claim is an invariant error, mirroring `record_provider_execution_terminal`.
- `operation_claim` / `operation_lease_is_active` — project claims for reconciliation.

Operation keys cover promotion report identity, retry run id, and finalization candidate fingerprint. Claims persist through the same atomic `store::mutate_record` read-modify-write the rest of the lifecycle uses, so concurrent controller passes converge on one owner.

## Scope
Deliberately the **primitive only**. Wiring it into `run_cook`'s promote / dispatch / finalize boundaries is separate, reviewable follow-up work (see the multi-PR plan on #8357). Nothing in the live cook loop changes yet, so there is zero behavior risk in this PR.

## Testing
`homeboy-agents --lib agent_task_lifecycle::tests::operation_claims` — 8 passing, all with **injected result values and no real Git/GitHub mutations** (AC#7): acquire→lease-held, immutable completed result, idempotent double-complete, expired-lease reclaim, independent keys, terminal-without-claim invariant error, active-lease reporting, unknown-operation absence.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Mapping the cook promote→finalize side-effect window, designing the durable claim primitive off the `reserve_provider_execution` pattern, and deterministic coverage.

Refs #8357, #9181