### PR TITLE
fix(audit): preserve grammar quote delimiters

### DIFF
--- a/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
@@ -581,6 +581,30 @@ fn php_metadata_grammar() -> Grammar {
 }
 
 #[test]
+fn successive_fingerprints_at_stable_path_observe_current_methods() {
+    let grammar = php_metadata_grammar();
+    let dir = tempfile::tempdir().expect("temporary audit root");
+    let path = dir.path().join("StableSource.php");
+    let initial = "<?php\nclass StableSource {\n    public function canExtract(): bool { return true; }\n}\n";
+    std::fs::write(&path, initial).expect("initial source");
+
+    let first_content = std::fs::read_to_string(&path).expect("initial source content");
+    let first = fingerprint_from_grammar(&first_content, &grammar, "StableSource.php")
+        .expect("initial fingerprint");
+    assert_eq!(first.methods, vec!["canExtract"]);
+
+    // The double quote is data inside a single-quoted string. It must not leave
+    // the parser in multiline-string state and hide declarations below it.
+    let updated = "<?php\nclass StableSource {\n    public function canExtract(): bool { return strpos( 'marker=\"value', 'marker' ) !== false; }\n    public function extract(): array { return array(); }\n    public function getMethod(): string { return 'stable'; }\n}\n";
+    std::fs::write(&path, updated).expect("updated source");
+
+    let second_content = std::fs::read_to_string(&path).expect("updated source content");
+    let second = fingerprint_from_grammar(&second_content, &grammar, "StableSource.php")
+        .expect("updated fingerprint");
+    assert_eq!(second.methods, vec!["canExtract", "extract", "getMethod"]);
+}
+
+#[test]
 fn grammar_contract_metadata_suppresses_framework_unused_params() {
     let grammar = php_metadata_grammar();
     let content = "<?php\nclass Sample {\n    public function contractExecute( string $input ): bool {\n        return true;\n    }\n    public function route( FrameworkRequest $request ): bool {\n        return true;\n    }\n    public function helper( int $left, int $right ): int {\n        return $left * 2;\n    }\n}\n";

--- a/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/tests.rs
@@ -585,7 +585,8 @@ fn successive_fingerprints_at_stable_path_observe_current_methods() {
     let grammar = php_metadata_grammar();
     let dir = tempfile::tempdir().expect("temporary audit root");
     let path = dir.path().join("StableSource.php");
-    let initial = "<?php\nclass StableSource {\n    public function canExtract(): bool { return true; }\n}\n";
+    let initial =
+        "<?php\nclass StableSource {\n    public function canExtract(): bool { return true; }\n}\n";
     std::fs::write(&path, initial).expect("initial source");
 
     let first_content = std::fs::read_to_string(&path).expect("initial source content");

--- a/crates/homeboy-engine-primitives/src/grammar/mod.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/mod.rs
@@ -30,7 +30,7 @@ mod strings;
 mod types;
 
 pub use strings::find_unclosed_raw_string_on_line;
-use strings::{line_closes_regular_string, line_has_unclosed_regular_string};
+use strings::{line_closes_regular_string, unclosed_regular_string_quote};
 
 pub use extract::cached_regex;
 pub use extract::{extract, namespace, Symbol};
@@ -336,6 +336,20 @@ mod tests {
 
         assert_eq!(lines[1].region, Region::LineComment);
         assert_eq!(lines[2].region, Region::Code);
+    }
+
+    #[test]
+    fn php_single_quoted_string_can_contain_unpaired_double_quote() {
+        let content = "<?php\n$value = 'marker=\"value';\nfunction current_method() {}\n";
+        let grammar = php_grammar();
+        let lines = walk_lines(content, &grammar);
+
+        assert_eq!(lines[1].region, Region::Code);
+        assert_eq!(lines[2].region, Region::Code);
+        assert_eq!(
+            method_names(&extract(content, &grammar)),
+            vec!["current_method"]
+        );
     }
 
     // ---- Extraction tests ----

--- a/crates/homeboy-engine-primitives/src/grammar/parser.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/parser.rs
@@ -5,7 +5,7 @@
 
 use super::types::{BlockSyntax, CommentSyntax, Grammar, StringSyntax};
 use super::{
-    find_unclosed_raw_string_on_line, line_closes_regular_string, line_has_unclosed_regular_string,
+    find_unclosed_raw_string_on_line, line_closes_regular_string, unclosed_regular_string_quote,
 };
 
 // ============================================================================
@@ -112,7 +112,14 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
     let mut block_comment_end = String::new();
     let mut in_raw_string = false;
     let mut raw_string_close = String::new();
-    let mut in_regular_string = false;
+    let mut regular_string_quote = None;
+    let quote_chars: Vec<char> = grammar
+        .strings
+        .quotes
+        .iter()
+        .filter_map(|quote| quote.chars().next())
+        .collect();
+    let escape = grammar.strings.escape.chars().next().unwrap_or('\\');
 
     for (i, line) in content.lines().enumerate() {
         let trimmed = line.trim();
@@ -125,12 +132,12 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
                 in_raw_string = false;
             }
             Region::StringLiteral
-        } else if in_regular_string {
+        } else if let Some(quote) = regular_string_quote {
             // Inside a multi-line regular string. Some grammar profiles permit
             // newline escapes in ordinary strings, and fixture source in tests
             // commonly uses that form.
-            if line_closes_regular_string(line) {
-                in_regular_string = false;
+            if line_closes_regular_string(line, quote, escape) {
+                regular_string_quote = None;
             }
             Region::StringLiteral
         } else if in_block_comment {
@@ -167,8 +174,10 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
                 if let Some(close) = find_unclosed_raw_string_on_line(line) {
                     in_raw_string = true;
                     raw_string_close = close;
-                } else if line_has_unclosed_regular_string(line) {
-                    in_regular_string = true;
+                } else if let Some(quote) =
+                    unclosed_regular_string_quote(line, &quote_chars, escape)
+                {
+                    regular_string_quote = Some(quote);
                 }
                 // The opening line itself is Code (it has real code on it);
                 // subsequent lines inside the string are StringLiteral.

--- a/crates/homeboy-engine-primitives/src/grammar/strings.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/strings.rs
@@ -53,36 +53,45 @@ pub fn find_unclosed_raw_string_on_line(line: &str) -> Option<String> {
     None
 }
 
-pub(crate) fn line_has_unclosed_regular_string(line: &str) -> bool {
+pub(crate) fn unclosed_regular_string_quote(
+    line: &str,
+    quote_chars: &[char],
+    escape: char,
+) -> Option<char> {
     let bytes = line.as_bytes();
     let mut pos = 0;
-    let mut in_string = false;
+    let mut active_quote = None;
 
     while pos < bytes.len() {
         let byte = bytes[pos];
+        let ch = byte as char;
 
-        if byte == b'"' && !is_escaped(bytes, pos) {
+        if quote_chars.contains(&ch) && !is_escaped_with(bytes, pos, escape as u8) {
             // Raw string openers are handled separately. Treat the opening
             // delimiter as non-regular so `r#"..."#` does not toggle us.
-            if !in_string && pos > 0 && bytes[pos - 1] == b'r' {
+            if active_quote.is_none() && ch == '"' && pos > 0 && bytes[pos - 1] == b'r' {
                 pos += 1;
                 continue;
             }
-            in_string = !in_string;
+            match active_quote {
+                Some(open) if open == ch => active_quote = None,
+                None => active_quote = Some(ch),
+                Some(_) => {}
+            }
         }
 
         pos += 1;
     }
 
-    in_string
+    active_quote
 }
 
-pub(crate) fn line_closes_regular_string(line: &str) -> bool {
+pub(crate) fn line_closes_regular_string(line: &str, quote: char, escape: char) -> bool {
     let bytes = line.as_bytes();
     let mut pos = 0;
 
     while pos < bytes.len() {
-        if bytes[pos] == b'"' && !is_escaped(bytes, pos) {
+        if bytes[pos] == quote as u8 && !is_escaped_with(bytes, pos, escape as u8) {
             return true;
         }
         pos += 1;
@@ -91,14 +100,14 @@ pub(crate) fn line_closes_regular_string(line: &str) -> bool {
     false
 }
 
-fn is_escaped(bytes: &[u8], pos: usize) -> bool {
+fn is_escaped_with(bytes: &[u8], pos: usize, escape: u8) -> bool {
     if pos == 0 {
         return false;
     }
 
     let mut backslashes = 0;
     let mut i = pos;
-    while i > 0 && bytes[i - 1] == b'\\' {
+    while i > 0 && bytes[i - 1] == escape {
         backslashes += 1;
         i -= 1;
     }


### PR DESCRIPTION
## Summary
- track the active grammar-declared quote delimiter while walking multiline strings
- prevent a different quote character inside a string from hiding all later declarations
- cover stable-path source rewrites so a subsequent fingerprint observes the current method set

## Root cause
The reported fingerprints looked stale, but neither Homeboy's audit pipeline nor the failing CI run reused a persisted path-keyed fingerprint. The run had a Homeboy cache miss, installed WordPress extension revision `1cd18d31` fresh, built a new source snapshot, and passed current file content into fingerprinting.

The generic grammar walker only counted double quotes when deciding whether a line opened a multiline regular string. In a grammar with both single- and double-quoted strings, an unmatched double quote used as data inside a balanced single-quoted string incorrectly opened multiline-string state. Declarations on following lines were classified as string content and omitted from the method fingerprint, producing the stale-looking `missing_method` findings.

## Generic cache contract
Audit fingerprints remain content-derived and ephemeral: each audit builds a fresh source snapshot and fingerprints its loaded content with the active provider grammar. There is no persisted fingerprint cache to key by path, content hash, or provider revision. This fix preserves that contract by correcting the generic parser state derived from the current content and grammar-declared delimiters, rather than adding a second cache or a provider-specific invalidation path.

## Validation
- `cargo test -p homeboy-engine-primitives grammar:: --lib` (43 passed)
- `cargo test -p homeboy-code-audit --lib` (848 passed, 1 ignored)
- `git diff --check`

The full primitive package additionally passed 178 tests; two unrelated process-supervision tests failed because their child shell could not open the environment's transient Rust toolchain path. `rustfmt` and `rustdoc` are not installed in this environment, so format/doc checks could not execute locally.

Closes #9960