### PR TITLE
fix(agent-task): scope stale reconciliation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -73,7 +73,7 @@ fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
         command: None,
         cwd: None,
         runner: ActivityRunnerRefs {
-            runner_id,
+            runner_id: runner_id.clone(),
             job_id: job_id.clone(),
             transport: remote_run_id,
         },
@@ -106,31 +106,35 @@ fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
             .collect(),
         source_projections: Vec::new(),
         state_conflicts: Vec::new(),
-        next_actions: actions_for_agent_task(&record.run_id, state),
+        next_actions: actions_for_agent_task(&record.run_id, runner_id.as_deref(), state),
     }
 }
 
-fn actions_for_agent_task(run_id: &str, state: ActivityState) -> Vec<ActivityNextAction> {
+fn actions_for_agent_task(
+    run_id: &str,
+    runner_id: Option<&str>,
+    state: ActivityState,
+) -> Vec<ActivityNextAction> {
+    let command_prefix = runner_id
+        .map(|runner_id| format!("homeboy runner exec {runner_id} -- homeboy agent-task"))
+        .unwrap_or_else(|| "homeboy agent-task".to_string());
     let mut actions = vec![
-        action("status", format!("homeboy agent-task status {run_id}")),
-        action("logs", format!("homeboy agent-task logs {run_id}")),
-        action(
-            "artifacts",
-            format!("homeboy agent-task artifacts {run_id}"),
-        ),
+        action("status", format!("{command_prefix} status {run_id}")),
+        action("logs", format!("{command_prefix} logs {run_id}")),
+        action("artifacts", format!("{command_prefix} artifacts {run_id}")),
     ];
     if is_active(state) {
         actions.push(action("watch", format!("homeboy activity watch {run_id}")));
     } else if is_failure(state) {
         actions.push(action(
             "retry",
-            format!("homeboy agent-task retry --run {run_id}"),
+            format!("{command_prefix} retry --run {run_id}"),
         ));
     }
     if matches!(state, ActivityState::Stale) {
         actions.push(action(
             "reconcile",
-            format!("homeboy agent-task reconcile {run_id} --dry-run"),
+            format!("{command_prefix} reconcile {run_id} --dry-run"),
         ));
     }
     actions
@@ -141,4 +145,19 @@ fn actions_for_agent_task(run_id: &str, state: ActivityState) -> Vec<ActivityNex
 /// agent-task subsystem.
 pub fn register() {
     register_activity_agent_task_provider(Box::new(AgentTaskActivityProvider));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runner_backed_actions_execute_on_the_owning_runner() {
+        let actions = actions_for_agent_task("run-1", Some("lab-a"), ActivityState::Stale);
+
+        assert!(actions.iter().any(|action| {
+            action.command
+                == "homeboy runner exec lab-a -- homeboy agent-task reconcile run-1 --dry-run"
+        }));
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -128,7 +128,10 @@ fn actions_for_agent_task(run_id: &str, state: ActivityState) -> Vec<ActivityNex
         ));
     }
     if matches!(state, ActivityState::Stale) {
-        actions.push(action("reconcile", "homeboy agent-task active --reconcile"));
+        actions.push(action(
+            "reconcile",
+            format!("homeboy agent-task reconcile {run_id} --dry-run"),
+        ));
     }
     actions
 }

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -408,7 +408,9 @@ fn discovery_run(
         "homeboy agent-task".to_string()
     } else {
         match runner_id.as_deref() {
-            Some(runner_id) => format!("homeboy --runner {runner_id} agent-task"),
+            // Lifecycle records resident on a runner must execute there. The
+            // global `--runner` flag is only for portable Lab offload commands.
+            Some(runner_id) => format!("homeboy runner exec {runner_id} -- homeboy agent-task"),
             None => "homeboy agent-task".to_string(),
         }
     };

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -284,7 +284,7 @@ fn discovery_report(
 
 fn liveness_summary(runs: &[AgentTaskDiscoveryRun]) -> AgentTaskLivenessSummary {
     let mut summary = AgentTaskLivenessSummary {
-        reconcile_command: "homeboy agent-task active --reconcile",
+        reconcile_command: "homeboy agent-task active --reconcile --dry-run",
         ..Default::default()
     };
     for run in runs {
@@ -448,7 +448,7 @@ fn discovery_run(
             promote: aggregate_path
                 .map(|path| format!("homeboy agent-task promote {path} --to-worktree <handle>"))
                 .unwrap_or_else(|| format!("{command_prefix} review {run_id}")),
-            reconcile: format!("{command_prefix} cancel {run_id} --reason stale-running"),
+            reconcile: format!("{command_prefix} reconcile {run_id} --dry-run"),
         },
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -12,6 +12,10 @@ use super::discovery::{discover_runs, AgentTaskDiscoveryFilter, AgentTaskLivenes
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AgentTaskReconcileReport {
     pub schema: &'static str,
+    /// `fleet` for the explicit bulk operation or `run:<id>` for a scoped repair.
+    pub scope: String,
+    /// `preview` unless the caller supplied explicit `--apply` authorization.
+    pub authorization: &'static str,
     /// `true` when no records were actually mutated (preview mode).
     pub dry_run: bool,
     pub considered: usize,
@@ -25,9 +29,11 @@ pub struct AgentTaskReconcileRun {
     pub run_id: String,
     pub liveness: AgentTaskLiveness,
     pub source: String,
+    /// State observed from the durable record after its runner/provider refresh.
+    pub authoritative_state: agent_task_lifecycle::AgentTaskRunState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<String>,
-    /// `reconciled`, `would-reconcile` (dry run), or `failed`.
+    /// `reconciled`, `would-reconcile` (preview), `no-op`, or `failed`.
     pub action: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -77,6 +83,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
                         run_id: run.run_id,
                         liveness,
                         source: run.source,
+                        authoritative_state: agent_task_lifecycle::AgentTaskRunState::Running,
                         stale_reason: run.stale_reason,
                         action: "failed",
                         error: Some(error.message),
@@ -93,6 +100,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
                 run_id: run.run_id,
                 liveness,
                 source: run.source,
+                authoritative_state: agent_task_lifecycle::AgentTaskRunState::Running,
                 stale_reason: run.stale_reason,
                 action: "would-reconcile",
                 error: None,
@@ -116,6 +124,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
                     run_id: run.run_id,
                     liveness,
                     source: run.source,
+                    authoritative_state: agent_task_lifecycle::AgentTaskRunState::Running,
                     stale_reason: run.stale_reason,
                     action: "reconciled",
                     error: None,
@@ -127,6 +136,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
                     run_id: run.run_id,
                     liveness,
                     source: run.source,
+                    authoritative_state: agent_task_lifecycle::AgentTaskRunState::Running,
                     stale_reason: run.stale_reason,
                     action: "failed",
                     error: Some(error.message),
@@ -137,8 +147,126 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
 
     Ok(AgentTaskReconcileReport {
         schema: "homeboy/agent-task-reconcile/v1",
+        scope: "fleet".to_string(),
+        authorization: if dry_run { "preview" } else { "explicit-apply" },
         dry_run,
         considered: runs.len(),
+        reconciled,
+        failed,
+        runs,
+    })
+}
+
+/// Reconcile one durable run after refreshing its authoritative lifecycle and
+/// runner projection. This is intentionally a separate operation from fleet
+/// reconciliation: a state or ownership change becomes a no-op rather than a
+/// reason to inspect or mutate any other record (#10001).
+pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileReport> {
+    let authoritative = agent_task_lifecycle::status(run_id)?;
+    let resolved_run_id = authoritative.run_id.clone();
+    let source = authoritative
+        .runner_id()
+        .map(|runner_id| format!("runner:{runner_id}"))
+        .unwrap_or_else(|| "local".to_string());
+    let candidate = discover_runs(AgentTaskDiscoveryFilter::Active)?
+        .runs
+        .into_iter()
+        .find(|run| run.run_id == resolved_run_id);
+
+    let mut runs = Vec::new();
+    let mut reconciled = 0;
+    let mut failed = 0;
+    match candidate {
+        Some(run) if run.liveness.is_some_and(AgentTaskLiveness::is_reconcilable) => {
+            let liveness = run.liveness.expect("checked reconcilable liveness");
+            // Re-read immediately before apply. A newly-live runner or a changed
+            // owner is authoritative and turns this scoped request into a no-op.
+            let refreshed = agent_task_lifecycle::status(&resolved_run_id)?;
+            let still_reconcilable = discover_runs(AgentTaskDiscoveryFilter::Active)?
+                .runs
+                .into_iter()
+                .find(|run| run.run_id == resolved_run_id)
+                .and_then(|run| run.liveness)
+                .is_some_and(AgentTaskLiveness::is_reconcilable);
+            if refreshed.state.is_terminal() || !still_reconcilable {
+                runs.push(AgentTaskReconcileRun {
+                    run_id: resolved_run_id,
+                    liveness,
+                    source: run.source,
+                    authoritative_state: refreshed.state,
+                    stale_reason: run.stale_reason,
+                    action: "no-op",
+                    error: None,
+                });
+            } else if dry_run {
+                runs.push(AgentTaskReconcileRun {
+                    run_id: resolved_run_id,
+                    liveness,
+                    source: run.source,
+                    authoritative_state: refreshed.state,
+                    stale_reason: run.stale_reason,
+                    action: "would-reconcile",
+                    error: None,
+                });
+            } else {
+                let reason = run
+                    .stale_reason
+                    .clone()
+                    .unwrap_or_else(|| format!("reconciled stale-{} run", liveness.as_str()));
+                match agent_task_lifecycle::cancel_run(&resolved_run_id, Some(&reason)) {
+                    Ok(record) => {
+                        reconciled += 1;
+                        runs.push(AgentTaskReconcileRun {
+                            run_id: resolved_run_id,
+                            liveness,
+                            source: run.source,
+                            authoritative_state: record.state,
+                            stale_reason: run.stale_reason,
+                            action: "reconciled",
+                            error: None,
+                        });
+                    }
+                    Err(error) => {
+                        failed += 1;
+                        runs.push(AgentTaskReconcileRun {
+                            run_id: resolved_run_id,
+                            liveness,
+                            source: run.source,
+                            authoritative_state: refreshed.state,
+                            stale_reason: run.stale_reason,
+                            action: "failed",
+                            error: Some(error.message),
+                        });
+                    }
+                }
+            }
+        }
+        Some(run) => runs.push(AgentTaskReconcileRun {
+            run_id: resolved_run_id,
+            liveness: run.liveness.unwrap_or(AgentTaskLiveness::Active),
+            source: run.source,
+            authoritative_state: authoritative.state,
+            stale_reason: run.stale_reason,
+            action: "no-op",
+            error: None,
+        }),
+        None => runs.push(AgentTaskReconcileRun {
+            run_id: resolved_run_id,
+            liveness: AgentTaskLiveness::Active,
+            source,
+            authoritative_state: authoritative.state,
+            stale_reason: None,
+            action: "no-op",
+            error: None,
+        }),
+    }
+
+    Ok(AgentTaskReconcileReport {
+        schema: "homeboy/agent-task-reconcile/v1",
+        scope: format!("run:{}", authoritative.run_id),
+        authorization: if dry_run { "preview" } else { "explicit-apply" },
+        dry_run,
+        considered: runs.iter().filter(|run| run.action != "no-op").count(),
         reconciled,
         failed,
         runs,

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -857,7 +857,7 @@ fn discovery_active_classifies_liveness_and_source() {
         assert_eq!(summary.stale, 1);
         assert_eq!(
             summary.reconcile_command,
-            "homeboy agent-task active --reconcile"
+            "homeboy agent-task active --reconcile --dry-run"
         );
     });
 }
@@ -917,6 +917,93 @@ fn reconcile_cancels_stale_running_record_without_manual_edit() {
         let empty = reconcile_stale_active_runs(false).expect("nothing to reconcile");
         assert_eq!(empty.considered, 0);
         assert_eq!(empty.reconciled, 0);
+    });
+}
+
+#[test]
+fn scoped_reconcile_applies_only_the_inspected_run_and_preserves_other_stale_records() {
+    with_isolated_home(|_| {
+        for run_id in ["run-scoped-target", "run-scoped-unrelated"] {
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
+                record.tasks[0].state = AgentTaskState::Running;
+                record.metadata = serde_json::json!({ "runner_pid": u32::MAX });
+            })
+            .expect("stale record stored");
+        }
+
+        // Normalize the unrelated record before snapshotting it. The scoped
+        // operation must not write it while reconciling the requested run.
+        let unrelated_before = serde_json::to_value(
+            lifecycle_status("run-scoped-unrelated").expect("unrelated status"),
+        )
+        .expect("serialize unrelated record");
+
+        let preview = reconcile_run("run-scoped-target", true).expect("scoped preview");
+        assert_eq!(preview.scope, "run:run-scoped-target");
+        assert_eq!(preview.authorization, "preview");
+        assert_eq!(preview.considered, 1);
+        assert_eq!(preview.runs[0].action, "would-reconcile");
+        assert_eq!(
+            lifecycle_status("run-scoped-target")
+                .expect("target after preview")
+                .state,
+            AgentTaskRunState::Running
+        );
+
+        let applied = reconcile_run("run-scoped-target", false).expect("scoped apply");
+        assert_eq!(applied.authorization, "explicit-apply");
+        assert_eq!(applied.reconciled, 1);
+        assert_eq!(
+            lifecycle_status("run-scoped-target")
+                .expect("target after apply")
+                .state,
+            AgentTaskRunState::Cancelled
+        );
+        assert_eq!(
+            serde_json::to_value(
+                lifecycle_status("run-scoped-unrelated").expect("unrelated after")
+            )
+            .expect("serialize unrelated record"),
+            unrelated_before
+        );
+    });
+}
+
+#[test]
+fn scoped_reconcile_is_a_no_op_when_the_owner_becomes_live_after_preview() {
+    with_isolated_home(|_| {
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-owner-changed"))
+            .expect("submitted");
+        agent_task_lifecycle::rewrite_record_for_test("run-owner-changed", |record| {
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
+            record.tasks[0].state = AgentTaskState::Running;
+            record.metadata = serde_json::json!({ "runner_pid": u32::MAX });
+        })
+        .expect("stale record stored");
+
+        assert_eq!(
+            reconcile_run("run-owner-changed", true)
+                .expect("preview")
+                .runs[0]
+                .action,
+            "would-reconcile"
+        );
+        agent_task_lifecycle::rewrite_record_for_test("run-owner-changed", |record| {
+            record.metadata = serde_json::json!({ "runner_pid": std::process::id() });
+        })
+        .expect("live owner stored");
+
+        let report = reconcile_run("run-owner-changed", false).expect("apply after owner change");
+        assert_eq!(report.reconciled, 0);
+        assert_eq!(report.runs[0].action, "no-op");
+        assert_eq!(
+            lifecycle_status("run-owner-changed")
+                .expect("owner-changed record")
+                .state,
+            AgentTaskRunState::Running
+        );
     });
 }
 
@@ -1053,7 +1140,7 @@ fn discovery_runner_backed_run_emits_runner_scoped_commands() {
         );
         assert_eq!(
             run.commands.reconcile,
-            "homeboy --runner homeboy-lab agent-task cancel run-runner-commands --reason stale-running"
+            "homeboy --runner homeboy-lab agent-task reconcile run-runner-commands --dry-run"
         );
     });
 }

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1128,19 +1128,19 @@ fn discovery_runner_backed_run_emits_runner_scoped_commands() {
         // Commands must be valid for the run's location: runner-scoped.
         assert_eq!(
             run.commands.status,
-            "homeboy --runner homeboy-lab agent-task status run-runner-commands"
+            "homeboy runner exec homeboy-lab -- homeboy agent-task status run-runner-commands"
         );
         assert_eq!(
             run.commands.logs,
-            "homeboy --runner homeboy-lab agent-task logs run-runner-commands"
+            "homeboy runner exec homeboy-lab -- homeboy agent-task logs run-runner-commands"
         );
         assert_eq!(
             run.commands.review,
-            "homeboy --runner homeboy-lab agent-task review run-runner-commands"
+            "homeboy runner exec homeboy-lab -- homeboy agent-task review run-runner-commands"
         );
         assert_eq!(
             run.commands.reconcile,
-            "homeboy --runner homeboy-lab agent-task reconcile run-runner-commands --dry-run"
+            "homeboy runner exec homeboy-lab -- homeboy agent-task reconcile run-runner-commands --dry-run"
         );
     });
 }

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -298,9 +298,17 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         }
         ["agent-task", "active"] => {
             metadata.mutating(
-                "reads active runs by default; --reconcile cancels stale active records unless --dry-run is passed",
+                "reads active runs by default; --reconcile previews the full fleet mutation set and --apply authorizes its cancellation",
             );
             metadata.dry_run_flag = Some("--dry-run");
+            metadata.dangerous_flags = vec!["--apply"];
+        }
+        ["agent-task", "reconcile"] => {
+            metadata.mutating(
+                "previews reconciliation for one durable run; --apply authorizes a scoped lifecycle mutation after provider-state inspection",
+            );
+            metadata.dry_run_flag = Some("--dry-run");
+            metadata.dangerous_flags = vec!["--apply"];
         }
         ["agent-task", "controller", "init"]
         | ["agent-task", "controller", "from-spec"]

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -76,11 +76,12 @@ pub(crate) fn run_with_cook_progress(
         ),
         AgentTaskCommand::Active(active_args) => {
             if active_args.reconcile {
-                status::reconcile_active(active_args.dry_run)
+                status::reconcile_active(!active_args.apply)
             } else {
                 status::list_active(active_args.into())
             }
         }
+        AgentTaskCommand::Reconcile(args) => status::reconcile_run(&args.run_id, !args.apply),
         AgentTaskCommand::ReconcileRecords(args) => status::reconcile_records(args.dry_run),
         AgentTaskCommand::Latest(latest_args) => status::list_runs(
             agent_task_service::AgentTaskDiscoveryFilter::Latest,

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -53,6 +53,8 @@ pub enum AgentTaskCommand {
     Status(StatusArgs),
     List(ListArgs),
     Active(ActiveArgs),
+    /// Preview or apply reconciliation for one durable run.
+    Reconcile(ReconcileArgs),
     ReconcileRecords(ReconcileRecordsArgs),
     Latest(LatestArgs),
     Logs(LogsArgs),
@@ -97,8 +99,18 @@ pub struct ActiveArgs {
     pub limit: Option<usize>,
     #[arg(long = "reconcile")]
     pub reconcile: bool,
-    #[arg(long = "dry-run", requires = "reconcile")]
+    #[arg(long = "dry-run", requires = "reconcile", conflicts_with = "apply")]
     pub dry_run: bool,
+    #[arg(long = "apply", requires = "reconcile", conflicts_with = "dry_run")]
+    pub apply: bool,
+}
+#[derive(Args, Debug)]
+pub struct ReconcileArgs {
+    pub run_id: String,
+    #[arg(long = "dry-run", conflicts_with = "apply")]
+    pub dry_run: bool,
+    #[arg(long = "apply", conflicts_with = "dry_run")]
+    pub apply: bool,
 }
 #[derive(Args, Debug)]
 pub struct ReconcileRecordsArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -114,18 +114,25 @@ pub(super) fn list_active(
         map.insert("buckets".to_string(), buckets);
         map.insert(
             "reconcile_hint".to_string(),
-            json!("run `homeboy agent-task active --reconcile` (or the per-run `commands.reconcile`) to safely cancel stale-running records without manual state edits"),
+            json!("run the per-run `commands.reconcile` preview, then repeat it with `--apply` after reviewing authoritative provider state"),
         );
     }
     attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
 }
 
-/// `agent-task active --reconcile`: safely cancel stale/suspect/unreconciled
-/// running records through the lifecycle cancel path. With `dry_run`, the
-/// candidates are reported but no record is mutated (#5682).
+/// `agent-task active --reconcile`: preview stale/suspect/unreconciled records
+/// across the fleet. `--apply` is required to mutate the previewed set (#10001).
 pub(super) fn reconcile_active(dry_run: bool) -> CmdResult<Value> {
     let report = agent_task_service_direct::reconcile_stale_active_runs(dry_run)?;
+    let exit = if report.failed > 0 { 1 } else { 0 };
+    Ok((serde_json::to_value(report).unwrap_or(Value::Null), exit))
+}
+
+/// `agent-task reconcile <run-id>` always addresses exactly one durable run.
+/// It previews by default; `--apply` is the explicit operator authorization.
+pub(super) fn reconcile_run(run_id: &str, dry_run: bool) -> CmdResult<Value> {
+    let report = agent_task_service_direct::reconcile_run(run_id, dry_run)?;
     let exit = if report.failed > 0 { 1 } else { 0 };
     Ok((serde_json::to_value(report).unwrap_or(Value::Null), exit))
 }
@@ -212,7 +219,10 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
         metadata.next_actions.push(
             CommandNextAction::new(
                 "reconcile stale run",
-                "homeboy agent-task active --reconcile".to_string(),
+                format!(
+                    "homeboy agent-task reconcile {} --dry-run",
+                    quote_arg(run_id)
+                ),
             )
             .with_kind(CommandNextActionKind::Repair),
         );
@@ -1493,7 +1503,7 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
         "next_action": if terminal {
             format!("homeboy agent-task review {run_id}")
         } else if stale {
-            "homeboy agent-task active --reconcile".to_string()
+            format!("homeboy agent-task reconcile {} --dry-run", quote_arg(run_id))
         } else if waiting_for_capacity {
             "await runner completion or reconnect; the runner will claim this FIFO queue entry under its capacity lease".to_string()
         } else {
@@ -2129,7 +2139,7 @@ mod tests {
         assert_eq!(stale["liveness"]["provider_boundary"]["status"], "absent");
         assert_eq!(
             stale["liveness"]["next_action"],
-            "homeboy agent-task active --reconcile"
+            "homeboy agent-task reconcile agent-task-ghost --dry-run"
         );
 
         let accepted_handoff = compact_status_summary(

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -188,6 +188,7 @@ impl Commands {
                     | agent_task::AgentTaskCommand::Review(_)
                     | agent_task::AgentTaskCommand::List(_)
                     | agent_task::AgentTaskCommand::Active(_)
+                    | agent_task::AgentTaskCommand::Reconcile(_)
                     | agent_task::AgentTaskCommand::Latest(_),
             }) => LabCommandContract::runner_resident_read_polling(AGENT_TASK_STATUS_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -142,7 +142,7 @@ fn reclassify_stale_running(items: &mut [ActivityItem]) {
         item.state = ActivityState::Stale;
         let reconcile = action(
             "reconcile stale activity",
-            "homeboy agent-task active --reconcile",
+            format!("homeboy agent-task reconcile {} --dry-run", item.id),
         );
         if !item
             .next_actions
@@ -392,10 +392,13 @@ mod tests {
             .find(|item| item.id == "stale-running")
             .expect("stale row present");
         assert_eq!(reclassified.state, ActivityState::Stale);
-        assert!(reclassified
-            .next_actions
-            .iter()
-            .any(|action| action.command == "homeboy agent-task active --reconcile"));
+        assert!(
+            reclassified
+                .next_actions
+                .iter()
+                .any(|action| action.command
+                    == "homeboy agent-task reconcile stale-running --dry-run")
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -140,9 +140,18 @@ fn reclassify_stale_running(items: &mut [ActivityItem]) {
             continue;
         }
         item.state = ActivityState::Stale;
+        if item.kind != "agent-task" {
+            continue;
+        }
+        let command_prefix = item
+            .runner
+            .runner_id
+            .as_deref()
+            .map(|runner_id| format!("homeboy runner exec {runner_id} -- homeboy agent-task"))
+            .unwrap_or_else(|| "homeboy agent-task".to_string());
         let reconcile = action(
             "reconcile stale activity",
-            format!("homeboy agent-task reconcile {} --dry-run", item.id),
+            format!("{command_prefix} reconcile {} --dry-run", item.id),
         );
         if !item
             .next_actions
@@ -392,13 +401,26 @@ mod tests {
             .find(|item| item.id == "stale-running")
             .expect("stale row present");
         assert_eq!(reclassified.state, ActivityState::Stale);
-        assert!(
-            reclassified
-                .next_actions
-                .iter()
-                .any(|action| action.command
-                    == "homeboy agent-task reconcile stale-running --dry-run")
-        );
+        assert!(reclassified.next_actions.iter().all(|action| {
+            action.command != "homeboy agent-task reconcile stale-running --dry-run"
+        }));
+    }
+
+    #[test]
+    fn stale_agent_task_reconciliation_runs_on_the_owning_runner() {
+        let now = chrono::Utc::now();
+        let mut stale = item("agent-task-stale", ActivityState::Running);
+        stale.kind = "agent-task".to_string();
+        stale.updated_at = Some((now - chrono::Duration::hours(6)).to_rfc3339());
+        stale.runner.runner_id = Some("lab-a".to_string());
+
+        let report = report_from_items(vec![stale], "homeboy activity");
+
+        assert_eq!(report.items[0].state, ActivityState::Stale);
+        assert!(report.items[0].next_actions.iter().any(|action| {
+            action.command
+                == "homeboy runner exec lab-a -- homeboy agent-task reconcile agent-task-stale --dry-run"
+        }));
     }
 
     #[test]

--- a/docs/commands/activity.md
+++ b/docs/commands/activity.md
@@ -28,4 +28,4 @@ Human output is a compact table followed by next-action command lines per item.
 
 ## Scope
 
-This is a local read model only. List, show, and watch do not reconcile or otherwise mutate persisted state. Use the structured `reconcile` actions when shown, such as `homeboy runs reconcile` or `homeboy agent-task active --reconcile`, to invoke the existing explicit reconciliation services. It does not create a daemon, event bus, or offloaded job, and the Lab contract marks it local-only.
+This is a local read model only. List, show, and watch do not reconcile or otherwise mutate persisted state. Agent-task stale actions target the inspected run with `homeboy agent-task reconcile <run-id> --dry-run`; review the authoritative provider-state preview, then add `--apply` to authorize that one lifecycle mutation. It does not create a daemon, event bus, or offloaded job, and the Lab contract marks it local-only.

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -28,7 +28,8 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `submit` | Persist an agent-task plan and return a durable run id without executing it. |
 | `status <run-id>` | Read durable run status. |
 | `list [--limit <n>]` | List durable runs, newest first. |
-| `active [--limit <n>] [--reconcile [--dry-run]]` | List queued and running durable runs, newest first, or reconcile stale active records. |
+| `active [--limit <n>] [--reconcile [--dry-run\|--apply]]` | List queued and running durable runs, newest first, or preview/reconcile the explicit fleet mutation set. |
+| `reconcile <run-id> [--dry-run\|--apply]` | Preview or reconcile one durable run after refreshing its authoritative provider state. |
 | `latest [--limit <n>]` | Show the latest durable run. |
 | `logs <run-id> [--raw]` | Read the canonical durable event stream; `--raw` adds transport frames for diagnostics. |
 | `artifacts <run-id>` | List artifacts and evidence refs recorded for a completed run. |
@@ -38,7 +39,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
 | `prompts save\|list\|show\|remove` | Manage markdown prompts in Homeboy-owned storage. |
 
-`agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `agent-task active --reconcile` cancels stale, suspect, or unreconciled active records through the durable lifecycle path; add `--dry-run` to report candidates without mutating records.
+`agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `agent-task reconcile <run-id>` is the recovery path emitted by status and activity: it previews only that run by default, refreshes runner/provider state before classification, and requires `--apply` to mutate it. If ownership or provider state changes before apply, it reports a no-op. `agent-task active --reconcile` is an explicit fleet operation: it previews every candidate by default and requires `--apply` to reconcile the displayed set.
 
 Machine-readable `cook`, `resume`, `adopt`, and `status` responses default to bounded summaries: stable ids, states, totals, timestamps when present, artifact/evidence references, and actionable failure reasons are retained while nested provider evidence is projected away. Use `cook --full`, `resume --full`, `adopt --full`, or the emitted `full_command`; use the emitted `evidence_command` (with `--task` or `--kind`) to retrieve selected durable evidence.
 


### PR DESCRIPTION
Closes #10001

## Summary
- add run-scoped reconciliation with preview-by-default and explicit `--apply` authorization
- update status and activity actions to target the inspected run, including runner-scoped command prefixes
- require an explicit apply step for fleet reconciliation and cover multi-run isolation plus ownership changes

## Verification
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p homeboy-agents scoped_reconcile --lib`
- `cargo test -p homeboy-core stale_heartbeat_running_rows_are_reclassified --lib`
- `cargo run --quiet -- agent-task reconcile --help`

## AI assistance
Model: OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`)
Tool: OpenCode
Used for: Implementing scoped reconciliation, updating command guidance and documentation, and drafting targeted tests under Chris Huber's direction.