### PR TITLE
feat(agent-task): wire cook promotion through the operation claim (slice 3)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -43,16 +43,66 @@ use super::cook_promotion::{
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
 
+/// Lease window for a cook promotion operation claim. Long enough that a healthy
+/// controller finishes promoting and records the result within it; a crashed
+/// controller's lease elapses so a resumed pass can reconcile and continue.
+const PROMOTION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Durable operation key for the promotion of one cook attempt. Promotion is
+/// one-per-`run_id`, so the run id is the stable operation identity (#8357).
+fn promotion_operation_key(run_id: &str) -> String {
+    format!("promote:{run_id}")
+}
+
+/// Promote a cook attempt under a durable exactly-once operation claim.
+///
+/// `promote_or_load_attempt` already loads an already-persisted promotion, but
+/// the fresh-promote path performs its external effect (`promote_attempt`) and
+/// only then records the result. A controller crash in that window re-runs the
+/// effect on restart. The claim closes it: reserve `promote:<run_id>` before the
+/// effect, complete it after the result is durable, and on a resumed pass return
+/// the persisted promotion instead of repeating the effect (#8357).
+fn promote_with_operation_claim(
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+) -> Result<AgentTaskPromotionReport> {
+    let operation_key = promotion_operation_key(run_id);
+    match agent_task_lifecycle::claim_cook_operation(run_id, &operation_key, PROMOTION_CLAIM_LEASE)?
+    {
+        // A prior pass already promoted and recorded the result. Load the durable
+        // promotion rather than repeating the external effect.
+        agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(_) => {
+            promote_or_load_attempt(options, run_id)
+        }
+        // Another pass holds a still-fresh lease. The persisted-promotion read in
+        // `promote_or_load_attempt` still resolves an already-produced promotion;
+        // if none exists yet, promotion proceeds (content-addressed and idempotent
+        // on disk). Do not mark the claim completed from here — its owner does.
+        agent_task_lifecycle::ClaimOutcome::LeaseHeld => promote_or_load_attempt(options, run_id),
+        // This pass owns the operation. Promote, then record the result as the
+        // claim's immutable completion.
+        agent_task_lifecycle::ClaimOutcome::Acquired => {
+            let promotion = promote_or_load_attempt(options, run_id)?;
+            agent_task_lifecycle::complete_cook_operation(
+                run_id,
+                &operation_key,
+                serde_json::to_value(&promotion)
+                    .map_err(|error| Error::internal_json(error.to_string(), None))?,
+            )?;
+            Ok(promotion)
+        }
+    }
+}
+
 /// The generic cook side-effect boundary the attempt loop drives its external
 /// effects through: promotion, moving-base recovery, and PR finalization.
 ///
 /// Routing every external effect through one injectable object (rather than a
 /// mix of free-function calls and ad-hoc closures) gives durable exactly-once
 /// operation claims a single wiring point, and lets deterministic tests inject
-/// side effects without real Git/GitHub mutations (#8357). This slice is a pure
-/// structural boundary: [`DefaultCookSideEffects`] preserves the exact prior
-/// behavior by delegating to the existing free functions. Claim wiring for
-/// promotion, retry dispatch, and finalization follows as separate changes.
+/// side effects without real Git/GitHub mutations (#8357). Promotion is wired
+/// through the claim primitive here (`promote_with_operation_claim`); retry
+/// dispatch and finalization follow as separate slices.
 pub(crate) trait CookSideEffectService {
     /// Promote the successful candidate for `run_id`, or load the already-persisted
     /// promotion when this attempt was interrupted after promoting.
@@ -105,7 +155,7 @@ where
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
     ) -> Result<AgentTaskPromotionReport> {
-        promote_or_load_attempt(options, run_id)
+        promote_with_operation_claim(options, run_id)
     }
 
     fn recover_moving_base(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3474,6 +3474,81 @@ fn restarted_cook_alias_and_exact_id_reuse_the_same_persisted_promotion() {
     });
 }
 
+fn promotion_claim_options(cook_id: &str, run_id: &str) -> AgentTaskCookServiceOptions {
+    AgentTaskCookServiceOptions {
+        cook_id: cook_id.to_string(),
+        initial_run_id: run_id.to_string(),
+        initial_plan: AgentTaskPlan::new(cook_id, Vec::new()),
+        to_worktree: "homeboy@8058".to_string(),
+        source_worktree_path: None,
+        provider_command: None,
+        provider_invocation: None,
+        gates: VerifyGateOptions::default(),
+        max_attempts: 1,
+        no_finalize: true,
+        base: "main".to_string(),
+        task_base_sha: None,
+        head: None,
+        title: "Cook".to_string(),
+        commit_message: "test".to_string(),
+        source_refs: Vec::new(),
+        protected_branches: Vec::new(),
+        ai_tool: "test".to_string(),
+        ai_model: None,
+        ai_used_for: "test".to_string(),
+        attempt_dispatcher: None,
+        harvest_context: Default::default(),
+    }
+}
+
+#[test]
+fn promotion_operation_claim_completes_once_and_replays_persisted_result() {
+    // #8357: promoting a cook attempt reserves a durable operation claim before
+    // the effect and completes it with the result. An already-persisted
+    // promotion (the resume path) loads without repeating the effect, and the
+    // claim is marked completed so a subsequent pass replays the same result.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-promote-claim";
+        let run_id = "run-promote-claim";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).unwrap();
+        // Seed an already-applied promotion so the promote path loads it rather
+        // than performing a real git/worktree promotion.
+        agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(promotion(run_id)).unwrap(),
+        )
+        .unwrap();
+
+        let options = promotion_claim_options(cook_id, run_id);
+        let operation_key = format!("promote:{run_id}");
+
+        // No claim exists until the first promote pass.
+        assert!(
+            agent_task_lifecycle::operation_claim(run_id, &operation_key)
+                .unwrap()
+                .is_none()
+        );
+
+        let first = promote_with_operation_claim(&options, run_id).unwrap();
+        assert_eq!(first.source.run_id.as_deref(), Some(run_id));
+
+        // The claim is now completed with the promotion result.
+        let claim = agent_task_lifecycle::operation_claim(run_id, &operation_key)
+            .unwrap()
+            .expect("promotion claim recorded");
+        assert_eq!(claim.state, agent_task_lifecycle::ClaimState::Completed);
+        assert!(!agent_task_lifecycle::operation_lease_is_active(run_id, &operation_key).unwrap());
+
+        // A resumed pass replays the same promotion via AlreadyCompleted without
+        // re-running the effect.
+        let replayed = promote_with_operation_claim(&options, run_id).unwrap();
+        assert_eq!(replayed.source.run_id, first.source.run_id);
+        assert_eq!(replayed.patch_artifact.id, first.patch_artifact.id);
+    });
+}
+
 #[test]
 fn historical_applied_promotion_restores_only_its_exact_checkpoint_baseline() {
     homeboy_core::test_support::with_isolated_home(|_| {


### PR DESCRIPTION
## Summary
Slice 3 of the #8357 exactly-once plan. `promote_or_load_attempt` loads an already-persisted promotion, but the fresh-promote path performs its external effect (`promote_attempt`) and **only then** records the result. A controller crash in that window re-runs the effect on restart.

Bracket promotion with the durable operation claim (primitive #9909) at the single `DefaultCookSideEffects::promote` boundary (#9914):
- Reserve `promote:<run_id>` **before** the effect.
- Complete it with the promotion result **after** it is durable.
- On a resumed pass the claim is `completed` → load the persisted promotion via `AlreadyCompleted` instead of repeating the effect.
- A still-fresh lease held by another pass falls back to the existing idempotent load-or-promote path without stealing the completion.

Promotion is one-per-attempt, so the run id is the stable operation identity. **Happy-path behavior is unchanged** — the claim only closes the promote-then-record crash window.

## Testing
- `promotion_operation_claim_completes_once_and_replays_persisted_result` (new) — first promote reserves + completes the claim with the result and clears the active lease; a resumed pass replays the same promotion via `AlreadyCompleted`.
- `moving_base_continuation_finalizes_without_a_second_provider_dispatch` — passes (promote→finalize happy path through the boundary, unchanged).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Identifying the promote-then-record crash window, bracketing promotion with the claim at the side-effect boundary, and deterministic coverage.

Refs #8357, #9181