### PR TITLE
Enforce core-agnostic-source in core-side orchestration crates (#10023)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -154,14 +154,10 @@
           "#[cfg(test)]"
         ],
         "include_path_contains": [
+          "crates/homeboy-agents/src/",
+          "crates/homeboy-cli/src/commands/",
           "crates/homeboy-core/src/",
-          "crates/homeboy-cli/src/commands/component.rs",
-          "crates/homeboy-cli/src/commands/extension.rs",
-          "crates/homeboy-cli/src/commands/lint.rs",
-          "crates/homeboy-cli/src/commands/report.rs",
-          "crates/homeboy-cli/src/commands/resources/",
-          "crates/homeboy-cli/src/commands/review/",
-          "crates/homeboy-cli/src/commands/test.rs"
+          "crates/homeboy-release/src/"
         ],
         "kind": "core_boundary_leak",
         "suggestion": "Move ecosystem-specific behavior into extension metadata/rules, or add an explicit audit allowlist for intentional examples.",


### PR DESCRIPTION
Fixes #10023. Follow-up to the #9965 / #9993 exchange.

## Problem
The `core_boundary_leak:core-agnostic-source` policy exists to keep ecosystem/toolchain knowledge out of core-side code, but its `include_path_contains` covered only `crates/homeboy-core/src/` plus seven individually-listed `homeboy-cli` command files. **`homeboy-release`, `homeboy-agents`, and the rest of `homeboy-cli/src/commands/` were unenforced.**

This is not hypothetical — the merged #9965 fix added a hardcoded package-manager path list to `homeboy-release`:

```rust
const GENERATED_METADATA: &[&str] = &[
    "vendor/composer/installed.json",
    "vendor/composer/installed.php",
];
```

`composer` is **already a configured term** for this policy; the code was unflagged purely because the crate was out of scope. It was later replaced with a declaration-driven approach (#9993), but nothing prevented the next one.

## Change
Extend `include_path_contains` to:
- `crates/homeboy-release/src/`
- `crates/homeboy-agents/src/`
- `crates/homeboy-cli/src/commands/` — subsumes the seven individually-listed command files, which are folded in

Deliberately unchanged:
- **`homeboy-extension` stays out of scope** — it is the layer that legitimately owns ecosystem knowledge (it carries by far the most such literals, correctly).
- The sibling `detector-agnostic-source` policy is intentionally narrow (audit detectors only).
- All 14 excludes, 28 terms, and 453 baseline fingerprints are preserved; the diff touches only the scope list.

## Why no baseline regeneration
The audit gate runs `--profile=pr --changed-since <before>` (see `release.yml`), so it is **differential** — pre-existing occurrences in untouched files are not evaluated and CI will not retroactively fail.

Measured pre-existing occurrences in production source (everything after `#[cfg(test)]` excluded):

| crate | occurrences |
|---|---|
| `homeboy-release` | 23 |
| `homeboy-cli` (newly in scope) | 18 |
| `homeboy-core` (already in scope) | 10 |
| `homeboy-agents` | 7 |

~58 total, and most of `homeboy-core`'s are explanatory comments. These surface only when their files are next modified — which is the intended burn-down behavior: each is then either moved behind a declaration/extension seam or explicitly allow-listed with a reason.

## Context: why scope, not a new crate
The intuitive fix is "extract the agnostic engine into its own crate," but that extraction has largely already happened — `homeboy-engine-primitives` (~10k lines: `shell.rs`, `local_files.rs`, `language.rs`, `canonical_json.rs`) is that base, and `homeboy-core` has **no ecosystem crate dependencies** (contracts only). The leaks are string literals, not dependency coupling, so a large re-carve would be high-risk churn for ~58 literals. The missing piece was enforcement scope.

## Verification
- `homeboy.json` remains valid JSON; diff is config-only (+3/-7), key order preserved.
- Excludes / terms / baseline fingerprint counts unchanged.
