### PR TITLE
feat(agent-task): surface local cook provider execution in logs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1360,7 +1360,13 @@ pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRu
             let refs = artifact_refs_for_outcomes(&aggregate.outcomes);
             (aggregate.events, refs)
         }
-        Err(_) => (queued_events(&record.tasks), record.artifact_refs.clone()),
+        Err(_) => {
+            // Surface a local cook's durable running provider execution so the
+            // live bridge status advances past "task submitted" too (#8396).
+            let mut events = queued_events(&record.tasks);
+            events.extend(local_provider_execution_events(&record));
+            (events, record.artifact_refs.clone())
+        }
     };
     let normalized_events = normalize_progress_events(&record.run_id, &events, &artifact_refs);
     let latest_event_cursor = normalized_events
@@ -2390,11 +2396,16 @@ pub fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog>
         }
         Err(_) => {
             let raw_events = runner_job_raw_events(&record);
-            (
-                runner_job_progress_events(&record).unwrap_or_else(|| queued_events(&record.tasks)),
-                record.artifact_refs.clone(),
-                raw_events,
-            )
+            // Before any aggregate exists, a local (in-process) cook that is
+            // actively running the provider otherwise shows only "task submitted".
+            // Surface the durable running provider execution so `agent-task logs`
+            // distinguishes active provider execution from a hung preflight (#8396).
+            let progress = runner_job_progress_events(&record).unwrap_or_else(|| {
+                let mut events = queued_events(&record.tasks);
+                events.extend(local_provider_execution_events(&record));
+                events
+            });
+            (progress, record.artifact_refs.clone(), raw_events)
         }
     };
     let events = if raw_events.is_empty() {
@@ -2408,6 +2419,56 @@ pub fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog>
         events,
         raw_events: include_raw.then_some(raw_events).unwrap_or_default(),
     })
+}
+
+/// Synthesize progress events from the durable running provider executions of a
+/// local (in-process) cook. `reserve_provider_execution` records each attempt
+/// (backend, model, started_at, `state:"running"`) before the scheduler blocks
+/// on the backend, but until an aggregate exists `agent-task logs` shows only
+/// "task submitted". Surface the running executions so logs reflect active
+/// provider work rather than a stalled preflight (#8396).
+fn local_provider_execution_events(record: &AgentTaskRunRecord) -> Vec<AgentTaskProgressEvent> {
+    let Some(executions) = record
+        .metadata
+        .get("provider_executions")
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+    executions
+        .iter()
+        .filter(|execution| execution.get("state").and_then(Value::as_str) == Some("running"))
+        .map(|execution| {
+            let task_id = execution
+                .get("task_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| record.tasks.first().map(|task| task.task_id.clone()))
+                .unwrap_or_else(|| record.run_id.clone());
+            let backend = execution
+                .get("backend")
+                .and_then(Value::as_str)
+                .unwrap_or("provider");
+            let mut message = format!("provider execution running: {backend}");
+            if let Some(model) = execution.get("model").and_then(Value::as_str) {
+                if !model.is_empty() {
+                    message.push_str(&format!(" ({model})"));
+                }
+            }
+            if let Some(started_at) = execution.get("started_at").and_then(Value::as_str) {
+                message.push_str(&format!("; started {started_at}"));
+            }
+            AgentTaskProgressEvent {
+                task_id,
+                state: AgentTaskState::Running,
+                attempt: execution
+                    .get("attempt")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(1) as u32,
+                message: Some(message),
+            }
+        })
+        .collect()
 }
 
 fn runner_job_progress_events(record: &AgentTaskRunRecord) -> Option<Vec<AgentTaskProgressEvent>> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -119,6 +119,44 @@ fn legacy_v1_pin_migration_failures_leave_durable_record_unchanged() {
     });
 }
 
+#[test]
+fn local_cook_logs_surface_running_provider_execution_before_aggregate() {
+    // #8396: while a local cook runs the provider (no aggregate yet), logs must
+    // advance past "task submitted" to reflect the durable running provider
+    // execution, so operators can tell active execution from a hung preflight.
+    with_isolated_home(|_| {
+        let run_id = "local-cook-running";
+        submit_plan(&test_plan(), Some(run_id)).expect("submitted");
+        rewrite_record_for_test(run_id, |record| {
+            record.metadata["provider_executions"] = serde_json::json!([{
+                "key": "task:1",
+                "task_id": "task",
+                "attempt": 1,
+                "backend": "opencode",
+                "model": "openai/gpt-5.6-sol",
+                "state": "running",
+                "started_at": "2026-07-24T00:00:00Z"
+            }]);
+        })
+        .expect("running provider execution recorded");
+
+        let log = logs(run_id).expect("logs resolve for a running local cook");
+        let messages: Vec<&str> = log
+            .events
+            .iter()
+            .filter_map(|event| event.message.as_deref())
+            .collect();
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("provider execution running")
+                    && message.contains("opencode")
+                    && message.contains("openai/gpt-5.6-sol")),
+            "logs must surface the running provider execution, got: {messages:?}"
+        );
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn submit_plan_persists_owner_only_plan_file_before_observation() {


### PR DESCRIPTION
## Summary
Completes the remaining #8396 gap. My earlier PR #9884 surfaced in-flight provider execution in `status --full`'s provider boundary and advanced the heartbeat, but **`agent-task logs` (and the bridge `run_status`) still showed only "task submitted"** while a local (in-process) cook was actively running the provider — the exact indistinguishable-from-hung-preflight symptom the issue names.

## Change
`reserve_provider_execution` already records each running attempt durably (backend, model, started_at, `state:"running"`). This synthesizes progress events from those running `provider_executions` entries in the **no-aggregate fallback** of both `logs` and `run_status`, so logs advance to:

```
provider execution running: opencode (openai/gpt-5.6-sol); started 2026-07-24T00:00:00Z
```

while the provider is active. Runner-backed runs are unaffected (they take the `runner_job_events` path).

## Acceptance criteria (#8396)
- [x] Record provider execution start before blocking (existing `reserve_provider_execution`).
- [x] Expose backend, handle, start time, advancing liveness while active (status boundary via #9884).
- [x] **Emit bounded progress/heartbeat events so `status`, `logs`, and `activity` distinguish provider execution from preflight** — logs now reflect the running execution (this PR).
- [x] Deterministically cover the running projection for local CLI backends.

## Testing
- `local_cook_logs_surface_running_provider_execution_before_aggregate` (new) — a local cook with a durable running `provider_executions` entry and no aggregate surfaces the "provider execution running: opencode (openai/gpt-5.6-sol)" event via `agent-task logs`.
- `cargo check -p homeboy-agents --lib --tests` — clean.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the no-aggregate logs fallback, synthesizing progress events from the durable running provider executions, and coverage.

Closes #8396
Refs #9181