### PR TITLE
fix(fuzz): summarize failed run root causes

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
@@ -71,7 +71,7 @@ pub fn run(args: FuzzArgs, _global: &GlobalArgs) -> CmdResult<FuzzOutput> {
         }
         Some(FuzzCommand::Inspect(inspect_args)) => {
             let output = run_inspect(inspect_args)?;
-            let exit = i32::from(output.status != "ok");
+            let exit = i32::from(output.inspection_status != "ok");
             Ok((FuzzOutput::Inspect(output), exit))
         }
         None => {

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -19,6 +19,7 @@ use homeboy::rig::{self, FuzzPrepareReport, RigSpec};
 use homeboy_extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
 use uuid::Uuid;
 
+use super::inspect::fuzz_failure_diagnostic;
 use super::planning::{load_sequence_plan, plan_inventory_selection, with_sequence_plan_metadata};
 use super::report::{
     evaluate_expected_metric_gates, evaluate_fuzz_gates_for_profile, fuzz_coverage_completeness,
@@ -213,6 +214,33 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         &results_path,
     );
     let campaign_contract = fuzz_campaign_contract(fuzz_config.as_ref(), args.seed.as_deref());
+    let diagnostic = (!success)
+        .then(|| {
+            let result = serde_json::json!({
+                "workload_id": workload_id,
+                "campaign": results,
+            });
+            homeboy::core::observation::ObservationStore::open_initialized()
+                .ok()
+                .and_then(|store| {
+                    homeboy::core::observation::runs_service::require_run(&store, &effective_run_id)
+                        .ok()
+                })
+                .map(|run| {
+                    fuzz_failure_diagnostic(
+                        &run,
+                        Some(&effective_run_id),
+                        &result,
+                        &[&runner_output.stderr, &runner_output.stdout],
+                        persisted_evidence
+                            .evidence_refs
+                            .iter()
+                            .map(|reference| reference.canonical_uri().to_string())
+                            .collect(),
+                    )
+                })
+        })
+        .flatten();
     run_dir.finish(success);
 
     Ok((
@@ -259,6 +287,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
             runner_contract: fuzz_runner_contract(fuzz_config.as_ref()),
             evidence_refs: persisted_evidence.evidence_refs,
             evidence_followups,
+            diagnostic,
         },
         exit_code,
     ))

--- a/crates/homeboy-cli/src/commands/fuzz/inspect.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/inspect.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 
 use homeboy::core::artifact_ref::{artifact_uri, EvidenceRef};
-use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore};
+use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore, RunRecord};
 use homeboy::fuzz::inspect_fuzz_result_envelope_artifact;
 
 use super::types::{FuzzInspectArgs, FuzzInspectCandidate, FuzzInspectOutput};
+use super::types_extra::{FuzzDiagnosticSourceIdentity, FuzzFailureDiagnostic};
 use homeboy::fuzz::fuzz_result_envelope_evidence_ref;
 
 /// Artifact kinds that hold the raw fuzz runner input/result pair, ordered by
@@ -15,10 +16,9 @@ const RAW_FUZZ_RESULT_KINDS: &[&str] = &["fuzz_results", "fuzz_result_envelope"]
 
 /// Implement `homeboy fuzz inspect <run-id>`.
 ///
-/// Resolves the raw fuzz runner result for a run and prints it directly so an
-/// operator debugging a remote Lab fuzz failure does not have to chase a remote
-/// temp path or read large runner job logs. Works against either the `fuzz` run
-/// id or the Lab `runner-exec` run id that offloaded it, because
+/// Resolves the raw fuzz runner result for a run and emits a bounded diagnosis.
+/// `--raw` and `--full` retain exact artifact access. Works against either the
+/// `fuzz` run id or the Lab `runner-exec` run id that offloaded it, because
 /// [`runs_service::list_artifacts_for_run`] already folds in downstream Lab job
 /// artifacts that share the same `remote_job_id`.
 pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzInspectOutput> {
@@ -68,7 +68,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
     else {
         return Ok(FuzzInspectOutput {
             command: "fuzz.inspect".to_string(),
-            status: "not_found".to_string(),
+            inspection_status: "not_found".to_string(),
+            campaign_status: None,
             run_id: args.run_id.clone(),
             source_run_id: args.run_id.clone(),
             artifact_id: String::new(),
@@ -79,6 +80,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             fetch_command: None,
             result: None,
             raw: None,
+            diagnostic: None,
             envelope_summary: None,
             candidates: candidate_index,
             next_steps: vec![
@@ -104,7 +106,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
     if !path.is_file() {
         return Ok(FuzzInspectOutput {
             command: "fuzz.inspect".to_string(),
-            status: "unavailable".to_string(),
+            inspection_status: "unavailable".to_string(),
+            campaign_status: None,
             run_id: args.run_id.clone(),
             source_run_id: selected.run_id.clone(),
             artifact_id: selected.id.clone(),
@@ -115,6 +118,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             fetch_command: fetch_command.clone(),
             result: None,
             raw: None,
+            diagnostic: None,
             envelope_summary: None,
             candidates: candidate_index,
             next_steps: vec![
@@ -135,14 +139,17 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
     })?;
     let text = String::from_utf8_lossy(&bytes).to_string();
 
+    let parsed = serde_json::from_slice::<serde_json::Value>(&bytes).ok();
     let (result, raw) = if args.raw {
-        (None, Some(text))
+        (None, Some(text.clone()))
+    } else if args.full {
+        (parsed.clone(), parsed.is_none().then_some(text.clone()))
     } else {
-        match serde_json::from_slice::<serde_json::Value>(&bytes) {
-            Ok(value) => (Some(value), None),
-            Err(_) => (None, Some(text)),
-        }
+        (None, None)
     };
+    let diagnostic_input = parsed
+        .clone()
+        .unwrap_or_else(|| serde_json::json!({ "error": bounded(&text, 600) }));
 
     let envelope_summary = inspect_fuzz_result_envelope_artifact(selected)
         .filter(|inspection| inspection.valid)
@@ -150,17 +157,33 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
 
     Ok(FuzzInspectOutput {
         command: "fuzz.inspect".to_string(),
-        status: "ok".to_string(),
+        inspection_status: "ok".to_string(),
+        campaign_status: parsed.as_ref().and_then(campaign_status),
         run_id: args.run_id.clone(),
         source_run_id: selected.run_id.clone(),
         artifact_id: selected.id.clone(),
         artifact_kind: selected.kind.clone(),
         artifact_path: selected.path.clone(),
-        canonical_ref,
-        evidence_ref,
+        canonical_ref: canonical_ref.clone(),
+        evidence_ref: evidence_ref.clone(),
         fetch_command,
         result,
         raw,
+        diagnostic: Some(fuzz_failure_diagnostic(
+            &run,
+            Some(&selected.run_id),
+            &diagnostic_input,
+            &[],
+            canonical_ref
+                .iter()
+                .cloned()
+                .chain(
+                    evidence_ref
+                        .iter()
+                        .map(|reference| reference.canonical_uri().to_string()),
+                )
+                .collect(),
+        )),
         envelope_summary,
         candidates: candidate_index,
         next_steps: vec![
@@ -174,6 +197,175 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
             ),
         ],
     })
+}
+
+pub(super) fn fuzz_failure_diagnostic(
+    run: &RunRecord,
+    source_run_id: Option<&str>,
+    result: &serde_json::Value,
+    output: &[&str],
+    mut evidence_refs: Vec<String>,
+) -> FuzzFailureDiagnostic {
+    let campaign = result.get("campaign").unwrap_or(result);
+    let failed_case = campaign
+        .get("cases")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|cases| {
+            cases
+                .iter()
+                .find(|case| {
+                    matches!(
+                        case.get("status").and_then(serde_json::Value::as_str),
+                        Some("failed" | "error")
+                    )
+                })
+                .or_else(|| cases.first())
+        });
+    let case_id = failed_case
+        .and_then(|case| case.get("id").or_else(|| case.get("case_id")))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .or_else(|| find_string(result, &["case_id"]));
+    let phase = find_string(result, &["phase", "phase_id"]);
+    let mut causes = diagnostic_strings(result);
+    causes.extend(
+        output
+            .iter()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| bounded(value, 600)),
+    );
+    causes.sort();
+    causes.dedup();
+    let joined = causes.join("\n");
+    let classification = if joined.contains("ELOOP") {
+        "pre_execution_assembly_failure"
+    } else if joined.contains("PHP")
+        && (joined.contains("Missing ") || joined.contains("exit code"))
+    {
+        "php_bootstrap_fatal"
+    } else if causes.is_empty() {
+        "failed_campaign"
+    } else {
+        "workload_execution_failure"
+    }
+    .to_string();
+    causes.truncate(4);
+    let executions = if classification == "pre_execution_assembly_failure" {
+        0
+    } else {
+        find_u64(result, &["executions", "execution_count", "executionCount"])
+            .unwrap_or_else(|| u64::from(case_id.is_some()))
+    };
+    if let Some(source_run_id) = source_run_id {
+        evidence_refs.push(format!("homeboy://run/{source_run_id}"));
+    }
+    evidence_refs.sort();
+    evidence_refs.dedup();
+    let runtime = find_string(result, &["runtime", "runtime_id", "runtime_kind"]);
+    FuzzFailureDiagnostic {
+        run_id: run.id.clone(),
+        rig_id: run
+            .rig_id
+            .clone()
+            .or_else(|| find_string(result, &["rig_id"])),
+        workload_id: find_string(result, &["workload_id"]),
+        case_id,
+        phase,
+        classification,
+        root_cause_chain: causes,
+        executions,
+        source_identity: FuzzDiagnosticSourceIdentity {
+            component: run
+                .component_id
+                .clone()
+                .or_else(|| find_string(result, &["component"])),
+            homeboy_version: run.homeboy_version.clone(),
+            git_sha: run.git_sha.clone(),
+            runtime,
+        },
+        evidence_refs,
+        inspect_command: format!("homeboy fuzz inspect {}", run.id),
+    }
+}
+
+fn campaign_status(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("campaign")
+        .unwrap_or(value)
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn find_string(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    match value {
+        serde_json::Value::Object(object) => object.iter().find_map(|(key, value)| {
+            (keys.contains(&key.as_str()))
+                .then(|| value.as_str().map(str::to_string))
+                .flatten()
+                .or_else(|| find_string(value, keys))
+        }),
+        serde_json::Value::Array(values) => {
+            values.iter().find_map(|value| find_string(value, keys))
+        }
+        _ => None,
+    }
+}
+
+fn find_u64(value: &serde_json::Value, keys: &[&str]) -> Option<u64> {
+    match value {
+        serde_json::Value::Object(object) => object.iter().find_map(|(key, value)| {
+            (keys.contains(&key.as_str()))
+                .then(|| value.as_u64())
+                .flatten()
+                .or_else(|| find_u64(value, keys))
+        }),
+        serde_json::Value::Array(values) => values.iter().find_map(|value| find_u64(value, keys)),
+        _ => None,
+    }
+}
+
+fn diagnostic_strings(value: &serde_json::Value) -> Vec<String> {
+    const KEYS: &[&str] = &[
+        "error",
+        "message",
+        "failure_reason",
+        "stderr",
+        "stdout",
+        "reason",
+    ];
+    fn visit(value: &serde_json::Value, key: Option<&str>, values: &mut Vec<String>) {
+        if values.len() >= 12 {
+            return;
+        }
+        match value {
+            serde_json::Value::Object(object) => {
+                for (key, value) in object {
+                    visit(value, Some(key), values);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for value in items {
+                    visit(value, key, values);
+                }
+            }
+            serde_json::Value::String(value) if key.is_some_and(|key| KEYS.contains(&key)) => {
+                values.push(bounded(value, 600))
+            }
+            _ => {}
+        }
+    }
+    let mut values = Vec::new();
+    visit(value, None, &mut values);
+    values
+}
+
+fn bounded(value: &str, limit: usize) -> String {
+    let mut result = value.chars().take(limit).collect::<String>();
+    if value.chars().count() > limit {
+        result.push_str("...[truncated]");
+    }
+    result
 }
 
 fn fuzz_inspect_evidence_ref(artifact: &ArtifactRecord) -> Option<EvidenceRef> {
@@ -226,10 +418,11 @@ mod tests {
             let output = run_inspect(FuzzInspectArgs {
                 run_id: run.id.clone(),
                 raw: false,
+                full: true,
             })
             .expect("inspect");
 
-            assert_eq!(output.status, "ok");
+            assert_eq!(output.inspection_status, "ok");
             assert_eq!(output.artifact_kind, "fuzz_results");
             assert_eq!(output.source_run_id, run.id);
             let result = output.result.expect("parsed json result");
@@ -289,10 +482,11 @@ mod tests {
             let output = run_inspect(FuzzInspectArgs {
                 run_id: runner_run.id.clone(),
                 raw: false,
+                full: true,
             })
             .expect("inspect");
 
-            assert_eq!(output.status, "ok");
+            assert_eq!(output.inspection_status, "ok");
             assert_eq!(output.source_run_id, fuzz_run.id);
             assert_eq!(
                 output
@@ -323,10 +517,11 @@ mod tests {
             let output = run_inspect(FuzzInspectArgs {
                 run_id: run.id.clone(),
                 raw: true,
+                full: false,
             })
             .expect("inspect");
 
-            assert_eq!(output.status, "ok");
+            assert_eq!(output.inspection_status, "ok");
             assert!(output.result.is_none());
             assert_eq!(output.raw.as_deref(), Some("{\"ok\":true}"));
         });
@@ -363,10 +558,11 @@ mod tests {
             let output = run_inspect(FuzzInspectArgs {
                 run_id: run.id.clone(),
                 raw: false,
+                full: true,
             })
             .expect("inspect");
 
-            assert_eq!(output.status, "ok");
+            assert_eq!(output.inspection_status, "ok");
             assert_eq!(output.artifact_kind, "runner-output");
             assert!(output
                 .canonical_ref
@@ -410,16 +606,104 @@ mod tests {
             let output = run_inspect(FuzzInspectArgs {
                 run_id: run.id.clone(),
                 raw: false,
+                full: false,
             })
             .expect("inspect");
 
-            assert_eq!(output.status, "not_found");
+            assert_eq!(output.inspection_status, "not_found");
             assert!(output.result.is_none());
             assert!(output.candidates.is_empty());
             assert!(output
                 .next_steps
                 .iter()
                 .any(|step| step.contains("runs evidence")));
+        });
+    }
+
+    #[test]
+    fn inspect_bounds_nested_codebox_failure_and_projects_statuses() {
+        with_isolated_home(|home| {
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("fuzz", serde_json::json!({ "exit_code": 255 })))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Fail, None)
+                .expect("finish");
+            let result = serde_json::json!({
+                "campaign": {
+                    "id": "codebox-campaign",
+                    "status": "failed",
+                    "cases": [{
+                        "id": "case-17",
+                        "status": "failed",
+                        "workload_id": "wordpress.run-php",
+                        "observed": {
+                            "phase": "bootstrap",
+                            "runtime_kind": "wp-codebox",
+                            "stderr": "PHP.run() failed with exit code 255\\nMissing /wordpress/wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-assets/actions.php",
+                            "stdout": "x".repeat(700_000),
+                            "generated": { "base64_payload": "y".repeat(700_000) }
+                        }
+                    }]
+                }
+            });
+            let path = home.path().join("codebox-results.json");
+            std::fs::write(&path, serde_json::to_vec(&result).unwrap()).expect("write");
+            store
+                .record_artifact(&run.id, "fuzz_results", &path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id.clone(),
+                raw: false,
+                full: false,
+            })
+            .expect("inspect");
+
+            assert_eq!(output.inspection_status, "ok");
+            assert_eq!(output.campaign_status.as_deref(), Some("failed"));
+            assert!(output.result.is_none());
+            assert!(output.raw.is_none());
+            let diagnostic = output.diagnostic.expect("diagnostic");
+            assert_eq!(diagnostic.classification, "php_bootstrap_fatal");
+            assert_eq!(diagnostic.case_id.as_deref(), Some("case-17"));
+            assert_eq!(diagnostic.phase.as_deref(), Some("bootstrap"));
+            assert_eq!(diagnostic.executions, 1);
+            assert!(diagnostic
+                .root_cause_chain
+                .join(" ")
+                .contains("actions.php"));
+            assert!(serde_json::to_vec(&diagnostic).unwrap().len() < 10_000);
+        });
+    }
+
+    #[test]
+    fn inspect_marks_eloop_as_pre_execution_with_zero_executions() {
+        with_isolated_home(|home| {
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("fuzz", serde_json::json!({})))
+                .expect("run");
+            let path = home.path().join("eloop-results.json");
+            std::fs::write(&path, br#"{"campaign":{"id":"assembly","status":"failed","metadata":{"error":"ELOOP: too many symbolic links while staging WP Codebox workload"}}}"#).expect("write");
+            store
+                .record_artifact(&run.id, "fuzz_results", &path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id,
+                raw: false,
+                full: false,
+            })
+            .expect("inspect");
+            let diagnostic = output.diagnostic.expect("diagnostic");
+            assert_eq!(diagnostic.classification, "pre_execution_assembly_failure");
+            assert_eq!(diagnostic.executions, 0);
         });
     }
 }

--- a/crates/homeboy-cli/src/commands/fuzz/inspect.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/inspect.rs
@@ -154,6 +154,9 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
     let envelope_summary = inspect_fuzz_result_envelope_artifact(selected)
         .filter(|inspection| inspection.valid)
         .and_then(|inspection| inspection.summary);
+    // The selected artifact can belong to a downstream Lab fuzz run rather than
+    // the runner-exec run used for lookup. Its record is the diagnostic source.
+    let diagnostic_run = runs_service::require_run(&store, &selected.run_id)?;
 
     Ok(FuzzInspectOutput {
         command: "fuzz.inspect".to_string(),
@@ -170,7 +173,7 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
         result,
         raw,
         diagnostic: Some(fuzz_failure_diagnostic(
-            &run,
+            &diagnostic_run,
             Some(&selected.run_id),
             &diagnostic_input,
             &[],
@@ -488,6 +491,13 @@ mod tests {
 
             assert_eq!(output.inspection_status, "ok");
             assert_eq!(output.source_run_id, fuzz_run.id);
+            assert_eq!(
+                output
+                    .diagnostic
+                    .as_ref()
+                    .map(|diagnostic| diagnostic.run_id.as_str()),
+                Some(fuzz_run.id.as_str())
+            );
             assert_eq!(
                 output
                     .result

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -1280,6 +1280,11 @@ fn fuzz_compare_parses_envelope_paths() {
 }
 
 #[test]
+fn fuzz_inspect_rejects_ambiguous_full_result_modes() {
+    assert!(FuzzCli::try_parse_from(["fuzz", "inspect", "run-1", "--raw", "--full"]).is_err());
+}
+
+#[test]
 fn fuzz_output_contract_has_stable_variant_discriminators() {
     let contract = serde_json::to_value(FuzzOutput::Contract(run_contract())).unwrap();
     assert_eq!(contract["variant"], "contract");

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -1327,6 +1327,7 @@ fn fuzz_output_contract_has_stable_variant_discriminators() {
         },
         evidence_refs: Vec::new(),
         evidence_followups: Vec::new(),
+        diagnostic: None,
     }))
     .unwrap();
     assert_eq!(run["variant"], "run");

--- a/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
@@ -61,6 +61,7 @@ fn fuzz_output_contract_includes_results_file_and_parsed_campaign() {
         },
         evidence_refs: Vec::new(),
         evidence_followups: Vec::new(),
+        diagnostic: None,
     }))
     .unwrap();
 

--- a/crates/homeboy-cli/src/commands/fuzz/types.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types.rs
@@ -190,11 +190,11 @@ pub(crate) struct FuzzInspectArgs {
     pub(crate) run_id: String,
 
     /// Print the complete result body as raw bytes/text.
-    #[arg(long = "raw")]
+    #[arg(long = "raw", conflicts_with = "full")]
     pub(crate) raw: bool,
 
     /// Print the complete parsed result body instead of the bounded diagnosis.
-    #[arg(long = "full")]
+    #[arg(long = "full", conflicts_with = "raw")]
     pub(crate) full: bool,
 }
 

--- a/crates/homeboy-cli/src/commands/fuzz/types.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types.rs
@@ -171,7 +171,7 @@ pub(crate) enum FuzzCommand {
     Replay(FuzzReplayArgs),
     /// Resolve minimization metadata for persisted fuzz cases
     Minimize(FuzzMinimizeArgs),
-    /// Print the raw fuzz runner result for a run without spelunking runner logs
+    /// Print a compact fuzz failure diagnosis or the complete runner result
     Inspect(FuzzInspectArgs),
 }
 
@@ -189,9 +189,13 @@ pub(crate) struct FuzzInspectArgs {
     #[arg(value_name = "RUN_ID")]
     pub(crate) run_id: String,
 
-    /// Print the result body as raw bytes/text instead of pretty JSON.
+    /// Print the complete result body as raw bytes/text.
     #[arg(long = "raw")]
     pub(crate) raw: bool,
+
+    /// Print the complete parsed result body instead of the bounded diagnosis.
+    #[arg(long = "full")]
+    pub(crate) full: bool,
 }
 
 #[derive(Args, Clone)]

--- a/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
@@ -63,15 +63,45 @@ pub struct FuzzDoctorExtensionOutput {
     pub update_command: String,
 }
 
-/// Raw fuzz-result inspection output for `homeboy fuzz inspect <run-id>`.
-///
-/// Surfaces the bytes a runner wrote to `HOMEBOY_FUZZ_RESULTS_FILE`
-/// (and/or the persisted result envelope) without requiring the operator
-/// to spelunk runner job logs or chase remote temp paths.
+/// Bounded failure projection shared by local execution and persisted inspection.
+#[derive(Clone, Serialize)]
+pub struct FuzzFailureDiagnostic {
+    pub run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workload_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub case_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    pub classification: String,
+    pub root_cause_chain: Vec<String>,
+    pub executions: u64,
+    pub source_identity: FuzzDiagnosticSourceIdentity,
+    pub evidence_refs: Vec<String>,
+    pub inspect_command: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct FuzzDiagnosticSourceIdentity {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homeboy_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
+}
+
+/// Compact fuzz-result inspection output for `homeboy fuzz inspect <run-id>`.
 #[derive(Serialize)]
 pub struct FuzzInspectOutput {
     pub command: String,
-    pub status: String,
+    pub inspection_status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub campaign_status: Option<String>,
     pub run_id: String,
     /// The run id that actually owns the raw fuzz-result artifact. For a
     /// Lab-offloaded run this is the downstream `fuzz` run discovered via the
@@ -85,10 +115,12 @@ pub struct FuzzInspectOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence_ref: Option<EvidenceRef>,
     pub fetch_command: Option<String>,
-    /// Parsed JSON body when the raw result is valid JSON; otherwise null.
+    /// Complete parsed JSON body, only present with `--full`.
     pub result: Option<serde_json::Value>,
-    /// Raw text body when the result is not valid JSON (or `--raw` text fallback).
+    /// Complete raw text body, present with `--raw` or invalid JSON.
     pub raw: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<FuzzFailureDiagnostic>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub envelope_summary: Option<homeboy::fuzz::FuzzResultEnvelopeArtifactSummary>,
     pub candidates: Vec<FuzzInspectCandidate>,
@@ -175,6 +207,8 @@ pub struct FuzzRunOutput {
     pub runner_contract: FuzzRunnerContract,
     pub evidence_refs: Vec<EvidenceRef>,
     pub evidence_followups: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<FuzzFailureDiagnostic>,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]

--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -16,6 +16,7 @@ homeboy fuzz report <results-file> [<component>] [--run-id <id>] [--inventory <p
 homeboy fuzz compare <baseline-envelope> <candidate-envelope> [--hotspot-policy <advisory|blocking|off>]
 homeboy fuzz replay [<artifact-or-case>] [--artifact <path>] [--case-id <id>] [--run-id <id>] [-- <runner-args>]
 homeboy fuzz minimize [<artifact-or-case>] [--artifact <path>] [--case-id <id>] [--run-id <id>] [--dry-run] [-- <runner-args>]
+homeboy fuzz inspect <run-id> [--raw|--full]
 ```
 
 ## Description
@@ -56,7 +57,9 @@ homeboy runs artifact get <run-id> <artifact-id> --output <path>
 homeboy fuzz replay --run-id <run-id> --case-id <case-id> --dry-run
 ```
 
-`homeboy runs show` renders the compact summary, coverage metadata when the
+`homeboy fuzz inspect <run-id>` renders a bounded failure diagnosis by default,
+with separate `inspection_status` and `campaign_status` fields. Use `--raw` or
+`--full` when the complete runner result is needed. `homeboy runs show` renders the compact summary, coverage metadata when the
 runner provides it, and fetch commands for recorded artifacts such as failing
 cases, repro cases, and coverage reports. Use `homeboy runs artifact get` for
 artifact bytes that are stored locally or mirrored from a runner.


### PR DESCRIPTION
## Summary
- project a bounded shared fuzz failure diagnostic for local runs and persisted Lab/local inspection
- separate retrieval `inspection_status` from workload `campaign_status`, with explicit PHP bootstrap and pre-execution ELOOP classifications
- retain complete artifacts behind `--raw` and `--full`, with oversized WP Codebox regression coverage

Closes #9990

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::fuzz::tests`

## AI assistance
- Model: OpenAI gpt-5.6-terra
- Tool: OpenCode
- Used for: Implemented the compact diagnostic projection, tests, documentation, and verification under Chris Huber's direction. Chris remains responsible for every line.