### PR TITLE
fix(review): preserve execution placement provenance

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -373,7 +373,6 @@ impl CliRuntime {
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
         normalize_cook_runner_option(&mut cli, &normalized);
-        crate::commands::utils::execution_provenance::capture(&cli, &normalized);
 
         if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
             output_file = None;
@@ -416,6 +415,10 @@ impl CliRuntime {
             }
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
+
+        // Persist the actual preflight decision with the command intent before
+        // placement routing can consume controller transport markers.
+        crate::commands::utils::execution_provenance::capture(&cli, &normalized);
 
         let route_result =
             crate::commands::route::route_after_parse(&cli, &normalized, output_file.as_deref());

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -373,6 +373,7 @@ impl CliRuntime {
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
         normalize_cook_runner_option(&mut cli, &normalized);
+        crate::commands::utils::execution_provenance::capture(&cli, &normalized);
 
         if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
             output_file = None;

--- a/crates/homeboy-cli/src/commands/review/observation.rs
+++ b/crates/homeboy-cli/src/commands/review/observation.rs
@@ -123,6 +123,7 @@ pub(super) fn review_observation_initial_metadata(
         "ci_profile": args.ci_profile,
         "report": args.report,
         "changed_file_count": changed_file_count,
+        "execution_provenance": crate::commands::utils::execution_provenance::captured(),
         "observation_status": "running",
     })
 }

--- a/crates/homeboy-cli/src/commands/runs_summary.rs
+++ b/crates/homeboy-cli/src/commands/runs_summary.rs
@@ -77,6 +77,7 @@ fn render_run_detail(run: &Value) -> String {
     if let Some(finished) = string_value(run, &["finished_at"]) {
         lines.push(format!("Finished: {finished}"));
     }
+    lines.extend(execution_provenance_lines(run));
 
     lines.extend(failure_summary_lines(run));
 
@@ -93,6 +94,43 @@ fn render_run_detail(run: &Value) -> String {
     lines.push(format!("Full output: homeboy runs show {run_id} --json"));
 
     finish(lines)
+}
+
+fn execution_provenance_lines(run: &Value) -> Vec<String> {
+    let Some(provenance) = value_at(run, &["metadata", "execution_provenance"]) else {
+        return Vec::new();
+    };
+    let Some(intent) = provenance.get("operator_intent") else {
+        return Vec::new();
+    };
+    let mut lines = vec!["Execution provenance:".to_string()];
+    if let Some(command) = intent.get("rerun_command").and_then(Value::as_str) {
+        lines.push(format!("  rerun: {command}"));
+    }
+    if let Some(placement) = intent.get("placement").and_then(Value::as_str) {
+        lines.push(format!("  requested placement: {placement}"));
+    }
+    if let Some(runner) = intent.get("runner_id").and_then(Value::as_str) {
+        lines.push(format!("  requested runner: {runner}"));
+    }
+    if let Some(execution) = provenance.get("resolved_execution") {
+        let location = execution
+            .get("location")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let runner = execution.get("runner_id").and_then(Value::as_str);
+        lines.push(match runner {
+            Some(runner) => format!("  resolved execution: {location} ({runner})"),
+            None => format!("  resolved execution: {location}"),
+        });
+    }
+    if let Some(origin) = provenance
+        .pointer("/resource_policy/decision_origin")
+        .and_then(Value::as_str)
+    {
+        lines.push(format!("  policy decision: {origin}"));
+    }
+    lines
 }
 
 fn failure_summary_lines(run: &Value) -> Vec<String> {
@@ -280,6 +318,32 @@ mod tests {
         assert!(!summary.contains("get: homeboy runs artifact get bench-run-42 admin_url"));
         // Compact: no raw JSON braces.
         assert!(!summary.contains("{\n"));
+    }
+
+    #[test]
+    fn show_summary_surfaces_execution_provenance_and_rerun_command() {
+        let payload = json!({
+            "variant": "show",
+            "payload": { "run": {
+                "id": "review-1", "kind": "review", "status": "pass", "artifacts": [],
+                "metadata": { "execution_provenance": {
+                    "operator_intent": {
+                        "rerun_command": "homeboy --placement local review --changed-since=origin/main",
+                        "placement": "local", "runner_id": null
+                    },
+                    "resolved_execution": { "location": "controller", "runner_id": null },
+                    "resource_policy": { "decision_origin": "explicit" }
+                }}
+            }}
+        });
+
+        let summary = render_runs_show_summary(&payload).expect("summary");
+        assert!(summary.contains("Execution provenance:\n"));
+        assert!(summary
+            .contains("rerun: homeboy --placement local review --changed-since=origin/main\n"));
+        assert!(summary.contains("requested placement: local\n"));
+        assert!(summary.contains("resolved execution: controller\n"));
+        assert!(summary.contains("policy decision: explicit\n"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -11,7 +11,7 @@ use clap::{Arg, ArgAction, Args, Command, CommandFactory};
 use crate::cli_surface::Cli;
 use homeboy::core::component::{self, Component};
 
-const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
+pub(crate) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CliFlagSpec {

--- a/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
+++ b/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
@@ -1,0 +1,263 @@
+//! Durable command provenance shared by observation-producing commands.
+
+use std::sync::{OnceLock, RwLock};
+
+use serde_json::{json, Value};
+
+use crate::cli_surface::{Cli, Placement};
+
+const SCHEMA: &str = "homeboy/execution-provenance/v1";
+
+fn captured_storage() -> &'static RwLock<Option<Value>> {
+    static STORAGE: OnceLock<RwLock<Option<Value>>> = OnceLock::new();
+    STORAGE.get_or_init(|| RwLock::new(None))
+}
+
+/// Capture normalized, redacted intent before placement routing consumes its
+/// transport markers. The same original argv reaches a Lab child, where its
+/// resolved execution identity is recorded independently.
+pub fn capture(cli: &Cli, normalized_args: &[String]) {
+    let mut slot = captured_storage()
+        .write()
+        .unwrap_or_else(|error| error.into_inner());
+    if slot.is_none() {
+        *slot = Some(build(cli, normalized_args));
+    }
+}
+
+/// Return the command provenance captured for this process, if any. Older
+/// callers and imported observations remain valid without this optional field.
+pub fn captured() -> Option<Value> {
+    captured_storage().read().ok().and_then(|slot| slot.clone())
+}
+
+fn build(cli: &Cli, normalized_args: &[String]) -> Value {
+    let execution = homeboy::core::resource_policy_context::lab_execution_runner_id()
+        .map(|runner_id| ("lab", Some(runner_id)))
+        .unwrap_or(("controller", None));
+    build_with_execution(cli, normalized_args, execution.0, execution.1)
+}
+
+fn build_with_execution(
+    cli: &Cli,
+    normalized_args: &[String],
+    location: &str,
+    runner_id: Option<String>,
+) -> Value {
+    let argv = redact_execution_argv(normalized_args);
+    let rerun_command = homeboy::core::redaction::redact_argv_shell_display(&argv);
+    let placement = placement_name(cli.placement);
+    let decision_origin = match (cli.runner.is_some(), cli.placement, location) {
+        (true, _, _) | (_, Placement::Local | Placement::Lab, _) => "explicit",
+        (_, Placement::LabOrLocal, "controller") => "fallback",
+        _ => "automatic",
+    };
+
+    json!({
+        "schema": SCHEMA,
+        "operator_intent": {
+            "argv": argv,
+            "rerun_command": rerun_command,
+            "placement": placement,
+            "runner_id": cli.runner,
+            "global_flags": {
+                "detach_after_handoff": cli.detach_after_handoff,
+                "allow_dirty_lab_workspace": cli.allow_dirty_lab_workspace,
+                "skip_deps_hydration": cli.skip_deps_hydration,
+                "runner_env": cli.runner_env.iter().map(|value| redact_env_assignment(value, &homeboy::core::redaction::RedactionPolicy::default())).collect::<Vec<_>>(),
+                "lab_env_json": cli.lab_env_json.as_ref().map(|value| redact_json_env(value, &homeboy::core::redaction::RedactionPolicy::default())),
+            },
+        },
+        "resolved_execution": {
+            "location": location,
+            "runner_id": runner_id,
+        },
+        "resource_policy": {
+            "decision_origin": decision_origin,
+            "preflight": crate::commands::utils::resource_policy::captured_context()
+                .as_ref()
+                .map(crate::commands::utils::resource_policy::resource_policy_context_to_json),
+        },
+    })
+}
+
+fn redact_execution_argv(args: &[String]) -> Vec<String> {
+    let policy = homeboy::core::redaction::RedactionPolicy::default();
+    let mut redacted = homeboy::core::redaction::redact_argv(args);
+    for index in 0..args.len() {
+        let replacement = match args[index].as_str() {
+            "--runner-env" if index + 1 < args.len() => {
+                Some(redact_env_assignment(&args[index + 1], &policy))
+            }
+            "--lab-env-json" if index + 1 < args.len() => {
+                Some(redact_json_env(&args[index + 1], &policy))
+            }
+            arg if arg.starts_with("--runner-env=") => Some(format!(
+                "--runner-env={}",
+                redact_env_assignment(&arg[13..], &policy)
+            )),
+            arg if arg.starts_with("--lab-env-json=") => Some(format!(
+                "--lab-env-json={}",
+                redact_json_env(&arg[15..], &policy)
+            )),
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            if matches!(args[index].as_str(), "--runner-env" | "--lab-env-json") {
+                redacted[index + 1] = replacement;
+            } else {
+                redacted[index] = replacement;
+            }
+        }
+    }
+    redacted
+}
+
+fn redact_env_assignment(
+    value: &str,
+    policy: &homeboy::core::redaction::RedactionPolicy,
+) -> String {
+    let Some((key, secret)) = value.split_once('=') else {
+        return policy.redact_env_value(value);
+    };
+    if is_sensitive_env_key(key) {
+        return format!("{key}=[redacted]");
+    }
+    policy
+        .redact_json(&json!({ key: secret }))
+        .get(key)
+        .and_then(Value::as_str)
+        .map(|secret| format!("{key}={secret}"))
+        .unwrap_or_else(|| policy.redact_env_value(value))
+}
+
+fn is_sensitive_env_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    [
+        "token",
+        "secret",
+        "password",
+        "credential",
+        "api_key",
+        "apikey",
+    ]
+    .iter()
+    .any(|needle| key.contains(needle))
+}
+
+fn redact_json_env(value: &str, policy: &homeboy::core::redaction::RedactionPolicy) -> String {
+    serde_json::from_str::<Value>(value)
+        .map(|value| policy.redact_json(&value).to_string())
+        .unwrap_or_else(|_| policy.redact_env_value(value))
+}
+
+fn placement_name(placement: Placement) -> &'static str {
+    match placement {
+        Placement::Auto => "auto",
+        Placement::Local => "local",
+        Placement::Lab => "lab",
+        Placement::LabOrLocal => "lab-or-local",
+    }
+}
+
+#[cfg(test)]
+pub fn reset_captured_for_test() {
+    if let Ok(mut slot) = captured_storage().write() {
+        *slot = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli_surface::Cli;
+    use clap::Parser;
+
+    fn provenance(args: &[&str]) -> Value {
+        let argv = args
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect::<Vec<_>>();
+        let cli = Cli::try_parse_from(&argv).expect("parse CLI");
+        build(&cli, &argv)
+    }
+
+    #[test]
+    fn preserves_explicit_local_lab_and_runner_intent() {
+        for (args, placement, runner, rerun_fragment) in [
+            (
+                vec!["homeboy", "--placement", "local", "review"],
+                "local",
+                None,
+                "--placement local",
+            ),
+            (
+                vec!["homeboy", "--placement", "lab", "review"],
+                "lab",
+                None,
+                "--placement lab",
+            ),
+            (
+                vec!["homeboy", "--runner", "lab-a", "review"],
+                "auto",
+                Some("lab-a"),
+                "--runner lab-a",
+            ),
+        ] {
+            let value = provenance(&args);
+            assert_eq!(value["operator_intent"]["placement"], placement);
+            assert_eq!(value["operator_intent"]["runner_id"], json!(runner));
+            assert_eq!(value["resource_policy"]["decision_origin"], "explicit");
+            assert!(value["operator_intent"]["rerun_command"]
+                .as_str()
+                .expect("rerun command")
+                .contains(rerun_fragment));
+        }
+    }
+
+    #[test]
+    fn records_lab_or_local_controller_execution_as_fallback() {
+        let value = provenance(&["homeboy", "--placement=lab-or-local", "review"]);
+
+        assert_eq!(value["resolved_execution"]["location"], "controller");
+        assert_eq!(value["resource_policy"]["decision_origin"], "fallback");
+        assert!(value["operator_intent"]["rerun_command"]
+            .as_str()
+            .expect("rerun command")
+            .contains("--placement=lab-or-local"));
+    }
+
+    #[test]
+    fn records_resolved_lab_runner_separately_from_lab_intent() {
+        let args = ["homeboy", "--placement", "lab", "review"];
+        let argv = args
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect::<Vec<_>>();
+        let cli = Cli::try_parse_from(&argv).expect("parse CLI");
+        let value = build_with_execution(&cli, &argv, "lab", Some("runner-a".to_string()));
+
+        assert_eq!(value["operator_intent"]["placement"], "lab");
+        assert_eq!(value["resolved_execution"]["location"], "lab");
+        assert_eq!(value["resolved_execution"]["runner_id"], "runner-a");
+        assert_eq!(value["resource_policy"]["decision_origin"], "explicit");
+    }
+
+    #[test]
+    fn redacts_secrets_without_dropping_placement() {
+        let value = provenance(&[
+            "homeboy",
+            "--placement",
+            "local",
+            "--runner-env",
+            "API_TOKEN=secret-value",
+            "review",
+        ]);
+        let command = value["operator_intent"]["rerun_command"]
+            .as_str()
+            .expect("rerun command");
+
+        assert!(command.contains("--placement local"));
+        assert!(!command.contains("secret-value"));
+    }
+}

--- a/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
+++ b/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
@@ -83,7 +83,12 @@ fn build_with_execution(
 
 fn redact_execution_argv(args: &[String]) -> Vec<String> {
     let policy = homeboy::core::redaction::RedactionPolicy::default();
-    let mut redacted = homeboy::core::redaction::redact_argv(args);
+    let args = args
+        .iter()
+        .filter(|arg| arg.as_str() != crate::commands::utils::args::EXPLICIT_PASSTHROUGH_SENTINEL)
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut redacted = homeboy::core::redaction::redact_argv(&args);
     for index in 0..args.len() {
         let replacement = match args[index].as_str() {
             "--runner-env" if index + 1 < args.len() => {
@@ -259,5 +264,23 @@ mod tests {
 
         assert!(command.contains("--placement local"));
         assert!(!command.contains("secret-value"));
+    }
+
+    #[test]
+    fn rerun_command_omits_internal_passthrough_marker() {
+        let value = provenance(&[
+            "homeboy",
+            "review",
+            "test",
+            "--",
+            crate::commands::utils::args::EXPLICIT_PASSTHROUGH_SENTINEL,
+            "--filter=SmokeTest",
+        ]);
+        let command = value["operator_intent"]["rerun_command"]
+            .as_str()
+            .expect("rerun command");
+
+        assert!(command.contains("-- --filter=SmokeTest"));
+        assert!(!command.contains(crate::commands::utils::args::EXPLICIT_PASSTHROUGH_SENTINEL));
     }
 }

--- a/crates/homeboy-cli/src/commands/utils/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod entity_suggest;
+pub mod execution_provenance;
 pub mod resolve;
 pub mod resource_policy;
 pub mod response;


### PR DESCRIPTION
## Summary
- persist redacted normalized operator intent, resolved execution identity, and policy decision origin on review observations
- retain placement and behaviorally relevant global flags in copyable rerun commands
- surface provenance in `homeboy runs show`; exported bundles retain it through existing metadata serialization

Closes #10015

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli execution_provenance --lib`
- `cargo test -p homeboy-cli runs_summary --lib`

## AI Assistance
OpenCode using `openai/gpt-5.6-sol` implemented and tested this change. Chris Huber owns every line.