### PR TITLE
fix(agent-task): report failed cook-batch outcomes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -228,7 +228,7 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     }
     let mut totals = totals_for_children(&batch.child_runs);
     totals.unavailable = unavailable_child_runs.len();
-    let state = state_for_totals(&totals);
+    let state = aggregate_state(&totals);
     if batch.state != state {
         batch.state = state;
         changed = true;
@@ -424,24 +424,6 @@ fn totals_for_children(children: &[AgentTaskBatchChildRun]) -> AgentTaskBatchTot
         }
     }
     totals
-}
-
-fn state_for_totals(totals: &AgentTaskBatchTotals) -> AgentTaskBatchState {
-    if totals.running > 0 {
-        AgentTaskBatchState::Running
-    } else if totals.queued > 0 {
-        AgentTaskBatchState::Queued
-    } else if totals.unavailable > 0 {
-        AgentTaskBatchState::PartialFailure
-    } else if totals.failed > 0 || totals.partial_failure > 0 {
-        AgentTaskBatchState::PartialFailure
-    } else if totals.cancelled > 0 && totals.succeeded == 0 {
-        AgentTaskBatchState::Cancelled
-    } else if totals.cancelled > 0 {
-        AgentTaskBatchState::PartialFailure
-    } else {
-        AgentTaskBatchState::Succeeded
-    }
 }
 
 fn child_issue(child: &AgentTaskBatchChildRun, problem: String) -> AgentTaskBatchChildIssue {
@@ -733,6 +715,91 @@ mod tests {
             .next_actions
             .iter()
             .any(|action| action.contains("partial results only")));
+    }
+
+    #[test]
+    fn aggregate_state_matrix_is_shared_by_immediate_and_durable_batches() {
+        for (name, totals, state, exit_code) in [
+            (
+                "all-success",
+                AgentTaskBatchTotals {
+                    succeeded: 2,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::Succeeded,
+                0,
+            ),
+            (
+                "success-and-no-op",
+                AgentTaskBatchTotals {
+                    succeeded: 2,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::Succeeded,
+                0,
+            ),
+            (
+                "mixed",
+                AgentTaskBatchTotals {
+                    succeeded: 1,
+                    failed: 1,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::PartialFailure,
+                1,
+            ),
+            (
+                "all-failed",
+                AgentTaskBatchTotals {
+                    failed: 2,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::Failed,
+                1,
+            ),
+            (
+                "coordinator-infrastructure-failure",
+                AgentTaskBatchTotals {
+                    failed: 1,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::Failed,
+                1,
+            ),
+            (
+                "cancelled",
+                AgentTaskBatchTotals {
+                    cancelled: 2,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::Cancelled,
+                1,
+            ),
+        ] {
+            let actual = aggregate_state(&totals);
+            assert_eq!(actual, state, "{name}");
+            assert_eq!(actual.exit_code(), exit_code, "{name}");
+        }
+    }
+
+    #[test]
+    fn durable_status_marks_all_failed_children_as_failed() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let plan = AgentTaskPlan::new("fanout/failed", vec![request("a"), request("b")]);
+        submit_plan_batch(&plan, Some("batch/failed")).expect("batch submitted");
+        for run_id in ["batch_failed-a", "batch_failed-b"] {
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.state = AgentTaskRunState::Failed;
+            })
+            .expect("stage failed child");
+        }
+
+        let report = status("batch/failed").expect("durable failed status");
+
+        assert_eq!(report.batch.state, AgentTaskBatchState::Failed);
+        assert_eq!(report.batch.state.outcome_status(), "failed");
+        assert_eq!(report.batch.state.exit_code(), 1);
+        assert_eq!(report.totals.failed, 2);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -737,6 +737,26 @@ mod tests {
     fn aggregate_state_matrix_is_shared_by_immediate_and_durable_batches() {
         for (name, totals, state, exit_code) in [
             (
+                "queued-with-terminal-child",
+                AgentTaskBatchTotals {
+                    queued: 1,
+                    succeeded: 1,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::Queued,
+                0,
+            ),
+            (
+                "running-with-terminal-child",
+                AgentTaskBatchTotals {
+                    running: 1,
+                    failed: 1,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::Running,
+                0,
+            ),
+            (
                 "all-success",
                 AgentTaskBatchTotals {
                     succeeded: 2,

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -200,12 +200,20 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let mut unavailable_child_runs = Vec::new();
     let mut projection_pending_child_runs = Vec::new();
     let mut resumable_child_runs = Vec::new();
+    let mut timed_out_child_runs = HashSet::new();
     for child in &mut batch.child_runs {
         match agent_task_lifecycle::status(&child.run_id) {
             Ok(record) => {
                 if child.state != record.state {
                     child.state = record.state;
                     changed = true;
+                }
+                if record
+                    .totals
+                    .as_ref()
+                    .is_some_and(|totals| totals.timed_out > 0)
+                {
+                    timed_out_child_runs.insert(child.run_id.clone());
                 }
                 if let Some(pending) = projection_pending_child(child, &record)? {
                     projection_pending_child_runs.push(pending);
@@ -227,6 +235,13 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
         }
     }
     let mut totals = totals_for_children(&batch.child_runs);
+    for child in &batch.child_runs {
+        if timed_out_child_runs.contains(&child.run_id) && child.state == AgentTaskRunState::Failed
+        {
+            totals.failed = totals.failed.saturating_sub(1);
+            totals.timed_out += 1;
+        }
+    }
     totals.unavailable = unavailable_child_runs.len();
     let state = aggregate_state(&totals);
     if batch.state != state {
@@ -242,6 +257,7 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let commands = commands(&batch.batch_id);
     Ok(AgentTaskBatchStatusReport {
         schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
+        status: state.outcome_status().to_string(),
         next_actions: batch_next_actions(
             &unavailable_child_runs,
             &projection_pending_child_runs,
@@ -775,6 +791,15 @@ mod tests {
                 AgentTaskBatchState::Cancelled,
                 1,
             ),
+            (
+                "timed-out",
+                AgentTaskBatchTotals {
+                    timed_out: 1,
+                    ..Default::default()
+                },
+                AgentTaskBatchState::TimedOut,
+                1,
+            ),
         ] {
             let actual = aggregate_state(&totals);
             assert_eq!(actual, state, "{name}");
@@ -797,6 +822,7 @@ mod tests {
         let report = status("batch/failed").expect("durable failed status");
 
         assert_eq!(report.batch.state, AgentTaskBatchState::Failed);
+        assert_eq!(report.status, "failed");
         assert_eq!(report.batch.state.outcome_status(), "failed");
         assert_eq!(report.batch.state.exit_code(), 1);
         assert_eq!(report.totals.failed, 2);

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -38,6 +38,30 @@ pub enum AgentTaskBatchState {
     Failed,
     Cancelled,
 }
+
+impl AgentTaskBatchState {
+    /// The stable machine-readable outcome shared by immediate cooks, durable
+    /// batch status, resume, and their command-result envelopes.
+    pub fn outcome_status(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::PartialFailure => "partial_failure",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// A completed aggregate that needs operator action must never look like a
+    /// successful command to shell or JSON-envelope consumers.
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::Queued | Self::Running | Self::Succeeded => 0,
+            Self::PartialFailure | Self::Failed | Self::Cancelled => 1,
+        }
+    }
+}
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct AgentTaskBatchStatusReport {
     pub schema: &'static str,
@@ -88,6 +112,33 @@ pub struct AgentTaskBatchTotals {
     pub failed: usize,
     pub cancelled: usize,
     pub unavailable: usize,
+}
+
+/// Derive the one aggregate state for both durable and synchronous fanout.
+/// Successful no-op cooks contribute to `succeeded`; failures that leave no
+/// successful/cancelled peer are an unambiguous failed batch.
+pub fn aggregate_state(totals: &AgentTaskBatchTotals) -> AgentTaskBatchState {
+    if totals.running > 0 {
+        AgentTaskBatchState::Running
+    } else if totals.queued > 0 {
+        AgentTaskBatchState::Queued
+    } else if totals.unavailable > 0 {
+        AgentTaskBatchState::PartialFailure
+    } else if totals.failed > 0 || totals.partial_failure > 0 {
+        if totals.succeeded == 0 && totals.cancelled == 0 {
+            AgentTaskBatchState::Failed
+        } else {
+            AgentTaskBatchState::PartialFailure
+        }
+    } else if totals.cancelled > 0 {
+        if totals.succeeded == 0 {
+            AgentTaskBatchState::Cancelled
+        } else {
+            AgentTaskBatchState::PartialFailure
+        }
+    } else {
+        AgentTaskBatchState::Succeeded
+    }
 }
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AgentTaskBatchCommands {

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -37,6 +37,7 @@ pub enum AgentTaskBatchState {
     PartialFailure,
     Failed,
     Cancelled,
+    TimedOut,
 }
 
 impl AgentTaskBatchState {
@@ -50,6 +51,7 @@ impl AgentTaskBatchState {
             Self::PartialFailure => "partial_failure",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
+            Self::TimedOut => "timed_out",
         }
     }
 
@@ -58,13 +60,15 @@ impl AgentTaskBatchState {
     pub fn exit_code(self) -> i32 {
         match self {
             Self::Queued | Self::Running | Self::Succeeded => 0,
-            Self::PartialFailure | Self::Failed | Self::Cancelled => 1,
+            Self::PartialFailure | Self::Failed | Self::Cancelled | Self::TimedOut => 1,
         }
     }
 }
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct AgentTaskBatchStatusReport {
     pub schema: &'static str,
+    /// Additive top-level projection of `batch.state` for command envelopes.
+    pub status: String,
     pub batch: AgentTaskBatchRecord,
     pub totals: AgentTaskBatchTotals,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -111,6 +115,7 @@ pub struct AgentTaskBatchTotals {
     pub partial_failure: usize,
     pub failed: usize,
     pub cancelled: usize,
+    pub timed_out: usize,
     pub unavailable: usize,
 }
 
@@ -125,7 +130,7 @@ pub fn aggregate_state(totals: &AgentTaskBatchTotals) -> AgentTaskBatchState {
     } else if totals.unavailable > 0 {
         AgentTaskBatchState::PartialFailure
     } else if totals.failed > 0 || totals.partial_failure > 0 {
-        if totals.succeeded == 0 && totals.cancelled == 0 {
+        if totals.succeeded == 0 && totals.cancelled == 0 && totals.timed_out == 0 {
             AgentTaskBatchState::Failed
         } else {
             AgentTaskBatchState::PartialFailure
@@ -133,6 +138,12 @@ pub fn aggregate_state(totals: &AgentTaskBatchTotals) -> AgentTaskBatchState {
     } else if totals.cancelled > 0 {
         if totals.succeeded == 0 {
             AgentTaskBatchState::Cancelled
+        } else {
+            AgentTaskBatchState::PartialFailure
+        }
+    } else if totals.timed_out > 0 {
+        if totals.succeeded == 0 {
+            AgentTaskBatchState::TimedOut
         } else {
             AgentTaskBatchState::PartialFailure
         }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -548,24 +548,10 @@ where
     for (index, cell) in rx {
         cells[index] = Some(cell);
     }
-    let cooks = cells.into_iter().flatten().collect::<Vec<_>>();
-    let failed = cooks.iter().filter(|cell| cell.exit_code != 0).count();
-    Ok(AgentTaskRunResult {
-        exit_code: if failed == 0 { 0 } else { 1 },
-        value: AgentTaskCookBatchReport {
-            schema: "homeboy/agent-task-cook-batch/v1",
-            batch_id: options.batch_id,
-            status: if failed == 0 {
-                "succeeded".to_string()
-            } else {
-                "failed".to_string()
-            },
-            total,
-            succeeded: total - failed,
-            failed,
-            cooks,
-        },
-    })
+    Ok(cook_batch_result(
+        options.batch_id,
+        cells.into_iter().flatten().collect(),
+    ))
 }
 
 /// Resume a persisted cook batch after its original synchronous coordinator
@@ -659,23 +645,33 @@ where
         cells.push(cell);
     }
 
-    let failed = cells.iter().filter(|cell| cell.exit_code != 0).count();
-    Ok(AgentTaskRunResult {
+    Ok(cook_batch_result(batch.batch_id, cells))
+}
+
+fn cook_batch_result(
+    batch_id: String,
+    cooks: Vec<AgentTaskCookBatchCellReport>,
+) -> AgentTaskRunResult<AgentTaskCookBatchReport> {
+    let total = cooks.len();
+    let failed = cooks.iter().filter(|cell| cell.exit_code != 0).count();
+    let status = match failed {
+        0 => "succeeded",
+        failed if failed == total => "failed",
+        _ => "partial_failure",
+    };
+
+    AgentTaskRunResult {
         exit_code: if failed == 0 { 0 } else { 1 },
         value: AgentTaskCookBatchReport {
             schema: "homeboy/agent-task-cook-batch/v1",
-            batch_id: batch.batch_id,
-            status: if failed == 0 {
-                "succeeded".to_string()
-            } else {
-                "failed".to_string()
-            },
+            batch_id,
+            status: status.to_string(),
             total,
             succeeded: total - failed,
             failed,
-            cooks: cells,
+            cooks,
         },
-    })
+    }
 }
 
 /// Reconstruct one batch child's cook from its durable recipe and re-run it.

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -464,6 +464,8 @@ pub struct AgentTaskCookBatchReport {
     pub batch_id: String,
     pub status: String,
     pub total: usize,
+    pub queued: usize,
+    pub running: usize,
     pub succeeded: usize,
     pub failed: usize,
     pub cancelled: usize,
@@ -663,6 +665,8 @@ fn cook_batch_result(
     let mut totals = crate::agent_task_batch::AgentTaskBatchTotals::default();
     for cell in &cooks {
         match cell.status.as_str() {
+            "queued" => totals.queued += 1,
+            "running" | "in_flight" => totals.running += 1,
             "cancelled" => totals.cancelled += 1,
             "timed_out" => totals.timed_out += 1,
             _ if cell.exit_code == 0 => totals.succeeded += 1,
@@ -678,6 +682,8 @@ fn cook_batch_result(
             batch_id,
             status: state.outcome_status().to_string(),
             total,
+            queued: totals.queued,
+            running: totals.running,
             succeeded: totals.succeeded,
             failed: totals.failed,
             cancelled: totals.cancelled,
@@ -807,7 +813,7 @@ fn cook_report_exit_code(report: &AgentTaskCookReport) -> i32 {
     // could not carry to a green, finalized state is a non-zero resume result
     // the operator must still act on.
     match report.status.as_str() {
-        "review_ready" | "green_no_finalize" => 0,
+        "queued" | "running" | "in_flight" | "review_ready" | "green_no_finalize" => 0,
         _ => {
             if report
                 .finalization

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -450,6 +450,7 @@ pub struct AgentTaskCookBatchOptions {
 pub struct AgentTaskCookBatchCellReport {
     pub cook_id: String,
     pub initial_run_id: String,
+    pub status: String,
     pub exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<AgentTaskCookReport>,
@@ -465,6 +466,8 @@ pub struct AgentTaskCookBatchReport {
     pub total: usize,
     pub succeeded: usize,
     pub failed: usize,
+    pub cancelled: usize,
+    pub timed_out: usize,
     pub cooks: Vec<AgentTaskCookBatchCellReport>,
 }
 
@@ -526,6 +529,7 @@ where
                     Ok(result) => AgentTaskCookBatchCellReport {
                         cook_id: cook.cook_id,
                         initial_run_id: cook.initial_run_id,
+                        status: result.value.status.clone(),
                         exit_code: result.exit_code,
                         result: Some(result.value),
                         error: None,
@@ -533,6 +537,7 @@ where
                     Err(error) => AgentTaskCookBatchCellReport {
                         cook_id: cook.cook_id,
                         initial_run_id: cook.initial_run_id,
+                        status: "failed".to_string(),
                         exit_code: 1,
                         result: None,
                         error: Some(error.to_string()),
@@ -622,6 +627,7 @@ where
                 AgentTaskCookBatchCellReport {
                     cook_id: report.cook_id.clone(),
                     initial_run_id: cook_id,
+                    status: report.status.clone(),
                     exit_code,
                     result: Some(report),
                     error: None,
@@ -630,6 +636,7 @@ where
             Err(error) => AgentTaskCookBatchCellReport {
                 cook_id: child.task_id.clone(),
                 initial_run_id: cook_id,
+                status: "failed".to_string(),
                 exit_code: 1,
                 result: None,
                 error: Some(error.to_string()),
@@ -653,13 +660,16 @@ fn cook_batch_result(
     cooks: Vec<AgentTaskCookBatchCellReport>,
 ) -> AgentTaskRunResult<AgentTaskCookBatchReport> {
     let total = cooks.len();
-    let failed = cooks.iter().filter(|cell| cell.exit_code != 0).count();
-    let state =
-        crate::agent_task_batch::aggregate_state(&crate::agent_task_batch::AgentTaskBatchTotals {
-            succeeded: total - failed,
-            failed,
-            ..Default::default()
-        });
+    let mut totals = crate::agent_task_batch::AgentTaskBatchTotals::default();
+    for cell in &cooks {
+        match cell.status.as_str() {
+            "cancelled" => totals.cancelled += 1,
+            "timed_out" => totals.timed_out += 1,
+            _ if cell.exit_code == 0 => totals.succeeded += 1,
+            _ => totals.failed += 1,
+        }
+    }
+    let state = crate::agent_task_batch::aggregate_state(&totals);
 
     AgentTaskRunResult {
         exit_code: state.exit_code(),
@@ -668,8 +678,10 @@ fn cook_batch_result(
             batch_id,
             status: state.outcome_status().to_string(),
             total,
-            succeeded: total - failed,
-            failed,
+            succeeded: totals.succeeded,
+            failed: totals.failed,
+            cancelled: totals.cancelled,
+            timed_out: totals.timed_out,
             cooks,
         },
     }
@@ -785,11 +797,7 @@ fn child_finalization_value(cell: &AgentTaskCookBatchCellReport) -> Value {
     serde_json::json!({
         "resumed_at": chrono::Utc::now().to_rfc3339(),
         "exit_code": cell.exit_code,
-        "status": cell
-            .result
-            .as_ref()
-            .map(|report| report.status.clone())
-            .unwrap_or_else(|| "error".to_string()),
+        "status": cell.status,
         "error": cell.error,
     })
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -654,18 +654,19 @@ fn cook_batch_result(
 ) -> AgentTaskRunResult<AgentTaskCookBatchReport> {
     let total = cooks.len();
     let failed = cooks.iter().filter(|cell| cell.exit_code != 0).count();
-    let status = match failed {
-        0 => "succeeded",
-        failed if failed == total => "failed",
-        _ => "partial_failure",
-    };
+    let state =
+        crate::agent_task_batch::aggregate_state(&crate::agent_task_batch::AgentTaskBatchTotals {
+            succeeded: total - failed,
+            failed,
+            ..Default::default()
+        });
 
     AgentTaskRunResult {
-        exit_code: if failed == 0 { 0 } else { 1 },
+        exit_code: state.exit_code(),
         value: AgentTaskCookBatchReport {
             schema: "homeboy/agent-task-cook-batch/v1",
             batch_id,
-            status: status.to_string(),
+            status: state.outcome_status().to_string(),
             total,
             succeeded: total - failed,
             failed,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2077,7 +2077,7 @@ fn cook_batch_preserves_order_concurrency_and_failure_isolation_process() {
 
     assert_eq!(entered.load(Ordering::SeqCst), 2);
     assert_eq!(result.exit_code, 1);
-    assert_eq!(result.value.status, "failed");
+    assert_eq!(result.value.status, "partial_failure");
     assert_eq!(result.value.total, 2);
     assert_eq!(result.value.succeeded, 1);
     assert_eq!(result.value.failed, 1);
@@ -2101,6 +2101,47 @@ fn cook_batch_preserves_order_concurrency_and_failure_isolation_process() {
             .status,
         "in_flight"
     );
+}
+
+#[test]
+fn cook_batch_aggregate_outcome_matrix_distinguishes_success_partial_and_failure() {
+    let cell = |id: &str, exit_code| AgentTaskCookBatchCellReport {
+        cook_id: id.to_string(),
+        initial_run_id: format!("{id}-run"),
+        exit_code,
+        result: None,
+        error: (exit_code != 0).then(|| "infrastructure admission failed".to_string()),
+    };
+
+    for (name, cells, status, exit_code) in [
+        (
+            "all-success",
+            vec![cell("one", 0), cell("two", 0)],
+            "succeeded",
+            0,
+        ),
+        (
+            "mixed",
+            vec![cell("one", 0), cell("two", 1)],
+            "partial_failure",
+            1,
+        ),
+        (
+            "all-failed",
+            vec![cell("one", 1), cell("two", 1)],
+            "failed",
+            1,
+        ),
+        ("infrastructure-error", vec![cell("one", 1)], "failed", 1),
+    ] {
+        let result = cook_batch_result(name.to_string(), cells);
+        assert_eq!(result.value.status, status, "{name}");
+        assert_eq!(result.exit_code, exit_code, "{name}");
+        assert_eq!(
+            result.value.succeeded + result.value.failed,
+            result.value.total
+        );
+    }
 }
 
 #[test]
@@ -4564,6 +4605,7 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
             .expect("resume harvests terminal children");
 
         assert_eq!(result.exit_code, 0, "both children finalize green");
+        assert_eq!(result.value.status, "succeeded");
         assert_eq!(result.value.total, 3);
         assert_eq!(result.value.succeeded, 3);
         assert_eq!(result.value.failed, 0);
@@ -4834,6 +4876,7 @@ fn resume_cook_batch_reports_a_child_with_no_recipe_as_unresumable() {
         .expect("resume returns a report even when a child cannot resume");
 
         assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status, "failed");
         assert_eq!(result.value.failed, 1);
         let cell = &result.value.cooks[0];
         assert_eq!(cell.exit_code, 1);

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2076,10 +2076,11 @@ fn cook_batch_preserves_order_concurrency_and_failure_isolation_process() {
     .expect("batch completes despite an individual cook failure");
 
     assert_eq!(entered.load(Ordering::SeqCst), 2);
-    assert_eq!(result.exit_code, 1);
-    assert_eq!(result.value.status, "partial_failure");
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.value.status, "running");
     assert_eq!(result.value.total, 2);
-    assert_eq!(result.value.succeeded, 1);
+    assert_eq!(result.value.succeeded, 0);
+    assert_eq!(result.value.running, 1);
     assert_eq!(result.value.failed, 1);
     assert_eq!(result.value.cooks[0].cook_id, "first");
     assert_eq!(result.value.cooks[0].exit_code, 1);
@@ -2154,6 +2155,19 @@ fn cook_batch_aggregate_outcome_matrix_distinguishes_success_partial_and_failure
             "timed_out",
             1,
         ),
+        ("in-flight", vec![cell("one", "in_flight", 0)], "running", 0),
+        (
+            "queued-with-terminal-child",
+            vec![cell("one", "queued", 0), cell("two", "review_ready", 0)],
+            "queued",
+            0,
+        ),
+        (
+            "running-with-terminal-child",
+            vec![cell("one", "running", 0), cell("two", "failed", 1)],
+            "running",
+            0,
+        ),
         (
             "infrastructure-error",
             vec![cell("one", "failed", 1)],
@@ -2168,7 +2182,9 @@ fn cook_batch_aggregate_outcome_matrix_distinguishes_success_partial_and_failure
             result.value.succeeded
                 + result.value.failed
                 + result.value.cancelled
-                + result.value.timed_out,
+                + result.value.timed_out
+                + result.value.queued
+                + result.value.running,
             result.value.total
         );
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2105,9 +2105,10 @@ fn cook_batch_preserves_order_concurrency_and_failure_isolation_process() {
 
 #[test]
 fn cook_batch_aggregate_outcome_matrix_distinguishes_success_partial_and_failure() {
-    let cell = |id: &str, exit_code| AgentTaskCookBatchCellReport {
+    let cell = |id: &str, status: &str, exit_code| AgentTaskCookBatchCellReport {
         cook_id: id.to_string(),
         initial_run_id: format!("{id}-run"),
+        status: status.to_string(),
         exit_code,
         result: None,
         error: (exit_code != 0).then(|| "infrastructure admission failed".to_string()),
@@ -2116,29 +2117,58 @@ fn cook_batch_aggregate_outcome_matrix_distinguishes_success_partial_and_failure
     for (name, cells, status, exit_code) in [
         (
             "all-success",
-            vec![cell("one", 0), cell("two", 0)],
+            vec![
+                cell("one", "review_ready", 0),
+                cell("two", "green_no_finalize", 0),
+            ],
             "succeeded",
             0,
         ),
         (
             "mixed",
-            vec![cell("one", 0), cell("two", 1)],
+            vec![cell("one", "review_ready", 0), cell("two", "failed", 1)],
             "partial_failure",
             1,
         ),
         (
             "all-failed",
-            vec![cell("one", 1), cell("two", 1)],
+            vec![cell("one", "failed", 1), cell("two", "failed", 1)],
             "failed",
             1,
         ),
-        ("infrastructure-error", vec![cell("one", 1)], "failed", 1),
+        (
+            "all-cancelled",
+            vec![cell("one", "cancelled", 1), cell("two", "cancelled", 1)],
+            "cancelled",
+            1,
+        ),
+        (
+            "cancelled-and-success",
+            vec![cell("one", "cancelled", 1), cell("two", "review_ready", 0)],
+            "partial_failure",
+            1,
+        ),
+        (
+            "timed-out",
+            vec![cell("one", "timed_out", 1)],
+            "timed_out",
+            1,
+        ),
+        (
+            "infrastructure-error",
+            vec![cell("one", "failed", 1)],
+            "failed",
+            1,
+        ),
     ] {
         let result = cook_batch_result(name.to_string(), cells);
         assert_eq!(result.value.status, status, "{name}");
         assert_eq!(result.exit_code, exit_code, "{name}");
         assert_eq!(
-            result.value.succeeded + result.value.failed,
+            result.value.succeeded
+                + result.value.failed
+                + result.value.cancelled
+                + result.value.timed_out,
             result.value.total
         );
     }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -133,14 +133,23 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )?;
     let exit_code = result.exit_code;
-    let report = result.value;
-    Ok((
+    Ok(batch_resume_result(result.value, exit_code, &args.batch_id))
+}
+
+fn batch_resume_result(
+    report: agent_task_service::AgentTaskCookBatchReport,
+    exit_code: i32,
+    batch_id: &str,
+) -> (Value, i32) {
+    (
         serde_json::json!({
             "schema": "homeboy/agent-task-cook-batch-resume/v1",
             "batch_id": report.batch_id,
             "status": report.status,
             "summary": {
                 "total": report.total,
+                "queued": report.queued,
+                "running": report.running,
                 "succeeded": report.succeeded,
                 "failed": report.failed,
                 "cancelled": report.cancelled,
@@ -148,13 +157,13 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
             },
             "cooks": report.cooks,
             "commands": {
-                "status": format!("homeboy agent-task fanout status {}", args.batch_id),
-                "artifacts": format!("homeboy agent-task fanout artifacts {}", args.batch_id),
-                "resume": format!("homeboy agent-task fanout resume {}", args.batch_id),
+                "status": format!("homeboy agent-task fanout status {batch_id}"),
+                "artifacts": format!("homeboy agent-task fanout artifacts {batch_id}"),
+                "resume": format!("homeboy agent-task fanout resume {batch_id}"),
             },
         }),
         exit_code,
-    ))
+    )
 }
 
 fn batch_artifacts(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
@@ -318,6 +327,8 @@ fn batch_cook_result(
             "status": report.status,
             "summary": {
                 "total": report.total,
+                "queued": report.queued,
+                "running": report.running,
                 "succeeded": report.succeeded,
                 "failed": report.failed,
                 "cancelled": report.cancelled,
@@ -1959,6 +1970,13 @@ mod tests {
         for cell in &mut all_failed_report.cooks {
             cell.exit_code = 1;
         }
+        let mut active_failed_report = result.value.clone();
+        active_failed_report.status = "running".to_string();
+        active_failed_report.queued = 0;
+        active_failed_report.running = 1;
+        active_failed_report.succeeded = 0;
+        active_failed_report.failed = 1;
+        active_failed_report.cooks[0].status = "in_flight".to_string();
         let (data, exit_code) = batch_cook_result(&plan, result);
         let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
             &Ok(data),
@@ -1992,6 +2010,34 @@ mod tests {
         assert_eq!(exit_code, 1);
         assert!(!envelope.success);
         assert_eq!(envelope.status, "failed");
+
+        let (immediate, exit_code) = batch_cook_result(
+            &plan,
+            agent_task_service::AgentTaskRunResult {
+                exit_code: 0,
+                value: active_failed_report.clone(),
+            },
+        );
+        let (resumed, resume_exit_code) =
+            batch_resume_result(active_failed_report, 0, "test-batch");
+        for (name, value, code) in [
+            ("immediate", immediate, exit_code),
+            ("resume", resumed, resume_exit_code),
+        ] {
+            assert_eq!(value["status"], "running", "{name}");
+            assert_eq!(code, 0, "{name}");
+            let summary = &value["summary"];
+            assert_eq!(
+                summary["queued"].as_u64().unwrap_or_default()
+                    + summary["running"].as_u64().unwrap_or_default()
+                    + summary["succeeded"].as_u64().unwrap_or_default()
+                    + summary["failed"].as_u64().unwrap_or_default()
+                    + summary["cancelled"].as_u64().unwrap_or_default()
+                    + summary["timed_out"].as_u64().unwrap_or_default(),
+                summary["total"].as_u64().unwrap_or_default(),
+                "{name}"
+            );
+        }
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -397,7 +397,10 @@ fn cook_batch_inner(
     } else {
         "ready"
     };
-    let exit_code = if blocked == 0 { 0 } else { 1 };
+    // A completed batch's aggregate result is authoritative. Worktree blocking
+    // remains a pre-execution failure, while child failures retain their durable
+    // evidence and produce the same nonzero result at every CLI boundary.
+    let exit_code = cook_batch_outer_exit_code(blocked, &run_result);
 
     Ok((
         serde_json::json!({
@@ -426,6 +429,17 @@ fn cook_batch_inner(
         }),
         exit_code,
     ))
+}
+
+fn cook_batch_outer_exit_code(blocked: usize, run_result: &Option<Value>) -> i32 {
+    if blocked > 0 {
+        1
+    } else {
+        run_result
+            .as_ref()
+            .and_then(|value| value["exit_code"].as_i64())
+            .unwrap_or(0) as i32
+    }
 }
 
 fn queue_or_reuse_worktrees(
@@ -1890,6 +1904,91 @@ mod tests {
             .as_str()
             .expect("resume command")
             .contains("fanout run-plan"));
+    }
+
+    #[test]
+    fn batch_cook_cli_envelope_preserves_partial_failure_and_nonzero_exit() {
+        let plan = test_batch_plan();
+        let result = agent_task_service::AgentTaskRunResult {
+            exit_code: 1,
+            value: agent_task_service::AgentTaskCookBatchReport {
+                schema: "homeboy/agent-task-cook-batch/v1",
+                batch_id: plan.fanout_id.clone(),
+                status: "partial_failure".to_string(),
+                total: 2,
+                succeeded: 1,
+                failed: 1,
+                cooks: vec![
+                    agent_task_service::AgentTaskCookBatchCellReport {
+                        cook_id: "first".to_string(),
+                        initial_run_id: "first-run".to_string(),
+                        exit_code: 0,
+                        result: None,
+                        error: None,
+                    },
+                    agent_task_service::AgentTaskCookBatchCellReport {
+                        cook_id: "second".to_string(),
+                        initial_run_id: "second-run".to_string(),
+                        exit_code: 1,
+                        result: None,
+                        error: Some("controller admission failed".to_string()),
+                    },
+                ],
+            },
+        };
+        let mut all_failed_report = result.value.clone();
+        all_failed_report.status = "failed".to_string();
+        all_failed_report.succeeded = 0;
+        all_failed_report.failed = 2;
+        for cell in &mut all_failed_report.cooks {
+            cell.exit_code = 1;
+        }
+        let (data, exit_code) = batch_cook_result(&plan, result);
+        let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
+            &Ok(data),
+            exit_code,
+            "agent-task fanout cook-batch",
+            None,
+        );
+
+        assert_eq!(exit_code, 1);
+        assert!(!envelope.success);
+        assert_eq!(envelope.exit_code, 1);
+        assert_eq!(envelope.status, "partial_failure");
+        assert_eq!(
+            envelope.data.expect("batch data")["status"],
+            "partial_failure"
+        );
+
+        let (data, exit_code) = batch_cook_result(
+            &plan,
+            agent_task_service::AgentTaskRunResult {
+                exit_code: 1,
+                value: all_failed_report,
+            },
+        );
+        let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
+            &Ok(data),
+            exit_code,
+            "agent-task fanout cook-batch",
+            None,
+        );
+        assert_eq!(exit_code, 1);
+        assert!(!envelope.success);
+        assert_eq!(envelope.status, "failed");
+    }
+
+    #[test]
+    fn cook_batch_outer_exit_code_uses_completed_child_outcome() {
+        assert_eq!(cook_batch_outer_exit_code(0, &None), 0);
+        assert_eq!(
+            cook_batch_outer_exit_code(0, &Some(json!({ "exit_code": 1 }))),
+            1
+        );
+        assert_eq!(
+            cook_batch_outer_exit_code(1, &Some(json!({ "exit_code": 0 }))),
+            1
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -143,6 +143,8 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
                 "total": report.total,
                 "succeeded": report.succeeded,
                 "failed": report.failed,
+                "cancelled": report.cancelled,
+                "timed_out": report.timed_out,
             },
             "cooks": report.cooks,
             "commands": {
@@ -314,7 +316,13 @@ fn batch_cook_result(
             "schema": AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
             "fanout_id": plan.fanout_id,
             "status": report.status,
-            "summary": { "total": report.total, "succeeded": report.succeeded, "failed": report.failed },
+            "summary": {
+                "total": report.total,
+                "succeeded": report.succeeded,
+                "failed": report.failed,
+                "cancelled": report.cancelled,
+                "timed_out": report.timed_out,
+            },
             "cooks": cooks,
             "commands": {
                 "status": format!("homeboy agent-task fanout status {}", plan.fanout_id),
@@ -1920,10 +1928,13 @@ mod tests {
                 total: 2,
                 succeeded: 1,
                 failed: 1,
+                cancelled: 0,
+                timed_out: 0,
                 cooks: vec![
                     agent_task_service::AgentTaskCookBatchCellReport {
                         cook_id: "first".to_string(),
                         initial_run_id: "first-run".to_string(),
+                        status: "review_ready".to_string(),
                         exit_code: 0,
                         result: None,
                         error: None,
@@ -1931,6 +1942,7 @@ mod tests {
                     agent_task_service::AgentTaskCookBatchCellReport {
                         cook_id: "second".to_string(),
                         initial_run_id: "second-run".to_string(),
+                        status: "failed".to_string(),
                         exit_code: 1,
                         result: None,
                         error: Some("controller admission failed".to_string()),
@@ -1994,24 +2006,35 @@ mod tests {
     }
 
     #[test]
-    fn durable_failed_batch_status_envelope_is_unsuccessful() {
-        let state = batch::AgentTaskBatchState::Failed;
-        let exit_code = state.exit_code();
-        let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
-            &Ok(json!({ "batch": { "state": state.outcome_status() } })),
-            exit_code,
-            "agent-task fanout status",
-            None,
-        );
+    fn durable_batch_status_envelope_preserves_canonical_terminal_state() {
+        for state in [
+            batch::AgentTaskBatchState::Succeeded,
+            batch::AgentTaskBatchState::PartialFailure,
+            batch::AgentTaskBatchState::Failed,
+            batch::AgentTaskBatchState::Cancelled,
+            batch::AgentTaskBatchState::TimedOut,
+        ] {
+            let exit_code = state.exit_code();
+            let envelope =
+                crate::commands::utils::response::cli_response_for_json_result_for_command(
+                    &Ok(json!({
+                        "status": state.outcome_status(),
+                        "batch": { "state": state.outcome_status() }
+                    })),
+                    exit_code,
+                    "agent-task fanout status",
+                    None,
+                );
 
-        assert_eq!(exit_code, 1);
-        assert!(!envelope.success);
-        assert_eq!(envelope.exit_code, 1);
-        assert_eq!(envelope.status, "failed");
-        assert_eq!(
-            envelope.data.expect("durable status")["batch"]["state"],
-            "failed"
-        );
+            assert_eq!(envelope.success, exit_code == 0, "{state:?}");
+            assert_eq!(envelope.exit_code, exit_code, "{state:?}");
+            assert_eq!(envelope.status, state.outcome_status(), "{state:?}");
+            assert_eq!(
+                envelope.data.expect("durable status")["batch"]["state"],
+                state.outcome_status(),
+                "{state:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1926,6 +1926,8 @@ mod tests {
                 batch_id: plan.fanout_id.clone(),
                 status: "partial_failure".to_string(),
                 total: 2,
+                queued: 0,
+                running: 0,
                 succeeded: 1,
                 failed: 1,
                 cancelled: 0,
@@ -2008,6 +2010,8 @@ mod tests {
     #[test]
     fn durable_batch_status_envelope_preserves_canonical_terminal_state() {
         for state in [
+            batch::AgentTaskBatchState::Queued,
+            batch::AgentTaskBatchState::Running,
             batch::AgentTaskBatchState::Succeeded,
             batch::AgentTaskBatchState::PartialFailure,
             batch::AgentTaskBatchState::Failed,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -116,7 +116,9 @@ fn submit_fanout_batch(args: AgentTaskFanoutSubmitBatchArgs) -> CmdResult<Value>
 }
 
 fn batch_status(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
-    Ok((command_json_value(batch::status(&args.batch_id)?)?, 0))
+    let report = batch::status(&args.batch_id)?;
+    let exit_code = report.batch.state.exit_code();
+    Ok((command_json_value(report)?, exit_code))
 }
 
 /// Resume a durable fanout batch after its synchronous coordinator exited.
@@ -1988,6 +1990,27 @@ mod tests {
         assert_eq!(
             cook_batch_outer_exit_code(1, &Some(json!({ "exit_code": 0 }))),
             1
+        );
+    }
+
+    #[test]
+    fn durable_failed_batch_status_envelope_is_unsuccessful() {
+        let state = batch::AgentTaskBatchState::Failed;
+        let exit_code = state.exit_code();
+        let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
+            &Ok(json!({ "batch": { "state": state.outcome_status() } })),
+            exit_code,
+            "agent-task fanout status",
+            None,
+        );
+
+        assert_eq!(exit_code, 1);
+        assert!(!envelope.success);
+        assert_eq!(envelope.exit_code, 1);
+        assert_eq!(envelope.status, "failed");
+        assert_eq!(
+            envelope.data.expect("durable status")["batch"]["state"],
+            "failed"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -826,14 +826,19 @@ fn tail_text(value: String) -> String {
 }
 
 fn status_for_result(data: Option<&Value>, exit_code: i32) -> String {
+    let payload_status = data
+        .and_then(|value| value.get("status").and_then(Value::as_str))
+        .and_then(normalize_status);
     if exit_code != 0 {
+        // A partial result is still a command failure, but retaining its precise
+        // aggregate state lets machine consumers distinguish it from all-failed.
+        if payload_status == Some("partial_failure") {
+            return "partial_failure".to_string();
+        }
         return "failed".to_string();
     }
 
-    data.and_then(|value| value.get("status").and_then(Value::as_str))
-        .and_then(normalize_status)
-        .unwrap_or("succeeded")
-        .to_string()
+    payload_status.unwrap_or("succeeded").to_string()
 }
 
 fn normalize_status(status: &str) -> Option<&'static str> {

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -827,13 +827,23 @@ fn tail_text(value: String) -> String {
 
 fn status_for_result(data: Option<&Value>, exit_code: i32) -> String {
     let payload_status = data
-        .and_then(|value| value.get("status").and_then(Value::as_str))
+        .and_then(|value| {
+            value
+                .get("status")
+                .and_then(Value::as_str)
+                .or_else(|| value.pointer("/batch/state").and_then(Value::as_str))
+        })
         .and_then(normalize_status);
     if exit_code != 0 {
         // A partial result is still a command failure, but retaining its precise
         // aggregate state lets machine consumers distinguish it from all-failed.
-        if payload_status == Some("partial_failure") {
-            return "partial_failure".to_string();
+        if matches!(
+            payload_status,
+            Some("partial_failure" | "cancelled" | "timed_out")
+        ) {
+            return payload_status
+                .expect("matched canonical status")
+                .to_string();
         }
         return "failed".to_string();
     }

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -237,6 +237,9 @@ results and durable evidence remain available for `fanout status`, `artifacts`,
 and `resume`. This changes prior behavior where a failed `cook-batch --run-plan`
 could report a zero exit code; callers must treat nonzero as an unsuccessful batch.
 `fanout status` and `fanout resume` use the same aggregate state and exit policy.
+Active child cooks remain `queued` or `running` (including detached `in_flight`
+handoffs) with exit zero; a resume retains active children until their durable
+lifecycle reaches a terminal state.
 
 The generated plan uses the existing
 `homeboy/agent-task-batch-cook-fanout-plan/v1` contract. That means operators can

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -236,6 +236,7 @@ and exits non-zero; `failed` means every child failed and exits non-zero. Child
 results and durable evidence remain available for `fanout status`, `artifacts`,
 and `resume`. This changes prior behavior where a failed `cook-batch --run-plan`
 could report a zero exit code; callers must treat nonzero as an unsuccessful batch.
+`fanout status` and `fanout resume` use the same aggregate state and exit policy.
 
 The generated plan uses the existing
 `homeboy/agent-task-batch-cook-fanout-plan/v1` contract. That means operators can

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -229,6 +229,14 @@ by an active lock or another queue issue, the output reports `status: blocked`,
 lists the exact worktree rows and retry commands, and exits non-zero before any
 provider process starts.
 
+Completed cook batches use one aggregate outcome across the result payload, the
+`homeboy/command-result/v3` envelope, and the shell exit code: `succeeded` exits
+zero; `partial_failure` means at least one child succeeded and at least one failed,
+and exits non-zero; `failed` means every child failed and exits non-zero. Child
+results and durable evidence remain available for `fanout status`, `artifacts`,
+and `resume`. This changes prior behavior where a failed `cook-batch --run-plan`
+could report a zero exit code; callers must treat nonzero as an unsuccessful batch.
+
 The generated plan uses the existing
 `homeboy/agent-task-batch-cook-fanout-plan/v1` contract. That means operators can
 save the returned `plan` object and resume with:


### PR DESCRIPTION
## Summary
- derive cook-batch aggregate status from durable child results: `succeeded`, `partial_failure`, or `failed`
- propagate a completed batch failure through the public wrapper, command-result envelope, and process exit code
- retain child evidence and document the nonzero-exit compatibility change

Closes #9839

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents cook_batch_ --lib`
- `cargo test -p homeboy-cli fanout::tests::batch_cook_cli_envelope_preserves_partial_failure_and_nonzero_exit --lib`
- `cargo test -p homeboy-cli fanout::tests::cook_batch_outer_exit_code_uses_completed_child_outcome --lib`
- `cargo test --workspace` (fails in unrelated `stale_linked_rig_recovery::hermetic_fixture_command_cannot_use_operator_paths_or_installed_homeboy`, which rejects the current operator environment)

## AI Assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: inspected the batch result and CLI exit paths, implemented aggregate outcome semantics and tests, and drafted this change. Chris remains responsible for every line.