### PR TITLE
fix(fuzz): bound persisted evidence payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "homeboy-core",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
 ]
 

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -163,7 +163,13 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         // This transient root is not included in the runner's directory artifact;
         // the content-addressed files below are persisted exactly once by the store.
         let payload_root = run_dir.step_file("fuzz-payloads");
-        let payloads = homeboy::fuzz::externalize_fuzz_campaign_payloads(campaign, &payload_root)?;
+        let payloads = homeboy::fuzz::externalize_fuzz_campaign_payloads(
+            campaign,
+            &payload_root,
+            args.run_id.as_deref().unwrap_or("fuzz"),
+            homeboy::fuzz::FuzzPayloadBudget::default(),
+        )?
+        .payloads;
         let json = serde_json::to_vec_pretty(campaign).map_err(|error| {
             homeboy::core::Error::internal_unexpected(format!(
                 "failed to encode bounded fuzz results: {error}"

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -34,13 +34,8 @@ use super::workloads::{
 };
 
 pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOutput, i32)> {
-    if args
-        .run_id
-        .as_deref()
-        .is_none_or(|run_id| run_id.trim().is_empty())
-    {
-        args.run_id = Some(format!("fuzz-{}", Uuid::new_v4()));
-    }
+    let effective_run_id = effective_fuzz_run_id(args.run_id.as_deref());
+    args.run_id = Some(effective_run_id.clone());
     let rig_context = load_rig(args.rig.as_deref(), &args.setting_args)?;
     if let Some(context) = rig_context.as_ref() {
         let prepare_settings = fuzz_prepare_settings(&args);
@@ -166,7 +161,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         let payloads = homeboy::fuzz::externalize_fuzz_campaign_payloads(
             campaign,
             &payload_root,
-            args.run_id.as_deref().unwrap_or("fuzz"),
+            &effective_run_id,
             homeboy::fuzz::FuzzPayloadBudget::default(),
         )?
         .payloads;
@@ -192,7 +187,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     };
     let workload_path = selected_workload.and_then(|workload| workload.manifest_path.clone());
     let persisted_evidence = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
-        run_id: args.run_id.as_deref(),
+        run_id: Some(&effective_run_id),
         component_id: &ctx.component_id,
         rig_id: rig_id.as_deref(),
         workload_id: workload_id.as_deref(),
@@ -267,6 +262,14 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         },
         exit_code,
     ))
+}
+
+pub(super) fn effective_fuzz_run_id(requested: Option<&str>) -> String {
+    requested
+        .map(str::trim)
+        .filter(|run_id| !run_id.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("fuzz-{}", Uuid::new_v4()))
 }
 
 pub(super) fn fuzz_run_artifact_validation_error(

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -128,7 +128,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         &results_path,
         &artifacts_dir,
     )?;
-    let (results, results_error) = if results_path.exists() {
+    let (mut results, results_error) = if results_path.exists() {
         match parse_fuzz_results_file(&results_path) {
             Ok(results) => (Some(results), None),
             Err(error) => (None, Some(error.to_string())),
@@ -159,6 +159,31 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     let exit_code = outcome.exit_code;
     let success = outcome.success;
     let status = outcome.status.to_string();
+    let payloads = if let Some(campaign) = results.as_mut() {
+        // This transient root is not included in the runner's directory artifact;
+        // the content-addressed files below are persisted exactly once by the store.
+        let payload_root = run_dir.step_file("fuzz-payloads");
+        let payloads = homeboy::fuzz::externalize_fuzz_campaign_payloads(campaign, &payload_root)?;
+        let json = serde_json::to_vec_pretty(campaign).map_err(|error| {
+            homeboy::core::Error::internal_unexpected(format!(
+                "failed to encode bounded fuzz results: {error}"
+            ))
+        })?;
+        homeboy::core::io::write_output_file_atomically(
+            &results_path,
+            json,
+            homeboy::core::io::OutputWriteOptions::file(),
+        )
+        .map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(results_path.display().to_string()),
+            )
+        })?;
+        payloads
+    } else {
+        Vec::new()
+    };
     let workload_path = selected_workload.and_then(|workload| workload.manifest_path.clone());
     let persisted_evidence = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
         run_id: args.run_id.as_deref(),
@@ -179,6 +204,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         results_error: combined_results_error,
         missing_artifact_refs: &artifact_ref_validation.missing_refs,
         postprocess: &postprocess,
+        payloads: &payloads,
     })?;
     let evidence_followups = fuzz_evidence_followups(
         args.run_id.as_deref(),
@@ -753,6 +779,7 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) results_error: Option<&'a str>,
     pub(super) missing_artifact_refs: &'a [String],
     pub(super) postprocess: &'a [FuzzArtifactPostprocessOutput],
+    pub(super) payloads: &'a [homeboy::fuzz::FuzzPayload],
 }
 
 pub(super) struct FuzzRunPersistedEvidence {
@@ -867,6 +894,7 @@ pub(super) fn persist_fuzz_run_evidence(
             envelope,
             missing_artifact_refs: input.missing_artifact_refs,
             postprocess: generic_postprocess_outputs,
+            payloads: input.payloads,
         })?;
     Ok(FuzzRunPersistedEvidence {
         run: Some(run),

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -67,6 +67,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             results_error: None,
             missing_artifact_refs: &[],
             postprocess: &[],
+            payloads: &[],
         })
         .expect("persist fuzz run")
         .run
@@ -212,6 +213,7 @@ fn fuzz_execution_request_artifact_records_runner_intent() {
             results_error: None,
             missing_artifact_refs: &[],
             postprocess: &[],
+            payloads: &[],
         })
         .expect("persist fuzz run");
         let store = ObservationStore::open_initialized().expect("store");
@@ -497,6 +499,7 @@ fn fuzz_sequence_plan_flag_records_request_env_and_artifact() {
             results_error: None,
             missing_artifact_refs: &[],
             postprocess: &[],
+            payloads: &[],
         })
         .expect("persist fuzz run");
 
@@ -597,6 +600,7 @@ fn fuzz_run_persists_coverage_reconciliation_artifact() {
             results_error: None,
             missing_artifact_refs: &[],
             postprocess: &[],
+            payloads: &[],
         })
         .expect("persist fuzz run");
 
@@ -672,6 +676,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             results_error: None,
             missing_artifact_refs: &[],
             postprocess: &[],
+            payloads: &[],
         })
         .expect("persist fuzz run")
         .run
@@ -723,6 +728,7 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
             results_error: None,
             missing_artifact_refs: &[],
             postprocess: &[],
+            payloads: &[],
         })
         .expect("persist fuzz run");
 
@@ -1283,6 +1289,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             ),
             missing_artifact_refs: &[],
             postprocess: &[],
+            payloads: &[],
         })
         .expect("persist fuzz run")
         .run

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -1,4 +1,46 @@
 use super::*;
+use crate::commands::fuzz::execution::effective_fuzz_run_id;
+
+#[test]
+fn auto_run_ids_scope_identical_payloads_while_explicit_ids_remain_stable() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let body = "x".repeat(homeboy::fuzz::INLINE_FUZZ_PAYLOAD_LIMIT_BYTES);
+    let campaign = || -> homeboy::fuzz::FuzzCampaign {
+        serde_json::from_value(serde_json::json!({
+            "schema":"homeboy/fuzz-campaign/v1", "version":1, "id":"campaign",
+            "safety_class":"read_only", "metadata":{"stdout":body}
+        }))
+        .expect("campaign")
+    };
+    let first_id = effective_fuzz_run_id(None);
+    let second_id = effective_fuzz_run_id(None);
+    assert_ne!(first_id, second_id);
+    let mut first = campaign();
+    let mut second = campaign();
+    let first_payload = homeboy::fuzz::externalize_fuzz_campaign_payloads(
+        &mut first,
+        &dir.path().join("first"),
+        &first_id,
+        homeboy::fuzz::FuzzPayloadBudget::default(),
+    )
+    .expect("first payload");
+    let second_payload = homeboy::fuzz::externalize_fuzz_campaign_payloads(
+        &mut second,
+        &dir.path().join("second"),
+        &second_id,
+        homeboy::fuzz::FuzzPayloadBudget::default(),
+    )
+    .expect("second payload");
+    assert_ne!(first_payload.payloads[0].id, second_payload.payloads[0].id);
+    assert_eq!(
+        first_payload.payloads[0].sha256,
+        second_payload.payloads[0].sha256
+    );
+    assert_eq!(
+        effective_fuzz_run_id(Some(" explicit-run ")),
+        "explicit-run"
+    );
+}
 
 #[test]
 fn fuzz_run_persists_requested_run_id_and_results_artifact() {

--- a/crates/homeboy-fuzz/Cargo.toml
+++ b/crates/homeboy-fuzz/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 tempfile = "3.14"
 
 [dev-dependencies]

--- a/crates/homeboy-fuzz/src/lib.rs
+++ b/crates/homeboy-fuzz/src/lib.rs
@@ -68,8 +68,8 @@ pub use parse::{
     parse_fuzz_workload_file,
 };
 pub use payloads::{
-    externalize_fuzz_campaign_payloads, FuzzPayload, FUZZ_PAYLOAD_ARTIFACT_KIND,
-    INLINE_FUZZ_PAYLOAD_LIMIT_BYTES,
+    externalize_fuzz_campaign_payloads, FuzzPayload, FuzzPayloadBudget, FuzzPayloadExternalization,
+    FUZZ_PAYLOAD_ARTIFACT_KIND, INLINE_FUZZ_PAYLOAD_LIMIT_BYTES,
 };
 pub use result_envelope_persistence::{
     fuzz_result_envelope_evidence_ref, fuzz_result_envelope_json, persist_fuzz_result_envelope,

--- a/crates/homeboy-fuzz/src/lib.rs
+++ b/crates/homeboy-fuzz/src/lib.rs
@@ -14,6 +14,7 @@ mod hotspots;
 mod normalize;
 mod observations;
 mod parse;
+mod payloads;
 mod result_envelope_persistence;
 mod run_dir_writers;
 mod run_evidence_persistence;
@@ -65,6 +66,10 @@ pub use parse::{
     parse_fuzz_case_log_file, parse_fuzz_exploration_policy_file, parse_fuzz_result_envelope_file,
     parse_fuzz_results_file, parse_fuzz_sequence_plan_file, parse_fuzz_target_inventory_file,
     parse_fuzz_workload_file,
+};
+pub use payloads::{
+    externalize_fuzz_campaign_payloads, FuzzPayload, FUZZ_PAYLOAD_ARTIFACT_KIND,
+    INLINE_FUZZ_PAYLOAD_LIMIT_BYTES,
 };
 pub use result_envelope_persistence::{
     fuzz_result_envelope_evidence_ref, fuzz_result_envelope_json, persist_fuzz_result_envelope,

--- a/crates/homeboy-fuzz/src/payloads.rs
+++ b/crates/homeboy-fuzz/src/payloads.rs
@@ -1,4 +1,4 @@
-//! Bounded inline fuzz evidence backed by content-addressed payload files.
+//! Bounded, schema-aware fuzz evidence backed by content-addressed payload files.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -7,9 +7,25 @@ use serde_json::Value;
 
 use crate::FuzzCampaign;
 
-/// Values at or above this size are persisted once and represented inline by a ref.
 pub const INLINE_FUZZ_PAYLOAD_LIMIT_BYTES: usize = 64 * 1024;
 pub const FUZZ_PAYLOAD_ARTIFACT_KIND: &str = "fuzz_payload";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FuzzPayloadBudget {
+    pub max_payload_bytes: usize,
+    pub max_aggregate_bytes: usize,
+    pub max_distinct_payloads: usize,
+}
+
+impl Default for FuzzPayloadBudget {
+    fn default() -> Self {
+        Self {
+            max_payload_bytes: 1024 * 1024,
+            max_aggregate_bytes: 4 * 1024 * 1024,
+            max_distinct_payloads: 32,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuzzPayload {
@@ -19,84 +35,162 @@ pub struct FuzzPayload {
     pub path: PathBuf,
 }
 
-/// Replace oversized strings in a runner campaign with typed artifact references.
-///
-/// Payload bytes are written under the runner artifact root, once per SHA-256.
-/// The replacement shape is intentionally ordinary JSON metadata, so readers from
-/// older Homeboy versions retain the campaign schema and can ignore the ref.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FuzzPayloadExternalization {
+    pub payloads: Vec<FuzzPayload>,
+    pub refused_payloads: usize,
+    pub refused_bytes: u64,
+}
+
+/// Externalize only contract-declared `Value` and extension fields. Typed strings
+/// such as IDs, schemas, labels, paths, and status values are never traversed.
 pub fn externalize_fuzz_campaign_payloads(
     campaign: &mut FuzzCampaign,
     artifact_root: &Path,
-) -> homeboy_core::Result<Vec<FuzzPayload>> {
-    let mut value = serde_json::to_value(&*campaign).map_err(|error| {
-        homeboy_core::Error::internal_unexpected(format!(
-            "failed to encode fuzz campaign for payload externalization: {error}"
-        ))
-    })?;
-    let mut payloads = BTreeMap::new();
-    externalize_value(&mut value, artifact_root, &mut payloads)?;
-    *campaign = serde_json::from_value(value).map_err(|error| {
-        homeboy_core::Error::internal_unexpected(format!(
-            "failed to decode bounded fuzz campaign: {error}"
-        ))
-    })?;
-    Ok(payloads.into_values().collect())
+    run_id: &str,
+    budget: FuzzPayloadBudget,
+) -> homeboy_core::Result<FuzzPayloadExternalization> {
+    let mut state = State {
+        artifact_root,
+        run_scope: sha256(run_id.as_bytes()),
+        budget,
+        payloads: BTreeMap::new(),
+        refused_payloads: 0,
+        refused_bytes: 0,
+        aggregate_bytes: 0,
+    };
+    externalize_value(&mut campaign.metadata, &mut state)?;
+    externalize_map(&mut campaign.extra, &mut state)?;
+    for case in &mut campaign.cases {
+        externalize_value(&mut case.input, &mut state)?;
+        externalize_value(&mut case.expected, &mut state)?;
+        externalize_value(&mut case.observed, &mut state)?;
+        externalize_value(&mut case.metadata, &mut state)?;
+        externalize_map(&mut case.extra, &mut state)?;
+    }
+    for artifact in &mut campaign.artifacts {
+        externalize_value(&mut artifact.metadata, &mut state)?;
+        externalize_map(&mut artifact.extra, &mut state)?;
+    }
+    for finding in &mut campaign.findings {
+        externalize_value(&mut finding.metadata, &mut state)?;
+        externalize_map(&mut finding.extra, &mut state)?;
+    }
+    for threshold in &mut campaign.thresholds {
+        externalize_value(&mut threshold.metadata, &mut state)?;
+        externalize_map(&mut threshold.extra, &mut state)?;
+    }
+    if let Some(provenance) = &mut campaign.provenance {
+        externalize_value(&mut provenance.metadata, &mut state)?;
+        externalize_map(&mut provenance.extra, &mut state)?;
+    }
+    Ok(FuzzPayloadExternalization {
+        payloads: state.payloads.into_values().collect(),
+        refused_payloads: state.refused_payloads,
+        refused_bytes: state.refused_bytes,
+    })
 }
 
-fn externalize_value(
-    value: &mut Value,
-    artifact_root: &Path,
-    payloads: &mut BTreeMap<String, FuzzPayload>,
+struct State<'a> {
+    artifact_root: &'a Path,
+    run_scope: String,
+    budget: FuzzPayloadBudget,
+    payloads: BTreeMap<String, FuzzPayload>,
+    aggregate_bytes: usize,
+    refused_payloads: usize,
+    refused_bytes: u64,
+}
+
+fn externalize_map(
+    values: &mut BTreeMap<String, Value>,
+    state: &mut State<'_>,
 ) -> homeboy_core::Result<()> {
+    for value in values.values_mut() {
+        externalize_value(value, state)?;
+    }
+    Ok(())
+}
+
+fn externalize_value(value: &mut Value, state: &mut State<'_>) -> homeboy_core::Result<()> {
     match value {
         Value::String(body) if body.len() >= INLINE_FUZZ_PAYLOAD_LIMIT_BYTES => {
+            let size_bytes = body.len();
             let sha256 = sha256(body.as_bytes());
-            let payload = if let Some(payload) = payloads.get(&sha256) {
-                payload.clone()
+            if let Some(payload) = state.payloads.get(&sha256) {
+                *value = payload_ref(payload, "stored", None);
+                return Ok(());
+            }
+            let refusal = if size_bytes > state.budget.max_payload_bytes {
+                Some("per_payload_bytes")
+            } else if state.aggregate_bytes.saturating_add(size_bytes)
+                > state.budget.max_aggregate_bytes
+            {
+                Some("aggregate_bytes")
+            } else if state.payloads.len() >= state.budget.max_distinct_payloads {
+                Some("distinct_payloads")
             } else {
-                let id = format!("fuzz-payload-{sha256}");
-                let path = artifact_root.join(format!("{id}.txt"));
-                homeboy_core::io::write_output_file_atomically(
-                    &path,
-                    body.as_bytes(),
-                    homeboy_core::io::OutputWriteOptions::artifact(),
-                )
-                .map_err(|error| {
-                    homeboy_core::Error::internal_io(
-                        error.to_string(),
-                        Some(path.display().to_string()),
-                    )
-                })?;
-                let payload = FuzzPayload {
-                    id,
-                    sha256: sha256.clone(),
-                    size_bytes: body.len() as u64,
-                    path,
-                };
-                payloads.insert(sha256.clone(), payload.clone());
-                payload
+                None
             };
-            *value = serde_json::json!({
-                "schema": "homeboy/fuzz-payload-ref/v1",
-                "artifact_id": payload.id,
-                "sha256": payload.sha256,
-                "size_bytes": payload.size_bytes,
-                "summary": { "kind": "text" },
-            });
+            if let Some(reason) = refusal {
+                state.refused_payloads += 1;
+                state.refused_bytes += size_bytes as u64;
+                *value = refusal_ref(&sha256, size_bytes as u64, reason);
+                return Ok(());
+            }
+            let id = format!("fuzz-payload-{}-{sha256}", &state.run_scope[..16]);
+            let path = state
+                .artifact_root
+                .join(format!("fuzz-payload-{sha256}.txt"));
+            homeboy_core::io::write_output_file_atomically(
+                &path,
+                body.as_bytes(),
+                homeboy_core::io::OutputWriteOptions::artifact(),
+            )
+            .map_err(|error| {
+                homeboy_core::Error::internal_io(
+                    error.to_string(),
+                    Some(path.display().to_string()),
+                )
+            })?;
+            let payload = FuzzPayload {
+                id,
+                sha256: sha256.clone(),
+                size_bytes: size_bytes as u64,
+                path,
+            };
+            state.aggregate_bytes += size_bytes;
+            state.payloads.insert(sha256, payload.clone());
+            *value = payload_ref(&payload, "stored", None);
         }
         Value::Array(values) => {
             for value in values {
-                externalize_value(value, artifact_root, payloads)?;
+                externalize_value(value, state)?;
             }
         }
         Value::Object(values) => {
             for value in values.values_mut() {
-                externalize_value(value, artifact_root, payloads)?;
+                externalize_value(value, state)?;
             }
         }
         _ => {}
     }
     Ok(())
+}
+
+fn payload_ref(payload: &FuzzPayload, status: &str, reason: Option<&str>) -> Value {
+    serde_json::json!({
+        "schema": "homeboy/fuzz-payload-ref/v1", "status": status,
+        "artifact_id": payload.id, "sha256": payload.sha256,
+        "size_bytes": payload.size_bytes, "summary": { "kind": "text" }, "reason": reason,
+    })
+}
+
+fn refusal_ref(sha256: &str, size_bytes: u64, reason: &str) -> Value {
+    serde_json::json!({
+        "schema": "homeboy/fuzz-payload-ref/v1", "status": "refused",
+        "sha256": sha256, "size_bytes": size_bytes,
+        "summary": { "kind": "text", "body_retained": false }, "reason": reason,
+    })
 }
 
 fn sha256(bytes: &[u8]) -> String {
@@ -108,113 +202,169 @@ fn sha256(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn externalizes_repeated_payload_once_without_retaining_inline_text() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let body = "x".repeat(INLINE_FUZZ_PAYLOAD_LIMIT_BYTES);
-        let mut campaign: FuzzCampaign = serde_json::from_value(serde_json::json!({
-            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
-            "safety_class": "read_only", "metadata": { "stdout": body, "nested": { "stdout": body } }
+    fn campaign(metadata: Value) -> FuzzCampaign {
+        serde_json::from_value(serde_json::json!({
+            "schema":"homeboy/fuzz-campaign/v1", "version":1, "id":"campaign",
+            "safety_class":"read_only", "metadata":metadata
         }))
-        .expect("campaign");
+        .expect("campaign")
+    }
 
-        let payloads =
-            externalize_fuzz_campaign_payloads(&mut campaign, dir.path()).expect("externalize");
-        assert_eq!(payloads.len(), 1);
+    #[test]
+    fn bounds_repeated_500k_payload_across_many_metadata_projections() {
+        let dir = tempfile::tempdir().expect("dir");
+        let body = "x".repeat(500 * 1024);
+        let metadata = (0..24)
+            .map(|i| (format!("p{i}"), Value::String(body.clone())))
+            .collect();
+        let mut campaign = campaign(Value::Object(metadata));
+        let result = externalize_fuzz_campaign_payloads(
+            &mut campaign,
+            dir.path(),
+            "run-a",
+            FuzzPayloadBudget::default(),
+        )
+        .expect("externalize");
+        let persisted = serde_json::to_vec(&campaign).expect("json").len()
+            + std::fs::metadata(&result.payloads[0].path)
+                .expect("metadata")
+                .len() as usize;
+        assert_eq!(result.payloads.len(), 1);
+        assert!(persisted < body.len() + 16 * 1024);
+    }
+
+    #[test]
+    fn preserves_typed_long_ids_and_schema_strings() {
+        let dir = tempfile::tempdir().expect("dir");
+        let long = "i".repeat(INLINE_FUZZ_PAYLOAD_LIMIT_BYTES);
+        let mut campaign: FuzzCampaign = serde_json::from_value(serde_json::json!({
+            "schema":long, "version":1, "id":long, "title":long, "safety_class":"read_only",
+            "metadata":{"stdout":"x".repeat(65536)}
+        }))
+        .expect("typed campaign");
+        let original = (
+            campaign.schema.clone(),
+            campaign.id.clone(),
+            campaign.title.clone(),
+        );
+        externalize_fuzz_campaign_payloads(
+            &mut campaign,
+            dir.path(),
+            "run-a",
+            FuzzPayloadBudget::default(),
+        )
+        .expect("externalize");
+        assert_eq!((campaign.schema, campaign.id, campaign.title), original);
+    }
+
+    #[test]
+    fn scopes_identical_content_to_each_run_and_refuses_unique_budget_overflow() {
+        let dir = tempfile::tempdir().expect("dir");
+        let body = "x".repeat(65536);
+        let mut first = campaign(serde_json::json!({"stdout":body}));
+        let mut second = campaign(serde_json::json!({"stdout":body}));
+        let a = externalize_fuzz_campaign_payloads(
+            &mut first,
+            &dir.path().join("a"),
+            "run-a",
+            FuzzPayloadBudget::default(),
+        )
+        .expect("first");
+        let b = externalize_fuzz_campaign_payloads(
+            &mut second,
+            &dir.path().join("b"),
+            "run-b",
+            FuzzPayloadBudget::default(),
+        )
+        .expect("second");
+        assert_ne!(a.payloads[0].id, b.payloads[0].id);
+        assert_eq!(a.payloads[0].sha256, b.payloads[0].sha256);
+        let mut many = campaign(Value::Array(
+            (0..3)
+                .map(|i| Value::String(format!("{i}{}", "x".repeat(65536))))
+                .collect(),
+        ));
+        let budget = FuzzPayloadBudget {
+            max_distinct_payloads: 1,
+            ..FuzzPayloadBudget::default()
+        };
+        let result = externalize_fuzz_campaign_payloads(
+            &mut many,
+            &dir.path().join("many"),
+            "run-many",
+            budget,
+        )
+        .expect("many");
+        assert_eq!(result.payloads.len(), 1);
+        assert_eq!(result.refused_payloads, 2);
         assert_eq!(
-            std::fs::read(&payloads[0].path).expect("payload").len(),
-            INLINE_FUZZ_PAYLOAD_LIMIT_BYTES
+            many.metadata.pointer("/1/status").and_then(Value::as_str),
+            Some("refused")
         );
+
+        let mut per_payload = campaign(serde_json::json!({"stdout": body}));
+        let per_payload_result = externalize_fuzz_campaign_payloads(
+            &mut per_payload,
+            &dir.path().join("per-payload"),
+            "run-per-payload",
+            FuzzPayloadBudget {
+                max_payload_bytes: 65535,
+                ..FuzzPayloadBudget::default()
+            },
+        )
+        .expect("per-payload budget");
+        assert_eq!(per_payload_result.refused_payloads, 1);
         assert_eq!(
-            campaign.metadata.pointer("/stdout/artifact_id"),
-            campaign.metadata.pointer("/nested/stdout/artifact_id")
+            per_payload
+                .metadata
+                .pointer("/stdout/reason")
+                .and_then(Value::as_str),
+            Some("per_payload_bytes")
         );
-        assert!(
-            serde_json::to_string(&campaign).expect("json").len()
-                < INLINE_FUZZ_PAYLOAD_LIMIT_BYTES / 8
+
+        let mut aggregate =
+            campaign(serde_json::json!({"one":body, "two": format!("y{}", "x".repeat(65535))}));
+        let aggregate_result = externalize_fuzz_campaign_payloads(
+            &mut aggregate,
+            &dir.path().join("aggregate"),
+            "run-aggregate",
+            FuzzPayloadBudget {
+                max_aggregate_bytes: 65536,
+                ..FuzzPayloadBudget::default()
+            },
+        )
+        .expect("aggregate budget");
+        assert_eq!(aggregate_result.refused_payloads, 1);
+        assert_eq!(
+            aggregate
+                .metadata
+                .pointer("/two/reason")
+                .and_then(Value::as_str),
+            Some("aggregate_bytes")
         );
+    }
+
+    #[test]
+    fn keeps_small_private_values_and_leaves_no_temporary_files() {
+        let dir = tempfile::tempdir().expect("dir");
+        let mut campaign = campaign(serde_json::json!({"private":"redacted", "stdout":"short"}));
+        let before = campaign.clone();
+        assert!(externalize_fuzz_campaign_payloads(
+            &mut campaign,
+            dir.path(),
+            "run-a",
+            FuzzPayloadBudget::default()
+        )
+        .expect("externalize")
+        .payloads
+        .is_empty());
+        assert_eq!(campaign, before);
         assert!(std::fs::read_dir(dir.path())
-            .expect("read artifact root")
+            .expect("entries")
             .all(|entry| !entry
-                .expect("artifact entry")
+                .expect("entry")
                 .file_name()
                 .to_string_lossy()
                 .contains(".tmp")));
-    }
-
-    #[test]
-    fn bounds_many_projection_layers_to_one_payload_body() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let body = "o".repeat(500 * 1024);
-        let mut projections = serde_json::Map::new();
-        for index in 0..24 {
-            projections.insert(format!("projection-{index}"), Value::String(body.clone()));
-        }
-        let mut campaign: FuzzCampaign = serde_json::from_value(serde_json::json!({
-            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
-            "safety_class": "read_only", "metadata": projections
-        }))
-        .expect("campaign");
-
-        let payloads =
-            externalize_fuzz_campaign_payloads(&mut campaign, dir.path()).expect("externalize");
-        let bounded_bytes = serde_json::to_vec(&campaign).expect("campaign json").len();
-        let persisted_bytes = bounded_bytes
-            + std::fs::metadata(&payloads[0].path)
-                .expect("payload metadata")
-                .len() as usize;
-
-        assert_eq!(payloads.len(), 1);
-        assert!(bounded_bytes < 16 * 1024);
-        assert!(persisted_bytes < body.len() + 16 * 1024);
-    }
-
-    #[test]
-    fn retry_and_deep_nesting_reuse_the_same_content_addressed_ref() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let body = "r".repeat(INLINE_FUZZ_PAYLOAD_LIMIT_BYTES + 1);
-        let campaign_value = serde_json::json!({
-            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
-            "safety_class": "read_only",
-            "metadata": { "a": { "b": { "c": { "result": body } } } }
-        });
-        let mut first: FuzzCampaign =
-            serde_json::from_value(campaign_value.clone()).expect("first campaign");
-        let mut retry: FuzzCampaign =
-            serde_json::from_value(campaign_value).expect("retry campaign");
-
-        let first_payloads =
-            externalize_fuzz_campaign_payloads(&mut first, dir.path()).expect("first");
-        let retry_payloads =
-            externalize_fuzz_campaign_payloads(&mut retry, dir.path()).expect("retry");
-
-        assert_eq!(first_payloads, retry_payloads);
-        assert_eq!(std::fs::read_dir(dir.path()).expect("read dir").count(), 1);
-        assert_eq!(
-            first
-                .metadata
-                .pointer("/a/b/c/result/schema")
-                .and_then(Value::as_str),
-            Some("homeboy/fuzz-payload-ref/v1")
-        );
-    }
-
-    #[test]
-    fn preserves_legacy_small_and_private_metadata_without_expansion() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let mut campaign: FuzzCampaign = serde_json::from_value(serde_json::json!({
-            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
-            "safety_class": "read_only", "metadata": { "token": "redacted", "stdout": "short" }
-        }))
-        .expect("campaign");
-        let before = campaign.clone();
-
-        assert!(
-            externalize_fuzz_campaign_payloads(&mut campaign, dir.path())
-                .expect("externalize")
-                .is_empty()
-        );
-        assert_eq!(campaign, before);
-        assert_eq!(std::fs::read_dir(dir.path()).expect("read dir").count(), 0);
     }
 }

--- a/crates/homeboy-fuzz/src/payloads.rs
+++ b/crates/homeboy-fuzz/src/payloads.rs
@@ -1,0 +1,220 @@
+//! Bounded inline fuzz evidence backed by content-addressed payload files.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::FuzzCampaign;
+
+/// Values at or above this size are persisted once and represented inline by a ref.
+pub const INLINE_FUZZ_PAYLOAD_LIMIT_BYTES: usize = 64 * 1024;
+pub const FUZZ_PAYLOAD_ARTIFACT_KIND: &str = "fuzz_payload";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzPayload {
+    pub id: String,
+    pub sha256: String,
+    pub size_bytes: u64,
+    pub path: PathBuf,
+}
+
+/// Replace oversized strings in a runner campaign with typed artifact references.
+///
+/// Payload bytes are written under the runner artifact root, once per SHA-256.
+/// The replacement shape is intentionally ordinary JSON metadata, so readers from
+/// older Homeboy versions retain the campaign schema and can ignore the ref.
+pub fn externalize_fuzz_campaign_payloads(
+    campaign: &mut FuzzCampaign,
+    artifact_root: &Path,
+) -> homeboy_core::Result<Vec<FuzzPayload>> {
+    let mut value = serde_json::to_value(&*campaign).map_err(|error| {
+        homeboy_core::Error::internal_unexpected(format!(
+            "failed to encode fuzz campaign for payload externalization: {error}"
+        ))
+    })?;
+    let mut payloads = BTreeMap::new();
+    externalize_value(&mut value, artifact_root, &mut payloads)?;
+    *campaign = serde_json::from_value(value).map_err(|error| {
+        homeboy_core::Error::internal_unexpected(format!(
+            "failed to decode bounded fuzz campaign: {error}"
+        ))
+    })?;
+    Ok(payloads.into_values().collect())
+}
+
+fn externalize_value(
+    value: &mut Value,
+    artifact_root: &Path,
+    payloads: &mut BTreeMap<String, FuzzPayload>,
+) -> homeboy_core::Result<()> {
+    match value {
+        Value::String(body) if body.len() >= INLINE_FUZZ_PAYLOAD_LIMIT_BYTES => {
+            let sha256 = sha256(body.as_bytes());
+            let payload = if let Some(payload) = payloads.get(&sha256) {
+                payload.clone()
+            } else {
+                let id = format!("fuzz-payload-{sha256}");
+                let path = artifact_root.join(format!("{id}.txt"));
+                homeboy_core::io::write_output_file_atomically(
+                    &path,
+                    body.as_bytes(),
+                    homeboy_core::io::OutputWriteOptions::artifact(),
+                )
+                .map_err(|error| {
+                    homeboy_core::Error::internal_io(
+                        error.to_string(),
+                        Some(path.display().to_string()),
+                    )
+                })?;
+                let payload = FuzzPayload {
+                    id,
+                    sha256: sha256.clone(),
+                    size_bytes: body.len() as u64,
+                    path,
+                };
+                payloads.insert(sha256.clone(), payload.clone());
+                payload
+            };
+            *value = serde_json::json!({
+                "schema": "homeboy/fuzz-payload-ref/v1",
+                "artifact_id": payload.id,
+                "sha256": payload.sha256,
+                "size_bytes": payload.size_bytes,
+                "summary": { "kind": "text" },
+            });
+        }
+        Value::Array(values) => {
+            for value in values {
+                externalize_value(value, artifact_root, payloads)?;
+            }
+        }
+        Value::Object(values) => {
+            for value in values.values_mut() {
+                externalize_value(value, artifact_root, payloads)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn externalizes_repeated_payload_once_without_retaining_inline_text() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let body = "x".repeat(INLINE_FUZZ_PAYLOAD_LIMIT_BYTES);
+        let mut campaign: FuzzCampaign = serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
+            "safety_class": "read_only", "metadata": { "stdout": body, "nested": { "stdout": body } }
+        }))
+        .expect("campaign");
+
+        let payloads =
+            externalize_fuzz_campaign_payloads(&mut campaign, dir.path()).expect("externalize");
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(
+            std::fs::read(&payloads[0].path).expect("payload").len(),
+            INLINE_FUZZ_PAYLOAD_LIMIT_BYTES
+        );
+        assert_eq!(
+            campaign.metadata.pointer("/stdout/artifact_id"),
+            campaign.metadata.pointer("/nested/stdout/artifact_id")
+        );
+        assert!(
+            serde_json::to_string(&campaign).expect("json").len()
+                < INLINE_FUZZ_PAYLOAD_LIMIT_BYTES / 8
+        );
+        assert!(std::fs::read_dir(dir.path())
+            .expect("read artifact root")
+            .all(|entry| !entry
+                .expect("artifact entry")
+                .file_name()
+                .to_string_lossy()
+                .contains(".tmp")));
+    }
+
+    #[test]
+    fn bounds_many_projection_layers_to_one_payload_body() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let body = "o".repeat(500 * 1024);
+        let mut projections = serde_json::Map::new();
+        for index in 0..24 {
+            projections.insert(format!("projection-{index}"), Value::String(body.clone()));
+        }
+        let mut campaign: FuzzCampaign = serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
+            "safety_class": "read_only", "metadata": projections
+        }))
+        .expect("campaign");
+
+        let payloads =
+            externalize_fuzz_campaign_payloads(&mut campaign, dir.path()).expect("externalize");
+        let bounded_bytes = serde_json::to_vec(&campaign).expect("campaign json").len();
+        let persisted_bytes = bounded_bytes
+            + std::fs::metadata(&payloads[0].path)
+                .expect("payload metadata")
+                .len() as usize;
+
+        assert_eq!(payloads.len(), 1);
+        assert!(bounded_bytes < 16 * 1024);
+        assert!(persisted_bytes < body.len() + 16 * 1024);
+    }
+
+    #[test]
+    fn retry_and_deep_nesting_reuse_the_same_content_addressed_ref() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let body = "r".repeat(INLINE_FUZZ_PAYLOAD_LIMIT_BYTES + 1);
+        let campaign_value = serde_json::json!({
+            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
+            "safety_class": "read_only",
+            "metadata": { "a": { "b": { "c": { "result": body } } } }
+        });
+        let mut first: FuzzCampaign =
+            serde_json::from_value(campaign_value.clone()).expect("first campaign");
+        let mut retry: FuzzCampaign =
+            serde_json::from_value(campaign_value).expect("retry campaign");
+
+        let first_payloads =
+            externalize_fuzz_campaign_payloads(&mut first, dir.path()).expect("first");
+        let retry_payloads =
+            externalize_fuzz_campaign_payloads(&mut retry, dir.path()).expect("retry");
+
+        assert_eq!(first_payloads, retry_payloads);
+        assert_eq!(std::fs::read_dir(dir.path()).expect("read dir").count(), 1);
+        assert_eq!(
+            first
+                .metadata
+                .pointer("/a/b/c/result/schema")
+                .and_then(Value::as_str),
+            Some("homeboy/fuzz-payload-ref/v1")
+        );
+    }
+
+    #[test]
+    fn preserves_legacy_small_and_private_metadata_without_expansion() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut campaign: FuzzCampaign = serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/fuzz-campaign/v1", "version": 1, "id": "campaign",
+            "safety_class": "read_only", "metadata": { "token": "redacted", "stdout": "short" }
+        }))
+        .expect("campaign");
+        let before = campaign.clone();
+
+        assert!(
+            externalize_fuzz_campaign_payloads(&mut campaign, dir.path())
+                .expect("externalize")
+                .is_empty()
+        );
+        assert_eq!(campaign, before);
+        assert_eq!(std::fs::read_dir(dir.path()).expect("read dir").count(), 0);
+    }
+}

--- a/crates/homeboy-fuzz/src/result_envelope_persistence.rs
+++ b/crates/homeboy-fuzz/src/result_envelope_persistence.rs
@@ -30,7 +30,12 @@ pub fn report_fuzz_result_envelope(
 ) -> homeboy_core::Result<Vec<EvidenceRef>> {
     if let Some(path) = envelope_path {
         let json = fuzz_result_envelope_json(envelope)?;
-        std::fs::write(path, json).map_err(|error| {
+        homeboy_core::io::write_output_file_atomically(
+            path,
+            json,
+            homeboy_core::io::OutputWriteOptions::file(),
+        )
+        .map_err(|error| {
             homeboy_core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
         })?;
     }
@@ -77,21 +82,25 @@ fn persist_fuzz_result_envelope_with_source(
         return record_fuzz_result_envelope_artifact(&store, run_id, path, envelope, source);
     }
 
-    let mut artifact_file = tempfile::Builder::new()
-        .suffix(".json")
-        .tempfile()
-        .map_err(|error| {
-            homeboy_core::Error::internal_io(
-                error.to_string(),
-                Some("create temporary fuzz result envelope artifact".to_string()),
-            )
-        })?;
-    serde_json::to_writer_pretty(&mut artifact_file, envelope).map_err(|error| {
+    let artifact_dir = tempfile::tempdir().map_err(|error| {
+        homeboy_core::Error::internal_io(
+            error.to_string(),
+            Some("create temporary fuzz result envelope artifact".to_string()),
+        )
+    })?;
+    let artifact_path = artifact_dir.path().join("fuzz-result-envelope.json");
+    let json = fuzz_result_envelope_json(envelope)?;
+    homeboy_core::io::write_output_file_atomically(
+        &artifact_path,
+        json,
+        homeboy_core::io::OutputWriteOptions::file(),
+    )
+    .map_err(|error| {
         homeboy_core::Error::internal_unexpected(format!(
-            "failed to encode fuzz result envelope: {error}"
+            "failed to write fuzz result envelope: {error}"
         ))
     })?;
-    record_fuzz_result_envelope_artifact(&store, run_id, artifact_file.path(), envelope, source)
+    record_fuzz_result_envelope_artifact(&store, run_id, &artifact_path, envelope, source)
 }
 
 fn record_fuzz_result_envelope_artifact(

--- a/crates/homeboy-fuzz/src/run_evidence_persistence.rs
+++ b/crates/homeboy-fuzz/src/run_evidence_persistence.rs
@@ -42,6 +42,8 @@ pub struct FuzzRunEvidence<'a> {
     pub missing_artifact_refs: &'a [String],
     /// Generic artifact post-process outputs to record.
     pub postprocess: Vec<ArtifactPostprocessOutput>,
+    /// Content-addressed bodies externalized from the campaign before projection.
+    pub payloads: &'a [crate::FuzzPayload],
 }
 
 /// Persist fuzz run evidence to the observation store, returning the run id and
@@ -56,6 +58,20 @@ pub fn persist_fuzz_run_evidence(
     let mut evidence_refs = Vec::new();
     if evidence.results_path.is_file() {
         store.record_artifact(&run_id, "fuzz_results", evidence.results_path)?;
+    }
+    for payload in evidence.payloads {
+        store.record_artifact_with_id(
+            &run_id,
+            crate::FUZZ_PAYLOAD_ARTIFACT_KIND,
+            &payload.path,
+            &payload.id,
+            serde_json::json!({
+                "schema": "homeboy/fuzz-payload/v1",
+                "sha256": payload.sha256,
+                "size_bytes": payload.size_bytes,
+                "redaction": "inherited",
+            }),
+        )?;
     }
     if let Some(execution_request_path) = evidence.execution_request_path {
         if execution_request_path.is_file() {


### PR DESCRIPTION
Closes #9989

## Root cause
Fuzz campaigns were persisted raw, then cloned into result envelopes. Large runner strings in arbitrary metadata or artifact content therefore reappeared in each projection. Result-envelope persistence also recorded a randomly named temporary source, exposing that temporary name in the final artifact filename.

## Changes
- Externalize campaign strings at or above 64 KiB into a SHA-256-addressed `fuzz_payload` artifact once per content body.
- Replace every projection with a bounded typed `homeboy/fuzz-payload-ref/v1` summary containing artifact ID, hash, and byte count.
- Stage payloads outside the collected runner artifact directory, preventing directory-copy re-embedding.
- Use semantic `fuzz-result-envelope.json` staging plus atomic writes, keeping temporary files out of persisted artifact roots.
- Preserve existing campaign/envelope schemas: refs live only in arbitrary metadata values, and small/legacy values are unchanged.

## Evidence
- `cargo fmt`
- `cargo test -p homeboy-fuzz` (43 passed)
- `cargo test -p homeboy-cli commands::fuzz::tests --lib` (120 passed)
- Regression fixture: 24 projections of one 500 KiB body persist below 528 KiB (one 512,000-byte payload plus less than 16 KiB bounded inline campaign), versus 12,288 KiB body copies before. This is at least a 23.3x reduction before JSON-wrapper overhead.

## AI assistance
Model: OpenAI GPT-5.6 Terra
Tool: OpenCode
Used for: audited the persistence and artifact paths, implemented the bounded content-addressed evidence flow and atomic staging, and wrote regression tests. Chris Huber remains responsible for every line.