### PR TITLE
fix(cli): diagnose legacy Cook executor flags

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -291,6 +291,7 @@ impl CliRuntime {
     }
 
     fn parse_matches(&self, normalized: Vec<String>) -> ArgMatches {
+        let diagnostic_args = normalized.clone();
         match Cli::command_with_scoped_lab_args().try_get_matches_from(normalized.clone()) {
             Ok(matches) => matches,
             Err(static_err) => match self
@@ -299,16 +300,20 @@ impl CliRuntime {
             {
                 Ok(matches) => matches,
                 Err(err) => {
-                    if let Some(output) =
-                        try_augment_clap_error(&err, &self.extension_discovery().health)
-                    {
+                    if let Some(output) = try_augment_clap_error(
+                        &err,
+                        &diagnostic_args,
+                        &self.extension_discovery().health,
+                    ) {
                         eprintln!("{}", output);
                         std::process::exit(2);
                     }
 
-                    if let Some(output) =
-                        try_augment_clap_error(&static_err, &self.extension_discovery().health)
-                    {
+                    if let Some(output) = try_augment_clap_error(
+                        &static_err,
+                        &diagnostic_args,
+                        &self.extension_discovery().health,
+                    ) {
                         eprintln!("{}", output);
                         std::process::exit(2);
                     }
@@ -1097,12 +1102,34 @@ fn is_runs_artifact_get_runner_option(args: &[String]) -> bool {
         })
 }
 
-/// Attempt to augment a clap error with entity suggestions.
-/// Returns Some(augmented_message) if the unrecognized string matches a known entity.
+struct ArgumentMigration {
+    command: &'static str,
+    command_path: &'static [&'static str],
+    historical_flags: &'static [&'static str],
+    diagnostic: &'static str,
+}
+
+const ARGUMENT_MIGRATIONS: &[ArgumentMigration] = &[ArgumentMigration {
+    command: "homeboy agent-task cook",
+    command_path: &["agent-task", "cook"],
+    historical_flags: &["--provider", "--provider-id", "--dispatch-selector"],
+    diagnostic: "executor selection now uses `--backend <backend>` and optional `--selector <provider-id>`.\n\
+Example: `homeboy agent-task cook --backend opencode --selector opencode.agent-task-executor ...`\n\
+List available executor providers: `homeboy agent-task providers`\n\
+`--provider-argv` is promotion-only: it configures the deprecated promotion apply-provider invocation and cannot select an executor.",
+}];
+
+/// Attempt to augment a clap error with semantic argument migrations or entity suggestions.
+/// Returns Some(augmented_message) when an actionable diagnostic is available.
 fn try_augment_clap_error(
     e: &clap::Error,
+    argv: &[String],
     extension_health: &ExtensionCliHealth,
 ) -> Option<String> {
+    if let Some(output) = semantic_argument_migration_diagnostic(e, argv) {
+        return Some(output);
+    }
+
     // Extract unrecognized subcommand and parent command from error.
     let unrecognized = extract_unrecognized_from_error(e)?;
     let parent_command = extract_parent_command_from_error(e)?;
@@ -1134,6 +1161,38 @@ fn try_augment_clap_error(
     }
 
     Some(output)
+}
+
+fn semantic_argument_migration_diagnostic(e: &clap::Error, argv: &[String]) -> Option<String> {
+    if e.kind() != clap::error::ErrorKind::UnknownArgument {
+        return None;
+    }
+
+    let migration = ARGUMENT_MIGRATIONS.iter().find(|migration| {
+        argv.windows(migration.command_path.len()).any(|command| {
+            command
+                .iter()
+                .map(String::as_str)
+                .eq(migration.command_path.iter().copied())
+        })
+    })?;
+    let argument = argv.iter().find_map(|argument| {
+        migration
+            .historical_flags
+            .iter()
+            .find(|flag| {
+                argument.as_str() == **flag
+                    || argument
+                        .strip_prefix(**flag)
+                        .is_some_and(|suffix| suffix.starts_with('='))
+            })
+            .map(|flag| (*flag).to_string())
+    })?;
+
+    Some(format!(
+        "error: historical executor selection flag '{argument}' is not supported\n\nhint: {}\n\nFor more information, try '{} --help'",
+        migration.diagnostic, migration.command
+    ))
 }
 
 fn append_extension_health_hints(hints: &mut Vec<String>, extension_health: &ExtensionCliHealth) {
@@ -1497,7 +1556,12 @@ mod tests {
             broken_link_ids: vec!["sample-runtime".to_string()],
         };
 
-        let output = try_augment_clap_error(&err, &health).expect("extension health hint");
+        let output = try_augment_clap_error(
+            &err,
+            &["homeboy".to_string(), "sample-cli".to_string()],
+            &health,
+        )
+        .expect("extension health hint");
 
         assert!(output.contains("extension-provided commands may be unavailable"));
         assert!(output.contains("broken extension link(s): sample-runtime"));

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1114,7 +1114,7 @@ const ARGUMENT_MIGRATIONS: &[ArgumentMigration] = &[ArgumentMigration {
     command_path: &["agent-task", "cook"],
     historical_flags: &["--provider", "--provider-id", "--dispatch-selector"],
     diagnostic: "executor selection now uses `--backend <backend>` and optional `--selector <provider-id>`.\n\
-Example: `homeboy agent-task cook --backend opencode --selector opencode.agent-task-executor ...`\n\
+Example: `homeboy agent-task cook --backend opencode --selector opencode.agent-task-executor --to-worktree repo@branch --goal 'Describe the task' --verify 'cargo test' --no-finalize`\n\
 List available executor providers: `homeboy agent-task providers`\n\
 `--provider-argv` is promotion-only: it configures the deprecated promotion apply-provider invocation and cannot select an executor.",
 }];

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -258,7 +258,7 @@ pub struct AgentTaskCookArgs {
         long = "provider-argv",
         value_name = "ARG",
         conflicts_with = "provider_command",
-        long_help = "Promotion apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
+        long_help = "Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
     )]
     pub provider_argv: Vec<String>,
     #[command(flatten)]

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -217,7 +217,7 @@ pub struct ReviewArgs {
         long = "provider-argv",
         value_name = "ARG",
         conflicts_with = "provider_command",
-        long_help = "Promotion apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
+        long_help = "Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
     )]
     pub provider_argv: Vec<String>,
 }
@@ -239,7 +239,7 @@ pub struct PromoteArgs {
         long = "provider-argv",
         value_name = "ARG",
         conflicts_with = "provider_command",
-        long_help = "Promotion apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
+        long_help = "Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
     )]
     pub provider_argv: Vec<String>,
     #[arg(long, value_name = "TASK_ID")]

--- a/tests/agent_task_provider_flag_diagnostic.rs
+++ b/tests/agent_task_provider_flag_diagnostic.rs
@@ -1,0 +1,65 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+#[test]
+fn historical_cook_executor_flags_emit_the_migration_snapshot() {
+    for flag in ["--provider", "--provider-id", "--dispatch-selector"] {
+        let output = cook_command([flag, "opencode.agent-task-executor"]);
+
+        assert_eq!(output.status.code(), Some(2), "{flag}");
+        assert!(output.stdout.is_empty(), "{flag}");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stderr),
+            format!(
+                "error: historical executor selection flag '{flag}' is not supported\n\
+\nhint: executor selection now uses `--backend <backend>` and optional `--selector <provider-id>`.\n\
+Example: `homeboy agent-task cook --backend opencode --selector opencode.agent-task-executor ...`\n\
+List available executor providers: `homeboy agent-task providers`\n\
+`--provider-argv` is promotion-only: it configures the deprecated promotion apply-provider invocation and cannot select an executor.\n\
+\nFor more information, try 'homeboy agent-task cook --help'\n"
+            ),
+            "{flag}"
+        );
+    }
+}
+
+#[test]
+fn cook_accepts_current_executor_selection_flags() {
+    for selector_flag in ["--selector", "--dispatch-provider-id"] {
+        let output = cook_command([
+            "--backend",
+            "opencode",
+            selector_flag,
+            "opencode.agent-task-executor",
+            "--help",
+        ]);
+
+        assert!(output.status.success(), "{selector_flag}: {output:?}");
+        assert!(String::from_utf8_lossy(&output.stdout).contains("--backend <BACKEND>"));
+    }
+}
+
+#[test]
+fn unrelated_unknown_cook_flag_keeps_clap_diagnostic_without_promotion_hint() {
+    let output = cook_command(["--unrelated-unknown-flag"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr.contains("unexpected argument '--unrelated-unknown-flag' found"));
+    assert!(!stderr.contains("historical executor selection flag"));
+    assert!(!stderr.contains("--provider-argv"));
+}
+
+fn cook_command<const N: usize>(args: [&str; N]) -> Output {
+    Command::new(homeboy_bin())
+        .args(["agent-task", "cook"])
+        .args(args)
+        .env("HOME", tempfile::tempdir().expect("home").path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run homeboy")
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}

--- a/tests/agent_task_provider_flag_diagnostic.rs
+++ b/tests/agent_task_provider_flag_diagnostic.rs
@@ -13,7 +13,7 @@ fn historical_cook_executor_flags_emit_the_migration_snapshot() {
             format!(
                 "error: historical executor selection flag '{flag}' is not supported\n\
 \nhint: executor selection now uses `--backend <backend>` and optional `--selector <provider-id>`.\n\
-Example: `homeboy agent-task cook --backend opencode --selector opencode.agent-task-executor ...`\n\
+Example: `homeboy agent-task cook --backend opencode --selector opencode.agent-task-executor --to-worktree repo@branch --goal 'Describe the task' --verify 'cargo test' --no-finalize`\n\
 List available executor providers: `homeboy agent-task providers`\n\
 `--provider-argv` is promotion-only: it configures the deprecated promotion apply-provider invocation and cannot select an executor.\n\
 \nFor more information, try 'homeboy agent-task cook --help'\n"


### PR DESCRIPTION
## Summary
- replace misleading Cook executor-flag suggestions with a semantic migration diagnostic for `--provider`, `--provider-id`, and `--dispatch-selector`
- direct callers to `--backend` and `--selector`, with an OpenCode example and `agent-task providers` discovery
- clarify that `--provider-argv` is promotion-only and add binary CLI snapshots for legacy, current, and unrelated flags

Closes #10000

## Verification
- `cargo fmt --check`
- `cargo test --test agent_task_provider_flag_diagnostic`
- `cargo test -p homeboy-cli cli_runtime::tests::invalid_dynamic_command_points_to_extension_health_when_links_are_broken`
- `cargo test --workspace` (ran for 10 minutes without a failure before the environment timeout during long-running integration tests)

## AI Assistance
- Model: `openai/gpt-5.6-terra`
- Tool: OpenCode
- Used for: implementing the semantic CLI migration diagnostic, integration coverage, and verification under Chris Huber's direction.