### PR TITLE
Fix controller hydration of runner evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -687,6 +687,66 @@ pub(crate) fn record_terminal_artifact_projection(
     store::write_record(record)
 }
 
+/// Replace runner-local file references with controller-resolvable aggregate
+/// references before persisting a terminal runner result. The original location
+/// is deliberately not retained as a durable URI: it is meaningful only on the
+/// producing runner and would make a controller attempt local IO against it.
+pub(crate) fn project_runner_evidence_refs(
+    record: &AgentTaskRunRecord,
+    aggregate: &mut AgentTaskAggregate,
+) {
+    let Some(runner_id) = record
+        .runner_id()
+        .filter(|runner_id| !runner_id.trim().is_empty())
+    else {
+        return;
+    };
+    let runner_job_id = record
+        .runner_job_id()
+        .filter(|job_id| !job_id.trim().is_empty());
+    let encoded_run_id = homeboy_core::execution_contract::encode_uri_component(&record.run_id);
+
+    for outcome in &mut aggregate.outcomes {
+        let mut projected = Vec::new();
+        for evidence in &mut outcome.evidence_refs {
+            if !evidence.uri.starts_with("file://") {
+                continue;
+            }
+            let reference_digest = format!("{:x}", sha2::Sha256::digest(evidence.uri.as_bytes()));
+            let encoded_task_id =
+                homeboy_core::execution_contract::encode_uri_component(&outcome.task_id);
+            evidence.uri = format!(
+                "homeboy://agent-task/run/{encoded_run_id}/aggregate#outcome={encoded_task_id}&evidence={reference_digest}"
+            );
+            projected.push((reference_digest, evidence.kind.clone()));
+        }
+        if projected.is_empty() {
+            continue;
+        }
+        if !outcome.metadata.is_object() {
+            outcome.metadata = json!({});
+        }
+        if !outcome.metadata["runner_evidence_projection"].is_object() {
+            outcome.metadata["runner_evidence_projection"] = json!({});
+        }
+        let projections = outcome.metadata["runner_evidence_projection"]
+            .as_object_mut()
+            .expect("runner evidence projection is an object");
+        for (reference_digest, kind) in projected {
+            projections.insert(
+                reference_digest,
+                json!({
+                    "kind": kind,
+                    "source_runner_id": runner_id,
+                    "source_runner_job_id": runner_job_id,
+                    "retention": "controller_aggregate",
+                    "redaction": "producer_redacted",
+                }),
+            );
+        }
+    }
+}
+
 /// The authoritative model recorded on an aggregate outcome, if any.
 ///
 /// Locates the outcome for `task_id` and reads its concrete model through the

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -273,16 +273,18 @@ fn project_terminal_runner_lifecycle_event(
     preserve_terminal_runner_identity(record, event)?;
     validate_runner_job_snapshot(record, snapshot)?;
     validate_terminal_child_identity(record, snapshot, event)?;
-    let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
+    let mut aggregate = event.aggregate.clone();
+    crate::agent_task_lifecycle::project_runner_evidence_refs(record, &mut aggregate);
+    let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
     let aggregate_path = store::aggregate_path(&record.run_id)
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "aggregate.json".to_string());
-    apply_aggregate_to_record(record, &projection_plan, &event.aggregate, aggregate_path);
+    apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
     // The aggregate is the task result. A successful enclosing daemon job only
     // proves transport completion, not task success.
     record_runner_job_terminal_metadata(record, snapshot.job.status, &snapshot.events);
-    store::write_aggregate_and_record(record, &event.aggregate)?;
-    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &event.aggregate)
+    store::write_aggregate_and_record(record, &aggregate)?;
+    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &aggregate)
 }
 
 pub(crate) fn project_persisted_terminal_runner_events(
@@ -324,17 +326,19 @@ pub(crate) fn project_persisted_terminal_runner_events(
         return Ok(false);
     };
     validate_terminal_child_event_identity(record, &event)?;
-    let projection_plan = aggregate_projection_plan_from_outcomes(&event.aggregate);
+    let mut aggregate = event.aggregate.clone();
+    crate::agent_task_lifecycle::project_runner_evidence_refs(record, &mut aggregate);
+    let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
     let aggregate_path = store::aggregate_path(&record.run_id)
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "aggregate.json".to_string());
-    apply_aggregate_to_record(record, &projection_plan, &event.aggregate, aggregate_path);
+    apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
     record.ensure_metadata_object().insert(
         "terminal_transport_recovery".to_string(),
         json!("persisted_runner_job_events"),
     );
-    store::write_aggregate_and_record(record, &event.aggregate)?;
-    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &event.aggregate)?;
+    store::write_aggregate_and_record(record, &aggregate)?;
+    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &aggregate)?;
     Ok(true)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -980,6 +980,30 @@ fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
             aggregate.outcomes[0].metadata["terminal_recovery"],
             "authenticated_compact_summary"
         );
+        for evidence in &aggregate.outcomes[0].evidence_refs {
+            assert!(
+                !evidence.uri.starts_with("file://"),
+                "runner-local evidence must not reach the controller as a file URI"
+            );
+            let hydrated = crate::agent_task_service::hydrate_evidence_ref(
+                run_id,
+                evidence,
+                Some("task-a"),
+                None,
+                Some(&aggregate),
+            );
+            assert_eq!(hydrated.status, "ok", "{}", evidence.uri);
+        }
+        let projections = aggregate.outcomes[0].metadata["runner_evidence_projection"]
+            .as_object()
+            .expect("runner evidence projection metadata");
+        assert_eq!(projections.len(), 6);
+        assert!(projections.values().all(|projection| {
+            projection["source_runner_id"] == "homeboy-lab"
+                && projection["source_runner_job_id"] == runner_job_id
+                && projection["retention"] == "controller_aggregate"
+                && projection["redaction"] == "producer_redacted"
+        }));
         let report = artifacts(run_id).expect("recovered artifact projection");
         assert_eq!(report.artifacts.len(), 4);
         assert_eq!(report.artifacts[0].id, "patch");

--- a/crates/homeboy-agents/src/agent_task_service/status_support.rs
+++ b/crates/homeboy-agents/src/agent_task_service/status_support.rs
@@ -207,6 +207,9 @@ fn hydrate_homeboy_evidence_ref(
     plan: Option<&AgentTaskPlan>,
     aggregate: Option<&AgentTaskAggregate>,
 ) -> Result<HydratedContent> {
+    if let Some(diagnostic) = hydrate_typed_diagnostic_ref(uri, task_id, aggregate) {
+        return Ok(diagnostic);
+    }
     let parsed = parse_agent_task_homeboy_uri(uri)?;
     if parsed.run_id != run_id {
         return Err(homeboy_core::Error::validation_invalid_argument(
@@ -316,6 +319,51 @@ fn hydrate_homeboy_evidence_ref(
     };
 
     Ok(HydratedContent {
+        source: "homeboy".to_string(),
+        truncated: false,
+        bytes_read: None,
+        omitted_bytes: None,
+        content,
+    })
+}
+
+/// Provider failures emit typed `homeboy://agent-task/<diagnostic-class>` refs.
+/// Their durable content is the matching aggregate diagnostic, not a local file.
+fn hydrate_typed_diagnostic_ref(
+    uri: &str,
+    task_id: Option<&str>,
+    aggregate: Option<&AgentTaskAggregate>,
+) -> Option<HydratedContent> {
+    let diagnostic_class = uri.strip_prefix("homeboy://agent-task/")?;
+    if diagnostic_class.starts_with("run/") || diagnostic_class.contains('/') {
+        return None;
+    }
+    let diagnostic = aggregate?.outcomes.iter().find_map(|outcome| {
+        task_id
+            .map(|task_id| task_id == outcome.task_id)
+            .unwrap_or(true)
+            .then(|| {
+                outcome
+                    .diagnostics
+                    .iter()
+                    .find(|diagnostic| diagnostic.class == diagnostic_class)
+                    .map(|diagnostic| (outcome, diagnostic))
+            })
+            .flatten()
+    });
+    let content = match diagnostic {
+        Some((outcome, diagnostic)) => json!({
+            "task_id": outcome.task_id,
+            "status": outcome.status,
+            "failure_classification": outcome.failure_classification,
+            "diagnostic": diagnostic,
+        }),
+        None => json!({
+            "summary": "The typed diagnostic is not present in this durable aggregate.",
+            "diagnostic_class": diagnostic_class,
+        }),
+    };
+    Some(HydratedContent {
         source: "homeboy".to_string(),
         truncated: false,
         bytes_read: None,
@@ -642,6 +690,74 @@ mod tests {
         assert_eq!(
             error.details["context"],
             "agent_task.evidence.hydrate.read: evidence.json"
+        );
+    }
+
+    #[test]
+    fn typed_provider_diagnostic_ref_hydrates_from_the_durable_aggregate() {
+        let aggregate: AgentTaskAggregate = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-aggregate/v1",
+            "plan_id": "provider-preflight",
+            "status": "failed",
+            "totals": { "skipped": 0, "failed": 1 },
+            "outcomes": [{
+                "schema": "homeboy/agent-task-outcome/v1",
+                "task_id": "cook",
+                "status": "provider_error",
+                "failure_classification": "provider",
+                "diagnostics": [{
+                    "class": "agent_task.provider_executable_missing",
+                    "message": "opencode is unavailable",
+                    "data": { "provider": "opencode" }
+                }]
+            }]
+        }))
+        .expect("aggregate");
+        let evidence = AgentTaskEvidenceRef {
+            kind: "diagnostic".to_string(),
+            uri: "homeboy://agent-task/agent_task.provider_executable_missing".to_string(),
+            label: None,
+        };
+
+        let hydrated = hydrate_evidence_ref(
+            "controller-run",
+            &evidence,
+            Some("cook"),
+            None,
+            Some(&aggregate),
+        );
+
+        assert_eq!(hydrated.status, "ok");
+        assert_eq!(hydrated.source, "homeboy");
+        assert_eq!(
+            hydrated.content["diagnostic"]["message"],
+            "opencode is unavailable"
+        );
+    }
+
+    #[test]
+    fn typed_diagnostic_without_a_matching_entry_remains_readable() {
+        let evidence = AgentTaskEvidenceRef {
+            kind: "diagnostic".to_string(),
+            uri: "homeboy://agent-task/agent_task.provider_executable_missing".to_string(),
+            label: None,
+        };
+        let aggregate: AgentTaskAggregate = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-aggregate/v1",
+            "plan_id": "provider-preflight",
+            "status": "failed",
+            "totals": { "skipped": 0 },
+            "outcomes": []
+        }))
+        .expect("aggregate");
+
+        let hydrated =
+            hydrate_evidence_ref("controller-run", &evidence, None, None, Some(&aggregate));
+
+        assert_eq!(hydrated.status, "ok");
+        assert_eq!(
+            hydrated.content["diagnostic_class"],
+            "agent_task.provider_executable_missing"
         );
     }
 }


### PR DESCRIPTION
## Summary
- project runner-local evidence refs to stable controller aggregate URIs during terminal runner reconciliation
- retain runner/job, reference digest, retention, and redaction provenance in the durable aggregate
- hydrate typed provider diagnostic refs from aggregate diagnostics, with readable fallback content

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_service::status_support::tests --no-fail-fast`
- `cargo test -p homeboy-agents terminal_transport_recovery_replaces_lossy_historical_compact_aggregate --no-fail-fast`

Closes #9911

## AI assistance
Substantive implementation and tests were drafted with OpenAI gpt-5.6-sol using OpenCode. Chris remains responsible for every line.