### PR TITLE
fix(ssh): forward piped stdin

### DIFF
--- a/crates/homeboy-cli/src/commands/ssh.rs
+++ b/crates/homeboy-cli/src/commands/ssh.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use std::io::IsTerminal;
 use homeboy::core::engine::shell;
 use homeboy::core::server::{self, Server};
 use homeboy::core::server::{resolve_context, SshClient, SshResolveArgs};
@@ -141,7 +142,11 @@ pub fn run(args: SshArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Ss
                         "No command resolved for non-interactive SSH execution".to_string(),
                     )
                 })?;
-                let output = client.execute(cmd);
+                let output = if std::io::stdin().is_terminal() {
+                    client.execute(cmd)
+                } else {
+                    client.execute_with_piped_stdin(cmd)
+                };
 
                 Ok((
                     SshOutput::Connect(connect_output_from_execution(
@@ -240,7 +245,11 @@ pub(super) fn execute_raw_command(
             "No command resolved for non-interactive SSH execution".to_string(),
         )
     })?;
-    let output = client.execute(cmd);
+    let output = if std::io::stdin().is_terminal() {
+        client.execute(cmd)
+    } else {
+        client.execute_with_piped_stdin(cmd)
+    };
     Ok((output.stdout, output.stderr, output.exit_code))
 }
 

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -75,7 +75,7 @@ clap = { version = "4.5", features = ["derive", "string"] }
 sha2 = "0.10.9"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Pipes", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [dev-dependencies]
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit", features = ["test-support"] }

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -75,7 +75,7 @@ clap = { version = "4.5", features = ["derive", "string"] }
 sha2 = "0.10.9"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [dev-dependencies]
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit", features = ["test-support"] }

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{Cursor, Read, Write};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -26,7 +26,25 @@ pub fn execute_local_command(command: &str) -> CommandOutput {
 /// `sh -c` argv (where they would be visible in `ps`). The bytes are written on
 /// a dedicated thread and stdin is closed (EOF) once they are flushed.
 pub(crate) fn execute_local_command_with_stdin(command: &str, stdin: &[u8]) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, None, None, None, Some(stdin.to_vec()))
+    execute_local_command_in_dir_impl(
+        command,
+        None,
+        None,
+        None,
+        Some(Box::new(Cursor::new(stdin.to_vec()))),
+    )
+}
+
+/// Run a local command while streaming bytes from a reader into its stdin.
+///
+/// This is the localhost implementation of the non-interactive SSH stdin
+/// contract. Keeping the reader streaming avoids buffering piped artifacts in
+/// the controller process.
+pub(crate) fn execute_local_command_with_stdin_reader(
+    command: &str,
+    stdin: impl Read + Send + 'static,
+) -> CommandOutput {
+    execute_local_command_in_dir_impl(command, None, None, None, Some(Box::new(stdin)))
 }
 
 pub(crate) fn execute_local_command_with_stdin_and_timeout(
@@ -34,7 +52,13 @@ pub(crate) fn execute_local_command_with_stdin_and_timeout(
     stdin: &[u8],
     timeout: Duration,
 ) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, None, None, Some(timeout), Some(stdin.to_vec()))
+    execute_local_command_in_dir_impl(
+        command,
+        None,
+        None,
+        Some(timeout),
+        Some(Box::new(Cursor::new(stdin.to_vec()))),
+    )
 }
 
 /// Run a local command, capturing stdout/stderr.
@@ -71,7 +95,7 @@ fn execute_local_command_in_dir_impl(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
     timeout: Option<Duration>,
-    stdin: Option<Vec<u8>>,
+    stdin: Option<Box<dyn Read + Send>>,
 ) -> CommandOutput {
     run_local_command(
         command,
@@ -88,7 +112,7 @@ fn run_local_command(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
     timeout: Option<Duration>,
-    stdin: Option<Vec<u8>>,
+    stdin: Option<Box<dyn Read + Send>>,
     stream_mode: StreamMode,
 ) -> CommandOutput {
     #[cfg(windows)]
@@ -142,13 +166,19 @@ fn run_local_command(
     );
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
 
-    // Stream the provided stdin bytes on a dedicated thread, then close the pipe
-    // (EOF). The command's own stdin is empty for this path, so the buffer is
-    // small and never deadlocks against the captured stdout/stderr pipes.
-    let stdin_handle = stdin.and_then(|bytes| {
+    // Stream stdin independently while stdout/stderr are drained, so a large
+    // producer cannot deadlock against a verbose child command.
+    let stdin_handle = stdin.and_then(|mut reader| {
         child.stdin.take().map(|mut pipe| {
             thread::spawn(move || {
-                let _ = pipe.write_all(&bytes);
+                let mut buffer = [0u8; 64 * 1024];
+                loop {
+                    match reader.read(&mut buffer) {
+                        Ok(0) => return Ok(()),
+                        Ok(count) => pipe.write_all(&buffer[..count])?,
+                        Err(error) => return Err(error),
+                    }
+                }
             })
         })
     });
@@ -172,9 +202,9 @@ fn run_local_command(
         wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
     let interrupted_signal = active_cleanup_signal();
 
-    if let Some(handle) = stdin_handle {
-        let _ = handle.join();
-    }
+    let stdin_failed = stdin_handle
+        .and_then(|handle| handle.join().ok())
+        .is_some_and(|result: std::io::Result<()>| result.is_err());
     let stdout = stdout_handle
         .and_then(|h| h.join().ok())
         .unwrap_or_default();
@@ -185,21 +215,28 @@ fn run_local_command(
     let output = match status {
         Ok(status) => CommandOutput {
             stdout,
-            stderr: stderr_with_delegated_failure(
-                stderr_with_timeout(
-                    stderr_with_interruption(stderr, interrupted_signal),
-                    timed_out,
-                    timeout,
+            stderr: stdin_failure_message(
+                stderr_with_delegated_failure(
+                    stderr_with_timeout(
+                        stderr_with_interruption(stderr, interrupted_signal),
+                        timed_out,
+                        timeout,
+                    ),
+                    delegated_failure.as_ref(),
                 ),
-                delegated_failure.as_ref(),
+                stdin_failed,
             ),
             success: status.success()
                 && interrupted_signal.is_none()
                 && delegated_failure.is_none()
-                && !timed_out,
+                && !timed_out
+                && !stdin_failed,
             exit_code: timed_out_exit_code(
                 timed_out,
-                interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+                stdin_failure_exit_code(
+                    stdin_failed,
+                    interrupted_exit_code(interrupted_signal, status.code().unwrap_or(-1)),
+                ),
             ),
             timed_out,
             child_resource: Some(monitor.finish()),
@@ -230,6 +267,24 @@ fn run_local_command(
         cleanup_guard.cleanup();
     }
     output
+}
+
+fn stdin_failure_message(mut stderr: String, stdin_failed: bool) -> String {
+    if stdin_failed {
+        if !stderr.is_empty() && !stderr.ends_with('\n') {
+            stderr.push('\n');
+        }
+        stderr.push_str("Homeboy stdin delivery failed before command completion.");
+    }
+    stderr
+}
+
+fn stdin_failure_exit_code(stdin_failed: bool, exit_code: i32) -> i32 {
+    if stdin_failed && exit_code == 0 {
+        1
+    } else {
+        exit_code
+    }
 }
 
 fn read_all<R: Read>(mut src: R) -> String {

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -1,5 +1,9 @@
 use std::io::{Cursor, Read, Write};
-use std::process::{Command, Stdio};
+use std::process::{ChildStdin, Command, Stdio};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -31,20 +35,16 @@ pub(crate) fn execute_local_command_with_stdin(command: &str, stdin: &[u8]) -> C
         None,
         None,
         None,
-        Some(Box::new(Cursor::new(stdin.to_vec()))),
+        Some(StdinSource::Reader(Box::new(Cursor::new(stdin.to_vec())))),
     )
 }
 
-/// Run a local command while streaming bytes from a reader into its stdin.
-///
-/// This is the localhost implementation of the non-interactive SSH stdin
-/// contract. Keeping the reader streaming avoids buffering piped artifacts in
-/// the controller process.
-pub(crate) fn execute_local_command_with_stdin_reader(
-    command: &str,
-    stdin: impl Read + Send + 'static,
-) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, None, None, None, Some(Box::new(stdin)))
+pub(crate) fn execute_local_command_with_piped_stdin(command: &str) -> CommandOutput {
+    let stdin = match piped_stdin_file() {
+        Ok(stdin) => stdin,
+        Err(error) => return stdin_source_error(error),
+    };
+    execute_local_command_in_dir_impl(command, None, None, None, Some(StdinSource::Piped(stdin)))
 }
 
 pub(crate) fn execute_local_command_with_stdin_and_timeout(
@@ -57,7 +57,7 @@ pub(crate) fn execute_local_command_with_stdin_and_timeout(
         None,
         None,
         Some(timeout),
-        Some(Box::new(Cursor::new(stdin.to_vec()))),
+        Some(StdinSource::Reader(Box::new(Cursor::new(stdin.to_vec())))),
     )
 }
 
@@ -95,7 +95,7 @@ fn execute_local_command_in_dir_impl(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
     timeout: Option<Duration>,
-    stdin: Option<Box<dyn Read + Send>>,
+    stdin: Option<StdinSource>,
 ) -> CommandOutput {
     run_local_command(
         command,
@@ -112,7 +112,7 @@ fn run_local_command(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
     timeout: Option<Duration>,
-    stdin: Option<Box<dyn Read + Send>>,
+    stdin: Option<StdinSource>,
     stream_mode: StreamMode,
 ) -> CommandOutput {
     #[cfg(windows)]
@@ -168,19 +168,11 @@ fn run_local_command(
 
     // Stream stdin independently while stdout/stderr are drained, so a large
     // producer cannot deadlock against a verbose child command.
-    let stdin_handle = stdin.and_then(|mut reader| {
-        child.stdin.take().map(|mut pipe| {
-            thread::spawn(move || {
-                let mut buffer = [0u8; 64 * 1024];
-                loop {
-                    match reader.read(&mut buffer) {
-                        Ok(0) => return Ok(()),
-                        Ok(count) => pipe.write_all(&buffer[..count])?,
-                        Err(error) => return Err(error),
-                    }
-                }
-            })
-        })
+    let stdin_handle = stdin.and_then(|source| {
+        child
+            .stdin
+            .take()
+            .map(|pipe| spawn_stdin_pump(pipe, source))
     });
 
     let stdout_handle = child.stdout.take().map(|pipe| {
@@ -203,8 +195,8 @@ fn run_local_command(
     let interrupted_signal = active_cleanup_signal();
 
     let stdin_failed = stdin_handle
-        .and_then(|handle| handle.join().ok())
-        .is_some_and(|result: std::io::Result<()>| result.is_err());
+        .and_then(StdinPump::finish_after_child)
+        .is_some_and(|result| result.is_err());
     let stdout = stdout_handle
         .and_then(|h| h.join().ok())
         .unwrap_or_default();
@@ -267,6 +259,127 @@ fn run_local_command(
         cleanup_guard.cleanup();
     }
     output
+}
+
+pub(crate) enum StdinSource {
+    Reader(Box<dyn Read + Send>),
+    Piped(std::fs::File),
+}
+
+pub(crate) struct StdinPump {
+    cancelled: Arc<AtomicBool>,
+    cancellable: bool,
+    handle: thread::JoinHandle<std::io::Result<()>>,
+}
+
+impl StdinPump {
+    pub(crate) fn finish_after_child(self) -> Option<std::io::Result<()>> {
+        if self.cancellable {
+            self.cancelled.store(true, Ordering::Release);
+        }
+        self.handle.join().ok()
+    }
+}
+
+pub(crate) fn spawn_stdin_pump(pipe: ChildStdin, source: StdinSource) -> StdinPump {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let pump_cancelled = Arc::clone(&cancelled);
+    let cancellable = matches!(&source, StdinSource::Piped(_));
+    let handle = thread::spawn(move || match source {
+        StdinSource::Reader(mut reader) => copy_stdin_to_child(reader.as_mut(), pipe),
+        StdinSource::Piped(reader) => copy_piped_stdin_to_child(reader, pipe, pump_cancelled),
+    });
+    StdinPump {
+        cancelled,
+        cancellable,
+        handle,
+    }
+}
+
+fn copy_stdin_to_child(reader: &mut dyn Read, mut pipe: ChildStdin) -> std::io::Result<()> {
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => return Ok(()),
+            Ok(count) => pipe.write_all(&buffer[..count])?,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn copy_piped_stdin_to_child(
+    mut reader: std::fs::File,
+    mut pipe: ChildStdin,
+    cancelled: Arc<AtomicBool>,
+) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let mut descriptor = libc::pollfd {
+        fd: reader.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let mut buffer = [0u8; 64 * 1024];
+    while !cancelled.load(Ordering::Acquire) {
+        let result = unsafe { libc::poll(&mut descriptor, 1, 20) };
+        if result < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+            continue;
+        }
+        if result == 0 {
+            continue;
+        }
+        match reader.read(&mut buffer) {
+            Ok(0) => return Ok(()),
+            Ok(count) => pipe.write_all(&buffer[..count])?,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn copy_piped_stdin_to_child(
+    mut reader: std::fs::File,
+    pipe: ChildStdin,
+    _cancelled: Arc<AtomicBool>,
+) -> std::io::Result<()> {
+    copy_stdin_to_child(&mut reader, pipe)
+}
+
+#[cfg(unix)]
+pub(crate) fn piped_stdin_file() -> std::io::Result<std::fs::File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let descriptor = unsafe { libc::dup(std::io::stdin().as_raw_fd()) };
+    if descriptor < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(unsafe { std::fs::File::from_raw_fd(descriptor) })
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn piped_stdin_file() -> std::io::Result<std::fs::File> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "piped stdin forwarding is not available on this platform",
+    ))
+}
+
+fn stdin_source_error(error: std::io::Error) -> CommandOutput {
+    CommandOutput {
+        stdout: String::new(),
+        stderr: format!("Homeboy cannot forward piped stdin: {error}"),
+        success: false,
+        exit_code: -1,
+        timed_out: false,
+        child_resource: None,
+    }
 }
 
 fn stdin_failure_message(mut stderr: String, stdin_failed: bool) -> String {

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -371,7 +371,11 @@ fn copy_piped_stdin_to_child(
             )
         };
         if result == 0 {
-            return Err(std::io::Error::last_os_error());
+            let error = std::io::Error::last_os_error();
+            if windows_pipe_error_is_eof(error.raw_os_error(), available) {
+                return Ok(());
+            }
+            return Err(error);
         }
         if available == 0 {
             thread::sleep(Duration::from_millis(20));
@@ -384,6 +388,13 @@ fn copy_piped_stdin_to_child(
         }
     }
     Ok(())
+}
+
+/// Windows reports a closed anonymous pipe through `PeekNamedPipe` as an
+/// error rather than a zero-byte read. Treat only the no-bytes-remaining form
+/// as EOF so an empty pipeline keeps normal no-input command semantics.
+pub(super) fn windows_pipe_error_is_eof(error_code: Option<i32>, available: u32) -> bool {
+    available == 0 && matches!(error_code, Some(109 | 233))
 }
 
 #[cfg(all(not(unix), not(windows)))]

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -342,7 +342,51 @@ fn copy_piped_stdin_to_child(
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn copy_piped_stdin_to_child(
+    mut reader: std::fs::File,
+    mut pipe: ChildStdin,
+    cancelled: Arc<AtomicBool>,
+) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{GetFileType, FILE_TYPE_PIPE};
+    use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+
+    let handle = reader.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
+    if unsafe { GetFileType(handle) } != FILE_TYPE_PIPE {
+        return copy_stdin_to_child(&mut reader, pipe);
+    }
+
+    let mut buffer = [0u8; 64 * 1024];
+    while !cancelled.load(Ordering::Acquire) {
+        let mut available = 0;
+        let result = unsafe {
+            PeekNamedPipe(
+                handle,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                &mut available,
+                std::ptr::null_mut(),
+            )
+        };
+        if result == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if available == 0 {
+            thread::sleep(Duration::from_millis(20));
+            continue;
+        }
+        match reader.read(&mut buffer) {
+            Ok(0) => return Ok(()),
+            Ok(count) => pipe.write_all(&buffer[..count])?,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(not(unix), not(windows)))]
 fn copy_piped_stdin_to_child(
     mut reader: std::fs::File,
     pipe: ChildStdin,
@@ -363,7 +407,33 @@ pub(crate) fn piped_stdin_file() -> std::io::Result<std::fs::File> {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+pub(crate) fn piped_stdin_file() -> std::io::Result<std::fs::File> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use windows_sys::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let process = unsafe { GetCurrentProcess() };
+    let mut duplicate: HANDLE = std::ptr::null_mut();
+    let result = unsafe {
+        DuplicateHandle(
+            process,
+            std::io::stdin().as_raw_handle() as HANDLE,
+            process,
+            &mut duplicate,
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        )
+    };
+    if result == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(unsafe { std::fs::File::from_raw_handle(duplicate) })
+    }
+}
+
+#[cfg(all(not(unix), not(windows)))]
 pub(crate) fn piped_stdin_file() -> std::io::Result<std::fs::File> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -18,8 +18,9 @@ use super::super::{
 use super::host::{is_local_host, is_transient_ssh_error};
 use super::local_exec::{
     execute_local_command, execute_local_command_in_dir_with_timeout,
-    execute_local_command_interactive, execute_local_command_with_stdin,
-    execute_local_command_with_stdin_and_timeout, execute_local_command_with_stdin_reader,
+    execute_local_command_interactive, execute_local_command_with_piped_stdin,
+    execute_local_command_with_stdin, execute_local_command_with_stdin_and_timeout,
+    piped_stdin_file, spawn_stdin_pump, StdinSource,
 };
 use super::{CommandOutput, SshClient};
 
@@ -385,8 +386,13 @@ impl SshClient {
     pub fn execute_with_piped_stdin(&self, command: &str) -> CommandOutput {
         let effective = self.prepend_env(command);
         if self.is_local {
-            return execute_local_command_with_stdin_reader(&effective, std::io::stdin());
+            return execute_local_command_with_piped_stdin(&effective);
         }
+
+        let stdin = match piped_stdin_file() {
+            Ok(stdin) => stdin,
+            Err(error) => return ssh_process_error(error),
+        };
 
         let args = self.build_ssh_args(Some(&effective), false);
         let mut cmd = Command::new("ssh");
@@ -394,7 +400,7 @@ impl SshClient {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        run_command_with_stdin_reader(cmd, std::io::stdin())
+        run_command_with_stdin_source(cmd, StdinSource::Piped(stdin))
     }
 
     /// Execute a short, read-only probe with a hard wall-clock deadline.
@@ -482,31 +488,23 @@ impl SshClient {
     }
 }
 
-pub(super) fn run_command_with_stdin_reader(
+pub(super) fn run_command_with_stdin_source(
     mut cmd: Command,
-    mut reader: impl Read + Send + 'static,
+    source: StdinSource,
 ) -> CommandOutput {
     let mut child = match cmd.spawn() {
         Ok(child) => child,
         Err(error) => return ssh_process_error(error),
     };
-    let writer = child.stdin.take().map(|mut pipe| {
-        thread::spawn(move || {
-            let mut buffer = [0u8; 64 * 1024];
-            loop {
-                match reader.read(&mut buffer) {
-                    Ok(0) => return Ok(()),
-                    Ok(count) => pipe.write_all(&buffer[..count])?,
-                    Err(error) => return Err(error),
-                }
-            }
-        })
-    });
+    let writer = child
+        .stdin
+        .take()
+        .map(|pipe| spawn_stdin_pump(pipe, source));
     let stdout = child.stdout.take().map(read_stream);
     let stderr = child.stderr.take().map(read_stream);
     let status = child.wait();
     let stdin_failed = writer
-        .and_then(|writer| writer.join().ok())
+        .and_then(|writer| writer.finish_after_child())
         .is_some_and(|result: std::io::Result<()>| result.is_err());
     let stdout = stdout
         .and_then(|reader| reader.join().ok())

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -19,7 +19,7 @@ use super::host::{is_local_host, is_transient_ssh_error};
 use super::local_exec::{
     execute_local_command, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_with_stdin,
-    execute_local_command_with_stdin_and_timeout,
+    execute_local_command_with_stdin_and_timeout, execute_local_command_with_stdin_reader,
 };
 use super::{CommandOutput, SshClient};
 
@@ -377,6 +377,26 @@ impl SshClient {
         self.execute_with_stdin(&effective, SshStdin::None)
     }
 
+    /// Execute a command with bytes read directly from the controller's stdin.
+    ///
+    /// This is intentionally separate from [`execute`]: callers must opt in
+    /// after establishing that stdin is piped. Input-bearing commands are never
+    /// retried because a partial stream cannot be replayed safely.
+    pub fn execute_with_piped_stdin(&self, command: &str) -> CommandOutput {
+        let effective = self.prepend_env(command);
+        if self.is_local {
+            return execute_local_command_with_stdin_reader(&effective, std::io::stdin());
+        }
+
+        let args = self.build_ssh_args(Some(&effective), false);
+        let mut cmd = Command::new("ssh");
+        cmd.args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        run_command_with_stdin_reader(cmd, std::io::stdin())
+    }
+
     /// Execute a short, read-only probe with a hard wall-clock deadline.
     ///
     /// Status/version checks must return partial diagnostics instead of allowing
@@ -459,6 +479,90 @@ impl SshClient {
         }
         crate::server::process_cleanup::configure_process_group_cleanup(&mut cmd);
         execute_command_with_stdin_timeout(cmd, stdin, timeout)
+    }
+}
+
+pub(super) fn run_command_with_stdin_reader(
+    mut cmd: Command,
+    mut reader: impl Read + Send + 'static,
+) -> CommandOutput {
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(error) => return ssh_process_error(error),
+    };
+    let writer = child.stdin.take().map(|mut pipe| {
+        thread::spawn(move || {
+            let mut buffer = [0u8; 64 * 1024];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => return Ok(()),
+                    Ok(count) => pipe.write_all(&buffer[..count])?,
+                    Err(error) => return Err(error),
+                }
+            }
+        })
+    });
+    let stdout = child.stdout.take().map(read_stream);
+    let stderr = child.stderr.take().map(read_stream);
+    let status = child.wait();
+    let stdin_failed = writer
+        .and_then(|writer| writer.join().ok())
+        .is_some_and(|result: std::io::Result<()>| result.is_err());
+    let stdout = stdout
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    let mut stderr = stderr
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    if stdin_failed {
+        if !stderr.is_empty() && !stderr.ends_with('\n') {
+            stderr.push('\n');
+        }
+        stderr.push_str("Homeboy SSH stdin delivery failed before command completion.");
+    }
+    match status {
+        Ok(status) => {
+            let exit_code = status.code().unwrap_or(-1);
+            CommandOutput {
+                stdout,
+                stderr,
+                success: status.success() && !stdin_failed,
+                exit_code: if stdin_failed && exit_code == 0 {
+                    1
+                } else {
+                    exit_code
+                },
+                timed_out: false,
+                child_resource: None,
+            }
+        }
+        Err(error) => CommandOutput {
+            stdout,
+            stderr: format!("{stderr}\nSSH error: {error}"),
+            success: false,
+            exit_code: -1,
+            timed_out: false,
+            child_resource: None,
+        },
+    }
+}
+
+fn read_stream(mut pipe: impl Read + Send + 'static) -> thread::JoinHandle<String> {
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = pipe.read_to_end(&mut bytes);
+        String::from_utf8_lossy(&bytes).to_string()
+    })
+}
+
+fn ssh_process_error(error: std::io::Error) -> CommandOutput {
+    CommandOutput {
+        stdout: String::new(),
+        stderr: format!("SSH error: {error}"),
+        success: false,
+        exit_code: -1,
+        timed_out: false,
+        child_resource: None,
     }
 }
 

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -10,11 +10,11 @@ use super::delegated::{DELEGATED_RUN_POLL_MS_ENV, DELEGATED_RUN_STATUS_FILE_ENV}
 use super::host::{get_local_ips, is_local_host};
 use super::local_exec::{
     execute_local_command_in_dir, execute_local_command_interactive,
-    execute_local_command_passthrough, execute_local_command_stderr_passthrough,
+    execute_local_command_passthrough, execute_local_command_stderr_passthrough, StdinSource,
 };
 use super::ssh_client::{
     build_secret_env_stdin_block, execute_command_with_stdin_timeout,
-    execute_command_with_writer_factory, run_command_with_stdin_reader,
+    execute_command_with_writer_factory, run_command_with_stdin_source,
     wrap_command_with_secret_env_read_loop, SECRET_ENV_STDIN_SENTINEL,
 };
 use super::{CommandOutput, SshClient};
@@ -195,7 +195,8 @@ fn piped_stdin_preserves_binary_bytes_exactly() {
         crate::engine::shell::quote_path(&path.path().to_string_lossy())
     ));
 
-    let output = run_command_with_stdin_reader(command, Cursor::new(payload));
+    let output =
+        run_command_with_stdin_source(command, StdinSource::Reader(Box::new(Cursor::new(payload))));
 
     assert!(output.success, "{}", output.stderr);
     assert_eq!(
@@ -207,9 +208,9 @@ fn piped_stdin_preserves_binary_bytes_exactly() {
 #[test]
 fn piped_stdin_handles_large_payload_with_backpressure() {
     let payload = vec![0xA5; 8 * 1024 * 1024];
-    let output = run_command_with_stdin_reader(
+    let output = run_command_with_stdin_source(
         piped_command("cat >/dev/null; printf complete"),
-        Cursor::new(payload),
+        StdinSource::Reader(Box::new(Cursor::new(payload))),
     );
 
     assert!(output.success, "{}", output.stderr);
@@ -218,9 +219,9 @@ fn piped_stdin_handles_large_payload_with_backpressure() {
 
 #[test]
 fn closed_remote_stdin_cannot_report_success() {
-    let output = run_command_with_stdin_reader(
+    let output = run_command_with_stdin_source(
         piped_command("exec 0<&-; exit 0"),
-        Cursor::new(vec![0x5A; 1024 * 1024]),
+        StdinSource::Reader(Box::new(Cursor::new(vec![0x5A; 1024 * 1024]))),
     );
 
     assert!(!output.success);
@@ -230,17 +231,61 @@ fn closed_remote_stdin_cannot_report_success() {
 
 #[test]
 fn empty_piped_stdin_allows_a_zero_exit_no_op() {
-    let output = run_command_with_stdin_reader(piped_command("true"), Cursor::new(Vec::new()));
+    let output = run_command_with_stdin_source(
+        piped_command("true"),
+        StdinSource::Reader(Box::new(Cursor::new(Vec::new()))),
+    );
 
     assert!(output.success, "{}", output.stderr);
     assert_eq!(output.exit_code, 0);
 }
 
+#[cfg(unix)]
+fn idle_pipe() -> (std::fs::File, std::fs::File) {
+    use std::os::fd::FromRawFd;
+
+    let mut descriptors = [0; 2];
+    assert_eq!(unsafe { libc::pipe(descriptors.as_mut_ptr()) }, 0);
+    unsafe {
+        (
+            std::fs::File::from_raw_fd(descriptors[0]),
+            std::fs::File::from_raw_fd(descriptors[1]),
+        )
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn idle_piped_stdin_is_cancelled_after_zero_exit() {
+    let (reader, _producer) = idle_pipe();
+    let started = Instant::now();
+
+    let output = run_command_with_stdin_source(piped_command("exit 0"), StdinSource::Piped(reader));
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.exit_code, 0);
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[cfg(unix)]
+#[test]
+fn idle_piped_stdin_is_cancelled_after_nonzero_exit() {
+    let (reader, _producer) = idle_pipe();
+    let started = Instant::now();
+
+    let output =
+        run_command_with_stdin_source(piped_command("exit 42"), StdinSource::Piped(reader));
+
+    assert!(!output.success);
+    assert_eq!(output.exit_code, 42);
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
 #[test]
 fn transport_failure_preserves_its_nonzero_exit_code() {
-    let output = run_command_with_stdin_reader(
+    let output = run_command_with_stdin_source(
         piped_command("cat >/dev/null; exit 255"),
-        Cursor::new(b"payload".to_vec()),
+        StdinSource::Reader(Box::new(Cursor::new(b"payload".to_vec()))),
     );
 
     assert!(!output.success);
@@ -257,7 +302,10 @@ impl Read for FailingReader {
 
 #[test]
 fn local_producer_failure_cannot_report_success() {
-    let output = run_command_with_stdin_reader(piped_command("cat >/dev/null"), FailingReader);
+    let output = run_command_with_stdin_source(
+        piped_command("cat >/dev/null"),
+        StdinSource::Reader(Box::new(FailingReader)),
+    );
 
     assert!(!output.success);
     assert_ne!(output.exit_code, 0);

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -10,7 +10,8 @@ use super::delegated::{DELEGATED_RUN_POLL_MS_ENV, DELEGATED_RUN_STATUS_FILE_ENV}
 use super::host::{get_local_ips, is_local_host};
 use super::local_exec::{
     execute_local_command_in_dir, execute_local_command_interactive,
-    execute_local_command_passthrough, execute_local_command_stderr_passthrough, StdinSource,
+    execute_local_command_passthrough, execute_local_command_stderr_passthrough,
+    windows_pipe_error_is_eof, StdinSource,
 };
 use super::ssh_client::{
     build_secret_env_stdin_block, execute_command_with_stdin_timeout,
@@ -312,6 +313,34 @@ fn local_producer_failure_cannot_report_success() {
     assert!(output.stderr.contains("stdin delivery failed"));
 }
 
+#[test]
+fn windows_closed_pipe_errors_are_eof_only_when_empty() {
+    assert!(windows_pipe_error_is_eof(Some(109), 0));
+    assert!(windows_pipe_error_is_eof(Some(233), 0));
+    assert!(!windows_pipe_error_is_eof(Some(109), 1));
+    assert!(!windows_pipe_error_is_eof(Some(5), 0));
+    assert!(!windows_pipe_error_is_eof(None, 0));
+}
+
+#[cfg(windows)]
+fn closed_windows_pipe(bytes: &[u8]) -> std::fs::File {
+    use std::os::windows::io::FromRawHandle;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::System::Pipes::CreatePipe;
+
+    let mut reader: HANDLE = std::ptr::null_mut();
+    let mut writer: HANDLE = std::ptr::null_mut();
+    assert_ne!(
+        unsafe { CreatePipe(&mut reader, &mut writer, std::ptr::null(), 0) },
+        0
+    );
+    let reader = unsafe { std::fs::File::from_raw_handle(reader) };
+    let mut writer = unsafe { std::fs::File::from_raw_handle(writer) };
+    std::io::Write::write_all(&mut writer, bytes).expect("write pipe bytes");
+    drop(writer);
+    reader
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_empty_redirected_stdin_preserves_no_input_execution() {
@@ -320,6 +349,36 @@ fn windows_empty_redirected_stdin_preserves_no_input_execution() {
 
     assert!(output.success, "{}", output.stderr);
     assert_eq!(output.exit_code, 0);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_closed_empty_pipe_is_eof() {
+    let output = run_command_with_stdin_source(
+        piped_command("exit 0"),
+        StdinSource::Piped(closed_windows_pipe(b"")),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_closed_pipe_delivers_buffered_bytes_before_eof() {
+    let target = tempfile::NamedTempFile::new().expect("payload target");
+    let output = run_command_with_stdin_source(
+        piped_command(&format!(
+            "cat > {}",
+            crate::engine::shell::quote_path(&target.path().to_string_lossy())
+        )),
+        StdinSource::Piped(closed_windows_pipe(b"payload")),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(
+        std::fs::read(target.path()).expect("read payload"),
+        b"payload"
+    );
 }
 
 #[test]

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::io::{Cursor, Read};
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use super::super::{
@@ -12,8 +14,8 @@ use super::local_exec::{
 };
 use super::ssh_client::{
     build_secret_env_stdin_block, execute_command_with_stdin_timeout,
-    execute_command_with_writer_factory, wrap_command_with_secret_env_read_loop,
-    SECRET_ENV_STDIN_SENTINEL,
+    execute_command_with_writer_factory, run_command_with_stdin_reader,
+    wrap_command_with_secret_env_read_loop, SECRET_ENV_STDIN_SENTINEL,
 };
 use super::{CommandOutput, SshClient};
 
@@ -172,6 +174,94 @@ fn injected_stdin_write_failure_kills_a_term_ignoring_child_without_leaking_secr
     assert!(output.stderr.contains("stdin delivery failed"));
     assert!(!output.stdout.contains("stdin-failure-secret"));
     assert!(!output.stderr.contains("stdin-failure-secret"));
+}
+
+fn piped_command(script: &str) -> Command {
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", script])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
+}
+
+#[test]
+fn piped_stdin_preserves_binary_bytes_exactly() {
+    let path = tempfile::NamedTempFile::new().expect("temporary payload target");
+    let payload = [0, 255, 1, b'\n', 0, 42, 128];
+    let command = piped_command(&format!(
+        "cat > {}",
+        crate::engine::shell::quote_path(&path.path().to_string_lossy())
+    ));
+
+    let output = run_command_with_stdin_reader(command, Cursor::new(payload));
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(
+        std::fs::read(path.path()).expect("read received payload"),
+        payload
+    );
+}
+
+#[test]
+fn piped_stdin_handles_large_payload_with_backpressure() {
+    let payload = vec![0xA5; 8 * 1024 * 1024];
+    let output = run_command_with_stdin_reader(
+        piped_command("cat >/dev/null; printf complete"),
+        Cursor::new(payload),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.stdout, "complete");
+}
+
+#[test]
+fn closed_remote_stdin_cannot_report_success() {
+    let output = run_command_with_stdin_reader(
+        piped_command("exec 0<&-; exit 0"),
+        Cursor::new(vec![0x5A; 1024 * 1024]),
+    );
+
+    assert!(!output.success);
+    assert_ne!(output.exit_code, 0);
+    assert!(output.stderr.contains("stdin delivery failed"));
+}
+
+#[test]
+fn empty_piped_stdin_allows_a_zero_exit_no_op() {
+    let output = run_command_with_stdin_reader(piped_command("true"), Cursor::new(Vec::new()));
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.exit_code, 0);
+}
+
+#[test]
+fn transport_failure_preserves_its_nonzero_exit_code() {
+    let output = run_command_with_stdin_reader(
+        piped_command("cat >/dev/null; exit 255"),
+        Cursor::new(b"payload".to_vec()),
+    );
+
+    assert!(!output.success);
+    assert_eq!(output.exit_code, 255);
+}
+
+struct FailingReader;
+
+impl Read for FailingReader {
+    fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+        Err(std::io::Error::other("producer failed"))
+    }
+}
+
+#[test]
+fn local_producer_failure_cannot_report_success() {
+    let output = run_command_with_stdin_reader(piped_command("cat >/dev/null"), FailingReader);
+
+    assert!(!output.success);
+    assert_ne!(output.exit_code, 0);
+    assert!(output.stderr.contains("stdin delivery failed"));
 }
 
 #[test]

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -312,6 +312,16 @@ fn local_producer_failure_cannot_report_success() {
     assert!(output.stderr.contains("stdin delivery failed"));
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_empty_redirected_stdin_preserves_no_input_execution() {
+    let file = tempfile::tempfile().expect("empty redirected stdin file");
+    let output = run_command_with_stdin_source(piped_command("exit 0"), StdinSource::Piped(file));
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.exit_code, 0);
+}
+
 #[test]
 fn test_non_local_hosts() {
     assert!(!is_local_host("example.com"));

--- a/docs/commands/ssh.md
+++ b/docs/commands/ssh.md
@@ -61,6 +61,13 @@ The connect action uses an interactive SSH session and does not print the JSON e
 
 When a command is provided, it is executed non-interactively and Homeboy captures stdout/stderr into the JSON response.
 
+Piped stdin is streamed byte-for-byte to the remote command, including binary data. Homeboy closes remote stdin after local EOF and reports a nonzero result if the local stream cannot be delivered. This supports normal Unix composition without staging an intermediate file:
+
+```sh
+git format-patch -1 --stdout | homeboy ssh homeboy-lab -- git -C /srv/project am
+printf 'payload' | homeboy ssh homeboy-lab -- sha256sum
+```
+
 Non-interactive command responses include `exit_code`, `success`, `result_classification`, and `failure_reason` when the command fails. This makes empty-output commands unambiguous: a command that exits `0` reports `success: true`, while a no-output failure reports the actual exit code and whether Homeboy classified it as a remote command failure or SSH transport failure.
 
 `homeboy ssh` shows the server shell environment. Runner-specific job environment is injected by `homeboy runner exec`; inspect it with `homeboy runner env <runner-id>` or `homeboy runner exec <runner-id> -- printenv NAME`.


### PR DESCRIPTION
## Summary
- stream non-terminal stdin to non-interactive `homeboy ssh` commands without buffering
- fail the command when a local producer or remote stdin closes before delivery, even if the remote exit status is zero
- preserve interactive SSH and document patch/checksum pipelines

Closes #9988

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core server::client::tests`
- `cargo test -p homeboy-cli ssh`
- `cargo test --workspace` (fails outside this change: `tests/stale_linked_rig_recovery.rs::hermetic_fixture_command_cannot_use_operator_paths_or_installed_homeboy` rejects an operator path in the current environment)

## AI Assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** Audited SSH transport paths, implemented binary-safe piped stdin forwarding and deterministic coverage, and drafted this PR under Chris Huber's direction. Chris remains responsible for every line.