### PR TITLE
fix(cook): ensure declared destination worktrees

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -372,6 +372,16 @@ where
     if let Some(runner_id) = execution_runner_id.as_deref() {
         metadata["runner_id"] = json!(runner_id);
     }
+    // Surface controller-owned worktree convergence in the run record as well
+    // as the immutable plan, so status and resumed execution retain the same
+    // reviewer-facing evidence.
+    if let Some(provision) = plan
+        .tasks
+        .first()
+        .and_then(|task| task.metadata.get("worktree_provision"))
+    {
+        metadata["worktree_provision"] = provision.clone();
+    }
     if let Some(route) = homeboy_core::notification_route::current() {
         route.insert_into_metadata(&mut metadata);
     }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -220,10 +220,7 @@ mod tests {
         let help = rendered_cook_help();
         // Each core flag renders with operator-facing help, not a blank line.
         assert!(help.contains("--goal"), "{help}");
-        assert!(
-            help.contains("Workspace handle of the existing worktree"),
-            "{help}"
-        );
+        assert!(help.contains("Workspace handle the cook edits"), "{help}");
         assert!(
             help.contains("Deterministic verification command"),
             "{help}"
@@ -244,10 +241,10 @@ pub struct AgentTaskCookArgs {
     /// the run and used to frame the agent's task and the review.
     #[arg(long, value_name = "TEXT")]
     pub goal: Option<String>,
-    /// Workspace handle of the existing worktree the cook edits, verifies, and
-    /// finalizes into (e.g. `repo@branch-slug`). This checkout is authoritative:
-    /// the agent's changes, the `--verify` gates, and the resulting PR all
-    /// operate on it. Create it first with `workspace worktree add`.
+    /// Workspace handle the cook edits, verifies, and finalizes into (e.g.
+    /// `repo@branch-slug`). Existing destinations are reused. A missing managed
+    /// destination is created through its configured provider when --repo,
+    /// --base, --head, and --task-url declare explicit intent.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: String,
     #[arg(

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -51,12 +51,14 @@ pub(crate) fn run_cook(args: AgentTaskCookArgs) -> CmdResult<Value> {
 
 /// Converge a Cook promotion destination before compiling a task plan. This is
 /// controller-owned so local and Lab dispatch use the same managed checkout.
-pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {
+pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::core::Result<Value> {
     let destination = std::path::Path::new(&args.to_worktree);
     if destination.is_dir()
         || homeboy::core::worktree::resolve_workspace_ref_if_present(&args.to_worktree)?.is_some()
     {
-        return Ok(());
+        return Ok(
+            serde_json::json!({ "action": "existing", "kind": "path_or_homeboy", "handle": args.to_worktree }),
+        );
     }
 
     let repo = args.dispatch.repo.clone().ok_or_else(|| {
@@ -85,7 +87,25 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
         },
         &defaults::load_config(),
     )
-    .map(|_| ())
+    .map(|provision| {
+        serde_json::json!({
+            "action": provision.action,
+            "provider": provision.resolution.provider_id,
+            "idempotency_key": provision.idempotency_key,
+            "handle": provision.resolution.worktree.handle,
+            "path": provision.resolution.worktree.path,
+            "branch": provision.resolution.worktree.branch,
+        })
+    })
+}
+
+pub(crate) fn record_cook_provision(plan: &mut AgentTaskPlan, provision: Value) {
+    if let Some(task) = plan.tasks.first_mut() {
+        if !task.metadata.is_object() {
+            task.metadata = serde_json::json!({});
+        }
+        task.metadata["worktree_provision"] = provision;
+    }
 }
 
 pub(crate) fn validate_cook_request(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {
@@ -179,7 +199,7 @@ where
     // the requirement here is safe end to end (#7608). Finalizing cooks still
     // require a gate, but now say so with a copy-pasteable example instead of a
     // bare rejection.
-    provision_cook_destination(&args)?;
+    let provision = provision_cook_destination(&args)?;
 
     let mut dispatch_args = args.dispatch.clone();
     if dispatch_args.prompt.is_none() {
@@ -196,7 +216,7 @@ where
                 .unwrap_or_else(|| agent_task_lifecycle::cook_attempt_run_id(cook_id, 1)),
         );
     }
-    let (run_id, initial_plan) = if let Some(attempt_plan) = args.attempt_plan.as_deref() {
+    let (run_id, mut initial_plan) = if let Some(attempt_plan) = args.attempt_plan.as_deref() {
         let run_id = dispatch_args.run_id.clone().ok_or_else(|| {
             homeboy::core::Error::internal_unexpected(
                 "agent-task cook attempt plan requires an attempt run id".to_string(),
@@ -227,6 +247,7 @@ where
         };
         (run_id, plan)
     };
+    record_cook_provision(&mut initial_plan, provision);
     let cook_id = requested_cook_id.unwrap_or_else(|| run_id.clone());
     // Capture the resolved task workspace before dispatch. The provider may
     // commit and leave a clean tree, so resolving this after it runs would

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -84,7 +84,27 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             task_url,
         },
         &defaults::load_config(),
-    )?;
+    )
+    .map(|_| ())
+}
+
+pub(crate) fn validate_cook_request(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    if !args.gates.has_deterministic_gate() && !args.no_finalize {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "verify",
+            "agent-task cook requires at least one deterministic --verify or --private-verify gate before it can commit, push, and open a PR",
+            None,
+            Some(vec!["Provide a deterministic verification gate, e.g. --verify \"cargo test\".".to_string()]),
+        ));
+    }
+    if args.dispatch.core.queue_only {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "queue-only",
+            "agent-task cook cannot queue its controller-owned lifecycle",
+            None,
+            None,
+        ));
+    }
     Ok(())
 }
 
@@ -149,7 +169,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    provision_cook_destination(&args)?;
+    validate_cook_request(&args)?;
     // Deterministic gates exist to make *publication* safe: a green gate is the
     // proof a cook may commit, push, and open a PR. A `--no-finalize` cook does
     // none of those, so a gate is not meaningful there — read-only/exploratory
@@ -159,27 +179,7 @@ where
     // the requirement here is safe end to end (#7608). Finalizing cooks still
     // require a gate, but now say so with a copy-pasteable example instead of a
     // bare rejection.
-    if !args.gates.has_deterministic_gate() && !args.no_finalize {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "verify",
-            "agent-task cook requires at least one deterministic --verify or --private-verify gate before it can commit, push, and open a PR",
-            None,
-            Some(vec![
-                "Provide a gate, e.g. --verify \"cargo test\" (or --private-verify for a secret gate).".to_string(),
-                "For a read-only or exploratory cook with nothing to verify, pass --no-finalize (skips commit, push, and PR); a no-op gate like --verify true also works.".to_string(),
-            ]),
-        ));
-    }
-    if args.dispatch.core.queue_only {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "queue-only",
-            "agent-task cook cannot queue its controller-owned lifecycle; it must retain provider completion to ingest artifacts, promote candidates, run gates, and finalize",
-            None,
-            Some(vec![
-                "Use `homeboy agent-task run-plan --plan <materialized-plan> --record-run-id <run-id> --queue-only` only when a controller owns the corresponding continuation.".to_string(),
-            ]),
-        ));
-    }
+    provision_cook_destination(&args)?;
 
     let mut dispatch_args = args.dispatch.clone();
     if dispatch_args.prompt.is_none() {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -15,6 +15,10 @@ use homeboy::agents::agent_tasks::scheduler::{
 };
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::core::command_invocation::CommandInvocation;
+use homeboy::core::defaults;
+use homeboy::core::worktree_providers::{
+    provision_apply_enabled_worktree_provider_from_config, WorktreeProviderCreateIntent,
+};
 
 use super::super::CmdResult;
 use super::args::{
@@ -43,6 +47,45 @@ fn aggregate_value_with_failure_reasons(aggregate: &AgentTaskAggregate) -> Value
 
 pub(crate) fn run_cook(args: AgentTaskCookArgs) -> CmdResult<Value> {
     run_cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
+}
+
+/// Converge a Cook promotion destination before compiling a task plan. This is
+/// controller-owned so local and Lab dispatch use the same managed checkout.
+pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    let destination = std::path::Path::new(&args.to_worktree);
+    if destination.is_dir()
+        || homeboy::core::worktree::resolve_workspace_ref_if_present(&args.to_worktree)?.is_some()
+    {
+        return Ok(());
+    }
+
+    let repo = args.dispatch.repo.clone().ok_or_else(|| {
+        homeboy::core::Error::validation_missing_argument(vec![
+            "--repo <repo> is required to create a missing --to-worktree destination".to_string(),
+        ])
+    })?;
+    let head = args.head.clone().ok_or_else(|| {
+        homeboy::core::Error::validation_missing_argument(vec![
+            "--head <branch> is required to create a missing --to-worktree destination".to_string(),
+        ])
+    })?;
+    let task_url = args.dispatch.task_url.clone().ok_or_else(|| {
+        homeboy::core::Error::validation_missing_argument(vec![
+            "--task-url <url> is required to create a missing --to-worktree destination"
+                .to_string(),
+        ])
+    })?;
+    provision_apply_enabled_worktree_provider_from_config(
+        &WorktreeProviderCreateIntent {
+            handle: args.to_worktree.clone(),
+            repo,
+            base: args.base.clone(),
+            head,
+            task_url,
+        },
+        &defaults::load_config(),
+    )?;
+    Ok(())
 }
 
 pub(super) fn promotion_provider(args: PromotionProviderArgs) -> CmdResult<Value> {
@@ -106,6 +149,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
+    provision_cook_destination(&args)?;
     // Deterministic gates exist to make *publication* safe: a green gate is the
     // proof a cook may commit, push, and open a PR. A `--no-finalize` cook does
     // none of those, so a gate is not meaningful there — read-only/exploratory

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -44,6 +44,96 @@ fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("provider tempdir");
+        let ensured = temp.path().join("ensured");
+        let provider = temp.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  printf '%s\\n' '{{\"worktrees\":[]}}'\nelse\n  touch '{}'\nfi\n",
+                ensured.display()
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        provider.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    ensure: Some(vec![provider.display().to_string(), "ensure".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                    },
+                ),
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+        for invalid_args in [vec!["--queue-only"], vec![]] {
+            let mut args = vec![
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--prompt",
+                "exercise validation",
+                "--to-worktree",
+                "missing@destination",
+                "--repo",
+                "homeboy",
+                "--base",
+                "main",
+                "--head",
+                "fix/9908",
+                "--task-url",
+                "https://github.com/Extra-Chill/homeboy/issues/9908",
+            ];
+            args.extend(invalid_args);
+            let cli = Cli::parse_from(args);
+            let Commands::AgentTask(agent_task) = cli.command else {
+                panic!("agent-task command")
+            };
+            let AgentTaskCommand::Cook(cook) = agent_task.command else {
+                panic!("cook command")
+            };
+            run_cook_with_executor(cook, ExtensionProviderAgentTaskExecutor::default())
+                .expect_err("invalid Cook input is rejected before provider ensure");
+        }
+        assert!(
+            !ensured.exists(),
+            "invalid Cook inputs must cause zero ensure mutations"
+        );
+    });
+}
+
 #[test]
 fn from_spec_dispatch_defaults_use_spec_git_checkout() {
     let repo = tempfile::tempdir().expect("repo dir");

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -116,6 +116,10 @@ fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_command
             status_value["metadata"]["pre_execution_failure"]["retryable"],
             true
         );
+        assert_eq!(
+            status_value["metadata"]["worktree_provision"]["action"], "existing",
+            "status projects the persisted Cook worktree evidence"
+        );
 
         dispatcher.unavailable.store(false, Ordering::SeqCst);
         let (resumed, exit_code) = run_cook_with_executor_and_dispatcher(
@@ -126,6 +130,18 @@ fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_command
         .expect("same immutable cook resumes after runner repair");
         assert_eq!(exit_code, 0);
         assert_eq!(resumed["status"], "in_flight");
+        assert_eq!(
+            status(StatusArgs {
+                run_id: "cook-cli-preflight-recovery".to_string(),
+                bridge: false,
+                since_cursor: None,
+                full: true,
+            })
+            .expect("resumed Cook status")
+            .0["metadata"]["worktree_provision"]["action"],
+            "existing",
+            "resuming preserves Cook worktree evidence"
+        );
 
         let error = run_cook_with_executor_and_dispatcher(
             recoverable_runner_cook_args(source.path(), Some("changed immutable title")),

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -890,6 +890,7 @@ fn materialize_agent_task_cook_plan(
     else {
         return Ok(None);
     };
+    crate::commands::agent_task::run::validate_cook_request(cook)?;
     crate::commands::agent_task::run::provision_cook_destination(cook)?;
     let mut dispatch = cook.dispatch.clone();
     if dispatch.prompt.is_none() {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -891,7 +891,7 @@ fn materialize_agent_task_cook_plan(
         return Ok(None);
     };
     crate::commands::agent_task::run::validate_cook_request(cook)?;
-    crate::commands::agent_task::run::provision_cook_destination(cook)?;
+    let provision = crate::commands::agent_task::run::provision_cook_destination(cook)?;
     let mut dispatch = cook.dispatch.clone();
     if dispatch.prompt.is_none() {
         dispatch.prompt = cook.goal.clone();
@@ -901,8 +901,11 @@ fn materialize_agent_task_cook_plan(
     }
     let mut request =
         homeboy::agents::agent_tasks::dispatch_service::resolve_dispatch_request(dispatch.into())?;
-    homeboy::agents::agent_tasks::dispatch_service::build_controller_dispatch_plan(&mut request)
-        .map(Some)
+    let mut plan = homeboy::agents::agent_tasks::dispatch_service::build_controller_dispatch_plan(
+        &mut request,
+    )?;
+    crate::commands::agent_task::run::record_cook_provision(&mut plan, provision);
+    Ok(Some(plan))
 }
 
 fn lab_route_dispatch_timeout(command: &Commands) -> Option<std::time::Duration> {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -890,6 +890,7 @@ fn materialize_agent_task_cook_plan(
     else {
         return Ok(None);
     };
+    crate::commands::agent_task::run::provision_cook_destination(cook)?;
     let mut dispatch = cook.dispatch.clone();
     if dispatch.prompt.is_none() {
         dispatch.prompt = cook.goal.clone();

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -308,6 +308,10 @@ pub struct WorktreeProviderCommands {
     /// `resolve`. Exact handle lookups prefer `resolve` when it is configured.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub list: Option<Vec<String>>,
+    /// Create a missing managed worktree. Homeboy expands `{handle}`, `{repo}`,
+    /// `{base}`, `{head}`, and `{task_url}` from an explicit Cook destination.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cleanup_preview: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -308,10 +308,11 @@ pub struct WorktreeProviderCommands {
     /// `resolve`. Exact handle lookups prefer `resolve` when it is configured.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub list: Option<Vec<String>>,
-    /// Create a missing managed worktree. Homeboy expands `{handle}`, `{repo}`,
-    /// `{base}`, `{head}`, and `{task_url}` from an explicit Cook destination.
+    /// Atomically return an existing managed worktree or create it. Homeboy
+    /// expands `{handle}`, `{repo}`, `{base}`, `{head}`, `{task_url}`, and a
+    /// stable `{idempotency_key}` from an explicit Cook destination.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub create: Option<Vec<String>>,
+    pub ensure: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cleanup_preview: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -91,6 +91,17 @@ pub struct WorktreeProviderResolution {
     pub worktree: WorktreeProviderHandle,
 }
 
+/// Explicit destination inputs required to create a managed worktree without
+/// inferring repository or branch policy from a product-specific provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeProviderCreateIntent {
+    pub handle: String,
+    pub repo: String,
+    pub base: String,
+    pub head: String,
+    pub task_url: String,
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct WorktreeProviderHandleSafety {
     pub dirty: bool,
@@ -159,6 +170,141 @@ pub fn resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination
         gate_feedback_baseline,
         trusted_unpushed_destination,
     )
+}
+
+/// Resolve a managed destination, creating it through an apply-enabled command
+/// provider only when all branch and task intent is explicit.
+pub fn provision_apply_enabled_worktree_provider_from_config(
+    intent: &WorktreeProviderCreateIntent,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderResolution> {
+    if let Ok(resolution) =
+        resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
+    {
+        return Ok(resolution);
+    }
+
+    let mut providers = config
+        .worktree_providers
+        .iter()
+        .filter_map(|(id, provider)| {
+            provider
+                .enabled
+                .then_some((id.as_str(), provider))
+                .filter(|(_, provider)| provider.commands.create.is_some())
+        })
+        .collect::<Vec<_>>();
+    providers.sort_by_key(|(id, _)| *id);
+    if providers.len() > 1 {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree handle `{}` is missing and multiple providers can create it: {}",
+                intent.handle,
+                providers
+                    .iter()
+                    .map(|(id, _)| *id)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Some(intent.handle.clone()),
+            Some(vec!["Configure exactly one enabled worktree provider commands.create template for this Cook destination.".to_string()]),
+        ));
+    }
+    let Some((provider_id, provider)) = providers.first().copied() else {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree handle `{}` is missing and no enabled worktree provider configures commands.create",
+                intent.handle
+            ),
+            Some(intent.handle.clone()),
+            Some(vec!["Configure an enabled generic worktree provider commands.create argv template.".to_string()]),
+        ));
+    };
+    let command = expand_create_command(
+        provider
+            .commands
+            .create
+            .as_ref()
+            .expect("filtered create command"),
+        intent,
+    );
+    let rendered_command = render_provider_command(&command);
+    if !provider.apply_enabled {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree handle `{}` is missing and provider `{provider_id}` creation is disabled",
+                intent.handle
+            ),
+            Some(intent.handle.clone()),
+            Some(vec![format!("Create it with: {rendered_command}")]),
+        ));
+    }
+    run_provider_create_command(provider_id, &command)?;
+    resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
+}
+
+fn expand_create_command(command: &[String], intent: &WorktreeProviderCreateIntent) -> Vec<String> {
+    command
+        .iter()
+        .map(|argument| {
+            argument
+                .replace("{handle}", &intent.handle)
+                .replace("{repo}", &intent.repo)
+                .replace("{base}", &intent.base)
+                .replace("{head}", &intent.head)
+                .replace("{task_url}", &intent.task_url)
+        })
+        .collect()
+}
+
+fn render_provider_command(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|argument| format!("'{}'", argument.replace('\'', "'\\\"'\\\"'")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn run_provider_create_command(provider_id: &str, command: &[String]) -> Result<()> {
+    let Some((program, args)) = command
+        .split_first()
+        .filter(|(program, _)| !program.trim().is_empty())
+    else {
+        return Err(Error::validation_invalid_argument(
+            "worktree_providers.commands.create",
+            format!("worktree provider `{provider_id}` create command must include an executable"),
+            Some(provider_id.to_string()),
+            None,
+        ));
+    };
+    let output = Command::new(program).args(args).output().map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree provider `{provider_id}` create command could not start: {error}"),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument_with_evidence(
+        "to_worktree",
+        format!(
+            "worktree provider `{provider_id}` create command failed with {}",
+            output
+                .status
+                .code()
+                .map(|code| format!("exit code {code}"))
+                .unwrap_or_else(|| "a signal".to_string())
+        ),
+        Some(provider_id.to_string()),
+        None,
+        Some(provider_command_evidence(command, &output)),
+    ))
 }
 
 fn resolve_worktree_provider_with_policy_from_config(
@@ -1112,6 +1258,85 @@ mod tests {
                 .expect("list result mapping")
                 .items,
             "$.result.items"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provision_creates_missing_destination_from_explicit_generic_intent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("destination");
+        let state = temp.path().join("state");
+        let script = temp.path().join("provider");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    printf '%s\\n' '{{\"worktrees\":[]}}'\n  fi\nelse\n  git init -b fix/9908 '{}' >/dev/null\n  printf '%s|%s|%s|%s|%s' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" > '{}'\nfi\n",
+                state.display(),
+                workspace.display(),
+                workspace.display(),
+                state.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("executable");
+        let mut config = HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        script.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    create: Some(vec![
+                        script.display().to_string(),
+                        "create".to_string(),
+                        "{handle}".to_string(),
+                        "{repo}".to_string(),
+                        "{base}".to_string(),
+                        "{head}".to_string(),
+                        "{task_url}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(WorktreeProviderListResultMapping {
+                    items: "$.worktrees".to_string(),
+                    handle: "$.handle".to_string(),
+                    path: "$.path".to_string(),
+                    branch: "$.branch".to_string(),
+                    dirty: "$.safety.dirty".to_string(),
+                    unpushed: "$.safety.unpushed".to_string(),
+                    primary: "$.safety.primary".to_string(),
+                }),
+            },
+        );
+
+        let resolution = provision_apply_enabled_worktree_provider_from_config(
+            &WorktreeProviderCreateIntent {
+                handle: "homeboy@fix-9908".to_string(),
+                repo: "homeboy".to_string(),
+                base: "main".to_string(),
+                head: "fix/9908".to_string(),
+                task_url: "https://github.com/Extra-Chill/homeboy/issues/9908".to_string(),
+            },
+            &config,
+        )
+        .expect("provider creates then resolves destination");
+
+        assert_eq!(resolution.provider_id, "fixture");
+        assert_eq!(resolution.worktree.handle, "homeboy@fix-9908");
+        assert_eq!(
+            fs::read_to_string(state).expect("creation intent"),
+            "homeboy@fix-9908|homeboy|main|fix/9908|https://github.com/Extra-Chill/homeboy/issues/9908"
         );
     }
 

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -102,6 +102,13 @@ pub struct WorktreeProviderCreateIntent {
     pub task_url: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeProviderProvision {
+    pub resolution: WorktreeProviderResolution,
+    pub action: &'static str,
+    pub idempotency_key: String,
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct WorktreeProviderHandleSafety {
     pub dirty: bool,
@@ -177,11 +184,22 @@ pub fn resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination
 pub fn provision_apply_enabled_worktree_provider_from_config(
     intent: &WorktreeProviderCreateIntent,
     config: &HomeboyConfig,
-) -> Result<WorktreeProviderResolution> {
-    if let Ok(resolution) =
-        resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
-    {
-        return Ok(resolution);
+) -> Result<WorktreeProviderProvision> {
+    match resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None) {
+        Ok(resolution) => {
+            return Ok(WorktreeProviderProvision {
+                resolution,
+                action: "adopted",
+                idempotency_key: provision_idempotency_key(intent),
+            })
+        }
+        Err(error)
+            if error
+                .details
+                .get("worktree_provider_lookup")
+                .and_then(Value::as_str)
+                == Some("not_found") => {}
+        Err(error) => return Err(error),
     }
 
     let mut providers = config
@@ -191,7 +209,7 @@ pub fn provision_apply_enabled_worktree_provider_from_config(
             provider
                 .enabled
                 .then_some((id.as_str(), provider))
-                .filter(|(_, provider)| provider.commands.create.is_some())
+                .filter(|(_, provider)| provider.commands.ensure.is_some())
         })
         .collect::<Vec<_>>();
     providers.sort_by_key(|(id, _)| *id);
@@ -199,7 +217,7 @@ pub fn provision_apply_enabled_worktree_provider_from_config(
         return Err(Error::validation_invalid_argument(
             "to_worktree",
             format!(
-                "worktree handle `{}` is missing and multiple providers can create it: {}",
+                "worktree handle `{}` is missing and multiple providers can ensure it: {}",
                 intent.handle,
                 providers
                     .iter()
@@ -208,45 +226,64 @@ pub fn provision_apply_enabled_worktree_provider_from_config(
                     .join(", ")
             ),
             Some(intent.handle.clone()),
-            Some(vec!["Configure exactly one enabled worktree provider commands.create template for this Cook destination.".to_string()]),
+            Some(vec!["Configure exactly one enabled worktree provider commands.ensure template for this Cook destination.".to_string()]),
         ));
     }
     let Some((provider_id, provider)) = providers.first().copied() else {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
             format!(
-                "worktree handle `{}` is missing and no enabled worktree provider configures commands.create",
+                "worktree handle `{}` is missing and no enabled worktree provider configures commands.ensure",
                 intent.handle
             ),
             Some(intent.handle.clone()),
-            Some(vec!["Configure an enabled generic worktree provider commands.create argv template.".to_string()]),
+            Some(vec!["Configure an enabled generic worktree provider commands.ensure argv template.".to_string()]),
         ));
     };
-    let command = expand_create_command(
+    let idempotency_key = provision_idempotency_key(intent);
+    let command = expand_ensure_command(
         provider
             .commands
-            .create
+            .ensure
             .as_ref()
-            .expect("filtered create command"),
+            .expect("filtered ensure command"),
         intent,
+        &idempotency_key,
     );
     let rendered_command = render_provider_command(&command);
     if !provider.apply_enabled {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
             format!(
-                "worktree handle `{}` is missing and provider `{provider_id}` creation is disabled",
+                "worktree handle `{}` is missing and provider `{provider_id}` ensure is disabled",
                 intent.handle
             ),
             Some(intent.handle.clone()),
             Some(vec![format!("Create it with: {rendered_command}")]),
         ));
     }
-    run_provider_create_command(provider_id, &command)?;
-    resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
+    run_provider_ensure_command(provider_id, &command)?;
+    let resolution =
+        resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)?;
+    Ok(WorktreeProviderProvision {
+        resolution,
+        action: "ensured",
+        idempotency_key,
+    })
 }
 
-fn expand_create_command(command: &[String], intent: &WorktreeProviderCreateIntent) -> Vec<String> {
+fn provision_idempotency_key(intent: &WorktreeProviderCreateIntent) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        intent.handle, intent.repo, intent.base, intent.head
+    )
+}
+
+fn expand_ensure_command(
+    command: &[String],
+    intent: &WorktreeProviderCreateIntent,
+    idempotency_key: &str,
+) -> Vec<String> {
     command
         .iter()
         .map(|argument| {
@@ -256,6 +293,7 @@ fn expand_create_command(command: &[String], intent: &WorktreeProviderCreateInte
                 .replace("{base}", &intent.base)
                 .replace("{head}", &intent.head)
                 .replace("{task_url}", &intent.task_url)
+                .replace("{idempotency_key}", idempotency_key)
         })
         .collect()
 }
@@ -268,14 +306,14 @@ fn render_provider_command(command: &[String]) -> String {
         .join(" ")
 }
 
-fn run_provider_create_command(provider_id: &str, command: &[String]) -> Result<()> {
+fn run_provider_ensure_command(provider_id: &str, command: &[String]) -> Result<()> {
     let Some((program, args)) = command
         .split_first()
         .filter(|(program, _)| !program.trim().is_empty())
     else {
         return Err(Error::validation_invalid_argument(
-            "worktree_providers.commands.create",
-            format!("worktree provider `{provider_id}` create command must include an executable"),
+            "worktree_providers.commands.ensure",
+            format!("worktree provider `{provider_id}` ensure command must include an executable"),
             Some(provider_id.to_string()),
             None,
         ));
@@ -283,7 +321,7 @@ fn run_provider_create_command(provider_id: &str, command: &[String]) -> Result<
     let output = Command::new(program).args(args).output().map_err(|error| {
         Error::validation_invalid_argument(
             "to_worktree",
-            format!("worktree provider `{provider_id}` create command could not start: {error}"),
+            format!("worktree provider `{provider_id}` ensure command could not start: {error}"),
             Some(provider_id.to_string()),
             None,
         )
@@ -294,7 +332,7 @@ fn run_provider_create_command(provider_id: &str, command: &[String]) -> Result<
     Err(Error::validation_invalid_argument_with_evidence(
         "to_worktree",
         format!(
-            "worktree provider `{provider_id}` create command failed with {}",
+            "worktree provider `{provider_id}` ensure command failed with {}",
             output
                 .status
                 .code()
@@ -389,7 +427,7 @@ fn resolve_worktree_provider_with_policy_from_config(
             },
         )
     };
-    Err(Error::validation_invalid_argument(
+    let mut error = Error::validation_invalid_argument(
         "to_worktree",
         format!(
             "worktree handle `{handle}` is not a Homeboy task worktree and was not returned by a configured worktree provider ({configured})"
@@ -403,7 +441,9 @@ fn resolve_worktree_provider_with_policy_from_config(
                 "Configure an enabled worktree provider commands.list command that returns typed worktree path, branch, and safety metadata.".to_string()
             },
         ]),
-    ))
+    );
+    error.details["worktree_provider_lookup"] = Value::String("not_found".to_string());
+    Err(error)
 }
 
 fn run_provider_resolve_command(
@@ -1297,7 +1337,7 @@ mod tests {
                         "resolve".to_string(),
                         "{handle}".to_string(),
                     ]),
-                    create: Some(vec![
+                    ensure: Some(vec![
                         script.display().to_string(),
                         "create".to_string(),
                         "{handle}".to_string(),
@@ -1332,8 +1372,9 @@ mod tests {
         )
         .expect("provider creates then resolves destination");
 
-        assert_eq!(resolution.provider_id, "fixture");
-        assert_eq!(resolution.worktree.handle, "homeboy@fix-9908");
+        assert_eq!(resolution.action, "ensured");
+        assert_eq!(resolution.resolution.provider_id, "fixture");
+        assert_eq!(resolution.resolution.worktree.handle, "homeboy@fix-9908");
         assert_eq!(
             fs::read_to_string(state).expect("creation intent"),
             "homeboy@fix-9908|homeboy|main|fix/9908|https://github.com/Extra-Chill/homeboy/issues/9908"

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1345,6 +1345,7 @@ mod tests {
                         "{base}".to_string(),
                         "{head}".to_string(),
                         "{task_url}".to_string(),
+                        "{idempotency_key}".to_string(),
                     ]),
                     ..Default::default()
                 },
@@ -1377,7 +1378,166 @@ mod tests {
         assert_eq!(resolution.resolution.worktree.handle, "homeboy@fix-9908");
         assert_eq!(
             fs::read_to_string(state).expect("creation intent"),
-            "homeboy@fix-9908|homeboy|main|fix/9908|https://github.com/Extra-Chill/homeboy/issues/9908"
+            "homeboy@fix-9908|homeboy|main|fix/9908|https://github.com/Extra-Chill/homeboy/issues/9908|homeboy@fix-9908:homeboy:main:fix/9908"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn concurrent_identical_provisioning_reuses_one_destination_and_idempotency_key() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::{Arc, Barrier};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("destination");
+        let lock = temp.path().join("ensure-lock");
+        let keys = temp.path().join("keys");
+        let script = temp.path().join("provider");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -d '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    printf '%s\\n' '{{\"worktrees\":[]}}'\n  fi\nelse\n  printf '%s\\n' \"$7\" >> '{}'\n  if mkdir '{}' 2>/dev/null; then\n    git init -b fix/9908 '{}' >/dev/null\n    rmdir '{}'\n  else\n    while [ -d '{}' ]; do sleep 0.01; done\n  fi\nfi\n",
+                workspace.display(),
+                workspace.display(),
+                keys.display(),
+                lock.display(),
+                workspace.display(),
+                lock.display(),
+                lock.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("executable");
+
+        let mut config = HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        script.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    ensure: Some(vec![
+                        script.display().to_string(),
+                        "ensure".to_string(),
+                        "{handle}".to_string(),
+                        "{repo}".to_string(),
+                        "{base}".to_string(),
+                        "{head}".to_string(),
+                        "{task_url}".to_string(),
+                        "{idempotency_key}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(WorktreeProviderListResultMapping {
+                    items: "$.worktrees".to_string(),
+                    handle: "$.handle".to_string(),
+                    path: "$.path".to_string(),
+                    branch: "$.branch".to_string(),
+                    dirty: "$.safety.dirty".to_string(),
+                    unpushed: "$.safety.unpushed".to_string(),
+                    primary: "$.safety.primary".to_string(),
+                }),
+            },
+        );
+        let intent = WorktreeProviderCreateIntent {
+            handle: "homeboy@fix-9908".to_string(),
+            repo: "homeboy".to_string(),
+            base: "main".to_string(),
+            head: "fix/9908".to_string(),
+            task_url: "https://github.com/Extra-Chill/homeboy/issues/9908".to_string(),
+        };
+        let barrier = Arc::new(Barrier::new(2));
+        let mut joins = Vec::new();
+        for _ in 0..2 {
+            let config = config.clone();
+            let intent = intent.clone();
+            let barrier = barrier.clone();
+            joins.push(std::thread::spawn(move || {
+                barrier.wait();
+                provision_apply_enabled_worktree_provider_from_config(&intent, &config)
+                    .expect("concurrent ensure converges")
+            }));
+        }
+        let provisions = joins
+            .into_iter()
+            .map(|join| join.join().expect("thread"))
+            .collect::<Vec<_>>();
+
+        assert!(workspace.is_dir());
+        assert!(
+            provisions
+                .iter()
+                .all(|provision| provision.resolution.worktree.path
+                    == workspace.display().to_string())
+        );
+        assert!(
+            provisions
+                .iter()
+                .all(|provision| provision.idempotency_key
+                    == "homeboy@fix-9908:homeboy:main:fix/9908")
+        );
+        let keys = fs::read_to_string(keys).expect("ensure keys");
+        assert!(keys
+            .lines()
+            .all(|key| key == "homeboy@fix-9908:homeboy:main:fix/9908"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lookup_auth_and_malformed_failures_do_not_run_ensure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ensured = temp.path().join("ensured");
+        let script = temp.path().join("provider");
+        fs::write(&script, format!("#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  case \"$2\" in auth) exit 77 ;; malformed) printf '{{' ;; esac\n  exit 0\nfi\ntouch '{}'\n", ensured.display())).expect("write provider");
+        let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("executable");
+        let mut config = HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        script.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    ensure: Some(vec![script.display().to_string(), "ensure".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            },
+        );
+        for handle in ["auth", "malformed"] {
+            let error = provision_apply_enabled_worktree_provider_from_config(
+                &WorktreeProviderCreateIntent {
+                    handle: handle.to_string(),
+                    repo: "homeboy".to_string(),
+                    base: "main".to_string(),
+                    head: "fix/9908".to_string(),
+                    task_url: "https://example.test/9908".to_string(),
+                },
+                &config,
+            )
+            .expect_err("lookup failure is not absence");
+            assert!(error.message.contains("provider `fixture` resolve command"));
+        }
+        assert!(
+            !ensured.exists(),
+            "ensure must never follow an auth or malformed lookup failure"
         );
     }
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,6 +106,7 @@ variables.
 ### `WorktreeProviderCommands`
 
 - `list`
+- `create` — Mutating argv template for a missing destination. Homeboy expands `{handle}`, `{repo}`, `{base}`, `{head}`, and `{task_url}` only from explicit Cook inputs; creation also requires `apply_enabled: true`.
 - `cleanup_preview`
 - `cleanup_apply`
 - `artifacts_preview`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,7 +106,7 @@ variables.
 ### `WorktreeProviderCommands`
 
 - `list`
-- `create` — Mutating argv template for a missing destination. Homeboy expands `{handle}`, `{repo}`, `{base}`, `{head}`, and `{task_url}` only from explicit Cook inputs; creation also requires `apply_enabled: true`.
+- `ensure` — Atomic create-or-return-existing argv template. Homeboy invokes it only after an explicit typed provider no-match, expands `{handle}`, `{repo}`, `{base}`, `{head}`, `{task_url}`, and `{idempotency_key}`, and requires `apply_enabled: true`.
 - `cleanup_preview`
 - `cleanup_apply`
 - `artifacts_preview`


### PR DESCRIPTION
Closes #9908

Adds a generic atomic worktree-provider `ensure` contract with typed not-found gating, stable idempotency, mutation-after-validation ordering, and durable redacted provision evidence projected through Cook status/resume.

## Verification
- `cargo fmt --all -- --check`
- Concurrent/idempotent provider ensure tests
- Auth/malformed no-mutation tests
- Invalid Cook zero-mutation tests
- Status/resume provision-evidence tests

## AI assistance
OpenCode using gpt-5.6-sol designed, implemented, reviewed, and hardened the generic provider contract and behavioral tests. Chris remains responsible for the submitted code.