### PR TITLE
fix(cook): verify immutable candidate checkouts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -161,8 +161,20 @@ pub struct AgentTaskGateReport {
     /// adoption needs to distinguish inherited failures from regressions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub baseline_comparison: Option<AgentTaskGateBaselineComparison>,
+    /// Immutable checkout identity used for this gate when verification runs
+    /// against a materialized candidate rather than the promotion destination.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_checkout: Option<AgentTaskGateCandidateCheckout>,
     #[serde(default, skip_serializing_if = "AgentTaskGateEnvironment::is_empty")]
     pub environment: AgentTaskGateEnvironment,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateCandidateCheckout {
+    pub schema: String,
+    pub commit: String,
+    pub tree: String,
+    pub candidate_sha256: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -308,6 +320,7 @@ impl AgentTaskGateReport {
             stderr: stderr.into(),
             failure_evidence,
             baseline_comparison: None,
+            candidate_checkout: None,
             environment,
         }
     }

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -140,7 +140,26 @@ pub fn resume_promoted_patch(
                 None,
             )
         })?;
-    let gates = run_promotion_gates(&options, &mut provider, target_path)?;
+    let expected_candidate = previous
+        .pointer("/provenance/candidate")
+        .filter(|candidate| !candidate.is_null())
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "promotion.provenance.candidate",
+                "promotion resume durable candidate fingerprint is invalid",
+                None,
+                None,
+            )
+        })?;
+    let gates = run_promotion_gates(
+        &options,
+        &mut provider,
+        target_path,
+        expected_candidate.as_ref(),
+    )?;
     let target =
         AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), Some(target_path));
     let candidate = if gates.status.patch_promoted() {
@@ -556,7 +575,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
         let target =
             AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), worktree_path);
         let gates = if let Some(worktree_path) = worktree_path {
-            run_promotion_gates(&options, provider, worktree_path)?
+            run_promotion_gates(&options, provider, worktree_path, None)?
         } else {
             PromotionGateRun::without_gates(options.dry_run)
         };
@@ -693,7 +712,27 @@ pub(super) fn promote_with_provider_and_checkpoint(
             capture_declared_base(worktree_path, options.base_ref.as_deref())?
         };
         (
-            run_promotion_gates(&options, provider, worktree_path)?,
+            run_promotion_gates(
+                &options,
+                provider,
+                worktree_path,
+                post_apply
+                    .as_ref()
+                    .and_then(|report| report.provenance.get("candidate"))
+                    .filter(|candidate| !candidate.is_null())
+                    .cloned()
+                    .map(serde_json::from_value)
+                    .transpose()
+                    .map_err(|_| {
+                        Error::validation_invalid_argument(
+                            "promotion.provenance.candidate",
+                            "post-apply promotion candidate fingerprint is invalid",
+                            None,
+                            None,
+                        )
+                    })?
+                    .as_ref(),
+            )?,
             verified_base,
         )
     } else {
@@ -1127,7 +1166,30 @@ fn promote_committed_changes(
     };
     let verified_base = if let Some(path) = applied_worktree_path.as_deref() {
         let verified_base = capture_declared_base(path, options.base_ref.as_deref())?;
-        (run_promotion_gates(options, provider, path)?, verified_base)
+        (
+            run_promotion_gates(
+                options,
+                provider,
+                path,
+                post_apply
+                    .as_ref()
+                    .and_then(|report| report.provenance.get("candidate"))
+                    .filter(|candidate| !candidate.is_null())
+                    .cloned()
+                    .map(serde_json::from_value)
+                    .transpose()
+                    .map_err(|_| {
+                        Error::validation_invalid_argument(
+                            "promotion.provenance.candidate",
+                            "post-apply promotion candidate fingerprint is invalid",
+                            None,
+                            None,
+                        )
+                    })?
+                    .as_ref(),
+            )?,
+            verified_base,
+        )
     } else {
         (PromotionGateRun::without_gates(options.dry_run), None)
     };
@@ -1180,6 +1242,7 @@ fn run_promotion_gates(
     options: &AgentTaskPromotionOptions,
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
     worktree_path: &Path,
+    expected_candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
 ) -> Result<PromotionGateRun> {
     if options.dry_run
         || (options.gates.verify.is_empty() && options.gates.private_verify.is_empty())
@@ -1187,7 +1250,14 @@ fn run_promotion_gates(
         return Ok(PromotionGateRun::without_gates(options.dry_run));
     }
 
-    let candidate_checkout = ImmutableCandidateCheckout::materialize(worktree_path)?;
+    let candidate_checkout = ImmutableCandidateCheckout::materialize(
+        worktree_path,
+        options
+            .source_run_id
+            .as_deref()
+            .unwrap_or("unrecorded-promotion"),
+        expected_candidate,
+    )?;
     let gate_path = candidate_checkout
         .as_ref()
         .map(ImmutableCandidateCheckout::path)
@@ -1249,11 +1319,21 @@ fn run_promotion_gates(
 struct ImmutableCandidateCheckout {
     source_root: PathBuf,
     path: PathBuf,
+    allocation: crate::controller_scratch::ControllerScratchAllocation,
     identity: AgentTaskGateCandidateCheckout,
 }
 
 impl ImmutableCandidateCheckout {
-    fn materialize(source_root: &Path) -> Result<Option<Self>> {
+    fn materialize(
+        source_root: &Path,
+        run_id: &str,
+        expected_candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
+    ) -> Result<Option<Self>> {
+        if !source_root.is_dir() {
+            // An external provider can report an opaque or not-yet-mounted
+            // destination. Preserve its existing direct verification path.
+            return Ok(None);
+        }
         let head = Command::new("git")
             .args(["rev-parse", "--verify", "HEAD^{commit}"])
             .current_dir(source_root)
@@ -1266,6 +1346,16 @@ impl ImmutableCandidateCheckout {
         }
         let candidate =
             crate::agent_task_promotion::candidate_fingerprint(&source_root.display().to_string())?;
+        if let Some(expected_candidate) = expected_candidate {
+            if &candidate != expected_candidate {
+                return Err(Error::validation_invalid_argument(
+                    "promotion.provenance.candidate",
+                    "promotion destination differs from the checkpointed candidate before deterministic verification",
+                    Some(source_root.display().to_string()),
+                    None,
+                ));
+            }
+        }
         let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } =
             candidate
         else {
@@ -1286,14 +1376,14 @@ impl ImmutableCandidateCheckout {
                 "homeboy: immutable promotion candidate",
             ],
         )?;
-        let parent = std::env::temp_dir().join("homeboy-promotion-candidate-gates");
-        std::fs::create_dir_all(&parent).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("create immutable promotion candidate directory".to_string()),
-            )
-        })?;
-        let path = parent.join(format!("candidate-{}", uuid::Uuid::new_v4()));
+        let allocation = crate::controller_scratch::allocate_attempt(
+            run_id,
+            "promotion-candidate-checkout",
+            "candidate",
+            1,
+        )?;
+        crate::controller_scratch::mark_attempt_ephemeral(&allocation)?;
+        let path = allocation.path.clone();
         git_output(
             source_root,
             &[
@@ -1307,6 +1397,7 @@ impl ImmutableCandidateCheckout {
         let checkout = Self {
             source_root: source_root.to_path_buf(),
             path,
+            allocation,
             identity: AgentTaskGateCandidateCheckout {
                 schema: "homeboy/agent-task-gate-candidate-checkout/v1".to_string(),
                 commit,
@@ -1345,6 +1436,11 @@ impl Drop for ImmutableCandidateCheckout {
             .arg(&self.path)
             .current_dir(&self.source_root)
             .status();
+        let _ = crate::controller_scratch::release_attempt(
+            &self.allocation,
+            "candidate_checkout_removed",
+            serde_json::json!({ "commit": self.identity.commit, "tree": self.identity.tree }),
+        );
         let _ = Command::new("git")
             .args(["worktree", "prune"])
             .current_dir(&self.source_root)

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -10,7 +10,8 @@ use crate::agent_task::{
     AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::agent_task_gate::{
-    AgentTaskGateRevealPolicy, AgentTaskGateStatus, AgentTaskGateVisibility,
+    AgentTaskGateCandidateCheckout, AgentTaskGateRevealPolicy, AgentTaskGateStatus,
+    AgentTaskGateVisibility,
 };
 use crate::agent_task_scheduler::{AgentTaskAggregate, AGENT_TASK_AGGREGATE_SCHEMA};
 use crate::agent_task_timeout_artifacts::{
@@ -171,6 +172,7 @@ pub fn resume_promoted_patch(
             "artifact_metadata": artifact.metadata,
             "worktree_path": target_path,
             "dependencies_materialized": gates.dependencies_materialized,
+            "candidate_checkout": gates.candidate_checkout,
             "candidate": candidate,
             "resumed_post_apply_promotion": true,
             "resume_contract": previous.pointer("/provenance/resume_contract"),
@@ -594,6 +596,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
                 "worktree_path": worktree_path,
                 "verified_revision": verified_revision,
                 "dependencies_materialized": gates.dependencies_materialized,
+                "candidate_checkout": gates.candidate_checkout,
                 "candidate": candidate,
             }),
             operator_notification,
@@ -730,6 +733,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             "artifact_metadata": artifact.metadata,
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
+            "candidate_checkout": gates.candidate_checkout,
             "candidate": candidate,
             "destination_baseline": candidate,
             "prior_baseline": promotion_chain_baseline,
@@ -1159,6 +1163,7 @@ fn promote_committed_changes(
             "artifact_metadata": artifact.map(|artifact| artifact.metadata.clone()).unwrap_or(Value::Null),
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
+            "candidate_checkout": gates.candidate_checkout,
             "change_source": "local_commits",
             "base_ref": committed_patch.base_ref,
             "commit_range": committed_patch.commit_range,
@@ -1182,15 +1187,21 @@ fn run_promotion_gates(
         return Ok(PromotionGateRun::without_gates(options.dry_run));
     }
 
-    // Materialize dependencies via the component's resolved dependency providers
-    // before running verify gates so dependency misses do not mask gate signal.
-    homeboy_core::hygiene::materialize_worktree_dependencies(worktree_path)?;
+    let candidate_checkout = ImmutableCandidateCheckout::materialize(worktree_path)?;
+    let gate_path = candidate_checkout
+        .as_ref()
+        .map(ImmutableCandidateCheckout::path)
+        .unwrap_or(worktree_path);
+    // Materialize dependencies in the immutable checkout so repository-owned
+    // verification sees the candidate as committed content, never the dirty
+    // promotion target that finalization still owns.
+    homeboy_core::hygiene::materialize_worktree_dependencies(gate_path)?;
     let mut deterministic_gates = Vec::new();
     for (index, command) in options.gates.verify.iter().enumerate() {
         deterministic_gates.push(run_promotion_gate(
             options,
             provider,
-            worktree_path,
+            gate_path,
             index + 1,
             command,
             AgentTaskGateVisibility::Visible,
@@ -1202,7 +1213,7 @@ fn run_promotion_gates(
         deterministic_gates.push(run_promotion_gate(
             options,
             provider,
-            worktree_path,
+            gate_path,
             private_offset + index + 1,
             command,
             AgentTaskGateVisibility::Private,
@@ -1218,12 +1229,141 @@ fn run_promotion_gates(
         .map(HomeboyGateResult::from)
         .collect();
 
+    let candidate_checkout = candidate_checkout.map(|checkout| checkout.identity());
+    if let Some(candidate_checkout) = &candidate_checkout {
+        for gate in &mut deterministic_gates {
+            gate.candidate_checkout = Some(candidate_checkout.clone());
+        }
+    }
     Ok(PromotionGateRun {
         status: status_for_report(options.dry_run, has_gate_failure),
         deterministic_gates,
         gate_results,
         dependencies_materialized: true,
+        candidate_checkout,
     })
+}
+
+/// A run-scoped detached worktree whose commit tree is exactly the promoted
+/// candidate. The source destination stays dirty for final commit/push/PR.
+struct ImmutableCandidateCheckout {
+    source_root: PathBuf,
+    path: PathBuf,
+    identity: AgentTaskGateCandidateCheckout,
+}
+
+impl ImmutableCandidateCheckout {
+    fn materialize(source_root: &Path) -> Result<Option<Self>> {
+        let head = Command::new("git")
+            .args(["rev-parse", "--verify", "HEAD^{commit}"])
+            .current_dir(source_root)
+            .output()
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if !head.status.success() {
+            // Provider-owned and bootstrap destinations can still be verified,
+            // but have no committed Git candidate to materialize.
+            return Ok(None);
+        }
+        let candidate =
+            crate::agent_task_promotion::candidate_fingerprint(&source_root.display().to_string())?;
+        let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } =
+            candidate
+        else {
+            return Ok(None);
+        };
+        let commit = git_output(
+            source_root,
+            &[
+                "-c",
+                "user.name=Homeboy",
+                "-c",
+                "user.email=homeboy@localhost",
+                "commit-tree",
+                &fingerprint.tree,
+                "-p",
+                &fingerprint.head,
+                "-m",
+                "homeboy: immutable promotion candidate",
+            ],
+        )?;
+        let parent = std::env::temp_dir().join("homeboy-promotion-candidate-gates");
+        std::fs::create_dir_all(&parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create immutable promotion candidate directory".to_string()),
+            )
+        })?;
+        let path = parent.join(format!("candidate-{}", uuid::Uuid::new_v4()));
+        git_output(
+            source_root,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                &path.display().to_string(),
+                &commit,
+            ],
+        )?;
+        let checkout = Self {
+            source_root: source_root.to_path_buf(),
+            path,
+            identity: AgentTaskGateCandidateCheckout {
+                schema: "homeboy/agent-task-gate-candidate-checkout/v1".to_string(),
+                commit,
+                tree: fingerprint.tree,
+                candidate_sha256: fingerprint.sha256,
+            },
+        };
+        let status = git_output(
+            &checkout.path,
+            &["status", "--porcelain", "--untracked-files=all"],
+        )?;
+        if !status.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "promotion",
+                "immutable candidate checkout is unexpectedly dirty",
+                Some(checkout.path.display().to_string()),
+                None,
+            ));
+        }
+        Ok(Some(checkout))
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn identity(&self) -> AgentTaskGateCandidateCheckout {
+        self.identity.clone()
+    }
+}
+
+impl Drop for ImmutableCandidateCheckout {
+    fn drop(&mut self) {
+        let _ = Command::new("git")
+            .args(["worktree", "remove", "--force"])
+            .arg(&self.path)
+            .current_dir(&self.source_root)
+            .status();
+        let _ = Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(&self.source_root)
+            .status();
+    }
+}
+
+fn git_output(path: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn run_promotion_gate(

--- a/crates/homeboy-agents/src/agent_task_promotion/promote/gate_run.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote/gate_run.rs
@@ -1,4 +1,4 @@
-use crate::agent_task_gate::AgentTaskGateReport;
+use crate::agent_task_gate::{AgentTaskGateCandidateCheckout, AgentTaskGateReport};
 use crate::agent_task_promotion::AgentTaskPromotionStatus;
 use homeboy_core::gate::HomeboyGateResult;
 
@@ -7,6 +7,7 @@ pub(super) struct PromotionGateRun {
     pub(super) deterministic_gates: Vec<AgentTaskGateReport>,
     pub(super) gate_results: Vec<HomeboyGateResult>,
     pub(super) dependencies_materialized: bool,
+    pub(super) candidate_checkout: Option<AgentTaskGateCandidateCheckout>,
 }
 
 impl PromotionGateRun {
@@ -20,6 +21,7 @@ impl PromotionGateRun {
             deterministic_gates: Vec::new(),
             gate_results: Vec::new(),
             dependencies_materialized: false,
+            candidate_checkout: None,
         }
     }
 }

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -124,10 +124,9 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
         let status = Command::new("git")
             .args(["status", "--porcelain", "--untracked-files=all"])
             .current_dir(cwd)
-            .output()
-            .expect("inspect verification checkout");
+            .output();
         self.verify_worktrees_clean
-            .push(status.status.success() && status.stdout.is_empty());
+            .push(status.is_ok_and(|status| status.status.success() && status.stdout.is_empty()));
         if self.run_verify_command {
             return crate::agent_task_gate::run_gate_command_with_policy(
                 cwd,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -55,6 +55,8 @@ pub(super) struct FakePromotionWorkspaceProvider {
     )>,
     verify_exit_code: i32,
     verify_transport_error: bool,
+    run_verify_command: bool,
+    verify_worktrees_clean: Vec<bool>,
     force_add_ignored_file: bool,
     apply_to_git: bool,
 }
@@ -118,6 +120,22 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
                 "simulated verification transport interruption",
                 Some("promotion gate transport".to_string()),
             ));
+        }
+        let status = Command::new("git")
+            .args(["status", "--porcelain", "--untracked-files=all"])
+            .current_dir(cwd)
+            .output()
+            .expect("inspect verification checkout");
+        self.verify_worktrees_clean
+            .push(status.status.success() && status.stdout.is_empty());
+        if self.run_verify_command {
+            return crate::agent_task_gate::run_gate_command_with_policy(
+                cwd,
+                index,
+                command,
+                visibility,
+                reveal_policy,
+            );
         }
         Ok(AgentTaskGateReport::new(
             format!("gate-{index}"),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -419,7 +419,7 @@ fn empty_patch_failing_gate_is_reported_against_pinned_candidate() {
         homeboy_core::gate::HomeboyGateStatus::Failed
     );
     assert_eq!(provider.apply_calls.len(), 0);
-    assert_eq!(provider.verify_calls[0].0, repo);
+    assert_ne!(provider.verify_calls[0].0, repo);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1015,6 +1015,59 @@ fn promotion_runs_clean_checkout_gate_against_immutable_candidate() {
 }
 
 #[test]
+fn promotion_rejects_mutation_after_checkpoint_before_gate_materialization() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init", "-b", "main"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Homeboy Test"]);
+    std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+    std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+    git(&workspace, &["add", "."]);
+    git(&workspace, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(workspace.clone()),
+        apply_to_git: true,
+        ..Default::default()
+    };
+
+    let error = promote_with_provider_and_checkpoint(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("immutable-candidate-checkpoint".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+        &mut |_| {
+            std::fs::write(workspace.join("src/lib.rs"), "tampered\n")
+                .expect("mutate destination after checkpoint");
+            Ok(())
+        },
+    )
+    .expect_err("verification rejects a destination that changed after checkpointing");
+
+    assert!(error
+        .message
+        .contains("differs from the checkpointed candidate"));
+}
+
+#[test]
 fn resumed_verification_runs_clean_checkout_gate_for_exact_dirty_candidate() {
     let temp = tempfile::tempdir().expect("tempdir");
     let target = temp.path().join("target");

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -944,6 +944,146 @@ fn explicit_candidate_gate_failure_is_recorded_after_normal_promotion_handoff() 
 }
 
 #[test]
+fn promotion_runs_clean_checkout_gate_against_immutable_candidate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init", "-b", "main"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Homeboy Test"]);
+    std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+    std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+    git(&workspace, &["add", "."]);
+    git(&workspace, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(workspace.clone()),
+        apply_to_git: true,
+        run_verify_command: true,
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("immutable-candidate-first-attempt".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec![
+                    "test -z \"$(git status --porcelain)\" && test \"$(cat src/lib.rs)\" = new"
+                        .to_string(),
+                ],
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("clean-checkout gate accepts the dirty promoted candidate");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(provider.verify_worktrees_clean, vec![true]);
+    assert_ne!(provider.verify_calls[0].0, workspace);
+    assert!(Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(&workspace)
+        .output()
+        .expect("inspect promotion destination")
+        .stdout
+        .starts_with(b" M src/lib.rs"));
+    let checkout = report.deterministic_gates[0]
+        .candidate_checkout
+        .as_ref()
+        .expect("gate candidate checkout identity");
+    assert_eq!(
+        checkout.tree,
+        report.provenance["candidate_checkout"]["tree"]
+    );
+    assert_eq!(
+        checkout.candidate_sha256,
+        report.provenance["candidate_checkout"]["candidate_sha256"]
+    );
+}
+
+#[test]
+fn resumed_verification_runs_clean_checkout_gate_for_exact_dirty_candidate() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let target = temp.path().join("target");
+    std::fs::create_dir(&target).expect("target");
+    git(&target, &["init", "-b", "main"]);
+    git(&target, &["config", "user.email", "test@example.com"]);
+    git(&target, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(target.join("src")).expect("src");
+    std::fs::write(target.join("src/lib.rs"), "old\n").expect("base");
+    git(&target, &["add", "."]);
+    git(&target, &["commit", "-m", "base"]);
+    std::fs::write(target.join("src/lib.rs"), "new\n").expect("apply candidate");
+    let candidate =
+        crate::agent_task_promotion::candidate_fingerprint(target.to_string_lossy().as_ref())
+            .expect("candidate fingerprint");
+    let (source_path, source) = write_patch_source(&temp);
+    let options = AgentTaskPromotionOptions {
+        source,
+        source_run_id: Some("immutable-candidate-follow-up".to_string()),
+        source_path: Some(source_path),
+        source_worktree_path: None,
+        base_ref: None,
+        task_base_sha: None,
+        candidate_ref: None,
+        to_worktree: "fixture@target".to_string(),
+        task_id: None,
+        artifact_id: None,
+        dry_run: false,
+        gates: VerifyGateOptions {
+            verify: vec![
+                "test -z \"$(git status --porcelain)\" && test \"$(cat src/lib.rs)\" = new"
+                    .to_string(),
+            ],
+            rerun_completed_gates: true,
+            ..Default::default()
+        },
+        provider_command: None,
+        provider_invocation: None,
+    };
+    let previous = serde_json::json!({
+        "schema": "homeboy/agent-task-promotion-report/v1",
+        "status": "applied",
+        "source_run_id": "immutable-candidate-follow-up",
+        "source": { "task_id": "task-1" },
+        "to_worktree": "fixture@target",
+        "target": { "worktree": "fixture@target", "path": target },
+        "patch_artifact": { "id": "patch", "kind": "patch", "sha256": sha256_hex(VALID_PATCH) },
+        "provenance": { "candidate": candidate },
+    });
+
+    let report = resume_promoted_patch(options.clone(), &target, &previous)
+        .expect("follow-up verification accepts the exact dirty candidate");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(report.deterministic_gates.len(), 1);
+    assert!(report.deterministic_gates[0].candidate_checkout.is_some());
+    assert!(Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(&target)
+        .output()
+        .expect("inspect promotion destination")
+        .stdout
+        .starts_with(b" M src/lib.rs"));
+    std::fs::write(target.join("unrelated.txt"), "drift\n").expect("diverge target");
+    let error = resume_promoted_patch(options, &target, &previous);
+    assert!(error.is_err(), "divergent destination fails closed");
+}
+
+#[test]
 fn gate_failure_preserves_the_pre_gate_candidate_baseline_for_feedback_retry() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path().join("workspace");

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -257,7 +257,7 @@ fn empty_patch_runs_public_and_private_gates_against_pinned_candidate() {
     assert_eq!(report.provenance["verified_revision"], revision);
     assert_eq!(provider.apply_calls.len(), 0);
     assert_eq!(provider.verify_calls.len(), 2);
-    assert_eq!(provider.verify_calls[0].0, repo);
+    assert_ne!(provider.verify_calls[0].0, repo);
     assert_eq!(provider.verify_calls[1].2, AgentTaskGateVisibility::Private);
     assert_eq!(
         provider.verify_calls[1].3,

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -34,6 +34,10 @@ pub struct ControllerScratchResource {
     #[serde(default)]
     pub lease_id: String,
     pub reconstructable: bool,
+    /// Controller-created temporary state that can be removed even when it is a
+    /// detached Git checkout with no upstream.
+    #[serde(default)]
+    pub ephemeral: bool,
     pub retention: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_ref: Option<String>,
@@ -142,6 +146,7 @@ fn allocate_attempt_at_index(
             lifecycle_state: "active".to_string(),
             lease_id: lease_id.clone(),
             reconstructable: true,
+            ephemeral: false,
             retention: "P7D".to_string(),
             source_ref: None,
             created_at: chrono::Utc::now().to_rfc3339(),
@@ -189,6 +194,47 @@ pub fn release_attempt(
             write_index_at_unlocked(&allocation.index_path, &index)?;
         }
         Ok(())
+    })
+}
+
+/// Mark a controller-owned allocation as disposable temporary state. This is
+/// intentionally separate from ordinary attempt scratch: an interrupted
+/// detached checkout has no upstream by design, so the normal unpushed-Git
+/// retention guard would otherwise retain it forever.
+pub fn mark_attempt_ephemeral(allocation: &ControllerScratchAllocation) -> Result<()> {
+    with_index_lock(&allocation.index_path, || {
+        let mut index = read_index_at_unlocked(&allocation.index_path)?;
+        let resource = index
+            .resources
+            .iter_mut()
+            .find(|resource| {
+                resource.lease_id == allocation.lease_id
+                    && Path::new(&resource.path) == allocation.path.as_path()
+            })
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "controller_scratch.lease_id",
+                    "allocated scratch lease is not registered",
+                    Some(allocation.lease_id.clone()),
+                    None,
+                )
+            })?;
+        resource.ephemeral = true;
+        write_index_at_unlocked(&allocation.index_path, &index)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn abandon_attempt_for_test(allocation: &ControllerScratchAllocation) -> Result<()> {
+    with_index_lock(&allocation.index_path, || {
+        let mut index = read_index_at_unlocked(&allocation.index_path)?;
+        let resource = index
+            .resources
+            .iter_mut()
+            .find(|resource| resource.lease_id == allocation.lease_id)
+            .expect("test allocation is registered");
+        resource.owner_pid = u32::MAX;
+        write_index_at_unlocked(&allocation.index_path, &index)
     })
 }
 
@@ -422,6 +468,7 @@ fn register_outcome_resources_unlocked(run_id: &str, outcomes: &[AgentTaskOutcom
                     .get("reconstructable")
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(false),
+                ephemeral: false,
                 retention: value
                     .get("retention")
                     .and_then(serde_json::Value::as_str)
@@ -716,7 +763,7 @@ fn cleanup_block_reason(
     if !retention_expired(resource.finalized_at.as_deref(), retention, path, now) {
         return Ok(Some("retention has not expired".to_string()));
     }
-    if git_dirty_or_unpushed(path) {
+    if !resource.ephemeral && git_dirty_or_unpushed(path) {
         return Ok(Some("git checkout has dirty or unpushed state".to_string()));
     }
     Ok(None)
@@ -1130,6 +1177,7 @@ mod tests {
             lifecycle_state: "active".to_string(),
             lease_id: "test-lease".to_string(),
             reconstructable: true,
+            ephemeral: false,
             retention: "0s".to_string(),
             source_ref: None,
             created_at: chrono::Utc::now().to_rfc3339(),
@@ -1294,6 +1342,41 @@ mod tests {
             assert_eq!(resource.owner_pid, std::process::id());
             assert!(resource.reconstructable);
             assert!(!resource.created_at.is_empty());
+        });
+    }
+
+    #[test]
+    fn interrupted_ephemeral_git_checkout_is_reclaimable() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let allocation = allocate_attempt("run-candidate", "promotion", "candidate", 1)
+                .expect("allocate candidate checkout");
+            mark_attempt_ephemeral(&allocation).expect("mark ephemeral");
+            let output = Command::new("git")
+                .args(["init"])
+                .current_dir(&allocation.path)
+                .output()
+                .expect("initialize candidate checkout");
+            assert!(output.status.success());
+            fs::write(allocation.path.join("candidate.txt"), "candidate\n")
+                .expect("write candidate state");
+            abandon_attempt_for_test(&allocation).expect("simulate interrupted owner");
+
+            let first = cleanup(ControllerScratchCleanupOptions {
+                apply: false,
+                limit: 1,
+                retention_override_seconds: Some(0),
+            })
+            .expect("reconcile interrupted checkout");
+            assert_eq!(first.candidate_count, 0);
+
+            let second = cleanup(ControllerScratchCleanupOptions {
+                apply: true,
+                limit: 1,
+                retention_override_seconds: Some(0),
+            })
+            .expect("reap interrupted checkout");
+            assert_eq!(second.applied_count, 1);
+            assert!(!allocation.path.exists());
         });
     }
 


### PR DESCRIPTION
Closes #9689

Binds deterministic Cook gates to the checkpointed candidate identity and runs them in a detached immutable checkout. Durable scratch allocation makes interrupted checkouts reclaimable while the publication destination remains unchanged.

## Verification
- `cargo fmt --check`
- Immutable candidate and mutation-between-checkpoint regressions
- Promotion suite comparison against current main

## AI assistance
OpenCode using gpt-5.6-sol analyzed the lifecycle, implemented and hardened the change, and added regression coverage. Chris remains responsible for the submitted code.