### PR TITLE
feat(release): surface low-confidence bump on non-conventional histories

### DIFF
--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -1141,6 +1141,8 @@ fn semver_recommendation(
         requested_bump: requested.to_string(),
         is_underbump,
         reasons: vec![],
+        non_conventional_commit_count: 0,
+        considered_commit_count: 0,
         bump_policy: None,
     }
 }

--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -547,6 +547,8 @@ mod tests {
             requested_bump: requested_bump.to_string(),
             is_underbump: false,
             reasons: Vec::new(),
+            non_conventional_commit_count: 0,
+            considered_commit_count: 0,
             bump_policy: None,
         }
     }

--- a/crates/homeboy-release/src/release/planning_policy.rs
+++ b/crates/homeboy-release/src/release/planning_policy.rs
@@ -331,6 +331,8 @@ mod tests {
             requested_bump: requested.to_string(),
             is_underbump: false,
             reasons: vec![],
+            non_conventional_commit_count: 0,
+            considered_commit_count: 0,
             bump_policy: None,
         }
     }

--- a/crates/homeboy-release/src/release/planning_semver.rs
+++ b/crates/homeboy-release/src/release/planning_semver.rs
@@ -27,6 +27,12 @@ pub(super) fn build_semver_recommendation(
         return Ok(None);
     }
 
+    let non_conventional_commit_count = commits
+        .iter()
+        .filter(|c| c.category == git::CommitCategory::Other)
+        .count();
+    let considered_commit_count = commits.len();
+
     if is_explicit_version {
         return Ok(Some(ReleaseSemverRecommendation {
             latest_tag: latest_tag.clone(),
@@ -36,6 +42,8 @@ pub(super) fn build_semver_recommendation(
             requested_bump: requested_bump.to_string(),
             is_underbump: false,
             reasons: Vec::new(),
+            non_conventional_commit_count,
+            considered_commit_count,
             bump_policy: None,
         }));
     }
@@ -78,6 +86,17 @@ pub(super) fn build_semver_recommendation(
         (requested, is_underbump)
     };
 
+    let mut reasons = recommendation_reasons(&commits, recommended);
+    if let Some(warning) = low_confidence_bump_warning(
+        recommended,
+        non_conventional_commit_count,
+        considered_commit_count,
+    ) {
+        // Lead with the low-confidence signal so it is not buried under the
+        // per-commit reason lines when the output is truncated.
+        reasons.insert(0, warning);
+    }
+
     Ok(Some(ReleaseSemverRecommendation {
         latest_tag: latest_tag.clone(),
         range: commit_range(latest_tag.as_deref()),
@@ -85,9 +104,43 @@ pub(super) fn build_semver_recommendation(
         recommended_bump: recommended.map(|r| r.as_str().to_string()),
         requested_bump: requested.as_str().to_string(),
         is_underbump,
-        reasons: recommendation_reasons(&commits, recommended),
+        reasons,
+        non_conventional_commit_count,
+        considered_commit_count,
         bump_policy: None,
     }))
+}
+
+/// Fraction of non-conventional commits above which a low (patch/none)
+/// auto-detected bump is flagged as low-confidence. On repos that don't use
+/// conventional-commit prefixes, most commits classify `other` and can only ever
+/// drive a `patch`, so a majority-non-conventional history recommending patch is
+/// exactly the silent under-bump the operator should see before tagging (#6851).
+const LOW_CONFIDENCE_NON_CONVENTIONAL_FRACTION: f64 = 0.5;
+
+/// A warning when the auto-detected bump is likely too low because the history
+/// lacks conventional-commit prefixes. Only fires for a low recommendation
+/// (patch or none) — a `feat:`/breaking-driven minor/major is already confident.
+fn low_confidence_bump_warning(
+    recommended: Option<git::SemverBump>,
+    non_conventional_commit_count: usize,
+    considered_commit_count: usize,
+) -> Option<String> {
+    if considered_commit_count == 0 {
+        return None;
+    }
+    let is_low = matches!(recommended, None | Some(git::SemverBump::Patch));
+    if !is_low {
+        return None;
+    }
+    let fraction = non_conventional_commit_count as f64 / considered_commit_count as f64;
+    if fraction < LOW_CONFIDENCE_NON_CONVENTIONAL_FRACTION {
+        return None;
+    }
+    let recommended_label = recommended.map(|r| r.as_str()).unwrap_or("none");
+    Some(format!(
+        "low-confidence bump: {non_conventional_commit_count} of {considered_commit_count} commits have no conventional-commit prefix and were treated as `other` (patch-level). Auto-detected `{recommended_label}` may under-bump — pass an explicit --bump (e.g. minor) if this range adds features."
+    ))
 }
 
 pub(super) fn validate_release_version_floor(

--- a/crates/homeboy-release/src/release/planning_semver.rs
+++ b/crates/homeboy-release/src/release/planning_semver.rs
@@ -334,11 +334,13 @@ fn commit_range(latest_tag: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_semver_recommendation, release_version_floor_base, resolve_tag_and_commits,
-        validate_current_version_tag_reachable, validate_release_version_floor,
+        build_semver_recommendation, low_confidence_bump_warning, release_version_floor_base,
+        resolve_tag_and_commits, validate_current_version_tag_reachable,
+        validate_release_version_floor,
     };
     use crate::release::scope::ReleaseScope;
     use homeboy_core::component::{CommandScopeConfig, Component, ScopeConfig, VersionTarget};
+    use homeboy_core::git::SemverBump;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")
@@ -856,5 +858,61 @@ mod tests {
         assert_eq!(latest_tag.as_deref(), Some("v0.1.0"));
         assert_eq!(commits.len(), 2);
         assert_eq!(commits[0].subject, "fix: second work");
+    }
+
+    #[test]
+    fn low_confidence_warning_fires_on_majority_non_conventional_low_bump() {
+        // Majority non-conventional + a patch recommendation → warn.
+        let warning = low_confidence_bump_warning(Some(SemverBump::Patch), 6, 10)
+            .expect("majority non-conventional patch bump warns");
+        assert!(warning.contains("6 of 10"));
+        assert!(warning.contains("under-bump"));
+
+        // No recommendation at all with non-conventional commits also warns.
+        assert!(low_confidence_bump_warning(None, 3, 4).is_some());
+    }
+
+    #[test]
+    fn low_confidence_warning_silent_when_confident_or_conventional() {
+        // A minor/major recommendation is feat-/breaking-driven → confident.
+        assert!(low_confidence_bump_warning(Some(SemverBump::Minor), 9, 10).is_none());
+        // Mostly-conventional history recommending patch → not low-confidence.
+        assert!(low_confidence_bump_warning(Some(SemverBump::Patch), 2, 10).is_none());
+        // Empty range → nothing to warn about.
+        assert!(low_confidence_bump_warning(Some(SemverBump::Patch), 0, 0).is_none());
+    }
+
+    #[test]
+    fn non_conventional_commits_surface_low_confidence_warning_end_to_end() {
+        // A range of plain (non-conventional) feature subjects auto-detects a
+        // patch and must surface the low-confidence warning + the counts (#6851).
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "seed.txt", "seed", "seed");
+        run_git(dir, &["tag", "v0.1.0"]);
+        commit_file(dir, "a.rs", "a", "Add public runtime descriptor API");
+        commit_file(dir, "b.rs", "b", "Add browser connector SDK primitives");
+        commit_file(dir, "c.rs", "c", "Complete browser SDK v1 contract");
+
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let scope = ReleaseScope::resolve(&component, "fixture").expect("scope");
+        let recommendation = build_semver_recommendation(&component, "none", &scope)
+            .expect("recommendation builds")
+            .expect("some recommendation");
+
+        assert_eq!(recommendation.recommended_bump.as_deref(), Some("patch"));
+        assert_eq!(recommendation.non_conventional_commit_count, 3);
+        assert_eq!(recommendation.considered_commit_count, 3);
+        assert!(
+            recommendation
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("low-confidence bump") && reason.contains("3 of 3")),
+            "expected a low-confidence warning, got: {:?}",
+            recommendation.reasons
+        );
     }
 }

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -136,6 +136,15 @@ pub struct ReleaseSemverRecommendation {
     pub requested_bump: String,
     pub is_underbump: bool,
     pub reasons: Vec<String>,
+    /// How many commits in range carried no recognizable conventional-commit
+    /// prefix (`feat:`/`fix:`/etc.). On repos that don't use conventional commits
+    /// these are classified `other` and only ever drive a `patch` bump, so a
+    /// high count next to a low bump is a silent under-bump signal (#6851).
+    #[serde(default)]
+    pub non_conventional_commit_count: usize,
+    /// Total commits considered for the bump (excludes merge/release noise).
+    #[serde(default)]
+    pub considered_commit_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bump_policy: Option<ReleaseBumpPolicy>,
 }
@@ -617,6 +626,8 @@ mod tests {
             requested_bump: "minor".to_string(),
             is_underbump: false,
             reasons: Vec::new(),
+            non_conventional_commit_count: 0,
+            considered_commit_count: 0,
             bump_policy: None,
         };
         let plan = ReleasePlan::new(


### PR DESCRIPTION
## Summary
`homeboy release` auto-derives the version bump from conventional-commit prefixes. On repos that don't use `feat:`/`fix:` — plain subjects like `Add public runtime descriptor API` — those commits classify as `other` and can only ever drive a **patch**. So a large range of new public API silently ships a patch, with **no signal** that auto-detection under-bumped (#6851). The real example: 78 commits of new SDK/contract APIs on wp-codebox → auto-detected `patch` (`v0.10.1`) when `minor` was warranted.

## Change
- Count the commits with **no recognizable conventional prefix**. When they are a **majority** of the range AND the auto-detected bump is **low** (patch/none), lead the recommendation `reasons` with an explicit low-confidence warning naming the counts and suggesting an explicit `--bump`:

  > `low-confidence bump: 3 of 3 commits have no conventional-commit prefix and were treated as 'other' (patch-level). Auto-detected 'patch' may under-bump — pass an explicit --bump (e.g. minor) if this range adds features.`

- Expose `non_conventional_commit_count` / `considered_commit_count` on the semver recommendation so the release plan/preflight (and any tooling) can render the evidence.

## Scope
This is the issue's fix #1 (surface the decision + evidence, warn on low-confidence). It **does not** change the bump itself or add the fuzzy verb-based auto-escalation (fix #3) — the operator stays in control; they just get the signal before tagging. Serde-default fields keep the change backward-compatible.

## Testing
`homeboy-release --lib planning_semver::tests` — 3 new pass:
- warning fires on majority-non-conventional + low bump; also on `None` recommendation.
- warning silent when confident (minor/major), mostly-conventional, or empty range.
- end-to-end: three plain `Add`/`Complete` subjects → `patch` recommendation with the low-confidence warning + `3 of 3` counts.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing conventional-commit classification to the `other`→patch path, adding the non-conventional count + low-confidence warning, and coverage.

Refs #6851