### PR TITLE
refactor(agent-task): route cook side effects through one boundary (slice 2)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -43,6 +43,89 @@ use super::cook_promotion::{
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
 
+/// The generic cook side-effect boundary the attempt loop drives its external
+/// effects through: promotion, moving-base recovery, and PR finalization.
+///
+/// Routing every external effect through one injectable object (rather than a
+/// mix of free-function calls and ad-hoc closures) gives durable exactly-once
+/// operation claims a single wiring point, and lets deterministic tests inject
+/// side effects without real Git/GitHub mutations (#8357). This slice is a pure
+/// structural boundary: [`DefaultCookSideEffects`] preserves the exact prior
+/// behavior by delegating to the existing free functions. Claim wiring for
+/// promotion, retry dispatch, and finalization follows as separate changes.
+pub(crate) trait CookSideEffectService {
+    /// Promote the successful candidate for `run_id`, or load the already-persisted
+    /// promotion when this attempt was interrupted after promoting.
+    fn promote(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        run_id: &str,
+    ) -> Result<AgentTaskPromotionReport>;
+
+    /// Rebase and re-verify a candidate whose base moved under it.
+    fn recover_moving_base(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        recovery: &MovingBaseCookRecovery,
+    ) -> Result<AgentTaskPromotionReport>;
+
+    /// Commit, push, and open/update the PR for a green promoted candidate, or
+    /// load the already-finalized PR when this attempt was interrupted after
+    /// finalizing.
+    fn finalize(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        run_id: &str,
+        promotion: &AgentTaskPromotionReport,
+    ) -> Result<Value>;
+}
+
+/// Production cook side-effect boundary. Each method delegates to the existing
+/// promotion/finalization free functions, so behavior is identical to the prior
+/// direct calls; the trait only relocates the call sites behind one seam.
+pub(crate) struct DefaultCookSideEffects<F> {
+    finalize: F,
+}
+
+impl<F> DefaultCookSideEffects<F>
+where
+    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
+{
+    pub(crate) fn new(finalize: F) -> Self {
+        Self { finalize }
+    }
+}
+
+impl<F> CookSideEffectService for DefaultCookSideEffects<F>
+where
+    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
+{
+    fn promote(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        run_id: &str,
+    ) -> Result<AgentTaskPromotionReport> {
+        promote_or_load_attempt(options, run_id)
+    }
+
+    fn recover_moving_base(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        recovery: &MovingBaseCookRecovery,
+    ) -> Result<AgentTaskPromotionReport> {
+        recover_moving_base_cook_candidate(options, recovery)
+    }
+
+    fn finalize(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        run_id: &str,
+        promotion: &AgentTaskPromotionReport,
+    ) -> Result<Value> {
+        (self.finalize)(options, run_id, promotion)
+    }
+}
+
 /// The promotion checkpoint captures this before gates run, when it is the only
 /// complete authorization for reusing the dirty managed destination.
 pub(crate) fn gate_feedback_current_diff(promotion: &AgentTaskPromotionReport) -> String {
@@ -838,27 +921,18 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
-    run_cook_with_boundaries(
-        options,
-        executor,
-        finalize,
-        recover_moving_base_cook_candidate,
-    )
+    let side_effects = DefaultCookSideEffects::new(finalize);
+    run_cook_with_boundaries(options, executor, side_effects)
 }
 
-fn run_cook_with_boundaries<E, F, R>(
+fn run_cook_with_boundaries<E, S>(
     options: AgentTaskCookServiceOptions,
     executor: E,
-    mut finalize: F,
-    mut recover: R,
+    mut side_effects: S,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
     E: AgentTaskExecutorAdapter + Clone,
-    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
-    R: FnMut(
-        &AgentTaskCookServiceOptions,
-        &MovingBaseCookRecovery,
-    ) -> Result<AgentTaskPromotionReport>,
+    S: CookSideEffectService,
 {
     // A configured provider is controller authority. Resolve it before an
     // external runner can spend a provider attempt; explicit transports are
@@ -1303,7 +1377,7 @@ where
             ));
         }
 
-        let promotion = match promote_or_load_attempt(&options, &run_id) {
+        let promotion = match side_effects.promote(&options, &run_id) {
             Ok(report) => report,
             Err(error) => {
                 attempts.push(AgentTaskCookAttemptReport {
@@ -1370,7 +1444,7 @@ where
                 }
                 let mut active_moving_base_recovery = None;
                 let promotion = match moving_base_recovery_for_run(&run_id)? {
-                    Some(recovery) => match recover(&options, &recovery) {
+                    Some(recovery) => match side_effects.recover_moving_base(&options, &recovery) {
                         Ok(promotion) => {
                             agent_task_lifecycle::record_promotion(
                                 &run_id,
@@ -1431,7 +1505,7 @@ where
                     },
                     None => promotion,
                 };
-                let finalization = match finalize(&options, &run_id, &promotion) {
+                let finalization = match side_effects.finalize(&options, &run_id, &promotion) {
                     Ok(finalization) => {
                         if active_moving_base_recovery.is_some() {
                             agent_task_lifecycle::clear_cook_moving_base_recovery(&run_id)?;

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -126,6 +126,66 @@ where
     }
 }
 
+/// Test cook side-effect boundary with injectable `finalize` and
+/// `recover_moving_base` closures, so recovery/finalization control flow can be
+/// exercised without real Git/GitHub mutations. `promote` delegates to the real
+/// promotion path (tests that need to intercept promotion persist a promotion
+/// first, exactly as before).
+#[cfg(test)]
+pub(crate) struct TestCookSideEffects<F, R> {
+    finalize: F,
+    recover: R,
+}
+
+#[cfg(test)]
+impl<F, R> TestCookSideEffects<F, R>
+where
+    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
+    R: FnMut(
+        &AgentTaskCookServiceOptions,
+        &MovingBaseCookRecovery,
+    ) -> Result<AgentTaskPromotionReport>,
+{
+    pub(crate) fn new(finalize: F, recover: R) -> Self {
+        Self { finalize, recover }
+    }
+}
+
+#[cfg(test)]
+impl<F, R> CookSideEffectService for TestCookSideEffects<F, R>
+where
+    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
+    R: FnMut(
+        &AgentTaskCookServiceOptions,
+        &MovingBaseCookRecovery,
+    ) -> Result<AgentTaskPromotionReport>,
+{
+    fn promote(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        run_id: &str,
+    ) -> Result<AgentTaskPromotionReport> {
+        promote_or_load_attempt(options, run_id)
+    }
+
+    fn recover_moving_base(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        recovery: &MovingBaseCookRecovery,
+    ) -> Result<AgentTaskPromotionReport> {
+        (self.recover)(options, recovery)
+    }
+
+    fn finalize(
+        &mut self,
+        options: &AgentTaskCookServiceOptions,
+        run_id: &str,
+        promotion: &AgentTaskPromotionReport,
+    ) -> Result<Value> {
+        (self.finalize)(options, run_id, promotion)
+    }
+}
+
 /// The promotion checkpoint captures this before gates run, when it is the only
 /// complete authorization for reusing the dirty managed destination.
 pub(crate) fn gate_feedback_current_diff(promotion: &AgentTaskPromotionReport) -> String {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -369,26 +369,29 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         let second = run_cook_with_boundaries(
             options.clone(),
             UnusedExecutor,
-            move |_, _, promotion| {
-                finalization_count_for_finalize.fetch_add(1, Ordering::SeqCst);
-                assert_eq!(
-                    promotion.verified_base.as_ref().unwrap().sha,
-                    "pinned-refreshed-base"
-                );
-                Ok(serde_json::json!({"status":"review_ready", "run_id": run_id}))
-            },
-            move |options, recovery| {
-                rebase_count_for_recover.fetch_add(1, Ordering::SeqCst);
-                assert_eq!(
-                    options.gates.private_gate_reveal,
-                    crate::agent_task_gate::AgentTaskGateRevealPolicy::FullEvidence
-                );
-                let mut refreshed = recovery.promotion.clone();
-                refreshed.verified_base.as_mut().unwrap().sha = "pinned-refreshed-base".to_string();
-                refreshed.provenance["candidate"] =
-                    serde_json::json!({"kind":"git","fingerprint":{"tree":"rebased"}});
-                Ok(refreshed)
-            },
+            TestCookSideEffects::new(
+                move |_: &_, _: &_, promotion: &AgentTaskPromotionReport| {
+                    finalization_count_for_finalize.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(
+                        promotion.verified_base.as_ref().unwrap().sha,
+                        "pinned-refreshed-base"
+                    );
+                    Ok(serde_json::json!({"status":"review_ready", "run_id": run_id}))
+                },
+                move |options: &AgentTaskCookServiceOptions, recovery: &MovingBaseCookRecovery| {
+                    rebase_count_for_recover.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(
+                        options.gates.private_gate_reveal,
+                        crate::agent_task_gate::AgentTaskGateRevealPolicy::FullEvidence
+                    );
+                    let mut refreshed = recovery.promotion.clone();
+                    refreshed.verified_base.as_mut().unwrap().sha =
+                        "pinned-refreshed-base".to_string();
+                    refreshed.provenance["candidate"] =
+                        serde_json::json!({"kind":"git","fingerprint":{"tree":"rebased"}});
+                    Ok(refreshed)
+                },
+            ),
         )
         .unwrap();
         claim.complete().unwrap();
@@ -419,12 +422,14 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         let third = run_cook_with_boundaries(
             options,
             UnusedExecutor,
-            |_, _, _| panic!("failed rebased gates must not finalize"),
-            |_, recovery| {
-                let mut failed = recovery.promotion.clone();
-                failed.status = AgentTaskPromotionStatus::GateFailed;
-                Ok(failed)
-            },
+            TestCookSideEffects::new(
+                |_: &_, _: &_, _: &_| panic!("failed rebased gates must not finalize"),
+                |_: &AgentTaskCookServiceOptions, recovery: &MovingBaseCookRecovery| {
+                    let mut failed = recovery.promotion.clone();
+                    failed.status = AgentTaskPromotionStatus::GateFailed;
+                    Ok(failed)
+                },
+            ),
         )
         .unwrap();
         assert_eq!(third.value.status, "candidate_recoverable");


### PR DESCRIPTION
## Summary
Slice 2 of the #8357 exactly-once plan. The cook attempt loop drove its external effects through a **mix** of a direct `promote_or_load_attempt` call and two ad-hoc closures (`finalize`, `recover`). This consolidates all three behind a single `CookSideEffectService` trait, so durable exactly-once operation claims (the #9909 primitive) have **one wiring point** and deterministic tests can inject side effects without real Git/GitHub mutations.

## Change
- New `CookSideEffectService` trait: `promote`, `recover_moving_base`, `finalize`.
- `DefaultCookSideEffects` (production) delegates each method to the same free functions the loop called before — **behavior-preserving**.
- `run_cook_with_boundaries` now takes one `CookSideEffectService` instead of the two closure generics; the three call sites route through `side_effects.{promote,recover_moving_base,finalize}`.
- `TestCookSideEffects` (test-only) injects custom `finalize` + `recover` closures for the moving-base recovery test.

**No live cook behavior changes.** This only relocates the call sites behind the seam that slices 3–5 (wire promotion / retry / finalization through the claim primitive) build on.

## Testing
Behavior-preservation confirmed on the tests that exercise the promote→recover→finalize path through the new boundary:
- `moving_base_recovery_refreshes_authenticated_candidate_before_retrying_finalization` — **passes** (this is the test that injects custom finalize+recover via the boundary).
- `moving_base_continuation_finalizes_without_a_second_provider_dispatch` — **passes**.
- One adoption test (`detached_adoption_follow_up_...`) fails **identically on pristine origin/main** in this sandbox — it requires a real git origin with a `main` branch (`declared base 'main' was not found on origin`), an environment dependency unrelated to this change. Verified by reverting the files to `origin/main` and reproducing the same error. CI runs it against a real remote.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Consolidating the cook side-effect call sites behind one injectable trait, preserving behavior via a delegating default impl, and verifying via the moving-base tests.

Refs #8357, #9181