### PR TITLE
fix: release preflight steps no longer block the release they prepare

### DIFF
--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -535,7 +535,14 @@ fn run_changelog_bootstrap_preflight(
     step: &PlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
-    match super::planning_changelog::ensure_changelog_initialized(context.component) {
+    // The plan carries the authoritative dry-run flag on the step; fall back to
+    // the run-level option so a plan built without it still honours --dry-run.
+    let dry_run = step
+        .inputs
+        .get("dry_run")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(context.options.dry_run);
+    match super::planning_changelog::ensure_changelog_initialized(context.component, dry_run) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
             step_type: step.kind.clone(),

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -695,15 +695,46 @@ fn release_step_unexpected_dirty_files(
     context: &ReleaseExecutionContext,
     files: Vec<String>,
 ) -> Result<Vec<String>> {
-    if step.kind != "release.prepare" {
-        return Ok(files);
+    match step.kind.as_str() {
+        "release.prepare" => {
+            let allowed = release_prepare_allowed_dirty_files(context.component)?;
+            Ok(files
+                .into_iter()
+                .filter(|file| !allowed.iter().any(|allowed| file == allowed))
+                .collect())
+        }
+        // Hydration regenerates package-manager bookkeeping as a side effect of
+        // running at all. That churn is homeboy's own doing, not operator drift.
+        "preflight.dependencies" => Ok(files
+            .into_iter()
+            .filter(|file| !is_dependency_hydration_metadata(file))
+            .collect()),
+        _ => Ok(files),
     }
+}
 
-    let allowed = release_prepare_allowed_dirty_files(context.component)?;
-    Ok(files
-        .into_iter()
-        .filter(|file| !allowed.iter().any(|allowed| file == allowed))
-        .collect())
+/// Generated package-manager metadata that a dependency install rewrites even
+/// when it resolves no changes.
+///
+/// Composer regenerates `vendor/composer/installed.json` and `installed.php`
+/// during autoload generation on every `composer install`, including a no-op
+/// "Nothing to install" run. WordPress plugins commonly commit `vendor/` so the
+/// plugin works without a build step on the host, which made the release's own
+/// hydration step fail the working-tree gate it was preparing for (#9965).
+///
+/// Deliberately narrow: only the two files composer rewrites unconditionally.
+/// Real dependency changes still surface through `composer.lock` and the
+/// installed package sources, which remain guarded.
+fn is_dependency_hydration_metadata(file: &str) -> bool {
+    const GENERATED_METADATA: &[&str] = &[
+        "vendor/composer/installed.json",
+        "vendor/composer/installed.php",
+    ];
+
+    let normalized = file.trim_start_matches("./").replace('\\', "/");
+    GENERATED_METADATA
+        .iter()
+        .any(|generated| normalized == *generated || normalized.ends_with(&format!("/{generated}")))
 }
 
 fn release_prepare_allowed_dirty_files(
@@ -1432,6 +1463,52 @@ mod tests {
             .hints
             .iter()
             .any(|hint| hint.message.contains("Fix the build/test/package step")));
+    }
+
+    /// Regression for #9965: `composer install` rewrites
+    /// `vendor/composer/installed.{json,php}` on every run, including a no-op
+    /// "Nothing to install" run. WordPress plugins commonly commit `vendor/`, so
+    /// homeboy's own hydration step failed the working-tree gate it was
+    /// preparing for. That churn is expected noise; real source changes are not.
+    #[test]
+    fn dependency_preflight_dirty_guard_allows_generated_composer_metadata() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let options = ReleaseOptions::default();
+        let context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let unexpected = release_step_unexpected_dirty_files(
+            &plan_step("preflight.dependencies"),
+            &context,
+            vec![
+                "vendor/composer/installed.json".to_string(),
+                "vendor/composer/installed.php".to_string(),
+                // Monorepo form: the component sits under a subdirectory.
+                "plugins/h44-forms/vendor/composer/installed.json".to_string(),
+                "plugins/h44-forms/vendor/composer/installed.php".to_string(),
+                // Real dependency and source changes must still be reported.
+                "composer.lock".to_string(),
+                "src/Plugin.php".to_string(),
+            ],
+        )
+        .expect("guard should classify dirty files");
+
+        assert_eq!(
+            unexpected,
+            vec!["composer.lock", "src/Plugin.php"],
+            "only composer's unconditionally regenerated metadata may be excused"
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/planning_changelog.rs
+++ b/crates/homeboy-release/src/release/planning_changelog.rs
@@ -140,7 +140,12 @@ fn is_file_not_found_error(err: &Error) -> bool {
 /// First-release bootstrap: if the component's configured `changelog_target`
 /// doesn't exist on disk (and no fallback candidate exists), create a minimal
 /// changelog scaffold so downstream finalization has a file to update.
-pub(super) fn ensure_changelog_initialized(component: &Component) -> Result<()> {
+///
+/// A dry run must not touch the working tree: leaving an untracked scaffold
+/// behind makes the *next* real release fail its own working-tree gate on a file
+/// homeboy wrote (#9964). `read_changelog_for_release` already seeds the initial
+/// content in memory for dry runs, so skipping the write here loses nothing.
+pub(super) fn ensure_changelog_initialized(component: &Component, dry_run: bool) -> Result<()> {
     let Some(ref target) = component.changelog_target else {
         return Ok(());
     };
@@ -155,12 +160,28 @@ pub(super) fn ensure_changelog_initialized(component: &Component) -> Result<()> 
         return Ok(());
     }
 
+    if dry_run {
+        homeboy_core::log_status!(
+            "release",
+            "Dry run: would initialize changelog at {} (first release for {})",
+            configured_path.display(),
+            component.id
+        );
+        return Ok(());
+    }
+
     if let Some(parent) = configured_path.parent() {
         homeboy_core::engine::local_files::local().ensure_dir(parent)?;
     }
 
     homeboy_core::engine::local_files::local()
         .write(&configured_path, changelog::INITIAL_CHANGELOG_CONTENT)?;
+
+    // Stage the scaffold immediately. It is release-owned content that the
+    // release commit will include anyway, and leaving it untracked makes git
+    // report the whole new parent directory (e.g. `docs/`) as dirty, which no
+    // file-level allowlist can match (#9964).
+    stage_bootstrapped_changelog(component, &configured_path);
 
     homeboy_core::log_status!(
         "release",
@@ -170,6 +191,39 @@ pub(super) fn ensure_changelog_initialized(component: &Component) -> Result<()> 
     );
 
     Ok(())
+}
+
+/// Stage the freshly bootstrapped changelog so it is tracked from the moment it
+/// exists. Best-effort: a staging failure must not abort the release, because
+/// the file itself is already written and the working-tree gate tolerates the
+/// component's declared changelog target either way.
+fn stage_bootstrapped_changelog(component: &Component, changelog_path: &std::path::Path) {
+    let output = std::process::Command::new("git")
+        .arg("add")
+        .arg("--")
+        .arg(changelog_path)
+        .current_dir(&component.local_path)
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            homeboy_core::log_status!(
+                "release",
+                "Warning: could not stage bootstrapped changelog {}: {}",
+                changelog_path.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Err(err) => {
+            homeboy_core::log_status!(
+                "release",
+                "Warning: could not stage bootstrapped changelog {}: {}",
+                changelog_path.display(),
+                err
+            );
+        }
+    }
 }
 
 /// Group component-scoped commits into durable product-history changelog sections.
@@ -344,7 +398,7 @@ mod tests {
         let changelog_path = temp.path().join("CHANGELOG.md");
         assert!(!changelog_path.exists(), "precondition: no changelog yet");
 
-        ensure_changelog_initialized(&component).expect("preflight should bootstrap");
+        ensure_changelog_initialized(&component, false).expect("preflight should bootstrap");
 
         let content = std::fs::read_to_string(&changelog_path).expect("file created");
         assert_eq!(content, super::changelog::INITIAL_CHANGELOG_CONTENT);
@@ -363,7 +417,7 @@ mod tests {
         let docs_dir = temp.path().join("docs");
         assert!(!docs_dir.exists(), "precondition: no docs/ yet");
 
-        ensure_changelog_initialized(&component).expect("preflight should bootstrap");
+        ensure_changelog_initialized(&component, false).expect("preflight should bootstrap");
 
         assert!(docs_dir.is_dir(), "docs/ parent should be created");
         assert!(
@@ -380,7 +434,7 @@ mod tests {
         let original = "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### Added\n- real release\n";
         std::fs::write(&changelog_path, original).unwrap();
 
-        ensure_changelog_initialized(&component).expect("no-op on existing file");
+        ensure_changelog_initialized(&component, false).expect("no-op on existing file");
 
         let after = std::fs::read_to_string(&changelog_path).unwrap();
         assert_eq!(after, original, "existing changelog must not be rewritten");
@@ -395,7 +449,7 @@ mod tests {
         let fallback = temp.path().join("docs/CHANGELOG.md");
         std::fs::write(&fallback, "# Changelog\n\n## [0.1.0] - 2026-01-01\n").unwrap();
 
-        ensure_changelog_initialized(&component).expect("defer to fallback");
+        ensure_changelog_initialized(&component, false).expect("defer to fallback");
 
         assert!(
             !temp.path().join("CHANGELOG.md").exists(),
@@ -408,12 +462,59 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let component = component_with_changelog_target(&temp, None);
 
-        ensure_changelog_initialized(&component).expect("no-op without target");
+        ensure_changelog_initialized(&component, false).expect("no-op without target");
 
         if let Some(entry) = std::fs::read_dir(temp.path()).unwrap().next() {
             let path = entry.unwrap().path();
             panic!("should have created nothing, but found: {}", path.display());
         }
+    }
+
+    /// Regression for #9964: the bootstrapped changelog was left untracked, so
+    /// the release aborted on its own `working_tree` gate. Git reports a wholly
+    /// untracked new directory as `docs/`, which no file-level allowlist matches
+    /// — staging the file at creation keeps the tree clean instead.
+    #[test]
+    fn ensure_changelog_initialized_stages_the_bootstrapped_changelog() {
+        let temp = git_repo();
+        let component = component_with_changelog_target(&temp, Some("docs/CHANGELOG.md"));
+
+        ensure_changelog_initialized(&component, false).expect("preflight should bootstrap");
+
+        let status = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git status");
+        let status = String::from_utf8_lossy(&status.stdout);
+
+        assert!(
+            status.contains("A  docs/CHANGELOG.md"),
+            "bootstrapped changelog must be staged, got: {status:?}"
+        );
+        assert!(
+            !status.contains("?? docs/"),
+            "an untracked docs/ directory is what trips the working_tree gate: {status:?}"
+        );
+    }
+
+    /// Regression for #9964: a dry run must leave no scaffold behind, otherwise
+    /// the next real release fails its working-tree gate on a dry run's residue.
+    #[test]
+    fn ensure_changelog_initialized_dry_run_does_not_touch_the_working_tree() {
+        let temp = git_repo();
+        let component = component_with_changelog_target(&temp, Some("docs/CHANGELOG.md"));
+
+        ensure_changelog_initialized(&component, true).expect("dry run should be a no-op");
+
+        assert!(
+            !temp.path().join("docs").exists(),
+            "dry run must not create the changelog parent directory"
+        );
+        assert!(
+            !temp.path().join("docs/CHANGELOG.md").exists(),
+            "dry run must not write the changelog"
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/planning_worktree.rs
+++ b/crates/homeboy-release/src/release/planning_worktree.rs
@@ -86,7 +86,17 @@ pub(super) fn validate_working_tree_fail_fast(component: &Component) -> Result<(
         .collect();
 
     let build_artifacts = declared_build_artifact_paths(component);
-    let unexpected = filter_homeboy_managed_and_declared_artifacts(all_files, &build_artifacts);
+    let mut unexpected = filter_homeboy_managed_and_declared_artifacts(all_files, &build_artifacts);
+    // A changelog homeboy bootstrapped for this release is release-owned content,
+    // not operator drift. Excuse the declared changelog target (and the parent
+    // directory git collapses a wholly-untracked scaffold into) so the release
+    // cannot abort on a file it just wrote itself (#9964).
+    let bootstrapped = bootstrapped_changelog_paths(component);
+    unexpected.retain(|file| {
+        !bootstrapped
+            .iter()
+            .any(|allowed| paths_match(file, allowed))
+    });
     if unexpected.is_empty() {
         return Ok(());
     }
@@ -110,6 +120,36 @@ pub(super) fn validate_working_tree_fail_fast(component: &Component) -> Result<(
             ),
         ]),
     ))
+}
+
+/// Paths a first-release changelog bootstrap can legitimately make dirty.
+///
+/// Returns the declared changelog target plus every ancestor directory between
+/// it and the component root. `git status --untracked-files=normal` collapses a
+/// wholly-untracked directory into a single `docs/` entry rather than naming
+/// `docs/CHANGELOG.md`, so matching only the file path would never fire.
+fn bootstrapped_changelog_paths(component: &Component) -> Vec<String> {
+    let Some(target) = component.changelog_target.as_deref() else {
+        return Vec::new();
+    };
+    let target = target.trim().trim_start_matches("./").trim_matches('/');
+    if target.is_empty() {
+        return Vec::new();
+    }
+
+    let mut paths = vec![target.to_string()];
+    let mut parent = Path::new(target).parent();
+    while let Some(dir) = parent {
+        match dir.to_str() {
+            Some(dir) if !dir.is_empty() => {
+                paths.push(format!("{dir}/"));
+                paths.push(dir.to_string());
+            }
+            _ => break,
+        }
+        parent = dir.parent();
+    }
+    paths
 }
 
 const HOMEBOY_MANAGED_PREFIXES: &[&str] = &[
@@ -491,6 +531,51 @@ mod tests {
 
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.message.contains("Uncommitted changes detected"));
+        assert!(err.details.to_string().contains("src.rs"));
+    }
+
+    /// Regression for #9964: the gate must not abort on the changelog scaffold
+    /// homeboy itself wrote moments earlier. Git collapses a wholly untracked new
+    /// directory into a single `docs/` entry, so the allowlist has to cover the
+    /// parent directory form and not just `docs/CHANGELOG.md`.
+    #[test]
+    fn bootstrapped_changelog_directory_does_not_fail_the_working_tree_gate() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("README.md"), "initial\n").unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+
+        std::fs::create_dir_all(dir.join("docs")).unwrap();
+        std::fs::write(dir.join("docs/CHANGELOG.md"), "# Changelog\n").unwrap();
+
+        let mut component = git_component(dir);
+        component.changelog_target = Some("docs/CHANGELOG.md".to_string());
+
+        validate_working_tree_fail_fast(&component)
+            .expect("a bootstrapped changelog must not abort the release that created it");
+    }
+
+    /// The changelog allowlist must stay narrow: unrelated files inside the same
+    /// directory are still operator drift and must fail closed.
+    #[test]
+    fn changelog_allowance_does_not_excuse_other_files() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("README.md"), "initial\n").unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+
+        std::fs::create_dir_all(dir.join("docs")).unwrap();
+        std::fs::write(dir.join("docs/CHANGELOG.md"), "# Changelog\n").unwrap();
+        run_git(dir, &["add", "docs/CHANGELOG.md"]);
+        std::fs::write(dir.join("src.rs"), "unexpected\n").unwrap();
+
+        let mut component = git_component(dir);
+        component.changelog_target = Some("docs/CHANGELOG.md".to_string());
+
+        let err = validate_working_tree_fail_fast(&component)
+            .expect_err("unrelated dirty files must still fail fast");
         assert!(err.details.to_string().contains("src.rs"));
     }
 


### PR DESCRIPTION
## Summary

Two preflight steps that sabotage the release they are preparing.

- Fixes #9965 — `preflight.dependencies` dirties tracked composer files
- Fixes #9964 — bootstrapped changelog blocks its own release (**still reproducible on current main**, see below)

## #9964 — not fully fixed by #9981

#9981 patched `get_unexpected_uncommitted_files`, but the `preflight.working_tree` gate dispatches to **`validate_working_tree_fail_fast`** — a different function that was never touched. Verified against pristine `origin/main`:

```
Invalid argument 'working_tree': Uncommitted changes detected — refusing to release
tried: ["Unexpected dirty files (1): docs/"]
```

Two things made this unrecoverable rather than merely noisy:

- The scaffold was never staged, and `git status --untracked-files=normal` collapses a wholly untracked new directory into a single `docs/` entry — so a file-level allowlist for `docs/CHANGELOG.md` could never match.
- The step ignored its own `dry_run` input, so a dry run wrote the scaffold to disk and left residue that failed the *next* real release.

**Fix:** stage the scaffold at creation (release-owned content the release commit would include anyway), make dry runs leave the working tree untouched, and excuse the declared changelog target plus its parent directories in the fail-fast gate. Unrelated dirty files in the same directory still fail closed.

## #9965 — composer metadata

`composer install` rewrites `vendor/composer/installed.json` and `installed.php` during autoload generation on **every** run, including a no-op "Nothing to install" run. WordPress plugins commonly commit `vendor/` so the plugin works without a build step on the host — so homeboy's own hydration step dirtied tracked files and failed the working-tree gate it was preparing for.

The per-step allowlist hook already existed but was hardcoded to `release.prepare`. Extended to `preflight.dependencies`, excusing **only** the two files composer regenerates unconditionally. Real dependency changes still surface through `composer.lock` and the installed package sources; every other dirtied path still fails closed.

## Testing

11 tests passing, including new regressions for: staging the bootstrap, dry-run leaving no residue, the fail-fast gate accepting the changelog directory, the allowlist *not* excusing unrelated files, and the composer guard excusing only generated metadata (in both root and monorepo path forms).

Full `homeboy-release` suite single-threaded: 3 failures, all pre-existing on main and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Homeboy (OpenCode / claude-sonnet-4-6)