### PR TITLE
feat(audit): add safe audit-baseline prune command

### DIFF
--- a/crates/homeboy-cli/src/commands/audit_baseline.rs
+++ b/crates/homeboy-cli/src/commands/audit_baseline.rs
@@ -25,6 +25,21 @@ enum AuditBaselineCommand {
     Refresh(AuditBaselineRefreshArgs),
     /// Auto-merge a baseline-only `homeboy.json` merge/rebase conflict
     Merge(AuditBaselineMergeArgs),
+    /// Safely remove specific fingerprints from the baseline (no hand-editing)
+    Prune(AuditBaselinePruneArgs),
+}
+
+#[derive(Args)]
+pub struct AuditBaselinePruneArgs {
+    #[command(flatten)]
+    pub comp: PositionalComponentArgs,
+
+    #[command(flatten)]
+    pub extension_override: ExtensionOverrideArgs,
+
+    /// Fingerprint string(s) to remove from the baseline. Repeat for multiple.
+    #[arg(long = "fingerprint", value_name = "FINGERPRINT", required = true)]
+    pub fingerprints: Vec<String>,
 }
 
 #[derive(Args)]
@@ -69,7 +84,69 @@ pub fn run(args: AuditBaselineArgs, global: &GlobalArgs) -> CmdResult<AuditBasel
     match args.command {
         AuditBaselineCommand::Refresh(args) => refresh(args, global),
         AuditBaselineCommand::Merge(args) => merge(args, global),
+        AuditBaselineCommand::Prune(args) => prune(args, global),
     }
+}
+
+fn prune(
+    args: AuditBaselinePruneArgs,
+    _global: &GlobalArgs,
+) -> CmdResult<AuditBaselineRefreshOutput> {
+    let source_ctx = resolve_source_context(
+        &args.comp,
+        &SettingArgs::default(),
+        &args.extension_override,
+        None,
+    )?;
+    let source_path = source_ctx.source_path.to_string_lossy().to_string();
+    let source = Path::new(&source_path);
+    let baseline_path = source.join("homeboy.json").to_string_lossy().to_string();
+
+    fail_if_homeboy_json_has_conflict_markers(source)?;
+
+    let previous_count = baseline::load_baseline(source)
+        .map(|baseline| baseline.known_fingerprints.len())
+        .unwrap_or(0);
+
+    let result = baseline::prune_baseline(source, &args.fingerprints).map_err(|message| {
+        homeboy::core::Error::internal_io(message, Some("audit-baseline.prune".to_string()))
+    })?;
+
+    if !result.not_found.is_empty() {
+        eprintln!(
+            "[audit-baseline] {} requested fingerprint(s) were not in the baseline and were skipped:",
+            result.not_found.len()
+        );
+        for fingerprint in &result.not_found {
+            eprintln!("  - {fingerprint}");
+        }
+    }
+
+    eprintln!(
+        "[audit-baseline] pruned {}: -{} fingerprint(s), {} remaining",
+        baseline_path,
+        result.removed.len(),
+        result.remaining_count
+    );
+
+    let output = AuditBaselineRefreshOutput {
+        command: "audit-baseline.prune".to_string(),
+        component_id: source_ctx.component_id,
+        source_path,
+        baseline_path,
+        changed_since: "prune".to_string(),
+        previous_source: "current baseline".to_string(),
+        previous_count,
+        current_count: result.remaining_count,
+        added_count: 0,
+        resolved_count: result.removed.len(),
+        added_fingerprints: Vec::new(),
+        resolved_fingerprints: result.removed,
+    };
+
+    // A prune that matched nothing is a no-op the caller should notice.
+    let exit_code = if output.resolved_count == 0 { 1 } else { 0 };
+    Ok((output, exit_code))
 }
 
 fn refresh(

--- a/crates/homeboy-code-audit/src/baseline.rs
+++ b/crates/homeboy-code-audit/src/baseline.rs
@@ -254,7 +254,8 @@ pub type BaselinePruneResult = generic::PruneResult;
 /// Safely remove specific fingerprints from the audit baseline in `homeboy.json`
 /// without hand-editing the JSON array. Only fingerprints actually present are
 /// removed; the rest are reported as not-found. The surviving rows stay sorted
-/// so the diff is exactly the removed lines — no trailing-comma churn (#6861).
+/// and the output is valid canonical JSON, so a prune can't fat-finger the wrong
+/// row or break commas the way a manual `sed` edit can (#6861).
 pub fn prune_baseline(
     source_path: &Path,
     fingerprints: &[String],

--- a/crates/homeboy-code-audit/src/baseline.rs
+++ b/crates/homeboy-code-audit/src/baseline.rs
@@ -249,6 +249,20 @@ pub fn load_baseline(source_path: &Path) -> Option<AuditBaseline> {
         .map(normalize_loaded_baseline)
 }
 
+pub type BaselinePruneResult = generic::PruneResult;
+
+/// Safely remove specific fingerprints from the audit baseline in `homeboy.json`
+/// without hand-editing the JSON array. Only fingerprints actually present are
+/// removed; the rest are reported as not-found. The surviving rows stay sorted
+/// so the diff is exactly the removed lines — no trailing-comma churn (#6861).
+pub fn prune_baseline(
+    source_path: &Path,
+    fingerprints: &[String],
+) -> Result<BaselinePruneResult, String> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    generic::prune(&config, fingerprints).map_err(|error| error.message)
+}
+
 /// Compare an audit result against a saved baseline.
 pub fn compare(result: &CodeAuditResult, baseline: &AuditBaseline) -> BaselineComparison {
     let items: Vec<AuditFinding> = result.findings.iter().map(AuditFinding).collect();

--- a/crates/homeboy-engine-primitives/src/baseline.rs
+++ b/crates/homeboy-engine-primitives/src/baseline.rs
@@ -322,11 +322,11 @@ pub struct PruneResult {
 }
 
 /// Remove specific fingerprints from a baseline, in place, without re-running an
-/// audit. Only fingerprints that are actually present are removed; the rest are
-/// reported as `not_found` so a caller never silently drops the wrong row. The
-/// surviving fingerprints are kept sorted and `item_count` is updated, so the
-/// rewritten JSON differs from the original by exactly the pruned rows — no
-/// trailing-comma churn or incidental edits (#6861).
+/// audit or hand-editing the JSON array (#6861). Only fingerprints that are
+/// actually present are removed; the rest are reported as `not_found` so a
+/// caller never silently drops the wrong row. The surviving fingerprints are
+/// kept sorted and `item_count` is updated, and the output stays valid canonical
+/// JSON — eliminating the fat-finger / broken-comma risk of a manual `sed` edit.
 ///
 /// This mutates only `known_fingerprints`/`item_count`; baseline metadata and
 /// every other key in `homeboy.json` are preserved untouched.
@@ -571,4 +571,109 @@ fn days_to_date(mut days: u64) -> (u64, u64, u64) {
 
 fn is_leap_year(year: u64) -> bool {
     (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+#[cfg(test)]
+mod prune_tests {
+    use super::*;
+
+    struct Finding(String);
+
+    impl Fingerprintable for Finding {
+        fn fingerprint(&self) -> String {
+            self.0.clone()
+        }
+        fn description(&self) -> String {
+            self.0.clone()
+        }
+        fn context_label(&self) -> String {
+            "test".to_string()
+        }
+    }
+
+    fn seed(dir: &std::path::Path, fingerprints: &[&str]) -> BaselineConfig {
+        let config = BaselineConfig::new(dir, "audit");
+        let items: Vec<Finding> = fingerprints
+            .iter()
+            .map(|f| Finding(f.to_string()))
+            .collect();
+        save(
+            &config,
+            "test-component",
+            &items,
+            serde_json::json!({"note": "keep"}),
+        )
+        .unwrap();
+        config
+    }
+
+    #[test]
+    fn prune_removes_only_present_fingerprints_and_reports_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = seed(dir.path(), &["a", "b", "c"]);
+
+        let result = prune(&config, &["b".to_string(), "zzz".to_string()]).unwrap();
+
+        assert_eq!(result.removed, vec!["b".to_string()]);
+        assert_eq!(result.not_found, vec!["zzz".to_string()]);
+        assert_eq!(result.remaining_count, 2);
+
+        let loaded = load::<serde_json::Value>(&config).unwrap().unwrap();
+        assert_eq!(
+            loaded.known_fingerprints,
+            vec!["a".to_string(), "c".to_string()]
+        );
+        assert_eq!(loaded.item_count, 2);
+    }
+
+    #[test]
+    fn prune_preserves_metadata_and_other_json_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = seed(dir.path(), &["a", "b"]);
+        // Add an unrelated top-level key to prove prune leaves it untouched.
+        let path = config.json_path();
+        let mut root: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        root.as_object_mut()
+            .unwrap()
+            .insert("unrelated".to_string(), serde_json::json!({"x": 1}));
+        std::fs::write(&path, serde_json::to_string_pretty(&root).unwrap()).unwrap();
+
+        prune(&config, &["a".to_string()]).unwrap();
+
+        let after: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(after["unrelated"], serde_json::json!({"x": 1}));
+        assert_eq!(after["baselines"]["audit"]["metadata"]["note"], "keep");
+    }
+
+    #[test]
+    fn prune_removes_exactly_the_requested_rows_and_keeps_valid_sorted_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = seed(dir.path(), &["a", "b", "c", "d"]);
+        let path = config.json_path();
+
+        // Prune the LAST fingerprint row — the case that is most error-prone to
+        // hand-edit (removing it forces a trailing-comma change on the new-last
+        // row). The command does this safely and leaves valid, sorted JSON.
+        prune(&config, &["d".to_string()]).unwrap();
+
+        // JSON stays valid and parseable (no broken commas from a bad hand-edit).
+        let reloaded = load::<serde_json::Value>(&config).unwrap().unwrap();
+        assert_eq!(
+            reloaded.known_fingerprints,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            "exactly the pruned row is gone and survivors stay sorted"
+        );
+        assert_eq!(reloaded.item_count, 3);
+        assert!(!reloaded.known_fingerprints.contains(&"d".to_string()));
+    }
+
+    #[test]
+    fn prune_missing_baseline_reports_all_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let result = prune(&config, &["x".to_string()]).unwrap();
+        assert!(result.removed.is_empty());
+        assert_eq!(result.not_found, vec!["x".to_string()]);
+    }
 }

--- a/crates/homeboy-engine-primitives/src/baseline.rs
+++ b/crates/homeboy-engine-primitives/src/baseline.rs
@@ -39,7 +39,7 @@
 //! }
 //! ```
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -310,6 +310,103 @@ pub fn load<M: for<'de> Deserialize<'de> + Serialize>(
     })?;
 
     Ok(Some(baseline))
+}
+
+/// Outcome of a baseline prune: which requested fingerprints were removed and
+/// which were not present (so callers can report a safe, exact result).
+#[derive(Debug, Clone, Serialize)]
+pub struct PruneResult {
+    pub removed: Vec<String>,
+    pub not_found: Vec<String>,
+    pub remaining_count: usize,
+}
+
+/// Remove specific fingerprints from a baseline, in place, without re-running an
+/// audit. Only fingerprints that are actually present are removed; the rest are
+/// reported as `not_found` so a caller never silently drops the wrong row. The
+/// surviving fingerprints are kept sorted and `item_count` is updated, so the
+/// rewritten JSON differs from the original by exactly the pruned rows — no
+/// trailing-comma churn or incidental edits (#6861).
+///
+/// This mutates only `known_fingerprints`/`item_count`; baseline metadata and
+/// every other key in `homeboy.json` are preserved untouched.
+pub fn prune(config: &BaselineConfig, fingerprints: &[String]) -> Result<PruneResult> {
+    let requested: BTreeSet<&String> = fingerprints.iter().collect();
+    let path = config.json_path();
+    let mut root = read_json_or_empty(&path)?;
+
+    let baseline_value = root
+        .get_mut(BASELINES_KEY)
+        .and_then(|baselines| baselines.get_mut(config.key()));
+    let Some(baseline_value) = baseline_value else {
+        return Ok(PruneResult {
+            removed: Vec::new(),
+            not_found: fingerprints.to_vec(),
+            remaining_count: 0,
+        });
+    };
+
+    let known = baseline_value
+        .get_mut("known_fingerprints")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            Error::internal_io(
+                format!(
+                    "baseline '{}' has no known_fingerprints array",
+                    config.key()
+                ),
+                Some("baseline.prune".to_string()),
+            )
+        })?;
+
+    let present: BTreeSet<String> = known
+        .iter()
+        .filter_map(|value| value.as_str().map(str::to_string))
+        .collect();
+    let removed: Vec<String> = requested
+        .iter()
+        .filter(|fingerprint| present.contains(**fingerprint))
+        .map(|fingerprint| (*fingerprint).clone())
+        .collect();
+    let not_found: Vec<String> = requested
+        .iter()
+        .filter(|fingerprint| !present.contains(**fingerprint))
+        .map(|fingerprint| (*fingerprint).clone())
+        .collect();
+
+    if removed.is_empty() {
+        return Ok(PruneResult {
+            removed,
+            not_found,
+            remaining_count: known.len(),
+        });
+    }
+
+    let removed_set: BTreeSet<&String> = removed.iter().collect();
+    known.retain(|value| {
+        value
+            .as_str()
+            .is_none_or(|fingerprint| !removed_set.contains(&fingerprint.to_string()))
+    });
+    // Keep the surviving rows sorted so the diff is exactly the removed lines.
+    known.sort_by(|left, right| {
+        left.as_str()
+            .unwrap_or_default()
+            .cmp(right.as_str().unwrap_or_default())
+    });
+    let remaining_count = known.len();
+
+    if let Some(count) = baseline_value.get_mut("item_count") {
+        *count = Value::from(remaining_count);
+    }
+
+    write_json(&path, &root)?;
+
+    Ok(PruneResult {
+        removed,
+        not_found,
+        remaining_count,
+    })
 }
 
 pub fn compare<T: Fingerprintable, M: Serialize>(


### PR DESCRIPTION
## Summary
Burning down the audit baseline meant **hand-editing** the stringified fingerprint array in `homeboy.json`, which is error-prone (#6861): the fingerprints are long opaque keys that are easy to fat-finger, and a manual `sed`/edit can remove the wrong line or break the JSON.

Add a `baseline::prune` engine primitive + a `homeboy review audit baseline prune --fingerprint <fp>` command that removes named fingerprints **safely**:
- Removes only fingerprints **actually present**; the rest are reported as `not_found` so the wrong row is never silently dropped.
- Keeps the surviving rows **sorted**, updates `item_count`, and leaves **valid canonical JSON**.
- Preserves baseline **metadata and every other `homeboy.json` key** untouched.
- No-op prune (nothing matched) exits non-zero so a mistyped fingerprint is noticed.

## Honest scope note
The issue also floated "comma-stable serialization" so a prune diff is exactly `-N` lines. Pruning the *last* array row still shifts a trailing comma onto the new-last row — inherent to valid JSON arrays + `serde_json`'s pretty printer — so this PR does **not** claim a byte-stable diff. The value delivered is **safety and correctness** (no fat-fingering, no broken JSON, metadata preserved), which is the actual source of the near-mistakes the issue describes.

## Testing
`homeboy-engine-primitives --lib baseline::prune_tests` — 4 pass (present-only removal + not-found reporting; metadata/other-key preservation; last-row prune leaves valid sorted JSON; missing-baseline reports all not-found). `cargo check` clean on `homeboy-code-audit` and `homeboy-cli`.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Adding the safe prune primitive + CLI subcommand and coverage — including a test that surfaced and corrected a comma-churn overclaim.

Refs #6861