### PR TITLE
test(agent-task): exactly-once cook side-effect acceptance evaluation (slice 6)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3713,6 +3713,63 @@ fn duplicate_controller_passes_produce_one_promotion_and_one_finalization() {
 }
 
 #[test]
+fn concurrent_retry_dispatch_claims_admit_exactly_one_dispatcher() {
+    // #8357 acceptance (AC5): concurrent continuation attempts racing to dispatch
+    // the same retry run must admit exactly one dispatcher; the rest observe a
+    // held lease (or a completed claim) and do not send a second handoff. This
+    // exercises the claim's atomic converge-on-one-owner contract for the
+    // retry-dispatch key across real threads.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-concurrent-dispatch";
+        let next_run_id = "run-concurrent-dispatch-attempt-2";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(next_run_id)).unwrap();
+
+        let operation_key = retry_dispatch_operation_key(next_run_id);
+        let lease = std::time::Duration::from_secs(300);
+        let acquired = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(4));
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let key = operation_key.clone();
+                let run = next_run_id.to_string();
+                let acquired = Arc::clone(&acquired);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    if let agent_task_lifecycle::ClaimOutcome::Acquired =
+                        agent_task_lifecycle::claim_cook_operation(&run, &key, lease).unwrap()
+                    {
+                        acquired.fetch_add(1, Ordering::SeqCst);
+                        // The winning dispatcher records completion after its handoff.
+                        agent_task_lifecycle::complete_cook_operation(
+                            &run,
+                            &key,
+                            serde_json::json!({ "dispatched_run_id": run }),
+                        )
+                        .unwrap();
+                    }
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(
+            acquired.load(Ordering::SeqCst),
+            1,
+            "exactly one concurrent pass may dispatch the retry"
+        );
+        let claim = agent_task_lifecycle::operation_claim(next_run_id, &operation_key)
+            .unwrap()
+            .expect("dispatch claim recorded");
+        assert_eq!(claim.state, agent_task_lifecycle::ClaimState::Completed);
+    });
+}
+
+#[test]
 fn historical_applied_promotion_restores_only_its_exact_checkpoint_baseline() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let plan = AgentTaskPlan::new("cook-historical-baseline", Vec::new());

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3639,6 +3639,80 @@ fn finalization_operation_claim_finalizes_once_and_replays_recorded_result() {
 }
 
 #[test]
+fn duplicate_controller_passes_produce_one_promotion_and_one_finalization() {
+    // #8357 acceptance (AC5 + AC7): duplicate/concurrent controller passes over
+    // the same candidate must produce exactly one promotion checkpoint and one
+    // finalization side effect. Drive the PRODUCTION `DefaultCookSideEffects`
+    // boundary (which routes promote/finalize through the durable operation
+    // claims) with an injected finalize effect, so no real Git/GitHub mutation
+    // occurs. Promotion is seeded as already-applied so `promote` takes its load
+    // path rather than performing a real git promotion.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-acceptance-once";
+        let run_id = "run-acceptance-once";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).unwrap();
+        agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(promotion(run_id)).unwrap(),
+        )
+        .unwrap();
+
+        let options = promotion_claim_options(cook_id, run_id);
+        let finalize_calls = Arc::new(AtomicUsize::new(0));
+
+        // Run three independent controller passes, each with its own production
+        // side-effect boundary, exactly as three restarted/concurrent controllers
+        // would. The injected finalize effect increments a shared counter.
+        let mut finalizations = Vec::new();
+        for _ in 0..3 {
+            let calls = Arc::clone(&finalize_calls);
+            let mut side_effects = DefaultCookSideEffects::new(
+                move |_: &AgentTaskCookServiceOptions, rid: &str, _: &AgentTaskPromotionReport| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(serde_json::json!({"status": "review_ready", "run_id": rid}))
+                },
+            );
+            let promotion = side_effects.promote(&options, run_id).unwrap();
+            let finalization = side_effects.finalize(&options, run_id, &promotion).unwrap();
+            finalizations.push(finalization);
+        }
+
+        // Exactly one finalization side effect across all passes.
+        assert_eq!(
+            finalize_calls.load(Ordering::SeqCst),
+            1,
+            "duplicate controller passes must produce exactly one finalization side effect"
+        );
+        // Every pass observes the same review-ready finalization.
+        for finalization in &finalizations {
+            assert_eq!(finalization["status"], "review_ready");
+        }
+
+        // Exactly one durable promotion checkpoint and one completed finalization
+        // claim survive.
+        let promote_key = format!("promote:{run_id}");
+        let promote_claim = agent_task_lifecycle::operation_claim(run_id, &promote_key)
+            .unwrap()
+            .expect("promotion claim recorded");
+        assert_eq!(
+            promote_claim.state,
+            agent_task_lifecycle::ClaimState::Completed
+        );
+
+        let finalize_key = finalization_operation_key(run_id, &promotion(run_id));
+        let finalize_claim = agent_task_lifecycle::operation_claim(run_id, &finalize_key)
+            .unwrap()
+            .expect("finalization claim recorded");
+        assert_eq!(
+            finalize_claim.state,
+            agent_task_lifecycle::ClaimState::Completed
+        );
+    });
+}
+
+#[test]
 fn historical_applied_promotion_restores_only_its_exact_checkpoint_baseline() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let plan = AgentTaskPlan::new("cook-historical-baseline", Vec::new());


### PR DESCRIPTION
## Summary
Slice 6 (final) of the #8357 exactly-once plan. With promotion (#9918), retry dispatch (#9924), and finalization (#9930) all wired through the durable operation claim, this adds **service-level acceptance tests** proving the guarantees hold *together* — driving the **production** `DefaultCookSideEffects` boundary with injected side effects (no real Git/GitHub).

## Acceptance criteria covered
- **AC5** (one retry dispatch, one promotion per report, one finalization side effect) and **AC7** (deterministic, injected side effects):
  - `duplicate_controller_passes_produce_one_promotion_and_one_finalization` — three independent production side-effect boundaries over the same candidate produce **exactly one** finalization side effect; one completed promotion claim and one completed finalization claim survive; every pass observes the same review-ready result.
  - `concurrent_retry_dispatch_claims_admit_exactly_one_dispatcher` — four **real threads** race to claim the same retry-dispatch key; **exactly one** acquires/dispatches while the rest observe a held/completed claim, proving the claim converges on one owner under genuine concurrency.

The remaining ACs (1–4 reconciled-continuation lifecycle, 6 restart-at-checkpoint) were substantially covered before this work by the existing moving-base / detached-continuation / reconciliation suites; the slices 1–5 claim primitive + per-effect wiring (each with its own deterministic test) are what make AC5 hold. This slice demonstrates them cohesively through the production boundary.

## Testing
- `duplicate_controller_passes_produce_one_promotion_and_one_finalization` — passes.
- `concurrent_retry_dispatch_claims_admit_exactly_one_dispatcher` — passes (4-thread race).
- `cargo check -p homeboy-agents --lib --tests` — clean.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Designing service-level acceptance tests that exercise the production claim brackets with injected effects, including a real-thread concurrency race for the one-owner guarantee.

Closes #8357
Refs #9181