### PR TITLE
fix(cook): reject local detach handoff

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -398,6 +398,16 @@ fn run_split_placement_cook(
     // explicit `--placement` at argument parsing, so `--placement local` here
     // always means a fully local cook with no pinned runner.
     if cli.placement == homeboy::cli_surface::Placement::Local {
+        if cli.detach_after_handoff {
+            return Err(Error::validation_invalid_argument(
+                "detach-after-handoff",
+                "agent-task cook cannot detach after handoff with --placement local because no runner daemon owns the provider attempt",
+                None,
+                Some(vec![
+                    "Use --placement lab or --runner <runner-id> to detach after a runner daemon accepts the provider attempt.".to_string(),
+                ]),
+            ));
+        }
         return Ok(None);
     }
     let Some(runner_id) = runner_id else {

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -37,6 +37,31 @@ fn cook_rejects_invalid_controller_transport_before_worktree_resolution() {
 }
 
 #[test]
+fn cook_rejects_local_detach_before_worktree_resolution() {
+    let output = homeboy()
+        .args([
+            "--placement",
+            "local",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "missing@worktree",
+            "--verify",
+            "true",
+        ])
+        .output()
+        .expect("run homeboy");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("cannot detach after handoff with --placement local"));
+    assert!(!stdout.contains("worktree provider"));
+}
+
+#[test]
 fn cook_rejects_queue_only_before_worktree_resolution() {
     let output = homeboy()
         .args([


### PR DESCRIPTION
## Summary
- reject `agent-task cook --placement local --detach-after-handoff` before worktree resolution or durable lifecycle creation
- retain detached Cook support for Lab placement and runner-owned provider attempts
- cover the CLI rejection with a missing-worktree regression test

Closes #9933

## Verification
- `cargo fmt --check`
- `cargo test --test cook_lab_handoff_test`
- `cargo test -p homeboy-cli explicit_local_cook_does_not_enter_lab_attempt_dispatch`

## AI assistance
Drafted with gpt-5.6-sol via OpenCode. The agent inspected issue #9933 and the Cook/Lab routing flow, implemented the fail-fast validation and regression test, and ran the listed checks. Chris remains responsible for every line.