### PR TITLE
fix(lab): retry tokenless daemon startup

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -688,7 +688,13 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
                 // remain sufficient for later authoritative reconciliation.
                 return Ok(());
             }
-            Err(error) => {
+            Err(mut error) => {
+                // This boundary is reached only after runner preflight has
+                // accepted the Cook but before a provider command is handed
+                // off. Transport, daemon publication, and reconciliation
+                // failures here are safe to retry and must not spend provider
+                // budget by being classified as invalid input.
+                error.retryable = Some(true);
                 let recovery = format!(
                     "Resolve the Lab handoff, then retry controller-owned attempt `{run_id}`."
                 );

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -126,6 +126,7 @@ fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
             .expect_err("missing Lab target rejects after controller staging");
 
         assert!(!error.message.is_empty());
+        assert_eq!(error.retryable, Some(true));
         let record = agent_task_lifecycle::status("cook-preacceptance-order")
             .expect("controller record remains inspectable after preacceptance failure");
         assert!(record.lab_handoff.is_none());
@@ -137,6 +138,15 @@ fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
         assert_eq!(
             record.metadata["pre_execution_failure"]["phase"],
             "lab_handoff_preacceptance"
+        );
+        assert_eq!(record.metadata["pre_execution_failure"]["retryable"], true);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["failure_classification"],
+            "transient"
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["provider_executions_consumed"],
+            0
         );
     });
 }

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -9,13 +9,15 @@ use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 use crate::execution_contract::encode_uri_component;
-use crate::process::pid_is_running;
+use crate::process::{
+    pid_has_ownership_token, pid_is_running, terminate_pid_with_sigterm_and_wait,
+};
 
 use super::{
     acquire_daemon_operation_lock, acquire_daemon_operation_lock_for_ensure, parse_bind_addr,
@@ -1734,7 +1736,123 @@ where
     spawn_and_wait()
 }
 
+const STARTUP_LEASE_OBSERVATIONS: usize = 100;
+const STARTUP_LEASE_POLL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StartupLeaseObservation {
+    observed_pid: Option<u32>,
+    observed_lease_id: Option<String>,
+    observed_token: Option<String>,
+}
+
+/// A launch token is an attempt identity, never a general daemon readiness
+/// signal. In particular, another controller's daemon must not satisfy this
+/// wait merely because it happened to publish a live lease first.
+fn observe_startup_lease<ReadStatus, Sleep>(
+    pid: u32,
+    startup_token: &str,
+    observations: usize,
+    mut read_status: ReadStatus,
+    mut sleep: Sleep,
+) -> Result<std::result::Result<DaemonStartResult, StartupLeaseObservation>>
+where
+    ReadStatus: FnMut() -> Result<super::DaemonStatus>,
+    Sleep: FnMut(),
+{
+    let mut observed = StartupLeaseObservation {
+        observed_pid: None,
+        observed_lease_id: None,
+        observed_token: None,
+    };
+    for attempt in 0..=observations {
+        let status = read_status()?;
+        if let Some(state) = status.state {
+            if state.pid == pid && state.startup_token == startup_token {
+                return Ok(Ok(DaemonStartResult {
+                    pid,
+                    address: state.address,
+                    state_path: state.state_path,
+                    lease_id: state.lease_id,
+                }));
+            }
+            observed.observed_pid = Some(state.pid);
+            observed.observed_lease_id = Some(state.lease_id);
+            observed.observed_token =
+                (!state.startup_token.is_empty()).then_some(state.startup_token);
+        }
+        if attempt < observations {
+            sleep();
+        }
+    }
+    Ok(Err(observed))
+}
+
+fn cleanup_startup_attempt(pid: u32, startup_token: &str) -> Result<Vec<String>> {
+    let mut cleanup = Vec::new();
+    let state_path = crate::paths::daemon_state_file()?;
+    let status = read_status()?;
+    if let Some(state) = status
+        .state
+        .filter(|state| state.startup_token == startup_token)
+    {
+        let identity = super::DaemonLeaseIdentity::from_state(&state);
+        if !pid_is_running(state.pid) {
+            super::remove_lease_if_identity_matches(&state_path, &identity)?;
+            cleanup.push(format!("removed stale token lease for pid {}", state.pid));
+        } else if pid_has_ownership_token(state.pid, DAEMON_STARTUP_TOKEN_ENV, startup_token)? {
+            terminate_pid_with_sigterm_and_wait(state.pid, super::FORCE_STOP_WAIT)?;
+            super::remove_lease_if_identity_matches(&state_path, &identity)?;
+            cleanup.push(format!("terminated token-owned daemon pid {}", state.pid));
+        } else {
+            cleanup.push(format!(
+                "retained lease for pid {} because its token ownership could not be proven",
+                state.pid
+            ));
+        }
+    }
+    if pid_is_running(pid) && pid_has_ownership_token(pid, DAEMON_STARTUP_TOKEN_ENV, startup_token)?
+    {
+        terminate_pid_with_sigterm_and_wait(pid, super::FORCE_STOP_WAIT)?;
+        cleanup.push(format!("terminated token-owned launcher pid {pid}"));
+    }
+    Ok(cleanup)
+}
+
+fn startup_timeout_error(
+    pid: u32,
+    startup_token: &str,
+    observation: StartupLeaseObservation,
+    cleanup: Vec<String>,
+) -> Error {
+    let mut error = Error::internal_unexpected(format!(
+        "daemon process {pid} did not publish its isolated startup token before timeout"
+    ))
+    .with_hint("The daemon startup was not accepted because the expected token and PID did not match. Retry the Lab Cook; provider budget was not consumed.".to_string());
+    error.retryable = Some(true);
+    error.details = serde_json::json!({
+        "classification": "retryable_pre_provider_startup",
+        "expected": { "pid": pid, "startup_token": startup_token },
+        "observed": {
+            "pid": observation.observed_pid,
+            "lease_id": observation.observed_lease_id,
+            "startup_token": observation.observed_token,
+        },
+        "cleanup": cleanup,
+        "safe_next_action": "Retry the same Lab Cook. Inspect `homeboy daemon status` if the failure repeats.",
+    });
+    error
+}
+
 fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonStartResult> {
+    spawn_and_wait_for_lease_attempt(addr, startup_token, true)
+}
+
+fn spawn_and_wait_for_lease_attempt(
+    addr: &str,
+    startup_token: &str,
+    allow_retry: bool,
+) -> Result<DaemonStartResult> {
     let exe = std::env::current_exe().map_err(|e| {
         Error::internal_io(
             e.to_string(),
@@ -1761,36 +1879,33 @@ fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonSta
         .map_err(|e| Error::internal_io(e.to_string(), Some("spawn daemon".to_string())))?;
     let pid = child.id();
 
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        let status = read_status()?;
-        if let Some(state) = status.state {
-            if state.pid == pid && state.startup_token == startup_token {
-                return Ok(DaemonStartResult {
-                    pid,
-                    address: state.address,
-                    state_path: state.state_path,
-                    lease_id: state.lease_id,
-                });
+    match observe_startup_lease(
+        pid,
+        startup_token,
+        STARTUP_LEASE_OBSERVATIONS,
+        read_status,
+        || thread::sleep(STARTUP_LEASE_POLL),
+    )? {
+        Ok(result) => Ok(result),
+        Err(observation) => {
+            let cleanup = cleanup_startup_attempt(pid, startup_token)?;
+            if allow_retry {
+                // A launcher can lose the first publication race during an SSH
+                // handoff. Retry once with a new token; never adopt another
+                // controller's lease as this attempt's daemon.
+                return spawn_and_wait_for_lease_attempt(
+                    addr,
+                    &uuid::Uuid::new_v4().to_string(),
+                    false,
+                );
             }
-            if status.running {
-                return Ok(DaemonStartResult {
-                    pid: state.pid,
-                    address: state.address,
-                    state_path: state.state_path,
-                    lease_id: state.lease_id,
-                });
-            }
+            Err(startup_timeout_error(
+                pid,
+                startup_token,
+                observation,
+                cleanup,
+            ))
         }
-
-        if Instant::now() >= deadline {
-            return Err(Error::internal_unexpected(format!(
-                "daemon process {} did not publish matching startup token before timeout",
-                pid
-            )));
-        }
-
-        thread::sleep(Duration::from_millis(50));
     }
 }
 

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -1747,10 +1747,10 @@ struct StartupLeaseObservation {
 }
 
 /// A launch token is an attempt identity, never a general daemon readiness
-/// signal. In particular, another controller's daemon must not satisfy this
-/// wait merely because it happened to publish a live lease first.
+/// signal. The spawned `supervise` launcher and its `serve` child have distinct
+/// PIDs, so the live child lease is identified by its unique token.
 fn observe_startup_lease<ReadStatus, Sleep>(
-    pid: u32,
+    _launcher_pid: u32,
     startup_token: &str,
     observations: usize,
     mut read_status: ReadStatus,
@@ -1768,9 +1768,9 @@ where
     for attempt in 0..=observations {
         let status = read_status()?;
         if let Some(state) = status.state {
-            if state.pid == pid && state.startup_token == startup_token {
+            if status.running && state.startup_token == startup_token {
                 return Ok(Ok(DaemonStartResult {
-                    pid,
+                    pid: state.pid,
                     address: state.address,
                     state_path: state.state_path,
                     lease_id: state.lease_id,
@@ -1845,13 +1845,14 @@ fn startup_timeout_error(
 }
 
 fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonStartResult> {
-    spawn_and_wait_for_lease_attempt(addr, startup_token, true)
+    spawn_and_wait_for_lease_attempt(addr, startup_token, true, Vec::new())
 }
 
 fn spawn_and_wait_for_lease_attempt(
     addr: &str,
     startup_token: &str,
     allow_retry: bool,
+    mut cleanup_evidence: Vec<String>,
 ) -> Result<DaemonStartResult> {
     let exe = std::env::current_exe().map_err(|e| {
         Error::internal_io(
@@ -1889,6 +1890,7 @@ fn spawn_and_wait_for_lease_attempt(
         Ok(result) => Ok(result),
         Err(observation) => {
             let cleanup = cleanup_startup_attempt(pid, startup_token)?;
+            cleanup_evidence.extend(cleanup);
             if allow_retry {
                 // A launcher can lose the first publication race during an SSH
                 // handoff. Retry once with a new token; never adopt another
@@ -1897,13 +1899,14 @@ fn spawn_and_wait_for_lease_attempt(
                     addr,
                     &uuid::Uuid::new_v4().to_string(),
                     false,
+                    cleanup_evidence,
                 );
             }
             Err(startup_timeout_error(
                 pid,
                 startup_token,
                 observation,
-                cleanup,
+                cleanup_evidence,
             ))
         }
     }

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1321,7 +1321,7 @@ fn ensure_running_concurrent_callers_converge_on_same_daemon() {
 }
 
 #[test]
-fn startup_observation_requires_the_attempt_pid_and_token() {
+fn startup_observation_requires_a_live_attempt_token() {
     let expected = "attempt-token";
     let wrong = fake_status(Some(fake_daemon(4242, "other-lease")), true);
     let result = observe_startup_lease(4343, expected, 0, || Ok(wrong.clone()), || {})
@@ -1330,14 +1330,20 @@ fn startup_observation_requires_the_attempt_pid_and_token() {
     assert_eq!(observed.observed_pid, Some(4242));
     assert_eq!(observed.observed_lease_id.as_deref(), Some("other-lease"));
 
-    let mut stale = fake_status(Some(fake_daemon(4343, "stale-lease")), true);
+    let mut stale = fake_status(Some(fake_daemon(4242, "stale-lease")), true);
     stale.state.as_mut().expect("state").startup_token = expected.to_string();
     let result = observe_startup_lease(4343, expected, 0, || Ok(stale.clone()), || {})
         .expect("observe startup");
     assert!(
         result.is_ok(),
-        "the matching token and pid are the only adoption proof"
+        "the matching token identifies the serve child of this launcher"
     );
+
+    let mut dead = fake_status(Some(fake_daemon(4242, "dead-lease")), false);
+    dead.state.as_mut().expect("state").startup_token = expected.to_string();
+    let result = observe_startup_lease(4343, expected, 0, || Ok(dead.clone()), || {})
+        .expect("observe startup");
+    assert!(result.is_err(), "a stale matching token is not ready");
 }
 
 #[test]

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -7,7 +7,7 @@ use std::{os::unix::process::CommandExt, process::Command};
 
 use super::{
     artifact_content_url, ensure_running_with_operations, fetch_artifact_to_path,
-    reconcile_dead_lease_and_ensure_running_with_operations,
+    observe_startup_lease, reconcile_dead_lease_and_ensure_running_with_operations,
     reconcile_leaseless_orphan_store_with_operations,
 };
 use crate::api_jobs::{JobEventKind, JobStatus, JobStore};
@@ -1318,6 +1318,46 @@ fn ensure_running_concurrent_callers_converge_on_same_daemon() {
         assert_eq!(first.address, second.address);
         assert_eq!(state.lock().expect("state").starts, 1);
     });
+}
+
+#[test]
+fn startup_observation_requires_the_attempt_pid_and_token() {
+    let expected = "attempt-token";
+    let wrong = fake_status(Some(fake_daemon(4242, "other-lease")), true);
+    let result = observe_startup_lease(4343, expected, 0, || Ok(wrong.clone()), || {})
+        .expect("observe startup");
+    let observed = result.expect_err("wrong daemon must not be adopted");
+    assert_eq!(observed.observed_pid, Some(4242));
+    assert_eq!(observed.observed_lease_id.as_deref(), Some("other-lease"));
+
+    let mut stale = fake_status(Some(fake_daemon(4343, "stale-lease")), true);
+    stale.state.as_mut().expect("state").startup_token = expected.to_string();
+    let result = observe_startup_lease(4343, expected, 0, || Ok(stale.clone()), || {})
+        .expect("observe startup");
+    assert!(
+        result.is_ok(),
+        "the matching token and pid are the only adoption proof"
+    );
+}
+
+#[test]
+fn startup_observation_waits_for_delayed_token_without_provider_work() {
+    let expected = "attempt-token";
+    let missing = fake_status(None, false);
+    let mut ready = fake_status(Some(fake_daemon(4343, "lease-new")), true);
+    ready.state.as_mut().expect("state").startup_token = expected.to_string();
+    let states = Arc::new(Mutex::new(vec![missing, ready]));
+    let read_states = Arc::clone(&states);
+    let result = observe_startup_lease(
+        4343,
+        expected,
+        1,
+        move || Ok(read_states.lock().expect("states").remove(0)),
+        || {},
+    )
+    .expect("observe delayed startup")
+    .expect("matching delayed token is ready");
+    assert_eq!(result.lease_id, "lease-new");
 }
 
 #[test]


### PR DESCRIPTION
Closes #10022

## Summary
- bind daemon startup readiness to the spawned PID and its unique startup token, refusing unrelated live leases
- observe readiness with a bounded window, clean only token-proven stale startup state, and retry once with a fresh token
- classify Lab Cook preacceptance failures as retryable before provider dispatch, preserving zero provider executions
- retain actionable expected/observed identity and cleanup evidence on final startup timeout

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core daemon::control::control_test --lib` (41 passed)
- `cargo test -p homeboy-cli commands::infra::route::tests --lib` compiled the affected crates, then aborted on an existing Clap validation conflict: `--runner <RUNNER_ID>` cannot be used with `--placement <PLACEMENT>`.

## AI assistance
Model: OpenAI gpt-5.6-terra

Tool: OpenCode

Used to inspect the issue and existing lifecycle implementation, implement the token-scoped startup/retry behavior and tests, and run focused verification. Chris Huber remains responsible for every line.