### PR TITLE
fix: bound provider and runner discovery output

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -157,6 +157,12 @@ pub struct ProvidersArgs {
         value_name = "PROVIDER_ID"
     )]
     pub selector: Option<String>,
+    /// Restrict results to the runtime that owns the provider.
+    #[arg(long = "runtime", value_name = "RUNTIME")]
+    pub runtime: Option<String>,
+    /// Restrict results to `default` or `available` providers.
+    #[arg(long = "status", value_name = "STATUS")]
+    pub status: Option<String>,
     #[arg(long = "secret-env", value_name = "ENV")]
     pub secret_env: Vec<String>,
     #[arg(long = "validate-readiness")]
@@ -168,6 +174,9 @@ pub struct ProvidersArgs {
     /// stays within caller display limits (#9654).
     #[arg(long = "catalog", visible_alias = "all")]
     pub catalog: bool,
+    /// Return the complete provider declarations and discovery diagnostics.
+    #[arg(long)]
+    pub full: bool,
 }
 #[derive(Args, Debug)]
 pub struct AgentTaskDoctorArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -845,6 +845,10 @@ fn scope_providers(
     }
 }
 
+const DEFAULT_PROVIDER_LIMIT: usize = 20;
+const DEFAULT_DIAGNOSTIC_LIMIT: usize = 10;
+const DEFAULT_TEXT_LIMIT: usize = 500;
+
 pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     let catalog = if args.refresh {
         AgentTaskProviderCatalog::refresh()
@@ -879,9 +883,53 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     // into the full catalog; an absent `--backend` still shows everything.
     let scoped_backend = scoped_provider_backend(args.backend.as_deref(), args.catalog);
     let scoped_providers = scope_providers(all_providers, scoped_backend);
-    let providers: &[AgentTaskExecutorProvider] = &scoped_providers;
+    let filtered_providers = scoped_providers
+        .iter()
+        .filter(|provider| {
+            args.selector
+                .as_deref()
+                .is_none_or(|selector| provider.id == selector)
+                && args
+                    .runtime
+                    .as_deref()
+                    .is_none_or(|runtime| provider.runtime_id.as_deref() == Some(runtime))
+                && args
+                    .status
+                    .as_deref()
+                    .is_none_or(|status| provider_status(provider).eq_ignore_ascii_case(status))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let providers: &[AgentTaskExecutorProvider] = &filtered_providers;
     let fallback_sources =
         homeboy::agents::agent_tasks::provider::provider_secret_sources_for_providers(providers);
+
+    let full_command = provider_full_command(&args);
+    let shown_providers = if args.full {
+        providers.to_vec()
+    } else {
+        providers
+            .iter()
+            .take(DEFAULT_PROVIDER_LIMIT)
+            .cloned()
+            .collect()
+    };
+    let diagnostics = executor.diagnostics();
+    let shown_diagnostics = if args.full {
+        diagnostics
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|diagnostic| serde_json::to_value(diagnostic).unwrap_or(Value::Null))
+            .collect::<Vec<_>>()
+    } else {
+        diagnostics
+            .iter()
+            .take(DEFAULT_DIAGNOSTIC_LIMIT)
+            .map(compact_diagnostic)
+            .collect::<Vec<_>>()
+    };
 
     Ok((
         serde_json::json!({
@@ -893,24 +941,102 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
             "scope": {
                 "backend": scoped_backend,
                 "filtered": scoped_backend.is_some(),
-                "shown": providers.len(),
+                "shown": shown_providers.len(),
                 "total": all_providers.len(),
                 "catalog_command": "homeboy agent-task providers --catalog",
             },
-            "dispatch_config_layers": dispatch_config_layers(providers),
-            "provider_identity_catalog": provider_identity_catalog(providers),
+            "operator_summary": {
+                "identity": "agent-task providers",
+                "state": if providers.is_empty() { "empty" } else { "available" },
+                "risk": if diagnostics.is_empty() { Vec::new() } else { vec![format!("{} discovery diagnostic(s)", diagnostics.len())] },
+                "next_action": full_command.clone(),
+            },
+            "truncation": {
+                "providers": { "shown": shown_providers.len(), "omitted": providers.len().saturating_sub(shown_providers.len()), "evidence_ref": "agent-task:provider-catalog", "full_command": full_command.clone() },
+                "diagnostics": { "shown": shown_diagnostics.len(), "omitted": diagnostics.len().saturating_sub(shown_diagnostics.len()), "evidence_ref": "agent-task:provider-discovery-diagnostics", "full_command": full_command },
+            },
+            "dispatch_config_layers": if args.full { dispatch_config_layers(providers) } else { Value::Null },
+            "provider_identity_catalog": if args.full { provider_identity_catalog(providers) } else { Vec::new() },
             "capability_contract": homeboy::agents::agent_tasks::provider::provider_capability_contract(),
-            "providers": providers,
+            "providers": if args.full { serde_json::to_value(shown_providers).unwrap_or(Value::Null) } else { Value::Array(shown_providers.iter().map(compact_provider).collect()) },
             "readiness_validation": {
                 "validated": args.validate_readiness,
                 "backend": args.backend,
                 "selector": args.selector,
             },
-            "diagnostics": executor.diagnostics(),
+            "diagnostics": shown_diagnostics,
             "secret_env": homeboy::agents::agent_tasks::secrets::secret_env_status_with_fallbacks(&args.secret_env, &fallback_sources),
         }),
         0,
     ))
+}
+
+fn provider_status(provider: &AgentTaskExecutorProvider) -> &'static str {
+    if provider.default_backend {
+        "default"
+    } else {
+        "available"
+    }
+}
+
+fn compact_provider(provider: &AgentTaskExecutorProvider) -> Value {
+    serde_json::json!({
+        "id": bounded_text(&provider.id, 160),
+        "label": provider.label.as_deref().map(|value| bounded_text(value, 160)),
+        "backend": bounded_text(&provider.backend, 160),
+        "runtime_id": provider.runtime_id.as_deref().map(|value| bounded_text(value, 160)),
+        "extension_id": provider.extension_id.as_deref().map(|value| bounded_text(value, 160)),
+        "status": provider_status(provider),
+        "default_backend": provider.default_backend,
+        "capabilities": provider.capabilities.iter().take(12).map(|value| bounded_text(value, 120)).collect::<Vec<_>>(),
+    })
+}
+
+fn compact_diagnostic(diagnostic: &impl serde::Serialize) -> Value {
+    let mut value = serde_json::to_value(diagnostic).unwrap_or(Value::Null);
+    if let Some(Value::String(message)) = value.get_mut("message") {
+        *message = bounded_text(message, DEFAULT_TEXT_LIMIT);
+    }
+    if let Some(object) = value.as_object_mut() {
+        for key in ["response_body", "body", "stdout", "stderr"] {
+            if let Some(bytes) = object.get(key).and_then(Value::as_str).map(str::len) {
+                object.insert(
+                    key.to_string(),
+                    serde_json::json!({
+                        "summarized": true,
+                        "omitted_bytes": bytes,
+                        "evidence_ref": "agent-task:provider-discovery-diagnostics",
+                    }),
+                );
+            }
+        }
+    }
+    value
+}
+
+fn bounded_text(value: &str, limit: usize) -> String {
+    let mut chars = value.chars();
+    let bounded = chars.by_ref().take(limit).collect::<String>();
+    if chars.next().is_some() {
+        format!("{bounded}...")
+    } else {
+        bounded
+    }
+}
+
+fn provider_full_command(args: &ProvidersArgs) -> String {
+    let mut command = "homeboy agent-task providers --full".to_string();
+    for (flag, value) in [
+        ("backend", args.backend.as_deref()),
+        ("selector", args.selector.as_deref()),
+        ("runtime", args.runtime.as_deref()),
+        ("status", args.status.as_deref()),
+    ] {
+        if let Some(value) = value {
+            command.push_str(&format!(" --{flag} {value}"));
+        }
+    }
+    command
 }
 
 fn provider_identity_catalog(providers: &[AgentTaskExecutorProvider]) -> Vec<Value> {
@@ -1347,6 +1473,33 @@ mod tests {
         AgentTaskOutcomeStatus, AgentTaskReconciliationDecision, AGENT_TASK_ARTIFACT_SCHEMA,
     };
     use sha2::{Digest, Sha256};
+
+    #[test]
+    fn compact_provider_bounds_extensions_and_large_diagnostics() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "provider-".to_string() + &"x".repeat(10_000),
+            "backend": "backend-".to_string() + &"x".repeat(10_000),
+            "extension_id": "extension-".to_string() + &"x".repeat(10_000),
+            "runtime_id": "runtime-".to_string() + &"x".repeat(10_000),
+            "capabilities": vec!["capability-".to_string() + &"x".repeat(10_000); 100],
+        }))
+        .expect("provider fixture");
+        let providers = std::iter::repeat(provider)
+            .take(DEFAULT_PROVIDER_LIMIT + 100)
+            .map(|provider| compact_provider(&provider))
+            .take(DEFAULT_PROVIDER_LIMIT)
+            .collect::<Vec<_>>();
+        let diagnostic = compact_diagnostic(&serde_json::json!({
+            "class": "provider.error",
+            "message": "x".repeat(100_000),
+            "response_body": "x".repeat(100_000),
+        }));
+
+        assert_eq!(providers.len(), DEFAULT_PROVIDER_LIMIT);
+        assert!(serde_json::to_vec(&providers).expect("provider JSON").len() < 100_000);
+        assert!(diagnostic["message"].as_str().expect("message").len() <= DEFAULT_TEXT_LIMIT + 3);
+        assert_eq!(diagnostic["response_body"]["omitted_bytes"], 100_000);
+    }
 
     fn recoverable_review_aggregate(
         temp: &tempfile::TempDir,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -845,9 +845,9 @@ fn scope_providers(
     }
 }
 
-const DEFAULT_PROVIDER_LIMIT: usize = 20;
+const DEFAULT_PROVIDER_LIMIT: usize = 10;
 const DEFAULT_DIAGNOSTIC_LIMIT: usize = 10;
-const DEFAULT_TEXT_LIMIT: usize = 500;
+const DEFAULT_TEXT_LIMIT: usize = 256;
 
 pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     let catalog = if args.refresh {
@@ -940,8 +940,12 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
             },
             "scope": {
                 "backend": scoped_backend,
-                "filtered": scoped_backend.is_some(),
+                "filtered": scoped_backend.is_some()
+                    || args.selector.is_some()
+                    || args.runtime.is_some()
+                    || args.status.is_some(),
                 "shown": shown_providers.len(),
+                "matched": providers.len(),
                 "total": all_providers.len(),
                 "catalog_command": "homeboy agent-task providers --catalog",
             },
@@ -988,7 +992,7 @@ fn compact_provider(provider: &AgentTaskExecutorProvider) -> Value {
         "extension_id": provider.extension_id.as_deref().map(|value| bounded_text(value, 160)),
         "status": provider_status(provider),
         "default_backend": provider.default_backend,
-        "capabilities": provider.capabilities.iter().take(12).map(|value| bounded_text(value, 120)).collect::<Vec<_>>(),
+        "capabilities": provider.capabilities.iter().take(8).map(|value| bounded_text(value, 96)).collect::<Vec<_>>(),
     })
 }
 
@@ -1033,10 +1037,20 @@ fn provider_full_command(args: &ProvidersArgs) -> String {
         ("status", args.status.as_deref()),
     ] {
         if let Some(value) = value {
-            command.push_str(&format!(" --{flag} {value}"));
+            command.push_str(&format!(" --{flag} {}", shell_arg(value)));
         }
     }
     command
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn provider_identity_catalog(providers: &[AgentTaskExecutorProvider]) -> Vec<Value> {
@@ -1496,9 +1510,29 @@ mod tests {
         }));
 
         assert_eq!(providers.len(), DEFAULT_PROVIDER_LIMIT);
-        assert!(serde_json::to_vec(&providers).expect("provider JSON").len() < 100_000);
+        assert!(serde_json::to_vec(&providers).expect("provider JSON").len() < 20_000);
         assert!(diagnostic["message"].as_str().expect("message").len() <= DEFAULT_TEXT_LIMIT + 3);
         assert_eq!(diagnostic["response_body"]["omitted_bytes"], 100_000);
+    }
+
+    #[test]
+    fn provider_full_command_quotes_filter_values() {
+        let command = provider_full_command(&ProvidersArgs {
+            backend: Some("backend; touch /tmp/unwanted".to_string()),
+            selector: Some("provider id".to_string()),
+            runtime: None,
+            status: None,
+            secret_env: Vec::new(),
+            validate_readiness: false,
+            refresh: false,
+            catalog: false,
+            full: false,
+        });
+
+        assert_eq!(
+            command,
+            "homeboy agent-task providers --full --backend 'backend; touch /tmp/unwanted' --selector 'provider id'"
+        );
     }
 
     fn recoverable_review_aggregate(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
@@ -8,10 +8,13 @@ fn providers_output_includes_core_capability_contract() {
         let (value, status) = review::providers(ProvidersArgs {
             backend: None,
             selector: None,
+            runtime: None,
+            status: None,
             secret_env: Vec::new(),
             validate_readiness: false,
             refresh: false,
             catalog: false,
+            full: false,
         })
         .expect("providers output");
 

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -276,6 +276,10 @@ pub(super) enum RunnerCommand {
         /// to thousands of lines on a long-lived runner.
         #[arg(long)]
         generations: bool,
+
+        /// Return complete status, runtime diagnostics, followups, and generation detail.
+        #[arg(long)]
+        full: bool,
     },
     /// Close a runner tunnel and remove its persisted session state
     Disconnect {

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -168,9 +168,11 @@ pub fn run(
                 confirm_control_plane_lost,
             },
         )),
-        RunnerCommand::Status { id, generations } => {
-            map_registry(status_mod::status(id.as_deref(), generations))
-        }
+        RunnerCommand::Status {
+            id,
+            generations,
+            full,
+        } => map_registry(status_mod::status(id.as_deref(), generations, full)),
         RunnerCommand::Disconnect { id } => map_registry(registry::disconnect(&id)),
         RunnerCommand::RefreshHomeboy {
             runner_id,

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -16,21 +16,25 @@ use super::super::CmdResult;
 use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
     RunnerConnectionOutput, RunnerExecutableRequirementDiagnostics, RunnerExtra,
-    RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOutput, RunnerRuntimeDiagnostics,
-    RunnerRuntimePackageDiagnostics, RunnerToolDiagnostics, RunnerWorkflowBinaryGuidance,
-    RuntimeDiagnostic, RuntimePackageOutput, RuntimeProbeValue, SelectedRuntimeOutput,
+    RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOperatorSummary, RunnerOutput,
+    RunnerRuntimeDiagnostics, RunnerRuntimePackageDiagnostics, RunnerToolDiagnostics,
+    RunnerTruncation, RunnerWorkflowBinaryGuidance, RuntimeDiagnostic, RuntimePackageOutput,
+    RuntimeProbeValue, SelectedRuntimeOutput,
 };
 
-pub(super) fn status(id: Option<&str>, include_generations: bool) -> CmdResult<RunnerOutput> {
+const DEFAULT_STATUS_SESSION_LIMIT: usize = 20;
+
+pub(super) fn status(
+    id: Option<&str>,
+    include_generations: bool,
+    full: bool,
+) -> CmdResult<RunnerOutput> {
     let preferred_lab_runner = runner::resolve_default_lab_runner()?;
     if let Some(id) = id {
         let report = runner::status(id)?;
         // Also polls draining generations and retires only those that report
         // authoritative zero active jobs.
         let generation_inventory = runner::runner_generation_inventory(id)?;
-        let operator_hints = runner_status_operator_hints(&report);
-        let operator_commands = runner_status_operator_commands(&report);
-        let selected_lab_runner = selected_lab_runner_status(Some(id), Some(report.clone()))?;
         // Lead with the compact authoritative admission answer, summarizing the
         // draining generations by count rather than expanding the full ledger
         // (#9478/#9522). The full inventory stays available as detail below.
@@ -42,11 +46,39 @@ pub(super) fn status(id: Option<&str>, include_generations: bool) -> CmdResult<R
         // already carries the count, and on a long-lived runner the full
         // inventory runs to thousands of lines that make old ownership look like
         // current load. `--generations` opts back into the full detail.
-        let generation_inventory = if include_generations {
+        let generation_count = generation_inventory.len();
+        let generation_inventory = if include_generations || full {
             generation_inventory
         } else {
             Vec::new()
         };
+        if !full {
+            return Ok((
+                RunnerOutput {
+                    command: "runner.status".to_string(),
+                    id: Some(id.to_string()),
+                    extra: RunnerExtra {
+                        admission_summary,
+                        operator_summary: Some(operator_summary(&report)),
+                        truncation: Some(RunnerTruncation {
+                            omitted_generations: generation_count
+                                .saturating_sub(generation_inventory.len()),
+                            omitted_sessions: 0,
+                            evidence_ref: format!("runner:{}:generation-inventory", id),
+                            full_command: format!("homeboy runner status {} --full", shell_arg(id)),
+                        }),
+                        generation_inventory,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ));
+        }
+
+        let operator_hints = runner_status_operator_hints(&report);
+        let operator_commands = runner_status_operator_commands(&report);
+        let selected_lab_runner = selected_lab_runner_status(Some(id), Some(report.clone()))?;
         return Ok((
             RunnerOutput {
                 command: "runner.status".to_string(),
@@ -69,6 +101,31 @@ pub(super) fn status(id: Option<&str>, include_generations: bool) -> CmdResult<R
     }
 
     let sessions = runner::statuses()?;
+    if !full {
+        let omitted = sessions.len().saturating_sub(DEFAULT_STATUS_SESSION_LIMIT);
+        let sessions = sessions
+            .iter()
+            .take(DEFAULT_STATUS_SESSION_LIMIT)
+            .map(operator_summary)
+            .collect::<Vec<_>>();
+        return Ok((
+            RunnerOutput {
+                command: "runner.status".to_string(),
+                extra: RunnerExtra {
+                    operator_summaries: sessions,
+                    truncation: Some(RunnerTruncation {
+                        omitted_generations: 0,
+                        omitted_sessions: omitted,
+                        evidence_ref: "runner:session-inventory".to_string(),
+                        full_command: "homeboy runner status --full".to_string(),
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            0,
+        ));
+    }
     let operator_hints = sessions
         .iter()
         .flat_map(runner_status_operator_hints)
@@ -95,6 +152,41 @@ pub(super) fn status(id: Option<&str>, include_generations: bool) -> CmdResult<R
         },
         0,
     ))
+}
+
+fn operator_summary(report: &RunnerStatusReport) -> RunnerOperatorSummary {
+    let mut risk = Vec::new();
+    if !report.connected {
+        risk.push("disconnected".to_string());
+    }
+    if report.stale_daemon.is_some() {
+        risk.push("stale_daemon".to_string());
+    }
+    if report.active_job_count > 0 {
+        risk.push(format!("{} active job(s)", report.active_job_count));
+    }
+    if let Some(error) = &report.active_job_error {
+        risk.push(error.code.clone());
+    }
+    RunnerOperatorSummary {
+        identity: bounded_status_text(&report.runner_id),
+        state: format!("{:?}", report.state).to_ascii_lowercase(),
+        risk,
+        next_action: format!(
+            "homeboy runner status {} --full",
+            shell_arg(&report.runner_id)
+        ),
+    }
+}
+
+fn bounded_status_text(value: &str) -> String {
+    let mut chars = value.chars();
+    let bounded = chars.by_ref().take(256).collect::<String>();
+    if chars.next().is_some() {
+        format!("{bounded}...")
+    } else {
+        bounded
+    }
 }
 
 fn selected_lab_runner_status(

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -40,6 +40,12 @@ pub struct RunnerExtra {
     pub operator_hints: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub operator_commands: Vec<RunnerOperatorCommand>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator_summary: Option<RunnerOperatorSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub operator_summaries: Vec<RunnerOperatorSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<RunnerTruncation>,
 }
 
 impl Default for RunnerExtra {
@@ -55,8 +61,33 @@ impl Default for RunnerExtra {
             generation_inventory: Vec::new(),
             operator_hints: Vec::new(),
             operator_commands: Vec::new(),
+            operator_summary: None,
+            operator_summaries: Vec::new(),
+            truncation: None,
         }
     }
+}
+
+/// Bounded default status contract. Detailed status remains behind `--full`.
+#[derive(Debug, Serialize)]
+pub struct RunnerOperatorSummary {
+    pub identity: String,
+    pub state: String,
+    pub risk: Vec<String>,
+    pub next_action: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerTruncation {
+    pub omitted_generations: usize,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub omitted_sessions: usize,
+    pub evidence_ref: String,
+    pub full_command: String,
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary
- bound default provider discovery with backend, selector, runtime, and status filters plus explicit truncation metadata
- add compact runner status identity/state/risk/next-action projections and reserve complete diagnostics for `--full`
- summarize oversized diagnostic response bodies and cover high-cardinality provider output

Closes #9999

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli --lib commands::agent_task::tests::contract --no-fail-fast`
- `cargo test -p homeboy-cli --lib compact_provider_bounds_extensions_and_large_diagnostics --no-fail-fast`
- `cargo test -p homeboy-cli --lib commands::runner::tests::status --no-fail-fast`

## AI assistance
Model: OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`)
Tool: OpenCode
Used for: Implementing bounded CLI discovery projections, tests, and PR draft under Chris Huber's direction.