### PR TITLE
Advertise review test, not the nonexistent top-level test command (#9956)

### DIFF
--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -173,7 +173,7 @@ fn run_main_test_workflow_inner(
                     .build()]);
                 let hints = Some(vec![
                     format!(
-                        "Add or route a test for the changed source, or run the full suite: homeboy test {}",
+                        "Add or route a test for the changed source, or run the full suite: homeboy review test {}",
                         args.component_id
                     ),
                     "If these changes are intentionally test-exempt, exclude them from the release/test scope so the gate can pass with a typed reason.".to_string(),
@@ -209,7 +209,7 @@ fn run_main_test_workflow_inner(
                     "No impacted tests found for --changed-since {changed_ref} (no production or test source changed)"
                 ),
                 format!(
-                    "Run full suite if needed: homeboy test {}",
+                    "Run full suite if needed: homeboy review test {}",
                     args.component_id
                 ),
             ]);
@@ -402,7 +402,7 @@ fn run_main_test_workflow_inner(
 
     if status == "failed" && args.passthrough_args.is_empty() {
         hints.push(format!(
-            "To run specific tests: homeboy test {} -- --filter=TestName",
+            "To run specific tests: homeboy review test {} -- --filter=TestName",
             args.component_id
         ));
     }
@@ -430,7 +430,7 @@ fn run_main_test_workflow_inner(
 
     if !coverage_enabled {
         hints.push(format!(
-            "Collect coverage: homeboy test {} --coverage",
+            "Collect coverage: homeboy review test {} --coverage",
             args.component_id
         ));
     }
@@ -441,27 +441,29 @@ fn run_main_test_workflow_inner(
         && baseline_comparison.is_none()
     {
         hints.push(format!(
-            "Save test baseline: homeboy test {} --baseline",
+            "Save test baseline: homeboy review test {} --baseline",
             args.component_id
         ));
     }
 
     if baseline_comparison.is_some() && !args.baseline_flags.ratchet {
         hints.push(format!(
-            "Auto-update baseline on improvement: homeboy test {} --ratchet",
+            "Auto-update baseline on improvement: homeboy review test {} --ratchet",
             args.component_id
         ));
     }
 
     if status == "failed" && !args.analyze {
         hints.push(format!(
-            "Analyze failures: homeboy test {} --analyze",
+            "Analyze failures: homeboy review test {} --analyze",
             args.component_id
         ));
     }
 
     if args.passthrough_args.is_empty() {
-        hints.push("Pass args to test runner: homeboy test <component> -- [args]".to_string());
+        hints.push(
+            "Pass args to test runner: homeboy review test <component> -- [args]".to_string(),
+        );
     }
 
     hints.push("Full options: homeboy self docs commands/test".to_string());


### PR DESCRIPTION
Fixes #9956.

## Problem
`homeboy review` test-stage output advertised top-level `homeboy test <component> ...` commands, but the CLI has **no top-level `test` subcommand**. Following the generated remediation failed immediately:

```
error: unrecognized subcommand 'test'
```

Same command-shape class fixed for Lab fallback output in #8831, but it remained in normal review result hints.

## Fix
Repoint every review-facing test hint in the test workflow (`homeboy-extension/src/test/run.rs`) from the nonexistent `homeboy test <component>` to the valid `homeboy review test <component>`:
- run-specific-tests (`-- --filter=`)
- collect coverage (`--coverage`)
- save baseline (`--baseline`)
- auto-update baseline (`--ratchet`)
- analyze failures (`--analyze`)
- pass args to runner (`-- [args]`)
- the two "run the full suite" hints

Left unchanged (already correct): the deep-dive hint in `review/mod.rs` already renders `homeboy review <stage>`, and `homeboy refactor <component> --from lint --write` is a real top-level command. The remaining `homeboy test ...` strings in the codebase are test fixtures / observation-record commands, not review output.

## Acceptance criteria coverage
- ✅ Review no longer advertises a nonexistent top-level `homeboy test` command
- ✅ The advertised remediation (`homeboy review test ...`) is a valid, runnable command
- ✅ Aligns with the `review test` form already used elsewhere (e.g. refactor autofix hints, Lab fallback commands)

## Verification
- `cargo fmt --all --check` clean
- `cargo check -p homeboy-extension --lib` exit 0
- Docs/hint-string only; no behavior change

Diff: +10/-8, 1 file.
