### PR TITLE
ci(dx): add rustfmt --all --check gate to keep main formatting-clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,25 @@ jobs:
       - name: Compile all workspace test targets
         run: cargo check --workspace --tests --locked
 
+  # Keep `main` rustfmt-clean so a feature branch's `cargo fmt` only ever touches
+  # the files it changed. Without this gate, unformatted files drift onto main
+  # and get pulled into unrelated PRs (a bare `cargo fmt` reformats them, or a
+  # `rustfmt mod.rs` cascades across the module tree), ballooning otherwise-small
+  # diffs and forcing manual `git checkout --` of noise files (#6860). This is a
+  # non-differential whole-workspace check, so it catches drift anywhere.
+  rustfmt:
+    name: homeboy / Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check workspace formatting
+        run: cargo fmt --all --check
+
   homeboy:
     name: homeboy / ${{ matrix.title }}
     runs-on: ubuntu-latest

--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -350,8 +350,7 @@ impl Component {
     /// Return a stable serialization suitable for comparing resolved component
     /// configuration across independently loaded snapshots.
     pub fn canonical_identity(&self) -> serde_json::Result<String> {
-        serde_json::to_value(self)
-            .and_then(|value| serde_json::to_string(&canonical_json(value)))
+        serde_json::to_value(self).and_then(|value| serde_json::to_string(&canonical_json(value)))
     }
 
     /// Return a stable identity for comparing a component's *configured*


### PR DESCRIPTION
## Summary
`main` accumulated rustfmt drift because the **differential** Lint gate doesn't catch formatting on files outside a PR's changed scope. This creates two recurring traps on every small change (#6860):
1. A bare `cargo fmt` reformats ~20 unrelated drifted files onto an otherwise-2-file PR.
2. `rustfmt <mod.rs>` cascades across the whole module tree, re-introducing the same noise.

The workaround became fragile tribal knowledge ("never run bare `cargo fmt`; only `rustfmt` the leaf files you edited") — I've been hitting it all session.

## Change
- **Add a `rustfmt` CI job** running `cargo fmt --all --check` — a non-differential, whole-workspace check (modeled on the existing `workspace-tests-compile` safety-net job) that fails closed on drift anywhere. Once main is clean, a feature branch's `cargo fmt` only ever touches the files it changed.
- **Clean the one remaining drifted file**: `homeboy-component-contract/src/model.rs` had a single line-wrap that was non-canonical under `--all` (the differential gate never saw it because no PR changed that contract crate). Formatting it brings main to an `--all`-clean baseline so the new gate passes green.

This is plain DX/reviewability — not an audit-gate change (issue non-goal).

## Verification
- `cargo fmt --all --check` — exits 0 (clean) after the one-file format.
- `cargo check -p homeboy-component-contract --lib` — clean.
- YAML validated.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Diagnosing that only one file drifted under `--all`, adding the non-differential fmt gate, and cleaning the baseline.

Closes #6860