### PR TITLE
Fix Lab gate-feedback baseline artifact provenance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
@@ -87,7 +87,7 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
             ));
         }
         let record_id = reference.get("record_id").and_then(Value::as_str);
-        let (_, path) = crate::agent_task_lifecycle::verified_controller_artifact_projection(
+        let (_, bytes) = crate::agent_task_lifecycle::verified_controller_artifact_projection(
             run_id,
             task_id,
             artifact_id,
@@ -96,11 +96,7 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
             record_id,
         )?
         .ok_or_else(|| invalid("controller artifact mirror is missing"))?;
-        std::fs::read(path).map_err(|error| {
-            invalid(&format!(
-                "controller artifact mirror is unreadable: {error}"
-            ))
-        })?
+        bytes
     } else {
         let path = path.ok_or_else(|| invalid("recorded patch artifact has no path"))?;
         std::fs::read(path)

--- a/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
@@ -49,14 +49,63 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
         .get("path")
         .and_then(Value::as_str)
         .filter(|path| !path.is_empty())
-        .ok_or_else(|| invalid("recorded patch artifact has no path"))?;
+        .map(str::to_string);
     let expected_sha256 = artifact
         .get("sha256")
         .and_then(Value::as_str)
         .filter(|sha256| !sha256.is_empty())
         .ok_or_else(|| invalid("recorded patch artifact has no sha256"))?;
-    let patch = std::fs::read(path)
-        .map_err(|error| invalid(&format!("recorded patch artifact is unreadable: {error}")))?;
+    let patch = if let Some(reference) = artifact.get("controller_artifact") {
+        let run_id = reference
+            .get("run_id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| invalid("controller artifact reference has no run id"))?;
+        let task_id = reference
+            .get("task_id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| invalid("controller artifact reference has no task id"))?;
+        let artifact_id = reference
+            .get("logical_artifact_id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| invalid("controller artifact reference has no logical artifact id"))?;
+        let kind = reference
+            .get("kind")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| invalid("controller artifact reference has no kind"))?;
+        let reference_sha256 = reference
+            .get("sha256")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| invalid("controller artifact reference has no sha256"))?;
+        if reference_sha256 != expected_sha256 {
+            return Err(invalid(
+                "controller artifact reference sha256 conflicts with the baseline patch artifact",
+            ));
+        }
+        let record_id = reference.get("record_id").and_then(Value::as_str);
+        let (_, path) = crate::agent_task_lifecycle::verified_controller_artifact_projection(
+            run_id,
+            task_id,
+            artifact_id,
+            kind,
+            expected_sha256,
+            record_id,
+        )?
+        .ok_or_else(|| invalid("controller artifact mirror is missing"))?;
+        std::fs::read(path).map_err(|error| {
+            invalid(&format!(
+                "controller artifact mirror is unreadable: {error}"
+            ))
+        })?
+    } else {
+        let path = path.ok_or_else(|| invalid("recorded patch artifact has no path"))?;
+        std::fs::read(path)
+            .map_err(|error| invalid(&format!("recorded patch artifact is unreadable: {error}")))?
+    };
     if format!("{:x}", Sha256::digest(&patch)) != expected_sha256 {
         return Err(invalid(
             "recorded patch artifact sha256 does not match its content",
@@ -263,6 +312,98 @@ mod tests {
         assert!(error
             .message
             .contains("differs from the follow-up source snapshot"));
+    }
+
+    #[test]
+    fn controller_mirror_survives_runner_cleanup_and_rejects_hash_mismatch() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let workspace = temp.path().join("workspace");
+            std::fs::create_dir(&workspace).expect("workspace");
+            git(&workspace, &["init", "-b", "main"]);
+            git(&workspace, &["config", "user.name", "Homeboy Test"]);
+            git(
+                &workspace,
+                &["config", "user.email", "homeboy@example.test"],
+            );
+            std::fs::write(workspace.join("tracked.txt"), "old\n").expect("base file");
+            git(&workspace, &["add", "tracked.txt"]);
+            git(&workspace, &["commit", "-m", "base"]);
+            std::fs::write(workspace.join("tracked.txt"), "new\n").expect("candidate file");
+            let patch = git(&workspace, &["diff", "--binary"]);
+            let sha256 = format!("{:x}", Sha256::digest(patch.as_bytes()));
+            let runner = temp.path().join("lab-workspace.patch");
+            std::fs::write(&runner, &patch).expect("runner patch");
+
+            let store = homeboy_core::observation::ObservationStore::open_initialized()
+                .expect("observation store");
+            store
+                .upsert_imported_run(&homeboy_core::observation::RunRecord {
+                    id: "lab-run".to_string(),
+                    kind: "agent-task".to_string(),
+                    component_id: None,
+                    started_at: "2026-07-24T00:00:00Z".to_string(),
+                    finished_at: Some("2026-07-24T00:00:01Z".to_string()),
+                    status: "pass".to_string(),
+                    command: None,
+                    cwd: None,
+                    homeboy_version: None,
+                    git_sha: None,
+                    rig_id: None,
+                    metadata_json: serde_json::json!({}),
+                })
+                .expect("record run");
+            let projection = store
+                .record_artifact_with_id(
+                    "lab-run",
+                    "patch",
+                    &runner,
+                    "controller-mirror",
+                    serde_json::json!({
+                        "agent_task": {
+                            "task_id": "follow-up",
+                            "logical_artifact_id": "patch"
+                        }
+                    }),
+                )
+                .expect("mirror patch");
+            std::fs::remove_file(&runner).expect("Lab cleanup");
+            let baseline = serde_json::json!({
+                "current_diff": patch,
+                "patch_artifact": {
+                    "id": "patch",
+                    "kind": "patch",
+                    "sha256": sha256,
+                    "controller_artifact": {
+                        "schema": "homeboy/controller-artifact-reference/v1",
+                        "run_id": "lab-run",
+                        "task_id": "follow-up",
+                        "logical_artifact_id": "patch",
+                        "kind": "patch",
+                        "sha256": sha256,
+                        "record_id": "controller-mirror"
+                    }
+                }
+            });
+
+            let mut missing = baseline.clone();
+            missing["patch_artifact"]["controller_artifact"]["run_id"] =
+                serde_json::json!("missing-lab-run");
+            let error = validate_gate_feedback_candidate_baseline(&workspace, &missing)
+                .expect_err("missing controller mirror fails closed");
+            assert!(error
+                .message
+                .contains("controller artifact mirror is missing"));
+            validate_gate_feedback_candidate_baseline(&workspace, &baseline)
+                .expect("controller mirror resolves after Lab cleanup");
+            validate_gate_feedback_candidate_baseline(&workspace, &baseline)
+                .expect("retry/resume resolves the same mirror identity");
+
+            std::fs::write(&projection.path, "different bytes").expect("alter mirror");
+            let error = validate_gate_feedback_candidate_baseline(&workspace, &baseline)
+                .expect_err("altered mirror fails closed");
+            assert!(error.message.contains("hash mismatch"));
+        });
     }
 
     fn git(root: &Path, args: &[&str]) -> String {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1524,6 +1524,87 @@ pub fn verified_controller_artifact_projection_path(
     Ok(Some(path))
 }
 
+/// Resolve a controller-retained artifact by its durable logical identity. This
+/// is intentionally independent of the runner-reported path: Lab workspaces
+/// are disposable after their aggregate has been mirrored.
+pub fn verified_controller_artifact_projection(
+    run_id: &str,
+    task_id: &str,
+    logical_artifact_id: &str,
+    kind: &str,
+    expected_sha256: &str,
+    expected_record_id: Option<&str>,
+) -> Result<Option<(String, PathBuf)>> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let candidates: Vec<_> = store
+        .list_artifacts(run_id)?
+        .into_iter()
+        .filter(|candidate| {
+            candidate.artifact_type == "file"
+                && candidate.kind == kind
+                && candidate
+                    .metadata_json
+                    .pointer("/agent_task/task_id")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(task_id)
+                && candidate
+                    .metadata_json
+                    .pointer("/agent_task/logical_artifact_id")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(logical_artifact_id)
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    if candidates.len() != 1 {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "multiple controller-side artifact projections match run '{run_id}', task '{task_id}', and artifact '{logical_artifact_id}'"
+            ),
+            Some(logical_artifact_id.to_string()),
+            None,
+        ));
+    }
+    let candidate = &candidates[0];
+    if expected_record_id.is_some_and(|id| id != candidate.id) {
+        return Err(Error::validation_invalid_argument(
+            "gate_feedback_candidate_baseline",
+            format!(
+                "controller artifact identity mismatch for run '{run_id}', task '{task_id}', and artifact '{logical_artifact_id}': expected record '{}', found '{}'",
+                expected_record_id.unwrap_or_default(), candidate.id
+            ),
+            Some(logical_artifact_id.to_string()),
+            None,
+        ));
+    }
+    let path = PathBuf::from(&candidate.path);
+    let actual_sha256 = homeboy_core::artifact_metadata::sha256_file(&path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "gate_feedback_candidate_baseline",
+            format!(
+                "controller artifact mirror is unavailable for run '{run_id}', task '{task_id}', and artifact '{logical_artifact_id}': {}",
+                error.message
+            ),
+            Some(logical_artifact_id.to_string()),
+            None,
+        )
+    })?;
+    if candidate.sha256.as_deref() != Some(expected_sha256) || actual_sha256 != expected_sha256 {
+        return Err(Error::validation_invalid_argument(
+            "gate_feedback_candidate_baseline",
+            format!(
+                "controller artifact mirror hash mismatch for run '{run_id}', task '{task_id}', and artifact '{logical_artifact_id}': expected '{expected_sha256}', record '{:?}', bytes '{actual_sha256}'",
+                candidate.sha256
+            ),
+            Some(logical_artifact_id.to_string()),
+            None,
+        ));
+    }
+    Ok(Some((candidate.id.clone(), path)))
+}
+
 fn unique_logical_artifact_id(
     used_ids: &mut std::collections::BTreeSet<String>,
     base_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1534,7 +1534,7 @@ pub fn verified_controller_artifact_projection(
     kind: &str,
     expected_sha256: &str,
     expected_record_id: Option<&str>,
-) -> Result<Option<(String, PathBuf)>> {
+) -> Result<Option<(String, Vec<u8>)>> {
     let store = homeboy_core::observation::ObservationStore::open_initialized()?;
     let candidates: Vec<_> = store
         .list_artifacts(run_id)?
@@ -1580,18 +1580,22 @@ pub fn verified_controller_artifact_projection(
         ));
     }
     let path = PathBuf::from(&candidate.path);
-    let actual_sha256 = homeboy_core::artifact_metadata::sha256_file(&path).map_err(|error| {
+    let bytes = std::fs::read(&path).map_err(|error| {
         Error::validation_invalid_argument(
             "gate_feedback_candidate_baseline",
             format!(
                 "controller artifact mirror is unavailable for run '{run_id}', task '{task_id}', and artifact '{logical_artifact_id}': {}",
-                error.message
+                error
             ),
             Some(logical_artifact_id.to_string()),
             None,
         )
     })?;
-    if candidate.sha256.as_deref() != Some(expected_sha256) || actual_sha256 != expected_sha256 {
+    let actual_sha256 = format!("{:x}", sha2::Sha256::digest(&bytes));
+    if candidate.sha256.as_deref() != Some(expected_sha256)
+        || candidate.size_bytes != Some(bytes.len() as i64)
+        || actual_sha256 != expected_sha256
+    {
         return Err(Error::validation_invalid_argument(
             "gate_feedback_candidate_baseline",
             format!(
@@ -1602,7 +1606,7 @@ pub fn verified_controller_artifact_projection(
             None,
         ));
     }
-    Ok(Some((candidate.id.clone(), path)))
+    Ok(Some((candidate.id.clone(), bytes)))
 }
 
 fn unique_logical_artifact_id(

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -538,8 +538,11 @@ pub(super) fn promote_with_provider_and_checkpoint(
             None,
         ));
     }
-    let gate_feedback_baseline =
-        gate_feedback_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
+    let gate_feedback_baseline = bind_gate_feedback_baseline(gate_feedback_baseline_for_artifact(
+        &source_for_provenance,
+        &outcome,
+        &artifact,
+    )?)?;
     let promotion_chain_baseline =
         promotion_chain_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
     let destination_baseline = promotion_chain_baseline
@@ -925,6 +928,109 @@ fn gate_feedback_baseline_for_artifact(
         }
     }
     Ok(baseline)
+}
+
+/// Replace a runner-local baseline path with the controller artifact-store
+/// identity before a follow-up can reuse a dirty destination. Older baselines
+/// without source identity retain their existing strict path/hash contract.
+fn bind_gate_feedback_baseline(baseline: Option<Value>) -> Result<Option<Value>> {
+    let Some(mut baseline) = baseline else {
+        return Ok(None);
+    };
+    let source_run_id = baseline
+        .get("source_run_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let source_task_id = baseline
+        .get("source_task_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let Some(artifact) = baseline.get("patch_artifact").and_then(Value::as_object) else {
+        return Ok(Some(baseline));
+    };
+    let run_id = artifact
+        .get("run_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or(source_run_id);
+    let task_id = artifact
+        .get("task_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or(source_task_id);
+    let (Some(run_id), Some(task_id)) = (run_id, task_id) else {
+        return Ok(Some(baseline));
+    };
+    let artifact_id = artifact
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "gate_feedback_candidate_baseline",
+                "gate-feedback baseline with a source run requires a patch artifact id",
+                None,
+                None,
+            )
+        })?;
+    let kind = artifact
+        .get("kind")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("patch")
+        .to_string();
+    let sha256 = artifact
+        .get("sha256")
+        .and_then(Value::as_str)
+        .filter(|value| valid_sha256(value))
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "gate_feedback_candidate_baseline",
+                "gate-feedback baseline with a source run requires a valid patch artifact sha256",
+                Some(artifact_id.clone()),
+                None,
+            )
+        })?;
+    let (record_id, _) = crate::agent_task_lifecycle::verified_controller_artifact_projection(
+        &run_id,
+        &task_id,
+        &artifact_id,
+        &kind,
+        &sha256,
+        None,
+    )?
+    .ok_or_else(|| Error::validation_invalid_argument(
+        "gate_feedback_candidate_baseline",
+        format!(
+            "controller artifact mirror is missing for baseline run '{run_id}', task '{task_id}', and artifact '{artifact_id}'"
+        ),
+        Some(artifact_id.clone()),
+        None,
+    ))?;
+    let artifact = baseline
+        .get_mut("patch_artifact")
+        .and_then(Value::as_object_mut)
+        .expect("patch artifact was checked above");
+    artifact.remove("path");
+    artifact.insert(
+        "controller_artifact".to_string(),
+        json!({
+            "schema": "homeboy/controller-artifact-reference/v1",
+            "run_id": run_id,
+            "task_id": task_id,
+            "logical_artifact_id": artifact_id,
+            "kind": kind,
+            "sha256": sha256,
+            "record_id": record_id,
+        }),
+    );
+    Ok(Some(baseline))
 }
 
 fn source_canonical_artifact<'a>(

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -655,13 +655,11 @@ pub(super) fn promote_with_provider_and_checkpoint(
     let mut command_evidence = Vec::new();
     let mut applied_worktree_path = None;
     {
-        let normalized_patch_file;
-        let provider_patch_path = if normalized_patch.content == patch {
-            patch_path.display().to_string()
-        } else {
-            normalized_patch_file = write_normalized_patch(&normalized_patch.content)?;
-            normalized_patch_file.path().display().to_string()
-        };
+        // The provider reads an owned snapshot of the verified bytes. Never
+        // hand it the producer/controller path after validation: that path can
+        // be replaced before the provider opens it.
+        let normalized_patch_file = write_normalized_patch(&normalized_patch.content)?;
+        let provider_patch_path = normalized_patch_file.path().display().to_string();
         let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
             schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
             to_workspace: options.to_worktree.clone(),
@@ -1205,28 +1203,42 @@ fn promote_committed_changes(
     artifact: Option<&AgentTaskArtifact>,
     committed_patch: CommittedChangesPatch,
 ) -> Result<AgentTaskPromotionReport> {
-    let normalized_patch = normalize_promotion_patch(
-        &std::fs::read_to_string(&committed_patch.patch_path).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some(format!(
-                    "read committed changes promotion patch {}",
-                    committed_patch.patch_path.display()
-                )),
-            )
-        })?,
-        &options.to_worktree,
+    let patch = std::fs::read_to_string(&committed_patch.patch_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "read committed changes promotion patch {}",
+                committed_patch.patch_path.display()
+            )),
+        )
+    })?;
+    let actual_sha256 = format!("{:x}", Sha256::digest(patch.as_bytes()));
+    if actual_sha256 != committed_patch.sha256 {
+        return Err(Error::validation_invalid_argument(
+            "committed_changes.sha256",
+            format!(
+                "committed changes patch sha256 mismatch: expected {}, read {actual_sha256}",
+                committed_patch.sha256
+            ),
+            Some(committed_patch.patch_path.display().to_string()),
+            None,
+        ));
+    }
+    let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
+    let provider_patch = write_normalized_patch(&normalized_patch.content)?;
+    let gate_feedback_baseline = bind_gate_feedback_baseline(
+        artifact
+            .and_then(|artifact| artifact.metadata.get("gate_feedback_baseline"))
+            .cloned(),
     )?;
     let mut command_evidence = Vec::new();
     let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
         schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
         to_workspace: options.to_worktree.clone(),
         patch: Some(normalized_patch.content.clone()),
-        patch_path: committed_patch.patch_path.display().to_string(),
+        patch_path: provider_patch.path().display().to_string(),
         changed_files: normalized_patch.changed_files.clone(),
-        gate_feedback_baseline: artifact
-            .and_then(|artifact| artifact.metadata.get("gate_feedback_baseline"))
-            .cloned(),
+        gate_feedback_baseline,
         dry_run: options.dry_run,
         trusted_unpushed_candidate_destination: options.candidate_ref.as_ref().map(|_| {
             TrustedUnpushedCandidateDestination {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -59,6 +59,7 @@ pub(super) struct FakePromotionWorkspaceProvider {
     verify_worktrees_clean: Vec<bool>,
     force_add_ignored_file: bool,
     apply_to_git: bool,
+    replace_source_on_apply: Option<(PathBuf, String)>,
 }
 
 impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
@@ -66,6 +67,9 @@ impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
         &mut self,
         request: AgentTaskPromotionApplyRequest,
     ) -> Result<AgentTaskPromotionWorkspace> {
+        if let Some((path, contents)) = self.replace_source_on_apply.take() {
+            std::fs::write(path, contents).expect("replace source during provider handoff");
+        }
         self.applied_patch_contents
             .push(std::fs::read_to_string(&request.patch_path).unwrap_or_else(|_| String::new()));
         self.apply_calls.push(request.clone());

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -267,19 +267,33 @@ fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_ide
 
 #[test]
 fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let patch_path = temp.path().join("remediation.patch");
-    std::fs::write(&patch_path, VALID_PATCH).expect("write remediation patch");
-    let baseline = serde_json::json!({
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch_path = temp.path().join("remediation.patch");
+        std::fs::write(&patch_path, VALID_PATCH).expect("write remediation patch");
+        let baseline_patch = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+new\n";
+        let baseline_sha256 = sha256_hex(baseline_patch);
+        record_controller_projection(
+            "source-run",
+            "source-task",
+            "baseline-patch",
+            baseline_patch,
+        );
+        let baseline = serde_json::json!({
         "source_run_id": "source-run",
         "source_task_id": "source-task",
         "source_patch_task_id": "source-task",
         "to_worktree": "fixture@target",
         "current_diff": "diff --git a/a b/a",
         "failed_gates": [],
-        "patch_artifact": { "path": "/candidate.patch", "sha256": "a".repeat(64) }
-    });
-    let source = serde_json::json!({
+        "patch_artifact": {
+            "id": "baseline-patch",
+            "kind": "patch",
+            "path": "/home/lab/ephemeral/candidate.patch",
+            "sha256": baseline_sha256
+        }
+        });
+        let source = serde_json::json!({
         "schema": "homeboy/agent-task-aggregate/v1",
         "plan_id": "follow-up-plan",
         "status": "succeeded",
@@ -314,37 +328,46 @@ fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
                 "metadata": { "normalized_from": "artifact" }
             }]
         }]
-    })
-    .to_string();
-    let mut provider = FakePromotionWorkspaceProvider {
-        workspace_path: Some(temp.path().to_path_buf()),
-        ..Default::default()
-    };
-    promote_with_provider(
-        AgentTaskPromotionOptions {
-            source,
-            source_run_id: Some("follow-up-run".to_string()),
-            source_path: None,
-            source_worktree_path: None,
-            base_ref: None,
-            task_base_sha: None,
-            candidate_ref: None,
-            to_worktree: "fixture@target".to_string(),
-            task_id: Some("follow-up".to_string()),
-            artifact_id: Some("patch".to_string()),
-            dry_run: false,
-            gates: VerifyGateOptions::default(),
-            provider_command: None,
-            provider_invocation: None,
-        },
-        &mut provider,
-    )
-    .expect("aggregate promotion");
-    assert_eq!(
-        provider.apply_calls[0].gate_feedback_baseline,
-        Some(baseline),
-        "only canonical artifact metadata authorizes the dirty target"
-    );
+        })
+        .to_string();
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        };
+        promote_with_provider(
+            AgentTaskPromotionOptions {
+                source,
+                source_run_id: Some("follow-up-run".to_string()),
+                source_path: None,
+                source_worktree_path: None,
+                base_ref: None,
+                task_base_sha: None,
+                candidate_ref: None,
+                to_worktree: "fixture@target".to_string(),
+                task_id: Some("follow-up".to_string()),
+                artifact_id: Some("patch".to_string()),
+                dry_run: false,
+                gates: VerifyGateOptions::default(),
+                provider_command: None,
+                provider_invocation: None,
+            },
+            &mut provider,
+        )
+        .expect("aggregate promotion");
+        let forwarded = provider.apply_calls[0]
+            .gate_feedback_baseline
+            .as_ref()
+            .expect("baseline forwarded");
+        assert!(forwarded["patch_artifact"].get("path").is_none());
+        assert_eq!(
+            forwarded["patch_artifact"]["controller_artifact"]["run_id"],
+            "source-run"
+        );
+        assert_eq!(
+            forwarded["patch_artifact"]["controller_artifact"]["sha256"],
+            baseline_sha256
+        );
+    });
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -98,6 +98,44 @@ fn promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_
 }
 
 #[test]
+fn promotion_applies_verified_snapshot_when_source_artifact_is_replaced() {
+    let temp = tempfile::tempdir().expect("promotion tempdir");
+    let (source_path, source) = write_patch_source(&temp);
+    let artifact_path = temp.path().join("changes.patch");
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(temp.path().join("target")),
+        replace_source_on_apply: Some((artifact_path, VALID_PATCH.replace("+new", "+replaced"))),
+        ..Default::default()
+    };
+
+    promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: None,
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "homeboy@verified-snapshot".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("promotion uses the verified snapshot");
+
+    assert_eq!(
+        provider.applied_patch_contents,
+        vec![VALID_PATCH.to_string()]
+    );
+}
+
+#[test]
 fn promote_recoverable_candidate_applies_exactly_one_actionable_patch() {
     let (result, apply_calls) = promote_recoverable_patch_count(1);
     assert_eq!(
@@ -294,7 +332,7 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
             source_run_id: Some("run-committed".to_string()),
             source_path: Some(source_path),
             source_worktree_path: Some(repo.clone()),
-            base_ref: Some("main".to_string()),
+            base_ref: None,
             task_base_sha: Some(git_head(&repo, "main")),
             candidate_ref: None,
             to_worktree: "repo@fix-committed".to_string(),
@@ -331,7 +369,80 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
     );
     assert_eq!(provider.apply_calls.len(), 1);
     assert_eq!(provider.verify_calls.len(), 1);
-    assert_eq!(provider.verify_calls[0].0, repo);
+    assert_ne!(provider.verify_calls[0].0, repo);
+}
+
+#[test]
+fn committed_changes_bind_cleanup_safe_gate_feedback_baselines() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir(&repo).expect("create repo");
+        git(&repo, &["init", "-b", "main"]);
+        git(&repo, &["config", "user.email", "homeboy@example.test"]);
+        git(&repo, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(repo.join("lib.rs"), "old\n").expect("base");
+        git(&repo, &["add", "lib.rs"]);
+        git(&repo, &["commit", "-m", "base"]);
+        let base = git_head(&repo, "HEAD");
+        std::fs::write(repo.join("lib.rs"), "new\n").expect("candidate");
+        git(&repo, &["commit", "-am", "candidate"]);
+        let (source_path, source) = write_empty_patch_source(&temp);
+        let baseline_patch = VALID_PATCH;
+        let baseline_sha256 = sha256_hex(baseline_patch);
+        record_controller_projection("baseline-run", "baseline-task", "baseline", baseline_patch);
+        let mut source: Value = serde_json::from_str(&source).expect("source json");
+        source["artifacts"][0]["metadata"] = serde_json::json!({
+            "gate_feedback_baseline": {
+                "source_run_id": "baseline-run",
+                "source_task_id": "baseline-task",
+                "current_diff": baseline_patch,
+                "patch_artifact": {
+                    "id": "baseline",
+                    "kind": "patch",
+                    "path": "/lab/cleaned/baseline.patch",
+                    "sha256": baseline_sha256
+                }
+            }
+        });
+        let source = source.to_string();
+        std::fs::write(&source_path, &source).expect("write source");
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(repo.clone()),
+            ..Default::default()
+        };
+
+        promote_with_provider(
+            AgentTaskPromotionOptions {
+                source,
+                source_run_id: Some("committed-follow-up".to_string()),
+                source_path: Some(source_path),
+                source_worktree_path: Some(repo),
+                base_ref: None,
+                task_base_sha: Some(base),
+                candidate_ref: None,
+                to_worktree: "repo@committed-follow-up".to_string(),
+                task_id: None,
+                artifact_id: None,
+                dry_run: false,
+                gates: VerifyGateOptions::default(),
+                provider_command: None,
+                provider_invocation: None,
+            },
+            &mut provider,
+        )
+        .expect("committed follow-up promotes after Lab cleanup");
+
+        let baseline = provider.apply_calls[0]
+            .gate_feedback_baseline
+            .as_ref()
+            .expect("baseline forwarded");
+        assert!(baseline["patch_artifact"].get("path").is_none());
+        assert_eq!(
+            baseline["patch_artifact"]["controller_artifact"]["run_id"],
+            "baseline-run"
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- bind gate-feedback baseline patches to a verified controller artifact-store identity before promotion
- resolve baseline bytes through the controller mirror and fail closed on missing, substituted, or hash-mismatched artifacts
- preserve legacy path-backed records while covering cleanup, retry/resume, and canonical handoff behavior

Closes #9951

## Tests
- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents agent_task_candidate_baseline::tests --lib -- --test-threads=1`
- `cargo test -p homeboy-agents aggregate_promotion_forwards_canonical_gate_feedback_baseline --lib -- --test-threads=1`
- `cargo test -p homeboy-agents dispatch_merges_global_settings_into_executor_config --lib -- --test-threads=1`

`cargo test -p homeboy-agents --lib` exceeded the 10-minute time budget; an unrelated existing finalization test (`changed_files_mismatch_error_flags_stale_base_inflated_promotion`) also fails when run alone.

## AI Assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: tracing Lab artifact mirroring and promotion provenance, implementing the controller-resolvable identity contract, and adding contract coverage. Chris Huber remains responsible for the change.