### PR TITLE
fix(lab): retain detached Cook plan files

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -540,6 +540,12 @@ pub(super) struct FileUploadRequest {
     #[serde(default)]
     workspace_root: Option<String>,
     content_base64: String,
+    #[serde(default)]
+    sha256: Option<String>,
+    #[serde(default)]
+    private: bool,
+    #[serde(default)]
+    atomic: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/homeboy-core/src/daemon/runner_files.rs
+++ b/crates/homeboy-core/src/daemon/runner_files.rs
@@ -3,10 +3,12 @@
 //! paths safely within the runner root. Extracted from the `daemon` god file.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use base64::Engine;
 use serde_json::json;
+use sha2::Digest;
 
 use super::remote_runner;
 use super::runner_workspace_root;
@@ -75,9 +77,59 @@ pub(super) fn upload_runner_file(
                 None,
             )
         })?;
-    fs::write(&path, &content).map_err(|err| {
-        Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
-    })?;
+    if let Some(expected) = request.sha256.as_deref() {
+        let actual = format!("{:x}", sha2::Sha256::digest(&content));
+        if actual != expected {
+            return Err(Error::validation_invalid_argument(
+                "sha256",
+                "runner file upload content does not match its declared SHA-256",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+    }
+    if request.private || request.atomic {
+        let temp = path.with_file_name(format!(
+            ".{}.{}.tmp",
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("upload"),
+            uuid::Uuid::new_v4()
+        ));
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temp).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("create {}", temp.display())))
+        })?;
+        let write = file.write_all(&content).and_then(|_| file.sync_all());
+        if let Err(err) = write {
+            let _ = fs::remove_file(&temp);
+            return Err(Error::internal_io(
+                err.to_string(),
+                Some(format!("write {}", temp.display())),
+            ));
+        }
+        #[cfg(unix)]
+        if request.private {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&temp, fs::Permissions::from_mode(0o600)).map_err(|err| {
+                Error::internal_io(err.to_string(), Some(format!("chmod {}", temp.display())))
+            })?;
+        }
+        fs::rename(&temp, &path).map_err(|err| {
+            let _ = fs::remove_file(&temp);
+            Error::internal_io(err.to_string(), Some(format!("publish {}", path.display())))
+        })?;
+    } else {
+        fs::write(&path, &content).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
+        })?;
+    }
     Ok(json!({
         "runner_id": request.runner_id,
         "path": path.display().to_string(),

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -807,6 +807,11 @@ impl SshClient {
         self.execute_with_stdin(&remote_command, SshStdin::File(local_path))
     }
 
+    pub fn upload_file_private(&self, local_path: &str, remote_path: &str) -> CommandOutput {
+        let remote_command = format!("umask 077; cat > {}", shell::quote_path(remote_path));
+        self.execute_with_stdin(&remote_command, SshStdin::File(local_path))
+    }
+
     pub fn download_file(&self, remote_path: &str, local_path: &str) -> CommandOutput {
         if self.is_local {
             return match std::fs::copy(remote_path, local_path) {

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1137,7 +1137,26 @@ fn handle_reverse_broker_request(
         if let Some(parent) = Path::new(path).parent() {
             std::fs::create_dir_all(parent).expect("broker fixture upload parent");
         }
-        std::fs::write(path, content).expect("broker fixture upload write");
+        if request.body["private"].as_bool().unwrap_or(false) {
+            use std::io::Write;
+            let temporary = format!("{path}.fixture-private.tmp");
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            let mut file = options
+                .open(&temporary)
+                .expect("broker fixture private create");
+            file.write_all(&content)
+                .expect("broker fixture private write");
+            file.sync_all().expect("broker fixture private sync");
+            std::fs::rename(&temporary, path).expect("broker fixture private publish");
+        } else {
+            std::fs::write(path, content).expect("broker fixture upload write");
+        }
         return ok(json!({ "uploaded": true }));
     }
     if request.method == "POST" && request.path == "/files/download" {

--- a/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
+++ b/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
@@ -8,6 +8,7 @@
 //! - The legacy dispatch-envelope parser is retained only for pre-typed runners
 //!   that cannot surface the handoff through workload events/results.
 
+#[cfg(test)]
 use std::fs;
 
 use crate::agent_task_lifecycle_event::{
@@ -18,13 +19,12 @@ use homeboy_agents::agent_task::AgentTaskEvidenceRef;
 use homeboy_agents::agent_task_lifecycle::{
     cook_attempt_run_id, AgentTaskArtifactRef, AgentTaskRunRecord, AgentTaskRunState,
 };
-use homeboy_agents::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy_agents::agent_tasks::provider::{
     dependency_failure_patterns, AgentTaskProviderDependencyFailurePattern,
 };
-use homeboy_agents::agent_tasks::scheduler::{
-    AgentTaskAggregate, AgentTaskAggregateTotals, AgentTaskPlan,
-};
+use homeboy_agents::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskAggregateTotals};
+#[cfg(test)]
+use homeboy_agents::agent_tasks::{lifecycle as agent_task_lifecycle, scheduler::AgentTaskPlan};
 use homeboy_core::api_jobs::JobEvent;
 #[cfg(test)]
 use homeboy_core::api_jobs::JobEventKind;
@@ -40,9 +40,10 @@ use serde_json::Value;
 
 #[cfg(test)]
 use super::super::lab_args::materialize_inline_agent_task_json_specs_in_args;
-use super::super::lab_args::AgentTaskInlineJsonSpec;
+#[cfg(test)]
 use super::super::lab_workspaces::{workspace_mapping_entry, LabWorkspaceMappingEntry};
-use super::super::{sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
+#[cfg(test)]
+use super::super::RunnerWorkspaceSyncMode;
 use super::args_util::{subcommand_index, ArgEditor, CommandInvocation};
 use homeboy_agents::agent_task_promotion::mirror_agent_task_run_plan_aggregate;
 
@@ -67,58 +68,10 @@ fn materialize_inline_agent_task_tasks_arg_with(
     ))
 }
 
-pub(super) fn sync_inline_agent_task_file(
-    runner_id: &str,
-    spec: AgentTaskInlineJsonSpec<'_>,
-) -> Result<Option<(String, LabWorkspaceMappingEntry)>> {
-    serde_json::from_str::<serde_json::Value>(spec.spec).map_err(|err| {
-        Error::internal_json(
-            err.to_string(),
-            Some("parse remapped agent-task plan".to_string()),
-        )
-    })?;
-
-    let temp = tempfile::tempdir().map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some("create remapped agent-task plan workspace".to_string()),
-        )
-    })?;
-    let plan_file = temp.path().join(spec.filename);
-    if spec.role == "agent_task_attempt_plan_remapped" {
-        write_private_remapped_agent_task_plan(&plan_file, spec.spec)?;
-    } else {
-        fs::write(&plan_file, spec.spec).map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some("write remapped agent-task plan".to_string()),
-            )
-        })?;
-    }
-    let synced = sync_workspace(
-        runner_id,
-        RunnerWorkspaceSyncOptions {
-            path: temp.path().display().to_string(),
-            mode: RunnerWorkspaceSyncMode::Snapshot,
-            controller_routed_git: false,
-            changed_since_base: None,
-            git_fetch_refs: Vec::new(),
-            snapshot_includes: Vec::new(),
-            allow_dirty_lab_workspace: false,
-            run_isolation_token: None,
-        },
-    )?
-    .0;
-    let remote_spec = format!(
-        "@{}/{}",
-        synced.remote_path.trim_end_matches('/'),
-        spec.filename
-    );
-    let entry = workspace_mapping_entry(spec.role, &synced);
-    Ok(Some((remote_spec, entry)))
-}
-
-fn write_private_remapped_agent_task_plan(path: &std::path::Path, contents: &str) -> Result<()> {
+pub(crate) fn write_private_remapped_agent_task_plan(
+    path: &std::path::Path,
+    contents: &str,
+) -> Result<()> {
     write_file_owner_only(path, contents, "write remapped agent-task plan")
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -277,15 +277,22 @@ pub(crate) fn materialize_lab_at_files_on_runner(
                 format!("failed to create remote parent directory: {}", err.message),
             )
         })?;
-        transfer
-            .upload_file(&spec.local_path.display().to_string(), &spec.remote_path)
-            .map_err(|err| {
-                lab_at_file_materialization_error(
-                    runner_id,
-                    spec,
-                    format!("failed to upload file: {}", err.message),
-                )
-            })?;
+        let upload = if spec.private {
+            transfer.upload_private_file_atomic(
+                &spec.local_path.display().to_string(),
+                &spec.remote_path,
+                &spec.content_sha256,
+            )
+        } else {
+            transfer.upload_file(&spec.local_path.display().to_string(), &spec.remote_path)
+        };
+        upload.map_err(|err| {
+            lab_at_file_materialization_error(
+                runner_id,
+                spec,
+                format!("failed to upload file: {}", err.message),
+            )
+        })?;
     }
 
     Ok(())

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -132,7 +132,7 @@ use super::super::workload::{
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_lifecycle_identity_with,
     lab_pre_dispatch_failure_message, mirror_agent_task_run_plan_lifecycle,
-    parse_offloaded_agent_task_handoff_from_outputs, sync_inline_agent_task_file,
+    parse_offloaded_agent_task_handoff_from_outputs,
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::fallback::{

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -531,11 +531,14 @@ fn prepare_lab_offload_workspace_stage_inner(
                     )
                 })?;
             }
-            let specs = lab_at_file_specs(
+            let mut specs = lab_at_file_specs(
                 &[format!("@{}", plan_file.display())],
                 Path::new(&synced.local_path),
                 &remote_cwd,
             )?;
+            for file in &mut specs {
+                file.require_private();
+            }
             materialize_lab_at_files_on_runner(runner_id, &specs)?;
             let file = specs
                 .into_iter()

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1,6 +1,7 @@
 //! Workspace sync / remap staging for the standard (non-resident) offload path.
 
 use super::*;
+use crate::lab_workspaces::workspace_mapping_entry_for_materialized_file;
 use crate::offload_changed_since::{
     degrade_changed_since_to_full_scope, remove_controller_changed_since_args,
 };
@@ -510,7 +511,45 @@ fn prepare_lab_offload_workspace_stage_inner(
         &remapped_args,
         &path_remaps,
         Path::new(&synced.local_path),
-        |spec| sync_inline_agent_task_file(runner_id, spec),
+        |spec| {
+            let temp = tempfile::tempdir().map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some("create remapped agent-task plan workspace".to_string()),
+                )
+            })?;
+            let plan_file = temp.path().join(spec.filename);
+            if spec.role == "agent_task_attempt_plan_remapped" {
+                crate::lab::agent_task_bridge::write_private_remapped_agent_task_plan(
+                    &plan_file, spec.spec,
+                )?;
+            } else {
+                std::fs::write(&plan_file, spec.spec).map_err(|err| {
+                    Error::internal_io(
+                        err.to_string(),
+                        Some("write remapped agent-task plan".to_string()),
+                    )
+                })?;
+            }
+            let specs = lab_at_file_specs(
+                &[format!("@{}", plan_file.display())],
+                Path::new(&synced.local_path),
+                &remote_cwd,
+            )?;
+            materialize_lab_at_files_on_runner(runner_id, &specs)?;
+            let file = specs
+                .into_iter()
+                .next()
+                .ok_or_else(|| Error::internal_unexpected("missing remapped agent-task file"))?;
+            Ok(Some((
+                file.remote_spec.clone(),
+                workspace_mapping_entry_for_materialized_file(
+                    spec.role,
+                    file.local_path.display().to_string(),
+                    file.remote_path,
+                ),
+            )))
+        },
     )?;
     let remapped_args = agent_task_specs.argv;
     for synced_entry in agent_task_specs.workspace_entries {

--- a/crates/homeboy-lab-runner/src/lab_args/at_files.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/at_files.rs
@@ -18,6 +18,31 @@ pub(crate) struct LabAtFileSpec {
     pub(crate) local_path: PathBuf,
     pub(crate) remote_spec: String,
     pub(crate) remote_path: String,
+    pub(crate) content_sha256: String,
+    pub(crate) private: bool,
+}
+
+impl LabAtFileSpec {
+    /// Attempt plans can contain provider inputs and must remain owner-readable
+    /// while waiting in the durable reverse queue.
+    pub(crate) fn require_private(&mut self) {
+        self.private = true;
+        let filename = self
+            .local_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("input");
+        let parent = self
+            .remote_path
+            .rsplit_once('/')
+            .map_or(".", |(parent, _)| parent);
+        self.remote_path = format!(
+            "{parent}/private-sha256-{}-{}",
+            self.content_sha256,
+            sanitize_remote_filename(filename)
+        );
+        self.remote_spec = format!("@{}", self.remote_path);
+    }
 }
 
 pub(crate) fn lab_at_file_specs(
@@ -156,12 +181,22 @@ fn resolve_at_file_spec(
                 Some(format!("canonicalize Lab @file {}", candidate.display())),
             )
         })?;
-        let remote_path = remote_path_for_at_file(&local_path, raw_path, remote_cwd);
+        let content = std::fs::read(&local_path).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("read Lab @file {}", local_path.display())),
+            )
+        })?;
+        let content_sha256 = format!("{:x}", Sha256::digest(&content));
+        let remote_path =
+            remote_path_for_at_file(&content_sha256, local_path.file_name(), remote_cwd);
         return Ok(LabAtFileSpec {
             original_spec: spec.to_string(),
             local_path,
             remote_spec: format!("@{remote_path}"),
             remote_path,
+            content_sha256,
+            private: false,
         });
     }
 
@@ -173,20 +208,16 @@ fn resolve_at_file_spec(
     ))
 }
 
-fn remote_path_for_at_file(local_path: &Path, raw_path: &str, remote_cwd: &str) -> String {
-    let mut digest = Sha256::new();
-    digest.update(local_path.display().to_string().as_bytes());
-    digest.update(b"\0");
-    digest.update(raw_path.as_bytes());
-    let digest = format!("{:x}", digest.finalize());
-    let filename = local_path
-        .file_name()
-        .and_then(|value| value.to_str())
-        .unwrap_or("input");
+fn remote_path_for_at_file(
+    content_sha256: &str,
+    filename: Option<&std::ffi::OsStr>,
+    remote_cwd: &str,
+) -> String {
+    let filename = filename.and_then(|value| value.to_str()).unwrap_or("input");
     format!(
-        "{}/.homeboy/lab-at-files/{}-{}",
+        "{}/.homeboy/lab-at-files/sha256-{}-{}",
         remote_cwd.trim_end_matches('/'),
-        &digest[..16],
+        content_sha256,
         sanitize_remote_filename(filename)
     )
 }

--- a/crates/homeboy-lab-runner/src/lab_args/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/mod.rs
@@ -27,13 +27,13 @@ mod workspace_contract_tests;
 /// Lab offload rewriting can distinguish it from synthesized passthrough args.
 pub(super) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
 
+pub(super) use agent_task_specs::materialize_agent_task_specs_in_args;
 #[cfg(test)]
 pub(super) use agent_task_specs::materialize_inline_agent_task_json_specs_in_args;
 #[cfg(test)]
 pub(super) use agent_task_specs::{
     inline_agent_task_prompt_files_in_args, remap_agent_task_plan_in_args,
 };
-pub(super) use agent_task_specs::{materialize_agent_task_specs_in_args, AgentTaskInlineJsonSpec};
 pub(super) use at_files::{lab_at_file_specs, remap_lab_at_file_args, LabAtFileSpec};
 pub(super) use offload::{
     lab_offload_source_path, rewrite_lab_offload_args, rewrite_runner_resident_lab_offload_args,

--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -222,6 +222,25 @@ pub(super) fn workspace_mapping_entry(
     }
 }
 
+/// Record a file that was explicitly transferred into the primary workspace.
+/// Its controller-side staging file is intentionally short-lived, while the
+/// runner-resident path remains available to a later durable dispatch.
+pub(super) fn workspace_mapping_entry_for_materialized_file(
+    role: impl Into<String>,
+    local_path: impl Into<String>,
+    remote_path: impl Into<String>,
+) -> LabWorkspaceMappingEntry {
+    LabWorkspaceMappingEntry {
+        role: role.into(),
+        local_path: local_path.into(),
+        remote_path: remote_path.into(),
+        sync_mode: "explicit_file_transfer".to_string(),
+        snapshot_identity: "runner_resident".to_string(),
+        dependency_freshness: None,
+        source_provenance: None,
+    }
+}
+
 /// Build a workspace-mapping entry for a declared dependency checkout that the
 /// primary workspace sync already materialized on the runner (as a sibling of
 /// the primary remote path). Folding these into the offload workspace mapping

--- a/crates/homeboy-lab-runner/src/transport.rs
+++ b/crates/homeboy-lab-runner/src/transport.rs
@@ -6,6 +6,7 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::json;
 use serde_json::Value;
+use sha2::Digest;
 
 use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, ErrorCode, Result};
@@ -250,6 +251,82 @@ impl RunnerFileTransfer {
         Ok(())
     }
 
+    /// Publish a private file only after its content hash and owner-only mode
+    /// are established. The temporary file is never visible at the final path.
+    pub(crate) fn upload_private_file_atomic(
+        &self,
+        local_path: &str,
+        remote_path: &str,
+        expected_sha256: &str,
+    ) -> Result<()> {
+        let content = fs::read(local_path).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("read {local_path}")))
+        })?;
+        let actual_sha256 = format!("{:x}", sha2::Sha256::digest(&content));
+        if actual_sha256 != expected_sha256 {
+            return Err(Error::validation_invalid_argument(
+                "at_file",
+                "private runner file content does not match its declared SHA-256",
+                Some(remote_path.to_string()),
+                None,
+            ));
+        }
+        let temp_path = format!("{remote_path}.{}.tmp", uuid::Uuid::new_v4());
+        let result = match &self.channel {
+            RunnerFileChannel::DirectSsh(client) => {
+                let upload = client.upload_file_private(local_path, &temp_path);
+                if !upload.success {
+                    Err(file_transfer_operation_error(
+                        &self.runner_id,
+                        "private upload",
+                        remote_path,
+                        upload.stderr,
+                        "direct_ssh",
+                    ))
+                } else {
+                    let publish = client.execute(&format!(
+                        "test \"$(shasum -a 256 {} | awk '{{print $1}}')\" = {} && chmod 600 {} && mv -f {} {}",
+                        shell::quote_arg(&temp_path),
+                        shell::quote_arg(expected_sha256),
+                        shell::quote_arg(&temp_path),
+                        shell::quote_arg(&temp_path),
+                        shell::quote_arg(remote_path),
+                    ));
+                    if publish.success {
+                        Ok(())
+                    } else {
+                        Err(file_transfer_operation_error(
+                            &self.runner_id,
+                            "private publish",
+                            remote_path,
+                            publish.stderr,
+                            "direct_ssh",
+                        ))
+                    }
+                }
+            }
+            RunnerFileChannel::DaemonHttp { .. } | RunnerFileChannel::BrokerHttp { .. } => {
+                self.http_post_json(
+                    "/files/upload",
+                    self.private_file_upload_body(
+                        remote_path,
+                        base64::engine::general_purpose::STANDARD.encode(content),
+                        expected_sha256,
+                    ),
+                    "private upload",
+                    remote_path,
+                )?;
+                Ok(())
+            }
+        };
+        if result.is_err() {
+            if let RunnerFileChannel::DirectSsh(client) = &self.channel {
+                let _ = client.execute(&format!("rm -f {}", shell::quote_arg(&temp_path)));
+            }
+        }
+        result
+    }
+
     pub(crate) fn download_file(&self, remote_path: &str, local_path: &str) -> Result<()> {
         match &self.channel {
             RunnerFileChannel::DirectSsh(client) => {
@@ -354,6 +431,18 @@ impl RunnerFileTransfer {
             "path": path,
             "workspace_root": &self.workspace_root,
             "content_base64": content_base64,
+        })
+    }
+
+    fn private_file_upload_body(&self, path: &str, content_base64: String, sha256: &str) -> Value {
+        json!({
+            "runner_id": &self.runner_id,
+            "path": path,
+            "workspace_root": &self.workspace_root,
+            "content_base64": content_base64,
+            "sha256": sha256,
+            "private": true,
+            "atomic": true,
         })
     }
 }

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -268,7 +268,7 @@ fn run_once_output(
     let mut execution_envelope = claim.request.execution_envelope();
     let _command_assets =
         materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
-    let _private_at_files = verify_private_at_files(&execution_envelope)?;
+    let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
     materialize_snapshot_git_baseline(&execution_envelope)?;
     // Shared finisher so the exec-error and exec-success paths submit their
     // terminal job result through identical broker plumbing (#5091).
@@ -394,34 +394,49 @@ fn run_once_output(
 /// Verify them after a durable claim and before starting the child, then remove
 /// them after execution so retries can resume before claim without retaining
 /// plaintext after consumption.
-struct PrivateAtFileCleanup(Vec<std::path::PathBuf>);
+#[derive(Debug)]
+pub(super) struct PrivateAtFileCleanup(Vec<std::path::PathBuf>);
 
 impl Drop for PrivateAtFileCleanup {
     fn drop(&mut self) {
-        for path in &self.0 {
-            let _ = std::fs::remove_file(path);
+        let _ = self.cleanup();
+    }
+}
+
+impl PrivateAtFileCleanup {
+    fn cleanup(&mut self) -> std::result::Result<(), String> {
+        let mut failures = Vec::new();
+        self.0.retain(|path| match std::fs::remove_file(path) {
+            Ok(()) => false,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+            Err(err) => {
+                failures.push(format!("{}: {err}", path.display()));
+                true
+            }
+        });
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(failures.join(", "))
         }
     }
 }
 
-fn verify_private_at_files(
-    envelope: &homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope,
+pub(super) fn verify_private_at_files(
+    envelope: &mut homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope,
 ) -> Result<PrivateAtFileCleanup> {
     use sha2::{Digest, Sha256};
 
-    let command = envelope
+    let Some(command) = envelope
         .dispatch
-        .as_ref()
-        .map(|dispatch| &dispatch.command)
-        .into_iter()
-        .flatten();
-    let mut cleanup = Vec::new();
-    for argument in command {
-        let value = argument.strip_prefix('@').or_else(|| {
-            argument
-                .split_once('=')
-                .and_then(|(_, value)| value.strip_prefix('@'))
-        });
+        .as_mut()
+        .map(|dispatch| &mut dispatch.command)
+    else {
+        return Ok(PrivateAtFileCleanup(Vec::new()));
+    };
+    let mut cleanup = PrivateAtFileCleanup(Vec::new());
+    for argument in command.iter_mut() {
+        let value = at_file_path(argument);
         let Some(path) = value else {
             continue;
         };
@@ -437,51 +452,187 @@ fn verify_private_at_files(
         else {
             continue;
         };
+        // Register the controller-owned source before inspecting it so every
+        // rejected private input receives an owner-safe cleanup attempt.
+        cleanup.0.push(std::path::PathBuf::from(path));
         if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-            let _ = std::fs::remove_file(path);
-            return Err(Error::validation_invalid_argument(
-                "at_file",
+            return private_at_file_error(
+                &mut cleanup,
                 "private runner @file has an invalid SHA-256 identity",
-                Some(path.to_string()),
-                None,
-            ));
+                path,
+            );
         }
-        let metadata = std::fs::metadata(path).map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some(format!("stat private runner @file {path}")),
-            )
-        })?;
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                return private_at_file_error(
+                    &mut cleanup,
+                    &format!("stat private runner @file {path}: {err}"),
+                    path,
+                );
+            }
+        };
+        if !metadata.file_type().is_file() {
+            return private_at_file_error(
+                &mut cleanup,
+                "private runner @file is not a regular file",
+                path,
+            );
+        }
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             if metadata.permissions().mode() & 0o077 != 0 {
-                return Err(Error::validation_invalid_argument(
-                    "at_file",
+                return private_at_file_error(
+                    &mut cleanup,
                     "private runner @file is readable by group or other users",
-                    Some(path.to_string()),
-                    None,
-                ));
+                    path,
+                );
             }
         }
-        let content = std::fs::read(path).map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some(format!("read private runner @file {path}")),
-            )
-        })?;
-        if format!("{:x}", Sha256::digest(&content)) != expected {
-            let _ = std::fs::remove_file(path);
-            return Err(Error::validation_invalid_argument(
-                "at_file",
-                "private runner @file content does not match its SHA-256 identity",
-                Some(path.to_string()),
-                None,
-            ));
+        let mut file = match open_private_at_file(path) {
+            Ok(file) => file,
+            Err(err) => {
+                return private_at_file_error(
+                    &mut cleanup,
+                    &format!("read private runner @file {path}: {err}"),
+                    path,
+                );
+            }
+        };
+        let opened_metadata = match file.metadata() {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                return private_at_file_error(
+                    &mut cleanup,
+                    &format!("stat opened private runner @file {path}: {err}"),
+                    path,
+                );
+            }
+        };
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if opened_metadata.permissions().mode() & 0o077 != 0 {
+                return private_at_file_error(
+                    &mut cleanup,
+                    "opened private runner @file is readable by group or other users",
+                    path,
+                );
+            }
         }
-        cleanup.push(std::path::PathBuf::from(path));
+        let content = match read_private_at_file(&mut file) {
+            Ok(content) => content,
+            Err(err) => {
+                return private_at_file_error(
+                    &mut cleanup,
+                    &format!("read private runner @file {path}: {err}"),
+                    path,
+                );
+            }
+        };
+        if format!("{:x}", Sha256::digest(&content)) != expected {
+            return private_at_file_error(
+                &mut cleanup,
+                "private runner @file content does not match its SHA-256 identity",
+                path,
+            );
+        }
+        let snapshot = match write_private_at_file_snapshot(path, &content) {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                return private_at_file_error(
+                    &mut cleanup,
+                    &format!("write verified private runner @file snapshot: {err}"),
+                    path,
+                );
+            }
+        };
+        cleanup.0.push(snapshot.clone());
+        rewrite_at_file_argument(argument, &snapshot.display().to_string());
     }
-    Ok(PrivateAtFileCleanup(cleanup))
+    Ok(cleanup)
+}
+
+fn at_file_path(argument: &str) -> Option<&str> {
+    argument.strip_prefix('@').or_else(|| {
+        argument
+            .split_once('=')
+            .and_then(|(_, value)| value.strip_prefix('@'))
+    })
+}
+
+fn rewrite_at_file_argument(argument: &mut String, snapshot: &str) {
+    if argument.starts_with('@') {
+        *argument = format!("@{snapshot}");
+    } else if let Some((name, _)) = argument.split_once('=') {
+        *argument = format!("{name}=@{snapshot}");
+    }
+}
+
+fn private_at_file_error(
+    cleanup: &mut PrivateAtFileCleanup,
+    message: &str,
+    path: &str,
+) -> Result<PrivateAtFileCleanup> {
+    let cleanup_result = match cleanup.cleanup() {
+        Ok(()) => "private input cleanup succeeded".to_string(),
+        Err(err) => format!("private input cleanup failed: {err}"),
+    };
+    Err(Error::validation_invalid_argument(
+        "at_file",
+        format!("{message}; {cleanup_result}"),
+        Some(path.to_string()),
+        None,
+    ))
+}
+
+fn open_private_at_file(path: &str) -> std::io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(path)
+}
+
+fn read_private_at_file(file: &mut std::fs::File) -> std::io::Result<Vec<u8>> {
+    use std::io::Read;
+
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)?;
+    Ok(content)
+}
+
+pub(super) fn write_private_at_file_snapshot(
+    path: &str,
+    content: &[u8],
+) -> std::io::Result<std::path::PathBuf> {
+    use std::io::Write;
+
+    let source = std::path::Path::new(path);
+    let parent = source.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let snapshot = parent.join(format!(".homeboy-verified-{}", uuid::Uuid::new_v4()));
+    let temporary = snapshot.with_extension("tmp");
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    if let Err(err) = file.write_all(content).and_then(|_| file.sync_all()) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(err);
+    }
+    if let Err(err) = std::fs::rename(&temporary, &snapshot) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(err);
+    }
+    Ok(snapshot)
 }
 
 /// Snapshot transport intentionally excludes `.git`. Reconstruct the verified,

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -268,6 +268,7 @@ fn run_once_output(
     let mut execution_envelope = claim.request.execution_envelope();
     let _command_assets =
         materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
+    let _private_at_files = verify_private_at_files(&execution_envelope)?;
     materialize_snapshot_git_baseline(&execution_envelope)?;
     // Shared finisher so the exec-error and exec-success paths submit their
     // terminal job result through identical broker plumbing (#5091).
@@ -387,6 +388,100 @@ fn run_once_output(
         ),
         exit_code,
     ))
+}
+
+/// Private `@file` paths carry their SHA-256 in the runner-resident filename.
+/// Verify them after a durable claim and before starting the child, then remove
+/// them after execution so retries can resume before claim without retaining
+/// plaintext after consumption.
+struct PrivateAtFileCleanup(Vec<std::path::PathBuf>);
+
+impl Drop for PrivateAtFileCleanup {
+    fn drop(&mut self) {
+        for path in &self.0 {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+fn verify_private_at_files(
+    envelope: &homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope,
+) -> Result<PrivateAtFileCleanup> {
+    use sha2::{Digest, Sha256};
+
+    let command = envelope
+        .dispatch
+        .as_ref()
+        .map(|dispatch| &dispatch.command)
+        .into_iter()
+        .flatten();
+    let mut cleanup = Vec::new();
+    for argument in command {
+        let value = argument.strip_prefix('@').or_else(|| {
+            argument
+                .split_once('=')
+                .and_then(|(_, value)| value.strip_prefix('@'))
+        });
+        let Some(path) = value else {
+            continue;
+        };
+        let Some(filename) = std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+        else {
+            continue;
+        };
+        let Some(expected) = filename
+            .strip_prefix("private-sha256-")
+            .and_then(|value| value.split_once('-').map(|(digest, _)| digest))
+        else {
+            continue;
+        };
+        if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            let _ = std::fs::remove_file(path);
+            return Err(Error::validation_invalid_argument(
+                "at_file",
+                "private runner @file has an invalid SHA-256 identity",
+                Some(path.to_string()),
+                None,
+            ));
+        }
+        let metadata = std::fs::metadata(path).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("stat private runner @file {path}")),
+            )
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if metadata.permissions().mode() & 0o077 != 0 {
+                return Err(Error::validation_invalid_argument(
+                    "at_file",
+                    "private runner @file is readable by group or other users",
+                    Some(path.to_string()),
+                    None,
+                ));
+            }
+        }
+        let content = std::fs::read(path).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("read private runner @file {path}")),
+            )
+        })?;
+        if format!("{:x}", Sha256::digest(&content)) != expected {
+            let _ = std::fs::remove_file(path);
+            return Err(Error::validation_invalid_argument(
+                "at_file",
+                "private runner @file content does not match its SHA-256 identity",
+                Some(path.to_string()),
+                None,
+            ));
+        }
+        cleanup.push(std::path::PathBuf::from(path));
+    }
+    Ok(PrivateAtFileCleanup(cleanup))
 }
 
 /// Snapshot transport intentionally excludes `.git`. Reconstruct the verified,

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -395,7 +395,10 @@ fn run_once_output(
 /// them after execution so retries can resume before claim without retaining
 /// plaintext after consumption.
 #[derive(Debug)]
-pub(super) struct PrivateAtFileCleanup(Vec<std::path::PathBuf>);
+pub(super) struct PrivateAtFileCleanup {
+    paths: Vec<std::path::PathBuf>,
+    directories: Vec<std::path::PathBuf>,
+}
 
 impl Drop for PrivateAtFileCleanup {
     fn drop(&mut self) {
@@ -406,7 +409,7 @@ impl Drop for PrivateAtFileCleanup {
 impl PrivateAtFileCleanup {
     fn cleanup(&mut self) -> std::result::Result<(), String> {
         let mut failures = Vec::new();
-        self.0.retain(|path| match std::fs::remove_file(path) {
+        self.paths.retain(|path| match std::fs::remove_file(path) {
             Ok(()) => false,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
             Err(err) => {
@@ -414,6 +417,15 @@ impl PrivateAtFileCleanup {
                 true
             }
         });
+        self.directories
+            .retain(|path| match std::fs::remove_dir_all(path) {
+                Ok(()) => false,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+                Err(err) => {
+                    failures.push(format!("{}: {err}", path.display()));
+                    true
+                }
+            });
         if failures.is_empty() {
             Ok(())
         } else {
@@ -427,14 +439,38 @@ pub(super) fn verify_private_at_files(
 ) -> Result<PrivateAtFileCleanup> {
     use sha2::{Digest, Sha256};
 
+    #[cfg(not(unix))]
+    {
+        if envelope.dispatch.as_ref().is_some_and(|dispatch| {
+            dispatch
+                .command
+                .iter()
+                .any(|argument| is_private_at_file(argument))
+        }) {
+            return Err(Error::validation_invalid_argument(
+                "at_file",
+                "private detached runner @files require Unix owner-only filesystem guarantees",
+                None,
+                None,
+            ));
+        }
+    }
+
     let Some(command) = envelope
         .dispatch
         .as_mut()
         .map(|dispatch| &mut dispatch.command)
     else {
-        return Ok(PrivateAtFileCleanup(Vec::new()));
+        return Ok(PrivateAtFileCleanup {
+            paths: Vec::new(),
+            directories: Vec::new(),
+        });
     };
-    let mut cleanup = PrivateAtFileCleanup(Vec::new());
+    let mut cleanup = PrivateAtFileCleanup {
+        paths: Vec::new(),
+        directories: Vec::new(),
+    };
+    let mut snapshot_directory = None;
     for argument in command.iter_mut() {
         let value = at_file_path(argument);
         let Some(path) = value else {
@@ -454,7 +490,7 @@ pub(super) fn verify_private_at_files(
         };
         // Register the controller-owned source before inspecting it so every
         // rejected private input receives an owner-safe cleanup attempt.
-        cleanup.0.push(std::path::PathBuf::from(path));
+        cleanup.paths.push(std::path::PathBuf::from(path));
         if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
             return private_at_file_error(
                 &mut cleanup,
@@ -538,7 +574,24 @@ pub(super) fn verify_private_at_files(
                 path,
             );
         }
-        let snapshot = match write_private_at_file_snapshot(path, &content) {
+        if snapshot_directory.is_none() {
+            let directory = match private_at_file_snapshot_directory() {
+                Ok(directory) => directory,
+                Err(err) => {
+                    return private_at_file_error(
+                        &mut cleanup,
+                        &format!("create private runner @file snapshot directory: {err}"),
+                        path,
+                    );
+                }
+            };
+            cleanup.directories.push(directory.clone());
+            snapshot_directory = Some(directory);
+        }
+        let directory = snapshot_directory
+            .as_deref()
+            .expect("private snapshot directory");
+        let snapshot = match write_private_at_file_snapshot(directory, &content) {
             Ok(snapshot) => snapshot,
             Err(err) => {
                 return private_at_file_error(
@@ -548,10 +601,20 @@ pub(super) fn verify_private_at_files(
                 );
             }
         };
-        cleanup.0.push(snapshot.clone());
+        cleanup.paths.push(snapshot.clone());
         rewrite_at_file_argument(argument, &snapshot.display().to_string());
     }
     Ok(cleanup)
+}
+
+#[cfg(not(unix))]
+fn is_private_at_file(argument: &str) -> bool {
+    at_file_path(argument).is_some_and(|path| {
+        std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("private-sha256-"))
+    })
 }
 
 fn at_file_path(argument: &str) -> Option<&str> {
@@ -607,21 +670,19 @@ fn read_private_at_file(file: &mut std::fs::File) -> std::io::Result<Vec<u8>> {
 }
 
 pub(super) fn write_private_at_file_snapshot(
-    path: &str,
+    directory: &std::path::Path,
     content: &[u8],
 ) -> std::io::Result<std::path::PathBuf> {
     use std::io::Write;
 
-    let source = std::path::Path::new(path);
-    let parent = source.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let snapshot = parent.join(format!(".homeboy-verified-{}", uuid::Uuid::new_v4()));
+    let snapshot = directory.join(format!("verified-{}", uuid::Uuid::new_v4()));
     let temporary = snapshot.with_extension("tmp");
     let mut options = std::fs::OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
     }
     let mut file = options.open(&temporary)?;
     if let Err(err) = file.write_all(content).and_then(|_| file.sync_all()) {
@@ -633,6 +694,52 @@ pub(super) fn write_private_at_file_snapshot(
         return Err(err);
     }
     Ok(snapshot)
+}
+
+#[cfg(unix)]
+fn private_at_file_snapshot_directory() -> std::io::Result<std::path::PathBuf> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let root = std::env::var_os("XDG_DATA_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".local/share"))
+        })
+        .unwrap_or_else(std::env::temp_dir)
+        .join("homeboy/reverse-runner-private");
+    std::fs::create_dir_all(&root)?;
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700))?;
+    let root_metadata = std::fs::metadata(&root)?;
+    if root_metadata.permissions().mode() & 0o077 != 0
+        || root_metadata.uid() != unsafe { libc::geteuid() }
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "private runner snapshot root is not worker-owned 0700",
+        ));
+    }
+    let directory = root.join(format!("run-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir(&directory)?;
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700))?;
+    let directory_metadata = std::fs::metadata(&directory)?;
+    if directory_metadata.permissions().mode() & 0o077 != 0
+        || directory_metadata.uid() != unsafe { libc::geteuid() }
+    {
+        let _ = std::fs::remove_dir(&directory);
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "private runner snapshot directory is not worker-owned 0700",
+        ));
+    }
+    Ok(directory)
+}
+
+#[cfg(not(unix))]
+fn private_at_file_snapshot_directory() -> std::io::Result<std::path::PathBuf> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "private runner snapshots require Unix owner-only filesystem guarantees",
+    ))
 }
 
 /// Snapshot transport intentionally excludes `.git`. Reconstruct the verified,

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -12,7 +12,9 @@ use homeboy_core::server::{RunnerPolicy, RunnerSecretEnvRef};
 use homeboy_core::test_support;
 use sha2::{Digest, Sha256};
 
-use super::super::run::{run_loop, run_reverse_worker};
+use super::super::run::{
+    run_loop, run_reverse_worker, verify_private_at_files, write_private_at_file_snapshot,
+};
 use super::support::{
     spawn_cancelling_after_claim_broker, spawn_cancelling_on_second_snapshot_broker,
     spawn_failing_broker, spawn_mock_broker, spawn_mock_broker_until_finish,
@@ -244,6 +246,175 @@ fn reverse_worker_rejects_tampered_private_at_file() {
         assert!(!path.exists(), "tampered private input is removed");
         handle.join().expect("mock broker joins");
     });
+}
+
+#[cfg(unix)]
+#[test]
+fn private_at_file_snapshot_survives_source_replacement_before_exec() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().expect("private file directory");
+    let verified = b"verified plan";
+    let digest = format!("{:x}", Sha256::digest(verified));
+    let source = directory
+        .path()
+        .join(format!("private-sha256-{digest}-plan.json"));
+    std::fs::write(&source, verified).expect("write private plan");
+    std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o600))
+        .expect("lock private plan");
+    let request = RemoteRunnerJobRequest {
+        runner_id: "lab".to_string(),
+        project_id: None,
+        operation: "runner.exec".to_string(),
+        command: vec!["sh".to_string(), format!("@{}", source.display())],
+        cwd: Some("/tmp".to_string()),
+        env: Default::default(),
+        secret_env_names: Vec::new(),
+        secret_env_plan: Default::default(),
+        env_materialization: None,
+        capture_patch: false,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        require_paths: Vec::new(),
+        lab_runner_workload: None,
+        lifecycle: None,
+        metadata: None,
+    };
+    let mut envelope = request.execution_envelope();
+
+    let cleanup = verify_private_at_files(&mut envelope).expect("verify private input");
+    let snapshot = envelope.dispatch.as_ref().expect("dispatch").command[1]
+        .strip_prefix('@')
+        .expect("rewritten @file")
+        .to_string();
+    std::fs::write(&source, b"replaced after validation").expect("replace source");
+
+    assert_eq!(std::fs::read(&snapshot).expect("read snapshot"), verified);
+    drop(cleanup);
+    assert!(!source.exists(), "source cleanup runs after replacement");
+    assert!(
+        !std::path::Path::new(&snapshot).exists(),
+        "snapshot cleanup runs"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn private_at_file_unsafe_permissions_are_cleaned_before_error() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().expect("private file directory");
+    let content = b"private plan";
+    let digest = format!("{:x}", Sha256::digest(content));
+    let source = directory
+        .path()
+        .join(format!("private-sha256-{digest}-plan.json"));
+    std::fs::write(&source, content).expect("write private plan");
+    std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o644))
+        .expect("make private plan unsafe");
+    let request = private_at_file_request(&source);
+    let mut envelope = request.execution_envelope();
+
+    let error = verify_private_at_files(&mut envelope).expect_err("unsafe mode rejected");
+
+    assert!(error.message.contains("private input cleanup succeeded"));
+    assert!(!source.exists(), "unsafe plaintext is cleaned");
+}
+
+#[cfg(unix)]
+#[test]
+fn private_at_file_stat_failure_reports_cleanup_result() {
+    let directory = tempfile::tempdir().expect("private file directory");
+    let digest = format!("{:x}", Sha256::digest(b"private plan"));
+    let source = directory
+        .path()
+        .join(format!("private-sha256-{digest}-plan.json"));
+    let request = private_at_file_request(&source);
+    let mut envelope = request.execution_envelope();
+
+    let error = verify_private_at_files(&mut envelope).expect_err("missing input rejected");
+
+    assert!(error.message.contains("stat private runner @file"));
+    assert!(error.message.contains("private input cleanup succeeded"));
+}
+
+#[cfg(unix)]
+#[test]
+fn private_at_file_read_failure_is_cleaned_before_error() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().expect("private file directory");
+    let content = b"private plan";
+    let digest = format!("{:x}", Sha256::digest(content));
+    let source = directory
+        .path()
+        .join(format!("private-sha256-{digest}-plan.json"));
+    std::fs::write(&source, content).expect("write private plan");
+    std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o000))
+        .expect("make private plan unreadable");
+    let request = private_at_file_request(&source);
+    let mut envelope = request.execution_envelope();
+
+    let error = verify_private_at_files(&mut envelope).expect_err("unreadable input rejected");
+
+    assert!(error.message.contains("read private runner @file"));
+    assert!(error.message.contains("private input cleanup succeeded"));
+    assert!(!source.exists(), "unreadable plaintext is cleaned");
+}
+
+#[cfg(unix)]
+#[test]
+fn private_at_file_snapshot_is_atomically_published_with_owner_only_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().expect("private file directory");
+    let source = directory.path().join("private-sha256-source-plan.json");
+
+    let snapshot = write_private_at_file_snapshot(
+        source.to_str().expect("source path"),
+        b"complete verified content",
+    )
+    .expect("write snapshot");
+
+    assert_eq!(
+        std::fs::read(&snapshot).expect("read snapshot"),
+        b"complete verified content"
+    );
+    assert_eq!(
+        std::fs::metadata(&snapshot)
+            .expect("snapshot metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    let entries = std::fs::read_dir(directory.path())
+        .expect("list snapshot directory")
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect::<Vec<_>>();
+    assert!(entries.iter().all(|entry| !entry.ends_with(".tmp")));
+}
+
+fn private_at_file_request(path: &std::path::Path) -> RemoteRunnerJobRequest {
+    RemoteRunnerJobRequest {
+        runner_id: "lab".to_string(),
+        project_id: None,
+        operation: "runner.exec".to_string(),
+        command: vec!["sh".to_string(), format!("@{}", path.display())],
+        cwd: Some("/tmp".to_string()),
+        env: Default::default(),
+        secret_env_names: Vec::new(),
+        secret_env_plan: Default::default(),
+        env_materialization: None,
+        capture_patch: false,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        require_paths: Vec::new(),
+        lab_runner_workload: None,
+        lifecycle: None,
+        metadata: None,
+    }
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -287,6 +287,24 @@ fn private_at_file_snapshot_survives_source_replacement_before_exec() {
         .strip_prefix('@')
         .expect("rewritten @file")
         .to_string();
+    assert_ne!(
+        std::path::Path::new(&snapshot).parent(),
+        source.parent(),
+        "verified snapshot is outside the source-owner directory"
+    );
+    assert_eq!(
+        std::fs::metadata(
+            std::path::Path::new(&snapshot)
+                .parent()
+                .expect("snapshot parent")
+        )
+        .expect("snapshot parent metadata")
+        .permissions()
+        .mode()
+            & 0o777,
+        0o700,
+        "worker-owned snapshot directory is private"
+    );
     std::fs::write(&source, b"replaced after validation").expect("replace source");
 
     assert_eq!(std::fs::read(&snapshot).expect("read snapshot"), verified);
@@ -368,13 +386,9 @@ fn private_at_file_snapshot_is_atomically_published_with_owner_only_mode() {
     use std::os::unix::fs::PermissionsExt;
 
     let directory = tempfile::tempdir().expect("private file directory");
-    let source = directory.path().join("private-sha256-source-plan.json");
 
-    let snapshot = write_private_at_file_snapshot(
-        source.to_str().expect("source path"),
-        b"complete verified content",
-    )
-    .expect("write snapshot");
+    let snapshot = write_private_at_file_snapshot(directory.path(), b"complete verified content")
+        .expect("write snapshot");
 
     assert_eq!(
         std::fs::read(&snapshot).expect("read snapshot"),
@@ -415,6 +429,23 @@ fn private_at_file_request(path: &std::path::Path) -> RemoteRunnerJobRequest {
         lifecycle: None,
         metadata: None,
     }
+}
+
+#[cfg(not(unix))]
+#[test]
+fn private_at_file_is_rejected_without_unix_filesystem_guarantees() {
+    let directory = tempfile::tempdir().expect("private file directory");
+    let source = directory.path().join(
+        "private-sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-plan.json",
+    );
+    let request = private_at_file_request(&source);
+    let mut envelope = request.execution_envelope();
+
+    let error = verify_private_at_files(&mut envelope).expect_err("private input rejected");
+
+    assert!(error
+        .message
+        .contains("require Unix owner-only filesystem guarantees"));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -10,6 +10,7 @@ use homeboy_core::api_jobs::{
 use homeboy_core::secret_env_plan::SecretEnvPlan;
 use homeboy_core::server::{RunnerPolicy, RunnerSecretEnvRef};
 use homeboy_core::test_support;
+use sha2::{Digest, Sha256};
 
 use super::super::run::{run_loop, run_reverse_worker};
 use super::support::{
@@ -113,6 +114,135 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
             );
             assert!(result["metrics"]["sample_count"].as_u64().is_some());
         }
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn reverse_worker_verifies_private_at_file_then_cleans_it_up() {
+    use std::os::unix::fs::PermissionsExt;
+
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+            false,
+        )
+        .expect("create runner");
+        crate::merge(
+            Some("lab"),
+            &serde_json::json!({
+                "policy": RunnerPolicy {
+                    allow_raw_exec: Some(true),
+                    workspace_roots: vec!["/tmp".to_string()],
+                    allowed_commands: vec!["sh".to_string()],
+                    ..Default::default()
+                }
+            })
+            .to_string(),
+            &[],
+        )
+        .expect("set policy");
+        let directory = tempfile::tempdir().expect("private file directory");
+        let content = b"private plan";
+        let digest = format!("{:x}", Sha256::digest(content));
+        let path = directory
+            .path()
+            .join(format!("private-sha256-{digest}-plan.json"));
+        std::fs::write(&path, content).expect("write private plan");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("lock private plan");
+        let store = JobStore::default();
+        store
+            .submit_remote_runner_job(RemoteRunnerJobRequest {
+                runner_id: "lab".to_string(),
+                project_id: None,
+                operation: "runner.exec".to_string(),
+                command: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "test \"$(cat \"${1#@}\")\" = 'private plan'".to_string(),
+                    "--".to_string(),
+                    format!("@{}", path.display()),
+                ],
+                cwd: Some("/tmp".to_string()),
+                env: Default::default(),
+                secret_env_names: Vec::new(),
+                secret_env_plan: Default::default(),
+                env_materialization: None,
+                capture_patch: false,
+                source_snapshot: None,
+                path_materialization_plan: None,
+                require_paths: Vec::new(),
+                lab_runner_workload: None,
+                lifecycle: None,
+                metadata: None,
+            })
+            .expect("submit private file job");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        write_reverse_controller_session(&broker_url);
+
+        let (_, exit_code) = run_reverse_worker(worker_options(broker_url)).expect("run worker");
+
+        assert_eq!(exit_code, 0);
+        assert!(!path.exists(), "private input is removed after consumption");
+        handle.join().expect("mock broker joins");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn reverse_worker_rejects_tampered_private_at_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+            false,
+        )
+        .expect("create runner");
+        let directory = tempfile::tempdir().expect("private file directory");
+        let digest = format!("{:x}", Sha256::digest(b"expected"));
+        let path = directory
+            .path()
+            .join(format!("private-sha256-{digest}-plan.json"));
+        std::fs::write(&path, b"tampered").expect("write tampered plan");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("lock private plan");
+        let store = JobStore::default();
+        store
+            .submit_remote_runner_job(RemoteRunnerJobRequest {
+                runner_id: "lab".to_string(),
+                project_id: None,
+                operation: "runner.exec".to_string(),
+                command: vec!["sh".to_string(), format!("@{}", path.display())],
+                cwd: Some("/tmp".to_string()),
+                env: Default::default(),
+                secret_env_names: Vec::new(),
+                secret_env_plan: Default::default(),
+                env_materialization: None,
+                capture_patch: false,
+                source_snapshot: None,
+                path_materialization_plan: None,
+                require_paths: Vec::new(),
+                lab_runner_workload: None,
+                lifecycle: None,
+                metadata: None,
+            })
+            .expect("submit tampered file job");
+        let (broker_url, handle) = spawn_mock_broker(store.clone(), 3);
+        write_reverse_controller_session(&broker_url);
+
+        let error =
+            run_reverse_worker(worker_options(broker_url)).expect_err("tampered file rejected");
+
+        assert!(
+            error
+                .message
+                .contains("does not match its SHA-256 identity"),
+            "unexpected error: {error:#?}"
+        );
+        assert!(!path.exists(), "tampered private input is removed");
+        handle.join().expect("mock broker joins");
     });
 }
 

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -280,6 +280,22 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         .get(queued[0].id)
         .expect("completed broker job");
     assert_eq!(completed.status, JobStatus::Succeeded);
+    let private_at_files = checkout.join(".homeboy/lab-at-files");
+    let retained_private_files = match std::fs::read_dir(&private_at_files) {
+        Ok(entries) => entries
+            .filter_map(std::result::Result::ok)
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| {
+                name.starts_with("private-sha256-") || name.starts_with(".homeboy-verified-")
+            })
+            .collect::<Vec<_>>(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => panic!("read runner @file directory: {error}"),
+    };
+    assert!(
+        retained_private_files.is_empty(),
+        "worker removes private plan source and verified snapshot: {retained_private_files:?}"
+    );
     assert_eq!(
         broker
             .store


### PR DESCRIPTION
Closes #9980

## Summary
- materialize inline detached Cook plans into the runner-resident `.homeboy/lab-at-files` namespace instead of a short-lived nested workspace
- publish private attempt plans atomically with owner-only permissions and SHA-256 identities
- have Unix workers open private inputs without following symlinks, validate the opened descriptor and hash, atomically snapshot verified bytes in a worker-owned `0700` run directory, rewrite child argv to that snapshot, and clean source, snapshot, and run directory on every path
- reject private detached plans on non-Unix platforms until an equivalent ACL/no-follow contract is available
- retain reverse-capacity admission safety: only detached durable reverse Cook work can queue while capacity is full

## Verification
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p homeboy-lab-runner private_at_file -- --nocapture`
- `cargo test --test reverse_cook_queue_acceptance detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once -- --exact --nocapture`

## AI Assistance
OpenCode with OpenAI GPT-5.6 Terra was used to inspect the detached Cook lifecycle regression, implement private atomic plan-file transfer and worker-side integrity handling, and run focused verification. Chris Huber remains responsible for the change.