### PR TITLE
fix(lab): allow bounded process budget requests

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -300,6 +300,12 @@ pub struct RunnerResourceMetrics {
 pub struct RunnerResourceGuardLimits {
     pub rss_limit_bytes: u64,
     pub process_count_limit: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_count_limit_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_process_count_limit: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_count_limit_ceiling: Option<u64>,
     pub concurrency: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_capacity_bytes: Option<u64>,

--- a/crates/homeboy-lab-runner/src/execution/failure.rs
+++ b/crates/homeboy-lab-runner/src/execution/failure.rs
@@ -65,7 +65,7 @@ pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
     }
     if let Some(message) = runner_resource_guard_message(output) {
         error = error.with_hint(format!(
-            "Runner resource guard stopped the job before it could destabilize the runner daemon: {message}. Override only for trusted workloads with HOMEBOY_RUNNER_RESOURCE_GUARD_RSS_BYTES or HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT."
+            "Runner resource guard stopped the job before it could destabilize the runner daemon: {message}. Trusted jobs may request a bounded process budget with HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT; the runner-owned HOMEBOY_RUNNER_RESOURCE_GUARD_MAX_PROCESS_COUNT ceiling still applies. RSS policy remains runner-owned through HOMEBOY_RUNNER_RESOURCE_GUARD_RSS_BYTES."
         ));
     }
 

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -702,6 +702,9 @@ pub(crate) struct PreparedRunnerProcess {
     pub cwd: String,
     pub command: Vec<String>,
     pub env: HashMap<String, String>,
+    /// Public environment supplied by the authenticated execution request,
+    /// before runner-owned environment and secrets are merged.
+    pub resource_guard_env: HashMap<String, String>,
     pub secret_env_names: Vec<String>,
     pub source_snapshot: SourceSnapshot,
     pub require_paths: Vec<String>,

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -300,6 +300,7 @@ pub(crate) fn prepare_runner_process(
         cwd,
         command: request.command,
         env,
+        resource_guard_env: request_env,
         secret_env_names: secret_env_plan.secret_env_names(),
         source_snapshot,
         require_paths: request.require_paths,
@@ -418,6 +419,7 @@ pub(crate) fn prepare_daemon_local_process(
         cwd,
         command: request.command,
         env,
+        resource_guard_env: request_env,
         secret_env_names: secret_env_plan.secret_env_names(),
         source_snapshot,
         require_paths: request.require_paths,
@@ -429,7 +431,11 @@ pub(crate) fn execute_runner_process(plan: &PreparedRunnerProcess) -> Result<Pro
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
     apply_runner_process_env(&mut command, plan)?;
 
-    command_output(&mut command, plan.runner.settings.concurrency_limit)
+    command_output(
+        &mut command,
+        &plan.resource_guard_env,
+        plan.runner.settings.concurrency_limit,
+    )
 }
 
 pub(crate) fn execute_runner_process_until_cancelled_with_progress(
@@ -450,6 +456,7 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
         require_child_identity_acknowledgement,
         child_started,
         &plan.env,
+        &plan.resource_guard_env,
         &plan.secret_env_names,
         plan.runner.settings.concurrency_limit,
     )
@@ -1024,9 +1031,10 @@ pub(super) fn inherited_runner_process_env_keys() -> &'static [&'static str] {
 
 pub(super) fn command_output(
     command: &mut std::process::Command,
+    env: &HashMap<String, String>,
     concurrency_limit: Option<usize>,
 ) -> Result<ProcessOutput> {
-    let measured = measured_command_output(command, concurrency_limit)?;
+    let measured = measured_command_output(command, env, concurrency_limit)?;
     let output = measured.output;
     Ok(ProcessOutput {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
@@ -1044,6 +1052,7 @@ pub(super) fn command_output_until_cancelled_with_progress(
     require_child_identity_acknowledgement: bool,
     child_started: Option<Arc<dyn Fn(u32) -> Result<()> + Send + Sync + 'static>>,
     env: &HashMap<String, String>,
+    resource_guard_env: &HashMap<String, String>,
     secret_env_names: &[String],
     concurrency_limit: Option<usize>,
 ) -> Result<ProcessOutput> {
@@ -1066,6 +1075,7 @@ pub(super) fn command_output_until_cancelled_with_progress(
         require_child_identity_acknowledgement,
         stdout_line_observer,
         child_started,
+        resource_guard_env,
         concurrency_limit,
     )?;
     let output = measured.output;

--- a/crates/homeboy-lab-runner/src/execution/tests/prepare.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/prepare.rs
@@ -312,6 +312,58 @@ fn daemon_worker_marks_nested_cook_as_runner_hosted() {
 }
 
 #[test]
+fn daemon_prep_keeps_resource_guard_request_separate_from_runner_env() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("project");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let mut runner = local_runner(workspace.display().to_string());
+        runner.env.insert(
+            "HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT".to_string(),
+            "160".to_string(),
+        );
+        runner
+            .env
+            .insert("RUNNER_ONLY".to_string(), "1".to_string());
+
+        let plan = prepare_daemon_local_process(RunnerProcessRequest {
+            runner_id: "homeboy-lab".to_string(),
+            runner: Some(runner),
+            cwd: Some(workspace.display().to_string()),
+            project_id: None,
+            command: vec!["true".to_string()],
+            env: HashMap::from([(
+                "HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT".to_string(),
+                "200".to_string(),
+            )]),
+            secret_env_names: Vec::new(),
+            secret_env_plan: None,
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            require_paths: Vec::new(),
+            validate_require_paths_on_host: true,
+        })
+        .expect("prepare daemon worker process");
+
+        assert_eq!(
+            plan.env
+                .get("HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT")
+                .map(String::as_str),
+            Some("200")
+        );
+        assert_eq!(
+            plan.resource_guard_env
+                .get("HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT")
+                .map(String::as_str),
+            Some("200")
+        );
+        assert_eq!(plan.resource_guard_env.len(), 1);
+        assert!(!plan.resource_guard_env.contains_key("RUNNER_ONLY"));
+    });
+}
+
+#[test]
 fn runner_prep_drops_undeclared_sensitive_env() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::process::{Command, Output, Stdio};
 use std::sync::{mpsc, Arc, Mutex};
@@ -24,12 +25,16 @@ const FALLBACK_RSS_LIMIT_BYTES: u64 = 16 * 1024 * 1024 * 1024;
 const PREFERRED_HOST_HEADROOM_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 #[cfg(any(target_os = "linux", test))]
 const HOST_HEADROOM_DIVISOR: u64 = 10;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 const DEFAULT_PROCESS_COUNT_LIMIT: u64 = 128;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 const RSS_LIMIT_ENV: &str = "HOMEBOY_RUNNER_RESOURCE_GUARD_RSS_BYTES";
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 const PROCESS_COUNT_LIMIT_ENV: &str = "HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT";
+#[cfg(any(target_os = "linux", test))]
+const DEFAULT_PROCESS_COUNT_LIMIT_CEILING: u64 = 256;
+#[cfg(any(target_os = "linux", test))]
+const PROCESS_COUNT_LIMIT_CEILING_ENV: &str = "HOMEBOY_RUNNER_RESOURCE_GUARD_MAX_PROCESS_COUNT";
 
 fn require_process_tree_isolation() -> Result<()> {
     if supports_process_tree_isolation() {
@@ -75,6 +80,7 @@ struct MetricsState {
 
 pub(crate) fn measured_command_output(
     command: &mut Command,
+    resource_guard_env: &HashMap<String, String>,
     concurrency_limit: Option<usize>,
 ) -> Result<MeasuredOutput> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -83,7 +89,14 @@ pub(crate) fn measured_command_output(
         .spawn()
         .map_err(|error| runner_command_spawn_error(command, &error))?;
     let pid = child.id();
-    let collector = ResourceMetricsCollector::start(pid, started, None, None, concurrency_limit);
+    let collector = ResourceMetricsCollector::start(
+        pid,
+        started,
+        None,
+        None,
+        resource_guard_env,
+        concurrency_limit,
+    );
     let bounded_output =
         wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).map_err(|err| {
             Error::internal_io(err.to_string(), Some("wait for runner command".to_string()))
@@ -105,6 +118,7 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
     require_child_identity_acknowledgement: bool,
     stdout_line_observer: Option<StdoutLineObserver>,
     child_started: Option<Arc<dyn Fn(u32) -> Result<()> + Send + Sync + 'static>>,
+    resource_guard_env: &HashMap<String, String>,
     concurrency_limit: Option<usize>,
 ) -> Result<MeasuredOutput> {
     if require_child_identity_acknowledgement {
@@ -167,6 +181,7 @@ pub(crate) fn measured_command_output_until_cancelled_with_progress(
         started,
         progress_sink,
         Some(Arc::clone(&guard_violation)),
+        resource_guard_env,
         concurrency_limit,
     );
     let bounded_output = wait_with_bounded_output_until_cancelled_with_stdout_observer(
@@ -301,10 +316,11 @@ impl ResourceMetricsCollector {
         started: Instant,
         progress_sink: Option<RunnerCommandProgressSink>,
         guard_violation: Option<Arc<Mutex<Option<RunnerResourceGuardViolation>>>>,
+        resource_guard_env: &HashMap<String, String>,
         concurrency_limit: Option<usize>,
     ) -> Self {
         let supported = cfg!(target_os = "linux") && std::path::Path::new("/proc").exists();
-        let guard_limits = resolved_resource_guard_limits(concurrency_limit);
+        let guard_limits = resolved_resource_guard_limits(resource_guard_env, concurrency_limit);
         let state = Arc::new(Mutex::new(MetricsState::default()));
         if !supported && progress_sink.is_none() {
             return Self {
@@ -558,6 +574,7 @@ fn resource_guard_violation(
 
 #[cfg(target_os = "linux")]
 fn resolved_resource_guard_limits(
+    resource_guard_env: &HashMap<String, String>,
     concurrency_limit: Option<usize>,
 ) -> Option<RunnerResourceGuardLimits> {
     let concurrency = u64::try_from(concurrency_limit.unwrap_or(1).max(1)).unwrap_or(u64::MAX);
@@ -567,12 +584,13 @@ fn resolved_resource_guard_limits(
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok());
     let rss_limit = resolved_rss_limit(memory_capacity_bytes, explicit_rss_limit);
+    let process_count = resolved_process_count_limit(resource_guard_env);
     Some(RunnerResourceGuardLimits {
         rss_limit_bytes: rss_limit.rss_limit_bytes,
-        process_count_limit: resource_guard_limit(
-            PROCESS_COUNT_LIMIT_ENV,
-            DEFAULT_PROCESS_COUNT_LIMIT,
-        ),
+        process_count_limit: process_count.limit,
+        process_count_limit_source: Some(process_count.source),
+        requested_process_count_limit: process_count.requested,
+        process_count_limit_ceiling: Some(process_count.ceiling),
         concurrency,
         memory_capacity_bytes,
         host_headroom_bytes: rss_limit.host_headroom_bytes,
@@ -681,9 +699,65 @@ fn update_active_runner_rss(root_pid: u32, rss_bytes: u64) -> ActiveRunnerRss {
 
 #[cfg(not(target_os = "linux"))]
 fn resolved_resource_guard_limits(
+    _resource_guard_env: &HashMap<String, String>,
     _concurrency_limit: Option<usize>,
 ) -> Option<RunnerResourceGuardLimits> {
     None
+}
+
+#[cfg(any(target_os = "linux", test))]
+struct ResolvedProcessCountLimit {
+    limit: u64,
+    requested: Option<u64>,
+    ceiling: u64,
+    source: String,
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn resolved_process_count_limit(
+    resource_guard_env: &HashMap<String, String>,
+) -> ResolvedProcessCountLimit {
+    let runner_default_override = std::env::var(PROCESS_COUNT_LIMIT_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok());
+    let runner_default = runner_default_override.unwrap_or(DEFAULT_PROCESS_COUNT_LIMIT);
+    let ceiling = resource_guard_limit(
+        PROCESS_COUNT_LIMIT_CEILING_ENV,
+        DEFAULT_PROCESS_COUNT_LIMIT_CEILING,
+    );
+    let requested = resource_guard_env
+        .get(PROCESS_COUNT_LIMIT_ENV)
+        .and_then(|value| value.trim().parse::<u64>().ok());
+    resolve_process_count_limit(
+        runner_default,
+        ceiling,
+        requested,
+        runner_default_override.is_some(),
+    )
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn resolve_process_count_limit(
+    runner_default: u64,
+    ceiling: u64,
+    requested: Option<u64>,
+    runner_default_is_override: bool,
+) -> ResolvedProcessCountLimit {
+    let (limit, source) = match requested {
+        Some(0) if runner_default_is_override => (runner_default, "runner_override"),
+        Some(0) => (runner_default, "job_override_rejected"),
+        Some(_) if ceiling == 0 => (runner_default, "job_override_rejected"),
+        Some(requested) if requested > ceiling => (ceiling, "job_override_capped"),
+        Some(requested) => (requested, "job_override"),
+        None if runner_default_is_override => (runner_default, "runner_override"),
+        None => (runner_default, "default"),
+    };
+    ResolvedProcessCountLimit {
+        limit,
+        requested,
+        ceiling,
+        source: source.to_string(),
+    }
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -712,7 +786,7 @@ fn classify_resource_guard_violation(
     })
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 fn resource_guard_limit(env_name: &str, default_value: u64) -> u64 {
     std::env::var(env_name)
         .ok()
@@ -860,6 +934,7 @@ mod tests {
                 callback_pid.store(child_pid, Ordering::SeqCst);
                 Err(Error::internal_unexpected("persist child identity"))
             })),
+            &HashMap::new(),
             None,
         )
         .expect_err("callback failure returns");
@@ -907,6 +982,7 @@ mod tests {
             true,
             None,
             None,
+            &HashMap::new(),
             None,
         )
         .expect("command completes");
@@ -931,6 +1007,7 @@ mod tests {
             true,
             None,
             None,
+            &HashMap::new(),
             None,
         )
         .expect_err("unsupported platforms must fail before spawning a child");
@@ -972,6 +1049,7 @@ mod tests {
             true,
             None,
             None,
+            &HashMap::new(),
             None,
         )
         .expect_err("initial identity persistence failure must fail execution");
@@ -1013,7 +1091,7 @@ mod tests {
         let mut command = Command::new("sh");
         command.args(["-c", "exit 0"]);
 
-        let output = measured_command_output(&mut command, None)
+        let output = measured_command_output(&mut command, &HashMap::new(), None)
             .expect("ordinary measured command execution remains available");
 
         assert!(output.output.status.success());
@@ -1068,6 +1146,9 @@ mod tests {
         let limits = RunnerResourceGuardLimits {
             rss_limit_bytes: resolved.rss_limit_bytes,
             process_count_limit: 128,
+            process_count_limit_source: Some("default".to_string()),
+            requested_process_count_limit: None,
+            process_count_limit_ceiling: Some(256),
             concurrency: 8,
             memory_capacity_bytes: Some(96 * 1024 * 1024 * 1024),
             host_headroom_bytes: resolved.host_headroom_bytes,
@@ -1116,6 +1197,46 @@ mod tests {
         assert_eq!(limits.rss_limit_bytes, 7 * 1024 * 1024 * 1024);
         assert_eq!(limits.source, "explicit_override");
         assert_eq!(limits.aggregate_rss_budget_bytes, None);
+    }
+
+    #[test]
+    fn trusted_job_process_count_override_is_bounded_by_runner_ceiling() {
+        let accepted = resolve_process_count_limit(128, 256, Some(200), false);
+        assert_eq!(accepted.limit, 200);
+        assert_eq!(accepted.requested, Some(200));
+        assert_eq!(accepted.ceiling, 256);
+        assert_eq!(accepted.source, "job_override");
+
+        let capped = resolve_process_count_limit(128, 256, Some(512), false);
+        assert_eq!(capped.limit, 256);
+        assert_eq!(capped.requested, Some(512));
+        assert_eq!(capped.source, "job_override_capped");
+    }
+
+    #[test]
+    fn job_cannot_disable_runner_process_guard() {
+        let resolved = resolve_process_count_limit(128, 256, Some(0), false);
+        assert_eq!(resolved.limit, 128);
+        assert_eq!(resolved.source, "job_override_rejected");
+
+        let runner_disabled = resolve_process_count_limit(0, 256, Some(0), true);
+        assert_eq!(runner_disabled.limit, 0);
+        assert_eq!(runner_disabled.source, "runner_override");
+
+        let disabled_ceiling = resolve_process_count_limit(128, 0, Some(200), false);
+        assert_eq!(disabled_ceiling.limit, 128);
+        assert_eq!(disabled_ceiling.source, "job_override_rejected");
+    }
+
+    #[test]
+    fn job_ceiling_does_not_inherit_a_larger_runner_default() {
+        let runner_default = resolve_process_count_limit(512, 256, None, true);
+        assert_eq!(runner_default.limit, 512);
+        assert_eq!(runner_default.source, "runner_override");
+
+        let requested = resolve_process_count_limit(512, 256, Some(512), true);
+        assert_eq!(requested.limit, 256);
+        assert_eq!(requested.source, "job_override_capped");
     }
 }
 

--- a/crates/homeboy-lab-runner/src/worker/tests/result_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/result_tests.rs
@@ -211,6 +211,9 @@ fn reverse_worker_result_surfaces_resource_guard_violation() {
                 resource_guard: Some(RunnerResourceGuardLimits {
                     rss_limit_bytes: 23 * 1024 * 1024 * 1024,
                     process_count_limit: 128,
+                    process_count_limit_source: Some("default".to_string()),
+                    requested_process_count_limit: None,
+                    process_count_limit_ceiling: Some(256),
                     concurrency: 4,
                     memory_capacity_bytes: Some(96 * 1024 * 1024 * 1024),
                     host_headroom_bytes: Some((96 * 1024 * 1024 * 1024) / 10),
@@ -289,6 +292,13 @@ fn reverse_worker_result_surfaces_resource_guard_violation() {
     assert_eq!(guard.active_rss_bytes, Some(64 * 1024 * 1024 * 1024));
     assert_eq!(guard.aggregate_rss_bytes, Some(87 * 1024 * 1024 * 1024));
     assert_eq!(guard.rss_limit_bytes, 23 * 1024 * 1024 * 1024);
+    assert_eq!(guard.process_count_limit_source.as_deref(), Some("default"));
+    assert_eq!(guard.requested_process_count_limit, None);
+    assert_eq!(guard.process_count_limit_ceiling, Some(256));
+    let guard_json = serde_json::to_value(guard).expect("serialize resource guard evidence");
+    assert_eq!(guard_json["process_count_limit_source"], "default");
+    assert!(guard_json.get("requested_process_count_limit").is_none());
+    assert_eq!(guard_json["process_count_limit_ceiling"], 256);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- keep the Lab process guard default at 128 while allowing authenticated job requests to select a higher process budget
- cap job requests with the runner-owned `HOMEBOY_RUNNER_RESOURCE_GUARD_MAX_PROCESS_COUNT` policy, defaulting to 256
- preserve request provenance separately from merged runner environment and secrets, and serialize the effective decision for diagnostics

## Verification
- `cargo test -p homeboy-lab-runner resource_guard -- --test-threads=1`
- `cargo test -p homeboy-lab-runner process_count -- --test-threads=1`
- `cargo test -p homeboy-lab-runner job_cannot_disable_runner_process_guard -- --test-threads=1`
- `cargo test -p homeboy-lab-runner-contract`
- `git diff --check origin/main...HEAD`

The complete serial Lab runner suite compiled and ran 1,355 tests: 1,329 passed, 6 ignored, and 20 existing runner-configuration/provenance tests failed outside the changed guard paths.

Closes #9938.

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode implemented the bounded process-budget resolver, provenance separation, serialization evidence, and focused tests. Chris Huber reviewed and remains responsible for the change.