### PR TITLE
fix(lab): converge runtime before Cook preflight

### DIFF
--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -997,6 +997,61 @@ mod tests {
     }
 
     #[test]
+    fn pinned_handoff_blocks_a_concurrent_runner_binary_promotion() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut handoff = pinned_handoff_owner();
+            let pins = paths::runtime_promotion_dir()
+                .expect("runtime promotion directory")
+                .join(PIN_DIR);
+            for _ in 0..50 {
+                if pins.exists() && fs::read_dir(&pins).expect("list pins").count() == 1 {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(pins.exists(), "handoff pin was published");
+
+            let (promoted, promoted_result) = std::sync::mpsc::channel();
+            let promotion = std::thread::spawn(move || {
+                let _lease = acquire("runner binary promotion", "runner-a")
+                    .expect("promotion acquires after handoff drains");
+                promoted.send(()).expect("report promotion");
+            });
+            assert!(
+                promoted_result
+                    .recv_timeout(Duration::from_millis(100))
+                    .is_err(),
+                "runner promotion must not replace a generation while the handoff is pinned"
+            );
+
+            handoff.wait().expect("handoff exits and releases its pin");
+            promoted_result
+                .recv_timeout(Duration::from_secs(5))
+                .expect("promotion proceeds after pin release");
+            promotion.join().expect("promotion exits");
+        });
+    }
+
+    fn pinned_handoff_owner() -> std::process::Child {
+        let executable = std::env::current_exe().expect("resolve test executable");
+        Command::new(executable)
+            .args([
+                "--ignored",
+                "--exact",
+                "runtime_promotion::tests::pinned_handoff_owner_child",
+            ])
+            .spawn()
+            .expect("start pinned handoff owner")
+    }
+
+    #[test]
+    #[ignore = "invoked by pinned_handoff_blocks_a_concurrent_runner_binary_promotion"]
+    fn pinned_handoff_owner_child() {
+        let _pin = pin_cook_generation("handoff-attempt").expect("pin handoff generation");
+        std::thread::sleep(Duration::from_millis(350));
+    }
+
+    #[test]
     fn authorized_child_reenters_only_its_parent_transaction() {
         crate::test_support::with_isolated_home(|_| {
             let lease = acquire("parent", "lab").expect("parent acquires lease");

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -408,7 +408,10 @@ pub fn refresh_homeboy_binary(
         ));
     }
 
-    let promotion_lease = homeboy_core::runtime_promotion::acquire_for_generation_rotation(
+    // A Cook pin reserves its exact runtime from provider preflight through
+    // durable runner-job binding. A refresh must drain that reservation rather
+    // than rotating the configured binary underneath an admitted handoff.
+    let promotion_lease = homeboy_core::runtime_promotion::acquire(
         "runner binary promotion",
         options.runner_id.clone(),
     )?;

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1072,6 +1072,15 @@ fn promotion_handoff_intent(args: &[String], stdout: &str) -> Result<Option<Prom
     Ok(Some(PromotionPatchIntent { changed_files }))
 }
 
+fn final_preflight_homeboy_path<'a>(
+    converged_homeboy_path: Option<&'a str>,
+    runner: &'a Runner,
+) -> Result<&'a str> {
+    converged_homeboy_path
+        .map(Ok)
+        .unwrap_or_else(|| remote_runner_homeboy_path(runner, "Lab offload preflight"))
+}
+
 pub(crate) fn run_lab_offload_inner(
     request: LabOffloadRequest<'_>,
     selection: LabRunnerSelection,
@@ -1082,7 +1091,7 @@ pub(crate) fn run_lab_offload_inner(
     _runner_status: RunnerStatusReport,
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
-    let runner = load(runner_id)?;
+    let mut runner = load(runner_id)?;
     let mut runner_status = status_for_admission(runner_id)?;
     if runner.kind != super::super::super::RunnerKind::Ssh {
         return Err(Error::validation_invalid_argument(
@@ -1102,6 +1111,28 @@ pub(crate) fn run_lab_offload_inner(
         runner.settings.concurrency_limit,
         contract.hot_label,
     )?;
+
+    // A detached Cook must converge before deriving any provider-preflight
+    // input. Refresh can select a new runner executable, so the runner config,
+    // daemon session, and every command prefix below must come from a fresh
+    // observation rather than the stale pre-convergence snapshot.
+    let mut converged_homeboy_path = None;
+    if request.detach_after_handoff && request.durable_agent_task_plan.is_some() {
+        let converged = crate::lab_staging_controller::converge_lab_handoff_runtime(
+            runner_id,
+            selection.mode.clone(),
+            &homeboy_product_identity::build_identity().display,
+        )?;
+        runner = converged.runner;
+        runner_status = converged.status;
+        converged_homeboy_path = Some(converged.homeboy_path);
+        require_available_lab_runner(
+            runner_id,
+            &runner_status,
+            runner.settings.concurrency_limit,
+            contract.hot_label,
+        )?;
+    }
 
     let runner_workspace_root = request
         .job_overrides
@@ -1238,7 +1269,7 @@ pub(crate) fn run_lab_offload_inner(
             request.durable_agent_task_plan,
         )?;
     }
-    let homeboy_path = remote_runner_homeboy_path(&runner, "Lab offload preflight")?;
+    let homeboy_path = final_preflight_homeboy_path(converged_homeboy_path.as_deref(), &runner)?;
     let require_exact_runner_version = require_exact_runner_version(&runner.settings);
     let configured_build_identity =
         configured_runner_homeboy_build_identity(&runner, homeboy_path)?;
@@ -1311,17 +1342,7 @@ pub(crate) fn run_lab_offload_inner(
                 shell::quote_arg(runner_id)
             ))
     );
-    // A detached Cook must converge its exact controller build before provider
-    // readiness work. Otherwise a stale daemon can account for a provider run
-    // that will later execute an older lifecycle contract.
-    if request.detach_after_handoff && request.durable_agent_task_plan.is_some() {
-        crate::lab_staging_controller::converge_lab_handoff_runtime(
-            runner_id,
-            selection.mode.clone(),
-            &homeboy_product_identity::build_identity().display,
-        )?;
-        runner_status = crate::status_for_admission(runner_id)?;
-    } else if lab_runner_homeboy_has_blocking_drift_against_configured_identity(
+    if lab_runner_homeboy_has_blocking_drift_against_configured_identity(
         &runner_status,
         configured_build_identity.as_deref(),
         require_exact_runner_version,
@@ -2563,6 +2584,25 @@ mod tests {
             "cook"
         )
         .is_err());
+    }
+
+    #[test]
+    fn detached_provider_preflight_uses_the_converged_job_binary_path() {
+        let runner: Runner = serde_json::from_value(serde_json::json!({
+            "kind": "ssh",
+            "settings": { "homeboy_path": "/runner/stale-homeboy" },
+        }))
+        .expect("runner");
+        let path = final_preflight_homeboy_path(Some("/runner/current-homeboy"), &runner)
+            .expect("converged path");
+        let prefix = lab_offload_command_prefix(std::path::Path::new("/source"), path);
+
+        assert_eq!(path, "/runner/current-homeboy");
+        assert_eq!(prefix.argv.first().map(String::as_str), Some(path));
+        assert_ne!(
+            prefix.argv.first().map(String::as_str),
+            Some("/runner/stale-homeboy")
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1311,7 +1311,17 @@ pub(crate) fn run_lab_offload_inner(
                 shell::quote_arg(runner_id)
             ))
     );
-    if lab_runner_homeboy_has_blocking_drift_against_configured_identity(
+    // A detached Cook must converge its exact controller build before provider
+    // readiness work. Otherwise a stale daemon can account for a provider run
+    // that will later execute an older lifecycle contract.
+    if request.detach_after_handoff && request.durable_agent_task_plan.is_some() {
+        crate::lab_staging_controller::converge_lab_handoff_runtime(
+            runner_id,
+            selection.mode.clone(),
+            &homeboy_product_identity::build_identity().display,
+        )?;
+        runner_status = crate::status_for_admission(runner_id)?;
+    } else if lab_runner_homeboy_has_blocking_drift_against_configured_identity(
         &runner_status,
         configured_build_identity.as_deref(),
         require_exact_runner_version,

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -427,6 +427,12 @@ enum HandoffConvergenceAction {
     Refuse,
 }
 
+pub(crate) struct ConvergedLabHandoffRuntime {
+    pub(crate) runner: crate::Runner,
+    pub(crate) status: crate::RunnerStatusReport,
+    pub(crate) homeboy_path: String,
+}
+
 fn handoff_convergence_action(
     runner: &crate::Runner,
     status: &crate::RunnerStatusReport,
@@ -468,7 +474,7 @@ pub(crate) fn converge_lab_handoff_runtime(
     runner_id: &str,
     tunnel_mode: crate::RunnerTunnelMode,
     requested: &str,
-) -> Result<()> {
+) -> Result<ConvergedLabHandoffRuntime> {
     for _ in 0..2 {
         let runner = crate::load(runner_id)?;
         let command = crate::remote_runner_homeboy_path(&runner, "Lab handoff convergence")?;
@@ -499,7 +505,14 @@ pub(crate) fn converge_lab_handoff_runtime(
             daemon.as_deref(),
             command,
         ) {
-            HandoffConvergenceAction::Ready => return Ok(()),
+            HandoffConvergenceAction::Ready => {
+                let homeboy_path = command.to_string();
+                return Ok(ConvergedLabHandoffRuntime {
+                    runner,
+                    status,
+                    homeboy_path,
+                });
+            }
             HandoffConvergenceAction::Refuse => {
                 return Err(handoff_identity_error(
                     runner_id,

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -421,6 +421,126 @@ fn handoff_refresh_options(
     }
 }
 
+enum HandoffConvergenceAction {
+    Ready,
+    Refresh(crate::HomeboyBinaryRefreshMode),
+    Refuse,
+}
+
+fn handoff_convergence_action(
+    runner: &crate::Runner,
+    status: &crate::RunnerStatusReport,
+    requested: &str,
+    configured: Option<&str>,
+    daemon: Option<&str>,
+    command: &str,
+) -> HandoffConvergenceAction {
+    if handoff_identities_match(requested, configured, daemon) {
+        return HandoffConvergenceAction::Ready;
+    }
+    if automatic_handoff_convergence_allowed(runner)
+        && status.active_jobs.is_empty()
+        && status.active_job_state == crate::RunnerActiveJobState::Available
+        && status
+            .session
+            .as_ref()
+            .is_some_and(|session| session.mode == crate::RunnerTunnelMode::DirectSsh)
+    {
+        return HandoffConvergenceAction::Refresh(
+            if configured.is_some_and(|identity| {
+                canonical_homeboy_identity(identity) == canonical_homeboy_identity(requested)
+            }) {
+                crate::HomeboyBinaryRefreshMode::Select {
+                    binary_path: command.to_string(),
+                }
+            } else {
+                crate::HomeboyBinaryRefreshMode::Materialize
+            },
+        );
+    }
+    HandoffConvergenceAction::Refuse
+}
+
+/// Converge the runner control plane before provider or workspace work. Refresh
+/// output is insufficient evidence, so the next loop iteration re-reads both
+/// the daemon and configured job-binary identities.
+pub(crate) fn converge_lab_handoff_runtime(
+    runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
+    requested: &str,
+) -> Result<()> {
+    for _ in 0..2 {
+        let runner = crate::load(runner_id)?;
+        let command = crate::remote_runner_homeboy_path(&runner, "Lab handoff convergence")?;
+        let status = crate::status_for_admission(runner_id)?;
+        let session = status
+            .session
+            .as_ref()
+            .ok_or_else(|| handoff_identity_error(runner_id, requested, None, None))?;
+        if session.mode != tunnel_mode {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                format!(
+                    "Lab handoff requires `{}` transport, but runner `{runner_id}` is connected through `{}`",
+                    tunnel_mode.metadata_value(),
+                    session.mode.metadata_value(),
+                ),
+                Some(runner_id.to_string()),
+                None,
+            ));
+        }
+        let configured = crate::configured_runner_homeboy_build_identity(&runner, command)?;
+        let daemon = session.homeboy_build_identity.clone();
+        match handoff_convergence_action(
+            &runner,
+            &status,
+            requested,
+            configured.as_deref(),
+            daemon.as_deref(),
+            command,
+        ) {
+            HandoffConvergenceAction::Ready => return Ok(()),
+            HandoffConvergenceAction::Refuse => {
+                return Err(handoff_identity_error(
+                    runner_id,
+                    requested,
+                    configured.as_deref(),
+                    daemon.as_deref(),
+                ));
+            }
+            HandoffConvergenceAction::Refresh(mode) => {
+                let (report, exit_code) = crate::refresh_homeboy_binary(handoff_refresh_options(
+                    runner_id.to_string(),
+                    mode,
+                    requested,
+                ))?;
+                if exit_code != 0 || !report.daemon_refreshed {
+                    return Err(handoff_identity_error(
+                        runner_id,
+                        requested,
+                        configured.as_deref(),
+                        daemon.as_deref(),
+                    ));
+                }
+            }
+        }
+    }
+    let runner = crate::load(runner_id)?;
+    let command = crate::remote_runner_homeboy_path(&runner, "Lab handoff convergence")?;
+    let status = crate::status_for_admission(runner_id)?;
+    let configured = crate::configured_runner_homeboy_build_identity(&runner, command)?;
+    let daemon = status
+        .session
+        .as_ref()
+        .and_then(|session| session.homeboy_build_identity.clone());
+    Err(handoff_identity_error(
+        runner_id,
+        requested,
+        configured.as_deref(),
+        daemon.as_deref(),
+    ))
+}
+
 fn default_lab_staging_tunnel_mode() -> crate::RunnerTunnelMode {
     crate::RunnerTunnelMode::DirectSsh
 }
@@ -486,30 +606,37 @@ fn persist_lab_staging_recipe_for_transport(
 }
 
 fn ensure_current_controller_daemon() -> Result<homeboy_core::daemon::DaemonStartResult> {
-    let daemon = homeboy_core::daemon::ensure_running(homeboy_core::daemon::DEFAULT_ADDR)?;
-    let status = homeboy_core::daemon::read_status()?;
-    let Some(state) = status.state else {
-        return Err(Error::internal_unexpected(
-            "controller daemon did not publish a lease after startup",
-        ));
-    };
     let expected = homeboy_core::build_identity::current().display;
-    if state.build_identity.display == expected {
-        return Ok(daemon);
-    }
-    if !status.active_job_recovery_evidence.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "controller_daemon",
-            "controller daemon build does not match the submitting Homeboy binary while durable jobs are active",
-            Some(state.build_identity.display),
-            Some(vec!["Wait for the listed controller jobs to finish before retrying the Lab handoff.".to_string()]),
-        ));
-    }
+    for _ in 0..2 {
+        let daemon = homeboy_core::daemon::ensure_running(homeboy_core::daemon::DEFAULT_ADDR)?;
+        let status = homeboy_core::daemon::read_status()?;
+        let Some(state) = status.state else {
+            return Err(Error::internal_unexpected(
+                "controller daemon did not publish a lease after startup",
+            ));
+        };
+        if state.build_identity.display == expected {
+            return Ok(daemon);
+        }
+        if !status.active_job_recovery_evidence.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "controller_daemon",
+                "controller daemon build does not match the submitting Homeboy binary while durable jobs are active",
+                Some(state.build_identity.display),
+                Some(vec!["Wait for the listed controller jobs to finish before retrying the Lab handoff.".to_string()]),
+            ));
+        }
 
-    // A private staging recipe is a typed protocol payload. Replace an idle
-    // stale daemon before it can read a newer attachment with an older schema.
-    homeboy_core::daemon::stop_for_lease(&state.lease_id)?;
-    homeboy_core::daemon::ensure_running(homeboy_core::daemon::DEFAULT_ADDR)
+        // A private staging recipe is a typed protocol payload. Replace an idle
+        // stale daemon before it can read a newer attachment with an older schema.
+        homeboy_core::daemon::stop_for_lease(&state.lease_id)?;
+    }
+    Err(Error::validation_invalid_argument(
+        "controller_daemon",
+        "controller daemon did not converge to the submitting Homeboy build before Lab staging admission",
+        Some(expected),
+        None,
+    ))
 }
 
 /// Controller-owned admission for a detached agent-task attempt.
@@ -1621,50 +1748,19 @@ impl ProductionLabStagingOperations {
             // Mixed-version recovery: old recipes had no immutable binding.
             return Ok(None);
         };
-        let mut runner = crate::load(&request.recipe.runner_id)?;
-        let mut command =
-            crate::remote_runner_homeboy_path(&runner, "durable Lab handoff")?.to_string();
-        let mut status = Self::status_for_recipe_transport(request)?;
-        let configured = crate::configured_runner_homeboy_build_identity(&runner, &command)?;
+        converge_lab_handoff_runtime(
+            &request.recipe.runner_id,
+            request.recipe.tunnel_mode.clone(),
+            requested,
+        )?;
+        let runner = crate::load(&request.recipe.runner_id)?;
+        let command = crate::remote_runner_homeboy_path(&runner, "durable Lab handoff")?;
+        let status = Self::status_for_recipe_transport(request)?;
         let daemon = status
             .session
             .as_ref()
             .and_then(|session| session.homeboy_build_identity.clone());
-        if !handoff_identities_match(requested, configured.as_deref(), daemon.as_deref())
-            && automatic_handoff_convergence_allowed(&runner)
-            && status.active_jobs.is_empty()
-            && status.active_job_state == crate::RunnerActiveJobState::Available
-            && status
-                .session
-                .as_ref()
-                .is_some_and(|session| session.mode == crate::RunnerTunnelMode::DirectSsh)
-        {
-            let mode = if configured.as_deref().is_some_and(|identity| {
-                canonical_homeboy_identity(identity) == canonical_homeboy_identity(requested)
-            }) {
-                crate::HomeboyBinaryRefreshMode::Select {
-                    binary_path: command.to_string(),
-                }
-            } else {
-                crate::HomeboyBinaryRefreshMode::Materialize
-            };
-            let (report, exit_code) = crate::refresh_homeboy_binary(handoff_refresh_options(
-                request.recipe.runner_id.clone(),
-                mode,
-                requested,
-            ))?;
-            if exit_code == 0 && report.daemon_refreshed {
-                status = Self::status_for_recipe_transport(request)?;
-                runner = crate::load(&request.recipe.runner_id)?;
-                command =
-                    crate::remote_runner_homeboy_path(&runner, "durable Lab handoff")?.to_string();
-            }
-        }
-        let daemon = status
-            .session
-            .as_ref()
-            .and_then(|session| session.homeboy_build_identity.clone());
-        let configured = crate::configured_runner_homeboy_build_identity(&runner, &command)?;
+        let configured = crate::configured_runner_homeboy_build_identity(&runner, command)?;
         if !handoff_identities_match(requested, configured.as_deref(), daemon.as_deref()) {
             return Err(handoff_identity_error(
                 &request.recipe.runner_id,
@@ -3905,6 +4001,157 @@ mod tests {
 
         assert!(!options.allow_downgrade);
         assert_eq!(options.git_ref.as_deref(), Some("required"));
+    }
+
+    fn convergence_runner(allowed: bool) -> crate::Runner {
+        serde_json::from_value(json!({
+            "kind": "ssh",
+            "policy": { "allow_homeboy_convergence": allowed },
+        }))
+        .expect("runner")
+    }
+
+    fn convergence_status(daemon_identity: &str) -> crate::RunnerStatusReport {
+        crate::RunnerStatusReport {
+            runner_id: "lab-identity".to_string(),
+            connected: true,
+            state: crate::RunnerSessionState::Connected,
+            session: Some(crate::RunnerSession {
+                runner_id: "lab-identity".to_string(),
+                mode: crate::RunnerTunnelMode::DirectSsh,
+                role: crate::RunnerSessionRole::Controller,
+                server_id: None,
+                controller_id: None,
+                broker_url: None,
+                remote_daemon_address: None,
+                local_port: None,
+                local_url: None,
+                tunnel_pid: None,
+                remote_daemon_pid: None,
+                remote_daemon_lease_id: None,
+                homeboy_version: "test".to_string(),
+                homeboy_build_identity: Some(daemon_identity.to_string()),
+                connected_at: "now".to_string(),
+                worker_identity: None,
+                worker_pid: None,
+                last_seen_at: None,
+                leaseless_recovery_evidence: None,
+            }),
+            stale_daemon: None,
+            daemon_freshness: None,
+            active_jobs: Vec::new(),
+            active_runner_jobs: Vec::new(),
+            stale_runner_jobs: Vec::new(),
+            active_job_count: 0,
+            stale_runner_job_count: 0,
+            active_job_state: crate::RunnerActiveJobState::Available,
+            active_job_source: None,
+            active_job_error: None,
+            active_job_recovery_evidence: None,
+            session_path: "/tmp/lab-identity.json".to_string(),
+        }
+    }
+
+    #[test]
+    fn stale_daemon_converges_before_provider_work() {
+        let runner = convergence_runner(true);
+        let status = convergence_status("homeboy 1.2.2+stale");
+
+        assert!(matches!(
+            handoff_convergence_action(
+                &runner,
+                &status,
+                "homeboy 1.2.3+required",
+                Some("homeboy 1.2.3+required"),
+                Some("homeboy 1.2.2+stale"),
+                "/runner/homeboy",
+            ),
+            HandoffConvergenceAction::Refresh(crate::HomeboyBinaryRefreshMode::Select { .. })
+        ));
+    }
+
+    #[test]
+    fn stale_job_binary_converges_before_provider_work() {
+        let runner = convergence_runner(true);
+        let status = convergence_status("homeboy 1.2.3+required");
+
+        assert!(matches!(
+            handoff_convergence_action(
+                &runner,
+                &status,
+                "homeboy 1.2.3+required",
+                Some("homeboy 1.2.2+stale"),
+                Some("homeboy 1.2.3+required"),
+                "/runner/homeboy",
+            ),
+            HandoffConvergenceAction::Refresh(crate::HomeboyBinaryRefreshMode::Materialize)
+        ));
+    }
+
+    #[test]
+    fn exact_runtime_skips_convergence() {
+        let runner = convergence_runner(true);
+        let status = convergence_status("homeboy 1.2.3+required");
+
+        assert!(matches!(
+            handoff_convergence_action(
+                &runner,
+                &status,
+                "homeboy 1.2.3+required",
+                Some("homeboy 1.2.3+required"),
+                Some("homeboy 1.2.3+required"),
+                "/runner/homeboy",
+            ),
+            HandoffConvergenceAction::Ready
+        ));
+    }
+
+    #[test]
+    fn failed_convergence_refuses_before_provider_work() {
+        let runner = convergence_runner(false);
+        let status = convergence_status("homeboy 1.2.2+stale");
+
+        assert!(matches!(
+            handoff_convergence_action(
+                &runner,
+                &status,
+                "homeboy 1.2.3+required",
+                Some("homeboy 1.2.2+stale"),
+                Some("homeboy 1.2.2+stale"),
+                "/runner/homeboy",
+            ),
+            HandoffConvergenceAction::Refuse
+        ));
+    }
+
+    #[test]
+    fn concurrent_dispatch_rechecks_the_runtime_after_one_converges() {
+        let runner = convergence_runner(true);
+        let stale = convergence_status("homeboy 1.2.2+stale");
+        let converged = convergence_status("homeboy 1.2.3+required");
+
+        assert!(matches!(
+            handoff_convergence_action(
+                &runner,
+                &stale,
+                "homeboy 1.2.3+required",
+                Some("homeboy 1.2.3+required"),
+                Some("homeboy 1.2.2+stale"),
+                "/runner/homeboy",
+            ),
+            HandoffConvergenceAction::Refresh(_)
+        ));
+        assert!(matches!(
+            handoff_convergence_action(
+                &runner,
+                &converged,
+                "homeboy 1.2.3+required",
+                Some("homeboy 1.2.3+required"),
+                Some("homeboy 1.2.3+required"),
+                "/runner/homeboy",
+            ),
+            HandoffConvergenceAction::Ready
+        ));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -2945,6 +2945,15 @@ impl StageExecutionAdapter {
     where
         F: FnMut(&LabStagingCheckpoint) -> Result<()>,
     {
+        // The controller process owns materialization after the initiating Cook
+        // returns. Keep the generic runtime-generation admission barrier until
+        // the runner job is durably bound, so a concurrent refresh cannot swap
+        // the selected binary between exact identity validation and dispatch.
+        let mut runtime_generation_pin = checkpoint
+            .final_runner_job_id
+            .is_none()
+            .then(|| homeboy_core::runtime_promotion::pin_cook_generation(&request.recipe.run_id))
+            .transpose()?;
         self.operations
             .validate_recorded_identities(request, &checkpoint)?;
         loop {
@@ -3022,6 +3031,12 @@ impl StageExecutionAdapter {
                     LabStagingPhase::Completed => return Ok(checkpoint),
                 },
             };
+            // `dispatch_runner` binds the accepted job before returning. Once
+            // that binding exists, generation ownership moves to the durable
+            // runner record and this temporary admission pin can be released.
+            if matches!(effect, LabStagingStageEffect::Dispatch(_)) {
+                runtime_generation_pin.take();
+            }
             checkpoint = match effect {
                 LabStagingStageEffect::Workspace(source_snapshot_id, workspace_id) => {
                     LabStagingCheckpoint {


### PR DESCRIPTION
## Summary
- converge and re-verify the controller, runner daemon, and configured job binary before detached Cook provider preflight
- fail closed with requested/configured/daemon identity evidence and one exact refresh command
- preserve monotonic refresh safety and re-check concurrent convergence results

Closes #9985

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner lab_staging_controller --no-fail-fast`
- focused stale daemon, stale job binary, ready, refusal, and concurrent-dispatch tests

## AI Assistance
OpenCode using OpenAI gpt-5.6-sol was used to inspect the runtime handoff paths, implement the convergence gate and tests, and draft this PR. Chris Huber remains responsible for every line.