### PR TITLE
fix(audit): skip comment lines in core-boundary-leak ecosystem scan

### DIFF
--- a/crates/contracts/homeboy-audit-contract/src/source_policy.rs
+++ b/crates/contracts/homeboy-audit-contract/src/source_policy.rs
@@ -20,6 +20,19 @@ pub struct CoreBoundaryLeakConfig {
     /// Path substrings treated as example-only when not otherwise allowlisted.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub example_path_contains: Vec<String>,
+    /// Line prefixes whose lines are skipped by the ecosystem-term scan.
+    /// Defaults to Rust comment prefixes so a term that merely appears in a
+    /// comment/docstring (explaining behavior, not implementing it) is not a
+    /// finding — the detector measures architecture, not comment text (#6857).
+    #[serde(default = "default_comment_line_prefixes")]
+    pub ignore_line_prefixes: Vec<String>,
+}
+
+/// Rust comment prefixes: line (`//`), doc (`///`), and inner doc (`//!`).
+/// Lines starting with any of these are non-behavioral, so ecosystem terms
+/// mentioned in them are not core-boundary leaks (#6857).
+pub fn default_comment_line_prefixes() -> Vec<String> {
+    vec!["//".to_string(), "///".to_string(), "//!".to_string()]
 }
 
 impl CoreBoundaryLeakConfig {
@@ -40,6 +53,7 @@ impl CoreBoundaryLeakConfig {
             &mut self.example_path_contains,
             &other.example_path_contains,
         );
+        extend_unique(&mut self.ignore_line_prefixes, &other.ignore_line_prefixes);
     }
 
     /// Lower this config into generic source-policy rules. Core-boundary-leak
@@ -61,7 +75,15 @@ impl CoreBoundaryLeakConfig {
             include_path_contains: self.scan_path_contains.clone(),
             exclude_path_contains: self.allow_path_contains.clone(),
             allow_line_contains: self.allow_line_contains.clone(),
-            ignore_line_prefixes: Vec::new(),
+            // A term mentioned in a comment/docstring explains behavior, it does
+            // not implement it — skip comment lines so findings measure
+            // architecture, not comment text (#6857). Defaults to Rust comment
+            // prefixes; an explicit config override is honored.
+            ignore_line_prefixes: if self.ignore_line_prefixes.is_empty() {
+                default_comment_line_prefixes()
+            } else {
+                self.ignore_line_prefixes.clone()
+            },
             ignore_after_line_equals: Vec::new(),
             example_path_contains: self.example_path_contains.clone(),
             example_classification: None,

--- a/crates/homeboy-code-audit/src/detectors/source_policy.rs
+++ b/crates/homeboy-code-audit/src/detectors/source_policy.rs
@@ -549,7 +549,51 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
             allow_path_contains: vec!["src/core/fixtures/allowed".to_string()],
             allow_line_contains: vec!["homeboy-audit: allow-core-boundary-example".to_string()],
             example_path_contains: vec!["/fixtures/".to_string(), "/examples/".to_string()],
+            // Empty → the comment-prefix default applies at rule-build time.
+            ignore_line_prefixes: Vec::new(),
         }
+    }
+
+    #[test]
+    fn core_boundary_skips_terms_that_appear_only_in_comments() {
+        // #6857: a term mentioned in a doc/line/inner-doc comment explains
+        // behavior, it does not implement it — it must not be a finding.
+        let fp = rust_fp(
+            "src/core/engine.rs",
+            r#"//! This module intentionally mentions florp-run in its overview.
+
+/// Dispatch work. Historically this ran florpstack directly.
+fn dispatch() {
+    // florp-run used to live here; do not reintroduce it.
+    run_tool("generic-run");
+}
+"#,
+        );
+
+        let findings = run_core_boundary(&[&fp], &core_boundary_config());
+
+        assert!(
+            findings.is_empty(),
+            "ecosystem terms in comments must not be findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn core_boundary_still_reports_terms_in_executable_context() {
+        // The comment skip must not mask a genuine leak on a code line, even when
+        // the same line also carries a trailing comment.
+        let fp = rust_fp(
+            "src/core/engine.rs",
+            r#"fn dispatch() {
+    run_tool("florp-run");
+}
+"#,
+        );
+
+        let findings = run_core_boundary(&[&fp], &core_boundary_config());
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("florp-run"));
     }
 
     fn run_core_boundary(


### PR DESCRIPTION
## Summary
The core-boundary-leak / core-agnostic-source detector scanned **every** source line for configured ecosystem terms (`rust`/`php`/`cargo`/…), including doc and inline comment lines. A finding could therefore be created or cleared by editing a comment that merely *mentions* a term while explaining behavior — measuring comment text, not architecture (#6857). Earlier baseline burndown (#5229-era) had to reword comments to clear such findings.

## Root cause
`CoreBoundaryLeakConfig::to_source_policy_rules` hardcoded `ignore_line_prefixes: Vec::new()`, so the generic source-policy engine's existing comment-skip mechanism never engaged for this preset (the `thin_command_adapter` preset already configures `//`, `///`, `//!`).

## Change
- Add an `ignore_line_prefixes` field to `CoreBoundaryLeakConfig`, defaulting to the Rust comment prefixes (`//`, `///`, `//!`) via `default_comment_line_prefixes()`.
- Thread it into `to_source_policy_rules` (empty → comment-prefix default; explicit config override honored) and `merge`.

Terms appearing only in comments/docstrings are no longer findings. This **sharpens signal without relaxing the gate** — comments simply aren't the architectural signal the detector measures (issue non-goal).

> Scope note: this covers the primary case the issue describes (findings landing on comment/docstring lines). Stripping a term out of an *inline* comment on an otherwise-code line (`code; // rust`) is deliberately **not** done here — naive `//` splitting would false-negative on `//` inside string literals (`"http://…"`); a comment-aware tokenizer is a separate follow-up. Issue part (b) (test-only-reachability for command detectors) is also out of scope for this PR.

## Testing
`homeboy-code-audit --lib source_policy::tests::core_boundary` — 6 pass:
- `core_boundary_skips_terms_that_appear_only_in_comments` (new) — terms in `//!`/`///`/`//` comments → no finding.
- `core_boundary_still_reports_terms_in_executable_context` (new) — a term on a code line still flags.
- 4 existing tests unchanged (no regression).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the hardcoded empty `ignore_line_prefixes`, defaulting the core-boundary preset to skip comment lines, and coverage.

Refs #6857