### PR TITLE
Label JSON-spec flags correctly and hint @FILE on bare paths (#9891)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -5,7 +5,9 @@ use super::cook::VerifyGateArgs;
 
 #[derive(Args, Debug)]
 pub struct RunPlanArgs {
-    #[arg(long, value_name = "PATH")]
+    /// Agent-task plan as a JSON spec: inline JSON, `@FILE` to read a file, or
+    /// `-` to read stdin. A bare path is NOT accepted — use `@/path/plan.json`.
+    #[arg(long, value_name = "JSON|@FILE|-")]
     pub plan: String,
     #[arg(long, value_name = "ID")]
     pub record_run_id: Option<String>,
@@ -20,7 +22,9 @@ pub struct RunArgs {
 }
 #[derive(Args, Debug)]
 pub struct SubmitArgs {
-    #[arg(long, value_name = "PATH")]
+    /// Agent-task plan as a JSON spec: inline JSON, `@FILE` to read a file, or
+    /// `-` to read stdin. A bare path is NOT accepted — use `@/path/plan.json`.
+    #[arg(long, value_name = "JSON|@FILE|-")]
     pub plan: String,
     #[arg(long, value_name = "ID")]
     pub run_id: Option<String>,
@@ -323,9 +327,14 @@ pub struct FinalizePrArgs {
 }
 #[derive(Args, Debug)]
 pub struct GateFeedbackArgs {
-    #[arg(long, value_name = "PATH")]
+    /// Promotion report as a JSON spec: inline JSON, `@FILE` to read a file, or
+    /// `-` to read stdin. A bare path is NOT accepted — use
+    /// `@/path/promotion.json`.
+    #[arg(long, value_name = "JSON|@FILE|-")]
     pub promotion: String,
-    #[arg(long = "source-task", value_name = "PATH")]
+    /// Source task as a JSON spec: inline JSON, `@FILE` to read a file, or `-`
+    /// to read stdin. A bare path is NOT accepted — use `@/path/task.json`.
+    #[arg(long = "source-task", value_name = "JSON|@FILE|-")]
     pub source_task: String,
     #[arg(long, default_value_t = 1, value_name = "N")]
     pub attempt: u32,

--- a/crates/homeboy-core/src/config/json_io.rs
+++ b/crates/homeboy-core/src/config/json_io.rs
@@ -101,7 +101,41 @@ pub fn read_json_spec_to_string(spec: &str) -> Result<String> {
         return local_files::local().read(Path::new(path));
     }
 
+    // The remaining form is inline JSON. If the operator passed a bare path to
+    // an existing file (a common mistake, since these flags used to render as
+    // `<PATH>`), the string would otherwise be parsed as JSON and fail with an
+    // opaque "expected value" error. Detect that case and point at the `@FILE`
+    // form explicitly (#9891).
+    if !looks_like_inline_json(spec) && Path::new(spec.trim()).is_file() {
+        return Err(Error::validation_invalid_argument(
+            "json",
+            format!(
+                "'{}' is a file path, but this flag expects a JSON spec (inline JSON, @FILE, or - for stdin). Did you mean '@{}'?",
+                spec.trim(),
+                spec.trim()
+            ),
+            None,
+            None,
+        ));
+    }
+
     Ok(spec.to_string())
+}
+
+/// Whether a JSON spec string is plausibly inline JSON (object, array, string,
+/// or a JSON scalar) rather than a bare filesystem path.
+fn looks_like_inline_json(spec: &str) -> bool {
+    let trimmed = spec.trim_start();
+    trimmed.starts_with('{')
+        || trimmed.starts_with('[')
+        || trimmed.starts_with('"')
+        || trimmed.starts_with("true")
+        || trimmed.starts_with("false")
+        || trimmed.starts_with("null")
+        || trimmed
+            .chars()
+            .next()
+            .is_some_and(|c| c == '-' || c.is_ascii_digit())
 }
 
 /// Read a JSON value spec, preserving the report commands' legacy bare-path support.
@@ -197,6 +231,36 @@ mod tests {
         let value = read_json_value_spec_with_bare_path(path.to_str().unwrap(), "results").unwrap();
         fs::remove_file(path).unwrap();
         assert_eq!(value["source"], "file");
+    }
+
+    #[test]
+    fn json_spec_reads_inline_json_and_at_file() {
+        // Inline JSON passes through untouched.
+        assert_eq!(
+            read_json_spec_to_string(r#"{"a":1}"#).unwrap(),
+            r#"{"a":1}"#
+        );
+        // `@FILE` reads the file contents.
+        let path = temp_json_path("at-spec.json");
+        fs::write(&path, r#"{"from":"file"}"#).unwrap();
+        let raw = read_json_spec_to_string(&format!("@{}", path.display())).unwrap();
+        fs::remove_file(&path).unwrap();
+        assert_eq!(raw, r#"{"from":"file"}"#);
+    }
+
+    #[test]
+    fn json_spec_bare_existing_path_errors_with_at_file_hint() {
+        // A bare path to an existing file is a common mistake (#9891): instead
+        // of being parsed as broken inline JSON, it must produce a targeted
+        // error pointing at the `@FILE` form.
+        let path = temp_json_path("bare-path.json");
+        fs::write(&path, r#"{"plan":true}"#).unwrap();
+        let spec = path.to_str().unwrap().to_string();
+        let err = read_json_spec_to_string(&spec).unwrap_err();
+        fs::remove_file(&path).unwrap();
+        let message = err.message;
+        assert!(message.contains("is a file path"), "{message}");
+        assert!(message.contains(&format!("@{spec}")), "{message}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #9891.

## Problem
Several agent-task flags are documented as `<PATH>` but reject an ordinary path string:

```bash
homeboy agent-task run-plan --plan /tmp/plan.json
homeboy agent-task gate-feedback --promotion /tmp/promotion.json --source-task /tmp/task.json
# -> Invalid JSON: expected value at line 1 column 1   (with the literal path in `received`)
```

They actually go through `read_json_spec_to_string`, which accepts **inline JSON**, **`@FILE`**, or **`-`** (stdin) — never a bare path. The user had to discover the undocumented `@` convention, and `--help` rendered these as `<PATH>` with no mention of JSON/`@file`/stdin.

## Fix
Chose the "name it as a JSON spec" branch of the acceptance contract (these flags genuinely take JSON specs, and inline JSON / stdin are load-bearing):

- **Help:** renamed the misleading `value_name` from `PATH` to `JSON|@FILE|-` and documented every accepted form on `--plan` (run-plan and submit), `--promotion`, and `--source-task`.
- **Diagnostic:** in `read_json_spec_to_string`, when the spec is not plausibly inline JSON **and** is an existing file path, fail with a targeted error naming the file and suggesting `@<path>` — instead of silently treating the path string as broken JSON and emitting an opaque "expected value" error. So a bare existing `.json` path is never parsed as inline JSON.

`read_json_value_spec_with_bare_path` (the legacy report-command bare-path support) is unaffected — it resolves an existing path *before* reaching this fallthrough.

## Acceptance criteria coverage
- ✅ JSON-spec flags render as `<JSON|@FILE|->` with help for inline JSON, file input, and stdin
- ✅ A bare existing `.json` path is never parsed as inline JSON — it produces a clear `@FILE` hint
- ✅ Tests: inline JSON and `@FILE` still read; bare existing path errors with the hint

## Verification
- `cargo fmt -p homeboy-core -p homeboy-cli --check` clean
- `cargo check -p homeboy-core --lib --tests` and `-p homeboy-cli --lib` exit 0
- Full test run deferred to CI per this VPS's no-heavy-local-build rule

Diff: +77/-4, 2 files.