### PR TITLE
fix(status): bound git fetch and show progress so status can't hang silently

### DIFF
--- a/crates/homeboy-cli/src/commands/status/git_cache.rs
+++ b/crates/homeboy-cli/src/commands/status/git_cache.rs
@@ -139,12 +139,21 @@ pub(super) fn component_cache_key(component: &component::Component) -> String {
     format!("{}\0{}", component.id, component.local_path)
 }
 
+/// Per-component `git fetch` bound so an unresponsive remote can't stall
+/// `homeboy status` indefinitely in a many-component workspace (#7378). The
+/// fetch is best-effort — a timeout or missing remote falls back to local tag
+/// data, exactly like the previous unbounded best-effort fetch.
+const STATUS_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 fn fetch_origin_tags(path: &str) {
-    // Best-effort fetch — silently proceeds if no remote or network issue.
-    let _ = homeboy::core::engine::command::run_in_optional(
-        path,
-        "git",
+    // Best-effort, timeout-bounded fetch — silently proceeds on no remote,
+    // network issue, or timeout, using whatever local tags are already present.
+    let _ = git::run_git_with_env_timeout(
+        std::path::Path::new(path),
         &["fetch", "--tags", "--quiet"],
+        "status fetch origin tags",
+        &[],
+        STATUS_FETCH_TIMEOUT,
     );
 }
 

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -32,7 +32,7 @@ pub use types::{
     ProjectStatusRow, StatusArgs, StatusOutput, StatusResult, StatusTiming,
     UnregisteredContextStatusOutput, UnreleasedMerge, UpstreamDrift,
 };
-use types::{StatusTimer, READY_TO_DEPLOY_NOTE, UNRELEASED_MERGES_NOTE};
+use types::{StatusProgress, StatusTimer, READY_TO_DEPLOY_NOTE, UNRELEASED_MERGES_NOTE};
 
 pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusResult> {
     if args.path.is_some() {
@@ -128,7 +128,13 @@ fn summarize_components(
 
     if include_upstream_drift || include_unreleased_merges {
         timer.begin("inspect_upstream_and_unreleased");
-        for comp in &components {
+        // This phase runs a per-component `git fetch` and drift/merge probes. In
+        // a large workspace it is the slowest part of `status`, so emit a bounded
+        // progress line per component (to stderr, on a TTY) so operators see what
+        // it is working on instead of a silent hang (#7378).
+        let progress = StatusProgress::new(total);
+        for (index, comp) in components.iter().enumerate() {
+            progress.report(index, &comp.id);
             if include_upstream_drift {
                 if let Some(drift) = git_cache.fetch_upstream_drift_for(comp) {
                     if drift.is_behind() {

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -294,6 +294,11 @@ impl StatusProgress {
         }
     }
 
+    #[cfg(test)]
+    pub(super) fn is_active(&self) -> bool {
+        self.active
+    }
+
     pub(super) fn report(&self, index: usize, component_id: &str) {
         if !self.active {
             return;
@@ -364,5 +369,29 @@ impl serde::Serialize for StatusResult {
             StatusResult::Full(output) => output.serialize(serializer),
             StatusResult::Dashboard(output) => output.serialize(serializer),
         }
+    }
+}
+
+#[cfg(test)]
+mod progress_tests {
+    use super::StatusProgress;
+
+    #[test]
+    fn single_component_progress_is_inactive() {
+        // A 0- or 1-component status is fast and needs no spinner, regardless of
+        // whether stderr is a TTY (#7378).
+        assert!(!StatusProgress::new(0).is_active());
+        assert!(!StatusProgress::new(1).is_active());
+    }
+
+    #[test]
+    fn inactive_progress_report_and_drop_are_no_ops() {
+        // In the (non-TTY) test environment progress is inactive; report/drop
+        // must be safe no-ops that never panic or emit control characters.
+        let progress = StatusProgress::new(10);
+        assert!(!progress.is_active(), "non-TTY stderr yields inactive progress");
+        progress.report(0, "component-a");
+        progress.report(9, "component-b");
+        drop(progress);
     }
 }

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -273,6 +273,56 @@ impl StatusTimer {
     }
 }
 
+/// Emits a bounded, single-line progress indicator for the slow per-component
+/// git-inspection phase of `homeboy status`, so an operator sees what it is
+/// working on instead of a silent hang (#7378). Only writes to an interactive
+/// stderr (a TTY), so JSON/piped output stays clean; the final line is cleared
+/// on drop.
+pub(super) struct StatusProgress {
+    total: usize,
+    active: bool,
+}
+
+impl StatusProgress {
+    pub(super) fn new(total: usize) -> Self {
+        use std::io::IsTerminal;
+        Self {
+            total,
+            // Only render for a non-trivial component set on an interactive
+            // terminal — a single-component status is fast and needs no spinner.
+            active: total > 1 && std::io::stderr().is_terminal(),
+        }
+    }
+
+    pub(super) fn report(&self, index: usize, component_id: &str) {
+        if !self.active {
+            return;
+        }
+        use std::io::Write;
+        // Carriage-return in place so the phase occupies one line, not `total`.
+        let _ = write!(
+            std::io::stderr(),
+            "\r[status] inspecting {}/{}: {:<40}",
+            index + 1,
+            self.total,
+            component_id
+        );
+        let _ = std::io::stderr().flush();
+    }
+}
+
+impl Drop for StatusProgress {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        use std::io::Write;
+        // Clear the progress line so it does not linger above the report.
+        let _ = write!(std::io::stderr(), "\r{:<60}\r", "");
+        let _ = std::io::stderr().flush();
+    }
+}
+
 /// Summary counts for the project dashboard.
 #[derive(Debug, Serialize)]
 pub struct ProjectDashboardSummary {


### PR DESCRIPTION
## Summary
`homeboy status` produced no output and timed out after two minutes during a large workspace session (#7378). Two causes:
1. The per-component inspection phase runs a `git fetch --tags` **with no timeout** — one unresponsive remote (or many components) stalls the whole command.
2. **Nothing prints** until the entire run finishes, so a slow run is indistinguishable from a hang.

## Changes
- **Bound the fetch** (`fetch_origin_tags`): use `run_git_with_env_timeout` with a 15s cap. Still best-effort — a timeout / missing remote falls back to local tag data exactly like the prior unbounded fetch, so one slow remote can't stall status.
- **Progressive output** (`StatusProgress`): a bounded single-line `[status] inspecting N/total: <id>` indicator during the slow inspection phase, on an **interactive stderr only** (skipped for piped/JSON output and single-component runs), cleared on completion. Operators see what status is working on instead of a blank hang.

## Acceptance criteria
- [x] Prints an initial phase within a few seconds — the per-component progress line starts immediately.
- [x] Slow sections are bounded — the per-component fetch now has a 15s timeout.
- [x] A debug mode identifies the slow subsystem — the existing `--timings` flag prints `[status] <phase>... completed in Nms` per phase.

## Testing
- `commands::status::types::progress_tests` — 2 new: inactive for 0/1-component runs regardless of TTY; `report`/`drop` are safe no-ops when inactive.
- `commands::status::*` — 22 existing tests still pass (no regression from the bounded fetch or progress helper).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the silent hang to the unbounded per-component `git fetch` and the all-or-nothing output, bounding the fetch, adding progressive output, and coverage.

Closes #7378