### PR TITLE
fix(lab): preflight selected provider readiness

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -593,7 +593,7 @@ pub(crate) fn exec_lab_context(
             &context.source_path,
             &context.remapped_args,
             env.clone(),
-            source_snapshot.clone(),
+            Some(source_snapshot.clone()),
             contract.required_extensions.clone(),
             context.capability_preflight.clone(),
             &provider.runner_homeboy,
@@ -1336,6 +1336,24 @@ pub(crate) fn run_lab_offload_inner(
         redact_argv_shell_display(&command_prefix.argv),
         runner_id,
     );
+    // Validate the selected provider on the runner before any workspace, runtime,
+    // or overlay materialization. This invokes the provider's portable readiness
+    // contract without spawning the provider process or reserving a Lab slot.
+    let mut provider_admission_env = crate::effective_env(runner_id)?;
+    provider_admission_env.extend(request.job_overrides.env.clone());
+    preflight_agent_task_provider_on_runner(
+        runner_id,
+        &command_prefix.argv,
+        &runner_workspace_root,
+        &source_path,
+        request.normalized_args,
+        provider_admission_env,
+        None,
+        Vec::new(),
+        None,
+        &runner_homeboy,
+        &runner_status,
+    )?;
     let capability_contract =
         lab_runner_capability_contract(&contract, &source_path, &command_prefix.required_tools);
     let capability_plan = capability_contract

--- a/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
+++ b/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
@@ -39,7 +39,7 @@ pub(super) fn preflight_agent_task_provider_on_runner(
     source_path: &Path,
     args: &[String],
     env: std::collections::HashMap<String, String>,
-    source_snapshot: SourceSnapshot,
+    source_snapshot: Option<SourceSnapshot>,
     required_extensions: Vec<String>,
     capability_preflight: Option<RunnerCapabilityPreflight>,
     runner_homeboy: &serde_json::Value,
@@ -67,13 +67,15 @@ pub(super) fn preflight_agent_task_provider_on_runner(
     // runner command prefix, not forwarded caller args — but assert the same
     // path-translation contract the offload dispatch site enforces so no
     // controller-local path can ever ride this preflight to the remote runner.
-    preflight_remote_argv_path_translation(
-        "Lab agent-task provider preflight",
-        runner_id,
-        &command,
-        source_path,
-        remote_cwd,
-    )?;
+    if source_snapshot.is_some() {
+        preflight_remote_argv_path_translation(
+            "Lab agent-task provider preflight",
+            runner_id,
+            &command,
+            source_path,
+            remote_cwd,
+        )?;
+    }
     let probe = probe_agent_task_providers_on_runner(
         runner_id,
         remote_cwd,
@@ -320,27 +322,50 @@ fn probe_agent_task_providers_on_runner(
     remote_cwd: &str,
     command: &[String],
     env: std::collections::HashMap<String, String>,
-    source_snapshot: SourceSnapshot,
+    source_snapshot: Option<SourceSnapshot>,
     required_extensions: Vec<String>,
     capability_preflight: Option<RunnerCapabilityPreflight>,
     status_snapshot: RunnerStatusReport,
 ) -> Result<AgentTaskProviderProbeOutput> {
-    let (output, exit_code) = exec_with_status_snapshot(
-        runner_id,
-        RunnerExecOptions::command(command.to_vec())
-            .with_cwd(remote_cwd)
-            .with_env(env)
-            .with_source_snapshot(source_snapshot)
-            .with_required_extensions(required_extensions)
-            .with_optional_capability_preflight(capability_preflight),
-        Some(status_snapshot),
-    )?;
+    let options = provider_probe_options(
+        command,
+        remote_cwd,
+        env,
+        source_snapshot,
+        required_extensions,
+        capability_preflight,
+    );
+    let (output, exit_code) = exec_with_status_snapshot(runner_id, options, Some(status_snapshot))?;
 
     Ok(AgentTaskProviderProbeOutput {
         stdout: output.stdout,
         stderr: output.stderr,
         exit_code,
     })
+}
+
+fn provider_probe_options(
+    command: &[String],
+    remote_cwd: &str,
+    env: std::collections::HashMap<String, String>,
+    source_snapshot: Option<SourceSnapshot>,
+    required_extensions: Vec<String>,
+    capability_preflight: Option<RunnerCapabilityPreflight>,
+) -> RunnerExecOptions {
+    if let Some(source_snapshot) = source_snapshot {
+        RunnerExecOptions::command(command.to_vec())
+            .with_cwd(remote_cwd)
+            .with_env(env)
+            .with_source_snapshot(source_snapshot)
+            .with_required_extensions(required_extensions)
+            .with_optional_capability_preflight(capability_preflight)
+    } else {
+        RunnerExecOptions::command(command.to_vec())
+            .with_cwd(remote_cwd)
+            .with_env(env)
+            .with_required_extensions(required_extensions)
+            .with_optional_capability_preflight(capability_preflight)
+    }
 }
 
 fn runner_provider_refresh_is_safe(status: &RunnerStatusReport) -> bool {
@@ -1252,5 +1277,34 @@ mod tests {
             err.details["runner_remediation_command"],
             serde_json::json!("homeboy runner refresh-homeboy homeboy-lab --ref main --reconnect")
         );
+    }
+
+    #[test]
+    fn admission_probe_omits_source_snapshot_but_final_probe_retains_it() {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let admission = provider_probe_options(
+            &command,
+            "/runner/workspace",
+            Default::default(),
+            None,
+            Vec::new(),
+            None,
+        );
+        assert!(admission.source_snapshot.is_none());
+
+        let snapshot = SourceSnapshot {
+            local_path: Some("/controller/workspace".to_string()),
+            remote_path: Some("/runner/workspace".to_string()),
+            ..Default::default()
+        };
+        let final_probe = provider_probe_options(
+            &command,
+            "/runner/workspace",
+            Default::default(),
+            Some(snapshot),
+            Vec::new(),
+            None,
+        );
+        assert!(final_probe.source_snapshot.is_some());
     }
 }


### PR DESCRIPTION
## Summary
- validate selected agent-provider readiness on the chosen Lab runner before workspace and runtime materialization
- reuse the existing `agent-task providers --validate-readiness` provider capability contract with the runner effective environment and job overrides
- retain the source-backed final probe and cover the no-materialization admission probe

Closes #9890

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner provider_preflight --no-fail-fast`
- `cargo test -p homeboy-agents readiness_validation_fails_before_execution_when_provider_executable_is_missing --no-fail-fast`

## AI assistance
Model: `gpt-5.6-sol`
Tool: OpenCode
Usage: Used to inspect the readiness and Lab placement flow, implement the admission-time provider preflight, and add regression coverage. Chris remains responsible for the change.