### PR TITLE
fix(release): fail the lint gate on stale validation dependencies

### DIFF
--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -129,7 +129,7 @@ pub use refactor_protocol::{
     RewrittenImport,
 };
 pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
-pub use runner::{ExtensionRunner, RunnerOutput};
+pub use runner::{ExtensionRunner, RunnerOutput, STRICT_VALIDATION_DEPENDENCIES_ENV};
 pub use runtime_helper::{
     helper_path, BASH_PREFLIGHT_ENV, COMMAND_CAPTURE_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV,
 };

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -11,7 +11,12 @@ use homeboy_core::server::CommandOutput;
 use homeboy_engine_primitives::shell;
 use serde_json::json;
 
-const STRICT_VALIDATION_DEPENDENCIES_ENV: &str = "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES";
+/// Env var that makes a validation runner fail closed when a resolved
+/// validation dependency's local checkout is behind its upstream, instead of
+/// warning and proceeding. Set for blocking gates (differential CI lint, and
+/// the release preflight lint) so a stale dependency cannot silently determine
+/// the outcome (#9643).
+pub const STRICT_VALIDATION_DEPENDENCIES_ENV: &str = "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES";
 const STALE_VALIDATION_DEPENDENCY_PREFIX: &str = "Resolved validation dependency";
 const FAILURE_TAIL_LINES: usize = 80;
 

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -799,4 +799,23 @@ mod tests {
 
         assert!(stale_validation_dependency_message("", stderr).is_none());
     }
+
+    #[test]
+    fn strict_validation_dependencies_flag_reflects_env() {
+        // A runner without the strict env proceeds (warn-and-continue); setting
+        // HOMEBOY_STRICT_VALIDATION_DEPENDENCIES=1 makes it fail closed on a
+        // behind-upstream dependency — this is what the release lint gate sets
+        // so a stale checkout cannot silently determine the outcome (#9643).
+        let lenient = ExtensionRunner::for_context(context());
+        assert!(!lenient.strict_validation_dependencies());
+
+        let strict =
+            ExtensionRunner::for_context(context()).env(STRICT_VALIDATION_DEPENDENCIES_ENV, "1");
+        assert!(strict.strict_validation_dependencies());
+
+        // Only an explicit truthy value enables strict mode.
+        let disabled =
+            ExtensionRunner::for_context(context()).env(STRICT_VALIDATION_DEPENDENCIES_ENV, "0");
+        assert!(!disabled.strict_validation_dependencies());
+    }
 }

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -144,6 +144,12 @@ pub(super) fn validate_lint_quality(component: &Component) -> LintQualityOutcome
         None,
         &release_run_dir,
     )
+    .map(|runner| {
+        // The release lint gate is blocking, so a validation dependency resolved
+        // from a stale local checkout must not silently determine the outcome —
+        // fail closed on a behind-upstream dependency (#9643).
+        runner.env(extension::STRICT_VALIDATION_DEPENDENCIES_ENV, "1")
+    })
     .and_then(|runner| runner.run())
     {
         Ok(output) => output,


### PR DESCRIPTION
## Summary
Release lint hydrates validation dependencies from whatever local checkout the registry points at. When such a checkout is **behind origin**, Homeboy warned and then proceeded — letting stale dependency APIs (e.g. PHPStan signature errors) determine a **blocking release gate** (#9643):

```text
Resolved dependency agents-api via .../agents-api-fanout
Warning: ... behind origin/main by 3 commit(s).
...
```

So the release outcome depended on unrelated local checkout freshness rather than an explicit dependency identity — not deterministic enough for a blocking gate.

## Root cause
The runner **already** fails closed on a behind-upstream validation dependency when `HOMEBOY_STRICT_VALIDATION_DEPENDENCIES` is set (the detection + enforcement exist). That env was enabled only for **differential CI lint** (`changed_since.is_some()`), not for the **release preflight lint** — so release lint ran in warn-and-proceed mode.

## Change
- Enable `HOMEBOY_STRICT_VALIDATION_DEPENDENCIES` on the release lint runner (`validate_lint_quality`) — the gate is blocking, so a stale configured checkout must fail closed with an actionable error instead of silently warning.
- Export the env-var const (`STRICT_VALIDATION_DEPENDENCIES_ENV`) so the release crate references it by name rather than a bare string.

This addresses the issue's acceptance criterion "a stale configured checkout cannot silently determine release success/failure." (The broader per-dependency identity/SHA/freshness evidence record is a larger follow-up; this closes the actively-dangerous silent-proceed hole.)

## Testing
- `runner::tests::strict_validation_dependencies_flag_reflects_env` (new) — flag off by default; on only for an explicit truthy env value.
- `runner::tests::detects_stale_validation_dependency_warning` — unchanged (the message the strict path fails on).
- `planning_quality` release-lint tests — 5 pass (no regression from setting the env on the release runner).

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the warn-then-proceed to the strict-mode gate that release lint didn't enable, wiring it on the blocking release runner, and coverage.

Refs #9643