### PR TITLE
feat(agent-task): wire cook retry dispatch through the operation claim (slice 4)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -54,6 +54,17 @@ fn promotion_operation_key(run_id: &str) -> String {
     format!("promote:{run_id}")
 }
 
+/// Lease window for a retry-dispatch operation claim. A detached dispatch may
+/// take a while to be accepted by the runner; the lease is generous so a healthy
+/// controller completes it, while a crashed controller's lease still elapses.
+const RETRY_DISPATCH_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Durable operation key for the dispatch of one retry attempt. A retry is
+/// one-per-generated-`run_id`, so the next run id is the stable identity (#8357).
+fn retry_dispatch_operation_key(next_run_id: &str) -> String {
+    format!("dispatch:{next_run_id}")
+}
+
 /// Promote a cook attempt under a durable exactly-once operation claim.
 ///
 /// `promote_or_load_attempt` already loads an already-persisted promotion, but
@@ -939,14 +950,41 @@ where
             baseline.artifact_provenance();
         if let Some(dispatcher) = &options.attempt_dispatcher {
             // A detached dispatcher may return before any executor-side
-            // lifecycle write. Persist the exact materialized plan first so a
-            // continuation resumes this baseline-bound workspace contract.
+            // lifecycle write, so a controller crash after the runner accepts
+            // the retry but before its state advances would re-dispatch on
+            // restart. Bracket the dispatch with a durable operation claim keyed
+            // by the retry run id: a completed claim means the retry is already
+            // dispatched, so a resumed pass continues from it instead of
+            // sending a second handoff (#8357).
+            // Persist the exact materialized plan first so a continuation resumes
+            // this baseline-bound workspace contract, and so the run record the
+            // claim is written onto exists.
             agent_task_lifecycle::submit_plan(&follow_up_plan, Some(&next_run_id))?;
-            dispatcher.dispatch_attempt(
-                follow_up_plan,
+            let operation_key = retry_dispatch_operation_key(&next_run_id);
+            match agent_task_lifecycle::claim_cook_operation(
                 &next_run_id,
-                Some(baseline.capability()),
-            )?;
+                &operation_key,
+                RETRY_DISPATCH_CLAIM_LEASE,
+            )? {
+                agent_task_lifecycle::ClaimOutcome::Acquired => {
+                    dispatcher.dispatch_attempt(
+                        follow_up_plan,
+                        &next_run_id,
+                        Some(baseline.capability()),
+                    )?;
+                    agent_task_lifecycle::complete_cook_operation(
+                        &next_run_id,
+                        &operation_key,
+                        serde_json::json!({ "dispatched_run_id": next_run_id }),
+                    )?;
+                }
+                // The retry was already durably dispatched (completed) or is
+                // owned by a concurrent pass (lease held). Either way, do not
+                // send a second handoff; the persisted plan and run state carry
+                // the existing dispatch forward.
+                agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(_)
+                | agent_task_lifecycle::ClaimOutcome::LeaseHeld => {}
+            }
         } else {
             run_loaded_plan_with_derived_cook_baseline(
                 follow_up_plan,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3550,6 +3550,46 @@ fn promotion_operation_claim_completes_once_and_replays_persisted_result() {
 }
 
 #[test]
+fn retry_dispatch_operation_key_claim_dispatches_once() {
+    // #8357: the detached retry-dispatch path reserves a durable claim keyed by
+    // the retry run id before the handoff and completes it after. A resumed pass
+    // (or a concurrent one) observes the completed claim / held lease and must
+    // not send a second handoff. This exercises that exactly-once contract at the
+    // claim boundary without the full git-backed cook loop.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-dispatch-claim";
+        let next_run_id = "run-dispatch-claim-attempt-2";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(next_run_id)).unwrap();
+
+        let operation_key = retry_dispatch_operation_key(next_run_id);
+        let lease = std::time::Duration::from_secs(60);
+
+        // First pass acquires the claim → performs the (modeled) dispatch → completes.
+        assert_eq!(
+            agent_task_lifecycle::claim_cook_operation(next_run_id, &operation_key, lease).unwrap(),
+            agent_task_lifecycle::ClaimOutcome::Acquired
+        );
+        agent_task_lifecycle::complete_cook_operation(
+            next_run_id,
+            &operation_key,
+            serde_json::json!({ "dispatched_run_id": next_run_id }),
+        )
+        .unwrap();
+
+        // A resumed pass observes AlreadyCompleted and must not re-dispatch.
+        match agent_task_lifecycle::claim_cook_operation(next_run_id, &operation_key, lease)
+            .unwrap()
+        {
+            agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {
+                assert_eq!(result["dispatched_run_id"], next_run_id);
+            }
+            other => panic!("expected AlreadyCompleted, got {other:?}"),
+        }
+    });
+}
+
+#[test]
 fn historical_applied_promotion_restores_only_its_exact_checkpoint_baseline() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let plan = AgentTaskPlan::new("cook-historical-baseline", Vec::new());


### PR DESCRIPTION
## Summary
Slice 4 of the #8357 exactly-once plan. A detached retry dispatch (`dispatch_cook_follow_up`) persists the follow-up plan, hands the attempt to the runner, then links the execution. A controller crash **after the runner accepts the retry but before its state advances** would re-dispatch a second handoff on restart.

Bracket the detached `dispatch_attempt` with the durable operation claim (primitive #9909) keyed by the retry run id (`dispatch:<next_run_id>`):
- Persist the follow-up plan first (so the run record the claim writes onto exists, and a continuation resumes the baseline-bound workspace contract).
- Reserve the claim **before** the handoff; complete it **after**.
- A resumed pass observes `AlreadyCompleted` (or a `LeaseHeld` by a concurrent pass) and continues from the existing dispatch instead of sending a second one.

The in-process (non-detached) path is synchronous and self-recording, so it is unchanged.

## Testing
- `retry_dispatch_operation_key_claim_dispatches_once` (new) — the retry-dispatch key acquires once, completes with the dispatched run id, and replays `AlreadyCompleted` on a resumed pass (deterministic, no git backend).
- `resume_cook_batch_harvests_terminal_children_without_redispatching_the_provider` — passes (no-redispatch behavior through the detached path).
- The full detached-follow-up cook tests (`detached_adoption_follow_up_*`, `adoption_review_allowance_*`) fail **identically on pristine origin/main** in this sandbox with `declared base 'main' was not found on origin` — they require a real git origin, an environment dependency that fails *before* the dispatch claim runs. Verified by reverting cook.rs to origin/main and reproducing. CI runs them against a real remote.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Identifying the accept-then-record retry-dispatch crash window, bracketing the detached handoff with the claim, and deterministic coverage.

Refs #8357, #9181