### PR TITLE
fix(cli): keep diagnostics responsive during runtime promotion

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -9,6 +9,7 @@ use crate::cli_surface::{
     Commands, DynamicCommandDescriptor, ExtensionCommandArgContract, ExtensionCommandArgsContract,
     ExtensionCommandHealth, ExtensionCommandManifest,
 };
+use crate::command_capability::{classify as classify_command_capability, CommandCapability};
 use crate::commands;
 use crate::commands::cli;
 use crate::commands::output_runtime;
@@ -55,6 +56,7 @@ struct ExtensionCliDiscovery {
 enum StartupFastPath {
     Help,
     Version,
+    Identity,
 }
 
 pub fn run_startup_fast_path(args: &[String]) -> Option<std::process::ExitCode> {
@@ -65,6 +67,16 @@ pub fn run_startup_fast_path(args: &[String]) -> Option<std::process::ExitCode> 
             println!();
         }
         StartupFastPath::Version => println!("{}", upgrade::current_build_version()),
+        StartupFastPath::Identity => {
+            output_runtime::emit_json_result(
+                Ok(
+                    serde_json::to_value(homeboy::core::build_identity::current())
+                        .expect("build identity serializes"),
+                ),
+                None,
+                0,
+            );
+        }
     }
 
     Some(std::process::ExitCode::SUCCESS)
@@ -595,9 +607,16 @@ fn is_top_level_version_request(args: &[String]) -> bool {
 }
 
 fn startup_fast_path(args: &[String]) -> Option<StartupFastPath> {
+    if classify_command_capability(args) != CommandCapability::ReadOnly {
+        return None;
+    }
+
     match args {
         [_, flag] if flag == "--help" || flag == "-h" => Some(StartupFastPath::Help),
         [_, flag] if flag == "--version" || flag == "-V" => Some(StartupFastPath::Version),
+        [_, command, subcommand] if command == "self" && subcommand == "identity" => {
+            Some(StartupFastPath::Identity)
+        }
         _ => None,
     }
 }

--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -1,0 +1,66 @@
+//! Startup capability classification for runtime selection.
+//!
+//! This intentionally uses only argv so it can run before extension discovery,
+//! configuration hydration, or any mutation coordination.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandCapability {
+    /// The command may inspect local state but cannot change a controller runtime.
+    ReadOnly,
+    /// The command can change durable state or invoke an operation that can.
+    Mutation,
+}
+
+pub fn classify(args: &[String]) -> CommandCapability {
+    let args = args.get(1..).unwrap_or_default();
+
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        return CommandCapability::ReadOnly;
+    }
+
+    match args {
+        [flag] if flag == "--version" || flag == "-V" => CommandCapability::ReadOnly,
+        [command, subcommand]
+            if command == "self" && matches!(subcommand.as_str(), "identity" | "status") =>
+        {
+            CommandCapability::ReadOnly
+        }
+        // `status` can fetch repository metadata, but it never changes the
+        // selected controller runtime and must remain available for recovery.
+        [command, ..] if command == "status" => CommandCapability::ReadOnly,
+        _ => CommandCapability::Mutation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn classifies_runtime_safe_diagnostics_without_parsing_runtime_state() {
+        for command in [
+            args(&["homeboy", "--version"]),
+            args(&["homeboy", "self", "identity"]),
+            args(&["homeboy", "self", "status"]),
+            args(&["homeboy", "status"]),
+            args(&["homeboy", "agent-task", "retry", "--help"]),
+        ] {
+            assert_eq!(classify(&command), CommandCapability::ReadOnly);
+        }
+    }
+
+    #[test]
+    fn classifies_actions_as_mutations_by_default() {
+        for command in [
+            args(&["homeboy", "upgrade"]),
+            args(&["homeboy", "agent-task", "retry", "run-1", "--run"]),
+            args(&["homeboy", "runtime", "promotion-takeover"]),
+        ] {
+            assert_eq!(classify(&command), CommandCapability::Mutation);
+        }
+    }
+}

--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -25,9 +25,11 @@ pub fn classify(args: &[String]) -> CommandCapability {
         {
             CommandCapability::ReadOnly
         }
-        // `status` can fetch repository metadata, but it never changes the
-        // selected controller runtime and must remain available for recovery.
-        [command, ..] if command == "status" => CommandCapability::ReadOnly,
+        [command, rest @ ..]
+            if command == "status" && !rest.iter().any(|arg| arg == "--refresh") =>
+        {
+            CommandCapability::ReadOnly
+        }
         _ => CommandCapability::Mutation,
     }
 }
@@ -59,6 +61,7 @@ mod tests {
             args(&["homeboy", "upgrade"]),
             args(&["homeboy", "agent-task", "retry", "run-1", "--run"]),
             args(&["homeboy", "runtime", "promotion-takeover"]),
+            args(&["homeboy", "status", "--refresh"]),
         ] {
             assert_eq!(classify(&command), CommandCapability::Mutation);
         }

--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -68,7 +68,7 @@ pub struct SelfCleanupRuntimeTmpArgs {
 pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         SelfCommand::Status(_) => {
-            let status = self_status::collect_status();
+            let status = self_status::collect_status_read_only();
             let json = serde_json::to_value(status)
                 .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
             Ok((json, 0))

--- a/crates/homeboy-cli/src/commands/status/git_cache.rs
+++ b/crates/homeboy-cli/src/commands/status/git_cache.rs
@@ -16,6 +16,7 @@ use super::types::{UnreleasedMerge, UpstreamDrift};
 
 #[derive(Default)]
 pub(super) struct StatusGitCache {
+    refresh: bool,
     pub(super) upstream_drift: HashMap<String, Option<UpstreamDrift>>,
     fetched_tags: HashSet<String>,
     release_states: HashMap<String, Option<ReleaseState>>,
@@ -24,9 +25,18 @@ pub(super) struct StatusGitCache {
 }
 
 impl StatusGitCache {
+    pub(super) fn with_refresh(refresh: bool) -> Self {
+        Self {
+            refresh,
+            ..Self::default()
+        }
+    }
+}
+
+impl StatusGitCache {
     pub(super) fn fetch_origin_tags_for(&mut self, path: &str) {
         let cache_key = upstream_drift_cache_key(path);
-        if self.fetched_tags.insert(cache_key) {
+        if self.refresh && self.fetched_tags.insert(cache_key) {
             fetch_origin_tags(path);
         }
     }

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -35,6 +35,13 @@ pub use types::{
 use types::{StatusProgress, StatusTimer, READY_TO_DEPLOY_NOTE, UNRELEASED_MERGES_NOTE};
 
 pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusResult> {
+    // Refreshing remote refs changes Git metadata, so serialize it with other
+    // runtime mutations. Default status is intentionally snapshot-only.
+    let _refresh_lease = args
+        .refresh
+        .then(|| homeboy::core::runtime_promotion::acquire("status refresh", "status"))
+        .transpose()?;
+
     if args.path.is_some() {
         return run_path_status(&args);
     }
@@ -119,7 +126,7 @@ fn summarize_components(
     let mut upstream_drift = Vec::new();
     let mut unreleased_merges = Vec::new();
     let mut clean: usize = 0;
-    let mut git_cache = StatusGitCache::default();
+    let mut git_cache = StatusGitCache::with_refresh(args.refresh);
 
     let has_filter =
         args.uncommitted || args.needs_release || args.ready || args.docs_only || args.unreleased;
@@ -286,7 +293,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
         .collect();
     timer.finish("fetch_remote_versions");
 
-    let mut git_cache = StatusGitCache::default();
+    let mut git_cache = StatusGitCache::with_refresh(args.refresh);
 
     // Fetch upstream drift for all components
     timer.begin("inspect_upstream_drift");
@@ -543,6 +550,7 @@ mod tests {
             outdated: false,
             unreleased: false,
             timings: false,
+            refresh: false,
         }
     }
 
@@ -559,6 +567,7 @@ mod tests {
             outdated: false,
             unreleased: false,
             timings: false,
+            refresh: false,
         }
     }
 

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -47,6 +47,10 @@ pub struct StatusArgs {
     #[arg(long)]
     pub timings: bool,
 
+    /// Refresh remote Git refs before calculating drift and release state.
+    #[arg(long)]
+    pub refresh: bool,
+
     /// Show only components carrying merged-but-unreleased work (commits on
     /// origin/<default-branch> that are past the latest release tag).
     #[arg(long)]

--- a/crates/homeboy-cli/src/lib.rs
+++ b/crates/homeboy-cli/src/lib.rs
@@ -32,6 +32,7 @@ pub use homeboy_core::{is_zero, is_zero_u32, log_status};
 
 pub mod cli_runtime;
 pub mod cli_surface;
+pub mod command_capability;
 pub mod command_contract;
 #[doc(hidden)]
 pub mod commands;

--- a/crates/homeboy-upgrade/src/self_status.rs
+++ b/crates/homeboy-upgrade/src/self_status.rs
@@ -80,6 +80,17 @@ pub fn collect_status() -> SelfStatus {
     )
 }
 
+/// Collect only facts available from this process. This is the status view used
+/// by lock-bypassing diagnostics: package-manager and network probes can write
+/// caches outside Homeboy's runtime directory.
+pub fn collect_status_read_only() -> SelfStatus {
+    collect_status_with(
+        std::env::current_exe().ok(),
+        || Err("external release probe skipped for read-only status".to_string()),
+        |_command, _args| Err("external install probe skipped for read-only status".to_string()),
+    )
+}
+
 pub fn collect_status_with<F, R>(
     active_binary: Option<PathBuf>,
     fetch_latest_github: F,

--- a/tests/readonly_cli_lock_test.rs
+++ b/tests/readonly_cli_lock_test.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+use std::fs;
 use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use std::thread;
@@ -6,9 +8,12 @@ use std::time::{Duration, Instant};
 #[test]
 fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
     homeboy_core::test_support::with_isolated_home(|home| {
+        let repository = create_repository(home.path());
+        let git_before = git_metadata_snapshot(&repository);
         let _promotion = homeboy::core::runtime_promotion::acquire("test promotion", "test")
             .expect("hold runtime promotion lease");
         let home = home.path();
+        let home_before = filesystem_snapshot(home);
 
         for args in [
             vec!["--version"],
@@ -16,6 +21,11 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
             vec!["self", "identity"],
             vec!["self", "status"],
             vec!["status"],
+            vec![
+                "status",
+                "--path",
+                repository.to_str().expect("repository path"),
+            ],
         ] {
             let output = run_with_timeout(&args, home, Duration::from_secs(10));
             assert!(
@@ -29,7 +39,48 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
                 "{} produced no diagnostic output",
                 args.join(" ")
             );
+            assert_eq!(
+                git_metadata_snapshot(&repository),
+                git_before,
+                "{} changed Git metadata while bypassing the mutation lock",
+                args.join(" ")
+            );
+            assert_eq!(
+                filesystem_snapshot(home),
+                home_before,
+                "{} changed config or runtime state while bypassing the mutation lock",
+                args.join(" ")
+            );
         }
+
+        let output = run_with_timeout(
+            &[
+                "status",
+                "--path",
+                repository.to_str().expect("repository path"),
+                "--refresh",
+            ],
+            home,
+            Duration::from_secs(10),
+        );
+        assert!(
+            !output.status.success(),
+            "refresh must serialize with the held promotion"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("runtime_promotion.contended"),
+            "refresh serialization must report typed promotion contention"
+        );
+        assert_eq!(
+            git_metadata_snapshot(&repository),
+            git_before,
+            "blocked refresh changed Git metadata"
+        );
+        assert_eq!(
+            filesystem_snapshot(home),
+            home_before,
+            "blocked refresh changed config or runtime state"
+        );
 
         let output = run_with_timeout(
             &["upgrade", "--method", "binary"],
@@ -82,4 +133,52 @@ fn wait_for_output(mut child: Child, timeout: Duration) -> Output {
 
 fn homeboy_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}
+
+fn create_repository(home: &std::path::Path) -> PathBuf {
+    let repository = home.join("repository");
+    fs::create_dir(&repository).expect("create test repository");
+    for args in [
+        vec!["init"],
+        vec!["config", "user.email", "test@example.com"],
+        vec!["config", "user.name", "Test User"],
+    ] {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(&repository)
+            .status()
+            .expect("configure test repository");
+        assert!(status.success(), "configure test repository");
+    }
+    repository
+}
+
+fn git_metadata_snapshot(repository: &std::path::Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    filesystem_snapshot(&repository.join(".git"))
+}
+
+fn filesystem_snapshot(root: &std::path::Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    let mut snapshot = BTreeMap::new();
+    snapshot_directory(root, root, &mut snapshot);
+    snapshot
+}
+
+fn snapshot_directory(
+    root: &std::path::Path,
+    directory: &std::path::Path,
+    snapshot: &mut BTreeMap<PathBuf, Vec<u8>>,
+) {
+    for entry in fs::read_dir(directory).expect("read Git metadata") {
+        let path = entry.expect("read Git metadata entry").path();
+        if path.is_dir() {
+            snapshot_directory(root, &path, snapshot);
+        } else {
+            snapshot.insert(
+                path.strip_prefix(root)
+                    .expect("relative Git metadata")
+                    .into(),
+                fs::read(&path).expect("read Git metadata file"),
+            );
+        }
+    }
 }

--- a/tests/readonly_cli_lock_test.rs
+++ b/tests/readonly_cli_lock_test.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[test]
+fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let _promotion = homeboy::core::runtime_promotion::acquire("test promotion", "test")
+            .expect("hold runtime promotion lease");
+        let home = home.path();
+
+        for args in [
+            vec!["--version"],
+            vec!["--help"],
+            vec!["self", "identity"],
+            vec!["self", "status"],
+            vec!["status"],
+        ] {
+            let output = run_with_timeout(&args, home, Duration::from_secs(10));
+            assert!(
+                output.status.success(),
+                "{} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                !output.stdout.is_empty(),
+                "{} produced no diagnostic output",
+                args.join(" ")
+            );
+        }
+
+        let output = run_with_timeout(
+            &["upgrade", "--method", "binary"],
+            home,
+            Duration::from_secs(10),
+        );
+        assert!(
+            !output.status.success(),
+            "a concurrent mutation must not run"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("runtime_promotion.contended"),
+            "mutation exclusion must report typed promotion contention: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    });
+}
+
+fn run_with_timeout(args: &[&str], home: &std::path::Path, timeout: Duration) -> Output {
+    let child = Command::new(homeboy_bin())
+        .args(args)
+        .env("HOME", home)
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .current_dir(home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start Homeboy child");
+    wait_for_output(child, timeout)
+}
+
+fn wait_for_output(mut child: Child, timeout: Duration) -> Output {
+    let started = Instant::now();
+    loop {
+        if child.try_wait().expect("inspect Homeboy child").is_some() {
+            return child
+                .wait_with_output()
+                .expect("collect Homeboy child output");
+        }
+        if started.elapsed() >= timeout {
+            child.kill().expect("terminate blocked Homeboy child");
+            let output = child
+                .wait_with_output()
+                .expect("collect timed-out Homeboy child");
+            panic!("Homeboy child exceeded {timeout:?}: {output:?}");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
Closes #9228

## Summary
- Classify startup argv as read-only or mutation before runtime-sensitive initialization.
- Serve `self identity` from the read-only startup path while retaining its JSON envelope.
- Cover real child processes holding a runtime-promotion lease: version, help, identity, self status, and status complete; a concurrent upgrade returns typed contention.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy --test readonly_cli_lock_test --no-fail-fast`
- `cargo test -p homeboy-cli command_capability --no-fail-fast`
- `cargo test -p homeboy --test product_identity_test --no-fail-fast`

## AI assistance
AI assistance: Yes
Tool/model: OpenCode with OpenAI gpt-5.6-terra
Usage: Investigated the runtime-promotion and CLI startup paths, implemented the capability classification and process-concurrency coverage, and drafted this PR. Chris remains responsible for every line.