### PR TITLE
fix(status): resolve managed task worktrees like git status

### DIFF
--- a/crates/homeboy-core/src/component/resolution.rs
+++ b/crates/homeboy-core/src/component/resolution.rs
@@ -396,7 +396,54 @@ fn resolve_path_override(path: &str) -> Result<Component> {
         }
     }
 
+    // A managed task worktree of a registered component has no portable
+    // homeboy.json, so the checks above miss it. Match it to its registered
+    // component by shared git common dir or `<component>@<branch>` naming, so a
+    // bare-path resolution (e.g. top-level `homeboy status` from the worktree)
+    // resolves the same component `git status` does instead of a synthetic one
+    // (#9895).
+    if let Some(component) = registered_component_for_worktree_path(dir) {
+        return Ok(component);
+    }
+
     Ok(synthetic_component_for_path(path))
+}
+
+/// Whether `component_id` names a component registered in the standalone/project
+/// registry (as opposed to a synthetic ad-hoc target).
+fn component_is_registered(component_id: &str) -> bool {
+    crate::component::inventory()
+        .map(|components| components.iter().any(|c| c.id == component_id))
+        .unwrap_or(false)
+}
+
+/// Resolve a bare path to the registered component whose checkout owns it as a
+/// worktree — shared git common dir, or `<component>@<branch>` named beside the
+/// registered checkout. Returns the registered component rebased onto the
+/// worktree path. `None` when the path is not a worktree of any registered
+/// component (#9895).
+fn registered_component_for_worktree_path(dir: &Path) -> Option<Component> {
+    let cwd_git_root = detect_git_root(dir)?;
+    let components = crate::component::inventory().ok()?;
+    for mut registered in components {
+        let registered_path =
+            PathBuf::from(shellexpand::tilde(&registered.local_path).into_owned());
+        // A worktree is a *distinct* checkout of the registered component's repo:
+        // it shares the git common dir but the registered checkout does not live
+        // inside this working tree. Excluding the contained case avoids matching a
+        // monorepo root to one of its sub-directory components, which must remain
+        // a monorepo root rather than a single component (#9895).
+        let registered_is_contained = path_is_at_or_inside(&cwd_git_root, &registered_path);
+        if !registered_is_contained
+            && (same_git_common_dir(&registered_path, &cwd_git_root)
+                || is_named_component_worktree(&registered.id, &registered_path, &cwd_git_root))
+        {
+            registered.local_path = cwd_git_root.to_string_lossy().to_string();
+            crate::component::resolve_remote_path(&mut registered);
+            return Some(registered);
+        }
+    }
+    None
 }
 
 fn path_has_portable_config(path: &Path) -> Result<bool> {
@@ -453,7 +500,11 @@ pub fn resolve_target(spec: TargetSpec<'_>) -> Result<ResolvedTarget> {
     let synthetic = explicit_path
         .map(|path| path_has_portable_config(Path::new(path)).map(|has_config| !has_config))
         .transpose()?
-        .unwrap_or(false);
+        .unwrap_or(false)
+        // A registered component resolved for a managed worktree has no portable
+        // homeboy.json at the worktree path, but it is a real registered
+        // component — not a synthetic ad-hoc target (#9895).
+        && !component_is_registered(&component.id);
     if synthetic && !spec.allow_synthetic {
         return Err(Error::validation_invalid_argument(
             "target",

--- a/crates/homeboy-core/src/context/mod.rs
+++ b/crates/homeboy-core/src/context/mod.rs
@@ -86,16 +86,7 @@ pub fn run(path: Option<&str>) -> Result<(ContextOutput, i32)> {
         .collect();
 
     let mut matched_set: HashSet<String> = matched_components.into_iter().collect();
-    // Add the resolved component when it is a real registered component — even
-    // if the *checkout* at CWD is synthetic (a managed task worktree resolves to
-    // a registered component but the worktree path has no portable homeboy.json).
-    // This makes top-level `status` agree with `git status`, which uses the same
-    // resolved component id regardless of `synthetic` (#9895). A truly-synthetic
-    // ad-hoc directory (not in the registry) stays unregistered.
-    let resolved_is_registered = components
-        .iter()
-        .any(|c| c.id == resolved_target.component_id);
-    if !resolved_target.synthetic || resolved_is_registered {
+    if !resolved_target.synthetic {
         matched_set.insert(resolved_target.component_id.clone());
     }
     let mut matched: Vec<String> = matched_set.into_iter().collect();
@@ -579,6 +570,63 @@ mod tests {
                 Some(repo.canonicalize().unwrap().to_string_lossy().to_string())
             );
             assert_eq!(output.suggestion, None);
+        });
+    }
+
+    #[test]
+    fn context_resolves_managed_worktree_to_registered_component() {
+        // #9895: inside a managed task worktree of a registered component (the
+        // worktree checkout has no portable homeboy.json), top-level status must
+        // resolve the same registered component `git status` does — not report
+        // unregistered_context.
+        with_isolated_home(|home| {
+            let primary = home.path().join("wp-build-repo");
+            std::fs::create_dir_all(&primary).expect("primary dir");
+            init_git(&primary);
+            std::fs::write(primary.join("file.txt"), "seed\n").expect("seed file");
+            let git = |args: &[&str]| {
+                let out = std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(&primary)
+                    .output()
+                    .expect("git");
+                assert!(out.status.success(), "git {args:?} failed");
+            };
+            git(&["config", "user.email", "t@example.com"]);
+            git(&["config", "user.name", "T"]);
+            git(&["add", "."]);
+            git(&["commit", "-m", "seed"]);
+            write_component_registration(home.path(), "wp-build-repo", &primary);
+
+            // A managed worktree named `<component>@<branch>` beside the primary.
+            let worktree = home.path().join("wp-build-repo@audit-branch");
+            let add = std::process::Command::new("git")
+                .args([
+                    "worktree",
+                    "add",
+                    "-b",
+                    "audit-branch",
+                    worktree.to_str().unwrap(),
+                ])
+                .current_dir(&primary)
+                .output()
+                .expect("git worktree add");
+            assert!(
+                add.status.success(),
+                "worktree add failed: {}",
+                String::from_utf8_lossy(&add.stderr)
+            );
+
+            let (output, status) =
+                run(Some(worktree.to_str().expect("utf8 path"))).expect("context");
+
+            assert_eq!(status, 0);
+            assert!(
+                output.managed,
+                "managed worktree must resolve as managed, got suggestion: {:?}",
+                output.suggestion
+            );
+            assert_eq!(output.matched_components, vec!["wp-build-repo"]);
         });
     }
 

--- a/crates/homeboy-core/src/context/mod.rs
+++ b/crates/homeboy-core/src/context/mod.rs
@@ -86,7 +86,16 @@ pub fn run(path: Option<&str>) -> Result<(ContextOutput, i32)> {
         .collect();
 
     let mut matched_set: HashSet<String> = matched_components.into_iter().collect();
-    if !resolved_target.synthetic {
+    // Add the resolved component when it is a real registered component — even
+    // if the *checkout* at CWD is synthetic (a managed task worktree resolves to
+    // a registered component but the worktree path has no portable homeboy.json).
+    // This makes top-level `status` agree with `git status`, which uses the same
+    // resolved component id regardless of `synthetic` (#9895). A truly-synthetic
+    // ad-hoc directory (not in the registry) stays unregistered.
+    let resolved_is_registered = components
+        .iter()
+        .any(|c| c.id == resolved_target.component_id);
+    if !resolved_target.synthetic || resolved_is_registered {
         matched_set.insert(resolved_target.component_id.clone());
     }
     let mut matched: Vec<String> = matched_set.into_iter().collect();


### PR DESCRIPTION
## Summary
Top-level `homeboy status` reported `unregistered_context` inside a managed task worktree, while `homeboy git status` correctly resolved the component from the same CWD (#9895):

```
# from /Users/chubes/Developer/wp-build@audit-generated-html-quality
homeboy status    → {"status": "unregistered_context", "suggestion": "Repo not attached..."}
homeboy git status → {"component_id": "wp-build-repo", "success": true}
```

## Root cause
Both commands use `component::resolve_target`, but **bare-path resolution** (`resolve_path_override`) fell through to a **synthetic** component when the path had no portable `homeboy.json` — never checking whether the path is a **worktree of a registered component**. A managed worktree therefore resolved to a synthetic `<name>@<branch>` target, and top-level status (which drops synthetic resolutions) reported it as unregistered.

## Fix
- `resolve_path_override` now matches a bare worktree path to its registered component (shared git common dir, or `<component>@<branch>` naming) before the synthetic fallback, rebased onto the worktree path.
- A **monorepo root is excluded** (its registered components live *inside* the working tree), so it still resolves as a monorepo root rather than a single component.
- A registered component resolved for a worktree is no longer flagged `synthetic`, so top-level `status` treats it as managed — matching `git status`, which already uses the resolved id regardless of `synthetic`.

Fixing the shared resolver (not just `status`) means every bare-path command agrees on the component from a managed worktree — satisfying the issue's parity requirement.

## Testing
- `context::tests::context_resolves_managed_worktree_to_registered_component` (new) — from a git-native worktree of a registered component, top-level status resolves the registered component and reports `managed`.
- `context::tests::context_preserves_monorepo_contained_component_suggestion` — still passes (monorepo root stays a monorepo root, not a component — the regression I caught and guarded against).
- `component::resolution::tests` (36) and `context::tests` (33) — all pass.

## AI assistance
- AI assistance: Yes
- Tool: Homeboy (OpenCode / claude)
- Used for: Tracing the status/git-status disagreement to the synthetic-fallback in bare-path resolution, adding worktree→registered-component matching (with a monorepo guard), and coverage.

Closes #9895