### PR TITLE
fix(cook): keep goals out of explicit task cells

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -237,8 +237,9 @@ pub struct AgentTaskCookArgs {
     pub attempt_run_id: Option<String>,
     #[arg(long, hide = true)]
     pub attempt_plan: Option<String>,
-    /// One-line statement of what a successful cook must achieve. Recorded with
-    /// the run and used to frame the agent's task and the review.
+    /// One-line statement of what a successful cook must achieve. Recorded as
+    /// framing metadata for every provider cell and used for review. Without
+    /// --prompt, --task, or --tasks, it supplies the one provider task.
     #[arg(long, value_name = "TEXT")]
     pub goal: Option<String>,
     /// Workspace handle the cook edits, verifies, and finalizes into (e.g.

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -203,9 +203,6 @@ where
     let provision = provision_cook_destination(&args)?;
 
     let mut dispatch_args = dispatch_args_for_cook(&args);
-    if dispatch_args.cwd.is_none() && dispatch_args.workspace.is_none() {
-        dispatch_args.workspace = Some(args.to_worktree.clone());
-    }
     let requested_cook_id = dispatch_args.run_id.clone();
     if let Some(cook_id) = requested_cook_id.as_deref() {
         dispatch_args.run_id = Some(
@@ -226,27 +223,13 @@ where
             .run_id
             .clone()
             .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
-        let mut request = dispatch_service::resolve_dispatch_request(dispatch_args.into())?;
-        let plan = match dispatch_service::build_controller_dispatch_plan(&mut request) {
-            Ok(plan) => plan,
-            // A managed promotion handle may be intentionally unavailable until
-            // after provider execution. Keep the compiled task durable and let
-            // promotion report its established controlled policy failure.
-            Err(error)
-                if request.workspace.as_deref() == Some(args.to_worktree.as_str())
-                    && error.message.contains(
-                        "neither an existing directory nor a resolvable managed worktree handle",
-                    ) =>
-            {
-                request.workspace = None;
-                dispatch_service::build_controller_dispatch_plan(&mut request)?
-            }
-            Err(error) => return Err(error),
-        };
+        let plan = compile_cook_plan(&args, provision.clone())?;
         (run_id, plan)
     };
-    record_cook_provision(&mut initial_plan, provision);
-    record_cook_goal(&mut initial_plan, args.goal.as_deref());
+    if args.attempt_plan.is_some() {
+        record_cook_provision(&mut initial_plan, provision);
+        record_cook_goal(&mut initial_plan, args.goal.as_deref());
+    }
     let cook_id = requested_cook_id.unwrap_or_else(|| run_id.clone());
     // Capture the resolved task workspace before dispatch. The provider may
     // commit and leave a clean tree, so resolving this after it runs would
@@ -325,6 +308,37 @@ pub(super) fn dispatch_args_for_cook(args: &AgentTaskCookArgs) -> DispatchArgs {
         dispatch_args.prompt = args.goal.clone();
     }
     dispatch_args
+}
+
+/// Compile the one durable provider-cell plan used by local Cook and Lab handoff.
+pub(crate) fn compile_cook_plan(
+    args: &AgentTaskCookArgs,
+    provision: Value,
+) -> homeboy::core::Result<AgentTaskPlan> {
+    let mut dispatch = dispatch_args_for_cook(args);
+    if dispatch.cwd.is_none() && dispatch.workspace.is_none() {
+        dispatch.workspace = Some(args.to_worktree.clone());
+    }
+    let mut request = dispatch_service::resolve_dispatch_request(dispatch.into())?;
+    let mut plan = match dispatch_service::build_controller_dispatch_plan(&mut request) {
+        Ok(plan) => plan,
+        // A managed promotion handle may be intentionally unavailable until
+        // after provider execution. Keep the compiled task durable and let
+        // promotion report its established controlled policy failure.
+        Err(error)
+            if request.workspace.as_deref() == Some(args.to_worktree.as_str())
+                && error.message.contains(
+                    "neither an existing directory nor a resolvable managed worktree handle",
+                ) =>
+        {
+            request.workspace = None;
+            dispatch_service::build_controller_dispatch_plan(&mut request)?
+        }
+        Err(error) => return Err(error),
+    };
+    record_cook_provision(&mut plan, provision);
+    record_cook_goal(&mut plan, args.goal.as_deref());
+    Ok(plan)
 }
 
 fn record_cook_goal(plan: &mut AgentTaskPlan, goal: Option<&str>) {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -20,6 +20,7 @@ use homeboy::core::worktree_providers::{
     provision_apply_enabled_worktree_provider_from_config, WorktreeProviderCreateIntent,
 };
 
+use super::super::agent_task_dispatch::DispatchArgs;
 use super::super::CmdResult;
 use super::args::{
     AgentTaskCookArgs, PromotionProviderArgs, RetryArgs, RunArgs, RunPlanArgs, StatusArgs,
@@ -201,10 +202,7 @@ where
     // bare rejection.
     let provision = provision_cook_destination(&args)?;
 
-    let mut dispatch_args = args.dispatch.clone();
-    if dispatch_args.prompt.is_none() {
-        dispatch_args.prompt = args.goal.clone();
-    }
+    let mut dispatch_args = dispatch_args_for_cook(&args);
     if dispatch_args.cwd.is_none() && dispatch_args.workspace.is_none() {
         dispatch_args.workspace = Some(args.to_worktree.clone());
     }
@@ -248,6 +246,7 @@ where
         (run_id, plan)
     };
     record_cook_provision(&mut initial_plan, provision);
+    record_cook_goal(&mut initial_plan, args.goal.as_deref());
     let cook_id = requested_cook_id.unwrap_or_else(|| run_id.clone());
     // Capture the resolved task workspace before dispatch. The provider may
     // commit and leave a clean tree, so resolving this after it runs would
@@ -315,6 +314,33 @@ where
         ),
         result.exit_code,
     ))
+}
+
+pub(super) fn dispatch_args_for_cook(args: &AgentTaskCookArgs) -> DispatchArgs {
+    let mut dispatch_args = args.dispatch.clone();
+    let has_explicit_work = dispatch_args.prompt.is_some()
+        || !dispatch_args.tasks.is_empty()
+        || dispatch_args.core.tasks_json.is_some();
+    if !has_explicit_work {
+        dispatch_args.prompt = args.goal.clone();
+    }
+    dispatch_args
+}
+
+fn record_cook_goal(plan: &mut AgentTaskPlan, goal: Option<&str>) {
+    let Some(goal) = goal else {
+        return;
+    };
+    if !plan.metadata.is_object() {
+        plan.metadata = serde_json::json!({});
+    }
+    plan.metadata["cook_goal"] = serde_json::json!(goal);
+    for task in &mut plan.tasks {
+        if !task.metadata.is_object() {
+            task.metadata = serde_json::json!({});
+        }
+        task.metadata["cook_goal"] = serde_json::json!(goal);
+    }
 }
 
 fn git_head_sha(path: &Path) -> Option<String> {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -2,10 +2,32 @@
 
 use super::support::*;
 use clap::Parser;
+use homeboy::agents::agent_task_service::{
+    AgentTaskCookAttemptDispatcher, DerivedCookBaselineCapability,
+};
+use homeboy::core::{Error, Result};
 
 use crate::cli_surface::{Cli, Commands};
 
 use super::super::AgentTaskCommand;
+
+#[derive(Debug)]
+struct RecipeOnlyDispatcher;
+
+impl AgentTaskCookAttemptDispatcher for RecipeOnlyDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(json!({ "kind": "recipe-only" }))
+    }
+
+    fn dispatch_attempt(
+        &self,
+        _plan: AgentTaskPlan,
+        _run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        Err(Error::internal_unexpected("stop after durable recipe"))
+    }
+}
 
 #[test]
 fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
@@ -42,6 +64,144 @@ fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
             .contains("cannot queue its controller-owned lifecycle"));
         assert!(!homeboy::agents::agent_task_service::recipe_exists("cook-queue-only").unwrap());
     });
+}
+
+#[test]
+fn cook_goal_frames_explicit_task_without_creating_another_provider_cell() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--goal",
+            "Preserve the durable provider-cell contract",
+            "--task",
+            "Implement the targeted repair",
+            "--cwd",
+            workspace.path().to_str().expect("workspace path"),
+            "--to-worktree",
+            workspace.path().to_str().expect("workspace path"),
+            "--backend",
+            "fixture",
+            "--no-finalize",
+            "--run-id",
+            "cook-goal-task-one-cell",
+        ]);
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task cook command");
+        };
+        let AgentTaskCommand::Cook(cook) = agent_task.command else {
+            panic!("cook command");
+        };
+
+        let _ = run_cook_with_executor_and_dispatcher(
+            cook,
+            CapturingExecutor::default(),
+            Some(Arc::new(RecipeOnlyDispatcher)),
+        );
+
+        let recipe = homeboy::agents::agent_task_service::load_recipe("cook-goal-task-one-cell")
+            .expect("durable cook recipe");
+        let plan = &recipe.attempts[0].plan;
+        assert_eq!(plan.tasks.len(), 1);
+        assert_eq!(plan.options.execution_budget.max_provider_executions, 1);
+        assert_eq!(
+            plan.metadata["cook_goal"],
+            "Preserve the durable provider-cell contract"
+        );
+        assert_eq!(plan.tasks[0].instructions, "Implement the targeted repair");
+        assert_eq!(
+            plan.tasks[0].metadata["cook_goal"],
+            "Preserve the durable provider-cell contract"
+        );
+    });
+}
+
+#[test]
+fn cook_goal_without_explicit_work_remains_one_provider_cell() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--goal",
+            "Implement the targeted repair",
+            "--cwd",
+            workspace.path().to_str().expect("workspace path"),
+            "--to-worktree",
+            workspace.path().to_str().expect("workspace path"),
+            "--backend",
+            "fixture",
+            "--no-finalize",
+            "--run-id",
+            "cook-goal-only-one-cell",
+        ]);
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task cook command");
+        };
+        let AgentTaskCommand::Cook(cook) = agent_task.command else {
+            panic!("cook command");
+        };
+
+        let _ = run_cook_with_executor_and_dispatcher(
+            cook,
+            CapturingExecutor::default(),
+            Some(Arc::new(RecipeOnlyDispatcher)),
+        );
+
+        let recipe = homeboy::agents::agent_task_service::load_recipe("cook-goal-only-one-cell")
+            .expect("durable cook recipe");
+        let plan = &recipe.attempts[0].plan;
+        assert_eq!(plan.tasks.len(), 1);
+        assert_eq!(plan.tasks[0].instructions, "Implement the targeted repair");
+        assert_eq!(
+            plan.tasks[0].metadata["cook_goal"],
+            "Implement the targeted repair"
+        );
+    });
+}
+
+#[test]
+fn cook_goal_never_becomes_an_extra_prompt_when_work_is_explicit() {
+    for (work_flag, work_value) in [
+        ("--prompt", "implement the repair"),
+        ("--tasks", "@provider-cells.json"),
+    ] {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--goal",
+            "Preserve one cell per explicit task",
+            work_flag,
+            work_value,
+            "--to-worktree",
+            "homeboy@provider-cells",
+            "--backend",
+            "fixture",
+            "--no-finalize",
+        ]);
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task cook command");
+        };
+        let AgentTaskCommand::Cook(cook) = agent_task.command else {
+            panic!("cook command");
+        };
+
+        let dispatch = super::super::run::dispatch_args_for_cook(&cook);
+        assert_eq!(
+            dispatch.prompt.as_deref(),
+            (work_flag == "--prompt").then_some(work_value)
+        );
+        assert_eq!(
+            dispatch.core.tasks_json.as_deref(),
+            (work_flag == "--tasks").then_some(work_value)
+        );
+    }
 }
 
 #[cfg(unix)]

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -892,20 +892,7 @@ fn materialize_agent_task_cook_plan(
     };
     crate::commands::agent_task::run::validate_cook_request(cook)?;
     let provision = crate::commands::agent_task::run::provision_cook_destination(cook)?;
-    let mut dispatch = cook.dispatch.clone();
-    if dispatch.prompt.is_none() {
-        dispatch.prompt = cook.goal.clone();
-    }
-    if dispatch.cwd.is_none() && dispatch.workspace.is_none() {
-        dispatch.workspace = Some(cook.to_worktree.clone());
-    }
-    let mut request =
-        homeboy::agents::agent_tasks::dispatch_service::resolve_dispatch_request(dispatch.into())?;
-    let mut plan = homeboy::agents::agent_tasks::dispatch_service::build_controller_dispatch_plan(
-        &mut request,
-    )?;
-    crate::commands::agent_task::run::record_cook_provision(&mut plan, provision);
-    Ok(Some(plan))
+    crate::commands::agent_task::run::compile_cook_plan(cook, provision).map(Some)
 }
 
 fn lab_route_dispatch_timeout(command: &Commands) -> Option<std::time::Duration> {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -828,6 +828,67 @@ fn lab_cook_attempt_preserves_authorized_dirty_baseline_in_the_run_plan() {
 }
 
 #[test]
+fn lab_cook_materializes_goal_and_explicit_task_as_one_durable_cell() {
+    crate::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path());
+        let workspace = workspace.path().display().to_string();
+        let cook = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--goal",
+            "Preserve one provider cell",
+            "--task",
+            "Repair the Lab Cook compiler",
+            "--cwd",
+            &workspace,
+            "--to-worktree",
+            &workspace,
+            "--backend",
+            "fixture",
+            "--no-finalize",
+            "--run-id",
+            "cook-lab-goal-task",
+        ]);
+
+        let plan = materialize_agent_task_cook_plan(&cook)
+            .expect("materialize Lab Cook plan")
+            .expect("Cook plan");
+        assert_eq!(plan.tasks.len(), 1);
+        assert_eq!(plan.options.execution_budget.max_provider_executions, 1);
+        assert_eq!(plan.metadata["cook_goal"], "Preserve one provider cell");
+        assert_eq!(plan.tasks[0].instructions, "Repair the Lab Cook compiler");
+        assert_eq!(
+            plan.tasks[0].metadata["cook_goal"],
+            "Preserve one provider cell"
+        );
+
+        agent_task_lifecycle::submit_plan(&plan, Some("cook-lab-goal-task"))
+            .expect("persist Cook plan");
+        let retry_args = [
+            "homeboy",
+            "agent-task",
+            "retry",
+            "cook-lab-goal-task",
+            "--run",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let retry = Cli::parse_from(&retry_args);
+        let handoff = materialize_agent_task_retry_handoff(&retry, &retry_args)
+            .expect("materialize retry handoff")
+            .expect("retry handoff");
+        // The Homeboy projection is rebuilt when loading durable JSON; verify
+        // the provider-cell contract, which is what retry/resume dispatches.
+        assert_eq!(handoff.plan.tasks, plan.tasks);
+        assert_eq!(handoff.plan.options, plan.options);
+        assert_eq!(handoff.plan.metadata, plan.metadata);
+    });
+}
+
+#[test]
 fn detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_failure() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -501,6 +501,11 @@ promotes the selected patch into the target worktree, runs deterministic gates,
 retries red gates within the configured budget, then commits, pushes, and opens or
 updates a PR.
 
+`--goal` is one-line Cook framing metadata, recorded on the durable plan and each
+provider cell. When work is supplied with `--prompt`, repeated `--task`, or
+`--tasks`, those inputs alone determine the cell count; `--goal` never creates an
+additional cell. A goal without explicit work supplies one provider task.
+
 ```bash
 homeboy agent-task cook \
   --repo sample-plugin \


### PR DESCRIPTION
## Summary
- treat `--goal` as durable Cook framing metadata when explicit work is supplied
- preserve goal-only Cook as one provider task
- cover explicit task, prompt, tasks payload, recipe cell count, and budget semantics

Closes #9986

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-cli cook_goal --no-fail-fast`
- `cargo test -p homeboy-cli --lib --no-fail-fast` (timed out after 10 minutes; unrelated concurrent-suite failures were reported before timeout)

## AI assistance
Model: OpenAI GPT-5.6 Sol
Tool: OpenCode
Used for: Inspected the Cook plan-compilation path, implemented the goal-to-provider-cell contract, added tests and documentation, and ran verification. Chris Huber remains responsible for every line.