### PR TITLE
fix(agent-task): adopt pre-existing immutable candidate after no-op review

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -26,7 +26,7 @@ pub(crate) fn committed_changes_patch(
     if !worktree_path.is_dir() {
         return Ok(None);
     }
-    let Some(base_ref) = resolve_committed_changes_base(
+    let Some(mut base_ref) = resolve_committed_changes_base(
         worktree_path,
         options.task_base_sha.as_deref(),
         options.base_ref.as_deref(),
@@ -48,6 +48,31 @@ pub(crate) fn committed_changes_patch(
                 None,
             ));
         }
+    }
+
+    // Explicit adoption of a pre-existing immutable candidate: the cook can
+    // record the candidate commit itself as the task base, so a provider that
+    // reviews it and returns no-op leaves an empty base..candidate diff and
+    // promotion has nothing to adopt (#8895). When the caller supplied an
+    // explicit candidate_ref and the recorded base IS the candidate, resolve the
+    // effective base to the candidate's first parent so the immutable commit
+    // becomes the promotable change. Fail closed: a root commit (no parent)
+    // cannot be adopted this way. This only triggers for explicit adoption, so
+    // ordinary no-op cooks still reject a base-equal promotion.
+    if options.candidate_ref.is_some() && base_ref == candidate {
+        let parent = git_stdout(
+            worktree_path,
+            &["rev-parse", "--verify", &format!("{candidate}^{{commit}}~1")],
+        )
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "candidate_ref",
+                "adopted candidate equals the recorded task base but has no parent commit to adopt against; supply a candidate with at least one committed change",
+                Some(candidate.clone()),
+                None,
+            )
+        })?;
+        base_ref = parent.trim().to_string();
     }
     let is_ancestor = Command::new("git")
         .args(["merge-base", "--is-ancestor", &base_ref, &candidate])

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -636,6 +636,79 @@ fn promote_no_op_outcome_uses_audited_committed_candidate() {
 }
 
 #[test]
+fn adopt_no_op_pre_existing_candidate_when_base_equals_candidate() {
+    // #8895: a recovery agent prepares an immutable candidate commit, the cook
+    // records that commit AS the task base, and the provider reviews it and
+    // returns no-op. With an explicit candidate_ref the base is rebased to the
+    // candidate's parent so the immutable commit is adopted and promoted.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "agent@example.test"]);
+    git(&repo, &["config", "user.name", "Agent"]);
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::write(repo.join("lib.rs"), "base\n").expect("write base");
+    git(&repo, &["add", "lib.rs"]);
+    git(&repo, &["commit", "-m", "base"]);
+    // The pre-existing immutable candidate the recovery agent committed.
+    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["commit", "-am", "recovery: prepared candidate"]);
+    let candidate = git_head(&repo, "HEAD");
+
+    let source_path = temp.path().join("outcome.json");
+    let source = serde_json::json!({
+        "schema": AGENT_TASK_OUTCOME_SCHEMA,
+        "task_id": "task",
+        "status": "no_op",
+        "artifacts": []
+    })
+    .to_string();
+    std::fs::write(&source_path, &source).expect("write no-op outcome");
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            // The cook recorded the candidate commit itself as the task base.
+            task_base_sha: Some(candidate.clone()),
+            candidate_ref: Some(candidate.clone()),
+            to_worktree: "repo@promotion".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                private_verify: Vec::new(),
+                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("pre-existing immutable candidate is adopted after no-op review");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(report.patch_artifact.id, "committed-changes");
+    assert_eq!(report.changed_files, vec!["lib.rs"]);
+    assert_eq!(
+        report.provenance["candidate"]["fingerprint"]["head"],
+        candidate
+    );
+    assert_eq!(provider.apply_calls.len(), 1);
+    assert_eq!(provider.verify_calls.len(), 1);
+}
+
+#[test]
 fn promote_exports_all_agent_commits_after_the_recorded_task_base() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");


### PR DESCRIPTION
## Summary
`homeboy agent-task cook` could not finalize an already-committed candidate when the provider correctly returned `no_op` after reviewing it (#8895). The cook records the current candidate commit **as the task base**, so `committed_changes_patch` sees an empty `base..candidate` diff and returns `None`, and promotion rejects with:

> no-op promotion requires an audited committed candidate after the task base

...even though the reviewed candidate is a healthy, pushed, immutable commit (the documented control-plane recovery flow where a recovery agent prepares the commit and Homeboy ingests/reviews/verifies/promotes it).

## Fix
When the caller supplied an explicit `candidate_ref` (adoption) **and** the recorded base resolves to the candidate itself, resolve the effective promotion base to the candidate's **first parent**, so the immutable commit becomes the promotable change.

Fail-closed invariants preserved:
- Only triggers for **explicit adoption** (`candidate_ref.is_some()`) — ordinary no-op cooks without an adopted candidate still reject a base-equal promotion (AC#3).
- A **root commit** (no parent) cannot be adopted this way (returns a clear error).
- The candidate must still equal the recorded worktree HEAD, be clean, and be a descendant of its resolved base (existing checks).

## Testing
- `adopt_no_op_pre_existing_candidate_when_base_equals_candidate` (new) — recovery-committed candidate, `task_base_sha == candidate`, `candidate_ref` set, no-op outcome → promotes `Applied` with `changed_files=[lib.rs]` and the candidate head fingerprint.
- `promote_no_op_outcome_without_committed_candidate_rejects_before_apply` — still rejects (AC#3, no regression).
- `promote_no_op_outcome_uses_audited_committed_candidate` — still passes.

(One pre-existing part_b test, `promote_exports_all_agent_commits_after_the_recorded_task_base`, fails identically on `origin/main` in this sandbox — it needs a real `origin` remote; unrelated to this change, verified by reverting.)

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the base==candidate empty-diff rejection, rebasing the effective base to the candidate parent for explicit adoption, and coverage.

Refs #8895