### PR TITLE
Audit sibling agent-task help for leaked prose and lock it with tests (#9907)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/controller.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/controller.rs
@@ -44,9 +44,11 @@ pub enum AgentTaskControllerCommand {
     Proof(AgentTaskControllerProofArgs),
 }
 
-/// Shared dispatch overrides for controller subcommands that can spawn dispatch
-/// actions. Flattened into each controller args struct so the CLI surface is
-/// identical to declaring these fields inline.
+/// Dispatch overrides applied to actions a controller subcommand spawns, for
+/// when those actions do not specify their own backend, provider, or model.
+//
+// Implementation note (not shown in `--help`): flattened into each controller
+// args struct so the CLI surface is identical to declaring these fields inline.
 #[derive(Args, Debug, Clone)]
 pub struct AgentTaskControllerDispatchArgs {
     /// Executor backend to use for controller-spawned dispatch actions when the action omits one.

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -183,6 +183,53 @@ mod tests {
         assert!(!options.gate_environment.isolate_home);
         assert!(!options.gate_environment.isolate_xdg);
     }
+
+    #[derive(Parser)]
+    struct CookHelpCli {
+        #[command(flatten)]
+        cook: AgentTaskCookArgs,
+    }
+
+    fn rendered_cook_help() -> String {
+        use clap::CommandFactory;
+        CookHelpCli::command().render_long_help().to_string()
+    }
+
+    #[test]
+    fn cook_help_does_not_leak_internal_refactoring_prose() {
+        // #9898/#9907: help must describe the operator contract, never the Rust
+        // refactor behind the flags.
+        let help = rendered_cook_help();
+        for leaked in [
+            "Flattened into",
+            "#[arg] attributes",
+            "DispatchArgs",
+            "field group is declared once",
+            "reproduce the original flag",
+            "CLI surface for the dispatch inputs",
+        ] {
+            assert!(
+                !help.contains(leaked),
+                "cook help leaked internal prose {leaked:?}:\n{help}"
+            );
+        }
+    }
+
+    #[test]
+    fn cook_help_documents_core_workflow_flags() {
+        let help = rendered_cook_help();
+        // Each core flag renders with operator-facing help, not a blank line.
+        assert!(help.contains("--goal"), "{help}");
+        assert!(
+            help.contains("Workspace handle of the existing worktree"),
+            "{help}"
+        );
+        assert!(
+            help.contains("Deterministic verification command"),
+            "{help}"
+        );
+        assert!(help.contains("before opening the pull request"), "{help}");
+    }
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/homeboy-cli/src/commands/upgrade.rs
+++ b/crates/homeboy-cli/src/commands/upgrade.rs
@@ -315,6 +315,7 @@ mod tests {
             source_revision: None,
             upgraded: true,
             partial: false,
+            runner_convergence: None,
             message: "Upgraded to 0.228.7".to_string(),
             restart_required: false,
             extensions_updated: Vec::new(),


### PR DESCRIPTION
Completes #9907 (follow-up to #9898, already merged).

## Context
#9898 replaced the cook command description and the `DispatchCoreArgs` help heading. #9907 (filed independently, same root problem) adds two remaining acceptance items: a **sibling audit** and **regression coverage**.

## Changes
1. **Sibling audit** — swept every agent-task CLI arg doc comment for leaked derive/type/refactor prose. Found one remaining leak: `AgentTaskControllerDispatchArgs` still opened with *"Flattened into each controller args struct so the CLI surface is identical..."*. Replaced it with an operator-facing description (these are the dispatch overrides applied to controller-spawned actions), keeping the flatten note as a non-doc `//` comment. No other leaks remain.

2. **Regression coverage** — added semantic help assertions that render `AgentTaskCookArgs` long help and assert it:
   - **contains** operator-facing flag descriptions (`--goal`, the `--to-worktree` "authoritative worktree" text, the `--verify` "deterministic verification command" text, the `--no-finalize` "before opening the pull request" text), and
   - **never contains** the internal refactoring prose (`Flattened into`, `#[arg] attributes`, `DispatchArgs`, `field group is declared once`, `reproduce the original flag`, `CLI surface for the dispatch inputs`).

   These are **semantic substring checks**, not full-format snapshots, so unstable clap formatting is not blessed (per the acceptance criteria).

3. **Latent break fix** — the CLI upgrade test helper's `UpgradeResult` literal was missing the `runner_convergence` field added in #9842. That PR did not check the CLI crate with `--tests`, so the break only surfaces now. Added `runner_convergence: None`.

## Acceptance criteria coverage
- ✅ Internal type/refactoring text replaced with operator-facing description (done across #9898 + this)
- ✅ Sibling agent-task subcommand help audited for leaked derive/type prose
- ✅ Semantic help assertions for user-facing summaries without blessing full formatting

## Verification
- `cargo fmt -p homeboy-cli --check` clean
- `cargo check -p homeboy-cli --lib --tests` exit 0
- Docs/tests only; no behavior change

Diff: +53/-3, 3 files.