### PR TITLE
fix(lab): hydrate runtime overlay dependencies

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -401,6 +401,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         &synced.local_path,
         lab_runtime_overlays()?,
         &mut workspace_mapping,
+        request.skip_deps_hydration,
     )?;
     let runtime_overlay_env = runtime_overlay_env_overrides(&synced_runtime_overlays);
     let runtime_overlay_metadata = lab_runtime_overlay_metadata(&synced_runtime_overlays);

--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -140,7 +140,7 @@ pub(super) struct RuntimeOverlay {
 /// its opaque install step executed. Records the resolved remote path and the
 /// env var surfacing it, so callers can fold the overlay into the command env
 /// and offload metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub(super) struct SyncedRuntimeOverlay {
     pub(super) role: String,
     pub(super) local_path: String,
@@ -148,6 +148,11 @@ pub(super) struct SyncedRuntimeOverlay {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) install_workdir: Option<String>,
     pub(super) install_ran: bool,
+    /// The typed dependency-hydration record derived from the overlay's
+    /// materialized dependency contract. This is separate from `install_ran`:
+    /// an opaque install is an explicit overlay contract, while this record
+    /// captures providers discovered from the snapshot's package metadata.
+    pub(super) dependency_hydration: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) expose_remote_path_env: Option<String>,
     /// Build-freshness provenance for the synced artifact: the source SHA the
@@ -426,6 +431,7 @@ pub(super) fn sync_lab_runtime_overlays(
     primary_local_path: &str,
     overlays: Vec<RuntimeOverlay>,
     workspace_mapping: &mut Vec<LabWorkspaceMappingEntry>,
+    skip_deps_hydration: bool,
 ) -> Result<Vec<SyncedRuntimeOverlay>> {
     if overlays.is_empty() {
         return Ok(Vec::new());
@@ -495,12 +501,38 @@ pub(super) fn sync_lab_runtime_overlays(
             install_ran = true;
         }
 
+        // Snapshots intentionally omit installed dependency trees. Reuse the
+        // generic provider resolver against the overlay's own package metadata
+        // and execute its resulting plan on the runner before provider preflight.
+        // This keeps package-manager policy out of Lab and prevents a missing
+        // runtime dependency from being charged to an agent provider attempt.
+        let dependency_hydration = if skip_deps_hydration {
+            serde_json::json!({
+                "schema": "homeboy/lab-workspace-dependency-hydration/v1",
+                "status": "not_applied",
+                "reason": "opt_out",
+            })
+        } else {
+            serde_json::to_value(super::lab::offload::hydrate_lab_workspace_dependencies(
+                runner_id,
+                &synced.local_path,
+                &synced.remote_path,
+            )?)
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize runtime-overlay dependency hydration".to_string()),
+                )
+            })?
+        };
+
         synced_overlays.push(SyncedRuntimeOverlay {
             role: overlay.workspace.role.clone(),
             local_path: synced.local_path.clone(),
             remote_path: synced.remote_path.clone(),
             install_workdir,
             install_ran,
+            dependency_hydration,
             expose_remote_path_env: overlay.expose_remote_path_env.clone(),
             build_provenance,
         });
@@ -542,7 +574,7 @@ fn run_runtime_overlay_install_step(
         return Ok(());
     }
 
-    Err(Error::validation_invalid_argument(
+    let mut error = Error::validation_invalid_argument(
         "runtime_overlay.install",
         format!(
             "Lab offload runtime-overlay install step failed (exit {exit_code}) in remote workdir `{remote_workdir}`"
@@ -552,7 +584,13 @@ fn run_runtime_overlay_install_step(
             format!("install stderr: {}", output.stderr.trim()),
             "Verify the overlay install command succeeds on the runner, or package the runtime as a self-contained artifact so no install step is required.".to_string(),
         ]),
-    ))
+    );
+    // Runtime-overlay setup happens before the provider command is dispatched.
+    // Preserve that distinction for durable Cook accounting and retries.
+    error.details["classification"] = serde_json::json!("workspace_setup");
+    error.details["workspace"] = serde_json::json!(remote_workdir);
+    error.details["exit_code"] = serde_json::json!(exit_code);
+    Err(error)
 }
 
 /// Build the env-var deltas that surface synced runtime-overlay remote paths to

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/runtime_overlay.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/runtime_overlay.rs
@@ -14,6 +14,7 @@ fn synced(role: &str, remote: &str, env: Option<&str>) -> SyncedRuntimeOverlay {
         remote_path: remote.to_string(),
         install_workdir: None,
         install_ran: false,
+        dependency_hydration: serde_json::json!({"status": "skipped_no_provider"}),
         expose_remote_path_env: env.map(str::to_string),
         build_provenance:
             crate::runtime_overlay_freshness::RuntimeOverlayBuildProvenance::unverifiable(),
@@ -161,6 +162,10 @@ fn metadata_records_schema_count_and_overlays() {
         value["overlays"][0]["expose_remote_path_env"],
         "RUNTIME_CLI_DIR"
     );
+    assert_eq!(
+        value["overlays"][0]["dependency_hydration"]["status"],
+        "skipped_no_provider"
+    );
 }
 
 #[test]
@@ -176,9 +181,54 @@ fn empty_overlay_list_is_a_no_op_and_leaves_mapping_unchanged() {
         &dir.path().display().to_string(),
         Vec::new(),
         &mut mapping,
+        false,
     )
     .expect("no-op overlay sync");
 
     assert!(synced.is_empty());
     assert!(mapping.is_empty());
+}
+
+#[test]
+fn skips_declared_overlay_dependency_hydration_only_when_opted_out() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_workspace_root = tempfile::tempdir().expect("runner workspace root");
+        crate::create(
+            &serde_json::json!({
+                "id": "lab-overlay",
+                "kind": "local",
+                "workspace_root": runner_workspace_root.path(),
+            })
+            .to_string(),
+            false,
+        )
+        .expect("create local runner");
+        let overlay_dir = tempfile::tempdir().expect("overlay tempdir");
+        std::fs::write(
+            overlay_dir.path().join("homeboy-deps.json"),
+            r#"{"provider":"composer","commands":{"install":{"argv":["not-installed-composer","install"]}}}"#,
+        )
+        .expect("dependency contract");
+        let primary = tempfile::tempdir().expect("primary tempdir");
+        let mut mapping = Vec::new();
+        let overlays = parse_runtime_overlays(vec![RuntimeOverlaySpec {
+            path: overlay_dir.path().display().to_string(),
+            role: None,
+            snapshot_includes: Vec::new(),
+            install: None,
+            expose_remote_path_env: None,
+        }])
+        .expect("parse overlay");
+
+        let synced = sync_lab_runtime_overlays(
+            "lab-overlay",
+            &primary.path().display().to_string(),
+            overlays,
+            &mut mapping,
+            true,
+        )
+        .expect("opt-out bypasses the declared dependency command");
+        assert_eq!(synced[0].dependency_hydration["status"], "not_applied");
+        assert_eq!(synced[0].dependency_hydration["reason"], "opt_out");
+    });
 }


### PR DESCRIPTION
## Summary
- hydrate dependency providers declared by each materialized runtime overlay before provider preflight
- record typed overlay hydration evidence and honor `--skip-deps-hydration`
- classify explicit overlay install failures as pre-execution workspace setup failures

Closes #9931

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner lab_workspaces::tests::runtime_overlay -- --test-threads=1`
- `cargo test -p homeboy-lab-runner hydration_failure_classifies_as_workspace_setup -- --test-threads=1`

## AI assistance
- Model: gpt-5.6-sol
- Tool: OpenCode
- Used for: implementation, tests, and PR drafting. Chris remains responsible for every line.