### PR TITLE
refactor(proof): relocate loop-spec/controller validation to its module

### DIFF
--- a/crates/homeboy-core/src/proof/loop_spec_validation.rs
+++ b/crates/homeboy-core/src/proof/loop_spec_validation.rs
@@ -16,6 +16,10 @@ use std::sync::Mutex;
 
 use serde_json::Value;
 
+use homeboy_gate_contract::proof::HomeboyProofValidationDiagnostic;
+
+use super::validation::{diagnostic, path};
+
 /// A single loop-spec validation finding: a stable diagnostic code and a
 /// human-readable message. The caller attaches the JSON path.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,5 +69,62 @@ pub(crate) fn validate_materialized_loop_spec(spec: &Value) -> Vec<LoopSpecValid
     match slot.as_deref() {
         Some(provider) => provider.validate_materialized_loop_spec(spec),
         None => NoopProvider.validate_materialized_loop_spec(spec),
+    }
+}
+
+/// Validate a `homeboy/agent-task-loop-spec-materialization/v1` proof record:
+/// require the embedded `spec` and run it through the loop-spec provider. These
+/// agent-task-loop schemas are dispatched by the proof verb but are loop-spec
+/// behavior, so they live here rather than in generic proof validation (#6770).
+pub(super) fn validate_loop_spec_materialization_record(
+    value: &Value,
+    diagnostics: &mut Vec<HomeboyProofValidationDiagnostic>,
+) {
+    let Some(spec) = value.get("spec") else {
+        diagnostics.push(diagnostic(
+            "materialized_spec_missing",
+            "materialized controller output must include spec",
+            path("/spec"),
+        ));
+        return;
+    };
+    // Loop-spec schema + rule validation is agent-task behavior, delegated
+    // through the loop-spec validation hook so proof validation does not depend
+    // on the agent-task subsystem.
+    for finding in validate_materialized_loop_spec(spec) {
+        diagnostics.push(diagnostic(finding.code, finding.message, path("/spec")));
+    }
+}
+
+/// Validate a `homeboy/agent-task-loop-controller/v1` proof record: a completed
+/// controller must carry a terminal outcome and retain no executable
+/// next_actions. Loop-controller behavior, dispatched by the proof verb (#6770).
+pub(super) fn validate_controller_record(
+    value: &Value,
+    diagnostics: &mut Vec<HomeboyProofValidationDiagnostic>,
+) {
+    if value.get("state").and_then(Value::as_str) == Some("completed") {
+        if value
+            .get("terminal_outcomes")
+            .and_then(Value::as_array)
+            .is_none_or(Vec::is_empty)
+        {
+            diagnostics.push(diagnostic(
+                "completion_outcome_missing",
+                "completed controller records must include a terminal outcome explaining deterministic completion",
+                path("/terminal_outcomes"),
+            ));
+        }
+        if value
+            .get("next_actions")
+            .and_then(Value::as_array)
+            .is_some_and(|actions| !actions.is_empty())
+        {
+            diagnostics.push(diagnostic(
+                "completion_has_pending_actions",
+                "completed controller records must not retain executable next_actions",
+                path("/next_actions"),
+            ));
+        }
     }
 }

--- a/crates/homeboy-core/src/proof/validation.rs
+++ b/crates/homeboy-core/src/proof/validation.rs
@@ -31,10 +31,13 @@ pub fn validate_proof_value(value: Value) -> HomeboyProofValidationReport {
             )),
         },
         Some("homeboy/agent-task-loop-spec-materialization/v1") => {
-            validate_materialized_loop_spec(&value, &mut diagnostics);
+            super::loop_spec_validation::validate_loop_spec_materialization_record(
+                &value,
+                &mut diagnostics,
+            );
         }
         Some("homeboy/agent-task-loop-controller/v1") => {
-            validate_controller_record(&value, &mut diagnostics);
+            super::loop_spec_validation::validate_controller_record(&value, &mut diagnostics);
         }
         Some(schema) => diagnostics.push(diagnostic(
             "unsupported_schema",
@@ -200,56 +203,6 @@ fn artifact_satisfies_requirement(
             .unwrap_or(true)
 }
 
-fn validate_materialized_loop_spec(
-    value: &Value,
-    diagnostics: &mut Vec<HomeboyProofValidationDiagnostic>,
-) {
-    let Some(spec) = value.get("spec") else {
-        diagnostics.push(diagnostic(
-            "materialized_spec_missing",
-            "materialized controller output must include spec",
-            path("/spec"),
-        ));
-        return;
-    };
-    // Loop-spec schema + rule validation is agent-task behavior, delegated
-    // through the loop-spec validation hook so proof validation does not depend
-    // on the agent-task subsystem.
-    for finding in crate::proof::loop_spec_validation::validate_materialized_loop_spec(spec) {
-        diagnostics.push(diagnostic(finding.code, finding.message, path("/spec")));
-    }
-}
-
-fn validate_controller_record(
-    value: &Value,
-    diagnostics: &mut Vec<HomeboyProofValidationDiagnostic>,
-) {
-    if value.get("state").and_then(Value::as_str) == Some("completed") {
-        if value
-            .get("terminal_outcomes")
-            .and_then(Value::as_array)
-            .is_none_or(Vec::is_empty)
-        {
-            diagnostics.push(diagnostic(
-                "completion_outcome_missing",
-                "completed controller records must include a terminal outcome explaining deterministic completion",
-                path("/terminal_outcomes"),
-            ));
-        }
-        if value
-            .get("next_actions")
-            .and_then(Value::as_array)
-            .is_some_and(|actions| !actions.is_empty())
-        {
-            diagnostics.push(diagnostic(
-                "completion_has_pending_actions",
-                "completed controller records must not retain executable next_actions",
-                path("/next_actions"),
-            ));
-        }
-    }
-}
-
 fn validate_evidence_ref(
     reference: &str,
     path: String,
@@ -276,7 +229,7 @@ fn is_non_local_evidence_ref(reference: &str) -> bool {
     validated_public_url(reference).is_some()
 }
 
-fn diagnostic(
+pub(super) fn diagnostic(
     code: impl Into<String>,
     message: impl Into<String>,
     path: Option<String>,
@@ -288,7 +241,7 @@ fn diagnostic(
     }
 }
 
-fn path(value: &str) -> Option<String> {
+pub(super) fn path(value: &str) -> Option<String> {
     Some(value.to_string())
 }
 


### PR DESCRIPTION
## Summary
`proof/validation.rs` validated the agent-task-loop schemas (`agent-task-loop-spec-materialization/v1`, `agent-task-loop-controller/v1`) — loop-spec/controller behavior mis-scoped under the `proof` verb (#6770, deferred from the facade-adoption PR to keep that change tight).

Move `validate_loop_spec_materialization_record` and `validate_controller_record` into `proof/loop_spec_validation.rs` — the module that already owns loop-spec dispatch — and have `validate_proof_value` dispatch to them there. `proof/` now keeps generic proof/evidence validation; loop-spec/controller schema validation lives with the rest of the loop-spec code.

## Behavior-preserving
- Same diagnostics, codes, and JSON paths are produced (the functions moved verbatim, only renamed to avoid clashing with the existing provider `validate_materialized_loop_spec`).
- The shared `diagnostic`/`path` proof helpers are widened to `pub(super)` so the relocated functions reuse them.
- No consumer imported the moved functions by their old path — they were called only from `validate_proof_value` (verified: grep for the old paths is empty). The public provider-registration API (`register_loop_spec_validation_provider`) is unchanged.

`validation.rs`: 320 → 273 lines; `loop_spec_validation.rs`: 69 → 130.

## Testing
`homeboy-core --lib proof::` — 7 tests pass unchanged, including `proof_validation_requires_completed_controller_terminal_outcome` (exercises the relocated `validate_controller_record`) and the malformed-envelope test (exercises the loop-spec-materialization dispatch). These go through the public `validate_proof_value` entry point, so they verify the dispatch after relocation.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Confirming the mis-scoped functions had no external callers, relocating them + their shared helpers behavior-preservingly, and verifying via the proof test suite.

Closes #6770