### PR TITLE
Fix cleanup provider liveness

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -61,6 +61,7 @@ pub struct CleanupArgs {
 pub enum CleanupCategoryArg {
     RepoArtifacts,
     TaskWorktrees,
+    WorktreeProviders,
     TerminalRuns,
     PersistedRunArtifacts,
     RunnerDownloads,
@@ -597,6 +598,14 @@ const TASK_WORKTREES_METADATA: CleanupInventoryCategoryMetadata =
         apply_command: "homeboy worktree cleanup --cleanup-branches",
     };
 
+const WORKTREE_PROVIDERS_METADATA: CleanupInventoryCategoryMetadata =
+    CleanupInventoryCategoryMetadata {
+        category: "worktree_providers",
+        include_arg: "worktree-providers",
+        dry_run_command: "homeboy cleanup worktrees --all-providers",
+        apply_command: "homeboy cleanup worktrees --all-providers --apply",
+    };
+
 const PERSISTED_RUN_ARTIFACTS_METADATA: CleanupInventoryCategoryMetadata =
     CleanupInventoryCategoryMetadata {
         category: "persisted_run_artifacts",
@@ -662,7 +671,8 @@ const CONTROLLER_RUNTIMES_METADATA: CleanupInventoryCategoryMetadata =
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     let selected = CleanupCategorySelection::new(args.include, args.exclude);
     let apply = args.apply;
-    let configured = defaults::load_config().retention;
+    let config = defaults::load_config();
+    let configured = &config.retention;
     let terminal_run_days = args.older_than_days.unwrap_or(configured.terminal_run_days);
     let limit = args.limit.unwrap_or(configured.limit);
     if terminal_run_days < 0 || limit < 1 {
@@ -687,6 +697,31 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             allow_unmerged_branches: false,
         })?;
         categories.push(task_worktrees_category(output, apply)?);
+    }
+
+    if selected.includes(CleanupCategoryArg::WorktreeProviders) {
+        let output = cleanup::cleanup_resources_from_config(
+            ResourceCleanupOptions {
+                intent: cleanup_intent(apply),
+                artifacts: None,
+                worktree_providers: Some(WorktreeProviderCleanupOptions {
+                    provider: Vec::new(),
+                    all_providers: true,
+                    apply,
+                }),
+            },
+            config.clone(),
+        )?;
+        categories.push(category_from_output(
+            WORKTREE_PROVIDERS_METADATA,
+            apply,
+            0,
+            0,
+            output.failure_count,
+            0,
+            0,
+            output,
+        )?);
     }
 
     if selected.includes(CleanupCategoryArg::TerminalRuns) {
@@ -1499,6 +1534,21 @@ pub(crate) fn render_worktree_cleanup_summary(payload: &Value) -> Option<String>
             if let Some(phase) = provider.get("phase").and_then(Value::as_str) {
                 lines.push(format!("  Phase: {phase}"));
             }
+            if let Some(outcome) = provider.get("outcome").and_then(Value::as_str) {
+                lines.push(format!("  Outcome: {outcome}"));
+            }
+            if let Some(completeness) = provider
+                .get("inventory_completeness")
+                .and_then(Value::as_str)
+            {
+                lines.push(format!("  Inventory: {completeness}"));
+            }
+            if let Some(elapsed_ms) = provider.get("elapsed_ms").and_then(Value::as_u64) {
+                lines.push(format!("  Elapsed: {elapsed_ms} ms"));
+            }
+            if let Some(heartbeat_count) = provider.get("heartbeat_count").and_then(Value::as_u64) {
+                lines.push(format!("  Heartbeats: {heartbeat_count}"));
+            }
             if let Some(progress) = provider.get("last_progress").and_then(Value::as_str) {
                 lines.push(format!("  Last observed progress: {progress}"));
             }
@@ -2170,6 +2220,10 @@ mod tests {
                     {
                         "provider_id": "fixture",
                         "success": true,
+                        "outcome": "completed",
+                        "inventory_completeness": "complete",
+                        "elapsed_ms": 250,
+                        "heartbeat_count": 2,
                         "mode": "apply",
                         "command_run": ["provider-bin", "cleanup", "--apply"],
                         "phase": "running",
@@ -2193,6 +2247,10 @@ mod tests {
         assert!(summary.contains("Provider fixture: ok\n"));
         assert!(summary.contains("  Command: provider-bin cleanup --apply\n"));
         assert!(summary.contains("  Phase: running\n"));
+        assert!(summary.contains("  Outcome: completed\n"));
+        assert!(summary.contains("  Inventory: complete\n"));
+        assert!(summary.contains("  Elapsed: 250 ms\n"));
+        assert!(summary.contains("  Heartbeats: 2\n"));
         assert!(summary.contains("  Last observed progress: removed 10/20\n"));
         assert!(summary.contains("  Run: cleanup-run-1\n"));
         assert!(summary.contains("  Status command: provider status cleanup-run-1\n"));

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1037,6 +1037,10 @@ fn run_command_provider_cleanup_with_liveness(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     crate::engine::command::isolate_process_tree(&mut process);
+    eprintln!(
+        "[cleanup.worktrees provider={provider_id} phase={}] starting",
+        mode_phase(&mode)
+    );
     match process.spawn() {
         Ok(mut child) => {
             let started = std::time::Instant::now();

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
-use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, Stdio};
-use std::sync::{Arc, Mutex};
-use std::thread;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -12,6 +10,16 @@ use crate::defaults::{
     WorktreeProviderListResultMapping,
 };
 use crate::error::{CommandEvidence, Error, Result};
+
+#[cfg(not(test))]
+const PROVIDER_CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(test)]
+const PROVIDER_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(not(test))]
+const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_millis(100);
+const PROVIDER_CLEANUP_OUTPUT_LIMIT: usize = 64 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct WorktreeProviderCleanupOptions {
@@ -27,6 +35,22 @@ pub enum WorktreeProviderCleanupMode {
     Apply,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorktreeProviderCleanupOutcome {
+    Completed,
+    TimedOut,
+    Cancelled,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorktreeProviderInventoryCompleteness {
+    Complete,
+    Partial,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct WorktreeProviderCleanupOutput {
     pub command: &'static str,
@@ -34,6 +58,7 @@ pub struct WorktreeProviderCleanupOutput {
     pub provider_count: usize,
     pub success_count: usize,
     pub failure_count: usize,
+    pub inventory_completeness: WorktreeProviderInventoryCompleteness,
     pub providers: Vec<WorktreeProviderCleanupResult>,
 }
 
@@ -41,6 +66,10 @@ pub struct WorktreeProviderCleanupOutput {
 pub struct WorktreeProviderCleanupResult {
     pub provider_id: String,
     pub success: bool,
+    pub outcome: WorktreeProviderCleanupOutcome,
+    pub inventory_completeness: WorktreeProviderInventoryCompleteness,
+    pub elapsed_ms: u128,
+    pub heartbeat_count: usize,
     pub mode: WorktreeProviderCleanupMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_run: Option<Vec<String>>,
@@ -858,16 +887,24 @@ pub fn cleanup_worktree_providers_from_config(
         WorktreeProviderCleanupMode::Preview
     };
 
-    let providers = selected_providers(&options, &config)?;
-    let mut results = Vec::new();
-
-    for (provider_id, provider_config) in providers {
-        results.push(run_provider_cleanup(
-            &provider_id,
-            provider_config,
-            mode.clone(),
-        ));
-    }
+    let providers = selected_providers(&options, &config)?
+        .into_iter()
+        .map(|(id, provider)| (id, provider.clone()))
+        .collect::<Vec<_>>();
+    let mut results = std::thread::scope(|scope| {
+        let mut tasks = Vec::new();
+        for (provider_id, provider_config) in providers {
+            let mode = mode.clone();
+            tasks.push(
+                scope.spawn(move || run_provider_cleanup(&provider_id, &provider_config, mode)),
+            );
+        }
+        tasks
+            .into_iter()
+            .map(|task| task.join().expect("provider cleanup worker must not panic"))
+            .collect::<Vec<_>>()
+    });
+    results.sort_by(|left, right| left.provider_id.cmp(&right.provider_id));
 
     let success_count = results.iter().filter(|row| row.success).count();
     let failure_count = results.len().saturating_sub(success_count);
@@ -878,6 +915,13 @@ pub fn cleanup_worktree_providers_from_config(
         provider_count: results.len(),
         success_count,
         failure_count,
+        inventory_completeness: if results.iter().all(|row| {
+            row.inventory_completeness == WorktreeProviderInventoryCompleteness::Complete
+        }) {
+            WorktreeProviderInventoryCompleteness::Complete
+        } else {
+            WorktreeProviderInventoryCompleteness::Partial
+        },
         providers: results,
     })
 }
@@ -947,6 +991,22 @@ fn run_command_provider_cleanup(
     provider_config: &WorktreeProviderConfig,
     mode: WorktreeProviderCleanupMode,
 ) -> WorktreeProviderCleanupResult {
+    run_command_provider_cleanup_with_liveness(
+        provider_id,
+        provider_config,
+        mode,
+        PROVIDER_CLEANUP_TIMEOUT,
+        PROVIDER_CLEANUP_HEARTBEAT,
+    )
+}
+
+fn run_command_provider_cleanup_with_liveness(
+    provider_id: &str,
+    provider_config: &WorktreeProviderConfig,
+    mode: WorktreeProviderCleanupMode,
+    timeout: Duration,
+    heartbeat_interval: Duration,
+) -> WorktreeProviderCleanupResult {
     if mode == WorktreeProviderCleanupMode::Apply && !provider_config.apply_enabled {
         return provider_failure(provider_id, mode, "provider apply is not enabled");
     }
@@ -971,45 +1031,71 @@ fn run_command_provider_cleanup(
         );
     }
 
-    match Command::new(&command[0])
+    let mut process = Command::new(&command[0]);
+    process
         .args(&command[1..])
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
+        .stderr(Stdio::piped());
+    crate::engine::command::isolate_process_tree(&mut process);
+    match process.spawn() {
         Ok(mut child) => {
-            let stdout = child.stdout.take();
-            let stderr = child.stderr.take();
-            let stdout_lines = Arc::new(Mutex::new(Vec::new()));
-            let stderr_lines = Arc::new(Mutex::new(Vec::new()));
-
-            let stdout_handle = stdout.map(|stream| {
-                collect_provider_stream(
-                    provider_id.to_string(),
-                    "stdout",
-                    stream,
-                    Arc::clone(&stdout_lines),
-                )
-            });
-            let stderr_handle = stderr.map(|stream| {
-                collect_provider_stream(
-                    provider_id.to_string(),
-                    "stderr",
-                    stream,
-                    Arc::clone(&stderr_lines),
-                )
-            });
-
-            let wait_result = child.wait();
-            if let Some(handle) = stdout_handle {
-                let _ = handle.join();
-            }
-            if let Some(handle) = stderr_handle {
-                let _ = handle.join();
-            }
-
-            let stdout = joined_lines(&stdout_lines);
-            let stderr = joined_lines(&stderr_lines);
+            let started = std::time::Instant::now();
+            let mut heartbeats = 0;
+            let wait_result = crate::engine::command::wait_with_bounded_output_supervised(
+                &mut child,
+                PROVIDER_CLEANUP_OUTPUT_LIMIT,
+                timeout,
+                heartbeat_interval,
+                || false,
+                |elapsed, tail| {
+                    heartbeats += 1;
+                    eprintln!(
+                        "[cleanup.worktrees provider={provider_id} phase={} elapsed_ms={} remaining_ms={} heartbeat={heartbeats}] {}",
+                        mode_phase(&mode),
+                        elapsed.as_millis(),
+                        timeout.saturating_sub(elapsed).as_millis(),
+                        tail.lines().last().unwrap_or("waiting for provider output"),
+                    );
+                    Ok(())
+                },
+            );
+            let elapsed_ms = started.elapsed().as_millis();
+            let (output_status, outcome, stdout, stderr) = match wait_result {
+                Ok(output) => {
+                    let outcome = match output.termination {
+                        crate::engine::command::SupervisedCommandTermination::Completed
+                            if output.output.status.success() =>
+                        {
+                            WorktreeProviderCleanupOutcome::Completed
+                        }
+                        crate::engine::command::SupervisedCommandTermination::Completed => {
+                            WorktreeProviderCleanupOutcome::Failed
+                        }
+                        crate::engine::command::SupervisedCommandTermination::TimedOut => {
+                            WorktreeProviderCleanupOutcome::TimedOut
+                        }
+                        crate::engine::command::SupervisedCommandTermination::Cancelled => {
+                            WorktreeProviderCleanupOutcome::Cancelled
+                        }
+                    };
+                    (
+                        Some(output.output.status),
+                        outcome,
+                        String::from_utf8_lossy(&output.output.stdout).to_string(),
+                        String::from_utf8_lossy(&output.output.stderr).to_string(),
+                    )
+                }
+                Err(err) => {
+                    return provider_failure_with_details(
+                        provider_id,
+                        mode,
+                        Some(command.clone()),
+                        format!("failed to supervise provider command: {err}"),
+                        elapsed_ms,
+                        heartbeats,
+                    );
+                }
+            };
             let parsed_payload = parse_json_stdout(&stdout);
             let phase = provider_phase(&parsed_payload, &mode);
             let last_progress = provider_last_progress(&parsed_payload)
@@ -1018,30 +1104,18 @@ fn run_command_provider_cleanup(
             let run_refs = provider_run_refs(&parsed_payload);
             let follow_up_command = provider_follow_up_command(&run_refs);
 
-            let output_status = match wait_result {
-                Ok(status) => status,
-                Err(err) => {
-                    return WorktreeProviderCleanupResult {
-                        provider_id: provider_id.to_string(),
-                        success: false,
-                        mode,
-                        command_run: Some(command.clone()),
-                        status: None,
-                        stdout,
-                        stderr,
-                        parsed_payload,
-                        phase,
-                        last_progress,
-                        run_refs,
-                        follow_up_command,
-                        error: Some(format!("failed to wait for provider command: {err}")),
-                    };
-                }
-            };
-            let status = output_status.code();
+            let status = output_status.and_then(|status| status.code());
             WorktreeProviderCleanupResult {
                 provider_id: provider_id.to_string(),
-                success: output_status.success(),
+                success: outcome == WorktreeProviderCleanupOutcome::Completed,
+                inventory_completeness: if outcome == WorktreeProviderCleanupOutcome::Completed {
+                    WorktreeProviderInventoryCompleteness::Complete
+                } else {
+                    WorktreeProviderInventoryCompleteness::Partial
+                },
+                outcome: outcome.clone(),
+                elapsed_ms,
+                heartbeat_count: heartbeats,
                 mode,
                 command_run: Some(command.clone()),
                 status,
@@ -1052,59 +1126,28 @@ fn run_command_provider_cleanup(
                 last_progress,
                 run_refs,
                 follow_up_command,
-                error: output_status
-                    .success()
-                    .then_some(())
-                    .is_none()
-                    .then(|| "provider command failed".to_string()),
+                error: (outcome != WorktreeProviderCleanupOutcome::Completed).then(
+                    || match outcome {
+                        WorktreeProviderCleanupOutcome::TimedOut => {
+                            format!("provider timed out after {} ms", timeout.as_millis())
+                        }
+                        WorktreeProviderCleanupOutcome::Cancelled => {
+                            "provider command was cancelled".to_string()
+                        }
+                        _ => "provider command failed".to_string(),
+                    },
+                ),
             }
         }
-        Err(err) => {
-            let phase = Some(mode_phase(&mode).to_string());
-            WorktreeProviderCleanupResult {
-                provider_id: provider_id.to_string(),
-                success: false,
-                mode,
-                command_run: Some(command.clone()),
-                status: None,
-                stdout: String::new(),
-                stderr: String::new(),
-                parsed_payload: None,
-                phase,
-                last_progress: None,
-                run_refs: Vec::new(),
-                follow_up_command: None,
-                error: Some(format!("failed to execute provider command: {err}")),
-            }
-        }
+        Err(err) => provider_failure_with_details(
+            provider_id,
+            mode,
+            Some(command.clone()),
+            format!("failed to execute provider command: {err}"),
+            0,
+            0,
+        ),
     }
-}
-
-fn collect_provider_stream<R>(
-    provider_id: String,
-    stream_name: &'static str,
-    stream: R,
-    lines: Arc<Mutex<Vec<String>>>,
-) -> thread::JoinHandle<()>
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let reader = BufReader::new(stream);
-        for line in reader.lines().map_while(std::result::Result::ok) {
-            eprintln!("[cleanup.worktrees provider={provider_id} stream={stream_name}] {line}");
-            if let Ok(mut guard) = lines.lock() {
-                guard.push(line);
-            }
-        }
-    })
-}
-
-fn joined_lines(lines: &Arc<Mutex<Vec<String>>>) -> String {
-    lines
-        .lock()
-        .map(|guard| guard.join("\n"))
-        .unwrap_or_default()
 }
 
 fn last_non_empty_line(output: &str) -> Option<String> {
@@ -1121,12 +1164,27 @@ fn provider_failure(
     mode: WorktreeProviderCleanupMode,
     error: &str,
 ) -> WorktreeProviderCleanupResult {
+    provider_failure_with_details(provider_id, mode, None, error.to_string(), 0, 0)
+}
+
+fn provider_failure_with_details(
+    provider_id: &str,
+    mode: WorktreeProviderCleanupMode,
+    command_run: Option<Vec<String>>,
+    error: String,
+    elapsed_ms: u128,
+    heartbeat_count: usize,
+) -> WorktreeProviderCleanupResult {
     let phase = Some(mode_phase(&mode).to_string());
     WorktreeProviderCleanupResult {
         provider_id: provider_id.to_string(),
         success: false,
+        outcome: WorktreeProviderCleanupOutcome::Failed,
+        inventory_completeness: WorktreeProviderInventoryCompleteness::Partial,
+        elapsed_ms,
+        heartbeat_count,
         mode,
-        command_run: None,
+        command_run,
         status: None,
         stdout: String::new(),
         stderr: String::new(),
@@ -1135,7 +1193,7 @@ fn provider_failure(
         last_progress: None,
         run_refs: Vec::new(),
         follow_up_command: None,
-        error: Some(error.to_string()),
+        error: Some(error),
     }
 }
 
@@ -1681,6 +1739,73 @@ mod tests {
             output.providers[0].parsed_payload,
             Some(json!({ "mode": "preview" }))
         );
+    }
+
+    #[test]
+    fn cleanup_provider_liveness_is_bounded_and_reports_partial_inventory() {
+        let hanging = fake_provider_script_body("sleep 60\n");
+        let slow = fake_provider_script_body("sleep 0.12\nprintf '{\"mode\":\"preview\"}\\n'\n");
+        let failing = fake_provider_script_body("printf 'provider failed\\n' >&2\nexit 23\n");
+        let provider = |script: String| WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: false,
+            commands: WorktreeProviderCommands {
+                cleanup_preview: Some(vec![script]),
+                ..Default::default()
+            },
+            list_result_mapping: None,
+        };
+
+        let mut config = HomeboyConfig::default();
+        config
+            .worktree_providers
+            .insert("hanging".to_string(), provider(hanging));
+        config
+            .worktree_providers
+            .insert("slow".to_string(), provider(slow));
+        config
+            .worktree_providers
+            .insert("failing".to_string(), provider(failing));
+        let started = std::time::Instant::now();
+        let output = cleanup_worktree_providers_from_config(
+            WorktreeProviderCleanupOptions {
+                provider: Vec::new(),
+                all_providers: true,
+                apply: false,
+            },
+            config,
+        )
+        .expect("bounded cleanup completes");
+
+        assert!(started.elapsed() < Duration::from_secs(7));
+        assert_eq!(
+            output.inventory_completeness,
+            WorktreeProviderInventoryCompleteness::Partial
+        );
+        let hanging = output
+            .providers
+            .iter()
+            .find(|row| row.provider_id == "hanging")
+            .expect("hanging result");
+        assert_eq!(hanging.outcome, WorktreeProviderCleanupOutcome::TimedOut);
+        assert_eq!(
+            hanging.inventory_completeness,
+            WorktreeProviderInventoryCompleteness::Partial
+        );
+        let slow = output
+            .providers
+            .iter()
+            .find(|row| row.provider_id == "slow")
+            .expect("slow result");
+        assert_eq!(slow.outcome, WorktreeProviderCleanupOutcome::Completed);
+        assert!(slow.heartbeat_count > 0);
+        let failing = output
+            .providers
+            .iter()
+            .find(|row| row.provider_id == "failing")
+            .expect("failing result");
+        assert_eq!(failing.outcome, WorktreeProviderCleanupOutcome::Failed);
     }
 
     #[test]
@@ -2308,6 +2433,14 @@ mod tests {
         let script = dir.join("provider");
         fs::write(&script, "#!/bin/sh\nprintf '{\"mode\":\"%s\"}\n' \"$1\"\n")
             .expect("write script");
+        make_executable(&script);
+        script.to_string_lossy().to_string()
+    }
+
+    fn fake_provider_script_body(body: &str) -> String {
+        let dir = unique_fixture_script_dir();
+        let script = dir.join("provider");
+        fs::write(&script, format!("#!/bin/sh\n{body}")).expect("write script");
         make_executable(&script);
         script.to_string_lossy().to_string()
     }

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -254,6 +254,7 @@ pub fn wait_with_bounded_output_supervised(
     let mut last_heartbeat = started;
     let (status, termination) = loop {
         if let Some(status) = child.try_wait()? {
+            terminate_remaining_process_group(child.id())?;
             break (status, SupervisedCommandTermination::Completed);
         }
         if is_cancelled() {
@@ -299,6 +300,32 @@ pub fn wait_with_bounded_output_supervised(
         },
         termination,
     })
+}
+
+/// A command can exit before a background descendant closes inherited output
+/// pipes. Stop that remaining process group before joining capture readers.
+#[cfg(unix)]
+fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
+    if !process_group_is_running(root_pid) {
+        return Ok(());
+    }
+    signal_process_group(root_pid, libc::SIGTERM)?;
+    if wait_for_process_group_exit_without_child(root_pid, PROCESS_TREE_TERM_GRACE) {
+        return Ok(());
+    }
+    signal_process_group(root_pid, libc::SIGKILL)?;
+    if wait_for_process_group_exit_without_child(root_pid, PROCESS_TREE_KILL_GRACE) {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("process group {root_pid} remained alive after its root exited"),
+    ))
+}
+
+#[cfg(not(unix))]
+fn terminate_remaining_process_group(_root_pid: u32) -> io::Result<()> {
+    Ok(())
 }
 
 struct LiveOutputTail {
@@ -449,6 +476,18 @@ fn wait_for_process_group_exit(
         thread::sleep(PROCESS_TREE_POLL_INTERVAL);
     }
     Ok(true)
+}
+
+#[cfg(unix)]
+fn wait_for_process_group_exit_without_child(root_pid: u32, grace: Duration) -> bool {
+    let deadline = std::time::Instant::now() + grace;
+    while process_group_is_running(root_pid) {
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(PROCESS_TREE_POLL_INTERVAL);
+    }
+    true
 }
 
 /// Terminate an isolated child process tree and reap its direct child process.
@@ -742,6 +781,43 @@ mod tests {
                 .expect("cancel and reap process tree");
         assert!(!status.status.success());
 
+        let descendant_pid = std::fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<libc::pid_t>()
+            .expect("numeric descendant pid");
+        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completed_parent_does_not_deadlock_on_a_background_output_holder() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let pid_file = temp.path().join("descendant.pid");
+        let script = format!(
+            "sleep 30 & echo $! > {}; printf done",
+            shell_quote_path(&pid_file)
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        command.stdout(std::process::Stdio::piped());
+        command.stderr(std::process::Stdio::piped());
+        isolate_process_tree(&mut command);
+        let mut child = command.spawn().expect("spawn process tree");
+
+        let started = std::time::Instant::now();
+        let result = wait_with_bounded_output_supervised(
+            &mut child,
+            64,
+            Duration::from_secs(1),
+            Duration::from_millis(10),
+            || false,
+            |_, _| Ok(()),
+        )
+        .expect("completed parent is supervised");
+
+        assert!(started.elapsed() < Duration::from_secs(3));
+        assert_eq!(result.termination, SupervisedCommandTermination::Completed);
         let descendant_pid = std::fs::read_to_string(&pid_file)
             .expect("descendant pid")
             .trim()

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -56,6 +56,7 @@ const MIN_RUNNER_WORKSPACE_FREE_RATIO: f64 = 0.01;
 const METADATA_SSH_RECOVERY_ATTEMPTS: usize = 2;
 const WORKSPACE_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_METADATA_OUTPUT_LIMIT: usize = 4 * 1024;
+const WORKSPACE_PRUNE_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub fn sync_workspace(
     runner_id: &str,
@@ -1585,7 +1586,7 @@ fn ssh_runner_workspace_disk_probe(
         "p={path}; while [ ! -e \"$p\" ] && [ \"$p\" != / ]; do p=$(dirname \"$p\"); done; df -Pk \"$p\" 2>/dev/null | awk 'NR==2 {{print $2 \" \" $4}}'",
         path = shell::quote_arg(workspace_root),
     );
-    let output = client.execute(&command);
+    let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
     if !output.success {
         return Ok(None);
     }
@@ -1789,7 +1790,7 @@ fn prune_candidates_ssh(
     client.env.extend(runner.env.clone());
     let min_age = options.min_age_hours.saturating_mul(3600);
     let command = prune_scan_command(root, min_age);
-    let output = client.execute(&command);
+    let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
             "runner workspace prune scan failed: {}",
@@ -1906,7 +1907,7 @@ fn remove_workspace(runner: &super::super::Runner, root: &str, remote_path: &str
                 root = shell::quote_arg(root),
                 path = shell::quote_arg(remote_path),
             );
-            let output = client.execute(&command);
+            let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
             if output.success {
                 Ok(())
             } else {

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -22,6 +22,8 @@ Use `--sort size` to review the largest artifacts first, `--limit N` to bound th
 
 The JSON output includes worktree identity, candidate paths, estimated bytes, skipped reasons, applied rows, and a `summary` object. The terminal summary shows bounded candidate rows and points to the JSON output for full large reviews. `summary.invocation_reclaimed_bytes` reports bytes reclaimed by the current command, `summary.remaining_candidate_bytes` reports cleanup candidates still present after the command, and `summary.cumulative_session_reclaimed_bytes` carries the local cumulative total for repeated `--apply` runs against the same repository. Cleanup refuses unsafe path declarations and skips artifact paths that contain tracked or staged source changes.
 
+Configured worktree-provider previews run independently with a 30-second cancellation boundary. The output records each provider's typed `outcome`, `inventory_completeness`, elapsed time, and heartbeat count, so a timed-out or failed provider yields a partial inventory without blocking healthy providers. Preview commands remain the only provider operation invoked without `--apply`.
+
 Regular `homeboy cleanup` includes `repo-artifacts` inventory. After an agent-task provider exits, Homeboy also cleans declared rebuildable artifacts from that exact detached attempt worktree before applying its existing source-state and commit safety guard. Active sibling worktrees are not scanned by this lifecycle step.
 
 ## Shared Cargo Targets


### PR DESCRIPTION
## Summary
- supervise configured cleanup providers independently with bounded timeout, process-tree cancellation, and heartbeat diagnostics
- expose typed provider outcomes and inventory completeness so timeouts return partial inventory without blocking healthy providers
- bound SSH workspace prune operations and cover hanging, slow, and failing provider behavior

Closes #10018

## Validation
- `cargo fmt --check`
- `cargo test -p homeboy-core worktree_providers::tests::cleanup_provider_liveness_is_bounded_and_reports_partial_inventory -- --nocapture`
- `cargo test -p homeboy-lab-runner workspace::tests::prune`
- `cargo test -p homeboy-core worktree_providers::tests` (one existing unrelated idempotency-fixture assertion failed: `provision_creates_missing_destination_from_explicit_generic_intent`)

## AI assistance
Model: OpenAI GPT-5.6 Terra
Tool: OpenCode
Used for: Implementing and validating bounded cleanup provider supervision, typed partial inventory reporting, and SSH prune timeouts under Chris Huber's direction. Chris remains responsible for every line.