### PR TITLE
fix(runner): project terminal exec runs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -134,6 +134,12 @@ pub fn project_terminal_runner_result(
         return Ok(false);
     }
 
+    // Ad hoc runner-exec runs are observation records, not agent-task records.
+    // Their daemon terminal result is complete without an inner task aggregate.
+    if project_terminal_runner_exec_result(run_id, snapshot)? {
+        return Ok(true);
+    }
+
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
     // Bind a still-pending controller handoff to this authoritative terminal
     // snapshot's daemon job before validating identity (issue #9240). An

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -4,7 +4,8 @@
 
 use serde_json::{json, Value};
 
-use homeboy_core::api_jobs::RemoteRunnerJobRequest;
+use homeboy_core::api_jobs::{JobStatus, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
+use homeboy_core::observation::RunStatus;
 
 use super::*;
 
@@ -163,6 +164,157 @@ pub fn ensure_generic_runner_exec_run(
     remote_command: &[String],
 ) -> Result<homeboy_core::observation::RunRecord> {
     ensure_runner_exec_observation_run(run_id, runner_id, remote_workspace, remote_command, None)
+}
+
+/// Persist the output contract before submitting a daemon job. This gives a
+/// restarted controller the exact runner-side paths it must retain, rather than
+/// relying on ephemeral CLI arguments after the daemon has completed.
+pub fn record_runner_exec_artifact_declarations(
+    run_id: &str,
+    artifacts: &[String],
+    artifact_dirs: &[String],
+    summaries: &[String],
+) -> Result<()> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let run_id = sanitize_run_id(run_id);
+    let Some(mut run) = store.get_run(&run_id)? else {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("generic runner-exec run record not found: {run_id}"),
+            Some(run_id),
+            None,
+        ));
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "runner-exec artifact declarations require a generic runner-exec run",
+            Some(run.id),
+            None,
+        ));
+    }
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    metadata.insert(
+        "runner_exec_artifact_declarations".to_string(),
+        json!({
+            "artifacts": artifacts,
+            "artifact_dirs": artifact_dirs,
+            "summaries": summaries,
+        }),
+    );
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
+/// Retain controller-owned artifact IDs alongside the original declarations.
+/// These IDs remain usable after the daemon evicts its job/event retention.
+pub fn record_runner_exec_artifact_refs(
+    run_id: &str,
+    artifacts: &[homeboy_core::observation::ArtifactRecord],
+) -> Result<()> {
+    if artifacts.is_empty() {
+        return Ok(());
+    }
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let run_id = sanitize_run_id(run_id);
+    let Some(mut run) = store.get_run(&run_id)? else {
+        return Ok(());
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND) {
+        return Ok(());
+    }
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    let mut refs = metadata
+        .get("runner_exec_artifact_refs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for artifact in artifacts {
+        if refs.iter().any(|entry| entry["id"] == artifact.id) {
+            continue;
+        }
+        refs.push(json!({
+            "id": artifact.id.clone(),
+            "kind": artifact.kind.clone(),
+            "path": artifact.path.clone(),
+        }));
+    }
+    metadata.insert("runner_exec_artifact_refs".to_string(), Value::Array(refs));
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
+/// Finalize a generic runner-exec observation from a daemon-owned terminal
+/// snapshot. Agent-task projections intentionally remain separate: this record
+/// has no task aggregate to parse, so the daemon result itself is authoritative.
+pub fn project_terminal_runner_exec_result(
+    run_id: &str,
+    snapshot: &RunnerJobLogSnapshot,
+) -> Result<bool> {
+    if !snapshot.job.status.is_terminal() {
+        return Ok(false);
+    }
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(false);
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND) {
+        return Ok(false);
+    }
+    if RunStatus::from_label(&run.status).is_some_and(RunStatus::is_terminal) {
+        return Ok(false);
+    }
+
+    let runner_id = run
+        .metadata_json
+        .get("runner_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let exit_code = if snapshot.job.status == JobStatus::Succeeded {
+        0
+    } else {
+        1
+    };
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    metadata.insert("runner_job_id".to_string(), json!(snapshot.job.id));
+    metadata.insert("runner_job_status".to_string(), json!(snapshot.job.status));
+    metadata.insert("runner_job_events".to_string(), json!(snapshot.events));
+    let mut execution_record =
+        homeboy_core::runner_execution_envelope::RunnerExecutionRecord::terminal(
+            snapshot.job.id.to_string(),
+            runner_id,
+            "daemon",
+            exit_code,
+        )
+        .with_job_id(snapshot.job.id.to_string());
+    if snapshot.job.status == JobStatus::Cancelled {
+        execution_record.status = "cancelled".to_string();
+    }
+    metadata.insert(
+        "runner_execution_record".to_string(),
+        serde_json::to_value(execution_record).unwrap_or(Value::Null),
+    );
+    metadata.insert(
+        "runner_terminal_projection".to_string(),
+        json!({
+            "state": "projected",
+            "job_id": snapshot.job.id,
+            "status": snapshot.job.status,
+            "event_count": snapshot.events.len(),
+        }),
+    );
+    if snapshot.job.status != JobStatus::Succeeded {
+        metadata.insert(
+            "runner_failure_diagnostics".to_string(),
+            json!({ "job_status": snapshot.job.status, "events": snapshot.events }),
+        );
+    }
+    let status = if snapshot.job.status == JobStatus::Succeeded {
+        RunStatus::Pass
+    } else {
+        RunStatus::Fail
+    };
+    store.finish_run(&run.id, status, Some(run.metadata_json))?;
+    Ok(true)
 }
 
 /// Persist redacted submission ownership before a reverse-broker POST. The

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -427,6 +427,44 @@ pub fn project_terminal_runner_exec_result(
     Ok(true)
 }
 
+/// Finish a synchronous transport that has no daemon job identity (diagnostic
+/// SSH/local execution) after its declared evidence is safely retained.
+pub fn finish_runner_exec_direct(run_id: &str, transport: &str, exit_code: i32) -> Result<bool> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(false);
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND)
+        || RunStatus::from_label(&run.status).is_some_and(RunStatus::is_terminal)
+    {
+        return Ok(false);
+    }
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    metadata.insert(
+        "runner_execution_record".to_string(),
+        json!({
+            "transport": transport, "status": if exit_code == 0 { "succeeded" } else { "failed" },
+            "exit_code": exit_code,
+        }),
+    );
+    metadata.insert(
+        "runner_terminal_projection".to_string(),
+        json!({
+            "state": "projected", "transport": transport, "artifact_promotion": "complete",
+        }),
+    );
+    store.finish_run(
+        &run.id,
+        if exit_code == 0 {
+            RunStatus::Pass
+        } else {
+            RunStatus::Fail
+        },
+        Some(run.metadata_json),
+    )?;
+    Ok(true)
+}
+
 fn validate_runner_exec_snapshot_binding(
     run: &homeboy_core::observation::RunRecord,
     snapshot: &RunnerJobLogSnapshot,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -290,6 +290,63 @@ pub fn record_runner_exec_artifact_refs(
     store.upsert_imported_run_preserving_terminal(&run)
 }
 
+/// Persist one declaration's completed promotion immediately. The artifact IDs
+/// and content hashes make a replay skip that declaration after a crash while
+/// allowing later declarations to resume independently.
+pub fn record_runner_exec_declaration_promotion(
+    run_id: &str,
+    role: &str,
+    declaration: &str,
+    artifacts: &[homeboy_core::observation::ArtifactRecord],
+) -> Result<()> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let run_id = sanitize_run_id(run_id);
+    let Some(mut run) = store.get_run(&run_id)? else {
+        return Ok(());
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND) {
+        return Ok(());
+    }
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    let key = format!("{role}:{declaration}");
+    let mut states = metadata
+        .get("runner_exec_declaration_promotions")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    states.insert(
+        key,
+        json!({
+            "role": role,
+            "declaration": declaration,
+            "state": "promoted",
+            "artifacts": artifacts.iter().map(|artifact| json!({
+                "id": artifact.id,
+                "sha256": artifact.sha256,
+                "path": artifact.path,
+            })).collect::<Vec<_>>(),
+        }),
+    );
+    metadata.insert(
+        "runner_exec_declaration_promotions".to_string(),
+        Value::Object(states),
+    );
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
+pub fn runner_exec_declaration_is_promoted(
+    run: &homeboy_core::observation::RunRecord,
+    role: &str,
+    declaration: &str,
+) -> bool {
+    run.metadata_json
+        .pointer(&format!(
+            "/runner_exec_declaration_promotions/{role}:{declaration}/state"
+        ))
+        .and_then(Value::as_str)
+        == Some("promoted")
+}
+
 /// Finalize a generic runner-exec observation from a daemon-owned terminal
 /// snapshot. Agent-task projections intentionally remain separate: this record
 /// has no task aggregate to parse, so the daemon result itself is authoritative.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -202,6 +202,48 @@ pub fn record_runner_exec_artifact_declarations(
             "summaries": summaries,
         }),
     );
+    metadata.insert(
+        "runner_terminal_projection".to_string(),
+        json!({
+            "state": "awaiting_daemon_terminal",
+            "artifact_promotion": "pending",
+        }),
+    );
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
+/// Checkpoint the authoritative terminal snapshot before copying declared
+/// evidence. A restart can resume promotion from this durable boundary instead
+/// of terminalizing a run whose runner-side files were never retained.
+pub fn record_runner_exec_terminal_checkpoint(
+    run_id: &str,
+    snapshot: &RunnerJobLogSnapshot,
+) -> Result<()> {
+    if !snapshot.job.status.is_terminal() {
+        return Ok(());
+    }
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let run_id = sanitize_run_id(run_id);
+    let Some(mut run) = store.get_run(&run_id)? else {
+        return Ok(());
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND) {
+        return Ok(());
+    }
+    validate_runner_exec_snapshot_binding(&run, snapshot)?;
+    run.metadata_json
+        .as_object_mut()
+        .expect("metadata object")
+        .insert(
+            "runner_terminal_projection".to_string(),
+            json!({
+                "state": "terminal_checkpointed",
+                "artifact_promotion": "pending",
+                "job_id": snapshot.job.id,
+                "status": snapshot.job.status,
+                "event_count": snapshot.events.len(),
+            }),
+        );
     store.upsert_imported_run_preserving_terminal(&run)
 }
 
@@ -211,9 +253,6 @@ pub fn record_runner_exec_artifact_refs(
     run_id: &str,
     artifacts: &[homeboy_core::observation::ArtifactRecord],
 ) -> Result<()> {
-    if artifacts.is_empty() {
-        return Ok(());
-    }
     let store = homeboy_core::observation::ObservationStore::open_initialized()?;
     let run_id = sanitize_run_id(run_id);
     let Some(mut run) = store.get_run(&run_id)? else {
@@ -238,7 +277,16 @@ pub fn record_runner_exec_artifact_refs(
             "path": artifact.path.clone(),
         }));
     }
+    let artifact_count = refs.len();
     metadata.insert("runner_exec_artifact_refs".to_string(), Value::Array(refs));
+    metadata.insert(
+        "runner_terminal_projection".to_string(),
+        json!({
+            "state": "terminal_checkpointed",
+            "artifact_promotion": "complete",
+            "artifact_count": artifact_count,
+        }),
+    );
     store.upsert_imported_run_preserving_terminal(&run)
 }
 
@@ -263,30 +311,15 @@ pub fn project_terminal_runner_exec_result(
         return Ok(false);
     }
 
-    let runner_id = run
+    let runner_id = validate_runner_exec_snapshot_binding(&run, snapshot)?;
+    if run
         .metadata_json
-        .get("runner_id")
+        .pointer("/runner_terminal_projection/artifact_promotion")
         .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let runner_job_id = run
-        .metadata_json
-        .get("runner_job_id")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let snapshot_runner_id = snapshot.job.target_runner_id.as_deref().unwrap_or_default();
-    if runner_id.is_empty()
-        || runner_job_id.is_empty()
-        || runner_id != snapshot_runner_id
-        || runner_job_id != snapshot.job.id.to_string()
+        == Some("pending")
     {
-        return Err(Error::validation_invalid_argument(
-            "runner_job_id",
-            format!(
-                "terminal runner snapshot does not match durable binding ({runner_id}/{runner_job_id})"
-            ),
-            Some(run.id),
-            None,
+        return Err(Error::internal_unexpected(
+            "runner-exec terminal projection requires declared artifact promotion before finalization",
         ));
     }
     let exit_code = if snapshot.job.status == JobStatus::Succeeded {
@@ -335,6 +368,39 @@ pub fn project_terminal_runner_exec_result(
     };
     store.finish_run(&run.id, status, Some(run.metadata_json))?;
     Ok(true)
+}
+
+fn validate_runner_exec_snapshot_binding(
+    run: &homeboy_core::observation::RunRecord,
+    snapshot: &RunnerJobLogSnapshot,
+) -> Result<String> {
+    let runner_id = run
+        .metadata_json
+        .get("runner_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let runner_job_id = run
+        .metadata_json
+        .get("runner_job_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let snapshot_runner_id = snapshot.job.target_runner_id.as_deref().unwrap_or_default();
+    if runner_id.is_empty()
+        || runner_job_id.is_empty()
+        || runner_id != snapshot_runner_id
+        || runner_job_id != snapshot.job.id.to_string()
+    {
+        return Err(Error::validation_invalid_argument(
+            "runner_job_id",
+            format!(
+                "terminal runner snapshot does not match durable binding ({runner_id}/{runner_job_id})"
+            ),
+            Some(run.id.clone()),
+            None,
+        ));
+    }
+    Ok(runner_id)
 }
 
 /// Persist redacted submission ownership before a reverse-broker POST. The

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -347,6 +347,115 @@ pub fn runner_exec_declaration_is_promoted(
         == Some("promoted")
 }
 
+/// Bind a directory declaration to one immutable recursive tree before any of
+/// its children are copied. A replay of changed runner-side output fails closed
+/// instead of mixing two directory versions under one declaration.
+pub fn checkpoint_runner_exec_directory_tree(
+    run_id: &str,
+    declaration: &str,
+    tree_sha256: &str,
+) -> Result<()> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(());
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND) {
+        return Ok(());
+    }
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    let mut checkpoints = metadata
+        .get("runner_exec_directory_promotions")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(existing) = checkpoints
+        .get(declaration)
+        .and_then(|value| value.get("tree_sha256"))
+        .and_then(Value::as_str)
+        .filter(|existing| *existing != tree_sha256)
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact_dir",
+            format!(
+                "runner exec artifact directory changed after promotion checkpoint ({existing})"
+            ),
+            Some(declaration.to_string()),
+            None,
+        ));
+    }
+    checkpoints
+        .entry(declaration.to_string())
+        .or_insert_with(|| json!({ "tree_sha256": tree_sha256, "children": {} }));
+    metadata.insert(
+        "runner_exec_directory_promotions".to_string(),
+        Value::Object(checkpoints),
+    );
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
+pub fn runner_exec_directory_child_is_promoted(
+    run_id: &str,
+    declaration: &str,
+    relative_child: &str,
+) -> Result<bool> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(false);
+    };
+    Ok(run
+        .metadata_json
+        .get("runner_exec_directory_promotions")
+        .and_then(|value| value.get(declaration))
+        .and_then(|value| value.get("children"))
+        .and_then(|value| value.get(relative_child))
+        .and_then(|value| value.get("state"))
+        .and_then(Value::as_str)
+        == Some("promoted"))
+}
+
+pub fn record_runner_exec_directory_child_promotion(
+    run_id: &str,
+    declaration: &str,
+    relative_child: &str,
+    artifact: &homeboy_core::observation::ArtifactRecord,
+) -> Result<()> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(());
+    };
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    let mut checkpoints = metadata
+        .get("runner_exec_directory_promotions")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let checkpoint = checkpoints
+        .get_mut(declaration)
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            Error::internal_unexpected("runner-exec directory child has no tree checkpoint")
+        })?;
+    let children = checkpoint
+        .entry("children")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .expect("directory children object");
+    children.insert(
+        relative_child.to_string(),
+        json!({
+            "state": "promoted",
+            "id": artifact.id,
+            "sha256": artifact.sha256,
+            "artifact_type": artifact.artifact_type,
+        }),
+    );
+    metadata.insert(
+        "runner_exec_directory_promotions".to_string(),
+        Value::Object(checkpoints),
+    );
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
 /// Finalize a generic runner-exec observation from a daemon-owned terminal
 /// snapshot. Agent-task projections intentionally remain separate: this record
 /// has no task aggregate to parse, so the daemon result itself is authoritative.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -269,6 +269,26 @@ pub fn project_terminal_runner_exec_result(
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_string();
+    let runner_job_id = run
+        .metadata_json
+        .get("runner_job_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let snapshot_runner_id = snapshot.job.target_runner_id.as_deref().unwrap_or_default();
+    if runner_id.is_empty()
+        || runner_job_id.is_empty()
+        || runner_id != snapshot_runner_id
+        || runner_job_id != snapshot.job.id.to_string()
+    {
+        return Err(Error::validation_invalid_argument(
+            "runner_job_id",
+            format!(
+                "terminal runner snapshot does not match durable binding ({runner_id}/{runner_job_id})"
+            ),
+            Some(run.id),
+            None,
+        ));
+    }
     let exit_code = if snapshot.job.status == JobStatus::Succeeded {
         0
     } else {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -340,9 +340,10 @@ pub fn runner_exec_declaration_is_promoted(
     declaration: &str,
 ) -> bool {
     run.metadata_json
-        .pointer(&format!(
-            "/runner_exec_declaration_promotions/{role}:{declaration}/state"
-        ))
+        .get("runner_exec_declaration_promotions")
+        .and_then(Value::as_object)
+        .and_then(|promotions| promotions.get(&format!("{role}:{declaration}")))
+        .and_then(|promotion| promotion.get("state"))
         .and_then(Value::as_str)
         == Some("promoted")
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -236,6 +236,33 @@ fn generic_runner_exec_terminal_projection_is_authoritative_and_idempotent() {
     });
 }
 
+#[test]
+fn generic_runner_exec_rejects_stale_terminal_snapshot_binding() {
+    with_isolated_home(|_| {
+        let command = vec!["true".to_string()];
+        record_runner_exec_job_identity(
+            "runner-projection-stale",
+            "homeboy-lab",
+            "00000000-0000-0000-0000-000000000123",
+            "/runner/workspace",
+            &command,
+        )
+        .expect("bound run");
+        let mut stale = runner_snapshot("succeeded");
+        stale.job.id =
+            uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000124").expect("stale job id");
+        let error = project_terminal_runner_exec_result("runner-projection-stale", &stale)
+            .expect_err("delayed terminal snapshot is rejected");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        let run = homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("store")
+            .get_run("runner-projection-stale")
+            .expect("read")
+            .expect("run");
+        assert_eq!(run.status, "running");
+    });
+}
+
 fn runner_snapshot(status: &str) -> RunnerJobLogSnapshot {
     let job_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000123").expect("job id");
     let status = match status {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -3,7 +3,7 @@
 #![cfg(test)]
 
 use super::*;
-use homeboy_core::api_jobs::{Job, JobStore, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStatus, RunnerJobLogSnapshot};
 use homeboy_core::test_support::with_isolated_home;
 
 #[test]
@@ -173,4 +173,114 @@ fn generic_runner_exec_run_supports_artifact_attachment() {
             .expect("declared summary attaches to the generic run");
         assert_eq!(artifact.run_id, "adhoc-evidence-9485");
     });
+}
+
+#[test]
+fn generic_runner_exec_terminal_projection_is_authoritative_and_idempotent() {
+    with_isolated_home(|_| {
+        let command = vec!["node".to_string(), "fuzz.mjs".to_string()];
+        for (run_id, status, expected_status) in [
+            ("runner-projection-success", "succeeded", "pass"),
+            ("runner-projection-failure", "failed", "fail"),
+            ("runner-projection-cancel", "cancelled", "fail"),
+        ] {
+            record_runner_exec_job_identity(
+                run_id,
+                "homeboy-lab",
+                "00000000-0000-0000-0000-000000000123",
+                "/runner/workspace",
+                &command,
+            )
+            .expect("generic run bound to daemon job");
+            record_runner_exec_artifact_declarations(
+                run_id,
+                &["case-log.jsonl".to_string()],
+                &["artifacts".to_string()],
+                &["results.json".to_string()],
+            )
+            .expect("declared artifact contract persists before execution");
+
+            let snapshot = runner_snapshot(status);
+            assert!(project_terminal_runner_exec_result(run_id, &snapshot)
+                .expect("terminal daemon result projects"));
+            assert!(!project_terminal_runner_exec_result(run_id, &snapshot)
+                .expect("duplicate terminal projection is ignored"));
+
+            let store =
+                homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+            let run = store
+                .get_run(run_id)
+                .expect("read run")
+                .expect("projected run");
+            assert_eq!(run.status, expected_status);
+            assert!(run.finished_at.is_some());
+            assert_eq!(
+                run.metadata_json["runner_terminal_projection"]["state"],
+                "projected"
+            );
+            assert_eq!(
+                run.metadata_json["runner_execution_record"]["status"],
+                status
+            );
+            assert_eq!(
+                run.metadata_json["runner_exec_artifact_declarations"]["summaries"][0],
+                "results.json"
+            );
+            if status != "succeeded" {
+                assert_eq!(
+                    run.metadata_json["runner_failure_diagnostics"]["job_status"],
+                    status
+                );
+            }
+        }
+    });
+}
+
+fn runner_snapshot(status: &str) -> RunnerJobLogSnapshot {
+    let job_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000123").expect("job id");
+    let status = match status {
+        "succeeded" => JobStatus::Succeeded,
+        "failed" => JobStatus::Failed,
+        "cancelled" => JobStatus::Cancelled,
+        _ => panic!("terminal status"),
+    };
+    RunnerJobLogSnapshot {
+        job: Job {
+            id: job_id,
+            operation: "exec".to_string(),
+            status,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+            started_at_ms: Some(1),
+            finished_at_ms: Some(2),
+            event_count: 1,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            daemon_lease_id: None,
+            target_runner_id: Some("homeboy-lab".to_string()),
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+            runner_job_projection: None,
+        },
+        events: vec![JobEvent {
+            sequence: 1,
+            job_id,
+            kind: if status == JobStatus::Succeeded {
+                JobEventKind::Result
+            } else {
+                JobEventKind::Error
+            },
+            timestamp_ms: 2,
+            message: Some("terminal result".to_string()),
+            data: Some(serde_json::json!({
+                "exit_code": if status == JobStatus::Succeeded { 0 } else { 1 },
+                "classification": "timeout",
+            })),
+        }],
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -313,6 +313,45 @@ fn synchronous_diagnostic_ssh_and_local_runs_finish_with_artifacts_and_replay_sa
     });
 }
 
+#[test]
+fn declaration_replay_uses_literal_path_and_tilde_keys() {
+    with_isolated_home(|_| {
+        let run_id = "escaped-declaration-recovery";
+        ensure_generic_runner_exec_run(run_id, "runner", "/workspace", &["true".to_string()])
+            .expect("run");
+        let declarations = ["artifacts/result.json", "a~b/c"];
+        record_runner_exec_artifact_declarations(
+            run_id,
+            &declarations
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>(),
+            &[],
+            &[],
+        )
+        .expect("declarations");
+        for declaration in declarations {
+            record_runner_exec_declaration_promotion(run_id, "artifact", declaration, &[])
+                .expect("promotion checkpoint");
+            // A duplicate recovery writes the same key and must remain visible.
+            record_runner_exec_declaration_promotion(run_id, "artifact", declaration, &[])
+                .expect("duplicate checkpoint");
+        }
+        let run = homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("store")
+            .get_run(run_id)
+            .expect("read")
+            .expect("run");
+        for declaration in declarations {
+            assert!(runner_exec_declaration_is_promoted(
+                &run,
+                "artifact",
+                declaration,
+            ));
+        }
+    });
+}
+
 fn runner_snapshot(status: &str) -> RunnerJobLogSnapshot {
     let job_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000123").expect("job id");
     let status = match status {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -267,6 +267,52 @@ fn generic_runner_exec_rejects_stale_terminal_snapshot_binding() {
     });
 }
 
+#[test]
+fn synchronous_diagnostic_ssh_and_local_runs_finish_with_artifacts_and_replay_safely() {
+    with_isolated_home(|_| {
+        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+        let temp = tempfile::NamedTempFile::new().expect("artifact");
+        std::fs::write(temp.path(), "diagnostic output").expect("write artifact");
+        for (run_id, transport, exit_code, expected_status) in [
+            ("diagnostic-ssh-success", "diagnostic_ssh", 0, "pass"),
+            ("local-failure", "local", 17, "fail"),
+        ] {
+            ensure_generic_runner_exec_run(run_id, "runner", "/workspace", &["true".to_string()])
+                .expect("synchronous run");
+            record_runner_exec_artifact_declarations(
+                run_id,
+                &["diagnostic.log".to_string()],
+                &[],
+                &[],
+            )
+            .expect("artifact declaration");
+            let artifact = store
+                .record_artifact_with_id(
+                    run_id,
+                    "diagnostic_log",
+                    temp.path(),
+                    &format!("{run_id}-artifact"),
+                    serde_json::json!({ "promoted_by": "runner.exec" }),
+                )
+                .expect("artifact retained before direct terminal projection");
+            record_runner_exec_artifact_refs(run_id, &[artifact]).expect("artifact refs");
+            assert!(
+                finish_runner_exec_direct(run_id, transport, exit_code).expect("direct terminal")
+            );
+            assert!(
+                !finish_runner_exec_direct(run_id, transport, exit_code).expect("restart replay")
+            );
+            let run = store.get_run(run_id).expect("read").expect("run");
+            assert_eq!(run.status, expected_status);
+            assert_eq!(
+                run.metadata_json["runner_execution_record"]["transport"],
+                transport
+            );
+            assert_eq!(store.list_artifacts(run_id).expect("artifacts").len(), 1);
+        }
+    });
+}
+
 fn runner_snapshot(status: &str) -> RunnerJobLogSnapshot {
     let job_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000123").expect("job id");
     let status = match status {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -201,6 +201,10 @@ fn generic_runner_exec_terminal_projection_is_authoritative_and_idempotent() {
             .expect("declared artifact contract persists before execution");
 
             let snapshot = runner_snapshot(status);
+            record_runner_exec_terminal_checkpoint(run_id, &snapshot)
+                .expect("terminal snapshot checkpoint persists before promotion");
+            record_runner_exec_artifact_refs(run_id, &[])
+                .expect("empty declared promotion completes before terminal projection");
             assert!(project_terminal_runner_exec_result(run_id, &snapshot)
                 .expect("terminal daemon result projects"));
             assert!(!project_terminal_runner_exec_result(run_id, &snapshot)

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -164,6 +164,9 @@ impl CliRuntime {
         // can reconcile and resume runs dispatched to a remote runner without
         // core depending on runner behavior.
         crate::runner::register_runner_continuation_provider();
+        // Recover completed generic runner-exec jobs before this invocation can
+        // open a daemon store whose retention policy might evict their evidence.
+        let _ = crate::runner::reconcile_terminal_runner_exec_runs();
         // Register the runner daemon-exec driver so the daemon's /exec endpoint
         // can prepare and run a runner job as a local child without core
         // depending on runner process-execution behavior.

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -150,6 +150,15 @@ pub(super) fn exec(
         },
     )?;
     if let Some(run_id) = validated_run_id.as_deref() {
+        if let (Some(job), Some(events)) = (output.job.as_ref(), output.job_events.as_ref()) {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
+                run_id,
+                &homeboy::core::api_jobs::RunnerJobLogSnapshot {
+                    job: job.clone(),
+                    events: events.clone(),
+                },
+            )?;
+        }
         let artifacts = runner::promote_runner_exec_artifacts(run_id, &output, &artifact_outputs)?;
         let promoted_artifacts = artifacts
             .iter()
@@ -183,6 +192,15 @@ pub(super) fn exec(
             .cloned()
             .collect::<Vec<_>>();
         homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs(run_id, &retained)?;
+        if let (Some(job), Some(events)) = (output.job.as_ref(), output.job_events.as_ref()) {
+            homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
+                run_id,
+                &homeboy::core::api_jobs::RunnerJobLogSnapshot {
+                    job: job.clone(),
+                    events: events.clone(),
+                },
+            )?;
+        }
     }
     Ok((output, exit_code))
 }

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -241,6 +241,18 @@ pub(super) fn exec(
                     events: events.clone(),
                 },
             )?;
+        } else if matches!(
+            output.mode,
+            runner::RunnerExecMode::DiagnosticSsh | runner::RunnerExecMode::Local
+        ) {
+            homeboy_agents::agent_task_lifecycle::finish_runner_exec_direct(
+                run_id,
+                match output.mode {
+                    runner::RunnerExecMode::DiagnosticSsh => "diagnostic_ssh",
+                    _ => "local",
+                },
+                exit_code,
+            )?;
         }
         if matches!(
             output.mode,

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -159,18 +159,59 @@ pub(super) fn exec(
                 },
             )?;
         }
-        let artifacts = runner::promote_runner_exec_artifacts(run_id, &output, &artifact_outputs)?;
+        let mut artifacts = Vec::new();
+        for declaration in &artifact_outputs {
+            let promoted = runner::promote_runner_exec_artifacts(
+                run_id,
+                &output,
+                std::slice::from_ref(declaration),
+            )?;
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+                run_id,
+                "artifact",
+                declaration,
+                &promoted,
+            )?;
+            artifacts.extend(promoted);
+        }
         let promoted_artifacts = artifacts
             .iter()
             .filter_map(|record| runner::promoted_output(&output, record))
             .collect::<Vec<_>>();
-        let artifact_dir_records =
-            runner::promote_runner_exec_artifact_dirs(run_id, &output, &artifact_dir_outputs)?;
+        let mut artifact_dir_records = Vec::new();
+        for declaration in &artifact_dir_outputs {
+            let promoted = runner::promote_runner_exec_artifact_dirs(
+                run_id,
+                &output,
+                std::slice::from_ref(declaration),
+            )?;
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+                run_id,
+                "artifact_dir",
+                declaration,
+                &promoted,
+            )?;
+            artifact_dir_records.extend(promoted);
+        }
         let promoted_artifact_dir_records = artifact_dir_records
             .iter()
             .filter_map(|record| runner::promoted_output(&output, record))
             .collect::<Vec<_>>();
-        let summaries = runner::promote_runner_exec_summaries(run_id, &output, &summary_outputs)?;
+        let mut summaries = Vec::new();
+        for declaration in &summary_outputs {
+            let promoted = runner::promote_runner_exec_summaries(
+                run_id,
+                &output,
+                std::slice::from_ref(declaration),
+            )?;
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+                run_id,
+                "summary",
+                declaration,
+                &promoted,
+            )?;
+            summaries.extend(promoted);
+        }
         let structured_summaries = summaries
             .iter()
             .filter_map(|summary| runner::runner_exec_structured_summary(&output, summary))
@@ -200,6 +241,9 @@ pub(super) fn exec(
                     events: events.clone(),
                 },
             )?;
+        }
+        if matches!(output.mode, runner::RunnerExecMode::Daemon) {
+            homeboy_lab_runner::reconcile_runner_generation_after_evidence(&output.runner_id)?;
         }
     }
     Ok((output, exit_code))

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -93,6 +93,25 @@ pub(super) fn exec(
 
     let validated_run_id = validate_runner_exec_run_id(run_id)?;
     let (cwd, source_snapshot) = exec_workspace_context(runner_id, cwd, sync_workspace, false)?;
+    if let Some(run_id) = validated_run_id.as_deref() {
+        let runner_config = runner::load(runner_id)?;
+        let remote_cwd = cwd
+            .as_deref()
+            .or(runner_config.workspace_root.as_deref())
+            .unwrap_or(".");
+        homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+            run_id,
+            runner_id,
+            remote_cwd,
+            &prepared_command,
+        )?;
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_declarations(
+            run_id,
+            &artifact_outputs,
+            &artifact_dir_outputs,
+            &summary_outputs,
+        )?;
+    }
 
     let (mut output, exit_code) = runner::exec(
         runner_id,
@@ -157,6 +176,13 @@ pub(super) fn exec(
             .extend(promoted_artifact_dir_records);
         output.structured_summaries.extend(structured_summaries);
         output.promoted_outputs.extend(promoted_summaries);
+        let retained = artifacts
+            .iter()
+            .chain(artifact_dir_records.iter())
+            .chain(summaries.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs(run_id, &retained)?;
     }
     Ok((output, exit_code))
 }

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -242,7 +242,10 @@ pub(super) fn exec(
                 },
             )?;
         }
-        if matches!(output.mode, runner::RunnerExecMode::Daemon) {
+        if matches!(
+            output.mode,
+            runner::RunnerExecMode::Daemon | runner::RunnerExecMode::ReverseBroker
+        ) {
             homeboy_lab_runner::reconcile_runner_generation_after_evidence(&output.runner_id)?;
         }
     }

--- a/crates/homeboy-core/src/observation/mod.rs
+++ b/crates/homeboy-core/src/observation/mod.rs
@@ -59,8 +59,9 @@ pub use records::{
 };
 pub use run_failure_causes::{nested_failure_causes_from_run_detail, RunFailureCause};
 pub use store::{
-    ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,
-    PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV, SOURCE_SNAPSHOT_METADATA_ENV,
+    directory_tree_sha256, ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION,
+    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+    SOURCE_SNAPSHOT_METADATA_ENV,
 };
 pub use test_findings::{
     finding_records_from_failure_clusters, finding_records_from_test_analysis_input,

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rusqlite::{params, OptionalExtension};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::*;
@@ -343,6 +344,36 @@ impl ObservationStore {
         path: impl AsRef<Path>,
         metadata_json: serde_json::Value,
     ) -> Result<ArtifactRecord> {
+        self.record_directory_artifact_with_id_and_metadata(run_id, kind, path, None, metadata_json)
+    }
+
+    /// Record a directory under a caller-owned stable id. Replays return the
+    /// existing record only when its immutable tree digest and owner agree.
+    pub fn record_directory_artifact_with_id(
+        &self,
+        run_id: &str,
+        kind: &str,
+        path: impl AsRef<Path>,
+        artifact_id: &str,
+        metadata_json: serde_json::Value,
+    ) -> Result<ArtifactRecord> {
+        self.record_directory_artifact_with_id_and_metadata(
+            run_id,
+            kind,
+            path,
+            Some(artifact_id),
+            metadata_json,
+        )
+    }
+
+    fn record_directory_artifact_with_id_and_metadata(
+        &self,
+        run_id: &str,
+        kind: &str,
+        path: impl AsRef<Path>,
+        artifact_id: Option<&str>,
+        metadata_json: serde_json::Value,
+    ) -> Result<ArtifactRecord> {
         validate_required("run_id", run_id)?;
         validate_required("kind", kind)?;
         if self.get_run(run_id)?.is_none() {
@@ -381,7 +412,31 @@ impl ObservationStore {
             ));
         }
 
-        let id = Uuid::new_v4().to_string();
+        let id = artifact_id
+            .filter(|id| !id.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let tree_sha256 = directory_tree_sha256(path)?;
+        if let Some(existing) = self.get_artifact(&id)? {
+            let existing_matches = existing.run_id == run_id
+                && existing.kind == kind
+                && existing.artifact_type == "directory"
+                && existing.sha256.as_deref() == Some(tree_sha256.as_str())
+                && Path::new(&existing.path).is_dir()
+                && directory_tree_sha256(Path::new(&existing.path))
+                    .ok()
+                    .as_deref()
+                    == Some(tree_sha256.as_str());
+            if existing_matches {
+                return Ok(existing);
+            }
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                format!("stable artifact id '{id}' already records different content or ownership"),
+                Some(id),
+                None,
+            ));
+        }
         let created_at = chrono::Utc::now().to_rfc3339();
         let stored_path = persisted_artifact_path(run_id, &id, path)?;
         copy_artifact_directory(path, &stored_path)?;
@@ -401,7 +456,7 @@ impl ObservationStore {
                     kind,
                     "directory",
                     path_string,
-                    Option::<String>::None,
+                    Some(tree_sha256.clone()),
                     Option::<String>::None,
                     Option::<String>::None,
                     viewer_links_json,
@@ -972,6 +1027,77 @@ impl ObservationStore {
         })?;
         Ok(())
     }
+}
+
+/// Hash a directory tree independent of traversal order. Paths and entry types
+/// are included so a rename or file/directory swap cannot reuse prior evidence.
+pub fn directory_tree_sha256(path: &Path) -> Result<String> {
+    let mut entries = Vec::new();
+    collect_directory_tree_entries(path, Path::new(""), &mut entries)?;
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut digest = Sha256::new();
+    for (relative, kind, content) in entries {
+        digest.update(relative.as_os_str().as_encoded_bytes());
+        digest.update([0]);
+        digest.update(kind.as_bytes());
+        digest.update([0]);
+        digest.update(content.as_bytes());
+        digest.update([0]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn collect_directory_tree_entries(
+    root: &Path,
+    relative: &Path,
+    entries: &mut Vec<(PathBuf, &'static str, String)>,
+) -> Result<()> {
+    let directory = root.join(relative);
+    let mut children = fs::read_dir(&directory)
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", directory.display())),
+            )
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", directory.display())),
+            )
+        })?;
+    children.sort_by_key(|entry| entry.file_name());
+    for child in children {
+        let child_relative = relative.join(child.file_name());
+        let metadata = child.metadata().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("stat {}", child.path().display())),
+            )
+        })?;
+        if metadata.is_dir() {
+            entries.push((child_relative.clone(), "directory", String::new()));
+            collect_directory_tree_entries(root, &child_relative, entries)?;
+        } else if metadata.is_file() {
+            entries.push((
+                child_relative,
+                "file",
+                crate::artifact_metadata::sha256_file(&child.path())?,
+            ));
+        } else {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                format!(
+                    "artifact directory contains unsupported entry: {}",
+                    child.path().display()
+                ),
+                Some(child.path().display().to_string()),
+                None,
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn remote_projection_identity_matches(

--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -22,6 +22,7 @@ use super::records::{
     TriageItemRecord, TriagePullRequestSignals,
 };
 use crate::{paths, Error, Result};
+pub use artifacts::directory_tree_sha256;
 
 pub(crate) use helpers::*;
 

--- a/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
+++ b/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
@@ -74,38 +74,41 @@ pub fn promote_runner_exec_artifact_dirs(
                 None,
             ));
         }
-        let mut children = fs::read_dir(&record_dir)
-            .map_err(|err| {
-                Error::internal_io(
-                    err.to_string(),
-                    Some(format!("read {}", record_dir.display())),
-                )
-            })?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| {
-                Error::internal_io(
-                    err.to_string(),
-                    Some(format!("read {}", record_dir.display())),
-                )
-            })?;
-        children.sort_by_key(|entry| entry.file_name());
-        for child in children {
-            let record_path = child.path();
-            let metadata = child.metadata().map_err(|err| {
-                Error::internal_io(
-                    err.to_string(),
-                    Some(format!("stat {}", record_path.display())),
-                )
-            })?;
-            if !metadata.is_file() && !metadata.is_dir() {
+        let tree_sha256 = homeboy_core::observation::directory_tree_sha256(&record_dir)?;
+        homeboy_agents::agent_task_lifecycle::checkpoint_runner_exec_directory_tree(
+            run_id,
+            declared_dir,
+            &tree_sha256,
+        )?;
+        for (relative, record_path) in runner_exec_directory_children(&record_dir)? {
+            let relative_string = relative.display().to_string();
+            if homeboy_agents::agent_task_lifecycle::runner_exec_directory_child_is_promoted(
+                run_id,
+                declared_dir,
+                &relative_string,
+            )? {
                 continue;
             }
-            let name = child.file_name().to_string_lossy().to_string();
-            let declared_path = Path::new(declared_dir).join(&name).display().to_string();
-            let runner_path = runner_dir.join(&name);
+            let name = relative
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("artifact");
+            let declared_path = Path::new(declared_dir)
+                .join(&relative)
+                .display()
+                .to_string();
+            let runner_path = runner_dir.join(&relative);
+            let artifact_id = runner_exec_directory_child_id(
+                run_id,
+                &output.runner_id,
+                declared_dir,
+                &relative_string,
+            );
             let mut artifact_metadata = serde_json::json!({
                 "artifact_dir": declared_dir,
                 "declared_path": declared_path,
+                "relative_child": relative_string,
+                "tree_sha256": tree_sha256,
                 "evidence_role": RunnerExecEvidenceRole::Artifact.as_str(),
                 "promoted_by": "runner.exec",
                 "runner_path": runner_path.display().to_string(),
@@ -114,16 +117,106 @@ pub fn promote_runner_exec_artifact_dirs(
                 artifact_metadata["source"] = serde_json::json!("runner_path_attach");
                 artifact_metadata["runner_id"] = serde_json::json!(runner.id.clone());
             }
-            records.extend(record_runner_exec_output(
+            let record = record_runner_exec_directory_child(
                 &store,
                 run_id,
-                &runner_exec_artifact_kind(&name),
+                &runner_exec_artifact_kind(name),
                 &record_path,
+                &artifact_id,
                 artifact_metadata,
-            )?);
+            )?;
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_directory_child_promotion(
+                run_id,
+                declared_dir,
+                &relative_string,
+                &record,
+            )?;
+            records.push(record);
         }
     }
     Ok(records)
+}
+
+fn runner_exec_directory_children(root: &Path) -> homeboy_core::Result<Vec<(PathBuf, PathBuf)>> {
+    fn collect(
+        root: &Path,
+        relative: &Path,
+        children: &mut Vec<(PathBuf, PathBuf)>,
+    ) -> homeboy_core::Result<()> {
+        let directory = root.join(relative);
+        let mut entries = fs::read_dir(&directory)
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read {}", directory.display())),
+                )
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read {}", directory.display())),
+                )
+            })?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let path = entry.path();
+            let child_relative = relative.join(entry.file_name());
+            let metadata = entry.metadata().map_err(|error| {
+                Error::internal_io(error.to_string(), Some(format!("stat {}", path.display())))
+            })?;
+            if metadata.is_dir() {
+                children.push((child_relative.clone(), path));
+                collect(root, &child_relative, children)?;
+            } else if metadata.is_file() {
+                children.push((child_relative, path));
+            } else {
+                return Err(Error::validation_invalid_argument(
+                    "artifact_dir",
+                    format!(
+                        "runner exec artifact directory contains unsupported entry: {}",
+                        path.display()
+                    ),
+                    Some(path.display().to_string()),
+                    None,
+                ));
+            }
+        }
+        Ok(())
+    }
+    let mut children = Vec::new();
+    collect(root, Path::new(""), &mut children)?;
+    Ok(children)
+}
+
+fn runner_exec_directory_child_id(
+    run_id: &str,
+    binding: &str,
+    declaration: &str,
+    relative_child: &str,
+) -> String {
+    format!(
+        "runner-exec-dir-{:x}",
+        Sha256::digest(
+            format!("{run_id}\0{binding}\0artifact_dir\0{declaration}\0{relative_child}")
+                .as_bytes()
+        )
+    )
+}
+
+fn record_runner_exec_directory_child(
+    store: &ObservationStore,
+    run_id: &str,
+    kind: &str,
+    path: &Path,
+    artifact_id: &str,
+    metadata: serde_json::Value,
+) -> homeboy_core::Result<ArtifactRecord> {
+    if path.is_dir() {
+        return store.record_directory_artifact_with_id(run_id, kind, path, artifact_id, metadata);
+    }
+    let (kind, metadata) = typed_artifact_metadata(kind, path, metadata);
+    store.record_artifact_with_id(run_id, &kind, path, artifact_id, metadata)
 }
 
 /// Promote declared summary outputs into observation-store artifacts.
@@ -647,5 +740,118 @@ impl RunnerExecEvidenceRole {
             Self::Artifact => runner_exec_artifact_kind(declared),
             Self::Summary => runner_exec_summary_kind(declared),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_core::test_support::with_isolated_home;
+
+    fn output(cwd: &Path) -> RunnerExecOutput {
+        RunnerExecOutput {
+            variant: "exec",
+            command: "runner.exec",
+            runner_id: "local".to_string(),
+            dry_run: false,
+            mode: runner::RunnerExecMode::Local,
+            argv: vec!["true".to_string()],
+            remote_cwd: cwd.display().to_string(),
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            source_snapshot: None,
+            job: None,
+            runner_job: None,
+            job_id: None,
+            job_events: None,
+            mirror_run_id: None,
+            patch: None,
+            mutation_artifacts: None,
+            artifacts: Vec::new(),
+            promoted_outputs: Vec::new(),
+            structured_summaries: Vec::new(),
+            metrics: None,
+            capture: None,
+            execution_record: None,
+            runner_result: None,
+            handoff: None,
+            diagnostics: None,
+        }
+    }
+
+    #[test]
+    fn directory_replay_resumes_after_first_child_and_rejects_tree_mutation() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let directory = temp.path().join("evidence");
+            fs::create_dir(&directory).expect("directory");
+            fs::write(directory.join("first.txt"), "first").expect("first child");
+            fs::write(directory.join("second.txt"), "second").expect("second child");
+            let run_id = "directory-crash-recovery";
+            homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+                run_id,
+                "local",
+                &temp.path().display().to_string(),
+                &["true".to_string()],
+            )
+            .expect("run");
+
+            let tree = homeboy_core::observation::directory_tree_sha256(&directory).expect("tree");
+            homeboy_agents::agent_task_lifecycle::checkpoint_runner_exec_directory_tree(
+                run_id, "evidence", &tree,
+            )
+            .expect("tree checkpoint");
+            let store = ObservationStore::open_initialized().expect("store");
+            let first_id = runner_exec_directory_child_id(run_id, "local", "evidence", "first.txt");
+            let first = store
+                .record_artifact_with_id(
+                    run_id,
+                    "first_txt",
+                    directory.join("first.txt"),
+                    &first_id,
+                    serde_json::json!({}),
+                )
+                .expect("first artifact before simulated crash");
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_directory_child_promotion(
+                run_id,
+                "evidence",
+                "first.txt",
+                &first,
+            )
+            .expect("first child checkpoint");
+
+            let resumed = promote_runner_exec_artifact_dirs(
+                run_id,
+                &output(temp.path()),
+                &["evidence".to_string()],
+            )
+            .expect("recovery resumes only missing child");
+            assert_eq!(resumed.len(), 1);
+            assert_eq!(
+                resumed[0].id,
+                runner_exec_directory_child_id(run_id, "local", "evidence", "second.txt")
+            );
+            assert!(promote_runner_exec_artifact_dirs(
+                run_id,
+                &output(temp.path()),
+                &["evidence".to_string()],
+            )
+            .expect("duplicate replay")
+            .is_empty());
+            assert_eq!(store.list_artifacts(run_id).expect("artifacts").len(), 2);
+
+            fs::write(directory.join("second.txt"), "changed").expect("mutate tree");
+            let error = promote_runner_exec_artifact_dirs(
+                run_id,
+                &output(temp.path()),
+                &["evidence".to_string()],
+            )
+            .expect_err("tree mutation must not reuse the declaration checkpoint");
+            assert_eq!(
+                error.code,
+                homeboy_core::ErrorCode::ValidationInvalidArgument
+            );
+        });
     }
 }

--- a/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
+++ b/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
@@ -7,6 +7,7 @@
 //! and building the promoted-output/structured-summary views. It operates on
 //! core runner types, not command types.
 
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -252,7 +253,27 @@ fn record_runner_exec_output(
     }
 
     let (kind, metadata) = typed_artifact_metadata(kind, record_path, metadata);
-    let record = store.record_artifact_with_metadata(run_id, &kind, record_path, metadata)?;
+    let role = metadata
+        .get("evidence_role")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("artifact");
+    let declaration = metadata
+        .get("declared_path")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(record_path.to_str().unwrap_or_default());
+    let content_hash = homeboy_core::artifact_metadata::sha256_file(record_path)?;
+    let binding = metadata
+        .get("runner_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let artifact_id = format!(
+        "runner-exec-{:x}",
+        Sha256::digest(
+            format!("{run_id}\0{binding}\0{role}\0{declaration}\0{content_hash}").as_bytes()
+        )
+    );
+    let record =
+        store.record_artifact_with_id(run_id, &kind, record_path, &artifact_id, metadata)?;
     let mut records = vec![record.clone()];
     records.extend(persist_derived_fuzz_artifacts(store, run_id, &record)?);
     Ok(records)

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -272,16 +272,6 @@ pub(super) fn exec_via_reverse_broker(
         &redaction_env,
         &redaction_secret_env_names,
     );
-    if let Some(run_id) = run_id.as_deref() {
-        homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
-            run_id,
-            &homeboy_core::api_jobs::RunnerJobLogSnapshot {
-                job: job.clone(),
-                events: events.clone(),
-            },
-        )?;
-    }
-
     let mirror = if mirror_evidence {
         mirror_reverse_broker_evidence(
             runner,

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -272,6 +272,15 @@ pub(super) fn exec_via_reverse_broker(
         &redaction_env,
         &redaction_secret_env_names,
     );
+    if let Some(run_id) = run_id.as_deref() {
+        homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
+            run_id,
+            &homeboy_core::api_jobs::RunnerJobLogSnapshot {
+                job: job.clone(),
+                events: events.clone(),
+            },
+        )?;
+    }
 
     let mirror = if mirror_evidence {
         mirror_reverse_broker_evidence(

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -395,10 +395,6 @@ pub(super) fn exec_via_daemon(
         Some(&runner_result),
     );
     persist_runner_execution_transition(&execution_record, &cwd, &command)?;
-    // A completed job is a durable lifecycle transition. It is the primary
-    // trigger for draining-generation retirement, not a side effect of status.
-    super::super::generation_store::reconcile(&runner.id, accepted_session.as_ref())?;
-
     Ok((
         RunnerExecOutput {
             variant: "exec",

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -332,15 +332,6 @@ pub(super) fn exec_via_daemon(
         run_id.as_deref(),
         mirror_run_id.as_deref(),
     )?;
-    if let Some(run_id) = run_id.as_deref() {
-        homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
-            run_id,
-            &homeboy_core::api_jobs::RunnerJobLogSnapshot {
-                job: job.clone(),
-                events: events.clone(),
-            },
-        )?;
-    }
     fire_runner_direct_notification(
         run_id.as_deref(),
         &job,

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -123,6 +123,15 @@ pub use failure::runner_exec_failure_error;
 pub use handoff::{runner_job_cancel, runner_job_cancel_projection};
 pub use recovery::reconcile_terminal_runner_exec_runs;
 
+/// Retire a completed direct daemon generation only after controller-owned
+/// evidence has been checkpointed and projected.
+pub fn reconcile_runner_generation_after_evidence(runner_id: &str) -> Result<()> {
+    let session = super::connection::status(runner_id)
+        .ok()
+        .and_then(|report| report.session);
+    super::generation_store::reconcile(runner_id, session.as_ref())
+}
+
 #[derive(Debug, Clone)]
 pub struct RunnerExecOptions {
     pub cwd: Option<String>,

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -63,6 +63,7 @@ mod handoff;
 mod paths;
 mod policy;
 mod process;
+mod recovery;
 mod redaction;
 mod secrets;
 mod worker;
@@ -120,6 +121,7 @@ pub use artifact_promotion::{
 pub use daemon_api::daemon_api_post;
 pub use failure::runner_exec_failure_error;
 pub use handoff::{runner_job_cancel, runner_job_cancel_projection};
+pub use recovery::reconcile_terminal_runner_exec_runs;
 
 #[derive(Debug, Clone)]
 pub struct RunnerExecOptions {

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -54,10 +54,72 @@ pub fn reconcile_terminal_runner_exec_runs() -> Result<usize> {
                 .unwrap_or_default()
         };
         let output = recovered_output(&run, &snapshot, cwd);
-        let artifacts = promote_runner_exec_artifacts(&run.id, &output, &strings("artifacts"))?;
-        let directories =
-            promote_runner_exec_artifact_dirs(&run.id, &output, &strings("artifact_dirs"))?;
-        let summaries = promote_runner_exec_summaries(&run.id, &output, &strings("summaries"))?;
+        let mut artifacts = Vec::new();
+        for declaration in strings("artifacts") {
+            if homeboy_agents::agent_task_lifecycle::runner_exec_declaration_is_promoted(
+                &run,
+                "artifact",
+                &declaration,
+            ) {
+                continue;
+            }
+            let promoted = promote_runner_exec_artifacts(
+                &run.id,
+                &output,
+                std::slice::from_ref(&declaration),
+            )?;
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+                &run.id,
+                "artifact",
+                &declaration,
+                &promoted,
+            )?;
+            artifacts.extend(promoted);
+        }
+        let mut directories = Vec::new();
+        for declaration in strings("artifact_dirs") {
+            if homeboy_agents::agent_task_lifecycle::runner_exec_declaration_is_promoted(
+                &run,
+                "artifact_dir",
+                &declaration,
+            ) {
+                continue;
+            }
+            let promoted = promote_runner_exec_artifact_dirs(
+                &run.id,
+                &output,
+                std::slice::from_ref(&declaration),
+            )?;
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+                &run.id,
+                "artifact_dir",
+                &declaration,
+                &promoted,
+            )?;
+            directories.extend(promoted);
+        }
+        let mut summaries = Vec::new();
+        for declaration in strings("summaries") {
+            if homeboy_agents::agent_task_lifecycle::runner_exec_declaration_is_promoted(
+                &run,
+                "summary",
+                &declaration,
+            ) {
+                continue;
+            }
+            let promoted = promote_runner_exec_summaries(
+                &run.id,
+                &output,
+                std::slice::from_ref(&declaration),
+            )?;
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+                &run.id,
+                "summary",
+                &declaration,
+                &promoted,
+            )?;
+            summaries.extend(promoted);
+        }
         let retained = artifacts
             .iter()
             .chain(directories.iter())
@@ -127,19 +189,30 @@ fn record_evicted_evidence_loss(
     run: &homeboy_core::observation::RunRecord,
     error: &Error,
 ) -> Result<()> {
-    if run
+    let checkpointed = run
         .metadata_json
         .pointer("/runner_terminal_projection/state")
         .and_then(Value::as_str)
-        != Some("terminal_checkpointed")
-        || error.details.get("http_status").and_then(Value::as_u64) != Some(404)
-    {
+        == Some("terminal_checkpointed");
+    if error.details.get("http_status").and_then(Value::as_u64) != Some(404) {
+        return Ok(());
+    }
+    let has_declarations = run
+        .metadata_json
+        .get("runner_exec_artifact_declarations")
+        .and_then(Value::as_object)
+        .is_some_and(|declarations| {
+            declarations
+                .values()
+                .any(|value| value.as_array().is_some_and(|values| !values.is_empty()))
+        });
+    if !checkpointed && !has_declarations {
         return Ok(());
     }
     let mut metadata = run.metadata_json.clone();
     metadata["runner_terminal_projection"] = json!({
         "state": "unrecoverable_evidence_loss",
-        "classification": "daemon_evicted_missing_declared_artifacts",
+        "classification": if checkpointed { "daemon_evicted_missing_declared_artifacts" } else { "daemon_evicted_before_terminal_projection" },
         "runner_id": run.metadata_json["runner_id"],
         "runner_job_id": run.metadata_json["runner_job_id"],
     });

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -1,0 +1,148 @@
+//! Recovery of generic runner-exec evidence after a controller interruption.
+
+use super::*;
+
+/// Scan durable generic runner-exec runs, query their exact accepted runner-job
+/// binding, then retain declared evidence before terminal projection. This runs
+/// before command dispatch so a new daemon operation cannot evict a completed
+/// job while its controller checkpoint is still pending.
+pub fn reconcile_terminal_runner_exec_runs() -> Result<usize> {
+    let store = ObservationStore::open_initialized()?;
+    let mut reconciled = 0;
+    for run in store.list_active_runs()? {
+        if run.metadata_json.get("kind").and_then(Value::as_str) != Some("runner_exec") {
+            continue;
+        }
+        let (Some(runner_id), Some(job_id), Some(cwd)) = (
+            run.metadata_json.get("runner_id").and_then(Value::as_str),
+            run.metadata_json
+                .get("runner_job_id")
+                .and_then(Value::as_str),
+            run.cwd.as_deref(),
+        ) else {
+            continue;
+        };
+        let snapshot = match crate::evidence::runner_job_log_snapshot(runner_id, job_id) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                record_evicted_evidence_loss(&store, &run, &error)?;
+                continue;
+            }
+        };
+        if !snapshot.job.status.is_terminal() {
+            continue;
+        }
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
+            &run.id, &snapshot,
+        )?;
+        let declarations = run
+            .metadata_json
+            .get("runner_exec_artifact_declarations")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let strings = |key: &str| -> Vec<String> {
+            declarations
+                .get(key)
+                .and_then(Value::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        };
+        let output = recovered_output(&run, &snapshot, cwd);
+        let artifacts = promote_runner_exec_artifacts(&run.id, &output, &strings("artifacts"))?;
+        let directories =
+            promote_runner_exec_artifact_dirs(&run.id, &output, &strings("artifact_dirs"))?;
+        let summaries = promote_runner_exec_summaries(&run.id, &output, &strings("summaries"))?;
+        let retained = artifacts
+            .iter()
+            .chain(directories.iter())
+            .chain(summaries.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs(&run.id, &retained)?;
+        homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(&run.id, &snapshot)?;
+        reconciled += 1;
+    }
+    Ok(reconciled)
+}
+
+fn recovered_output(
+    run: &homeboy_core::observation::RunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+    cwd: &str,
+) -> RunnerExecOutput {
+    RunnerExecOutput {
+        variant: "exec",
+        command: "runner.exec",
+        runner_id: snapshot.job.target_runner_id.clone().unwrap_or_default(),
+        dry_run: false,
+        mode: RunnerExecMode::Daemon,
+        argv: run
+            .metadata_json
+            .get("remote_command")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        remote_cwd: cwd.to_string(),
+        exit_code: if snapshot.job.status == JobStatus::Succeeded {
+            0
+        } else {
+            1
+        },
+        stdout: String::new(),
+        stderr: String::new(),
+        source_snapshot: None,
+        job: Some(snapshot.job.clone()),
+        runner_job: None,
+        job_id: Some(snapshot.job.id.to_string()),
+        job_events: Some(snapshot.events.clone()),
+        mirror_run_id: None,
+        patch: None,
+        mutation_artifacts: None,
+        artifacts: Vec::new(),
+        promoted_outputs: Vec::new(),
+        structured_summaries: Vec::new(),
+        metrics: None,
+        capture: None,
+        execution_record: None,
+        runner_result: None,
+        handoff: None,
+        diagnostics: None,
+    }
+}
+
+fn record_evicted_evidence_loss(
+    store: &ObservationStore,
+    run: &homeboy_core::observation::RunRecord,
+    error: &Error,
+) -> Result<()> {
+    if run
+        .metadata_json
+        .pointer("/runner_terminal_projection/state")
+        .and_then(Value::as_str)
+        != Some("terminal_checkpointed")
+        || error.details.get("http_status").and_then(Value::as_u64) != Some(404)
+    {
+        return Ok(());
+    }
+    let mut metadata = run.metadata_json.clone();
+    metadata["runner_terminal_projection"] = json!({
+        "state": "unrecoverable_evidence_loss",
+        "classification": "daemon_evicted_missing_declared_artifacts",
+        "runner_id": run.metadata_json["runner_id"],
+        "runner_job_id": run.metadata_json["runner_job_id"],
+    });
+    store.finish_run(&run.id, RunStatus::Fail, Some(metadata))?;
+    Ok(())
+}

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -219,3 +219,48 @@ fn record_evicted_evidence_loss(
     store.finish_run(&run.id, RunStatus::Fail, Some(metadata))?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_core::test_support::with_isolated_home;
+    use homeboy_core::{Error, ErrorCode};
+
+    #[test]
+    fn daemon_eviction_preserves_literal_declaration_paths_in_loss_detection() {
+        with_isolated_home(|_| {
+            let run_id = "evicted-escaped-declaration";
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                run_id,
+                "runner",
+                "job",
+                "/workspace",
+                &["true".to_string()],
+            )
+            .expect("run");
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_declarations(
+                run_id,
+                &["artifacts/result.json".to_string(), "a~b/c".to_string()],
+                &[],
+                &[],
+            )
+            .expect("declarations");
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.get_run(run_id).expect("read").expect("run");
+            let error = Error {
+                code: ErrorCode::ValidationInvalidArgument,
+                message: "daemon job evicted".to_string(),
+                details: json!({ "http_status": 404 }),
+                hints: Vec::new(),
+                retryable: None,
+            };
+            record_evicted_evidence_loss(&store, &run, &error).expect("eviction recorded");
+            let terminal = store.get_run(run_id).expect("read").expect("terminal run");
+            assert_eq!(terminal.status, "fail");
+            assert_eq!(
+                terminal.metadata_json["runner_terminal_projection"]["classification"],
+                "daemon_evicted_before_terminal_projection"
+            );
+        });
+    }
+}

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -140,9 +140,10 @@ pub use evidence::{
 pub use execution::{
     daemon_api_get, daemon_api_post, exec, promote_runner_exec_artifact_dirs,
     promote_runner_exec_artifacts, promote_runner_exec_summaries, promoted_output,
-    reconcile_terminal_runner_exec_runs, runner_exec_failure_error, runner_exec_structured_summary,
-    runner_job_cancel, runner_job_cancel_projection, RunnerExecDiagnostics, RunnerExecMode,
-    RunnerExecOptions, RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecStructuredSummary,
+    reconcile_runner_generation_after_evidence, reconcile_terminal_runner_exec_runs,
+    runner_exec_failure_error, runner_exec_structured_summary, runner_job_cancel,
+    runner_job_cancel_projection, RunnerExecDiagnostics, RunnerExecMode, RunnerExecOptions,
+    RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecStructuredSummary,
 };
 pub(crate) use execution::{
     exec_with_status_snapshot, execute_runner_process_until_cancelled_with_progress,

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -140,9 +140,9 @@ pub use evidence::{
 pub use execution::{
     daemon_api_get, daemon_api_post, exec, promote_runner_exec_artifact_dirs,
     promote_runner_exec_artifacts, promote_runner_exec_summaries, promoted_output,
-    runner_exec_failure_error, runner_exec_structured_summary, runner_job_cancel,
-    runner_job_cancel_projection, RunnerExecDiagnostics, RunnerExecMode, RunnerExecOptions,
-    RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecStructuredSummary,
+    reconcile_terminal_runner_exec_runs, runner_exec_failure_error, runner_exec_structured_summary,
+    runner_job_cancel, runner_job_cancel_projection, RunnerExecDiagnostics, RunnerExecMode,
+    RunnerExecOptions, RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecStructuredSummary,
 };
 pub(crate) use execution::{
     exec_with_status_snapshot, execute_runner_process_until_cancelled_with_progress,


### PR DESCRIPTION
## Summary
- Finalize generic durable `runner exec --run-id` observation runs from the daemon terminal snapshot exactly once.
- Persist declared artifact paths before daemon admission and controller-owned artifact references after promotion.
- Preserve terminal daemon events as structured failure diagnostics for failed and cancelled jobs.

Closes #9495

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::runner_exec --no-fail-fast`
- `cargo check -p homeboy-cli`

## AI assistance
Substantive implementation and tests were drafted with OpenCode using `openai/gpt-5.6-terra`. Chris Huber remains responsible for review and every line.