### PR TITLE
fix(cook): report foreground lifecycle progress

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -779,6 +779,36 @@ pub fn reserve_provider_execution(
     Ok(reservation)
 }
 
+/// Persist the controller-owned Cook phase independently of provider output.
+/// This gives foreground observers a restart-safe liveness source without
+/// treating an arbitrary provider transcript line as durable state.
+pub fn record_cook_progress(
+    run_id: &str,
+    phase: &str,
+    attempt: u32,
+    detail: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let now = now_timestamp();
+        record.ensure_metadata_object().insert(
+            "cook_progress".to_string(),
+            json!({
+                "phase": phase,
+                "attempt": attempt,
+                "detail": detail,
+                "updated_at": now,
+            }),
+        );
+        if !record.state.is_terminal() && !record.is_runner_backed() {
+            record.updated_at = Some(now_timestamp());
+            update_lifecycle_heartbeat(record);
+        }
+        true
+    })?;
+    record.ok_or_else(|| Error::internal_unexpected("Cook progress record was unchanged"))
+}
+
 /// Record the provider's terminal result before controller-owned patch
 /// harvesting. Harvesting can fail or be interrupted independently of the
 /// provider execution, so it must not leave this reservation running.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -18,6 +18,26 @@ use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
 #[test]
+fn cook_progress_is_durable_across_active_and_terminal_lifecycle_states() {
+    with_isolated_home(|_| {
+        let run_id = "cook-progress-lifecycle";
+        submit_plan(&test_plan(), Some(run_id)).expect("submit run");
+
+        let active = record_cook_progress(run_id, "provider_start", 1, Some("fixture provider"))
+            .expect("record active progress");
+        assert_eq!(active.metadata["cook_progress"]["phase"], "provider_start");
+        assert!(active.lifecycle.heartbeat.is_some());
+
+        let cancelled = cancel_run(run_id, Some("fixture cancellation")).expect("cancel run");
+        assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+        let terminal = record_cook_progress(run_id, "terminal", 1, Some("cancelled"))
+            .expect("retain terminal progress");
+        assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
+        assert_eq!(terminal.metadata["cook_progress"]["phase"], "terminal");
+    });
+}
+
+#[test]
 fn provider_run_result_reads_declared_output_alias() {
     let role_aliases: AgentTaskProviderRoleAliases = serde_json::from_value(json!({
         "outputs": {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -5,6 +5,7 @@
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
 
 use crate::agent_task_cook_loop::{
     evaluate_cook_loop, AgentTaskCookLoopOptions, AgentTaskCookLoopReport, AgentTaskCookLoopStatus,
@@ -69,6 +70,27 @@ fn retry_dispatch_operation_key(next_run_id: &str) -> String {
 /// push, `gh pr create`) can take a while; the lease is generous so a healthy
 /// controller completes it, while a crashed controller's lease still elapses.
 const FINALIZATION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Foreground liveness is deliberately bounded. Provider-native progress still
+/// wins when available; this durable heartbeat covers quiet providers.
+const COOK_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+pub type CookProgressObserver<'a> = dyn Fn(&str, &str, &str) -> Result<()> + Send + Sync + 'a;
+
+fn report_cook_progress(
+    observer: Option<&CookProgressObserver<'_>>,
+    cook_id: &str,
+    run_id: &str,
+    phase: &str,
+    attempt: u32,
+    detail: Option<&str>,
+) -> Result<()> {
+    agent_task_lifecycle::record_cook_progress(run_id, phase, attempt, detail)?;
+    if let Some(observer) = observer {
+        observer(phase, cook_id, run_id)?;
+    }
+    Ok(())
+}
 
 /// Durable operation key for finalizing one cook candidate. Keyed by the run id
 /// plus the promoted candidate fingerprint (patch SHA), so re-finalizing the
@@ -1179,7 +1201,7 @@ where
 pub fn run_cook_with_durable_observer<E>(
     options: AgentTaskCookServiceOptions,
     executor: E,
-    observer: &dyn Fn(&str, &str) -> Result<()>,
+    observer: &CookProgressObserver<'_>,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
     E: AgentTaskExecutorAdapter + Clone,
@@ -1217,7 +1239,7 @@ fn run_cook_with_boundaries_observed<E, S>(
     options: AgentTaskCookServiceOptions,
     executor: E,
     mut side_effects: S,
-    durable_observer: Option<&dyn Fn(&str, &str) -> Result<()>>,
+    durable_observer: Option<&CookProgressObserver<'_>>,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
     E: AgentTaskExecutorAdapter + Clone,
@@ -1310,9 +1332,14 @@ where
             "materialized Cook lifecycle record does not match its initial run id",
         ));
     }
-    if let Some(observer) = durable_observer {
-        observer(&options.cook_id, &options.initial_run_id)?;
-    }
+    report_cook_progress(
+        durable_observer,
+        &options.cook_id,
+        &options.initial_run_id,
+        "provider_ready",
+        1,
+        None,
+    )?;
     // Transport readiness can serialize on a reconnect/runtime-promotion
     // lease. Complete it before entering the provider-attempt loop so that
     // waiting for a shared Lab session never consumes a cook attempt.
@@ -1395,6 +1422,18 @@ where
             })
             .unwrap_or(true);
         if needs_execution {
+            report_cook_progress(
+                durable_observer,
+                &cook_id,
+                &run_id,
+                if attempt == 1 {
+                    "provider_start"
+                } else {
+                    "retry"
+                },
+                attempt,
+                None,
+            )?;
             validate_cook_workspace(&options)?;
             // Claim the durable attempt before candidate baseline staging. That
             // staging can take longer than the foreground controller's timeout;
@@ -1513,14 +1552,35 @@ where
                     )
                 } else {
                     validate_cook_workspace(&options)?;
-                    run_loaded_plan_with_derived_cook_baseline(
-                        dispatch_plan,
-                        Some(&run_id),
-                        executor.clone(),
-                        effective_baseline.map(CookFollowUpBaseline::capability),
-                        Some(cook_attempt_harvest_context(&options.harvest_context)),
-                    )
-                    .map(|_| ())
+                    let (heartbeat_stop, heartbeat_wait) = mpsc::channel();
+                    let heartbeat_run_id = run_id.clone();
+                    let heartbeat_cook_id = cook_id.clone();
+                    std::thread::scope(|scope| {
+                        scope.spawn(move || {
+                            while let Err(mpsc::RecvTimeoutError::Timeout) =
+                                heartbeat_wait.recv_timeout(COOK_HEARTBEAT_INTERVAL)
+                            {
+                                let _ = report_cook_progress(
+                                    durable_observer,
+                                    &heartbeat_cook_id,
+                                    &heartbeat_run_id,
+                                    "heartbeat",
+                                    attempt,
+                                    Some("provider execution is still running"),
+                                );
+                            }
+                        });
+                        let result = run_loaded_plan_with_derived_cook_baseline(
+                            dispatch_plan,
+                            Some(&run_id),
+                            executor.clone(),
+                            effective_baseline.map(CookFollowUpBaseline::capability),
+                            Some(cook_attempt_harvest_context(&options.harvest_context)),
+                        )
+                        .map(|_| ());
+                        let _ = heartbeat_stop.send(());
+                        result
+                    })
                 }
             })();
             if let Err(error) = execution {
@@ -1686,6 +1746,14 @@ where
             ));
         }
 
+        report_cook_progress(
+            durable_observer,
+            &cook_id,
+            &run_id,
+            "promotion",
+            attempt,
+            None,
+        )?;
         let promotion = match side_effects.promote(&options, &run_id) {
             Ok(report) => report,
             Err(error) => {
@@ -1814,6 +1882,14 @@ where
                     },
                     None => promotion,
                 };
+                report_cook_progress(
+                    durable_observer,
+                    &cook_id,
+                    &run_id,
+                    "finalization",
+                    attempt,
+                    None,
+                )?;
                 let finalization = match side_effects.finalize(&options, &run_id, &promotion) {
                     Ok(finalization) => {
                         if active_moving_base_recovery.is_some() {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1238,6 +1238,41 @@ where
 fn run_cook_with_boundaries_observed<E, S>(
     options: AgentTaskCookServiceOptions,
     executor: E,
+    side_effects: S,
+    durable_observer: Option<&CookProgressObserver<'_>>,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
+where
+    E: AgentTaskExecutorAdapter + Clone,
+    S: CookSideEffectService,
+{
+    let result =
+        run_cook_with_boundaries_observed_inner(options, executor, side_effects, durable_observer)?;
+    if let Some(run_id) = result.value.latest_run_id.as_deref() {
+        let attempt = result
+            .value
+            .attempts
+            .last()
+            .map(|attempt| attempt.attempt)
+            .unwrap_or(1);
+        let phase = match result.value.status.as_str() {
+            "queued" | "running" | "in_flight" => "in_flight",
+            _ => "terminal",
+        };
+        report_cook_progress(
+            durable_observer,
+            &result.value.cook_id,
+            run_id,
+            phase,
+            attempt,
+            Some(&result.value.status),
+        )?;
+    }
+    Ok(result)
+}
+
+fn run_cook_with_boundaries_observed_inner<E, S>(
+    options: AgentTaskCookServiceOptions,
+    executor: E,
     mut side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1523,25 +1523,43 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
 
         let observed = Arc::new(Mutex::new(Vec::new()));
         let observer_records = observed.clone();
-        let result = run_cook_with_durable_observer(options, UnusedExecutor, &move |cook, run| {
-            let status =
-                agent_task_lifecycle::status(cook).expect("Cook alias resolves in observer");
-            let logs =
-                agent_task_lifecycle::logs(cook).expect("Cook alias logs resolve in observer");
-            assert_eq!(status.run_id, run);
-            assert!(!logs.events.is_empty());
-            observer_records
-                .lock()
-                .expect("observer records lock")
-                .push((cook.to_string(), run.to_string()));
-            Ok(())
-        })
-        .expect("restart repairs the Cook alias");
+        let result =
+            run_cook_with_durable_observer(options, UnusedExecutor, &move |phase, cook, run| {
+                let status =
+                    agent_task_lifecycle::status(cook).expect("Cook alias resolves in observer");
+                let logs =
+                    agent_task_lifecycle::logs(cook).expect("Cook alias logs resolve in observer");
+                assert_eq!(status.run_id, run);
+                assert!(!logs.events.is_empty());
+                observer_records
+                    .lock()
+                    .expect("observer records lock")
+                    .push((phase.to_string(), cook.to_string(), run.to_string()));
+                Ok(())
+            })
+            .expect("restart repairs the Cook alias");
 
         assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
         assert_eq!(
             observed.lock().expect("observer records lock").as_slice(),
-            &[(cook_id.to_string(), run_id.to_string())]
+            &[
+                (
+                    "provider_ready".to_string(),
+                    cook_id.to_string(),
+                    run_id.to_string()
+                ),
+                (
+                    "provider_start".to_string(),
+                    cook_id.to_string(),
+                    run_id.to_string()
+                ),
+            ]
+        );
+        assert_eq!(
+            agent_task_lifecycle::status(run_id)
+                .expect("durable progress")
+                .metadata["cook_progress"]["phase"],
+            "provider_start"
         );
         let index = agent_task_lifecycle::cook_index(cook_id).expect("repaired Cook index");
         assert_eq!(index.latest_run_id, run_id);

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1553,13 +1553,18 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
                     cook_id.to_string(),
                     run_id.to_string()
                 ),
+                (
+                    "in_flight".to_string(),
+                    cook_id.to_string(),
+                    run_id.to_string()
+                ),
             ]
         );
         assert_eq!(
             agent_task_lifecycle::status(run_id)
                 .expect("durable progress")
                 .metadata["cook_progress"]["phase"],
-            "provider_start"
+            "in_flight"
         );
         let index = agent_task_lifecycle::cook_index(cook_id).expect("repaired Cook index");
         assert_eq!(index.latest_run_id, run_id);

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -44,14 +44,12 @@ pub(crate) use status::diagnostic_summary_from_aggregate;
 
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     let progress = |phase: &str, cook_id: Option<&str>, run_id: Option<&str>| {
-        if crate::commands::utils::tty::is_stdout_tty() {
-            let identity = match (cook_id, run_id) {
-                (_, Some(run_id)) => format!(" [{run_id}]"),
-                (Some(cook_id), None) => format!(" [{cook_id}]"),
-                (None, None) => String::new(),
-            };
-            eprintln!("cook: {phase}{identity}");
-        }
+        let identity = match (cook_id, run_id) {
+            (_, Some(run_id)) => format!(" [{run_id}]"),
+            (Some(cook_id), None) => format!(" [{cook_id}]"),
+            (None, None) => String::new(),
+        };
+        crate::commands::utils::tty::status(&format!("cook: {phase}{identity}"));
         Ok(())
     };
     run_with_cook_progress(args, Some(&progress))

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -43,12 +43,25 @@ pub use args::{
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
-    run_with_cook_progress(args, None)
+    let progress = |phase: &str, cook_id: Option<&str>, run_id: Option<&str>| {
+        if crate::commands::utils::tty::is_stdout_tty() {
+            let identity = match (cook_id, run_id) {
+                (_, Some(run_id)) => format!(" [{run_id}]"),
+                (Some(cook_id), None) => format!(" [{cook_id}]"),
+                (None, None) => String::new(),
+            };
+            eprintln!("cook: {phase}{identity}");
+        }
+        Ok(())
+    };
+    run_with_cook_progress(args, Some(&progress))
 }
 
 pub(crate) fn run_with_cook_progress(
     args: AgentTaskArgs,
-    progress: Option<&dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()>>,
+    progress: Option<
+        &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
+    >,
 ) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::Doctor(doctor_args) => doctor::doctor(doctor_args),

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -246,7 +246,9 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress<E>(
     attempt_dispatcher: Option<
         Arc<dyn crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher>,
     >,
-    progress: Option<&dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()>>,
+    progress: Option<
+        &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
+    >,
 ) -> CmdResult<Value>
 where
     E: AgentTaskExecutorAdapter + Clone,
@@ -313,9 +315,9 @@ where
         .commit_message
         .clone()
         .unwrap_or_else(|| default_loop_commit_message(&args));
-    let durable_observer = |cook_id: &str, run_id: &str| {
+    let durable_observer = |phase: &str, cook_id: &str, run_id: &str| {
         progress
-            .map(|progress| progress("in_flight", Some(cook_id), Some(run_id)))
+            .map(|progress| progress(phase, Some(cook_id), Some(run_id)))
             .unwrap_or(Ok(()))
     };
     let result = agent_task_service::run_cook_with_durable_observer(


### PR DESCRIPTION
## Summary
- persist foreground Cook phase and bounded provider heartbeats in the durable lifecycle record
- project provider, retry, promotion, and finalization phases to TTY stderr and the existing #10006 output lease without contaminating JSON stdout
- preserve terminal output-file replacement and add lifecycle coverage for cancellation/restart state

Closes #10019

## Verification
- `cargo fmt --all --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-agents cook_progress_is_durable_across_active_and_terminal_lifecycle_states --lib`
- `cargo test -p homeboy-cli output_runtime --lib`

## AI assistance
- Model: OpenAI GPT-5.6 Terra
- Tool: OpenCode
- Used for: traced Cook lifecycle/output handling, implemented durable foreground progress and bounded heartbeat reporting, and added targeted lifecycle coverage.

Chris Huber remains responsible for every line.