### PR TITLE
Drive the dependencies dirty guard from declarations, not hardcoded ecosystem paths (#9965)

### DIFF
--- a/crates/homeboy-core/src/component/artifacts.rs
+++ b/crates/homeboy-core/src/component/artifacts.rs
@@ -39,6 +39,22 @@ struct ResolvedDeclaration {
     relative_path: String,
 }
 
+/// Component-relative paths the component declares as generated/reconstructable
+/// artifacts (`cleanup_artifacts`, by explicit path or glob, plus manifest
+/// declarations).
+///
+/// Callers that must distinguish operator-authored source changes from expected
+/// generated-file churn use this instead of hardcoding ecosystem-specific paths:
+/// the component (or its extension) owns the declaration, and core only honors
+/// it. Keeps toolchain knowledge out of core.
+pub fn declared_cleanup_artifact_paths(component: &Component) -> Result<Vec<String>> {
+    let component_path = PathBuf::from(&component.local_path);
+    Ok(cleanup_artifact_declarations(component, &component_path)?
+        .into_iter()
+        .map(|declaration| declaration.relative_path)
+        .collect())
+}
+
 pub fn cleanup_artifact_report(
     component: &Component,
     apply: bool,

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -23,7 +23,10 @@ pub mod resolution;
 pub mod scope;
 pub mod versioning;
 
-pub use artifacts::{cleanup_artifact_report, CleanupArtifactCandidate, CleanupArtifactReport};
+pub use artifacts::{
+    cleanup_artifact_report, declared_cleanup_artifact_paths, CleanupArtifactCandidate,
+    CleanupArtifactReport,
+};
 pub use audit::{
     ArtifactPortabilityConfig, AuditConfig, CommandStatusContractConfig,
     CommandStatusContractScenario, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -705,36 +705,34 @@ fn release_step_unexpected_dirty_files(
         }
         // Hydration regenerates package-manager bookkeeping as a side effect of
         // running at all. That churn is homeboy's own doing, not operator drift.
-        "preflight.dependencies" => Ok(files
-            .into_iter()
-            .filter(|file| !is_dependency_hydration_metadata(file))
-            .collect()),
+        // The component (or its extension) declares which generated paths are
+        // reconstructable, so this stays free of any toolchain's specific paths.
+        "preflight.dependencies" => {
+            let declared =
+                homeboy_core::component::declared_cleanup_artifact_paths(context.component)?;
+            Ok(files
+                .into_iter()
+                .filter(|file| {
+                    !declared
+                        .iter()
+                        .any(|artifact| declared_artifact_matches(file, artifact))
+                })
+                .collect())
+        }
         _ => Ok(files),
     }
 }
 
-/// Generated package-manager metadata that a dependency install rewrites even
-/// when it resolves no changes.
+/// Whether a dirty-file entry corresponds to a declared artifact path.
 ///
-/// Composer regenerates `vendor/composer/installed.json` and `installed.php`
-/// during autoload generation on every `composer install`, including a no-op
-/// "Nothing to install" run. WordPress plugins commonly commit `vendor/` so the
-/// plugin works without a build step on the host, which made the release's own
-/// hydration step fail the working-tree gate it was preparing for (#9965).
-///
-/// Deliberately narrow: only the two files composer rewrites unconditionally.
-/// Real dependency changes still surface through `composer.lock` and the
-/// installed package sources, which remain guarded.
-fn is_dependency_hydration_metadata(file: &str) -> bool {
-    const GENERATED_METADATA: &[&str] = &[
-        "vendor/composer/installed.json",
-        "vendor/composer/installed.php",
-    ];
-
-    let normalized = file.trim_start_matches("./").replace('\\', "/");
-    GENERATED_METADATA
-        .iter()
-        .any(|generated| normalized == *generated || normalized.ends_with(&format!("/{generated}")))
+/// Git reports entries relative to the repository root while declarations are
+/// component-relative, so match on either direction's path-boundary suffix.
+fn declared_artifact_matches(file: &str, declared: &str) -> bool {
+    let file = file.replace('\\', "/");
+    let declared = declared.replace('\\', "/");
+    file == declared
+        || file.ends_with(&format!("/{declared}"))
+        || declared.ends_with(&format!("/{file}"))
 }
 
 fn release_prepare_allowed_dirty_files(
@@ -1465,13 +1463,70 @@ mod tests {
             .any(|hint| hint.message.contains("Fix the build/test/package step")));
     }
 
-    /// Regression for #9965: `composer install` rewrites
-    /// `vendor/composer/installed.{json,php}` on every run, including a no-op
-    /// "Nothing to install" run. WordPress plugins commonly commit `vendor/`, so
-    /// homeboy's own hydration step failed the working-tree gate it was
-    /// preparing for. That churn is expected noise; real source changes are not.
+    /// Regression for #9965: a dependency install rewrites generated bookkeeping
+    /// on every run, including a no-op one. Components that commit those
+    /// generated files made homeboy's own hydration step fail the working-tree
+    /// gate it was preparing for. The component declares which paths are
+    /// reconstructable, so that churn is excused while real changes are not —
+    /// and core stays free of any toolchain's specific paths.
     #[test]
-    fn dependency_preflight_dirty_guard_allows_generated_composer_metadata() {
+    fn dependency_preflight_dirty_guard_allows_declared_generated_artifacts() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            cleanup_artifacts: vec![
+                homeboy_core::component::CleanupArtifactDeclaration {
+                    label: "generated dependency bookkeeping".to_string(),
+                    path: Some("deps/generated/state.json".to_string()),
+                    glob: None,
+                },
+                homeboy_core::component::CleanupArtifactDeclaration {
+                    label: "generated dependency map".to_string(),
+                    path: Some("deps/generated/map.bin".to_string()),
+                    glob: None,
+                },
+            ],
+            ..Default::default()
+        };
+        let options = ReleaseOptions::default();
+        let context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let unexpected = release_step_unexpected_dirty_files(
+            &plan_step("preflight.dependencies"),
+            &context,
+            vec![
+                "deps/generated/state.json".to_string(),
+                "deps/generated/map.bin".to_string(),
+                // Monorepo form: the component sits under a subdirectory, so git
+                // reports repo-root-relative paths.
+                "plugins/fixture/deps/generated/state.json".to_string(),
+                "plugins/fixture/deps/generated/map.bin".to_string(),
+                // The dependency lock and real source changes must still report.
+                "deps/lock.txt".to_string(),
+                "src/lib.rs".to_string(),
+            ],
+        )
+        .expect("guard should classify dirty files");
+
+        assert_eq!(
+            unexpected,
+            vec!["deps/lock.txt", "src/lib.rs"],
+            "only the component's declared generated artifacts may be excused"
+        );
+    }
+
+    /// Without a declaration nothing is excused: the component owns the list of
+    /// reconstructable paths, so an undeclared generated file still reports.
+    #[test]
+    fn dependency_preflight_dirty_guard_reports_undeclared_files() {
         let temp = tempfile::tempdir().expect("tempdir");
         let component = Component {
             id: "fixture".to_string(),
@@ -1491,24 +1546,11 @@ mod tests {
         let unexpected = release_step_unexpected_dirty_files(
             &plan_step("preflight.dependencies"),
             &context,
-            vec![
-                "vendor/composer/installed.json".to_string(),
-                "vendor/composer/installed.php".to_string(),
-                // Monorepo form: the component sits under a subdirectory.
-                "plugins/h44-forms/vendor/composer/installed.json".to_string(),
-                "plugins/h44-forms/vendor/composer/installed.php".to_string(),
-                // Real dependency and source changes must still be reported.
-                "composer.lock".to_string(),
-                "src/Plugin.php".to_string(),
-            ],
+            vec!["deps/generated/state.json".to_string()],
         )
         .expect("guard should classify dirty files");
 
-        assert_eq!(
-            unexpected,
-            vec!["composer.lock", "src/Plugin.php"],
-            "only composer's unconditionally regenerated metadata may be excused"
-        );
+        assert_eq!(unexpected, vec!["deps/generated/state.json"]);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up refactor to the merged #9965 fix (`5a4f24c48`). **No behavior regression** — same case fixed, ecosystem knowledge removed from core.

## Why
The merged fix excuses the dependency preflight's generated-file churn by hardcoding a specific package manager's bookkeeping paths (`is_dependency_hydration_metadata`) in `homeboy-release`. That puts ecosystem knowledge into core-side orchestration.

This is the exact class the **`core_boundary_leak:core-agnostic-source`** convention exists to prevent — and that toolchain is already one of its configured ecosystem terms. `homeboy-release` just isn't in the convention's `include_path_contains` scope yet, so it wasn't flagged. A scope gap, not a design endorsement.

It also doesn't generalize: the next ecosystem with non-deterministic generated files needs another hardcoded denylist entry in core.

## What changed
Drive the guard from the **existing declaration seam** instead:
- A component (or its extension) declares its generated, reconstructable paths as `cleanup_artifacts` in its **own `homeboy.json`** (supports `path` or `glob`).
- `preflight.dependencies` filters dirty files matching that declaration.
- Removed `is_dependency_hydration_metadata` and its hardcoded paths.

The reported case is preserved: the component declares the generated paths it commits. Any ecosystem now gets the same treatment with **no new core denylist entry**.

Adds `homeboy_core::component::declared_cleanup_artifact_paths()` — resolves `cleanup_artifacts` (path/glob + manifest declarations) to component-relative paths, for callers that must separate operator-authored changes from expected generated churn.

## Verification
- `grep` of the changed guard for ecosystem literals → **none** (remaining hits in the file are pre-existing code I didn't touch).
- Tests rewritten to use a **generic** declared artifact rather than a real ecosystem's paths, so the knowledge can't creep back in via fixtures. Coverage retained, including the monorepo (repo-root-relative) form.
- New case: undeclared generated files are still reported — the component owns the list.
- `cargo fmt --all --check` clean; `cargo check -p homeboy-core --lib` and `-p homeboy-release --lib --tests` exit 0.

Rebased onto current `main`; conflict with the merged fix resolved by keeping main's `match` structure and swapping the hardcoded check for the declaration lookup.

Diff: +103/-42, 3 files.
