### PR TITLE
Fix agent-task metadata read resource policy

### DIFF
--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -185,6 +185,8 @@ impl Commands {
                     | agent_task::AgentTaskCommand::Logs(_)
                     | agent_task::AgentTaskCommand::Artifacts(_)
                     | agent_task::AgentTaskCommand::Evidence(_)
+                    | agent_task::AgentTaskCommand::Diagnose(_)
+                    | agent_task::AgentTaskCommand::ReplayProviderBoundary(_)
                     | agent_task::AgentTaskCommand::Review(_)
                     | agent_task::AgentTaskCommand::List(_)
                     | agent_task::AgentTaskCommand::Active(_)

--- a/crates/homeboy-cli/src/commands/contract_lab_routing_tests.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing_tests.rs
@@ -160,8 +160,6 @@ fn agent_task_promote_with_runner_only_source_remains_lab_portable() {
         "homeboy@fix-7964",
         "--runner",
         "homeboy-lab",
-        "--placement",
-        "lab",
         "--dry-run",
     ]);
 

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -744,8 +744,6 @@ fn detached_agent_task_handoffs_do_not_use_trace_dispatch_timeout() {
         "cook-7971",
         "--runner",
         "homeboy-lab",
-        "--placement",
-        "lab",
     ]);
     let batch = Cli::parse_from([
         "homeboy",
@@ -769,8 +767,6 @@ fn detached_agent_task_handoffs_do_not_use_trace_dispatch_timeout() {
         "--run",
         "--runner",
         "homeboy-lab",
-        "--placement",
-        "lab",
     ]);
 
     for cli in [&cook, &batch, &retry] {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -233,13 +233,11 @@ fn fuzz_doctor_supports_runner_lab_placement_route() {
         "nodejs",
         "--runner",
         "homeboy-lab",
-        "--placement",
-        "lab",
     ]);
 
     let command = lab_offload_command(&cli.command).unwrap().unwrap();
     assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
-    assert_eq!(cli.placement, crate::cli_surface::Placement::Lab);
+    assert_eq!(cli.placement, crate::cli_surface::Placement::Auto);
     assert_eq!(command.hot_label, "fuzz doctor");
     assert!(lab_runner_supports_contract_label(command.hot_label));
     assert!(command.is_portable());
@@ -550,8 +548,6 @@ fn agent_task_controller_run_from_spec_supports_lab_placement_runner_routing() {
         "homeboy",
         "--runner",
         "homeboy-lab",
-        "--placement",
-        "lab",
         "agent-task",
         "controller",
         "run-from-spec",
@@ -562,7 +558,7 @@ fn agent_task_controller_run_from_spec_supports_lab_placement_runner_routing() {
 
     let command = lab_offload_command(&cli.command).unwrap().unwrap();
     assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
-    assert_eq!(cli.placement, crate::cli_surface::Placement::Lab);
+    assert_eq!(cli.placement, crate::cli_surface::Placement::Auto);
     assert_eq!(
         command.hot_label,
         "agent-task controller from-spec --resume/run-from-spec/materialize"

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -10,6 +10,132 @@
 use crate::cli_surface::Commands;
 use crate::commands::agent_task;
 
+/// Resource behavior is independent from a command's Lab portability contract.
+/// Bounded local record reads remain available for runner recovery; provider
+/// execution, gates, and artifact hydration retain their existing admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AgentTaskResourceBehavior {
+    BoundedMetadataRead,
+    AdmittedWorkload,
+    LocalControl,
+}
+
+/// Classify every `agent-task` subcommand before consulting its portability
+/// contract. `None` means this is not an agent-task command.
+pub(super) fn agent_task_resource_behavior(
+    command: &Commands,
+) -> Option<AgentTaskResourceBehavior> {
+    let Commands::AgentTask(args) = command else {
+        return None;
+    };
+
+    Some(match &args.command {
+        agent_task::AgentTaskCommand::Doctor(_)
+        | agent_task::AgentTaskCommand::Submit(_)
+        | agent_task::AgentTaskCommand::RuntimeRecover(_)
+        | agent_task::AgentTaskCommand::RuntimeValidate(_)
+        | agent_task::AgentTaskCommand::Cancel(_)
+        | agent_task::AgentTaskCommand::Prompts(_)
+        | agent_task::AgentTaskCommand::Contract(_)
+        | agent_task::AgentTaskCommand::CompileLoop(_)
+        | agent_task::AgentTaskCommand::Auth(_) => AgentTaskResourceBehavior::LocalControl,
+        agent_task::AgentTaskCommand::Cook(cook) if cook.dispatch.core.queue_only => {
+            AgentTaskResourceBehavior::LocalControl
+        }
+        agent_task::AgentTaskCommand::Cook(_)
+        | agent_task::AgentTaskCommand::RunPlan(_)
+        | agent_task::AgentTaskCommand::Run(_)
+        | agent_task::AgentTaskCommand::RunNext
+        | agent_task::AgentTaskCommand::Evidence(_)
+        | agent_task::AgentTaskCommand::Diagnose(_)
+        | agent_task::AgentTaskCommand::ReplayProviderBoundary(_)
+        | agent_task::AgentTaskCommand::Resume(_)
+        | agent_task::AgentTaskCommand::Review(_)
+        | agent_task::AgentTaskCommand::Promote(_)
+        | agent_task::AgentTaskCommand::Adopt(_)
+        | agent_task::AgentTaskCommand::PromotionProvider(_)
+        | agent_task::AgentTaskCommand::FinalizePr(_)
+        | agent_task::AgentTaskCommand::GateFeedback(_)
+        | agent_task::AgentTaskCommand::Providers(_)
+        | agent_task::AgentTaskCommand::Tool(_) => AgentTaskResourceBehavior::AdmittedWorkload,
+        agent_task::AgentTaskCommand::Retry(retry) if retry.run => {
+            AgentTaskResourceBehavior::AdmittedWorkload
+        }
+        agent_task::AgentTaskCommand::Retry(_) => AgentTaskResourceBehavior::LocalControl,
+        agent_task::AgentTaskCommand::Status(_)
+        | agent_task::AgentTaskCommand::List(_)
+        | agent_task::AgentTaskCommand::Latest(_)
+        | agent_task::AgentTaskCommand::Logs(_)
+        | agent_task::AgentTaskCommand::Artifacts(_) => {
+            AgentTaskResourceBehavior::BoundedMetadataRead
+        }
+        agent_task::AgentTaskCommand::Active(active) if !active.reconcile => {
+            AgentTaskResourceBehavior::BoundedMetadataRead
+        }
+        agent_task::AgentTaskCommand::Active(_)
+        | agent_task::AgentTaskCommand::Reconcile(_)
+        | agent_task::AgentTaskCommand::ReconcileRecords(_) => {
+            AgentTaskResourceBehavior::AdmittedWorkload
+        }
+        agent_task::AgentTaskCommand::Fanout(fanout) => match &fanout.command {
+            agent_task::AgentTaskFanoutCommand::Status(_)
+            | agent_task::AgentTaskFanoutCommand::Artifacts(_) => {
+                AgentTaskResourceBehavior::BoundedMetadataRead
+            }
+            agent_task::AgentTaskFanoutCommand::Resume(_)
+            | agent_task::AgentTaskFanoutCommand::RunPlan(_) => {
+                AgentTaskResourceBehavior::AdmittedWorkload
+            }
+            agent_task::AgentTaskFanoutCommand::CookBatch(_)
+            | agent_task::AgentTaskFanoutCommand::Plan(_)
+            | agent_task::AgentTaskFanoutCommand::Submit(_)
+            | agent_task::AgentTaskFanoutCommand::SubmitBatch(_) => {
+                AgentTaskResourceBehavior::LocalControl
+            }
+        },
+        agent_task::AgentTaskCommand::Loop(loop_args) => match &loop_args.command {
+            agent_task::AgentTaskLoopCommand::Status(_) => {
+                AgentTaskResourceBehavior::BoundedMetadataRead
+            }
+            agent_task::AgentTaskLoopCommand::Define(args) if args.resume => {
+                AgentTaskResourceBehavior::AdmittedWorkload
+            }
+            agent_task::AgentTaskLoopCommand::Resume(_) => {
+                AgentTaskResourceBehavior::AdmittedWorkload
+            }
+            agent_task::AgentTaskLoopCommand::Define(_)
+            | agent_task::AgentTaskLoopCommand::Stop(_) => AgentTaskResourceBehavior::LocalControl,
+        },
+        agent_task::AgentTaskCommand::Controller(controller) => match &controller.command {
+            agent_task::AgentTaskControllerCommand::Status(_)
+            | agent_task::AgentTaskControllerCommand::Diagnose(_)
+            | agent_task::AgentTaskControllerCommand::List => {
+                AgentTaskResourceBehavior::BoundedMetadataRead
+            }
+            agent_task::AgentTaskControllerCommand::FromSpec(args) if args.resume => {
+                AgentTaskResourceBehavior::AdmittedWorkload
+            }
+            agent_task::AgentTaskControllerCommand::RunFromSpec(_)
+            | agent_task::AgentTaskControllerCommand::Materialize(_)
+            | agent_task::AgentTaskControllerCommand::RunNext(_)
+            | agent_task::AgentTaskControllerCommand::Run(_)
+            | agent_task::AgentTaskControllerCommand::Resume(_)
+            | agent_task::AgentTaskControllerCommand::Proof(_) => {
+                AgentTaskResourceBehavior::AdmittedWorkload
+            }
+            agent_task::AgentTaskControllerCommand::Init(_)
+            | agent_task::AgentTaskControllerCommand::FromSpec(_)
+            | agent_task::AgentTaskControllerCommand::ValidateProof(_)
+            | agent_task::AgentTaskControllerCommand::Plan(_)
+            | agent_task::AgentTaskControllerCommand::Events(_)
+            | agent_task::AgentTaskControllerCommand::ApplyEvent(_)
+            | agent_task::AgentTaskControllerCommand::MarkHumanReady(_) => {
+                AgentTaskResourceBehavior::LocalControl
+            }
+        },
+    })
+}
+
 /// The `cook-batch` fanout coordinator is controller-owned in every mode: it
 /// compiles the plan (default), previews it (`--dry-run`), or runs the batch
 /// coordinator locally (`--run-plan`). In none of these modes may the
@@ -67,16 +193,8 @@ pub(super) fn is_plan_only_command(command: &Commands) -> bool {
     )
 }
 
-pub(super) fn is_read_only_agent_task(command: &Commands) -> bool {
-    matches!(
-        command,
-        Commands::AgentTask(agent_task::AgentTaskArgs {
-            command: agent_task::AgentTaskCommand::Status(_)
-                | agent_task::AgentTaskCommand::Logs(_)
-                | agent_task::AgentTaskCommand::Artifacts(_)
-                | agent_task::AgentTaskCommand::Review(_),
-        })
-    )
+pub(super) fn is_bounded_agent_task_metadata_read(command: &Commands) -> bool {
+    agent_task_resource_behavior(command) == Some(AgentTaskResourceBehavior::BoundedMetadataRead)
 }
 
 /// Local registry/source-state management (`rig install|update|sync|sources`)

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -9,8 +9,8 @@ use crate::runner::runners::LabRunnerReadiness;
 use crate::commands::resources::{DoctorOutput, ResourceRecommendation};
 
 use classification::{
-    is_controller_owned_fanout_coordination, is_lab_offloadable_fanout_coordinator,
-    is_local_registry_management, is_plan_only_command, is_read_only_agent_task,
+    is_bounded_agent_task_metadata_read, is_controller_owned_fanout_coordination,
+    is_lab_offloadable_fanout_coordinator, is_local_registry_management, is_plan_only_command,
 };
 use messages::{append_local_placement, primary_action, severity_str, warning_message};
 
@@ -194,7 +194,7 @@ fn runner_selection_context(
 pub fn hot_command(command: &Commands) -> Option<HotCommand> {
     if is_plan_only_command(command)
         || is_controller_owned_fanout_coordination(command)
-        || is_read_only_agent_task(command)
+        || is_bounded_agent_task_metadata_read(command)
         || is_local_registry_management(command)
     {
         return None;
@@ -653,15 +653,94 @@ mod tests {
     }
 
     #[test]
-    fn agent_task_inspection_commands_do_not_start_hot_workloads() {
+    fn bounded_agent_task_metadata_reads_bypass_hot_admission_for_all_runner_states() {
+        // These commands read bounded controller metadata. In particular, they
+        // must stay available when the selected runner is disconnected, stale,
+        // or has conflicting readiness observations, so preflight must not ask
+        // Lab for guidance before they run.
+        let runner_states = [
+            LabRunnerReadiness {
+                state: crate::runner::runners::LabRunnerReadinessState::Disconnected,
+                selected_runner_id: Some("homeboy-lab".to_string()),
+                available_runner_ids: Vec::new(),
+                reasons: vec!["runner is disconnected".to_string()],
+                remediation_commands: vec!["homeboy runner reconnect homeboy-lab".to_string()],
+            },
+            LabRunnerReadiness {
+                state: crate::runner::runners::LabRunnerReadinessState::Stale,
+                selected_runner_id: Some("homeboy-lab".to_string()),
+                available_runner_ids: Vec::new(),
+                reasons: vec!["runner daemon is stale".to_string()],
+                remediation_commands: vec!["homeboy runner refresh homeboy-lab".to_string()],
+            },
+            LabRunnerReadiness {
+                state: crate::runner::runners::LabRunnerReadinessState::ConnectedIneligible,
+                selected_runner_id: None,
+                available_runner_ids: vec!["homeboy-lab".to_string()],
+                reasons: vec!["conflicting runner readiness observations".to_string()],
+                remediation_commands: vec!["homeboy runner status homeboy-lab".to_string()],
+            },
+        ];
         for args in [
             ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "list"].as_slice(),
+            ["homeboy", "agent-task", "active"].as_slice(),
+            ["homeboy", "agent-task", "latest"].as_slice(),
+            ["homeboy", "agent-task", "fanout", "status", "batch-123"].as_slice(),
+            ["homeboy", "agent-task", "fanout", "artifacts", "batch-123"].as_slice(),
+            ["homeboy", "agent-task", "loop", "status", "loop-123"].as_slice(),
+            ["homeboy", "agent-task", "controller", "status", "loop-123"].as_slice(),
+            [
+                "homeboy",
+                "agent-task",
+                "controller",
+                "diagnose",
+                "loop-123",
+            ]
+            .as_slice(),
+            ["homeboy", "agent-task", "controller", "list"].as_slice(),
+        ] {
+            let cli = Cli::parse_from(args);
+            for readiness in &runner_states {
+                let warning = hot_command(&cli.command).and_then(|command| {
+                    evaluate_with_runner_hint(
+                        command,
+                        &resources(ResourceRecommendation::Hot),
+                        Some(readiness),
+                    )
+                });
+                assert!(
+                    warning.is_none(),
+                    "{args:?} must not emit hot-machine or Lab guidance while runner is {}",
+                    readiness.state.as_str(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn agent_task_hydration_and_review_remain_resource_managed() {
+        // Hydration and review can load full evidence or run promotion work, so
+        // unlike metadata inspection they retain their portability admission.
+        for args in [
+            ["homeboy", "agent-task", "evidence", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "diagnose", "agent-task-123"].as_slice(),
+            [
+                "homeboy",
+                "agent-task",
+                "replay-provider-boundary",
+                "agent-task-123",
+            ]
+            .as_slice(),
             ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
         ] {
             let cli = Cli::parse_from(args);
-            assert!(hot_command(&cli.command).is_none());
+            assert!(
+                hot_command(&cli.command).is_some(),
+                "{args:?} must retain resource admission"
+            );
         }
     }
 

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -41,6 +41,18 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 
 `agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `agent-task reconcile <run-id>` is the recovery path emitted by status and activity: it previews only that run by default, refreshes runner/provider state before classification, and requires `--apply` to mutate it. If ownership or provider state changes before apply, it reports a no-op. `agent-task active --reconcile` is an explicit fleet operation: it previews every candidate by default and requires `--apply` to reconcile the displayed set.
 
+### Resource Behavior
+
+Resource admission follows command capability rather than command names. Bounded
+controller metadata reads (`status`, `logs`, metadata-only `artifacts`, `list`,
+`active`, `latest`, and their fanout/loop/controller equivalents) always inspect
+local durable state and produce no hot-machine or Lab-routing guidance. This
+keeps recovery inspection available when a runner is disconnected, stale, or
+reports conflicting readiness. Provider execution, deterministic gates, explicit
+evidence or provider-boundary hydration, and review remain subject to their
+admission and routing contracts. Reconciliation is an explicit workload even
+when it begins with an inspection.
+
 Machine-readable `cook`, `resume`, `adopt`, and `status` responses default to bounded summaries: stable ids, states, totals, timestamps when present, artifact/evidence references, and actionable failure reasons are retained while nested provider evidence is projected away. Use `cook --full`, `resume --full`, `adopt --full`, or the emitted `full_command`; use the emitted `evidence_command` (with `--task` or `--kind`) to retrieve selected durable evidence.
 
 `agent-task replay-provider-boundary <run-id>` is a focused inspect/replay path for

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -45,13 +45,15 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 
 Resource admission follows command capability rather than command names. Bounded
 controller metadata reads (`status`, `logs`, metadata-only `artifacts`, `list`,
-`active`, `latest`, and their fanout/loop/controller equivalents) always inspect
-local durable state and produce no hot-machine or Lab-routing guidance. This
-keeps recovery inspection available when a runner is disconnected, stale, or
-reports conflicting readiness. Provider execution, deterministic gates, explicit
-evidence or provider-boundary hydration, and review remain subject to their
-admission and routing contracts. Reconciliation is an explicit workload even
-when it begins with an inspection.
+`active`, `latest`, and their fanout/loop/controller equivalents) run locally by
+default and produce no hot-machine or Lab-routing guidance. This keeps recovery
+inspection available when a runner is disconnected, stale, or reports conflicting
+readiness. An explicit `--runner` retains runner-resident polling for status,
+logs, artifacts, list, active, latest, and fanout state reads when the durable
+state lives there. Provider execution, deterministic gates, explicit evidence or
+provider-boundary hydration, and review remain subject to their admission and
+routing contracts. Reconciliation is an explicit workload even when it begins
+with an inspection.
 
 Machine-readable `cook`, `resume`, `adopt`, and `status` responses default to bounded summaries: stable ids, states, totals, timestamps when present, artifact/evidence references, and actionable failure reasons are retained while nested provider evidence is projected away. Use `cook --full`, `resume --full`, `adopt --full`, or the emitted `full_command`; use the emitted `evidence_command` (with `--task` or `--kind`) to retrieve selected durable evidence.
 
@@ -706,10 +708,11 @@ It includes schema ids, provider capability metadata, status/failure enum values
 and default redaction policy metadata without naming or depending on any specific
 executor provider.
 
-`agent-task status`, `logs`, `artifacts`, and `review` are read-only durable
-lifecycle inspection commands. They do not start workloads and are not gated by
-warm-machine resource policy; use `homeboy runner exec <runner> -- homeboy
-agent-task status <run-id>` when the durable state lives on a Lab runner host.
+`agent-task status`, `logs`, and `artifacts` are read-only durable lifecycle
+inspection commands. They do not start workloads and are not gated by warm-machine
+resource policy; use `homeboy runner exec <runner> -- homeboy agent-task status
+<run-id>` when the durable state lives on a Lab runner host. `agent-task review`
+hydrates aggregate evidence and remains resource-managed.
 
 ## Deterministic Smoke Gate
 


### PR DESCRIPTION
## Summary
- classify every `agent-task` command by bounded metadata read, admitted workload, or local control behavior
- keep lifecycle metadata inspection local without hot-machine or Lab guidance, including disconnected, stale, and conflicting runner states
- retain resource admission for explicit evidence hydration, provider-boundary replay, and review

Closes #9998

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::utils::resource_policy --lib`
- `cargo test -p homeboy-cli` exceeded 10 minutes; focused policy tests passed. The broader suite reported existing integration failures outside this change before timeout.

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode drafted the resource-behavior classification, tests, and documentation. Chris Huber remains responsible for the change.