### PR TITLE
Add ssh --raw for pipeable remote stdout (#9894)

### DIFF
--- a/crates/homeboy-cli/src/commands/contract_output_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_output_routing.rs
@@ -7,7 +7,7 @@
 
 use crate::cli_surface::Commands;
 use crate::command_contract::CommandSpec;
-use crate::commands::{adapter, file, logs, report, review, runner, runtime, trace};
+use crate::commands::{adapter, file, logs, report, review, runner, runtime, ssh, trace};
 
 use crate::command_contract::{
     CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor,
@@ -45,6 +45,9 @@ impl Commands {
         }
 
         match self {
+            Commands::Ssh(args) if ssh::is_raw_command(args) => {
+                raw_ops_descriptor(CommandRawOutputMode::PlainText, output_file_mode)
+            }
             Commands::Ssh(args) if args.subcommand.is_none() && args.command.is_empty() => {
                 raw_ops_descriptor(
                     CommandRawOutputMode::InteractivePassthrough,

--- a/crates/homeboy-cli/src/commands/raw_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/raw_output/mod.rs
@@ -1,9 +1,11 @@
 use crate::cli_surface::Commands;
 use crate::command_contract::{CommandRawOutputMode, CommandStdoutMode};
 
-use super::output_runtime::CommandRun;
+use super::output_runtime::{CommandPresentation, CommandRun};
 use super::utils::{response as output, tty};
-use super::{file, release, report, review, runner, runs, runtime, self_cmd, trace, GlobalArgs};
+use super::{
+    file, release, report, review, runner, runs, runtime, self_cmd, ssh, trace, GlobalArgs,
+};
 
 pub enum RawExecution {
     Handled(i32),
@@ -78,8 +80,25 @@ fn run_plain_text(command: Commands, global: &GlobalArgs) -> CommandRun {
         Commands::Runner(args) if runner::is_compact_exec_stdout(&args) => {
             runner_compact_exec(args, global)
         }
+        Commands::Ssh(args) => ssh_raw(args),
         Commands::Runtime(args) => raw_stdout_only(runtime::run_plain_text(args)),
         _ => raw_stdout_only(unsupported_output("plain text")),
+    }
+}
+
+/// Emit only the remote command's stdout to local stdout and its stderr to local
+/// stderr, exiting with the remote exit code (#9894).
+fn ssh_raw(args: ssh::SshArgs) -> CommandRun {
+    match ssh::execute_raw_command(&args) {
+        Ok((stdout, stderr, exit_code)) => {
+            CommandRun::from_raw_stdout("ssh", Ok(stdout), exit_code, None).with_presentation(
+                CommandPresentation {
+                    stdout: None,
+                    stderr: Some(stderr),
+                },
+            )
+        }
+        Err(err) => CommandRun::from_raw_stdout("ssh", Err(err), 1, None),
     }
 }
 

--- a/crates/homeboy-cli/src/commands/ssh.rs
+++ b/crates/homeboy-cli/src/commands/ssh.rs
@@ -30,8 +30,21 @@ pub struct SshArgs {
     #[arg(long)]
     pub user: Option<String>,
 
+    /// Write only the remote command's stdout to local stdout (and its stderr to
+    /// local stderr), exiting with the remote exit code. Ideal for piping a
+    /// remote export straight into a file. Combine with `--output <path>` to also
+    /// persist the structured envelope. Requires a non-interactive command.
+    #[arg(long)]
+    pub raw: bool,
+
     #[command(subcommand)]
     pub subcommand: Option<SshSubcommand>,
+}
+
+/// Whether this invocation requested raw stdout mode for a non-interactive
+/// remote command.
+pub(super) fn is_raw_command(args: &SshArgs) -> bool {
+    args.raw && args.subcommand.is_none() && !args.command.is_empty()
 }
 
 #[derive(Subcommand)]
@@ -131,23 +144,13 @@ pub fn run(args: SshArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Ss
                 let output = client.execute(cmd);
 
                 Ok((
-                    SshOutput::Connect(SshConnectOutput {
-                        resolved_type: result.resolved_type,
-                        project_id: result.project_id,
-                        server_id: result.server_id,
-                        // Prefer the quoted/normalized command string for JSON output so
-                        // multi-arg invocations remain unambiguous (e.g. args containing spaces).
-                        command: command_string.clone(),
-                        stdout: Some(output.stdout),
-                        stderr: Some(output.stderr),
-                        success: output.success,
-                        exit_code: output.exit_code,
-                        result_classification: ssh_result_classification(
-                            output.success,
-                            output.exit_code,
-                        ),
-                        failure_reason: ssh_failure_reason(output.success, output.exit_code),
-                    }),
+                    SshOutput::Connect(connect_output_from_execution(
+                        &result.resolved_type,
+                        result.project_id.clone(),
+                        &result.server_id,
+                        command_string.clone(),
+                        &output,
+                    )),
                     output.exit_code,
                 ))
             } else {
@@ -172,6 +175,73 @@ pub fn run(args: SshArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Ss
             }
         }
     }
+}
+
+fn connect_output_from_execution(
+    resolved_type: &str,
+    project_id: Option<String>,
+    server_id: &str,
+    // Prefer the quoted/normalized command string for JSON output so multi-arg
+    // invocations remain unambiguous (e.g. args containing spaces).
+    command: Option<String>,
+    output: &homeboy::core::server::CommandOutput,
+) -> SshConnectOutput {
+    SshConnectOutput {
+        resolved_type: resolved_type.to_string(),
+        project_id,
+        server_id: server_id.to_string(),
+        command,
+        stdout: Some(output.stdout.clone()),
+        stderr: Some(output.stderr.clone()),
+        success: output.success,
+        exit_code: output.exit_code,
+        result_classification: ssh_result_classification(output.success, output.exit_code),
+        failure_reason: ssh_failure_reason(output.success, output.exit_code),
+    }
+}
+
+/// Execute a non-interactive remote command and return its raw stdout/stderr and
+/// exit code, for `--raw` mode. Resolution mirrors [`run`], but the caller emits
+/// the remote streams directly instead of a JSON envelope.
+pub(super) fn execute_raw_command(
+    args: &SshArgs,
+) -> homeboy::core::Result<(String, String, i32)> {
+    let resolve_args = if args.as_server {
+        SshResolveArgs {
+            id: None,
+            project: None,
+            server: args.target.clone(),
+        }
+    } else {
+        SshResolveArgs {
+            id: args.target.clone(),
+            project: None,
+            server: None,
+        }
+    };
+    let result = resolve_context(&resolve_args)?;
+
+    let command_string: Option<String> = if args.command.len() == 1 {
+        Some(args.command[0].clone())
+    } else {
+        Some(shell::quote_args(&args.command))
+    };
+    let effective_command = match (&result.project_id, &result.base_path, &command_string) {
+        (Some(_), Some(bp), Some(cmd)) => Some(format!("cd {} && {}", shell::quote_path(bp), cmd)),
+        _ => command_string.clone(),
+    };
+
+    let mut client = SshClient::from_server(&result.server, &result.server_id)?;
+    if let Some(ref user_override) = args.user {
+        client.user = user_override.clone();
+    }
+    let cmd = effective_command.as_deref().ok_or_else(|| {
+        homeboy::core::Error::internal_unexpected(
+            "No command resolved for non-interactive SSH execution".to_string(),
+        )
+    })?;
+    let output = client.execute(cmd);
+    Ok((output.stdout, output.stderr, output.exit_code))
 }
 
 fn ssh_result_classification(success: bool, exit_code: i32) -> String {
@@ -236,5 +306,26 @@ mod tests {
             ssh_failure_reason(false, 255).as_deref(),
             Some("SSH transport failed with exit code 255")
         );
+    }
+
+    fn raw_args(command: Vec<&str>, raw: bool) -> SshArgs {
+        SshArgs {
+            target: Some("wp-build-runtime".to_string()),
+            command: command.into_iter().map(str::to_string).collect(),
+            as_server: false,
+            user: None,
+            raw,
+            subcommand: None,
+        }
+    }
+
+    #[test]
+    fn is_raw_command_requires_raw_flag_and_a_command() {
+        // Raw mode applies only to a non-interactive command with --raw.
+        assert!(is_raw_command(&raw_args(vec!["printf", "hi"], true)));
+        // Without --raw it is the normal JSON-envelope path.
+        assert!(!is_raw_command(&raw_args(vec!["printf", "hi"], false)));
+        // --raw with no command (interactive) is not a raw stdout invocation.
+        assert!(!is_raw_command(&raw_args(vec![], true)));
     }
 }


### PR DESCRIPTION
Fixes #9894.

## Problem
`homeboy ssh <target> <command>` always embedded remote stdout in a `homeboy/command-result` JSON envelope. Exporting a remote artifact required a manual extraction step:

```sh
homeboy ssh --output ./export.json wp-build-runtime "wp wp-build export 1353 --out=-"
jq -r '.data.stdout' ./export.json > ./bundle.json
```

This duplicated large output, made binary streaming impractical, and pushed operators toward ad-hoc SSH/SCP.

## Fix
Add `--raw`, mirroring the `runner exec --raw` contract:
- writes **only** the remote command's stdout to local stdout, and its stderr to local stderr;
- exits with the **remote** exit code;
- `--output <path>` may still be combined with `--raw` to capture the structured envelope separately (the output-file mode flows through the raw descriptor);
- requires a non-interactive command — `--raw` with no command stays the interactive passthrough path.

Routing reuses the existing `CommandRawOutputMode::PlainText` contract (the same one `homeboy file` raw-read uses): `ssh::is_raw_command` gates the descriptor in `contract_output_routing`, and `run_plain_text` emits the remote streams via `ssh::execute_raw_command`, which shares its resolution logic with `run`. Project and configured-server targets behave identically.

## Acceptance criteria coverage
- ✅ `--raw` writes only remote stdout to local stdout, remote stderr to local stderr
- ✅ Exits with the remote command's exit code
- ✅ `--output <path>` combinable with `--raw` for the structured envelope
- ✅ Project and configured-server targets behave identically (shared resolution)
- ✅ Empty output produces empty stdout (no envelope framing in raw mode)

## Tests
`is_raw_command` gate: requires the flag + a command; excludes the interactive (no-command) case.

## Verification
- `cargo fmt -p homeboy-cli --check` clean
- `cargo check -p homeboy-cli --lib --tests` exit 0
- Full test run deferred to CI per this VPS's no-heavy-local-build rule

Diff: +133/-20, 3 files.