### PR TITLE
Fix adopted baseline gate finalization

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -118,10 +118,13 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         .filter(|gate| gate.status == AgentTaskGateStatus::Failed)
         .map(gate_failure)
         .collect();
-    let failed_gate_results: Vec<HomeboyGateResult> =
-        normalized_promotion_gate_results(&options.promotion_report)
-            .filter(|gate| gate.status == HomeboyGateStatus::Failed)
-            .collect();
+    let failed_gate_results: Vec<HomeboyGateResult> = options
+        .promotion_report
+        .gate_outcome()
+        .gate_results
+        .into_iter()
+        .filter(|gate| gate.status == HomeboyGateStatus::Failed)
+        .collect();
     let retry_budget_remaining = options.max_attempts.saturating_sub(options.attempt);
     let quality = classify_cook_loop_quality(&options.promotion_report);
     let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
@@ -216,9 +219,12 @@ fn classify_cook_loop_quality(report: &AgentTaskPromotionReport) -> AgentTaskCoo
         };
     }
 
-    let has_passed_gate = normalized_promotion_gate_results(report)
+    let outcome = report.gate_outcome();
+    let has_passed_gate = outcome
+        .gate_results
+        .iter()
         .any(|gate| gate.status == HomeboyGateStatus::Passed);
-    if report.status == AgentTaskPromotionStatus::Applied && has_passed_gate {
+    if outcome.status == AgentTaskPromotionStatus::Applied && has_passed_gate {
         return AgentTaskCookLoopQualityReport {
             classification: AgentTaskCookLoopQualityClassification::VerifiedPatch,
             summary: "cook produced a patch and deterministic gates passed".to_string(),
@@ -230,42 +236,6 @@ fn classify_cook_loop_quality(report: &AgentTaskPromotionReport) -> AgentTaskCoo
         classification: AgentTaskCookLoopQualityClassification::PatchProduced,
         summary: "cook produced a patch that needs promotion or verification".to_string(),
         signals,
-    }
-}
-
-fn normalized_promotion_gate_results(
-    report: &AgentTaskPromotionReport,
-) -> impl Iterator<Item = HomeboyGateResult> + '_ {
-    if report.gate_results.is_empty() {
-        EitherGateResults::Legacy(
-            report
-                .deterministic_gates
-                .iter()
-                .cloned()
-                .map(HomeboyGateResult::from),
-        )
-    } else {
-        EitherGateResults::Normalized(report.gate_results.iter().cloned())
-    }
-}
-
-enum EitherGateResults<L, R> {
-    Legacy(L),
-    Normalized(R),
-}
-
-impl<T, L, R> Iterator for EitherGateResults<L, R>
-where
-    L: Iterator<Item = T>,
-    R: Iterator<Item = T>,
-{
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Legacy(iter) => iter.next(),
-            Self::Normalized(iter) => iter.next(),
-        }
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::agent_task_gate::{AgentTaskGateReport, VerifyGateOptions};
+use crate::agent_task_gate::{AgentTaskGateReport, AgentTaskGateStatus, VerifyGateOptions};
 use homeboy_core::command_invocation::CommandInvocation;
-use homeboy_core::gate::HomeboyGateResult;
+use homeboy_core::gate::{HomeboyGateResult, HomeboyGateVisibility};
 use homeboy_core::git::output_allow_empty;
 use homeboy_core::stream_capture::StreamCaptureMetadata;
 
@@ -72,6 +72,86 @@ pub struct AgentTaskPromotionReport {
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub provenance: Value,
     pub operator_notification: AgentTaskPromotionNotification,
+}
+
+/// The single durable projection of deterministic gate evidence for a promoted
+/// candidate. Detailed gate reports are authoritative; `gate_results` and the
+/// promotion status are compatibility views derived from them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentTaskPromotionGateOutcome {
+    pub status: AgentTaskPromotionStatus,
+    pub gate_results: Vec<HomeboyGateResult>,
+}
+
+impl AgentTaskPromotionReport {
+    pub fn gate_outcome(&self) -> AgentTaskPromotionGateOutcome {
+        let gate_results = self
+            .deterministic_gates
+            .iter()
+            .cloned()
+            .map(HomeboyGateResult::from)
+            .collect::<Vec<_>>();
+        let all_gates_passed = !self.deterministic_gates.is_empty()
+            && self.deterministic_gates.iter().all(durable_gate_passed);
+        let status = if self.status == AgentTaskPromotionStatus::GateFailed && all_gates_passed {
+            AgentTaskPromotionStatus::Applied
+        } else {
+            self.status
+        };
+        AgentTaskPromotionGateOutcome {
+            status,
+            gate_results,
+        }
+    }
+
+    /// Rebuild compatibility fields from the authoritative detailed reports
+    /// before a report crosses a durable boundary.
+    pub fn normalize_gate_outcome(&mut self) {
+        let outcome = self.gate_outcome();
+        self.status = outcome.status;
+        self.gate_results = outcome.gate_results;
+    }
+
+    /// A reviewer-visible command needs a durable passing gate for this exact
+    /// command and immutable candidate. Status-only evidence never qualifies.
+    pub fn has_visible_passed_gate_for_command(&self, command: &str) -> bool {
+        self.gate_outcome().status == AgentTaskPromotionStatus::Applied
+            && self.deterministic_gates.iter().any(|gate| {
+                gate.visibility == HomeboyGateVisibility::Visible
+                    && gate.command.as_slice() == ["sh", "-lc", command]
+                    && durable_gate_passed(gate)
+                    && self.gate_candidate_identity_matches(gate)
+            })
+    }
+
+    fn gate_candidate_identity_matches(&self, gate: &AgentTaskGateReport) -> bool {
+        let Some(candidate) = gate.candidate_checkout.as_ref() else {
+            return false;
+        };
+        let Some(recorded) = self.provenance.get("candidate_checkout") else {
+            return false;
+        };
+        if serde_json::to_value(candidate).ok().as_ref() != Some(recorded) {
+            return false;
+        }
+        self.provenance
+            .pointer("/adoption/candidate_ref")
+            .and_then(Value::as_str)
+            .is_none_or(|adopted| adopted == candidate.commit)
+    }
+}
+
+fn durable_gate_passed(gate: &AgentTaskGateReport) -> bool {
+    match gate.status {
+        AgentTaskGateStatus::Succeeded => gate.exit_code == 0,
+        AgentTaskGateStatus::AcceptedInheritedFailure => {
+            gate.exit_code != 0
+                && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
+                    comparison.matches_candidate_failure && !comparison.base_ref.is_empty()
+                })
+        }
+        AgentTaskGateStatus::Failed => false,
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -108,8 +108,25 @@ impl AgentTaskPromotionReport {
     /// before a report crosses a durable boundary.
     pub fn normalize_gate_outcome(&mut self) {
         let outcome = self.gate_outcome();
+        let status_changed = self.status != outcome.status;
         self.status = outcome.status;
         self.gate_results = outcome.gate_results;
+        if status_changed && self.status == AgentTaskPromotionStatus::Applied {
+            let target_path = self
+                .target
+                .path
+                .as_deref()
+                .unwrap_or(self.target.worktree.as_str());
+            self.operator_notification = AgentTaskPromotionNotification {
+                status: "completed".to_string(),
+                message: format!(
+                    "patch promoted into {}; finalize from {} using the verified_base_sha recorded in this promotion report",
+                    self.target.worktree, target_path
+                ),
+                resumable_blocker: None,
+                next_command: None,
+            };
+        }
     }
 
     /// A reviewer-visible command needs a durable passing gate for this exact

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -906,14 +906,7 @@ fn compare_adoption_gate_failures_to_base(
     }
     let all_failures_inherited = baseline_result?;
     if all_failures_inherited {
-        promotion.status = crate::agent_task_promotion::AgentTaskPromotionStatus::Applied;
-        for result in &mut promotion.gate_results {
-            if result.status == homeboy_core::gate::HomeboyGateStatus::Failed {
-                result.status = homeboy_core::gate::HomeboyGateStatus::Passed;
-                result.summary = "candidate failure matches the immutable baseline; no candidate regression detected".to_string();
-                result.retryable = Some(false);
-            }
-        }
+        promotion.normalize_gate_outcome();
     }
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -205,6 +205,7 @@ pub(crate) fn persisted_promotion_for_attempt(
         return Err(error);
     }
     restore_gate_feedback_baseline(&record, &mut promotion)?;
+    promotion.normalize_gate_outcome();
     Ok(Some(promotion))
 }
 
@@ -659,6 +660,8 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     promotion: &AgentTaskPromotionReport,
     backend: &mut B,
 ) -> Result<Value> {
+    let mut promotion = promotion.clone();
+    promotion.normalize_gate_outcome();
     if promotion.status != AgentTaskPromotionStatus::Applied {
         return Err(Error::validation_invalid_argument(
             "promotion",
@@ -669,10 +672,10 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     }
     crate::agent_task_lifecycle::record_promotion(
         successful_run_id,
-        serde_json::to_value(promotion).unwrap_or(Value::Null),
+        serde_json::to_value(&promotion).unwrap_or(Value::Null),
     )?;
     let finalization =
-        cook_finalization_options(options, successful_run_id, promotion, Vec::new())?;
+        cook_finalization_options(options, successful_run_id, &promotion, Vec::new())?;
     finalize_pr_with_backend(finalization, backend)
         .map(|report| serde_json::to_value(report).unwrap_or(Value::Null))
 }
@@ -802,9 +805,9 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     } else {
         let mut applied_run_id = None;
         for attempt in recipe.attempts.iter().rev() {
-            if persisted_promotion_for_attempt(&attempt.run_id)?
-                .is_some_and(|promotion| promotion.status == AgentTaskPromotionStatus::Applied)
-            {
+            if persisted_promotion_for_attempt(&attempt.run_id)?.is_some_and(|promotion| {
+                promotion.gate_outcome().status == AgentTaskPromotionStatus::Applied
+            }) {
                 applied_run_id = Some(attempt.run_id.clone());
                 break;
             }
@@ -826,7 +829,7 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             None,
         )
     })?;
-    if promotion.status != AgentTaskPromotionStatus::Applied {
+    if promotion.gate_outcome().status != AgentTaskPromotionStatus::Applied {
         return Err(Error::validation_invalid_argument(
             "latest_promotion.status",
             "recovery requires an applied promotion with green gates",
@@ -873,11 +876,7 @@ fn cook_review_dossier(
         .verify
         .iter()
         .map(|command| {
-            let matched = promotion.deterministic_gates.iter().any(|gate| {
-                gate.status == crate::agent_task_gate::AgentTaskGateStatus::Succeeded
-                    && gate.visibility == homeboy_core::gate::HomeboyGateVisibility::Visible
-                    && gate.command.as_slice() == ["sh", "-lc", command]
-            });
+            let matched = promotion.has_visible_passed_gate_for_command(command);
             if !matched {
                 return Err(Error::validation_invalid_argument(
                     "verification",

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -670,12 +670,12 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             None,
         ));
     }
+    let finalization =
+        cook_finalization_options(options, successful_run_id, &promotion, Vec::new())?;
     crate::agent_task_lifecycle::record_promotion(
         successful_run_id,
         serde_json::to_value(&promotion).unwrap_or(Value::Null),
     )?;
-    let finalization =
-        cook_finalization_options(options, successful_run_id, &promotion, Vec::new())?;
     finalize_pr_with_backend(finalization, backend)
         .map(|report| serde_json::to_value(report).unwrap_or(Value::Null))
 }
@@ -839,6 +839,12 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     }
     let options = super::cook_recipe::reconstruct_adoption_options(&recipe)?;
     let finalization = cook_finalization_options(&options, &run_id, &promotion, overrides)?;
+    if !preflight {
+        agent_task_lifecycle::record_promotion(
+            &run_id,
+            serde_json::to_value(&promotion).unwrap_or(Value::Null),
+        )?;
+    }
     let report = if preflight {
         preflight_pr_with_backend(finalization, backend)?
     } else {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3760,12 +3760,67 @@ fn promotion(run_id: &str) -> AgentTaskPromotionReport {
             "target": {"worktree": "homeboy@8058", "path": "/repo"},
             "patch_artifact": {"id": "patch", "kind": "patch", "path": "patch"},
             "changed_files": ["src/lib.rs"],
-            "deterministic_gates": [{"id": "gate", "visibility": "visible", "reveal_policy": "full_evidence", "status": "succeeded", "command": ["sh", "-lc", "cargo test --locked agent_task_promotion --lib"], "exit_code": 0}],
+            "deterministic_gates": [{"id": "gate", "visibility": "visible", "reveal_policy": "full_evidence", "status": "succeeded", "command": ["sh", "-lc", "cargo test --locked agent_task_promotion --lib"], "exit_code": 0, "candidate_checkout": {"schema": "homeboy/agent-task-gate-candidate-checkout/v1", "commit": "candidate", "tree": "candidate-tree", "candidate_sha256": "candidate-sha"}}],
             "gate_results": [{"id": "gate", "name": "cargo test --locked agent_task_promotion --lib", "kind": "command", "status": "passed"}],
             "operator_notification": {"status": "completed", "message": "complete"},
             "verified_base": {"base": "main", "sha": "verified-base"},
-            "provenance": {"worktree_path": "/repo"}
+            "provenance": {"worktree_path": "/repo", "candidate_checkout": {"schema": "homeboy/agent-task-gate-candidate-checkout/v1", "commit": "candidate", "tree": "candidate-tree", "candidate_sha256": "candidate-sha"}}
         })).unwrap()
+}
+
+#[test]
+fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
+    let run_id = "cook-10010-attempt-1";
+    let command = "cargo test --locked agent_task_promotion --lib";
+    let mut accepted = promotion(run_id);
+    accepted.status = crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed;
+    accepted.deterministic_gates[0].status =
+        crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure;
+    accepted.deterministic_gates[0].exit_code = 1;
+    accepted.deterministic_gates[0].baseline_comparison =
+        Some(crate::agent_task_gate::AgentTaskGateBaselineComparison {
+            base_ref: "immutable-base".to_string(),
+            exit_code: 1,
+            failure_fingerprint: "inherited failure".to_string(),
+            matches_candidate_failure: true,
+        });
+    accepted.normalize_gate_outcome();
+
+    assert_eq!(
+        accepted.status,
+        crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+    );
+    assert_eq!(
+        accepted.gate_results[0].status,
+        homeboy_core::gate::HomeboyGateStatus::Passed
+    );
+    assert!(accepted.has_visible_passed_gate_for_command(command));
+
+    let mut regression = accepted.clone();
+    regression.status = crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed;
+    regression.deterministic_gates[0]
+        .baseline_comparison
+        .as_mut()
+        .unwrap()
+        .matches_candidate_failure = false;
+    regression.normalize_gate_outcome();
+    assert_eq!(
+        regression.status,
+        crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
+    );
+    assert!(!regression.has_visible_passed_gate_for_command(command));
+
+    let mut wrong_command = accepted.clone();
+    wrong_command.deterministic_gates[0].command[2] = "cargo test arbitrary".to_string();
+    assert!(!wrong_command.has_visible_passed_gate_for_command(command));
+
+    let mut wrong_candidate = accepted;
+    wrong_candidate.deterministic_gates[0]
+        .candidate_checkout
+        .as_mut()
+        .unwrap()
+        .commit = "other-candidate".to_string();
+    assert!(!wrong_candidate.has_visible_passed_gate_for_command(command));
 }
 
 #[test]
@@ -4239,7 +4294,7 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
 }
 
 #[test]
-fn recovery_hydrates_durable_cook_evidence_and_can_preflight_without_mutation() {
+fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mutation() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-9750";
         let run_id = "cook-9750-attempt-1";
@@ -4253,11 +4308,22 @@ fn recovery_hydrates_durable_cook_evidence_and_can_preflight_without_mutation() 
         persist_initial_recipe(&options).unwrap();
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).unwrap();
         seed_review_form_aggregate(run_id, &options.initial_plan);
-        agent_task_lifecycle::record_promotion(
-            run_id,
-            serde_json::to_value(promotion(run_id)).unwrap(),
-        )
-        .unwrap();
+        let mut adopted = promotion(run_id);
+        adopted.status = crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed;
+        adopted.deterministic_gates[0].status =
+            crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure;
+        adopted.deterministic_gates[0].exit_code = 1;
+        adopted.deterministic_gates[0].baseline_comparison =
+            Some(crate::agent_task_gate::AgentTaskGateBaselineComparison {
+                base_ref: "immutable-base".to_string(),
+                exit_code: 1,
+                failure_fingerprint: "inherited failure".to_string(),
+                matches_candidate_failure: true,
+            });
+        // This simulates a restart after adoption before a stale owning attempt
+        // status can be reconciled. Recovery derives the durable gate outcome.
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(adopted).unwrap())
+            .unwrap();
 
         let mut preflight_backend = CaptureBackend::default();
         let preflight =

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4320,6 +4320,13 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
                 failure_fingerprint: "inherited failure".to_string(),
                 matches_candidate_failure: true,
             });
+        adopted.operator_notification =
+            crate::agent_task_promotion::AgentTaskPromotionNotification {
+                status: "blocked".to_string(),
+                message: "patch promoted, but deterministic gates failed".to_string(),
+                resumable_blocker: Some("stale gate failure".to_string()),
+                next_command: None,
+            };
         // This simulates a restart after adoption before a stale owning attempt
         // status can be reconciled. Recovery derives the durable gate outcome.
         agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(adopted).unwrap())
@@ -4333,6 +4340,15 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
         assert!(!preflight_backend.committed);
         assert!(!preflight_backend.pushed);
         assert!(!preflight_backend.created);
+        let preflight_record = agent_task_lifecycle::status(run_id).unwrap();
+        assert_eq!(
+            preflight_record.metadata["latest_promotion"]["status"],
+            "gate_failed"
+        );
+        assert_eq!(
+            preflight_record.metadata["latest_promotion"]["operator_notification"]["status"],
+            "blocked"
+        );
 
         let mut publish_backend = CaptureBackend::default();
         let report = recover_cook_pr_with_backend(
@@ -4353,6 +4369,16 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
         assert!(publish_backend
             .body
             .contains("Recovered from durable Cook evidence."));
+        let record = agent_task_lifecycle::status(run_id).unwrap();
+        assert_eq!(record.metadata["latest_promotion"]["status"], "applied");
+        assert_eq!(
+            record.metadata["latest_promotion"]["operator_notification"]["status"],
+            "completed"
+        );
+        assert!(
+            record.metadata["latest_promotion"]["operator_notification"]["resumable_blocker"]
+                .is_null()
+        );
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 
 use homeboy::agents::agent_task_service as agent_task_service_direct;
 use homeboy::agents::agent_tasks::lifecycle as agent_task_lifecycle;
+use homeboy::agents::agent_tasks::promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 use homeboy::agents::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::agents::agent_tasks::{AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
@@ -1020,9 +1021,24 @@ pub(crate) fn execution_states_from_aggregate(
         })
         .collect::<Vec<_>>();
     let promotion_status = record
-        .pointer("/metadata/latest_promotion/status")
-        .and_then(Value::as_str)
-        .unwrap_or("not_attempted");
+        .pointer("/metadata/latest_promotion")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<AgentTaskPromotionReport>(value).ok())
+        .map(|promotion| match promotion.gate_outcome().status {
+            AgentTaskPromotionStatus::DryRun => "dry_run",
+            AgentTaskPromotionStatus::VerificationPending => "verification_pending",
+            AgentTaskPromotionStatus::Applied => "applied",
+            AgentTaskPromotionStatus::GateFailed => "gate_failed",
+            AgentTaskPromotionStatus::VerifiedNoChanges => "verified_no_changes",
+            AgentTaskPromotionStatus::NoChangesGateFailed => "no_changes_gate_failed",
+            AgentTaskPromotionStatus::NoChanges => "no_changes",
+        })
+        .unwrap_or_else(|| {
+            record
+                .pointer("/metadata/latest_promotion/status")
+                .and_then(Value::as_str)
+                .unwrap_or("not_attempted")
+        });
     let finalization_status = record
         .pointer("/metadata/cook_finalization/status")
         .and_then(Value::as_str)

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -888,6 +888,47 @@ fn execution_states_distinguish_patch_noop_provider_failure_and_gate_failure() {
     assert_eq!(gate_failure["gate"]["state"], "failed");
 }
 
+#[test]
+fn execution_states_prefer_adopted_normalized_gate_outcome_over_stale_attempt_failure() {
+    let states = super::super::status::execution_states_from_aggregate(
+        &aggregate_for_execution_outcome(fixture_execution_outcome(
+            AgentTaskOutcomeStatus::ProviderError,
+            Some(AgentTaskFailureClassification::Provider),
+            Vec::new(),
+            Value::Null,
+        )),
+        &json!({
+            "metadata": {
+                "latest_promotion": {
+                    "schema": "homeboy/agent-task-promotion-report/v1",
+                    "status": "gate_failed",
+                    "source": {"kind": "aggregate", "task_id": "task", "run_id": "run"},
+                    "to_worktree": "worktree",
+                    "target": {"worktree": "worktree"},
+                    "patch_artifact": {"id": "patch", "kind": "patch", "path": "patch"},
+                    "deterministic_gates": [{
+                        "id": "gate",
+                        "visibility": "visible",
+                        "reveal_policy": "full_evidence",
+                        "status": "accepted_inherited_failure",
+                        "command": ["sh", "-lc", "cargo test"],
+                        "exit_code": 1,
+                        "baseline_comparison": {
+                            "base_ref": "immutable-base",
+                            "exit_code": 1,
+                            "failure_fingerprint": "inherited",
+                            "matches_candidate_failure": true
+                        }
+                    }],
+                    "operator_notification": {"status": "completed", "message": "complete"}
+                }
+            }
+        }),
+    );
+    assert_eq!(states["gate"]["state"], "passed");
+    assert_eq!(states["promotion"]["state"], "applied");
+}
+
 fn execution_states(outcome: AgentTaskOutcome, promotion_status: &str) -> Value {
     super::super::status::execution_states_from_aggregate(
         &aggregate_for_execution_outcome(outcome),


### PR DESCRIPTION
## Summary
- derive one durable promotion gate outcome from detailed gate reports
- allow accepted inherited failures to satisfy exact candidate-bound, visible command evidence
- normalize stale adoption state for status and recovered finalization

Closes #10010

## Testing
- `cargo fmt --check`
- focused adoption outcome, restart recovery, and terminal status tests
- `cargo test -p homeboy-agents --lib --no-fail-fast` exceeded ten minutes; unrelated pre-existing `agent_task_executor_evidence` tests failed before timeout

## AI assistance
- OpenCode using `openai/gpt-5.6-terra` drafted the durable gate-outcome implementation and tests. Chris Huber reviewed and remains responsible for every line.