### PR TITLE
feat(agent-task): wire cook finalization through the operation claim (slice 5)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -65,6 +65,75 @@ fn retry_dispatch_operation_key(next_run_id: &str) -> String {
     format!("dispatch:{next_run_id}")
 }
 
+/// Lease window for a finalization operation claim. PR finalization (commit,
+/// push, `gh pr create`) can take a while; the lease is generous so a healthy
+/// controller completes it, while a crashed controller's lease still elapses.
+const FINALIZATION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Durable operation key for finalizing one cook candidate. Keyed by the run id
+/// plus the promoted candidate fingerprint (patch SHA), so re-finalizing the
+/// same candidate is idempotent while a genuinely different candidate finalizes
+/// on its own claim (#8357).
+fn finalization_operation_key(run_id: &str, promotion: &AgentTaskPromotionReport) -> String {
+    match promotion.patch_artifact.sha256.as_deref() {
+        Some(sha) => format!("finalize:{run_id}:{sha}"),
+        None => format!("finalize:{run_id}"),
+    }
+}
+
+/// Finalize a cook candidate under a durable exactly-once operation claim.
+///
+/// PR finalization performs its external effects (commit, push, `gh pr create`)
+/// and only then records the result. A controller crash after the PR is created
+/// but before the result is durable would open a second PR on restart. The claim
+/// closes it: reserve `finalize:<run_id>:<sha>` before the effect and complete it
+/// with the finalization result after it is durable. A resumed pass replays the
+/// recorded finalization via `AlreadyCompleted` instead of finalizing again
+/// (#8357).
+fn finalize_with_operation_claim(
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    finalize: &mut dyn FnMut(
+        &AgentTaskCookServiceOptions,
+        &str,
+        &AgentTaskPromotionReport,
+    ) -> Result<Value>,
+) -> Result<Value> {
+    let operation_key = finalization_operation_key(run_id, promotion);
+    match agent_task_lifecycle::claim_cook_operation(
+        run_id,
+        &operation_key,
+        FINALIZATION_CLAIM_LEASE,
+    )? {
+        // The candidate was already finalized. Replay the recorded finalization
+        // (`finalize_or_load_cook_pr` also loads the persisted result) rather
+        // than opening a second PR.
+        agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {
+            if result.is_null() {
+                finalize(options, run_id, promotion)
+            } else {
+                Ok(result)
+            }
+        }
+        // A concurrent pass owns a fresh lease. The load-or-finalize path still
+        // returns an already-recorded finalization when present; do not mark the
+        // claim completed from here — its owner does.
+        agent_task_lifecycle::ClaimOutcome::LeaseHeld => finalize(options, run_id, promotion),
+        // This pass owns the operation. Finalize, then record the result as the
+        // claim's immutable completion.
+        agent_task_lifecycle::ClaimOutcome::Acquired => {
+            let finalization = finalize(options, run_id, promotion)?;
+            agent_task_lifecycle::complete_cook_operation(
+                run_id,
+                &operation_key,
+                finalization.clone(),
+            )?;
+            Ok(finalization)
+        }
+    }
+}
+
 /// Promote a cook attempt under a durable exactly-once operation claim.
 ///
 /// `promote_or_load_attempt` already loads an already-persisted promotion, but
@@ -183,7 +252,7 @@ where
         run_id: &str,
         promotion: &AgentTaskPromotionReport,
     ) -> Result<Value> {
-        (self.finalize)(options, run_id, promotion)
+        finalize_with_operation_claim(options, run_id, promotion, &mut self.finalize)
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3590,6 +3590,55 @@ fn retry_dispatch_operation_key_claim_dispatches_once() {
 }
 
 #[test]
+fn finalization_operation_claim_finalizes_once_and_replays_recorded_result() {
+    // #8357: finalization runs its external effects (commit/push/PR) then records
+    // the result. The claim brackets it: the first pass finalizes exactly once and
+    // completes the claim, and a resumed pass replays the recorded finalization
+    // via AlreadyCompleted without opening a second PR. Uses an injected finalize
+    // closure so no real Git/GitHub mutation occurs.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-finalize-claim";
+        let run_id = "run-finalize-claim";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).unwrap();
+
+        let options = promotion_claim_options(cook_id, run_id);
+        let promotion = promotion(run_id);
+        let finalize_calls = Arc::new(AtomicUsize::new(0));
+
+        let calls = Arc::clone(&finalize_calls);
+        let mut finalize =
+            move |_: &AgentTaskCookServiceOptions, rid: &str, _: &AgentTaskPromotionReport| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(serde_json::json!({"status": "review_ready", "run_id": rid}))
+            };
+
+        let first =
+            finalize_with_operation_claim(&options, run_id, &promotion, &mut finalize).unwrap();
+        assert_eq!(first["status"], "review_ready");
+        assert_eq!(finalize_calls.load(Ordering::SeqCst), 1);
+
+        // A resumed pass replays the recorded finalization; the effect closure is
+        // NOT invoked a second time.
+        let replayed =
+            finalize_with_operation_claim(&options, run_id, &promotion, &mut finalize).unwrap();
+        assert_eq!(replayed["status"], "review_ready");
+        assert_eq!(
+            finalize_calls.load(Ordering::SeqCst),
+            1,
+            "a resumed finalization must not re-run the external PR effect"
+        );
+
+        let operation_key = finalization_operation_key(run_id, &promotion);
+        let claim = agent_task_lifecycle::operation_claim(run_id, &operation_key)
+            .unwrap()
+            .expect("finalization claim recorded");
+        assert_eq!(claim.state, agent_task_lifecycle::ClaimState::Completed);
+    });
+}
+
+#[test]
 fn historical_applied_promotion_restores_only_its_exact_checkpoint_baseline() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let plan = AgentTaskPlan::new("cook-historical-baseline", Vec::new());


### PR DESCRIPTION
## Summary
Slice 5 of #8357 — **the duplicate-PR window**. PR finalization performs its external effects (commit, push, `gh pr create`) and only then records the result. A controller crash after the PR is created but before the result is durable opens a **second PR** on restart. The `cook_finalization` load-check only helps once the record is written, not in that gap.

Bracket finalization with the durable operation claim (primitive #9909) at the single `DefaultCookSideEffects::finalize` boundary (#9914):
- Reserve `finalize:<run_id>:<sha>` — keyed by the promoted candidate fingerprint (patch SHA) — **before** the effect.
- Complete it with the finalization result **after** it is durable.
- A resumed pass replays the recorded finalization via `AlreadyCompleted` instead of opening a second PR.
- A still-fresh lease held by another pass falls back to the existing load-or-finalize path without stealing the completion.

**Happy-path behavior is unchanged** — the claim only closes the finalize-then-record crash window. This completes the promote / dispatch / finalize external-effect trio behind the exactly-once claim primitive.

## Testing
- `finalization_operation_claim_finalizes_once_and_replays_recorded_result` (new) — the injected finalize effect runs **exactly once**; a resumed pass replays the recorded result via `AlreadyCompleted` and does **not** re-invoke the PR effect; the claim is `Completed`.
- `moving_base_recovery_refreshes_authenticated_candidate_before_retrying_finalization` — passes (finalize through the boundary, unchanged).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Identifying the finalize-then-record duplicate-PR window, bracketing finalization with a candidate-fingerprint claim at the side-effect boundary, and deterministic coverage.

Refs #8357, #9181