### PR TITLE
fix: resolve deploy tags against pristine HEAD and isolate shared git roots

### DIFF
--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -11,7 +11,10 @@ use super::execution::{
     ReleaseArtifactPlan,
 };
 use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
-use super::orchestration_tag_checkout::{checkout_deploy_tags, restore_branches};
+use super::orchestration_tag_checkout::{
+    checkout_resolved_deploy_tags, partition_shared_root_conflicts, resolve_deploy_tags,
+    restore_branches,
+};
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{load_project_components, plan_components};
 use super::types::{ComponentDeployResult, DeployConfig, DeployOrchestrationResult, DeploySummary};
@@ -255,12 +258,78 @@ pub(super) fn deploy_components(
         check_unreleased_commits(&local_build_components, config)?;
     }
 
-    // Checkout the deploy tag for each component (unless --head or --skip-build).
-    let tag_checkouts = if !config.has_requested_refs() && !config.head && !config.skip_build {
-        checkout_deploy_tags(&local_build_components, config.expected_version.as_deref())?
-    } else {
-        Vec::new()
-    };
+    // Resolve the deploy tag for each component (unless --head or --skip-build).
+    //
+    // Resolution happens against the pristine worktree, before any checkout, so
+    // one component's detached checkout cannot rewind HEAD and downgrade a later
+    // component's `--merged HEAD` tag lookup. Components that share a git root
+    // but resolve to different commits cannot both be checked out in place — the
+    // last checkout would otherwise silently supply the content for all of them
+    // — so those are materialized into isolated detached worktrees (#9963).
+    let mut tag_checkouts = Vec::new();
+    let mut tag_ref_checkouts: Vec<ExactRefCheckout> = Vec::new();
+    let mut materialized_tag_refs: HashMap<String, String> = HashMap::new();
+    let mut components = components;
+    let mut local_build_components = local_build_components;
+    if !config.has_requested_refs() && !config.head && !config.skip_build {
+        let resolved =
+            resolve_deploy_tags(&local_build_components, config.expected_version.as_deref())?;
+        let (in_place, shared_root) = partition_shared_root_conflicts(resolved);
+
+        for entry in &shared_root {
+            homeboy_core::log_status!(
+                "deploy",
+                "'{}' shares a git root with a component deploying a different commit — \
+                 materializing tag {} in an isolated worktree",
+                entry.component.id,
+                entry.tag
+            );
+        }
+
+        // Preserve the tag provenance label (including any stale-tag annotation)
+        // so an isolated materialization reports exactly what an in-place tag
+        // checkout would have reported.
+        for entry in &shared_root {
+            materialized_tag_refs.insert(entry.component.id.clone(), entry.provenance_ref());
+        }
+
+        let materialized = shared_root
+            .into_iter()
+            .map(|entry| {
+                let requested_ref = entry.tag.clone();
+                let resolved_sha = entry.tag_commit_sha.clone();
+                ExactRefCheckout::materialize(
+                    &entry.component,
+                    &requested_ref,
+                    resolved_sha.as_deref(),
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        for checkout in &materialized {
+            checkout.verify()?;
+            checkout.hydrate_dependencies(config.skip_deps_hydration)?;
+        }
+
+        tag_checkouts = match checkout_resolved_deploy_tags(in_place) {
+            Ok(checkouts) => checkouts,
+            Err(err) => return Err(err),
+        };
+
+        // Repoint every materialized component at its isolated worktree so
+        // version reads, packaging, and provenance all observe the tagged tree.
+        for checkout in &materialized {
+            let materialized_component = &checkout.component;
+            for target in components
+                .iter_mut()
+                .chain(local_build_components.iter_mut())
+                .filter(|candidate| candidate.id == materialized_component.id)
+            {
+                *target = materialized_component.clone();
+            }
+        }
+        tag_ref_checkouts = materialized;
+    }
+    let components = components;
 
     // Verify expected version if --version was specified
     if let Some(ref expected) = config.expected_version {
@@ -337,6 +406,8 @@ pub(super) fn deploy_components(
             .find(|c| c.component_id == component.id)
         {
             Some(checkout.provenance_ref())
+        } else if let Some(tag_ref) = materialized_tag_refs.get(&component.id) {
+            Some(tag_ref.clone())
         } else if config.head {
             // Deploying from HEAD — record the current branch
             homeboy_core::engine::command::run_in_optional(
@@ -376,6 +447,11 @@ pub(super) fn deploy_components(
             build_provenance.built_from_commit = Some(identity.resolved_sha.clone());
         } else if let Some(artifact) = resolved_release_artifacts.get(&component.id) {
             build_provenance.built_from_commit = artifact.commit.clone();
+        } else if let Some(checkout) = tag_ref_checkouts
+            .iter()
+            .find(|checkout| checkout.component.id == component.id)
+        {
+            build_provenance.built_from_commit = Some(checkout.identity.resolved_sha.clone());
         } else if let Some(prepared_artifact) = config.prepared_artifact.as_ref() {
             build_provenance.built_from_commit = Some(prepared_artifact.source_commit.clone());
         }
@@ -415,6 +491,10 @@ pub(super) fn deploy_components(
             }
         }
     }
+
+    // Isolated tag worktrees delete themselves on drop. Hold them until every
+    // payload has been built, transferred, and smoke-checked.
+    drop(tag_ref_checkouts);
 
     Ok(DeployOrchestrationResult {
         results,
@@ -1537,6 +1617,155 @@ mod tests {
         let err = validate_preflighted_component_identities(&[drifted], &config)
             .expect_err("real config drift must still fail closed");
         assert!(err.message.contains("changed after release-set preflight"));
+    }
+
+    /// Build a monorepo whose components each get their own bump commit and tag,
+    /// mirroring a real `homeboy release` run over a multi-component project.
+    ///
+    /// Layout matches the #9963 report: a theme plus two plugins, each with a
+    /// prior release tag and a newly created one.
+    fn init_monorepo_with_per_component_tags(path: &Path) {
+        run_git(path, &["init", "-q"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test"]);
+
+        for (dir, file, version) in [
+            ("theme", "style.css", "0.2.1"),
+            ("plugins/forms", "forms.php", "0.2.0"),
+            ("plugins/core", "core.php", "0.1.0"),
+        ] {
+            std::fs::create_dir_all(path.join(dir)).expect("component dir");
+            std::fs::write(path.join(dir).join(file), format!("Version: {version}\n"))
+                .expect("write version file");
+        }
+        run_git(path, &["add", "-A"]);
+        run_git(path, &["commit", "-qm", "initial"]);
+        // Prior release tags all point at the base commit.
+        run_git(path, &["tag", "theme-v0.2.1"]);
+        run_git(path, &["tag", "forms-v0.2.0"]);
+        run_git(path, &["tag", "core-v0.1.0"]);
+
+        // The new release: one bump commit + tag per component.
+        for (dir, file, version, tag) in [
+            ("theme", "style.css", "0.2.2", "theme-v0.2.2"),
+            ("plugins/forms", "forms.php", "0.2.1", "forms-v0.2.1"),
+            ("plugins/core", "core.php", "0.1.1", "core-v0.1.1"),
+        ] {
+            std::fs::write(path.join(dir).join(file), format!("Version: {version}\n"))
+                .expect("write bumped version");
+            run_git(path, &["commit", "-qam", &format!("bump {dir}")]);
+            run_git(path, &["tag", tag]);
+        }
+    }
+
+    fn monorepo_component(id: &str, root: &Path, relative: &str, version_file: &str) -> Component {
+        let mut component = make_component(id, &root.join(relative).to_string_lossy());
+        component.version_targets = Some(vec![homeboy_core::component::VersionTarget {
+            file: version_file.to_string(),
+            pattern: Some("Version:\\s*([0-9.]+)".to_string()),
+            artifact_path: None,
+        }]);
+        component
+    }
+
+    /// Regression for #9963: resolving tags lazily inside the checkout loop let
+    /// an earlier component's detached checkout rewind HEAD, so later components
+    /// resolved their *previous* release tag via `git tag --merged HEAD`.
+    #[test]
+    fn deploy_tags_resolve_against_pristine_head_for_every_component() {
+        let dir = TempDir::new().expect("temp dir");
+        init_monorepo_with_per_component_tags(dir.path());
+
+        let components = vec![
+            monorepo_component("theme", dir.path(), "theme", "style.css"),
+            monorepo_component("forms", dir.path(), "plugins/forms", "forms.php"),
+            monorepo_component("core", dir.path(), "plugins/core", "core.php"),
+        ];
+
+        let resolved = resolve_deploy_tags(&components, None).expect("resolve deploy tags");
+
+        let tags: Vec<&str> = resolved.iter().map(|entry| entry.tag.as_str()).collect();
+        assert_eq!(
+            tags,
+            vec!["theme-v0.2.2", "forms-v0.2.1", "core-v0.1.1"],
+            "every component must resolve the tag it was just released with, \
+             not the previous release it would see after a sibling checkout rewound HEAD"
+        );
+    }
+
+    /// Regression for #9963: components sharing one git root but deploying
+    /// different commits cannot be checked out in place — the last checkout would
+    /// supply the packaged content for all of them.
+    #[test]
+    fn shared_git_root_with_differing_commits_is_routed_to_isolated_materialization() {
+        let dir = TempDir::new().expect("temp dir");
+        init_monorepo_with_per_component_tags(dir.path());
+
+        let components = vec![
+            monorepo_component("theme", dir.path(), "theme", "style.css"),
+            monorepo_component("forms", dir.path(), "plugins/forms", "forms.php"),
+            monorepo_component("core", dir.path(), "plugins/core", "core.php"),
+        ];
+
+        let resolved = resolve_deploy_tags(&components, None).expect("resolve deploy tags");
+        let (in_place, shared_root) = partition_shared_root_conflicts(resolved);
+
+        assert!(
+            in_place.is_empty(),
+            "no component may be checked out in place when siblings need different commits"
+        );
+        let mut ids: Vec<&str> = shared_root
+            .iter()
+            .map(|entry| entry.component.id.as_str())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["core", "forms", "theme"]);
+    }
+
+    /// A single-root component (the common non-monorepo case) must keep using the
+    /// cheap in-place checkout rather than paying for an isolated worktree.
+    #[test]
+    fn unshared_git_roots_still_check_out_in_place() {
+        let first = TempDir::new().expect("first temp dir");
+        let second = TempDir::new().expect("second temp dir");
+        init_repo_with_tag_gap(first.path());
+        init_repo_with_tag_gap(second.path());
+
+        let components = vec![
+            make_component("first", &first.path().to_string_lossy()),
+            make_component("second", &second.path().to_string_lossy()),
+        ];
+
+        let resolved = resolve_deploy_tags(&components, None).expect("resolve deploy tags");
+        let (in_place, shared_root) = partition_shared_root_conflicts(resolved);
+
+        assert_eq!(
+            in_place.len(),
+            2,
+            "separate repos never contend for a worktree"
+        );
+        assert!(shared_root.is_empty());
+    }
+
+    /// Components sharing a root that all resolve to the *same* commit are not in
+    /// conflict — one checkout serves them all.
+    #[test]
+    fn shared_git_root_at_one_commit_checks_out_in_place() {
+        let dir = TempDir::new().expect("temp dir");
+        init_monorepo_with_per_component_tags(dir.path());
+
+        // Both components resolve to the same tag commit, so a single in-place
+        // checkout is sufficient and correct.
+        let components = vec![
+            monorepo_component("theme", dir.path(), "theme", "style.css"),
+            monorepo_component("theme-dup", dir.path(), "theme", "style.css"),
+        ];
+
+        let resolved = resolve_deploy_tags(&components, Some("0.2.2")).expect("resolve tags");
+        let (in_place, shared_root) = partition_shared_root_conflicts(resolved);
+
+        assert_eq!(in_place.len(), 2, "one commit needs only one checkout");
+        assert!(shared_root.is_empty());
     }
 
     #[test]

--- a/crates/homeboy-release/src/deploy/orchestration_tag_checkout.rs
+++ b/crates/homeboy-release/src/deploy/orchestration_tag_checkout.rs
@@ -45,19 +45,74 @@ impl TagCheckout {
     }
 }
 
-/// Checkout the latest version tag for each component before building.
+/// A deploy tag resolved against the pristine, pre-checkout worktree.
 ///
-/// For each component, finds the latest semver tag, saves the current
-/// branch/ref, and checks out the tag. Returns a list of checkouts
-/// so branches can be restored after deployment.
+/// Resolution is deliberately separated from checkout. `latest_component_tag`
+/// resolves through `git tag --merged HEAD`, so resolving lazily inside the
+/// checkout loop let an earlier component's detached checkout rewind HEAD and
+/// silently downgrade every later component to its *previous* release tag
+/// (#9963).
+pub(super) struct ResolvedDeployTag {
+    pub(super) component: Component,
+    pub(super) tag: String,
+    pub(super) tag_sha: Option<String>,
+    /// Full commit sha the tag peels to. Annotated tags resolve to a tag object,
+    /// so this is always peeled with `^{commit}` to name the deployed content.
+    pub(super) tag_commit_sha: Option<String>,
+    head_commit: Option<String>,
+    pub(super) head_ahead: u32,
+    original_ref: String,
+    /// Git root that owns this component, used to detect components that would
+    /// otherwise contend for a single shared worktree.
+    pub(super) git_root: String,
+}
+
+impl ResolvedDeployTag {
+    /// Whether the pristine checkout already contains exactly this tag.
+    fn already_at_tag(&self) -> bool {
+        self.tag_commit_sha.is_some() && self.tag_commit_sha == self.head_commit
+    }
+
+    /// Human-readable provenance label for this resolved tag.
+    pub(super) fn provenance_ref(&self) -> String {
+        let mut label = match &self.tag_sha {
+            Some(sha) => format!("{} ({})", self.tag, sha),
+            None => self.tag.clone(),
+        };
+        if self.head_ahead > 0 {
+            label.push_str(&format!(
+                " [stale tag: HEAD was {} commit(s) ahead, not deployed]",
+                self.head_ahead
+            ));
+        }
+        label
+    }
+
+    fn into_checkout(self) -> TagCheckout {
+        TagCheckout {
+            component_id: self.component.id,
+            tag: self.tag,
+            original_ref: self.original_ref,
+            local_path: self.component.local_path,
+            tag_sha: self.tag_sha,
+            head_ahead: self.head_ahead,
+        }
+    }
+}
+
+/// Resolve the deploy tag for every component against the pristine checkout.
+///
+/// This performs no mutation: every tag, sha, and HEAD-gap measurement is taken
+/// before any component checks anything out, so resolution cannot be perturbed
+/// by a sibling component's checkout.
 ///
 /// Components without tags fail closed. Deploying the current checkout must be
 /// requested explicitly with `--head`.
-pub(super) fn checkout_deploy_tags(
+pub(super) fn resolve_deploy_tags(
     components: &[Component],
     expected_version: Option<&str>,
-) -> Result<Vec<TagCheckout>> {
-    let mut checkouts = Vec::new();
+) -> Result<Vec<ResolvedDeployTag>> {
+    let mut resolved = Vec::new();
 
     for component in components {
         // File components don't have tags — skip
@@ -72,9 +127,6 @@ pub(super) fn checkout_deploy_tags(
             None => match release::latest_component_tag(component) {
                 Ok(Some(t)) => t,
                 Ok(None) => {
-                    if !checkouts.is_empty() {
-                        restore_branches(&checkouts);
-                    }
                     return Err(Error::validation_invalid_argument(
                         "deploy",
                         format!(
@@ -90,9 +142,6 @@ pub(super) fn checkout_deploy_tags(
                     ));
                 }
                 Err(err) => {
-                    if !checkouts.is_empty() {
-                        restore_branches(&checkouts);
-                    }
                     return Err(Error::git_command_failed(format!(
                         "Could not read version tags for '{}': {}",
                         component.id, err
@@ -117,11 +166,17 @@ pub(super) fn checkout_deploy_tags(
         })
         .unwrap_or_else(|| "main".to_string());
 
-        // If already on this tag's commit, skip checkout
-        let tag_commit =
-            homeboy_core::engine::command::run_in_optional(path, "git", &["rev-parse", &tag]);
+        // Peel to the commit so annotated tags (which rev-parse to a tag object)
+        // compare correctly against HEAD and name real deployable content.
+        let tag_commit_sha = homeboy_core::engine::command::run_in_optional(
+            path,
+            "git",
+            &["rev-parse", "--verify", &format!("{tag}^{{commit}}")],
+        )
+        .map(|sha| sha.trim().to_string());
         let head_commit =
-            homeboy_core::engine::command::run_in_optional(path, "git", &["rev-parse", "HEAD"]);
+            homeboy_core::engine::command::run_in_optional(path, "git", &["rev-parse", "HEAD"])
+                .map(|sha| sha.trim().to_string());
 
         // Short sha of the tag being deployed, for unambiguous provenance.
         let tag_sha = homeboy_core::engine::command::run_in_optional(
@@ -141,60 +196,121 @@ pub(super) fn checkout_deploy_tags(
         .and_then(|out| out.trim().parse::<u32>().ok())
         .unwrap_or(0);
 
-        if tag_commit.is_some() && tag_commit == head_commit {
+        let git_root = homeboy_core::git::get_git_root(path).unwrap_or_else(|_| path.clone());
+
+        resolved.push(ResolvedDeployTag {
+            component: component.clone(),
+            tag,
+            tag_sha,
+            tag_commit_sha,
+            head_commit,
+            head_ahead,
+            original_ref,
+            git_root,
+        });
+    }
+
+    Ok(resolved)
+}
+
+/// Partition resolved tags into those safe to check out in place and those that
+/// must be materialized in isolation.
+///
+/// A single worktree can only hold one commit, so when two components share a
+/// git root and resolve to different commits, checking both out in place makes
+/// the last checkout win for every component (#9963). Those components are
+/// routed to per-component detached materialization instead.
+pub(super) fn partition_shared_root_conflicts(
+    resolved: Vec<ResolvedDeployTag>,
+) -> (Vec<ResolvedDeployTag>, Vec<ResolvedDeployTag>) {
+    let mut commits_by_root: std::collections::HashMap<&str, std::collections::BTreeSet<&str>> =
+        std::collections::HashMap::new();
+    for entry in &resolved {
+        if let Some(sha) = entry.tag_commit_sha.as_deref() {
+            commits_by_root
+                .entry(entry.git_root.as_str())
+                .or_default()
+                .insert(sha);
+        }
+    }
+
+    let conflicted: std::collections::HashSet<String> = commits_by_root
+        .iter()
+        .filter(|(_, commits)| commits.len() > 1)
+        .map(|(root, _)| (*root).to_string())
+        .collect();
+
+    resolved
+        .into_iter()
+        .partition(|entry| !conflicted.contains(&entry.git_root))
+}
+
+/// Check out already-resolved deploy tags in place.
+///
+/// Callers must only pass components that exclusively own their git root — a
+/// single worktree cannot simultaneously hold two different tags, so sharing one
+/// silently packages every component from whichever tag was checked out last.
+/// Use [`resolve_deploy_tags`] plus per-component materialization for shared
+/// roots.
+pub(super) fn checkout_resolved_deploy_tags(
+    resolved: Vec<ResolvedDeployTag>,
+) -> Result<Vec<TagCheckout>> {
+    let mut checkouts: Vec<TagCheckout> = Vec::new();
+
+    for entry in resolved {
+        let path = entry.component.local_path.clone();
+        let component_id = entry.component.id.clone();
+        let tag = entry.tag.clone();
+
+        if entry.already_at_tag() {
             homeboy_core::log_status!(
                 "deploy",
                 "'{}' is already at tag {} — no checkout needed",
-                component.id,
+                component_id,
                 tag
             );
-            checkouts.push(TagCheckout {
-                component_id: component.id.clone(),
-                tag: tag.clone(),
-                original_ref,
-                local_path: path.clone(),
-                tag_sha,
-                head_ahead,
-            });
+            checkouts.push(entry.into_checkout());
             continue;
         }
 
-        // Checkout the tag
         homeboy_core::log_status!(
             "deploy",
             "'{}' checking out tag {} for deploy...",
-            component.id,
+            component_id,
             tag
         );
         match homeboy_core::engine::command::run_in(
-            path,
+            &path,
             "git",
             &["checkout", &tag],
             "git checkout tag",
         ) {
-            Ok(_) => {
-                checkouts.push(TagCheckout {
-                    component_id: component.id.clone(),
-                    tag: tag.clone(),
-                    original_ref,
-                    local_path: path.clone(),
-                    tag_sha,
-                    head_ahead,
-                });
-            }
+            Ok(_) => checkouts.push(entry.into_checkout()),
             Err(e) => {
                 if !checkouts.is_empty() {
                     restore_branches(&checkouts);
                 }
                 return Err(Error::git_command_failed(format!(
                     "Failed to checkout tag {} for '{}': {}",
-                    tag, component.id, e
+                    tag, component_id, e
                 )));
             }
         }
     }
 
     Ok(checkouts)
+}
+
+/// Resolve and check out the deploy tag for each component before building.
+///
+/// Retained for single-root callers and tests; the orchestrator resolves and
+/// materializes separately so monorepo components never share one worktree.
+#[cfg(test)]
+pub(super) fn checkout_deploy_tags(
+    components: &[Component],
+    expected_version: Option<&str>,
+) -> Result<Vec<TagCheckout>> {
+    checkout_resolved_deploy_tags(resolve_deploy_tags(components, expected_version)?)
 }
 
 pub(super) fn deploy_tag_for_version(component: &Component, version: &str) -> String {


### PR DESCRIPTION
## Summary

Fixes #9963 — deploying a freshly created release tag shipped content one version behind the tag, while reporting success with the correct `deployed_ref`.

## Root cause

Reproduced exactly (theme `0.2.1`, forms `0.2.0`, core `0.1.0` — each one bump behind its tag). Two compounding defects in the monorepo tagged-deploy path:

**1. Tag resolution was perturbed by its own checkouts.** `latest_component_tag` resolves through `git tag --merged HEAD`, but tags were resolved *lazily inside* the checkout loop. Once the first component detached HEAD backward onto its tag, every later component's lookup ran against the rewound HEAD and silently resolved its *previous* release tag:

```
h44-lacrosse-theme -> resolved 'h44-lacrosse-theme-v0.2.2'   (HEAD=c2b50ff)
h44-forms          -> resolved 'h44-forms-v0.2.0'   <-- wanted v0.2.1
h44-core           -> resolved 'h44-core-v0.1.0'    <-- wanted v0.1.1
```

**2. All components shared one worktree.** A worktree holds one commit, and packaging runs *after* the whole checkout loop — so whichever tag was checked out last supplied the bytes for every component.

Both defects are silent: `deployed_ref` is reported from the requested tag, never from the materialized content, so the deploy looks correct.

## Fix

- `resolve_deploy_tags` measures every tag, sha, and HEAD gap against the **pristine** worktree before any mutation, so no component can perturb another's resolution.
- `partition_shared_root_conflicts` routes components that share a git root but need different commits into **isolated detached worktrees**, keeping the cheap in-place checkout for the ordinary single-root case.
- Tag provenance labels (including the stale-tag annotation) and the resolved commit are carried through materialization, so `deployed_ref` and `build_provenance.built_from_commit` still agree.

## Testing

4 new regression tests encoding the reproduction: pristine-HEAD resolution across all three components, shared-root routing, and both negative cases (separate repos, and a shared root at a single commit) so the isolation path is not taken unnecessarily.

Full `homeboy-release` suite run single-threaded: 3 failures, all **pre-existing on main** and unrelated (verified by re-running against a pristine tree). Note some `deploy::preparation` tests are flaky under parallel execution; single-threaded is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Homeboy (OpenCode / claude-sonnet-4-6)