### PR TITLE
Bound fresh cook review-form retries

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -841,7 +841,39 @@ pub(crate) enum CookFollowUpDispatch {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CookFollowUpBudgetScope {
     Cook,
+    FreshCookReview,
     CandidateAdoptionReview,
+}
+
+fn follow_up_budget_scope(
+    source_request: &crate::agent_task::AgentTaskRequest,
+    follow_up_request: &crate::agent_task::AgentTaskRequest,
+) -> CookFollowUpBudgetScope {
+    if follow_up_request.inputs["cook_loop"]["review_form_required"] == true
+        && source_request.inputs["cook_loop"]["execution_budget_authority"]["kind"]
+            != "fresh_cook_review"
+    {
+        CookFollowUpBudgetScope::FreshCookReview
+    } else {
+        CookFollowUpBudgetScope::Cook
+    }
+}
+
+fn scoped_follow_up_budget(
+    scope: CookFollowUpBudgetScope,
+    cook_budget: &AgentTaskExecutionBudget,
+    cook_usage: ExecutionBudgetUsage,
+) -> (AgentTaskExecutionBudget, ExecutionBudgetUsage) {
+    match scope {
+        CookFollowUpBudgetScope::Cook => (cook_budget.clone(), cook_usage),
+        CookFollowUpBudgetScope::FreshCookReview
+        | CookFollowUpBudgetScope::CandidateAdoptionReview => (
+            // One review execution plus one bounded replay when provider
+            // discovery fails before the review provider starts.
+            AgentTaskExecutionBudget::new(2, 1, 0),
+            ExecutionBudgetUsage::default(),
+        ),
+    }
 }
 
 /// Append and dispatch one remediation attempt from an authenticated promoted
@@ -883,16 +915,8 @@ where
                 && retryable_provider_discovery_failure(&recipe_attempt.run_id)
         })
         .cloned();
-    // The review plan itself permits one execution. The owning dispatch budget
-    // also permits one replay when executor startup cannot discover a provider.
-    let candidate_adoption_review_budget = AgentTaskExecutionBudget::new(2, 1, 0);
-    let (budget_limit, mut durable_budget_used) = match budget_scope {
-        CookFollowUpBudgetScope::Cook => (budget_limit, budget_used),
-        CookFollowUpBudgetScope::CandidateAdoptionReview => (
-            &candidate_adoption_review_budget,
-            ExecutionBudgetUsage::default(),
-        ),
-    };
+    let (budget_limit, mut durable_budget_used) =
+        scoped_follow_up_budget(budget_scope, budget_limit, budget_used);
     for recipe_attempt in related_attempts.clone() {
         if let Ok(aggregate) = agent_task_lifecycle::read_aggregate(&recipe_attempt.run_id) {
             durable_budget_used.add(execution_budget_usage(&aggregate));
@@ -909,7 +933,7 @@ where
                     .unwrap_or(u32::MAX),
             );
     }
-    let Some(remaining_budget) = budget_remaining(budget_limit, durable_budget_used) else {
+    let Some(remaining_budget) = budget_remaining(&budget_limit, durable_budget_used) else {
         return Ok(CookFollowUpDispatch::BudgetExhausted {
             reason: "max_provider_executions".to_string(),
         });
@@ -957,9 +981,14 @@ where
         "source_task_id": promotion.source.task_id,
         "source_patch_artifact_sha256": promotion.patch_artifact.sha256,
     });
-    if budget_scope == CookFollowUpBudgetScope::CandidateAdoptionReview {
+    if budget_scope != CookFollowUpBudgetScope::Cook {
+        let kind = match budget_scope {
+            CookFollowUpBudgetScope::FreshCookReview => "fresh_cook_review",
+            CookFollowUpBudgetScope::CandidateAdoptionReview => "candidate_adoption_review",
+            CookFollowUpBudgetScope::Cook => unreachable!(),
+        };
         follow_up_request.inputs["cook_loop"]["execution_budget_authority"] = serde_json::json!({
-            "kind": "candidate_adoption_review",
+            "kind": kind,
             "max_provider_executions": 2,
             "max_same_provider_retries": 1,
             "max_provider_rotations": 0,
@@ -1622,7 +1651,7 @@ where
 
         let review_form = review_form_from_aggregate(&aggregate)?;
         let feedback = evaluate_cook_loop(AgentTaskCookLoopOptions {
-            source_request,
+            source_request: source_request.clone(),
             promotion_report: promotion.clone(),
             attempt,
             max_attempts,
@@ -1818,6 +1847,7 @@ where
                 let budget_limit = budget_limit
                     .as_ref()
                     .expect("budget is initialized from the loaded attempt plan");
+                let budget_scope = follow_up_budget_scope(&source_request, &follow_up_request);
                 match dispatch_cook_follow_up(
                     &options,
                     executor.clone(),
@@ -1829,7 +1859,7 @@ where
                     &promotion,
                     follow_up_request,
                     false,
-                    CookFollowUpBudgetScope::Cook,
+                    budget_scope,
                     budget_limit,
                     budget_used,
                     &mut remediation_category_usage,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -163,6 +163,59 @@ fn cook_service_retry_uses_the_same_passed_context_after_ambient_mutation() {
 }
 
 #[test]
+fn fresh_cook_review_form_has_bounded_budget_independent_of_code_execution() {
+    let mut follow_up_request = batch_cook_options(
+        "fresh-review-budget",
+        Arc::new(AcceptedDetachedAttemptDispatcher),
+    )
+    .initial_plan
+    .tasks
+    .remove(0);
+    follow_up_request.inputs["cook_loop"]["review_form_required"] = serde_json::json!(true);
+    let mut source_request = follow_up_request.clone();
+    source_request.inputs = Value::Null;
+    let scope = follow_up_budget_scope(&source_request, &follow_up_request);
+    assert_eq!(scope, CookFollowUpBudgetScope::FreshCookReview);
+
+    let code_budget = crate::agent_task_scheduler::AgentTaskExecutionBudget::new(1, 0, 0);
+    let consumed_code_budget = ExecutionBudgetUsage {
+        executions: 1,
+        ..Default::default()
+    };
+    assert!(budget_remaining(&code_budget, consumed_code_budget).is_none());
+
+    let (review_budget, review_usage) =
+        scoped_follow_up_budget(scope, &code_budget, consumed_code_budget);
+    assert_eq!(
+        review_budget,
+        crate::agent_task_scheduler::AgentTaskExecutionBudget::new(2, 1, 0)
+    );
+    assert_eq!(review_usage.executions, 0);
+    assert_eq!(
+        budget_remaining(&review_budget, review_usage),
+        Some(crate::agent_task_scheduler::AgentTaskExecutionBudget::new(
+            2, 1, 0
+        ))
+    );
+
+    source_request.inputs["cook_loop"]["execution_budget_authority"] = serde_json::json!({
+        "kind": "fresh_cook_review",
+        "max_provider_executions": 2,
+    });
+    assert_eq!(
+        follow_up_budget_scope(&source_request, &follow_up_request),
+        CookFollowUpBudgetScope::Cook,
+        "a review-only retry cannot mint another review allowance"
+    );
+
+    follow_up_request.inputs["cook_loop"]["review_form_required"] = serde_json::json!(false);
+    assert_eq!(
+        follow_up_budget_scope(&source_request, &follow_up_request),
+        CookFollowUpBudgetScope::Cook
+    );
+}
+
+#[test]
 fn moving_base_recovery_report_retains_typed_evidence_and_exact_continuation() {
     let recovery = MovingBaseCookRecovery {
         schema: "homeboy/agent-task-cook-moving-base-recovery/v1".to_string(),


### PR DESCRIPTION
## Summary

- give fresh cook candidates a separate bounded review-form execution allowance after code generation succeeds
- preserve the existing user budget for code and gate remediation
- carry the authenticated promoted candidate through form-only follow-ups without selecting or applying another patch
- prevent a review-only retry from minting another review allowance

Fixes #9958.

## Production evidence

Run `agent-task-8114ad88-2549-4c37-b703-654f224cb9da-attempt-1-55565f4f` produced a successful 9,383-byte patch (`cd6f8540be604de94af7a494c6335a6c3eaca86a008fe04252d6aa6cd582bec4`) with provider exit code 0. Because the outcome omitted `outputs.review_form`, fresh cook requested a form-only follow-up, charged it against the already consumed default one-execution budget, and terminated as `execution_budget_exhausted` before verification/finalization.

Candidate adoption already had the required separate review authority. This change applies the same bounded contract to fresh cook while retaining distinct `fresh_cook_review` provenance.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents review_form --lib` (14 passed)
- `cargo test -p homeboy-agents fresh_cook_review_form_has_bounded_budget_independent_of_code_execution --lib`

The broader cook test slice currently has unrelated failures on `main` in durable claim and history projection tests. Exact baseline reproduction was confirmed for `adoption_replays_provider_discovery_failure_in_the_same_recipe_attempt` and `cook_report_latest_run_id_prefers_invocation_over_stale_cook_index`; this change does not modify those paths.

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode diagnosed the production cook lifecycle, implemented the bounded review authority and replay guard, and ran focused and baseline comparison tests with Chris Huber. Chris remains responsible for every line.
