### PR TITLE
fix(lab): honor snapshot exclusions during harvest

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -6,7 +6,7 @@ use homeboy_core::observation::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADA
 use homeboy_core::source_snapshot::SourceSnapshot;
 
 use super::snapshot::{
-    workspace_content_hash_for_policy, workspace_content_hash_v1,
+    snapshot_git_exclude_pathspecs, workspace_content_hash_for_policy, workspace_content_hash_v1,
     workspace_content_manifest_for_policy, WorkspaceContentManifest, WorkspaceContentManifestEntry,
 };
 use super::workspace_content_hash_algorithm;
@@ -248,25 +248,31 @@ fn verify_exact_snapshot_git_checkout(
     // reserved bookkeeping and @file paths are excluded from the verified
     // content hash, so they must not be reclassified as source dirt here.
     // All non-reserved paths still have to match the captured source state.
-    let dirty = !git(
-        workspace,
-        &[
-            "status",
-            "--porcelain",
-            "--untracked-files=all",
-            "--",
-            ".",
-            ":(exclude).homeboy/runner-workspace.json",
-            ":(exclude).homeboy/lab-at-files/**",
-        ],
-    )?
-    .is_empty();
+    let dirty = !git_status_ignoring_snapshot_excludes(workspace, provenance)?.is_empty();
     if dirty != provenance.source_dirty {
         return Err(
             "snapshot-git Git cleanliness does not match the verified source snapshot".to_string(),
         );
     }
     Ok(())
+}
+
+fn git_status_ignoring_snapshot_excludes(
+    workspace: &Path,
+    provenance: &VerifiedLabWorkspaceProvenance,
+) -> std::result::Result<String, String> {
+    let mut args = vec![
+        "status".to_string(),
+        "--porcelain".to_string(),
+        "--untracked-files=all".to_string(),
+        "--".to_string(),
+        ".".to_string(),
+        SYNTHETIC_BASELINE_PATHS[1].to_string(),
+        SYNTHETIC_BASELINE_PATHS[2].to_string(),
+    ];
+    args.extend(snapshot_git_exclude_pathspecs(&provenance.sync_excludes));
+    let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+    git(workspace, &args)
 }
 
 fn verify_git_materialization_root(
@@ -1898,6 +1904,67 @@ mod tests {
     }
 
     #[test]
+    fn exact_snapshot_git_checkout_ignores_declared_context_excludes_but_not_real_drift() {
+        let workspace = git_workspace();
+        std::fs::write(workspace.path().join("AGENTS.md"), "injected context\n")
+            .expect("context file");
+        git(workspace.path(), &["add", "AGENTS.md"]).expect("stage context file");
+        git(
+            workspace.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=test@homeboy.invalid",
+                "commit",
+                "--quiet",
+                "-m",
+                "context baseline",
+            ],
+        )
+        .expect("commit context file");
+        let provenance = VerifiedLabWorkspaceProvenance {
+            source_revision: git(workspace.path(), &["rev-parse", "HEAD"])
+                .expect("source revision"),
+            source_dirty: false,
+            materialization_mode: "snapshot-git".to_string(),
+            runner_id: "lab".to_string(),
+            workspace_identity: "snapshot:verified-content".to_string(),
+            snapshot_hash: "sha256:verified-source".to_string(),
+            content_hash: String::new(),
+            content_hash_algorithm: "homeboy-workspace-content-v1".to_string(),
+            permission_policy: None,
+            content_manifest: None,
+            sync_excludes: vec!["AGENTS.md".to_string()],
+            local_source_path: None,
+            remote_workspace_path: workspace.path().display().to_string(),
+            synthetic_checkout_commit: None,
+            synthetic_checkout_ref: None,
+            synthetic_checkout_tree: None,
+        };
+
+        std::fs::remove_file(workspace.path().join("AGENTS.md")).expect("omit context file");
+        verify_exact_snapshot_git_checkout(workspace.path(), &provenance)
+            .expect("declared context omission is not source dirt");
+
+        std::fs::write(workspace.path().join("file.txt"), "changed\n").expect("tracked drift");
+        assert!(
+            verify_exact_snapshot_git_checkout(workspace.path(), &provenance)
+                .expect_err("tracked source drift must fail closed")
+                .contains("cleanliness does not match")
+        );
+        git(workspace.path(), &["checkout", "--", "file.txt"]).expect("restore tracked file");
+
+        std::fs::write(workspace.path().join("provider-output.txt"), "unexpected\n")
+            .expect("untracked drift");
+        assert!(
+            verify_exact_snapshot_git_checkout(workspace.path(), &provenance)
+                .expect_err("untracked source drift must fail closed")
+                .contains("cleanliness does not match")
+        );
+    }
+
+    #[test]
     fn snapshot_baseline_rejects_invalid_provenance_before_creating_git_metadata() {
         let workspace = tempfile::tempdir().expect("workspace");
         std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
@@ -2072,8 +2139,14 @@ mod tests {
             git_materialized,
         )
         .expect_err("changed snapshot-git workspace must fail");
-        assert!(error.contains("runner exec lab"));
-        assert!(error.contains("git status --short"));
+        assert!(
+            error.contains("homeboy runner exec --cwd") && error.contains(" lab -- git status"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.contains("git status --short"),
+            "unexpected error: {error}"
+        );
 
         let error = verify_lab_workspace(
             &workspace.path().display().to_string(),

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -75,11 +75,16 @@ pub(crate) fn snapshot_identity(
 ) -> Result<String> {
     let head =
         git_output(local_path, &["rev-parse", "HEAD"]).unwrap_or_else(|_| "nogit".to_string());
-    let status = git_output(local_path, &["status", "--porcelain=v1"])
+    let status = snapshot_git_output(local_path, &["status", "--porcelain=v1"], excludes)
         .unwrap_or_else(|_| "nogit".to_string());
-    let diff = git_output(local_path, &["diff", "--binary", "HEAD"]).unwrap_or_default();
-    let staged =
-        git_output(local_path, &["diff", "--cached", "--binary", "HEAD"]).unwrap_or_default();
+    let diff = snapshot_git_output(local_path, &["diff", "--binary", "HEAD"], excludes)
+        .unwrap_or_default();
+    let staged = snapshot_git_output(
+        local_path,
+        &["diff", "--cached", "--binary", "HEAD"],
+        excludes,
+    )
+    .unwrap_or_default();
     let mut hasher = Sha256::new();
     hasher.update(local_path.display().to_string().as_bytes());
     hasher.update(head.as_bytes());
@@ -88,6 +93,58 @@ pub(crate) fn snapshot_identity(
     hasher.update(staged.as_bytes());
     hash_snapshot_tree(local_path, local_path, excludes, includes, &mut hasher)?;
     Ok(format!("snapshot:{}", hex_prefix(&hasher.finalize(), 16)))
+}
+
+/// Return Git exclusion pathspecs with the same root and glob semantics as the
+/// snapshot traversal. A malformed Git pathspec is deliberately left to Git to
+/// reject so callers that validate provenance fail closed.
+pub(crate) fn snapshot_git_exclude_pathspecs(excludes: &[String]) -> Vec<String> {
+    let mut pathspecs = Vec::new();
+    for exclude in excludes {
+        let root_anchored = exclude.starts_with("./");
+        let pattern = exclude
+            .trim_start_matches("./")
+            .trim_end_matches('/')
+            .trim();
+        if pattern.is_empty() {
+            continue;
+        }
+        let pattern = if root_anchored || pattern.contains('/') {
+            pattern.to_string()
+        } else {
+            format!("**/{pattern}")
+        };
+        let pathspec = format!(":(exclude,top,glob){pattern}");
+        if !pathspecs.contains(&pathspec) {
+            pathspecs.push(pathspec);
+        }
+        // Snapshot traversal skips an excluded directory before visiting its
+        // children. Add its descendants explicitly because Git status reports
+        // files rather than the excluded directory entry itself.
+        if !pattern.contains('*') {
+            let descendants = format!(":(exclude,top,glob){pattern}/**");
+            if !pathspecs.contains(&descendants) {
+                pathspecs.push(descendants);
+            }
+        }
+    }
+    pathspecs
+}
+
+pub(crate) fn snapshot_git_output(
+    path: &Path,
+    command: &[&str],
+    excludes: &[String],
+) -> Result<String> {
+    let mut args = command
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect::<Vec<_>>();
+    args.push("--".to_string());
+    args.push(".".to_string());
+    args.extend(snapshot_git_exclude_pathspecs(excludes));
+    let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+    git_output(path, &args)
 }
 
 /// Stable v2 digest of the files a snapshot materializes. Unlike
@@ -635,6 +692,62 @@ pub(super) fn is_excluded(
             || glob_match(pattern, rel)
             || (!root_anchored && (pattern == name || glob_match(pattern, name)))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn snapshot_identity_ignores_declared_context_excludes() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        std::fs::write(workspace.path().join("AGENTS.md"), "context\n").expect("context file");
+        git(workspace.path(), &["init", "--quiet", "-b", "main"]);
+        git(workspace.path(), &["add", "--all"]);
+        git(
+            workspace.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=test@homeboy.invalid",
+                "commit",
+                "--quiet",
+                "-m",
+                "baseline",
+            ],
+        );
+        let excludes = vec!["AGENTS.md".to_string()];
+        let baseline =
+            snapshot_identity(workspace.path(), &excludes, &[]).expect("baseline identity");
+
+        std::fs::write(workspace.path().join("AGENTS.md"), "changed context\n")
+            .expect("change context");
+        assert_eq!(
+            snapshot_identity(workspace.path(), &excludes, &[]).expect("excluded identity"),
+            baseline,
+            "excluded context must not alter the snapshot identity"
+        );
+
+        std::fs::write(workspace.path().join("file.txt"), "changed source\n")
+            .expect("change source");
+        assert_ne!(
+            snapshot_identity(workspace.path(), &excludes, &[]).expect("changed identity"),
+            baseline,
+            "non-excluded source drift must alter the snapshot identity"
+        );
+    }
+
+    fn git(cwd: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(output.status.success(), "git {args:?} failed");
+    }
 }
 
 pub(crate) fn materialize_snapshot(


### PR DESCRIPTION
## Summary
- derive Git status and diff exclusions from the verified snapshot policy
- exempt intentionally omitted snapshot context from snapshot-git committed-harvest cleanliness validation
- retain fail-closed checks for non-excluded tracked and untracked drift

Closes #9886

## Tests
- `cargo test -p homeboy-lab-runner workspace::provenance::tests --lib`
- `cargo test -p homeboy-lab-runner workspace::snapshot::tests::snapshot_identity_ignores_declared_context_excludes --lib -- --exact`
- `rustfmt --check --edition 2021 crates/homeboy-lab-runner/src/workspace/snapshot.rs crates/homeboy-lab-runner/src/workspace/provenance.rs`

## AI Assistance
Substantive portions of this change were drafted with gpt-5.6-sol through OpenCode. Chris remains responsible for every line.