### PR TITLE
Fix canonical agent-task patch status

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -11,6 +11,7 @@ use super::{CmdResult, GlobalArgs};
 
 pub mod args;
 pub mod auth;
+pub(crate) mod candidate;
 pub mod contract;
 pub mod controller;
 pub mod doctor;

--- a/crates/homeboy-cli/src/commands/agent_task/candidate.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/candidate.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CandidateState {
     PatchAvailable,
+    NoChangesProduced,
     Empty,
     Missing,
     Unreadable,
@@ -23,6 +24,7 @@ impl CandidateState {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::PatchAvailable => "patch_available",
+            Self::NoChangesProduced => "no_changes_produced",
             Self::Empty => "empty",
             Self::Missing => "missing",
             Self::Unreadable => "unreadable",
@@ -47,6 +49,7 @@ pub(crate) struct CandidateCounts {
     pub(crate) retained_only: usize,
     pub(crate) unknown: usize,
     pub(crate) diff_bytes: u64,
+    no_changes_produced: bool,
 }
 
 impl CandidateCounts {
@@ -63,6 +66,8 @@ impl CandidateCounts {
             CandidateState::RetainedOnly
         } else if self.empty > 0 {
             CandidateState::Empty
+        } else if self.no_changes_produced {
+            CandidateState::NoChangesProduced
         } else {
             CandidateState::Unknown
         }
@@ -74,6 +79,7 @@ impl CandidateCounts {
                 self.available += 1;
                 self.diff_bytes += size.unwrap_or_default();
             }
+            CandidateState::NoChangesProduced => self.no_changes_produced = true,
             CandidateState::Empty => self.empty += 1,
             CandidateState::Missing => self.missing += 1,
             CandidateState::Unreadable => self.unreadable += 1,
@@ -135,7 +141,13 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateCounts {
         } else {
             match size {
                 Some(0) => CandidateState::Empty,
-                Some(_) if !using_canonical || readable_mirror(artifact) => {
+                // Finalization records the immutable aggregate only after Homeboy
+                // owns the artifact. Status must trust that durable fact rather
+                // than probing a possibly remote or evicted path.
+                Some(_)
+                    if !using_canonical
+                        || (is_canonical_mirror(artifact) && declared_location(artifact)) =>
+                {
                     CandidateState::PatchAvailable
                 }
                 Some(_) if declared_location(artifact) => CandidateState::Unreadable,
@@ -145,6 +157,13 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateCounts {
         };
         counts.record(state, size);
     }
+    counts.no_changes_produced = counts.available == 0
+        && counts.empty == 0
+        && counts.missing == 0
+        && counts.unreadable == 0
+        && counts.conflicting == 0
+        && counts.retained_only == 0
+        && aggregate_outcomes_are_no_op(payload);
     counts
 }
 
@@ -162,6 +181,19 @@ fn aggregate_artifacts(payload: &Value) -> Vec<&Value> {
                 .flatten()
         })
         .collect()
+}
+
+fn aggregate_outcomes_are_no_op(payload: &Value) -> bool {
+    let Some(outcomes) = payload
+        .pointer("/aggregate/outcomes")
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    !outcomes.is_empty()
+        && outcomes
+            .iter()
+            .all(|outcome| outcome.get("status").and_then(Value::as_str) == Some("no_op"))
 }
 
 fn is_patch(artifact: &Value) -> bool {
@@ -191,17 +223,6 @@ fn declared_location(artifact: &Value) -> bool {
             .get("url")
             .and_then(Value::as_str)
             .is_some_and(|url| !url.trim().is_empty())
-}
-
-fn readable_mirror(artifact: &Value) -> bool {
-    artifact
-        .get("url")
-        .and_then(Value::as_str)
-        .is_some_and(|url| url.starts_with("homeboy://agent-task/run/"))
-        || artifact
-            .get("path")
-            .and_then(Value::as_str)
-            .is_some_and(|path| std::fs::metadata(path).is_ok())
 }
 
 #[cfg(test)]
@@ -244,7 +265,7 @@ mod tests {
             (
                 "artifact_evicted",
                 json!({ "id": "evicted", "kind": "patch", "size_bytes": 1, "path": "/definitely-evicted-lab-patch", "metadata": { "executor_artifact_finalized": true } }),
-                CandidateState::Unreadable,
+                CandidateState::PatchAvailable,
             ),
             (
                 "retained_only",

--- a/crates/homeboy-cli/src/commands/agent_task/candidate.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/candidate.rs
@@ -1,0 +1,270 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CandidateState {
+    PatchAvailable,
+    Empty,
+    Missing,
+    Unreadable,
+    Conflicting,
+    RetainedOnly,
+    Unknown,
+}
+
+impl Default for CandidateState {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+impl CandidateState {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::PatchAvailable => "patch_available",
+            Self::Empty => "empty",
+            Self::Missing => "missing",
+            Self::Unreadable => "unreadable",
+            Self::Conflicting => "conflicting",
+            Self::RetainedOnly => "retained_only",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub(crate) fn is_recoverable(self) -> bool {
+        self == Self::PatchAvailable
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct CandidateCounts {
+    pub(crate) available: usize,
+    pub(crate) empty: usize,
+    pub(crate) missing: usize,
+    pub(crate) unreadable: usize,
+    pub(crate) conflicting: usize,
+    pub(crate) retained_only: usize,
+    pub(crate) unknown: usize,
+    pub(crate) diff_bytes: u64,
+}
+
+impl CandidateCounts {
+    pub(crate) fn state(self) -> CandidateState {
+        if self.available > 0 {
+            CandidateState::PatchAvailable
+        } else if self.conflicting > 0 {
+            CandidateState::Conflicting
+        } else if self.unreadable > 0 {
+            CandidateState::Unreadable
+        } else if self.missing > 0 {
+            CandidateState::Missing
+        } else if self.retained_only > 0 {
+            CandidateState::RetainedOnly
+        } else if self.empty > 0 {
+            CandidateState::Empty
+        } else {
+            CandidateState::Unknown
+        }
+    }
+
+    fn record(&mut self, state: CandidateState, size: Option<u64>) {
+        match state {
+            CandidateState::PatchAvailable => {
+                self.available += 1;
+                self.diff_bytes += size.unwrap_or_default();
+            }
+            CandidateState::Empty => self.empty += 1,
+            CandidateState::Missing => self.missing += 1,
+            CandidateState::Unreadable => self.unreadable += 1,
+            CandidateState::Conflicting => self.conflicting += 1,
+            CandidateState::RetainedOnly => self.retained_only += 1,
+            CandidateState::Unknown => self.unknown += 1,
+        }
+    }
+}
+
+/// Classify promotion candidates from immutable aggregate artifacts. Finalized
+/// mirrored artifacts are authoritative; runner-local refs are only a fallback
+/// when no such artifact exists, so stale aliases cannot downgrade recovery.
+pub(crate) fn classify_candidates(payload: &Value) -> CandidateCounts {
+    let artifacts = aggregate_artifacts(payload);
+    let canonical: Vec<&Value> = artifacts
+        .iter()
+        .copied()
+        .filter(|artifact| is_patch(artifact) && is_canonical_mirror(artifact))
+        .collect();
+    let using_canonical = !canonical.is_empty();
+    let artifacts = if !using_canonical {
+        artifacts
+            .iter()
+            .copied()
+            .filter(|artifact| is_patch(artifact))
+            .collect()
+    } else {
+        canonical
+    };
+
+    let mut by_identity: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
+    for artifact in artifacts {
+        let identity = artifact
+            .get("id")
+            .or_else(|| artifact.get("artifact_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("unnamed")
+            .to_string();
+        by_identity.entry(identity).or_default().push(artifact);
+    }
+
+    let mut counts = CandidateCounts::default();
+    for artifacts in by_identity.into_values() {
+        let artifact = artifacts[0];
+        let size = artifact.get("size_bytes").and_then(Value::as_u64);
+        let conflicting = artifacts.iter().skip(1).any(|other| {
+            other.get("size_bytes") != artifact.get("size_bytes")
+                || other.get("sha256") != artifact.get("sha256")
+        });
+        let state = if conflicting {
+            CandidateState::Conflicting
+        } else if artifact
+            .pointer("/metadata/review_only")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            CandidateState::RetainedOnly
+        } else {
+            match size {
+                Some(0) => CandidateState::Empty,
+                Some(_) if !using_canonical || readable_mirror(artifact) => {
+                    CandidateState::PatchAvailable
+                }
+                Some(_) if declared_location(artifact) => CandidateState::Unreadable,
+                Some(_) => CandidateState::Missing,
+                None => CandidateState::Unknown,
+            }
+        };
+        counts.record(state, size);
+    }
+    counts
+}
+
+fn aggregate_artifacts(payload: &Value) -> Vec<&Value> {
+    payload
+        .pointer("/aggregate/outcomes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .flat_map(|outcome| {
+            outcome
+                .get("artifacts")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .collect()
+}
+
+fn is_patch(artifact: &Value) -> bool {
+    matches!(
+        artifact.get("kind").and_then(Value::as_str),
+        Some("patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact")
+    )
+}
+
+fn is_canonical_mirror(artifact: &Value) -> bool {
+    artifact
+        .pointer("/metadata/executor_artifact_finalized")
+        .and_then(Value::as_bool)
+        == Some(true)
+        || artifact
+            .get("url")
+            .and_then(Value::as_str)
+            .is_some_and(|url| url.starts_with("homeboy://agent-task/run/"))
+}
+
+fn declared_location(artifact: &Value) -> bool {
+    artifact
+        .get("path")
+        .and_then(Value::as_str)
+        .is_some_and(|path| !path.trim().is_empty())
+        || artifact
+            .get("url")
+            .and_then(Value::as_str)
+            .is_some_and(|url| !url.trim().is_empty())
+}
+
+fn readable_mirror(artifact: &Value) -> bool {
+    artifact
+        .get("url")
+        .and_then(Value::as_str)
+        .is_some_and(|url| url.starts_with("homeboy://agent-task/run/"))
+        || artifact
+            .get("path")
+            .and_then(Value::as_str)
+            .is_some_and(|path| std::fs::metadata(path).is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn lab_fixture(artifacts: Vec<Value>) -> Value {
+        json!({
+            "aggregate": { "outcomes": [{ "task_id": "cook-intelligence", "artifacts": artifacts }] },
+            "artifact_refs": [{ "task_id": "cook-intelligence", "kind": "patch", "uri": "runner-artifact://stale-alias" }]
+        })
+    }
+
+    fn mirrored_patch(id: &str, size_bytes: u64) -> Value {
+        json!({
+            "id": id,
+            "kind": "patch",
+            "size_bytes": size_bytes,
+            "sha256": "f".repeat(64),
+            "url": format!("homeboy://agent-task/run/lab-restarted/artifacts#task=cook-intelligence&artifact={id}"),
+            "metadata": { "executor_artifact_finalized": true, "source_provenance": { "runner_id": "homeboy-lab" } }
+        })
+    }
+
+    #[test]
+    fn lab_fixtures_keep_canonical_mirror_authoritative_across_restart_and_eviction() {
+        let available = classify_candidates(&lab_fixture(vec![mirrored_patch("patch", 32_318)]));
+        assert_eq!(available.state(), CandidateState::PatchAvailable);
+        assert_eq!(available.available, 1);
+        assert_eq!(available.diff_bytes, 32_318);
+
+        let fixtures = [
+            ("empty", mirrored_patch("empty", 0), CandidateState::Empty),
+            (
+                "missing",
+                json!({ "id": "missing", "kind": "patch", "size_bytes": 1, "metadata": { "executor_artifact_finalized": true } }),
+                CandidateState::Missing,
+            ),
+            (
+                "artifact_evicted",
+                json!({ "id": "evicted", "kind": "patch", "size_bytes": 1, "path": "/definitely-evicted-lab-patch", "metadata": { "executor_artifact_finalized": true } }),
+                CandidateState::Unreadable,
+            ),
+            (
+                "retained_only",
+                json!({ "id": "retained", "kind": "patch", "size_bytes": 1, "url": "homeboy://agent-task/run/lab/artifacts#task=cook&artifact=retained", "metadata": { "executor_artifact_finalized": true, "review_only": true } }),
+                CandidateState::RetainedOnly,
+            ),
+        ];
+        for (name, artifact, expected) in fixtures {
+            assert_eq!(
+                classify_candidates(&lab_fixture(vec![artifact])).state(),
+                expected,
+                "{name}"
+            );
+        }
+
+        let first = mirrored_patch("conflict", 32_318);
+        let second = mirrored_patch("conflict", 1);
+        assert_eq!(
+            classify_candidates(&lab_fixture(vec![first, second])).state(),
+            CandidateState::Conflicting
+        );
+    }
+}

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -970,6 +970,7 @@ pub(crate) fn execution_states_from_aggregate(
     let review =
         homeboy::agents::agent_tasks::AgentTaskAggregateReport::from(aggregate.outcomes.clone());
     let canonical = classify_candidates(&json!({ "aggregate": aggregate }));
+    let candidate_state = canonical.state();
     let provider = aggregate
         .outcomes
         .iter()
@@ -1000,6 +1001,11 @@ pub(crate) fn execution_states_from_aggregate(
         .map(|task| {
             let reason_code = if task.status == AgentTaskOutcomeStatus::NoOp {
                 "no_changes_produced"
+            } else if candidate_state != CandidateState::PatchAvailable
+                && task.decision
+                    == homeboy::agents::agent_tasks::AgentTaskReconciliationDecision::ApplyCandidate
+            {
+                candidate_state.as_str()
             } else {
                 match task.decision {
                 homeboy::agents::agent_tasks::AgentTaskReconciliationDecision::NoOp => {
@@ -1058,7 +1064,7 @@ pub(crate) fn execution_states_from_aggregate(
         "schema": "homeboy/agent-task-execution-states/v1",
         "provider": provider,
         "candidate": {
-            "state": canonical.state().as_str(),
+            "state": candidate_state.as_str(),
             "tasks": candidates,
         },
         "gate": {

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -23,6 +23,7 @@ use super::args::{
     CancelArgs, DiagnoseArgs, EvidenceArgs, LogsArgs, ReplayProviderBoundaryArgs,
     RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs,
 };
+use super::candidate::{classify_candidates, CandidateState};
 use crate::commands::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandNextAction, CommandNextActionKind,
     CommandResultRefs, ACTIONABLE_METADATA_KEY,
@@ -200,10 +201,13 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
         ..Default::default()
     };
 
-    let review_command = format!("homeboy agent-task review {run_id}");
-    metadata.next_actions.push(
-        CommandNextAction::new("review run", review_command).with_kind(CommandNextActionKind::Show),
-    );
+    if classify_candidates(value).state().is_recoverable() {
+        let review_command = format!("homeboy agent-task review {run_id}");
+        metadata.next_actions.push(
+            CommandNextAction::new("review run", review_command)
+                .with_kind(CommandNextActionKind::Show),
+        );
+    }
 
     if let Some(command) = transport_proxy_recovery_command(value) {
         metadata.next_actions.push(
@@ -932,6 +936,7 @@ fn enrich_with_diagnostic_summary(value: &mut Value, run_id: &str) -> homeboy::c
         value["failure_reasons"] = Value::Array(failure_reasons);
     }
     value["execution_states"] = execution_states_from_aggregate(&aggregate, value);
+    value["aggregate"] = serde_json::to_value(&aggregate).unwrap_or(Value::Null);
     Ok(())
 }
 
@@ -964,6 +969,7 @@ pub(crate) fn execution_states_from_aggregate(
 ) -> Value {
     let review =
         homeboy::agents::agent_tasks::AgentTaskAggregateReport::from(aggregate.outcomes.clone());
+    let canonical = classify_candidates(&json!({ "aggregate": aggregate }));
     let provider = aggregate
         .outcomes
         .iter()
@@ -1052,13 +1058,7 @@ pub(crate) fn execution_states_from_aggregate(
         "schema": "homeboy/agent-task-execution-states/v1",
         "provider": provider,
         "candidate": {
-            "state": if review.summary.apply_candidates > 0 {
-                "patch_available"
-            } else if review.summary.no_op > 0 {
-                "no_changes_produced"
-            } else {
-                "not_available"
-            },
+            "state": canonical.state().as_str(),
             "tasks": candidates,
         },
         "gate": {
@@ -1495,6 +1495,7 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
         .and_then(|queue| queue.get("state"))
         .and_then(Value::as_str)
         == Some("waiting_for_capacity");
+    let candidate_recoverable = classify_candidates(record).state().is_recoverable();
 
     // A local cook runs the provider in an in-process thread, so it has neither
     // provider handles nor a runner job id. `reserve_provider_execution` still
@@ -1521,7 +1522,7 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
         },
         "stale_reason": metadata.get("stale_running_reason"),
         "runner_queue": metadata.get("runner_queue"),
-        "next_action": if terminal {
+        "next_action": if terminal && candidate_recoverable {
             format!("homeboy agent-task review {run_id}")
         } else if stale {
             format!("homeboy agent-task reconcile {} --dry-run", quote_arg(run_id))
@@ -1794,16 +1795,28 @@ fn work_summary(
     let committed_changes = provider_committed_changes(record)
         || aggregate.is_some_and(aggregate_has_committed_changes)
         || latest_promotion.is_some_and(promotion_reports_committed_changes);
+    let canonical = classify_candidates(&json!({ "aggregate": aggregate }));
     let classification = work_classification(
         record,
         promotion_status,
         artifact_ref_count,
         evidence_ref_count,
         committed_changes,
+        canonical.state(),
     );
 
     json!({
         "classification": classification,
+        "candidate_state": canonical.state().as_str(),
+        "candidate_counts": {
+            "patch_available": canonical.available,
+            "empty": canonical.empty,
+            "missing": canonical.missing,
+            "unreadable": canonical.unreadable,
+            "conflicting": canonical.conflicting,
+            "retained_only": canonical.retained_only,
+            "unknown": canonical.unknown,
+        },
         "provider_execution_status": provider_status,
         "promotion_status": promotion_status,
         "artifact_ref_count": artifact_ref_count,
@@ -1845,9 +1858,13 @@ fn work_classification(
     artifact_ref_count: usize,
     evidence_ref_count: usize,
     committed_changes: bool,
+    candidate_state: CandidateState,
 ) -> &'static str {
     if committed_changes && promotion_status.is_some_and(is_no_change_promotion_status) {
         return "committed_changes_pending_promotion";
+    }
+    if candidate_state == CandidateState::PatchAvailable {
+        return "provider_completed_patch_available";
     }
     if promotion_status.is_some_and(is_no_change_promotion_status) {
         if artifact_ref_count == 0 && evidence_ref_count == 0 {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -842,6 +842,32 @@ fn execution_states_distinguish_patch_noop_provider_failure_and_gate_failure() {
     assert_eq!(patch["gate"]["state"], "passed");
     assert_eq!(patch["promotion"]["state"], "applied");
 
+    let missing = execution_states(
+        fixture_execution_outcome(
+            AgentTaskOutcomeStatus::Succeeded,
+            None,
+            vec![AgentTaskArtifact {
+                schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "missing-patch".to_string(),
+                kind: "patch".to_string(),
+                name: None,
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: None,
+                url: None,
+                mime: None,
+                size_bytes: Some(1),
+                sha256: None,
+                metadata: json!({ "executor_artifact_finalized": true }),
+            }],
+            Value::Null,
+        ),
+        "not_attempted",
+    );
+    assert_eq!(missing["candidate"]["state"], "missing");
+    assert_eq!(missing["candidate"]["tasks"][0]["reason_code"], "missing");
+
     let no_op_aggregate = aggregate_for_execution_outcome(fixture_execution_outcome(
         AgentTaskOutcomeStatus::NoOp,
         None,

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 
+use super::agent_task::candidate::{classify_candidates, CandidateState};
 use super::agent_task::{AgentTaskArgs, AgentTaskCommand, AgentTaskControllerCommand};
 use super::summary_json::{array_len, string_value, u64_value, usize_value, value_at};
 
@@ -88,7 +89,7 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     if let Some(artifact) = first_artifact {
         lines.push(format!("First artifact: {artifact}"));
     }
-    if metrics.non_empty_patches > 0 {
+    if metrics.candidate_state == CandidateState::PatchAvailable {
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
     } else {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
@@ -118,8 +119,10 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Diagnostic: {diagnostic}"));
     }
     lines.push(format!("Artifacts: {artifact_count}"));
-    if let Some(path) = aggregate_path.filter(|_| metrics.non_empty_patches > 0) {
-        lines.push(format!("Aggregate: {path}"));
+    if metrics.candidate_state == CandidateState::PatchAvailable {
+        if let Some(path) = aggregate_path {
+            lines.push(format!("Aggregate: {path}"));
+        }
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
     } else if state == "queued" && !is_transport_proxy(payload) {
         lines.push(format!("Next: homeboy agent-task run {run_id}"));
@@ -280,6 +283,7 @@ struct CodeProductionMetrics {
     /// unparseable). Used to render `unknown` instead of a misleading verified
     /// zero (#9742).
     changed_files_unknown_patches: usize,
+    candidate_state: CandidateState,
 }
 
 fn code_production_lines(metrics: &CodeProductionMetrics) -> Vec<String> {
@@ -308,6 +312,7 @@ fn code_production_lines(metrics: &CodeProductionMetrics) -> Vec<String> {
     };
     vec![
         patch_candidates,
+        format!("Candidate state: {}", metrics.candidate_state.as_str()),
         changed_files,
         format!("Diff bytes: {}", metrics.diff_bytes),
     ]
@@ -315,6 +320,19 @@ fn code_production_lines(metrics: &CodeProductionMetrics) -> Vec<String> {
 
 fn code_production_metrics(payload: &Value) -> CodeProductionMetrics {
     let mut metrics = CodeProductionMetrics::default();
+    let canonical = classify_candidates(payload);
+    if canonical.state() != CandidateState::Unknown {
+        metrics.non_empty_patches = canonical.available;
+        metrics.empty_patches = canonical.empty;
+        metrics.unknown_size_patches = canonical.unknown
+            + canonical.missing
+            + canonical.unreadable
+            + canonical.conflicting
+            + canonical.retained_only;
+        metrics.diff_bytes = canonical.diff_bytes;
+        metrics.candidate_state = canonical.state();
+        return metrics;
+    }
     for patch in collect_patch_artifacts(payload) {
         match patch.size_bytes {
             Some(size) if size > 0 => {
@@ -329,6 +347,13 @@ fn code_production_metrics(payload: &Value) -> CodeProductionMetrics {
             None => metrics.unknown_size_patches += 1,
         }
     }
+    metrics.candidate_state = if metrics.non_empty_patches > 0 {
+        CandidateState::PatchAvailable
+    } else if metrics.empty_patches > 0 {
+        CandidateState::Empty
+    } else {
+        CandidateState::Unknown
+    };
     metrics
 }
 
@@ -1171,6 +1196,28 @@ mod tests {
         assert!(summary.contains("Diff bytes: 683500\n"));
         assert!(summary.contains("Artifacts: 4\n"));
         assert!(summary.contains("Next: homeboy agent-task review recovered\n"));
+    }
+
+    #[test]
+    fn lab_restart_summary_uses_the_32318_byte_canonical_mirror_not_a_stale_alias() {
+        let payload = json!({
+            "run_id": "lab-restarted",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cook-intelligence", "state": "succeeded" }],
+            "artifact_refs": [{ "task_id": "cook-intelligence", "kind": "patch", "uri": "runner-artifact://stale-alias" }],
+            "aggregate": { "outcomes": [{ "task_id": "cook-intelligence", "artifacts": [{
+                "id": "patch", "kind": "patch", "size_bytes": 32318,
+                "url": "homeboy://agent-task/run/lab-restarted/artifacts#task=cook-intelligence&artifact=patch",
+                "metadata": { "executor_artifact_finalized": true, "source_provenance": { "runner_id": "homeboy-lab" } }
+            }] }] }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("Status: succeeded\n"));
+        assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
+        assert!(summary.contains("Diff bytes: 32318\n"));
+        assert!(summary.contains("Next: homeboy agent-task review lab-restarted\n"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -43,6 +43,7 @@ pub(super) fn agent_task_resource_behavior(
             AgentTaskResourceBehavior::LocalControl
         }
         agent_task::AgentTaskCommand::Cook(_)
+        | agent_task::AgentTaskCommand::CookContinue(_)
         | agent_task::AgentTaskCommand::RunPlan(_)
         | agent_task::AgentTaskCommand::Run(_)
         | agent_task::AgentTaskCommand::RunNext


### PR DESCRIPTION
## Summary
- classify aggregate patch candidates once, prioritizing finalized Homeboy mirrors over runner-local aliases
- use that classification for text summaries, execution states, work summaries, and review actions
- cover the 32,318-byte Lab restart case plus empty, missing, unreadable/evicted, conflicting, and retained-only artifacts

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli lab_fixtures_keep_canonical_mirror_authoritative_across_restart_and_eviction`
- `cargo test -p homeboy-cli lab_restart_summary_uses_the_32318_byte_canonical_mirror_not_a_stale_alias`

Closes #9957

## AI assistance
OpenCode, using OpenAI GPT-5.6 Terra, was used to inspect the existing status paths, implement the shared candidate classifier and tests, and validate the targeted Rust test suite. Chris Huber remains responsible for every line.