### PR TITLE
fix(deploy): detect remote content drift

### DIFF
--- a/crates/contracts/homeboy-release-contract/src/lib.rs
+++ b/crates/contracts/homeboy-release-contract/src/lib.rs
@@ -54,7 +54,7 @@ pub enum ComponentStatus {
 impl ComponentStatus {
     /// Whether deploying the configured source would advance the target.
     pub fn requires_deploy(&self) -> bool {
-        matches!(self, Self::NeedsUpdate)
+        matches!(self, Self::NeedsUpdate | Self::Missing)
     }
 }
 

--- a/crates/contracts/homeboy-release-contract/src/lib.rs
+++ b/crates/contracts/homeboy-release-contract/src/lib.rs
@@ -41,6 +41,12 @@ pub enum ComponentStatus {
     BehindUpstream,
     /// Remote matches a configured source checkout that is stale or detached
     SourceStale,
+    /// The target has the same release version but different deployed content.
+    RemoteModified,
+    /// The target does not exist.
+    Missing,
+    /// Local and remote both differ from the known release identity.
+    MixedDrift,
     /// Cannot determine status
     Unknown,
 }

--- a/crates/homeboy-cli/src/commands/fleet.rs
+++ b/crates/homeboy-cli/src/commands/fleet.rs
@@ -481,6 +481,9 @@ fn log_fleet_dashboard(result: &FleetStatusResult) {
                 FleetComponentDrift::BehindUpstream => "⬇️  behind upstream",
                 FleetComponentDrift::NeedsRelease => "🔶 needs release",
                 FleetComponentDrift::DocsOnly => "📝 docs only",
+                FleetComponentDrift::RemoteModified => "⚠️  remote modified",
+                FleetComponentDrift::Missing => "❌ missing",
+                FleetComponentDrift::MixedDrift => "⚠️  mixed drift",
                 FleetComponentDrift::Unknown => "❓ unknown",
             };
 

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -498,7 +498,10 @@ fn deployed_version_dashboard_status(
             ProjectComponentDashboardStatus::Current
         }
         homeboy_release::deploy::ComponentStatus::BehindUpstream
-        | homeboy_release::deploy::ComponentStatus::SourceStale => {
+        | homeboy_release::deploy::ComponentStatus::SourceStale
+        | homeboy_release::deploy::ComponentStatus::RemoteModified
+        | homeboy_release::deploy::ComponentStatus::Missing
+        | homeboy_release::deploy::ComponentStatus::MixedDrift => {
             unreachable!("version comparison only returns version statuses")
         }
     }

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -43,6 +43,7 @@ pub(super) fn agent_task_resource_behavior(
             AgentTaskResourceBehavior::LocalControl
         }
         agent_task::AgentTaskCommand::Cook(_)
+        | agent_task::AgentTaskCommand::CookContinue(_)
         | agent_task::AgentTaskCommand::RunPlan(_)
         | agent_task::AgentTaskCommand::Run(_)
         | agent_task::AgentTaskCommand::RunNext

--- a/crates/homeboy-core/src/fleet/check.rs
+++ b/crates/homeboy-core/src/fleet/check.rs
@@ -171,7 +171,7 @@ mod tests {
     use crate::test_support::with_isolated_home;
 
     #[test]
-    fn fleet_check_falls_back_to_cached_components_when_live_check_fails() {
+    fn fleet_check_omits_non_deployable_components_from_live_results() {
         with_isolated_home(|home| {
             let component_dir = home.path().join("tooling-component");
             std::fs::create_dir_all(&component_dir).expect("component dir");
@@ -210,12 +210,10 @@ mod tests {
             assert_eq!(exit_code, 0);
             assert_eq!(summary.projects_checked, 1);
             assert_eq!(summary.projects_failed, 0);
-            assert_eq!(summary.components_unknown, 1);
+            assert_eq!(summary.components_unknown, 0);
             assert_eq!(checks.len(), 1);
-            assert_eq!(checks[0].status, "checked_cached");
-            assert_eq!(checks[0].components.len(), 1);
-            assert_eq!(checks[0].components[0].component_id, "tooling-component");
-            assert_eq!(checks[0].components[0].status, "unknown");
+            assert_eq!(checks[0].status, "checked");
+            assert!(checks[0].components.is_empty());
 
             let (outdated_checks, outdated_summary, outdated_exit_code) =
                 collect_check("local-fleet", true).expect("outdated fleet check");

--- a/crates/homeboy-core/src/fleet/check.rs
+++ b/crates/homeboy-core/src/fleet/check.rs
@@ -56,6 +56,9 @@ pub fn collect_check(
                         Some(ComponentStatus::BehindRemote) => "behind_remote",
                         Some(ComponentStatus::BehindUpstream) => "behind_upstream",
                         Some(ComponentStatus::SourceStale) => "source_stale",
+                        Some(ComponentStatus::RemoteModified) => "remote_modified",
+                        Some(ComponentStatus::Missing) => "missing",
+                        Some(ComponentStatus::MixedDrift) => "mixed_drift",
                         Some(ComponentStatus::Unknown) | None => "unknown",
                     };
 

--- a/crates/homeboy-core/src/fleet/status.rs
+++ b/crates/homeboy-core/src/fleet/status.rs
@@ -35,6 +35,12 @@ pub enum FleetComponentDrift {
     BehindRemote,
     /// Local checkout is behind its upstream branch
     BehindUpstream,
+    /// Target content differs despite matching deployed version
+    RemoteModified,
+    /// Target is absent
+    Missing,
+    /// Version and content both differ
+    MixedDrift,
     /// Has releasable code commits since the current version baseline
     NeedsRelease,
     /// Only docs changes since last tag
@@ -294,7 +300,11 @@ fn collect_project_component_statuses(
                     FleetComponentDrift::Unknown => component_summary.unknown += 1,
                     // These describe remote or configured-source freshness, not a
                     // deployment required from the configured source.
-                    FleetComponentDrift::BehindRemote | FleetComponentDrift::BehindUpstream => {}
+                    FleetComponentDrift::BehindRemote
+                    | FleetComponentDrift::BehindUpstream
+                    | FleetComponentDrift::RemoteModified
+                    | FleetComponentDrift::Missing
+                    | FleetComponentDrift::MixedDrift => {}
                 }
 
                 statuses.push(FleetComponentStatus {
@@ -372,9 +382,9 @@ fn resolve_component_drift(
         Some(ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
         Some(ComponentStatus::BehindUpstream) => FleetComponentDrift::BehindUpstream,
         Some(ComponentStatus::SourceStale) => FleetComponentDrift::BehindUpstream,
-        Some(ComponentStatus::RemoteModified)
-        | Some(ComponentStatus::Missing)
-        | Some(ComponentStatus::MixedDrift) => FleetComponentDrift::Unknown,
+        Some(ComponentStatus::RemoteModified) => FleetComponentDrift::RemoteModified,
+        Some(ComponentStatus::Missing) => FleetComponentDrift::Missing,
+        Some(ComponentStatus::MixedDrift) => FleetComponentDrift::MixedDrift,
         Some(ComponentStatus::Unknown) | None => FleetComponentDrift::Unknown,
     };
 

--- a/crates/homeboy-core/src/fleet/status.rs
+++ b/crates/homeboy-core/src/fleet/status.rs
@@ -372,6 +372,9 @@ fn resolve_component_drift(
         Some(ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
         Some(ComponentStatus::BehindUpstream) => FleetComponentDrift::BehindUpstream,
         Some(ComponentStatus::SourceStale) => FleetComponentDrift::BehindUpstream,
+        Some(ComponentStatus::RemoteModified)
+        | Some(ComponentStatus::Missing)
+        | Some(ComponentStatus::MixedDrift) => FleetComponentDrift::Unknown,
         Some(ComponentStatus::Unknown) | None => FleetComponentDrift::Unknown,
     };
 

--- a/crates/homeboy-release/src/deploy/content_manifest.rs
+++ b/crates/homeboy-release/src/deploy/content_manifest.rs
@@ -1,0 +1,281 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+
+use homeboy_core::engine::shell;
+use homeboy_core::server::SshClient;
+
+use super::types::ContentManifestComparison;
+
+const ALGORITHM: &str = "sha256-tree-v1";
+const SCOPE: &str = "deployed-tree-excluding-homeboy-runtime";
+const MAX_DIFFERENCES: usize = 20;
+const PROBE_TIMEOUT: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Entry {
+    kind: char,
+    mode: String,
+    value: String,
+}
+
+#[derive(Default)]
+struct Manifest {
+    entries: BTreeMap<String, Entry>,
+}
+
+impl Manifest {
+    fn digest(&self) -> String {
+        let mut hash = Sha256::new();
+        for (path, entry) in &self.entries {
+            hash.update(path.as_bytes());
+            hash.update([0]);
+            hash.update([entry.kind as u8]);
+            hash.update([0]);
+            hash.update(entry.mode.as_bytes());
+            hash.update([0]);
+            hash.update(entry.value.as_bytes());
+            hash.update([b'\n']);
+        }
+        format!("{:x}", hash.finalize())
+    }
+}
+
+pub(super) fn compare(local: &Path, remote: &str, client: &SshClient) -> ContentManifestComparison {
+    let local = match local_manifest(local) {
+        Ok(manifest) => manifest,
+        Err(error) => return unavailable(format!("local manifest unavailable: {error}")),
+    };
+    let remote = match remote_manifest(remote, client) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => return comparison(&local, None, "missing", Vec::new(), None),
+        Err(error) => return unavailable(format!("remote manifest unavailable: {error}")),
+    };
+    let differences = differences(&local, &remote);
+    let status = if differences.is_empty() {
+        "match"
+    } else {
+        "different"
+    };
+    comparison(&local, Some(&remote), status, differences, None)
+}
+
+fn comparison(
+    local: &Manifest,
+    remote: Option<&Manifest>,
+    status: &str,
+    differences: Vec<String>,
+    diagnostic: Option<String>,
+) -> ContentManifestComparison {
+    ContentManifestComparison {
+        algorithm: ALGORITHM.to_string(),
+        scope: SCOPE.to_string(),
+        local_digest: Some(local.digest()),
+        remote_digest: remote.map(Manifest::digest),
+        status: status.to_string(),
+        differences,
+        diagnostic,
+    }
+}
+
+fn unavailable(diagnostic: String) -> ContentManifestComparison {
+    ContentManifestComparison {
+        algorithm: ALGORITHM.to_string(),
+        scope: SCOPE.to_string(),
+        local_digest: None,
+        remote_digest: None,
+        status: "unavailable".to_string(),
+        differences: Vec::new(),
+        diagnostic: Some(diagnostic),
+    }
+}
+
+fn local_manifest(root: &Path) -> Result<Manifest, String> {
+    if !root.exists() {
+        return Err(format!("{} does not exist", root.display()));
+    }
+    let mut manifest = Manifest::default();
+    visit(root, root, &mut manifest)?;
+    Ok(manifest)
+}
+
+fn visit(root: &Path, path: &Path, manifest: &mut Manifest) -> Result<(), String> {
+    for entry in fs::read_dir(path).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let child = entry.path();
+        let relative = child
+            .strip_prefix(root)
+            .map_err(|e| e.to_string())?
+            .to_string_lossy()
+            .replace('\\', "/");
+        if ignored(&relative) {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&child).map_err(|e| e.to_string())?;
+        #[cfg(unix)]
+        let mode = format!(
+            "{:o}",
+            std::os::unix::fs::PermissionsExt::mode(&metadata.permissions()) & 0o7777
+        );
+        #[cfg(not(unix))]
+        let mode = "0".to_string();
+        if metadata.file_type().is_symlink() {
+            let target = fs::read_link(&child)
+                .map_err(|e| e.to_string())?
+                .to_string_lossy()
+                .to_string();
+            manifest.entries.insert(
+                relative,
+                Entry {
+                    kind: 'l',
+                    mode,
+                    value: target,
+                },
+            );
+        } else if metadata.is_dir() {
+            visit(root, &child, manifest)?;
+        } else if metadata.is_file() {
+            manifest.entries.insert(
+                relative,
+                Entry {
+                    kind: 'f',
+                    mode,
+                    value: sha256(&child)?,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn sha256(path: &Path) -> Result<String, String> {
+    let mut file = fs::File::open(path).map_err(|e| e.to_string())?;
+    let mut hash = Sha256::new();
+    let mut buffer = [0; 65536];
+    loop {
+        let read = file.read(&mut buffer).map_err(|e| e.to_string())?;
+        if read == 0 {
+            break;
+        }
+        hash.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hash.finalize()))
+}
+
+fn remote_manifest(root: &str, client: &SshClient) -> Result<Option<Manifest>, String> {
+    if client.is_local {
+        return local_manifest(Path::new(root)).map(Some);
+    }
+    // The target computes hashes and returns compact records; content never crosses SSH.
+    let command = format!("root={}; test -e \"$root\" || exit 44; hash=$(command -v sha256sum || command -v shasum) || exit 45; find \"$root\" -mindepth 1 \\( -path '*/.git/*' -o -name .git -o -name '.homeboy-*' \\) -prune -o -type f -exec sh -c 'for f do rel=${{f#\"$1\"/}}; set -- $($2 \"$f\"); mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"f\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$1\"; done' sh \"$root\" \"$hash\" {{}} + -o -type l -exec sh -c 'for f do rel=${{f#\"$1\"/}}; mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"l\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$(readlink \"$f\")\"; done' sh \"$root\" {{}} +", shell::quote_path(root));
+    let output = client.execute_with_timeout(&command, PROBE_TIMEOUT);
+    if output.timed_out {
+        return Err(format!("timed out after {}s", PROBE_TIMEOUT.as_secs()));
+    }
+    if output.exit_code == 44 {
+        return Ok(None);
+    }
+    if !output.success {
+        return Err("remote does not provide a supported SHA-256 command".to_string());
+    }
+    parse_remote_manifest(&output.stdout).map(Some)
+}
+
+fn parse_remote_manifest(output: &str) -> Result<Manifest, String> {
+    let mut manifest = Manifest::default();
+    for line in output.lines() {
+        let mut fields = line.splitn(4, '\t');
+        let (Some(kind), Some(path), Some(mode), Some(value)) =
+            (fields.next(), fields.next(), fields.next(), fields.next())
+        else {
+            return Err("malformed remote manifest evidence".to_string());
+        };
+        if path.contains('\n') || ignored(path) {
+            continue;
+        }
+        let kind = match kind {
+            "f" => 'f',
+            "l" => 'l',
+            _ => return Err("unsupported remote manifest entry".to_string()),
+        };
+        manifest.entries.insert(
+            path.to_string(),
+            Entry {
+                kind,
+                mode: mode.to_string(),
+                value: value.to_string(),
+            },
+        );
+    }
+    Ok(manifest)
+}
+
+fn ignored(path: &str) -> bool {
+    path == ".git"
+        || path.starts_with(".git/")
+        || path.split('/').any(|part| part.starts_with(".homeboy-"))
+}
+
+fn differences(local: &Manifest, remote: &Manifest) -> Vec<String> {
+    let mut paths: BTreeMap<&str, ()> = BTreeMap::new();
+    paths.extend(local.entries.keys().map(|p| (p.as_str(), ())));
+    paths.extend(remote.entries.keys().map(|p| (p.as_str(), ())));
+    paths
+        .into_keys()
+        .filter(|path| local.entries.get(*path) != remote.entries.get(*path))
+        .take(MAX_DIFFERENCES)
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn local_manifest_detects_content_add_delete_mode_symlink_and_ignores_runtime() {
+        let temp = tempfile::tempdir().expect("temp");
+        let local = temp.path().join("local");
+        let remote = temp.path().join("remote");
+        fs::create_dir_all(&local).expect("local");
+        fs::create_dir_all(&remote).expect("remote");
+        fs::write(local.join("same"), "same").expect("same");
+        fs::write(remote.join("same"), "same").expect("same");
+        fs::write(local.join("changed"), "local").expect("local");
+        fs::write(remote.join("changed"), "remote").expect("remote");
+        fs::write(local.join("added"), "add").expect("add");
+        fs::write(remote.join("deleted"), "delete").expect("delete");
+        fs::write(local.join(".homeboy-upload.tmp"), "ignored").expect("runtime");
+        fs::write(remote.join(".homeboy-upload.tmp"), "other").expect("runtime");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("same", local.join("link")).expect("link");
+            std::os::unix::fs::symlink("changed", remote.join("link")).expect("link");
+        }
+        let result = compare(
+            &local,
+            remote.to_str().expect("path"),
+            &SshClient {
+                host: "local".to_string(),
+                user: "test".to_string(),
+                port: 22,
+                identity_file: None,
+                auth: None,
+                is_local: true,
+                env: Default::default(),
+            },
+        );
+        assert_eq!(result.status, "different");
+        assert!(result.differences.iter().any(|p| p == "changed"));
+        assert!(result.differences.iter().any(|p| p == "added"));
+        assert!(result.differences.iter().any(|p| p == "deleted"));
+        assert!(!result.differences.iter().any(|p| p.contains("homeboy")));
+    }
+    #[test]
+    fn remote_manifest_requires_well_formed_hash_evidence() {
+        assert!(parse_remote_manifest("f\tpath\t644\n").is_err());
+    }
+}

--- a/crates/homeboy-release/src/deploy/content_manifest.rs
+++ b/crates/homeboy-release/src/deploy/content_manifest.rs
@@ -117,10 +117,9 @@ fn visit(root: &Path, path: &Path, manifest: &mut Manifest) -> Result<(), String
         }
         let metadata = fs::symlink_metadata(&child).map_err(|e| e.to_string())?;
         #[cfg(unix)]
-        let mode = format!(
-            "{:o}",
-            std::os::unix::fs::PermissionsExt::mode(&metadata.permissions()) & 0o7777
-        );
+        let mode = executable_mode(std::os::unix::fs::PermissionsExt::mode(
+            &metadata.permissions(),
+        ));
         #[cfg(not(unix))]
         let mode = "0".to_string();
         if metadata.file_type().is_symlink() {
@@ -132,7 +131,7 @@ fn visit(root: &Path, path: &Path, manifest: &mut Manifest) -> Result<(), String
                 relative,
                 Entry {
                     kind: 'l',
-                    mode,
+                    mode: "0".to_string(),
                     value: target,
                 },
             );
@@ -171,7 +170,7 @@ fn remote_manifest(root: &str, client: &SshClient) -> Result<Option<Manifest>, S
         return local_manifest(Path::new(root)).map(Some);
     }
     // The target computes hashes and returns compact records; content never crosses SSH.
-    let command = format!("root={}; test -e \"$root\" || exit 44; hash=$(command -v sha256sum || command -v shasum) || exit 45; find \"$root\" -mindepth 1 \\( -path '*/.git/*' -o -name .git -o -name '.homeboy-*' \\) -prune -o -type f -exec sh -c 'for f do rel=${{f#\"$1\"/}}; set -- $($2 \"$f\"); mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"f\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$1\"; done' sh \"$root\" \"$hash\" {{}} + -o -type l -exec sh -c 'for f do rel=${{f#\"$1\"/}}; mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"l\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$(readlink \"$f\")\"; done' sh \"$root\" {{}} +", shell::quote_path(root));
+    let command = format!("root={}; test -e \"$root\" || exit 44; if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then exit 45; fi; find \"$root\" -mindepth 1 \\( -path '*/.git/*' -o -name .git -o -name '.homeboy-*' \\) -prune -o -type f -exec sh -c 'for f do rel=${{f#\"$1\"/}}; if command -v sha256sum >/dev/null 2>&1; then set -- $(sha256sum \"$f\"); else set -- $(shasum -a 256 \"$f\"); fi; mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"f\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$1\"; done' sh \"$root\" {{}} + -o -type l -exec sh -c 'for f do rel=${{f#\"$1\"/}}; mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"l\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$(readlink \"$f\")\"; done' sh \"$root\" {{}} +", shell::quote_path(root));
     let output = client.execute_with_timeout(&command, PROBE_TIMEOUT);
     if output.timed_out {
         return Err(format!("timed out after {}s", PROBE_TIMEOUT.as_secs()));
@@ -202,16 +201,33 @@ fn parse_remote_manifest(output: &str) -> Result<Manifest, String> {
             "l" => 'l',
             _ => return Err("unsupported remote manifest entry".to_string()),
         };
+        let mode = u32::from_str_radix(mode, 8)
+            .map_err(|_| "malformed remote manifest mode".to_string())?;
+        let mode = if kind == 'l' {
+            "0".to_string()
+        } else {
+            executable_mode(mode)
+        };
+        if kind == 'f' && (value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        {
+            return Err("malformed remote SHA-256 evidence".to_string());
+        }
         manifest.entries.insert(
             path.to_string(),
             Entry {
                 kind,
-                mode: mode.to_string(),
+                mode,
                 value: value.to_string(),
             },
         );
     }
     Ok(manifest)
+}
+
+fn executable_mode(mode: u32) -> String {
+    // Deploy normalizes ownership and group-write/setgid bits. Executability is
+    // the mode semantic that survives those target-specific adjustments.
+    format!("{:o}", mode & 0o111)
 }
 
 fn ignored(path: &str) -> bool {
@@ -277,5 +293,38 @@ mod tests {
     #[test]
     fn remote_manifest_requires_well_formed_hash_evidence() {
         assert!(parse_remote_manifest("f\tpath\t644\n").is_err());
+        assert!(parse_remote_manifest("f\tpath\t644\tnot-a-hash\n").is_err());
+    }
+    #[test]
+    #[cfg(unix)]
+    fn manifest_compares_executability_but_ignores_deploy_normalized_write_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp");
+        let local = temp.path().join("local");
+        let remote = temp.path().join("remote");
+        fs::create_dir_all(&local).expect("local");
+        fs::create_dir_all(&remote).expect("remote");
+        fs::write(local.join("script"), "same").expect("local script");
+        fs::write(remote.join("script"), "same").expect("remote script");
+        fs::set_permissions(local.join("script"), fs::Permissions::from_mode(0o644))
+            .expect("local mode");
+        fs::set_permissions(remote.join("script"), fs::Permissions::from_mode(0o664))
+            .expect("remote mode");
+        assert!(differences(
+            &local_manifest(&local).expect("local manifest"),
+            &local_manifest(&remote).expect("remote manifest")
+        )
+        .is_empty());
+
+        fs::set_permissions(remote.join("script"), fs::Permissions::from_mode(0o775))
+            .expect("remote executable mode");
+        assert_eq!(
+            differences(
+                &local_manifest(&local).expect("local manifest"),
+                &local_manifest(&remote).expect("remote manifest")
+            ),
+            vec!["script"]
+        );
     }
 }

--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod binding;
+mod content_manifest;
 mod effect;
 mod execution;
 mod generated_artifacts;

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -399,15 +399,16 @@ pub(super) fn deploy_components(
         };
         let manifest =
             super::content_manifest::compare(local_path, &prepared.install_dir, &ctx.client);
-        if manifest.status == "different"
-            && prepared.local_version == prepared.remote_version
+        if prepared.local_version == prepared.remote_version
             && !config.force
+            && manifest.status != "match"
+            && manifest.status != "missing"
         {
             return Err(Error::validation_invalid_argument(
                 "content_drift",
                 format!(
-                    "Refusing to overwrite remote-only content changes for '{}' at {}",
-                    prepared.component.id, prepared.install_dir
+                    "Refusing to overwrite '{}' at {} without a matching content manifest ({})",
+                    prepared.component.id, prepared.install_dir, manifest.status
                 ),
                 None,
                 Some(vec![

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -218,6 +218,7 @@ pub(super) fn deploy_components(
             &project,
             base_path,
             config,
+            &ctx.client,
         ));
     }
     if config.dry_run {
@@ -385,6 +386,37 @@ pub(super) fn deploy_components(
             });
         }
     };
+
+    // Re-probe immediately before the first destructive write. A same-version
+    // mismatch is remote-only content drift, not an ordinary local update.
+    for prepared in prepared_deployments.iter() {
+        let Some(local_path) = prepared
+            .artifact_path
+            .as_deref()
+            .filter(|path| path.is_dir())
+        else {
+            continue;
+        };
+        let manifest =
+            super::content_manifest::compare(local_path, &prepared.install_dir, &ctx.client);
+        if manifest.status == "different"
+            && prepared.local_version == prepared.remote_version
+            && !config.force
+        {
+            return Err(Error::validation_invalid_argument(
+                "content_drift",
+                format!(
+                    "Refusing to overwrite remote-only content changes for '{}' at {}",
+                    prepared.component.id, prepared.install_dir
+                ),
+                None,
+                Some(vec![
+                    "Review the bounded content_manifest differences with `homeboy deploy --check` first".to_string(),
+                    "Use the existing explicit --force --apply boundary only after that review".to_string(),
+                ]),
+            ));
+        }
+    }
 
     // Execute deployments only after every component passed the local preflight.
     let mut results: Vec<ComponentDeployResult> = vec![];

--- a/crates/homeboy-release/src/deploy/orchestration/modes.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/modes.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::project::Project;
+use homeboy_core::server::SshClient;
 
 use super::super::execution::{release_artifact_plan, ReleaseArtifactPlan};
 use super::super::orchestration_ref_checkout::resolve_exact_ref;
@@ -25,14 +26,31 @@ pub(super) fn run_check_mode(
     project: &Project,
     base_path: &str,
     config: &DeployConfig,
+    client: &SshClient,
 ) -> DeployOrchestrationResult {
     let mut git_probe_cache = GitProbeCache::default();
     let mut results: Vec<ComponentDeployResult> = components
         .iter()
         .map(|c| {
-            let status =
+            let mut status =
                 calculate_component_status_with_git_cache(c, remote_versions, &mut git_probe_cache);
             let release_state = calculate_release_state(c);
+            let manifest = super::super::content_manifest::compare(
+                std::path::Path::new(&c.local_path),
+                &super::super::path_roots::resolve_effective_remote_path(project, c, base_path)
+                    .unwrap_or_default(),
+                client,
+            );
+            if manifest.status == "missing" {
+                status = ComponentStatus::Missing;
+            } else if manifest.status == "different" && matches!(status, ComponentStatus::UpToDate)
+            {
+                status = ComponentStatus::RemoteModified;
+            } else if manifest.status == "different"
+                && matches!(status, ComponentStatus::BehindRemote)
+            {
+                status = ComponentStatus::MixedDrift;
+            }
             let mut result = ComponentDeployResult::new_for_project(c, project, base_path)
                 .with_status("checked")
                 .with_versions(
@@ -40,6 +58,7 @@ pub(super) fn run_check_mode(
                     remote_versions.get(&c.id).cloned(),
                 )
                 .with_component_status(status)
+                .with_content_manifest(manifest)
                 .with_source_identity(c, config.head);
             if let Some(state) = release_state {
                 result = result.with_release_state(state);
@@ -607,6 +626,7 @@ mod tests {
             &Project::default(),
             "/srv/site",
             &config,
+            &local_client(),
         );
         assert_eq!(checked.results[0].status, "checked");
         assert_eq!(checked.results[0].local_version.as_deref(), Some("1.2.3"));
@@ -637,6 +657,18 @@ mod tests {
             "{}",
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn local_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "test".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: Default::default(),
+        }
     }
 
     fn git_output(path: &Path, args: &[&str]) -> String {

--- a/crates/homeboy-release/src/deploy/orchestration/modes.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/modes.rs
@@ -46,8 +46,7 @@ pub(super) fn run_check_mode(
             } else if manifest.status == "different" && matches!(status, ComponentStatus::UpToDate)
             {
                 status = ComponentStatus::RemoteModified;
-            } else if manifest.status == "different"
-                && matches!(status, ComponentStatus::BehindRemote)
+            } else if manifest.status == "different" && !matches!(status, ComponentStatus::UpToDate)
             {
                 status = ComponentStatus::MixedDrift;
             }

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -953,10 +953,13 @@ mod tests {
             ComponentStatus::BehindRemote,
             ComponentStatus::BehindUpstream,
             ComponentStatus::SourceStale,
+            ComponentStatus::RemoteModified,
+            ComponentStatus::MixedDrift,
             ComponentStatus::Unknown,
         ] {
             assert!(!status.requires_deploy());
         }
+        assert!(ComponentStatus::Missing.requires_deploy());
     }
 
     #[test]

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -426,6 +426,20 @@ pub fn compare_deployed_versions(
 // homeboy-release-contract (see the DeployReason/ComponentStatus note above).
 pub use homeboy_release_contract::{ReleaseState, ReleaseStateBuckets, ReleaseStateStatus};
 
+/// Bounded, portable evidence from a local/remote tree comparison.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContentManifestComparison {
+    pub algorithm: String,
+    pub scope: String,
+    pub local_digest: Option<String>,
+    pub remote_digest: Option<String>,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub differences: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
+}
+
 /// Result for a single component deployment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 
@@ -436,6 +450,8 @@ pub struct ComponentDeployResult {
     pub deploy_reason: Option<DeployReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_status: Option<ComponentStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_manifest: Option<ContentManifestComparison>,
     pub local_version: Option<String>,
     pub remote_version: Option<String>,
     pub local_path: Option<String>,
@@ -498,6 +514,7 @@ impl ComponentDeployResult {
             status: String::new(),
             deploy_reason: None,
             component_status: None,
+            content_manifest: None,
             local_version: None,
             remote_version: None,
             local_path: Some(component.local_path.clone()),
@@ -594,6 +611,11 @@ impl ComponentDeployResult {
 
     pub(super) fn with_component_status(mut self, status: ComponentStatus) -> Self {
         self.component_status = Some(status);
+        self
+    }
+
+    pub(super) fn with_content_manifest(mut self, manifest: ContentManifestComparison) -> Self {
+        self.content_manifest = Some(manifest);
         self
     }
 


### PR DESCRIPTION
## Summary
- Compare deploy source and target trees with deterministic SHA-256 manifest evidence during checks.
- Report bounded differing relative paths and distinguish remote modification, missing target, and mixed drift.
- Refuse same-version directory overwrites after a fresh pre-write probe unless the existing explicit `--force --apply` boundary is used.

Closes #10058

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-release`
- `cargo test -p homeboy-release content_manifest`

## AI assistance
GPT-5.6 Terra via OpenCode drafted the content-manifest implementation, tests, and integration changes. Chris Huber remains responsible for review and every line.