### PR TITLE
fix(lab): remap gate-feedback paths safely

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
@@ -17,8 +17,8 @@ use homeboy_core::{Error, Result};
 
 use super::envelope::ExecutionEnvelope;
 use super::path_remap::{
-    is_absolute_controller_path, order_mappings_by_specificity, remap_local_path,
-    remap_paths_in_value, try_rewrite_flag_value_args, LabPathRemap,
+    is_absolute_controller_path, order_mappings_by_specificity, path_escapes_mapping,
+    remap_local_path, remap_paths_in_value, try_rewrite_flag_value_args, LabPathRemap,
 };
 
 pub(crate) struct AgentTaskSpecMaterialization<T> {
@@ -194,6 +194,7 @@ fn remap_agent_task_plan_spec(
         )
     })?;
     let controller_plan = value.clone();
+    reject_paths_escaping_mappings(&controller_plan, mappings)?;
     reject_unmapped_controller_paths(&controller_plan, mappings)?;
     remap_paths_in_value(&mut value, mappings);
     record_controller_workspace_provenance(&mut value, &controller_plan);
@@ -205,48 +206,136 @@ fn remap_agent_task_plan_spec(
     })
 }
 
-/// A persisted plan is executed on the runner without a controller filesystem.
-/// Reject every absolute controller path that has no materialized mapping rather
-/// than passing it through to fail later in provider setup or change harvest.
-fn reject_unmapped_controller_paths(value: &Value, mappings: &[&LabPathRemap]) -> Result<()> {
+/// Reject any path that starts below a controller mapping but crosses back out.
+/// This applies to every plan value because the mapping itself proves its
+/// controller origin, unlike an arbitrary absolute provider config string.
+fn reject_paths_escaping_mappings(value: &Value, mappings: &[&LabPathRemap]) -> Result<()> {
     fn visit(value: &Value, mappings: &[&LabPathRemap], pointer: &str) -> Result<()> {
         match value {
-            Value::String(path) if is_absolute_controller_path(path) => {
-                if remap_local_path(path, mappings).is_none() {
-                    return Err(Error::validation_invalid_argument(
-                        "plan",
-                        format!(
-                            "Lab offload cannot map controller-local path at {pointer} to the selected runner workspace"
-                        ),
-                        Some(path.clone()),
-                        Some(vec![
-                            "Include the referenced checkout or runtime overlay in the Lab workspace materialization plan.".to_string(),
-                            "Retry after Homeboy can materialize every controller-local path in the follow-up plan.".to_string(),
-                        ]),
-                    ));
-                }
+            Value::String(path)
+                if mappings
+                    .iter()
+                    .any(|mapping| path_escapes_mapping(path, mapping)) =>
+            {
+                Err(Error::validation_invalid_argument(
+                    "plan",
+                    format!(
+                        "Lab offload rejects controller-local path at {pointer} because it escapes the selected runner workspace"
+                    ),
+                    Some(path.clone()),
+                    Some(vec![
+                        "Use a path below the materialized controller workspace without `..` traversal.".to_string(),
+                    ]),
+                ))
             }
             Value::Array(items) => {
                 for (index, item) in items.iter().enumerate() {
                     visit(item, mappings, &format!("{pointer}/{index}"))?;
                 }
+                Ok(())
             }
             Value::Object(entries) => {
                 for (key, item) in entries {
-                    // This is an audit-only controller reference added after
-                    // remapping; it must remain stable for operator evidence.
-                    if key == "workspace_source_provenance" {
-                        continue;
-                    }
                     visit(item, mappings, &format!("{pointer}/{key}"))?;
                 }
+                Ok(())
             }
-            _ => {}
+            _ => Ok(()),
+        }
+    }
+
+    visit(value, mappings, "")
+}
+
+/// A persisted plan is executed on the runner without a controller filesystem.
+/// Validate only schema-declared controller path fields; opaque provider config
+/// may intentionally name a runner-native binary or service path.
+fn reject_unmapped_controller_paths(value: &Value, mappings: &[&LabPathRemap]) -> Result<()> {
+    fn validate(path: &str, mappings: &[&LabPathRemap], pointer: &str) -> Result<()> {
+        if !is_absolute_controller_path(path) {
+            return Ok(());
+        }
+        if remap_local_path(path, mappings).is_none() {
+            return Err(Error::validation_invalid_argument(
+                "plan",
+                format!(
+                    "Lab offload cannot map controller-local path at {pointer} to the selected runner workspace"
+                ),
+                Some(path.to_string()),
+                Some(vec![
+                    "Include the referenced checkout or runtime overlay in the Lab workspace materialization plan.".to_string(),
+                    "Retry after Homeboy can materialize every controller-local path in the follow-up plan.".to_string(),
+                ]),
+            ));
         }
         Ok(())
     }
 
-    visit(value, mappings, "")
+    let validate_value = |value: Option<&Value>, pointer: String| -> Result<()> {
+        if let Some(path) = value.and_then(Value::as_str) {
+            validate(path, mappings, &pointer)?;
+        }
+        Ok(())
+    };
+
+    for (index, contract) in value
+        .get("component_contracts")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .enumerate()
+    {
+        validate_value(
+            contract.get("path"),
+            format!("/component_contracts/{index}/path"),
+        )?;
+    }
+    for (index, task) in value
+        .get("tasks")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .enumerate()
+    {
+        let base = format!("/tasks/{index}");
+        validate_value(
+            task.pointer("/workspace/root"),
+            format!("{base}/workspace/root"),
+        )?;
+        validate_value(
+            task.pointer("/executor/config/workspace_root"),
+            format!("{base}/executor/config/workspace_root"),
+        )?;
+        validate_value(
+            task.pointer("/executor/config/workspace/root"),
+            format!("{base}/executor/config/workspace/root"),
+        )?;
+        validate_value(
+            task.pointer("/metadata/workspace/root"),
+            format!("{base}/metadata/workspace/root"),
+        )?;
+        validate_value(
+            task.pointer("/metadata/cook_continuation_workspace/candidate_source_root"),
+            format!("{base}/metadata/cook_continuation_workspace/candidate_source_root"),
+        )?;
+        validate_value(
+            task.pointer("/metadata/cook_continuation_workspace/task_workspace/root"),
+            format!("{base}/metadata/cook_continuation_workspace/task_workspace/root"),
+        )?;
+        for (contract_index, contract) in task
+            .get("component_contracts")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            validate_value(
+                contract.get("path"),
+                format!("{base}/component_contracts/{contract_index}/path"),
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn record_controller_workspace_provenance(remapped: &mut Value, controller: &Value) {

--- a/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
@@ -17,7 +17,8 @@ use homeboy_core::{Error, Result};
 
 use super::envelope::ExecutionEnvelope;
 use super::path_remap::{
-    order_mappings_by_specificity, remap_paths_in_value, try_rewrite_flag_value_args, LabPathRemap,
+    is_absolute_controller_path, order_mappings_by_specificity, remap_local_path,
+    remap_paths_in_value, try_rewrite_flag_value_args, LabPathRemap,
 };
 
 pub(crate) struct AgentTaskSpecMaterialization<T> {
@@ -193,6 +194,7 @@ fn remap_agent_task_plan_spec(
         )
     })?;
     let controller_plan = value.clone();
+    reject_unmapped_controller_paths(&controller_plan, mappings)?;
     remap_paths_in_value(&mut value, mappings);
     record_controller_workspace_provenance(&mut value, &controller_plan);
     serde_json::to_string(&value).map_err(|err| {
@@ -201,6 +203,50 @@ fn remap_agent_task_plan_spec(
             Some("serialize remapped agent-task plan".to_string()),
         )
     })
+}
+
+/// A persisted plan is executed on the runner without a controller filesystem.
+/// Reject every absolute controller path that has no materialized mapping rather
+/// than passing it through to fail later in provider setup or change harvest.
+fn reject_unmapped_controller_paths(value: &Value, mappings: &[&LabPathRemap]) -> Result<()> {
+    fn visit(value: &Value, mappings: &[&LabPathRemap], pointer: &str) -> Result<()> {
+        match value {
+            Value::String(path) if is_absolute_controller_path(path) => {
+                if remap_local_path(path, mappings).is_none() {
+                    return Err(Error::validation_invalid_argument(
+                        "plan",
+                        format!(
+                            "Lab offload cannot map controller-local path at {pointer} to the selected runner workspace"
+                        ),
+                        Some(path.clone()),
+                        Some(vec![
+                            "Include the referenced checkout or runtime overlay in the Lab workspace materialization plan.".to_string(),
+                            "Retry after Homeboy can materialize every controller-local path in the follow-up plan.".to_string(),
+                        ]),
+                    ));
+                }
+            }
+            Value::Array(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    visit(item, mappings, &format!("{pointer}/{index}"))?;
+                }
+            }
+            Value::Object(entries) => {
+                for (key, item) in entries {
+                    // This is an audit-only controller reference added after
+                    // remapping; it must remain stable for operator evidence.
+                    if key == "workspace_source_provenance" {
+                        continue;
+                    }
+                    visit(item, mappings, &format!("{pointer}/{key}"))?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    visit(value, mappings, "")
 }
 
 fn record_controller_workspace_provenance(remapped: &mut Value, controller: &Value) {

--- a/crates/homeboy-lab-runner/src/lab_args/path_remap.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/path_remap.rs
@@ -235,7 +235,42 @@ fn path_suffix<'a>(path: &'a str, prefix: &str) -> Option<String> {
     } else {
         path.strip_prefix(&prefix_with_separator)
     }?;
-    Some(rest.to_string())
+    normalize_relative_suffix(rest)
+}
+
+/// Whether a path starts beneath a mapped controller root but uses `..` to
+/// escape it. The caller must reject this rather than treating it as an
+/// unmapped path, since accepting it would make the remote join unsafe.
+pub(super) fn path_escapes_mapping(path: &str, mapping: &LabPathRemap) -> bool {
+    let path = normalize_path_separators(path);
+    let prefix = normalize_path_separators(&mapping.local)
+        .trim_end_matches('/')
+        .to_string();
+    let prefix_with_separator = format!("{prefix}/");
+    let rest = if is_windows_drive_path(&path) || is_windows_drive_path(&prefix) {
+        path.get(..prefix_with_separator.len())
+            .filter(|candidate| candidate.eq_ignore_ascii_case(&prefix_with_separator))
+            .and_then(|_| path.get(prefix_with_separator.len()..))
+    } else {
+        path.strip_prefix(&prefix_with_separator)
+    };
+    rest.is_some_and(|rest| normalize_relative_suffix(rest).is_none())
+}
+
+/// Normalize a relative suffix while retaining it below the mapped workspace.
+/// Returning `None` means a `..` would cross the mapping boundary.
+fn normalize_relative_suffix(suffix: &str) -> Option<String> {
+    let mut segments = Vec::new();
+    for segment in suffix.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop()?;
+            }
+            segment => segments.push(segment),
+        }
+    }
+    Some(segments.join("/"))
 }
 
 fn normalize_path_separators(path: &str) -> String {

--- a/crates/homeboy-lab-runner/src/lab_args/path_remap.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/path_remap.rs
@@ -199,15 +199,61 @@ pub(super) fn remap_local_path(text: &str, mappings: &[&LabPathRemap]) -> Option
         if mapping.local.is_empty() {
             continue;
         }
-        if text == mapping.local {
+        if paths_match(text, &mapping.local) {
             return Some(mapping.remote.clone());
         }
-        let prefix = format!("{}/", mapping.local.trim_end_matches('/'));
-        if let Some(rest) = text.strip_prefix(&prefix) {
+        if let Some(rest) = path_suffix(text, &mapping.local) {
             return Some(format!("{}/{}", mapping.remote.trim_end_matches('/'), rest));
         }
     }
     None
+}
+
+/// Compare controller paths without assuming the controller uses the runner's
+/// separator. Lab commonly materializes a Windows controller workspace on a
+/// Linux runner, so a `C:\\work\\repo` plan path must match its recorded mapping.
+fn paths_match(path: &str, prefix: &str) -> bool {
+    let path = normalize_path_separators(path);
+    let prefix = normalize_path_separators(prefix);
+    if is_windows_drive_path(&path) || is_windows_drive_path(&prefix) {
+        path.eq_ignore_ascii_case(&prefix)
+    } else {
+        path == prefix
+    }
+}
+
+fn path_suffix<'a>(path: &'a str, prefix: &str) -> Option<String> {
+    let path = normalize_path_separators(path);
+    let prefix = normalize_path_separators(prefix)
+        .trim_end_matches('/')
+        .to_string();
+    let prefix_with_separator = format!("{prefix}/");
+    let rest = if is_windows_drive_path(&path) || is_windows_drive_path(&prefix) {
+        path.get(..prefix_with_separator.len())
+            .filter(|candidate| candidate.eq_ignore_ascii_case(&prefix_with_separator))
+            .and_then(|_| path.get(prefix_with_separator.len()..))
+    } else {
+        path.strip_prefix(&prefix_with_separator)
+    }?;
+    Some(rest.to_string())
+}
+
+fn normalize_path_separators(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+pub(super) fn is_absolute_controller_path(path: &str) -> bool {
+    let path = normalize_path_separators(path);
+    path.starts_with('/')
+        || path.starts_with("~/")
+        || (path.len() >= 3
+            && path.as_bytes()[0].is_ascii_alphabetic()
+            && path.as_bytes()[1] == b':'
+            && path.as_bytes()[2] == b'/')
+}
+
+fn is_windows_drive_path(path: &str) -> bool {
+    path.len() >= 2 && path.as_bytes()[0].is_ascii_alphabetic() && path.as_bytes()[1] == b':'
 }
 
 fn remap_existing_canonical_path(text: &str, mappings: &[&LabPathRemap]) -> Option<String> {
@@ -230,5 +276,5 @@ fn remap_existing_canonical_path(text: &str, mappings: &[&LabPathRemap]) -> Opti
 }
 
 fn is_controller_path_like(value: &str) -> bool {
-    value.starts_with('/') || value.starts_with("~/")
+    is_absolute_controller_path(value)
 }

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -1993,6 +1993,100 @@ mod materialize_specs_tests {
     }
 
     #[test]
+    fn materialize_agent_task_specs_maps_windows_follow_up_paths_to_linux_workspace() {
+        let controller_workspace = r"C:\Users\chris\Developer\homeboy@follow-up";
+        let runner_workspace = "/home/chris/lab/homeboy-follow-up";
+        let mappings = vec![LabPathRemap {
+            local: controller_workspace.to_string(),
+            remote: runner_workspace.to_string(),
+        }];
+        let plan = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "plan_id": "gate-feedback-follow-up",
+            "tasks": [{
+                "task_id": "follow-up",
+                "workspace": { "root": format!(r"{controller_workspace}\candidate") },
+                "executor": { "backend": "fixture", "config": {
+                    "workspace_root": format!(r"{controller_workspace}\candidate"),
+                    "runtime_overlay": format!(r"{controller_workspace}\.homeboy\runtime")
+                }},
+                "metadata": {
+                    "cook_continuation_workspace": { "candidate_source_root": controller_workspace }
+                }
+            }]
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            plan,
+        ];
+        let mut staged = None;
+
+        materialize_agent_task_specs_in_args(&args, &mappings, Path::new("/tmp"), |spec| {
+            staged = Some(spec.spec.to_string());
+            Ok(None::<(String, ())>)
+        })
+        .expect("map follow-up plan");
+        let staged: serde_json::Value =
+            serde_json::from_str(&staged.expect("staged plan")).expect("plan JSON");
+
+        assert_eq!(
+            staged["tasks"][0]["workspace"]["root"],
+            format!("{runner_workspace}/candidate")
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["workspace_root"],
+            format!("{runner_workspace}/candidate")
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["runtime_overlay"],
+            format!("{runner_workspace}/.homeboy/runtime")
+        );
+        assert_eq!(
+            staged["tasks"][0]["metadata"]["cook_continuation_workspace"]["candidate_source_root"],
+            runner_workspace
+        );
+    }
+
+    #[test]
+    fn materialize_agent_task_specs_rejects_unmapped_windows_follow_up_path() {
+        let mappings = vec![LabPathRemap {
+            local: r"C:\Users\chris\Developer\homeboy@follow-up".to_string(),
+            remote: "/home/chris/lab/homeboy-follow-up".to_string(),
+        }];
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "tasks": [{
+                    "task_id": "follow-up",
+                    "workspace": { "root": r"D:\unmapped\candidate" },
+                    "executor": { "backend": "fixture" }
+                }]
+            })
+            .to_string(),
+        ];
+
+        let error =
+            match materialize_agent_task_specs_in_args(&args, &mappings, Path::new("/tmp"), |_| {
+                Ok(None::<(String, ())>)
+            }) {
+                Ok(_) => panic!("unmapped controller path must fail before Lab dispatch"),
+                Err(error) => error,
+            };
+
+        assert_eq!(error.details["field"], "plan");
+        assert!(error.message.contains("/tasks/0/workspace/root"));
+        assert!(error.message.contains("selected runner workspace"));
+    }
+
+    #[test]
     fn materialize_agent_task_specs_rewrites_fanout_child_cwd_to_runner_path() {
         let temp = tempfile::tempdir().expect("tempdir");
         let controller = temp.path().join("homeboy@cook-one");

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -2082,8 +2082,96 @@ mod materialize_specs_tests {
             };
 
         assert_eq!(error.details["field"], "plan");
-        assert!(error.message.contains("/tasks/0/workspace/root"));
         assert!(error.message.contains("selected runner workspace"));
+    }
+
+    #[test]
+    fn materialize_agent_task_specs_rejects_posix_workspace_traversal() {
+        let mappings = vec![LabPathRemap {
+            local: "/controller/workspace".to_string(),
+            remote: "/runner/workspace".to_string(),
+        }];
+        let args = follow_up_plan_args("/controller/workspace/../../outside", None);
+
+        let error =
+            materialize_agent_task_specs_in_args(&args, &mappings, Path::new("/tmp"), |_| {
+                Ok(None::<(String, ())>)
+            })
+            .err()
+            .expect("POSIX traversal must fail before Lab dispatch");
+
+        assert!(error
+            .message
+            .contains("escapes the selected runner workspace"));
+    }
+
+    #[test]
+    fn materialize_agent_task_specs_rejects_windows_workspace_traversal() {
+        let mappings = vec![LabPathRemap {
+            local: r"C:\controller\workspace".to_string(),
+            remote: "/runner/workspace".to_string(),
+        }];
+        let args = follow_up_plan_args(r"C:\controller\workspace\..\..\outside", None);
+
+        let error =
+            materialize_agent_task_specs_in_args(&args, &mappings, Path::new("/tmp"), |_| {
+                Ok(None::<(String, ())>)
+            })
+            .err()
+            .expect("Windows traversal must fail before Lab dispatch");
+
+        assert!(error
+            .message
+            .contains("escapes the selected runner workspace"));
+    }
+
+    #[test]
+    fn materialize_agent_task_specs_preserves_runner_native_binary_path() {
+        let mappings = vec![LabPathRemap {
+            local: "/controller/workspace".to_string(),
+            remote: "/runner/workspace".to_string(),
+        }];
+        let args = follow_up_plan_args("/controller/workspace/candidate", Some("/usr/bin/tool"));
+        let mut staged = None;
+
+        materialize_agent_task_specs_in_args(&args, &mappings, Path::new("/tmp"), |spec| {
+            staged = Some(spec.spec.to_string());
+            Ok(None::<(String, ())>)
+        })
+        .expect("runner-native binary path is not a controller workspace path");
+        let staged: serde_json::Value =
+            serde_json::from_str(&staged.expect("staged plan")).expect("plan JSON");
+
+        assert_eq!(
+            staged["tasks"][0]["workspace"]["root"],
+            "/runner/workspace/candidate"
+        );
+        assert_eq!(
+            staged["tasks"][0]["executor"]["config"]["binary_path"],
+            "/usr/bin/tool"
+        );
+    }
+
+    fn follow_up_plan_args(workspace_root: &str, binary_path: Option<&str>) -> Vec<String> {
+        let mut config = serde_json::json!({ "workspace_root": workspace_root });
+        if let Some(binary_path) = binary_path {
+            config["binary_path"] = serde_json::json!(binary_path);
+        }
+        vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "tasks": [{
+                    "task_id": "follow-up",
+                    "workspace": { "root": workspace_root },
+                    "executor": { "backend": "fixture", "config": config }
+                }]
+            })
+            .to_string(),
+        ]
     }
 
     #[test]


### PR DESCRIPTION
Closes #9091

Maps declared controller-origin paths into the selected Lab workspace across POSIX and Windows syntax, rejects traversal outside mapped roots, preserves runner-native provider paths, and fails closed before execution for unmappable declared controller fields.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner materialize_agent_task_specs --lib` (10 tests)

## AI assistance
OpenCode using gpt-5.6-sol traced the path leak, implemented and hardened the generic mapping contract, and added tests. Chris remains responsible for the submitted code.