### PR TITLE
fix(upgrade): don't switch/checkout an explicitly selected source checkout

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -816,9 +816,14 @@ const EXPLICIT_SOURCE_GIT_UPDATE_GUARD: &str = r#"HOMEBOY_REAL_GIT="$(command -v
 HOMEBOY_GIT_GUARD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-git-guard.XXXXXX")"
 cat > "$HOMEBOY_GIT_GUARD_DIR/git" <<'HOMEBOY_GIT_GUARD'
 #!/bin/sh
+# An explicitly selected --source-path is an immutable build input: build the
+# exact ref the caller checked out. Skip git subcommands that would rewrite or
+# move it. `switch`/`checkout` are skipped too so an upgrade command that runs
+# `git switch main` does not collide with another worktree that already has
+# main checked out (#6987) — the source stays on its current ref.
 for homeboy_git_arg in "$@"; do
   case "$homeboy_git_arg" in
-    pull|fetch|reset)
+    pull|fetch|reset|switch|checkout)
       echo "Skipping git $homeboy_git_arg for explicitly selected source checkout"
       exit 0
       ;;

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
@@ -653,6 +653,47 @@ fn explicit_source_upgrade_runs_build_phase_without_upstream_on_local_branch_or_
 }
 
 #[test]
+fn explicit_source_upgrade_skips_git_switch_main_and_reaches_build_phase() {
+    // #6987: an upgrade command that runs `git switch main` must not switch the
+    // explicitly selected source checkout — otherwise it collides with another
+    // worktree that owns main. The guard skips switch/checkout and the build
+    // phase still runs; the source stays on its original branch.
+    let checkout = source_workspace_with_package_name("homeboy");
+    git(
+        checkout.path(),
+        &["init", "--initial-branch", "task-branch"],
+    );
+    git(
+        checkout.path(),
+        &["config", "user.email", "test@example.com"],
+    );
+    git(checkout.path(), &["config", "user.name", "Homeboy Test"]);
+    git(checkout.path(), &["add", "."]);
+    git(checkout.path(), &["commit", "-m", "initial"]);
+
+    let build_marker = checkout.path().join("build-phase");
+    // A command that would move the checkout to main (and, without the guard,
+    // `set -e` would abort before the build). `git checkout -b` is also skipped.
+    let upgrade_command = format!(
+        "set -e\ngit switch main\ngit checkout main\nprintf built > {}",
+        shell_quote_path(&build_marker)
+    );
+    let command =
+        source_upgrade_command_for_prepared_workspace(&upgrade_command, checkout.path(), true)
+            .expect("explicit source command");
+
+    run_source_upgrade_command(&command, checkout.path(), Duration::from_secs(5))
+        .expect("guarded upgrade command reaches build phase despite git switch main");
+
+    assert_eq!(std::fs::read_to_string(build_marker).unwrap(), "built");
+    // The source checkout is untouched: still on its original task branch.
+    assert_eq!(
+        git_stdout(checkout.path(), &["branch", "--show-current"]),
+        "task-branch"
+    );
+}
+
+#[test]
 fn source_upgrade_command_preserves_snapshot_command() {
     let checkout = source_workspace_with_package_name("homeboy");
 


### PR DESCRIPTION
## Summary
`homeboy upgrade --method source --source-path <task-worktree>` runs the configured source upgrade command. A command containing `git switch main` fails when `main` is already checked out by another worktree (#6987):

```text
prepare source checkout: git switch main failed:
fatal: 'main' is already used by worktree at '.../homeboy@cook-...'
```

This blocked upgrading the controller binary from a clean task worktree — exactly when you've just landed Homeboy fixes in a worktree and want to dogfood them.

## Root cause
An explicitly-selected `--source-path` is treated as an **immutable build input** — `prepare_source_workspace_for_upgrade` already refuses to rewrite the worktree, and the upgrade command is wrapped in a git guard that skips `pull`/`fetch`/`reset`. But the guard did **not** skip `switch`/`checkout`, so an upgrade command that runs `git switch main` still executed and collided with the worktree that owns main.

## Fix
Extend the `EXPLICIT_SOURCE_GIT_UPDATE_GUARD` case list to also skip `switch|checkout`. The caller chose the exact ref to build, so the source stays on its current branch and never fights another worktree over main. The guard only applies to explicit-source-path upgrades, so ordinary (non-source / non-explicit) upgrades are unaffected.

## Testing
- `explicit_source_upgrade_skips_git_switch_main_and_reaches_build_phase` (new) — executes a guarded command with `git switch main` + `git checkout main`; asserts the build phase still runs (switch skipped, not aborted by `set -e`) and the checkout stays on its original `task-branch`.
- `explicit_source_upgrade_runs_build_phase_without_upstream_on_local_branch_or_detached_head` — still passes (no regression to the pull/fetch/reset guarding).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the worktree-collision to the source-upgrade git guard's case list, adding switch/checkout, and end-to-end coverage.

Closes #6987