### PR TITLE
Read top-level validation_dependencies from the manifest (#9926)

### DIFF
--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -312,17 +312,25 @@ pub fn validation_dependency_ids(local_path: &Path) -> Result<Vec<String>> {
     })?;
 
     let mut ids = Vec::new();
-    let Some(extensions) = manifest
+
+    // A top-level `validation_dependencies` key is the component-scoped
+    // declaration (as reported by `component show`); it must be forwarded into
+    // the recipe just like the `--setting-json` override, otherwise a `--path`
+    // review that changes only the checkout location silently drops the
+    // dependency (#9926). `collect_validation_dependency_ids` looks up the key
+    // on the object it is given, so pass the manifest root.
+    collect_validation_dependency_ids(&manifest, &mut ids);
+
+    // Per-extension declarations, at the extension level or under its settings.
+    if let Some(extensions) = manifest
         .get("extensions")
         .and_then(|value| value.as_object())
-    else {
-        return Ok(ids);
-    };
-
-    for extension in extensions.values() {
-        collect_validation_dependency_ids(extension, &mut ids);
-        if let Some(settings) = extension.get("settings") {
-            collect_validation_dependency_ids(settings, &mut ids);
+    {
+        for extension in extensions.values() {
+            collect_validation_dependency_ids(extension, &mut ids);
+            if let Some(settings) = extension.get("settings") {
+                collect_validation_dependency_ids(settings, &mut ids);
+            }
         }
     }
 
@@ -1136,5 +1144,63 @@ mod tests {
             ".homeboy/dependency-lifecycle/dependency-output-generated-report-json.json"
         ));
         assert!(Path::new(artifact).exists());
+    }
+
+    fn write_manifest(dir: &Path, contents: &str) {
+        fs::write(dir.join(PORTABLE_CONFIG_FILE), contents).expect("write manifest");
+    }
+
+    #[test]
+    fn validation_dependency_ids_reads_top_level_declaration() {
+        // #9926: a component-scoped top-level `validation_dependencies` must be
+        // collected (previously only extension-nested keys were read, so a
+        // `--path` review dropped the dependency).
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            r#"{"validation_dependencies": ["data-machine-events"]}"#,
+        );
+        let ids = validation_dependency_ids(dir.path()).expect("ids");
+        assert_eq!(ids, vec!["data-machine-events".to_string()]);
+    }
+
+    #[test]
+    fn validation_dependency_ids_reads_extension_nested_declaration() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            r#"{"extensions": {"wp": {"settings": {"validation_dependencies": ["shared-runtime"]}}}}"#,
+        );
+        let ids = validation_dependency_ids(dir.path()).expect("ids");
+        assert_eq!(ids, vec!["shared-runtime".to_string()]);
+    }
+
+    #[test]
+    fn validation_dependency_ids_merges_and_dedupes_top_level_and_nested() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            r#"{
+                "validation_dependencies": ["data-machine-events", "shared-runtime"],
+                "extensions": {"wp": {"validation_dependencies": ["shared-runtime"]}}
+            }"#,
+        );
+        let ids = validation_dependency_ids(dir.path()).expect("ids");
+        assert_eq!(
+            ids,
+            vec![
+                "data-machine-events".to_string(),
+                "shared-runtime".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn validation_dependency_ids_empty_without_declarations() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), r#"{"id": "some-component"}"#);
+        assert!(validation_dependency_ids(dir.path())
+            .expect("ids")
+            .is_empty());
     }
 }


### PR DESCRIPTION
Fixes #9926.

## Problem
`homeboy review test <component> --path <worktree> --placement local` did not forward the component's resolved `validation_dependencies` into the extension runner. The worktree's `homeboy.json` declares:

```json
"validation_dependencies": ["data-machine-events"]
```

`component show` reports the dependency correctly, but the generated recipe contained only the component under test (empty `extra_plugins`, a single `dependency-mount`), and the test failed:

```
Class "DataMachineEvents\Core\EventDatesTable" not found
```

Passing the same dependency as an explicit **absolute** `--setting-json validation_dependencies='["/abs/path"]'` succeeded.

## Root cause
`validation_dependency_ids()` (the manifest/source reader used by `dependency_checkouts_for_source`) only collected `validation_dependencies` nested under `extensions.*` (and their `settings`) — never a component-scoped **top-level** `validation_dependencies` key. Worse, it early-returned when there was no `extensions` object at all. The `--setting-json` override worked only because it flows through the separate `dependency_checkouts_for_settings` path.

## Fix
- Also collect the **top-level** `validation_dependencies` (via the same `collect_validation_dependency_ids` on the manifest root).
- No longer early-return when there is no `extensions` object; process both sources, then sort + dedup so top-level and nested declarations merge cleanly.

## Acceptance criteria coverage
- ✅ Resolved component settings are forwarded when `--path` changes only the checkout location (the top-level declaration is now read)
- ✅ Component-ID dependencies resolve without an absolute-path override
- ◻️ The deeper `--setting-json` component-ID registry-lookup arm noted in the issue is a separate settings-resolution concern; this PR fixes the top-level manifest declaration, the primary reported gap

## Tests
Top-level only, extension-nested only, merged + deduped, and empty (no declarations) manifests.

## Verification
- `cargo fmt -p homeboy-core --check` clean
- `cargo check -p homeboy-core --lib --tests` exit 0
- Full test run deferred to CI per this VPS's no-heavy-local-build rule

Diff: +75/-9, 1 file.