### PR TITLE
fix(release): dedupe canonical GitHub assets

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -43,6 +43,7 @@ pub(super) fn agent_task_resource_behavior(
             AgentTaskResourceBehavior::LocalControl
         }
         agent_task::AgentTaskCommand::Cook(_)
+        | agent_task::AgentTaskCommand::CookContinue(_)
         | agent_task::AgentTaskCommand::RunPlan(_)
         | agent_task::AgentTaskCommand::Run(_)
         | agent_task::AgentTaskCommand::RunNext

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -4,7 +4,10 @@ use crate::release::types::ReleaseState;
 use homeboy_core::component::GithubConfig;
 use homeboy_core::engine::shell::quote_arg;
 use homeboy_core::git::release_download::GitHubRepo;
+use serde::Serialize;
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::io::Read;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -35,6 +38,23 @@ pub(crate) struct GitHubReleaseAsset {
     pub size: u64,
     #[serde(default)]
     pub digest: Option<String>,
+}
+
+/// A content-addressed intent to publish bytes under one canonical remote name.
+/// The durable path is an implementation detail; extension and core publishers
+/// coordinate through this target-name plus digest identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ReleaseAssetPublication {
+    pub target_name: String,
+    pub sha256: String,
+    pub size: u64,
+    pub source_path: String,
+}
+
+impl ReleaseAssetPublication {
+    pub(crate) fn upload_spec(&self) -> String {
+        format!("{}#{}", self.source_path, self.target_name)
+    }
 }
 
 pub(crate) fn gh_is_available() -> bool {
@@ -72,6 +92,134 @@ pub(crate) fn github_release_artifact_paths(state: &ReleaseState) -> Vec<String>
                 .map(str::to_string)
         })
         .collect()
+}
+
+/// Resolve publication identities for all direct release artifacts.  The path
+/// declared by the producer names the remote target while a durable copy may
+/// provide the bytes after the source workspace has been cleaned up.
+pub(crate) fn github_release_publications(
+    state: &ReleaseState,
+) -> Result<Vec<ReleaseAssetPublication>, String> {
+    let mut publications: BTreeMap<String, ReleaseAssetPublication> = BTreeMap::new();
+    let mut direct_sources = HashSet::new();
+    for artifact in &state.artifacts {
+        let source_path = artifact
+            .durable_path
+            .as_deref()
+            .filter(|path| path_is_file(path))
+            .or_else(|| path_is_file(&artifact.path).then_some(artifact.path.as_str()))
+            .ok_or_else(|| format!("release artifact '{}' is missing", artifact.path))?;
+        let target_name = release_asset_name(&artifact.path);
+        if target_name.is_empty() {
+            return Err(format!(
+                "release artifact '{}' has no valid filename",
+                artifact.path
+            ));
+        }
+        let publication = publication_from_path(source_path, target_name)?;
+        direct_sources.insert(source_path.to_string());
+        match publications.get(&publication.target_name) {
+            Some(existing) if existing.sha256 == publication.sha256 => {}
+            Some(_) => {
+                return Err(format!(
+                    "release assets targeting '{}' have conflicting bytes",
+                    publication.target_name
+                ))
+            }
+            None => {
+                publications.insert(publication.target_name.clone(), publication);
+            }
+        }
+    }
+    // Distribution manifests can declare archives that were not explicit
+    // extension outputs. They retain their own filenames as canonical targets.
+    for source_path in github_release_asset_paths(state)? {
+        if direct_sources.contains(&source_path) {
+            continue;
+        }
+        let publication = publication_from_path(&source_path, release_asset_name(&source_path))?;
+        match publications.get(&publication.target_name) {
+            Some(existing) if existing.sha256 == publication.sha256 => {}
+            Some(_) => {
+                return Err(format!(
+                    "release assets targeting '{}' have conflicting bytes",
+                    publication.target_name
+                ))
+            }
+            None => {
+                publications.insert(publication.target_name.clone(), publication);
+            }
+        }
+    }
+    Ok(publications.into_values().collect())
+}
+
+fn publication_from_path(
+    source_path: &str,
+    target_name: String,
+) -> Result<ReleaseAssetPublication, String> {
+    let metadata = std::fs::metadata(source_path)
+        .map_err(|error| format!("could not read release artifact '{source_path}': {error}"))?;
+    if metadata.len() == 0 {
+        return Err(format!("release asset '{target_name}' is empty"));
+    }
+    let mut file = std::fs::File::open(source_path)
+        .map_err(|error| format!("could not hash release artifact '{source_path}': {error}"))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("could not hash release artifact '{source_path}': {error}"))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(ReleaseAssetPublication {
+        target_name,
+        sha256: format!("{:x}", hasher.finalize()),
+        size: metadata.len(),
+        source_path: source_path.to_string(),
+    })
+}
+
+/// Split publications into assets that must be uploaded and assets already
+/// proven present remotely. A remote digest is required to make idempotence
+/// safe: matching only a name or size could silently accept different bytes.
+pub(crate) fn reconcile_release_publications(
+    publications: &[ReleaseAssetPublication],
+    remote_assets: &[GitHubReleaseAsset],
+) -> Result<(Vec<ReleaseAssetPublication>, Vec<ReleaseAssetPublication>), String> {
+    let mut upload = Vec::new();
+    let mut existing = Vec::new();
+    for publication in publications {
+        let Some(remote) = remote_assets
+            .iter()
+            .find(|asset| asset.name == publication.target_name)
+        else {
+            upload.push(publication.clone());
+            continue;
+        };
+        let digest = remote
+            .digest
+            .as_deref()
+            .and_then(|value| value.strip_prefix("sha256:"));
+        match digest {
+            Some(digest) if digest == publication.sha256 && remote.size == publication.size => {
+                existing.push(publication.clone());
+            }
+            Some(_) => return Err(format!(
+                "GitHub Release asset '{}' conflicts with the canonical publication bytes",
+                publication.target_name
+            )),
+            None => return Err(format!(
+                "GitHub Release asset '{}' has no digest; cannot safely verify canonical publication ownership",
+                publication.target_name
+            )),
+        }
+    }
+    Ok((upload, existing))
 }
 
 /// Resolve every local asset required to publish a release. A cargo-dist
@@ -258,6 +406,32 @@ pub(crate) fn verify_release_assets(
                     "GitHub Release asset '{name}' digest does not match uploaded artifact"
                 ));
             }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn verify_release_publications(
+    publications: &[ReleaseAssetPublication],
+    assets: &[GitHubReleaseAsset],
+) -> Result<(), String> {
+    for publication in publications {
+        let asset = assets
+            .iter()
+            .find(|asset| asset.name == publication.target_name)
+            .ok_or_else(|| {
+                format!(
+                    "GitHub Release is missing uploaded asset '{}'",
+                    publication.target_name
+                )
+            })?;
+        if asset.size != publication.size
+            || asset.digest.as_deref() != Some(&format!("sha256:{}", publication.sha256))
+        {
+            return Err(format!(
+                "GitHub Release asset '{}' does not match the canonical publication bytes",
+                publication.target_name
+            ));
         }
     }
     Ok(())
@@ -565,6 +739,139 @@ mod tests {
         assert_eq!(
             error,
             "GitHub Release is missing uploaded asset 'homeboy-x86_64-unknown-linux-gnu.tar.xz'"
+        );
+    }
+
+    fn release_state_with_artifacts(
+        artifacts: Vec<crate::release::types::ReleaseArtifact>,
+    ) -> ReleaseState {
+        ReleaseState {
+            artifacts,
+            ..ReleaseState::default()
+        }
+    }
+
+    fn artifact(
+        path: &std::path::Path,
+        durable_path: Option<&std::path::Path>,
+    ) -> crate::release::types::ReleaseArtifact {
+        crate::release::types::ReleaseArtifact {
+            path: path.display().to_string(),
+            durable_path: durable_path.map(|path| path.display().to_string()),
+            artifact_type: None,
+            platform: None,
+        }
+    }
+
+    #[test]
+    fn numbered_durable_zip_publishes_to_the_declared_canonical_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().join("component.zip");
+        let durable = dir.path().join("01-component.zip");
+        std::fs::write(&durable, b"component bytes").expect("write durable zip");
+
+        let publications =
+            github_release_publications(&release_state_with_artifacts(vec![artifact(
+                &canonical,
+                Some(&durable),
+            )]))
+            .expect("publication identity");
+
+        assert_eq!(publications.len(), 1);
+        assert_eq!(publications[0].target_name, "component.zip");
+        assert_eq!(
+            publications[0].upload_spec(),
+            format!("{}#component.zip", durable.display())
+        );
+    }
+
+    #[test]
+    fn exact_remote_asset_is_reused_on_retry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("component.zip");
+        std::fs::write(&path, b"component bytes").expect("write zip");
+        let publications =
+            github_release_publications(&release_state_with_artifacts(vec![artifact(&path, None)]))
+                .expect("publication identity");
+        let remote = GitHubReleaseAsset {
+            name: "component.zip".to_string(),
+            size: publications[0].size,
+            digest: Some(format!("sha256:{}", publications[0].sha256)),
+        };
+
+        let (upload, existing) = reconcile_release_publications(&publications, &[remote])
+            .expect("reconcile exact asset");
+        assert!(upload.is_empty());
+        assert_eq!(existing, publications);
+    }
+
+    #[test]
+    fn conflicting_preexisting_canonical_asset_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("component.zip");
+        std::fs::write(&path, b"component bytes").expect("write zip");
+        let publications =
+            github_release_publications(&release_state_with_artifacts(vec![artifact(&path, None)]))
+                .expect("publication identity");
+
+        let error = reconcile_release_publications(
+            &publications,
+            &[GitHubReleaseAsset {
+                name: "component.zip".to_string(),
+                size: publications[0].size,
+                digest: Some("sha256:conflicting".to_string()),
+            }],
+        )
+        .expect_err("conflicting bytes must fail");
+        assert!(error.contains("conflicts with the canonical publication bytes"));
+    }
+
+    #[test]
+    fn distinct_component_assets_are_preserved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = dir.path().join("first.zip");
+        let second = dir.path().join("second.zip");
+        std::fs::write(&first, b"same bytes").expect("write first zip");
+        std::fs::write(&second, b"same bytes").expect("write second zip");
+
+        let publications = github_release_publications(&release_state_with_artifacts(vec![
+            artifact(&first, None),
+            artifact(&second, None),
+        ]))
+        .expect("publication identities");
+
+        assert_eq!(publications.len(), 2);
+        assert_eq!(
+            publications
+                .iter()
+                .map(|asset| &asset.target_name)
+                .collect::<Vec<_>>(),
+            vec!["first.zip", "second.zip"]
+        );
+    }
+
+    #[test]
+    fn mixed_extension_versions_keep_legacy_artifacts_and_add_publication_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().join("component.zip");
+        let durable = dir.path().join("01-component.zip");
+        std::fs::write(&durable, b"component bytes").expect("write durable zip");
+        let state = release_state_with_artifacts(vec![artifact(&canonical, Some(&durable))]);
+        let payload = crate::release::executor::package::build_release_payload(
+            &state,
+            "component",
+            ".",
+            None,
+            None,
+        );
+
+        assert_eq!(
+            payload["release"]["artifacts"][0]["path"],
+            canonical.display().to_string()
+        );
+        assert_eq!(
+            payload["release"]["asset_publications"][0]["target_name"],
+            "component.zip"
         );
     }
 }

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -53,7 +53,7 @@ pub(crate) struct ReleaseAssetPublication {
 
 impl ReleaseAssetPublication {
     pub(crate) fn upload_spec(&self) -> String {
-        format!("{}#{}", self.source_path, self.target_name)
+        self.source_path.clone()
     }
 }
 
@@ -116,7 +116,10 @@ pub(crate) fn github_release_publications(
                 artifact.path
             ));
         }
-        let publication = publication_from_path(source_path, target_name)?;
+        let publication = publication_from_path(
+            &stage_canonical_upload_path(source_path, &target_name)?,
+            target_name,
+        )?;
         direct_sources.insert(source_path.to_string());
         match publications.get(&publication.target_name) {
             Some(existing) if existing.sha256 == publication.sha256 => {}
@@ -137,7 +140,11 @@ pub(crate) fn github_release_publications(
         if direct_sources.contains(&source_path) {
             continue;
         }
-        let publication = publication_from_path(&source_path, release_asset_name(&source_path))?;
+        let target_name = release_asset_name(&source_path);
+        let publication = publication_from_path(
+            &stage_canonical_upload_path(&source_path, &target_name)?,
+            target_name,
+        )?;
         match publications.get(&publication.target_name) {
             Some(existing) if existing.sha256 == publication.sha256 => {}
             Some(_) => {
@@ -154,6 +161,39 @@ pub(crate) fn github_release_publications(
     Ok(publications.into_values().collect())
 }
 
+/// GitHub names an upload from the local filename; `gh`'s `#label` suffix only
+/// changes the display label. Keep a canonical durable filename beside numbered
+/// durable copies so retries and repair commands upload the intended asset name.
+fn stage_canonical_upload_path(source_path: &str, target_name: &str) -> Result<String, String> {
+    let source = std::path::Path::new(source_path);
+    if source.file_name().and_then(|name| name.to_str()) == Some(target_name) {
+        return Ok(source_path.to_string());
+    }
+    let parent = source
+        .parent()
+        .ok_or_else(|| format!("release artifact '{source_path}' has no parent directory"))?;
+    let target = parent.join(target_name);
+    if target.is_file() {
+        let source_digest = file_sha256(source_path)?;
+        let target_digest = file_sha256(&target.display().to_string())?;
+        if source_digest != target_digest {
+            return Err(format!(
+                "release assets targeting '{target_name}' have conflicting bytes"
+            ));
+        }
+        return Ok(target.display().to_string());
+    }
+    std::fs::hard_link(source, &target)
+        .or_else(|_| std::fs::copy(source, &target).map(|_| ()))
+        .map_err(|error| {
+            format!(
+                "could not stage canonical release artifact '{source_path}' as '{}': {error}",
+                target.display()
+            )
+        })?;
+    Ok(target.display().to_string())
+}
+
 fn publication_from_path(
     source_path: &str,
     target_name: String,
@@ -163,25 +203,30 @@ fn publication_from_path(
     if metadata.len() == 0 {
         return Err(format!("release asset '{target_name}' is empty"));
     }
-    let mut file = std::fs::File::open(source_path)
-        .map_err(|error| format!("could not hash release artifact '{source_path}': {error}"))?;
+    let sha256 = file_sha256(source_path)?;
+    Ok(ReleaseAssetPublication {
+        target_name,
+        sha256,
+        size: metadata.len(),
+        source_path: source_path.to_string(),
+    })
+}
+
+fn file_sha256(path: &str) -> Result<String, String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|error| format!("could not hash release artifact '{path}': {error}"))?;
     let mut hasher = Sha256::new();
     let mut buffer = [0; 8192];
     loop {
         let read = file
             .read(&mut buffer)
-            .map_err(|error| format!("could not hash release artifact '{source_path}': {error}"))?;
+            .map_err(|error| format!("could not hash release artifact '{path}': {error}"))?;
         if read == 0 {
             break;
         }
         hasher.update(&buffer[..read]);
     }
-    Ok(ReleaseAssetPublication {
-        target_name,
-        sha256: format!("{:x}", hasher.finalize()),
-        size: metadata.len(),
-        source_path: source_path.to_string(),
-    })
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 /// Split publications into assets that must be uploaded and assets already
@@ -781,7 +826,32 @@ mod tests {
         assert_eq!(publications[0].target_name, "component.zip");
         assert_eq!(
             publications[0].upload_spec(),
-            format!("{}#component.zip", durable.display())
+            canonical.display().to_string()
+        );
+        assert_eq!(
+            std::fs::read(&canonical).expect("staged canonical zip"),
+            b"component bytes"
+        );
+    }
+
+    #[test]
+    fn canonical_durable_name_rejects_conflicting_bytes_without_replacing_them() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = dir.path().join("component.zip");
+        let durable = dir.path().join("01-component.zip");
+        std::fs::write(&canonical, b"existing bytes").expect("write canonical zip");
+        std::fs::write(&durable, b"component bytes").expect("write durable zip");
+
+        let error = github_release_publications(&release_state_with_artifacts(vec![artifact(
+            &canonical,
+            Some(&durable),
+        )]))
+        .expect_err("conflicting durable canonical name must fail");
+
+        assert!(error.contains("targeting 'component.zip' have conflicting bytes"));
+        assert_eq!(
+            std::fs::read(&canonical).expect("canonical zip retained"),
+            b"existing bytes"
         );
     }
 

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -26,7 +26,8 @@ pub(crate) use run::validate_declared_build_artifact;
 // non-test surface.
 pub(crate) use gh_cli::{
     gh_failure_detail, gh_is_authenticated, gh_is_available, gh_release_exists,
-    gh_release_metadata, github_release_upload_timeout, run_gh_command, verify_release_assets,
+    gh_release_metadata, github_release_publications, github_release_upload_timeout,
+    reconcile_release_publications, run_gh_command, verify_release_publications,
 };
 
 // Re-exports consumed by the in-crate test suites — both this module's own

--- a/crates/homeboy-release/src/release/executor/github_release/results.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/results.rs
@@ -4,6 +4,7 @@ use crate::release::types::ReleaseStepResult;
 use homeboy_core::git::release_download::GitHubRepo;
 
 use super::super::{step_failed, step_success};
+use super::gh_cli::ReleaseAssetPublication;
 use super::notes::GitHubReleaseBody;
 use super::repair::{
     existing_draft_repair_hints, repair_data, repair_hints, GitHubReleaseRepairCommands,
@@ -184,6 +185,15 @@ pub(crate) fn upload_success_result(
     github: &GitHubRepo,
     artifact_count: usize,
 ) -> ReleaseStepResult {
+    upload_success_result_with_publications(tag, github, artifact_count, &[])
+}
+
+pub(crate) fn upload_success_result_with_publications(
+    tag: &str,
+    github: &GitHubRepo,
+    artifact_count: usize,
+    publications: &[ReleaseAssetPublication],
+) -> ReleaseStepResult {
     let url = published_release_url(github, tag, "", "");
     step_success(
         "github.release",
@@ -196,6 +206,7 @@ pub(crate) fn upload_success_result(
             "repo": github.repo,
             "url": url,
             "artifact_count": artifact_count,
+            "asset_publications": publications,
         })),
         Vec::new(),
     )

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -189,7 +189,7 @@ pub(crate) fn run_github_release(
             for path in &upload_specs {
                 upload_args.push(path);
             }
-            upload_args.extend_from_slice(&["--clobber", "-R", &repo_flag]);
+            upload_args.extend_from_slice(&["-R", &repo_flag]);
             Some(run_gh_command(
                 gh_command(&github, &component.github, &upload_args),
                 github_release_upload_timeout(),

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -6,7 +6,8 @@ use homeboy_core::error::{Error, Result};
 
 use super::super::step_success;
 use super::gh_cli::{
-    gh_command, gh_is_authenticated, gh_is_available, gh_release_exists, github_release_asset_paths,
+    gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
+    github_release_publications,
 };
 use super::notes::{
     build_github_release_body, github_changelog_url, github_release_notes_start_tag,
@@ -15,11 +16,11 @@ use super::notes::{
 use super::repair::{gh_auth_failure_message, github_release_repair_commands, log_repair_commands};
 use super::results::{
     create_failed_result, not_created_result, published_release_url, skipped_result,
-    upload_failed_result, upload_success_result,
+    upload_failed_result, upload_success_result_with_publications,
 };
 use super::{
-    gh_failure_detail, gh_release_metadata, github_release_upload_timeout, run_gh_command,
-    verify_release_assets,
+    gh_failure_detail, gh_release_metadata, github_release_upload_timeout,
+    reconcile_release_publications, run_gh_command, verify_release_publications,
 };
 
 /// Create a GitHub Release for the just-pushed tag.
@@ -86,9 +87,13 @@ pub(crate) fn run_github_release(
     // single API call — keeping the github.release step responsible for
     // the full Release lifecycle (entry + assets) instead of requiring a
     // separate publish.<target> step.
-    let artifact_paths = github_release_asset_paths(state)
+    let publications = github_release_publications(state)
         .map_err(|error| Error::validation_invalid_argument("release assets", error, None, None))?;
-    let has_artifacts = !artifact_paths.is_empty();
+    let artifact_paths = publications
+        .iter()
+        .map(|publication| publication.upload_spec())
+        .collect::<Vec<_>>();
+    let has_artifacts = !publications.is_empty();
     // Single repair-command builder for every failure path. The persisted
     // exact-body file only exists after `persist_release_body` runs below, so
     // early paths (gh missing / unauthenticated / upload) pass `None` and
@@ -141,11 +146,8 @@ pub(crate) fn run_github_release(
 
     let repo_flag = format!("{}/{}", github.owner, github.repo);
     if gh_release_exists(&github, &component.github, &tag, &repo_flag) {
-        // Release entry already exists (idempotent retry, or release
-        // created out of band). When the release has no artifacts to
-        // attach, skip — there is nothing to update. When artifacts are
-        // present, upload them with --clobber so retries keep the latest
-        // build attached without duplicating the GitHub Release entry.
+        // A pre-existing release is a retry boundary. Reconcile its assets by
+        // canonical name and digest before uploading anything.
         if !has_artifacts {
             homeboy_core::log_status!(
                 "release",
@@ -161,26 +163,44 @@ pub(crate) fn run_github_release(
             ));
         }
 
+        let metadata = gh_release_metadata(&github, &component.github, &tag, &repo_flag)
+            .map_err(|error| Error::internal_unexpected(error))?;
+        let (uploads, existing) = reconcile_release_publications(&publications, &metadata.assets)
+            .map_err(|error| {
+            Error::validation_invalid_argument("release assets", error, None, None)
+        })?;
         homeboy_core::log_status!(
             "release",
-            "GitHub Release {} already exists for {} — uploading {} artifact(s) with --clobber",
+            "GitHub Release {} already exists for {} — uploading {} canonical artifact(s), reusing {} verified artifact(s)",
             tag,
             repo_flag,
-            artifact_paths.len()
+            uploads.len(),
+            existing.len()
         );
 
-        let mut upload_args: Vec<&str> = vec!["release", "upload", &tag];
-        for path in &artifact_paths {
-            upload_args.push(path);
-        }
-        upload_args.extend_from_slice(&["--clobber", "-R", &repo_flag]);
+        let upload_specs = uploads
+            .iter()
+            .map(|publication| publication.upload_spec())
+            .collect::<Vec<_>>();
+        let upload_output = if upload_specs.is_empty() {
+            None
+        } else {
+            let mut upload_args: Vec<&str> = vec!["release", "upload", &tag];
+            for path in &upload_specs {
+                upload_args.push(path);
+            }
+            upload_args.extend_from_slice(&["--clobber", "-R", &repo_flag]);
+            Some(run_gh_command(
+                gh_command(&github, &component.github, &upload_args),
+                github_release_upload_timeout(),
+            ))
+        };
 
-        let upload_output = run_gh_command(
-            gh_command(&github, &component.github, &upload_args),
-            github_release_upload_timeout(),
-        );
-
-        if upload_output.timed_out || upload_output.exit_code != Some(0) {
+        if upload_output
+            .as_ref()
+            .is_some_and(|output| output.timed_out || output.exit_code != Some(0))
+        {
+            let upload_output = upload_output.expect("checked upload output");
             let detail = gh_failure_detail("gh release upload", &upload_output);
             let stderr = upload_output.stderr;
             let stdout = upload_output.stdout;
@@ -214,7 +234,7 @@ pub(crate) fn run_github_release(
                 ))
             }
         };
-        if let Err(error) = verify_release_assets(&artifact_paths, &metadata.assets) {
+        if let Err(error) = verify_release_publications(&publications, &metadata.assets) {
             return Ok(upload_failed_result(
                 &tag,
                 &github,
@@ -246,7 +266,12 @@ pub(crate) fn run_github_release(
             }
         }
 
-        return Ok(upload_success_result(&tag, &github, artifact_paths.len()));
+        return Ok(upload_success_result_with_publications(
+            &tag,
+            &github,
+            publications.len(),
+            &publications,
+        ));
     }
 
     let notes_start_tag = github_release_notes_start_tag(component, &tag);
@@ -361,7 +386,7 @@ pub(crate) fn run_github_release(
             ))
         }
     };
-    if let Err(error) = verify_release_assets(&artifact_paths, &metadata.assets) {
+    if let Err(error) = verify_release_publications(&publications, &metadata.assets) {
         return Ok(upload_failed_result(
             &tag,
             &github,
@@ -404,6 +429,7 @@ pub(crate) fn run_github_release(
             "repo": github.repo,
             "url": url,
             "artifact_count": artifact_paths.len(),
+            "asset_publications": publications,
             "generated_notes": generated_notes_ok,
             "published": true,
             "changelog_url": body.changelog_url,

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -408,6 +408,8 @@ pub(crate) fn build_release_payload(
     let tag = state.tag.clone().unwrap_or_else(|| format!("v{}", version));
     let notes = state.notes.clone().unwrap_or_default();
 
+    let publications = crate::release::executor::github_release::github_release_publications(state)
+        .unwrap_or_default();
     let mut payload = serde_json::json!({
         "release": {
             "version": version,
@@ -416,6 +418,7 @@ pub(crate) fn build_release_payload(
             "component_id": component_id,
             "local_path": component_local_path,
             "artifacts": state.artifacts,
+            "asset_publications": publications,
         }
     });
 


### PR DESCRIPTION
## Summary
- bind GitHub release assets to canonical target names plus SHA-256 digests
- reuse verified pre-existing assets on retry and reject canonical-name byte conflicts
- expose asset publication provenance to release results and extension payloads

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-release release::executor::github_release --lib`
- `cargo test -p homeboy-release` (661 passed; 5 pre-existing environment-sensitive failures in deploy/extension fixtures)

Closes #10029

## AI assistance
GPT-5.6 Terra via OpenCode drafted the implementation and tests. Chris remains responsible for every line.