### PR TITLE
fix(fuzz): keep rig list local

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
@@ -11,7 +11,7 @@ use homeboy_extension::ExtensionCapability;
 use super::super::{CmdResult, GlobalArgs};
 use super::compare::run_compare;
 use super::doctor::run_doctor;
-use super::execution::{fuzz_prepare_failure_message, run_run};
+use super::execution::run_run;
 use super::inspect::run_inspect;
 use super::planning::{run_campaign, run_plan};
 use super::replay::{run_minimize, run_replay};
@@ -19,7 +19,8 @@ use super::report::{run_report, run_validate};
 use super::stable::run_stable;
 use super::types::{
     FuzzArgs, FuzzCommand, FuzzContractOutput, FuzzDiscoverArgs, FuzzDiscoverOutput,
-    FuzzDiscoverSummary, FuzzListArgs, FuzzListOutput, FuzzOutput,
+    FuzzDiscoverSummary, FuzzListArgs, FuzzListComponentMapping, FuzzListDiagnostics,
+    FuzzListOutput, FuzzOutput,
 };
 use super::workloads::{fuzz_workloads, load_rig, resolve_component_id, resolve_fuzz_context};
 
@@ -166,18 +167,6 @@ pub(super) fn run_contract() -> FuzzContractOutput {
 
 pub(super) fn run_list(args: FuzzListArgs) -> homeboy::core::Result<FuzzListOutput> {
     let rig_context = load_rig(args.rig.as_deref(), &args.setting_args)?;
-    if let Some(context) = rig_context.as_ref() {
-        let prepare_settings = fuzz_list_prepare_settings(&args);
-        if let Some(prepare) = homeboy::rig::run_fuzz_prepare(&context.spec, &prepare_settings)? {
-            if !prepare.success {
-                return Err(homeboy::core::Error::rig_pipeline_failed(
-                    &context.spec.id,
-                    "fuzz_prepare",
-                    fuzz_prepare_failure_message(&prepare),
-                ));
-            }
-        }
-    }
     let effective_id = resolve_component_id(
         &args.comp,
         rig_context.as_ref().map(|context| &context.spec),
@@ -195,27 +184,78 @@ pub(super) fn run_list(args: FuzzListArgs) -> homeboy::core::Result<FuzzListOutp
         rig_context.as_ref(),
         ctx.extension_id.as_deref(),
     );
+    let mut ambiguity = Vec::new();
+    if let Some(context) = rig_context.as_ref() {
+        let extensions = homeboy::rig::extension_ids_for_workloads(
+            &context.spec,
+            homeboy::rig::RigWorkloadKind::Fuzz,
+        );
+        if extensions.len() > 1 && ctx.extension_id.is_none() {
+            ambiguity.push(format!(
+                "rig declares multiple fuzz workload extensions: {}",
+                extensions.join(", ")
+            ));
+        }
+    }
+    let mut workload_ids = workloads
+        .iter()
+        .map(|workload| workload.id.as_str())
+        .collect::<Vec<_>>();
+    workload_ids.sort_unstable();
+    for duplicate in workload_ids
+        .windows(2)
+        .filter_map(|ids| (ids[0] == ids[1]).then_some(ids[0]))
+    {
+        ambiguity.push(format!("duplicate declared fuzz workload id: {duplicate}"));
+    }
+    let rig_package = rig_context
+        .as_ref()
+        .and_then(|context| homeboy::rig::package_evidence(&context.spec.id));
+    if let Some(package) = rig_package
+        .as_ref()
+        .filter(|package| !package.freshness_verified)
+    {
+        ambiguity.push(format!(
+            "rig package freshness is {:?}: {}",
+            package.freshness,
+            package
+                .freshness_message
+                .as_deref()
+                .unwrap_or("source revision could not be verified")
+        ));
+    }
 
     Ok(FuzzListOutput {
         command: "fuzz.list".to_string(),
-        component: ctx.component_id,
+        component: ctx.component_id.clone(),
         rig_id: rig_context.map(|context| context.spec.id),
+        rig_package,
+        component_mapping: FuzzListComponentMapping {
+            requested_component: args.comp.id().map(str::to_string),
+            resolved_component: effective_id,
+            path: ctx.component.local_path.clone(),
+        },
+        extension_provider: ctx.extension_id.clone(),
         count: workloads.len(),
         workloads,
+        diagnostics: FuzzListDiagnostics {
+            completeness: if ambiguity.is_empty() {
+                "complete".to_string()
+            } else if ambiguity
+                .iter()
+                .any(|message| message.starts_with("rig package freshness"))
+            {
+                "incomplete".to_string()
+            } else {
+                "ambiguous".to_string()
+            },
+            ambiguity,
+            executable_availability: if args.remote_discovery {
+                "runner_discovered".to_string()
+            } else {
+                "not_requested".to_string()
+            },
+        },
         run_hint: "Select one workload with `homeboy fuzz run <component> --workload <id>`; offload heavy campaigns with the global `--runner <id>` flag when configured.".to_string(),
     })
-}
-
-fn fuzz_list_prepare_settings(args: &FuzzListArgs) -> Vec<(String, String)> {
-    args.setting_args
-        .setting
-        .iter()
-        .cloned()
-        .chain(
-            args.setting_args
-                .setting_json
-                .iter()
-                .map(|(key, value)| (key.clone(), value.to_string())),
-        )
-        .collect()
 }

--- a/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
@@ -251,7 +251,7 @@ pub(super) fn run_list(args: FuzzListArgs) -> homeboy::core::Result<FuzzListOutp
             },
             ambiguity,
             executable_availability: if args.remote_discovery {
-                "runner_discovered".to_string()
+                "remote_discovery_requested".to_string()
             } else {
                 "not_requested".to_string()
             },

--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -20,9 +20,9 @@ use super::report::{
 };
 use super::types::{
     FuzzCommand, FuzzDiscoverArgs, FuzzExecutionOutput, FuzzGateProfileArg, FuzzIsolationArg,
-    FuzzListArgs, FuzzListOutput, FuzzMinimizeArgs, FuzzOutput, FuzzPlanArgs, FuzzPlanStrategy,
-    FuzzReplayArgs, FuzzReportArgs, FuzzRunArgs, FuzzRunOutput, FuzzRunnerContract,
-    FuzzValidateArgs, FuzzWorkloadOutput,
+    FuzzListArgs, FuzzListComponentMapping, FuzzListDiagnostics, FuzzListOutput, FuzzMinimizeArgs,
+    FuzzOutput, FuzzPlanArgs, FuzzPlanStrategy, FuzzReplayArgs, FuzzReportArgs, FuzzRunArgs,
+    FuzzRunOutput, FuzzRunnerContract, FuzzValidateArgs, FuzzWorkloadOutput,
 };
 use super::workloads::{
     fuzz_workloads, resolve_component_id, resolve_fuzz_context, resolve_profile_workload_id,

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -15,6 +15,11 @@ fn lab_workload_arguments_follow_subcommands_and_option_values() {
         cli.args.lab_rig_workload_arguments().unwrap().component,
         None
     );
+    assert!(!cli.args.is_lab_offload_command());
+
+    let cli = FuzzCli::try_parse_from(["fuzz", "list", "--rig", "r", "--remote-discovery"])
+        .expect("remote discovery should parse");
+    assert!(cli.args.is_lab_offload_command());
 }
 
 #[test]
@@ -1297,8 +1302,20 @@ fn fuzz_output_contract_has_stable_variant_discriminators() {
         command: "fuzz.list".to_string(),
         component: "component-a".to_string(),
         rig_id: None,
+        rig_package: None,
+        component_mapping: FuzzListComponentMapping {
+            requested_component: None,
+            resolved_component: "component-a".to_string(),
+            path: "/tmp/component-a".to_string(),
+        },
+        extension_provider: None,
         workloads: Vec::new(),
         count: 0,
+        diagnostics: FuzzListDiagnostics {
+            completeness: "complete".to_string(),
+            ambiguity: Vec::new(),
+            executable_availability: "not_requested".to_string(),
+        },
         run_hint: "hint".to_string(),
     }))
     .unwrap();

--- a/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
@@ -411,6 +411,31 @@ fn fuzz_list_ignores_prepare_step_failure() {
 }
 
 #[test]
+fn fuzz_list_marks_forced_local_remote_discovery_as_requested() {
+    with_isolated_home(|home| {
+        let component_dir = home.path().join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        write_generic_fuzz_extension(home.path());
+        write_fuzz_prepare_rig(
+            home.path(),
+            &component_dir,
+            "false",
+            "runtime/ready.txt",
+            "materialize runtime dependency",
+        );
+        let mut args = fuzz_list_args();
+        args.remote_discovery = true;
+
+        let output = run_list(args).expect("local metadata listing should not prepare");
+
+        assert_eq!(
+            output.diagnostics.executable_availability,
+            "remote_discovery_requested"
+        );
+    });
+}
+
+#[test]
 fn fuzz_list_reports_ambiguous_duplicate_rig_workloads_without_running_them() {
     with_isolated_home(|home| {
         let component_dir = home.path().join("component");

--- a/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use std::process::Command;
+use std::time::{Duration, Instant};
 
 #[test]
 fn fuzz_workloads_include_rig_declared_paths() {
@@ -320,7 +322,7 @@ fn resolve_profile_workload_id_rejects_unknown_profile_with_available_profiles()
 }
 
 #[test]
-fn fuzz_list_materializes_prepare_dependencies_before_workload_validation() {
+fn fuzz_list_does_not_materialize_prepare_dependencies() {
     with_isolated_home(|home| {
         let component_dir = home.path().join("component");
         fs::create_dir_all(&component_dir).expect("component dir");
@@ -328,20 +330,22 @@ fn fuzz_list_materializes_prepare_dependencies_before_workload_validation() {
         write_fuzz_prepare_rig(
             home.path(),
             &component_dir,
-            r#"mkdir -p runtime && printf ready > runtime/ready.txt"#,
+            r#"sleep 2; mkdir -p runtime && printf ready > runtime/ready.txt"#,
             "runtime/ready.txt",
             "materialize runtime dependency",
         );
 
+        let started = Instant::now();
         let output = run_list(fuzz_list_args()).expect("fuzz list");
 
         assert_eq!(output.count, 1);
-        assert!(component_dir.join("runtime/ready.txt").is_file());
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(!component_dir.join("runtime/ready.txt").exists());
     });
 }
 
 #[test]
-fn fuzz_list_runs_declared_dependency_materialization_before_prepare_validation() {
+fn fuzz_list_does_not_run_declared_dependency_materialization() {
     with_isolated_home(|home| {
         let component_dir = home.path().join("component");
         fs::create_dir_all(&component_dir).expect("component dir");
@@ -351,12 +355,12 @@ fn fuzz_list_runs_declared_dependency_materialization_before_prepare_validation(
         let output = run_list(fuzz_list_args()).expect("fuzz list");
 
         assert_eq!(output.count, 1);
-        assert!(component_dir.join("runtime/ready.txt").is_file());
+        assert!(!component_dir.join("runtime/ready.txt").exists());
     });
 }
 
 #[test]
-fn fuzz_list_materializes_declared_plugin_subpath_dependency_before_prepare_validation() {
+fn fuzz_list_does_not_materialize_declared_plugin_subpath_dependency() {
     with_isolated_home(|home| {
         let component_dir = home.path().join("woocommerce");
         fs::create_dir_all(component_dir.join("plugins/woocommerce")).expect("plugin dir");
@@ -366,34 +370,28 @@ fn fuzz_list_materializes_declared_plugin_subpath_dependency_before_prepare_vali
         let output = run_list(fuzz_list_args()).expect("fuzz list");
 
         assert_eq!(output.count, 1);
-        assert!(component_dir
+        assert!(!component_dir
             .join("plugins/woocommerce/vendor/autoload_packages.php")
-            .is_file());
+            .exists());
     });
 }
 
 #[test]
-fn fuzz_list_reports_structured_dependency_materialization_failure() {
+fn fuzz_list_ignores_dependency_materialization_failure() {
     with_isolated_home(|home| {
         let component_dir = home.path().join("component");
         fs::create_dir_all(&component_dir).expect("component dir");
         write_generic_fuzz_extension(home.path());
         write_dependency_materialization_failure_rig(home.path(), &component_dir);
 
-        let error = match run_list(fuzz_list_args()) {
-            Ok(_) => panic!("dependency materialization should fail"),
-            Err(error) => error,
-        };
-        let message = error.to_string();
+        let output = run_list(fuzz_list_args()).expect("metadata listing should not prepare");
 
-        assert!(message.contains("fuzz_prepare"));
-        assert!(message.contains("dependency materialization runtime-dependencies"));
-        assert!(message.contains("did not produce required outputs"));
+        assert_eq!(output.count, 1);
     });
 }
 
 #[test]
-fn fuzz_list_reports_structured_prepare_step_failure() {
+fn fuzz_list_ignores_prepare_step_failure() {
     with_isolated_home(|home| {
         let component_dir = home.path().join("component");
         fs::create_dir_all(&component_dir).expect("component dir");
@@ -406,15 +404,132 @@ fn fuzz_list_reports_structured_prepare_step_failure() {
             "materialize runtime dependency",
         );
 
-        let error = match run_list(fuzz_list_args()) {
-            Ok(_) => panic!("prepare should fail"),
-            Err(error) => error,
-        };
-        let message = error.to_string();
+        let output = run_list(fuzz_list_args()).expect("metadata listing should not prepare");
 
-        assert!(message.contains("fuzz_prepare"));
-        assert!(message.contains("requirement `materialize runtime dependency` failed"));
-        assert!(message.contains("prepare command failed"));
+        assert_eq!(output.count, 1);
+    });
+}
+
+#[test]
+fn fuzz_list_reports_ambiguous_duplicate_rig_workloads_without_running_them() {
+    with_isolated_home(|home| {
+        let component_dir = home.path().join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        write_generic_fuzz_extension(home.path());
+        let rig_dir = home.path().join(".config/homeboy/rigs");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("package-fuzz.json"),
+            serde_json::json!({
+                "id": "package-fuzz",
+                "components": {
+                    "package": {
+                        "path": component_dir,
+                        "extensions": { "generic": { "settings": {} } }
+                    }
+                },
+                "fuzz": { "default_component": "package" },
+                "fuzz_workloads": {
+                    "generic": [
+                        { "path": "fuzz/duplicate.json" },
+                        { "path": "fuzz/duplicate.json" }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("rig config");
+
+        let output = run_list(fuzz_list_args()).expect("fuzz list");
+
+        assert_eq!(output.diagnostics.completeness, "ambiguous");
+        assert!(output
+            .diagnostics
+            .ambiguity
+            .iter()
+            .any(|message| message.contains("duplicate declared fuzz workload id")));
+    });
+}
+
+#[test]
+fn fuzz_list_reports_stale_installed_rig_package_provenance() {
+    with_isolated_home(|home| {
+        write_generic_fuzz_extension(home.path());
+        let component_dir = home.path().join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        let package = tempfile::tempdir().expect("rig package");
+        let rig_dir = package.path().join("rigs/package-fuzz");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            serde_json::json!({
+                "id": "package-fuzz",
+                "components": {
+                    "package": {
+                        "path": component_dir,
+                        "extensions": { "generic": { "settings": {} } }
+                    }
+                },
+                "fuzz": { "default_component": "package" },
+                "fuzz_workloads": { "generic": [{ "path": "fuzz/package.json" }] }
+            })
+            .to_string(),
+        )
+        .expect("rig config");
+        for args in [
+            vec!["init"],
+            vec!["add", "."],
+            vec![
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        ] {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(package.path())
+                .status()
+                .expect("run git");
+            assert!(status.success(), "git command should succeed");
+        }
+        homeboy::rig::install(
+            package.path().to_string_lossy().as_ref(),
+            Some("package-fuzz"),
+            false,
+        )
+        .expect("install rig package");
+        let status = Command::new("git")
+            .args([
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "advance source",
+            ])
+            .current_dir(package.path())
+            .status()
+            .expect("advance source revision");
+        assert!(status.success());
+
+        let output = run_list(fuzz_list_args()).expect("fuzz list");
+
+        assert_eq!(output.diagnostics.completeness, "incomplete");
+        assert!(output
+            .diagnostics
+            .ambiguity
+            .iter()
+            .any(|message| message.contains("rig package freshness is Stale")));
+        assert!(output
+            .rig_package
+            .as_ref()
+            .is_some_and(|package| !package.freshness_verified));
     });
 }
 
@@ -425,6 +540,7 @@ fn fuzz_list_args() -> FuzzListArgs {
             path: None,
         },
         rig: Some("package-fuzz".to_string()),
+        remote_discovery: false,
         extension_override: ExtensionOverrideArgs::default(),
         setting_args: SettingArgs::default(),
     }

--- a/crates/homeboy-cli/src/commands/fuzz/types.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types.rs
@@ -58,19 +58,14 @@ impl FuzzArgs {
         matches!(self.command, None | Some(FuzzCommand::Run(_)))
     }
 
-    /// Fuzz subcommands that offload to the configured Lab runner. `run`
-    /// executes the workload remotely; `list` enumerates the runner-resident
-    /// rig/extension fuzz workloads so the operator sees the same inventory the
-    /// runner would execute rather than the (possibly empty) local one. This
-    /// mirrors `bench`'s `is_lab_offload_command`, which routes its discovery
-    /// subcommands to the runner alongside `run`.
+    /// Fuzz subcommands that offload to the configured Lab runner. Listing is
+    /// local metadata discovery unless runner availability is requested.
     pub fn is_lab_offload_command(&self) -> bool {
         matches!(
             self.command,
-            None | Some(FuzzCommand::Run(_))
-                | Some(FuzzCommand::RunCampaign(_))
-                | Some(FuzzCommand::List(_))
+            None | Some(FuzzCommand::Run(_)) | Some(FuzzCommand::RunCampaign(_))
         ) || matches!(&self.command, Some(FuzzCommand::Plan(plan)) if plan.execute)
+            || matches!(&self.command, Some(FuzzCommand::List(args)) if args.remote_discovery)
     }
 
     pub(crate) fn lab_route_required_extension_ids(&self) -> Vec<String> {
@@ -226,6 +221,11 @@ pub(crate) struct FuzzListArgs {
     /// rig-declared fuzz workloads.
     #[arg(long, value_name = "RIG_ID")]
     pub(crate) rig: Option<String>,
+
+    /// Query the selected runner for runner-specific availability. Without
+    /// this flag list reads only local installed rig metadata.
+    #[arg(long)]
+    pub(crate) remote_discovery: bool,
 
     #[command(flatten)]
     pub(crate) extension_override: ExtensionOverrideArgs,
@@ -755,7 +755,7 @@ pub use super::types_extra::{
     FuzzContractGateProfileOutput, FuzzContractOutput, FuzzCoverageCompletenessOutput,
     FuzzCoverageSelectorSummaryOutput, FuzzDiscoverOutput, FuzzDiscoverSummary,
     FuzzExecutionOutput, FuzzGateEvaluation, FuzzGateStatusChange, FuzzInspectCandidate,
-    FuzzInspectOutput, FuzzListOutput, FuzzOutput, FuzzPlanOutput, FuzzReplayArtifactAccess,
-    FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput, FuzzReportOutput, FuzzRunOutput,
-    FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
+    FuzzInspectOutput, FuzzListComponentMapping, FuzzListDiagnostics, FuzzListOutput, FuzzOutput,
+    FuzzPlanOutput, FuzzReplayArtifactAccess, FuzzReplayEnv, FuzzReplayExecution, FuzzReplayOutput,
+    FuzzReportOutput, FuzzRunOutput, FuzzRunnerContract, FuzzValidateOutput, FuzzWorkloadOutput,
 };

--- a/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
@@ -177,9 +177,27 @@ pub struct FuzzListOutput {
     pub command: String,
     pub component: String,
     pub rig_id: Option<String>,
+    pub rig_package: Option<homeboy_extension::bench::parsing::RigPackageEvidence>,
+    pub component_mapping: FuzzListComponentMapping,
+    pub extension_provider: Option<String>,
     pub workloads: Vec<FuzzWorkloadOutput>,
     pub count: usize,
+    pub diagnostics: FuzzListDiagnostics,
     pub run_hint: String,
+}
+
+#[derive(Serialize)]
+pub struct FuzzListComponentMapping {
+    pub requested_component: Option<String>,
+    pub resolved_component: String,
+    pub path: String,
+}
+
+#[derive(Serialize)]
+pub struct FuzzListDiagnostics {
+    pub completeness: String,
+    pub ambiguity: Vec<String>,
+    pub executable_availability: String,
 }
 
 #[derive(Serialize)]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -43,6 +43,7 @@ pub(super) fn agent_task_resource_behavior(
             AgentTaskResourceBehavior::LocalControl
         }
         agent_task::AgentTaskCommand::Cook(_)
+        | agent_task::AgentTaskCommand::CookContinue(_)
         | agent_task::AgentTaskCommand::RunPlan(_)
         | agent_task::AgentTaskCommand::Run(_)
         | agent_task::AgentTaskCommand::RunNext

--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -47,8 +47,8 @@ rig package, declared default component, extension provider, and workload paths
 without materializing a workspace, running prepare hooks, or handing off to Lab.
 The output includes package source/revision evidence, component mapping, and
 completeness/ambiguity diagnostics. Pass `--remote-discovery` only when
-runner-specific availability is required; that projection runs on the selected
-runner.
+runner-specific availability is required; it requests that projection on the
+selected runner.
 
 Run one workload through the fuzz command surface:
 

--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -7,7 +7,7 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 ```bash
 homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--profile <id|lab>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive [--isolation-proof <path>]] [--allow-local-destructive-fuzz] [-- <runner-args>]
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--profile <id|lab>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive [--isolation-proof <path>]] [--allow-local-destructive-fuzz] [-- <runner-args>]
-homeboy fuzz list [<component>] [--rig <id>]
+homeboy fuzz list [<component>] [--rig <id>] [--remote-discovery]
 homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--execute|--dry-run] [--resume] [--allow-destructive [--isolation-proof <path>]]
 homeboy fuzz stable plan --manifest <path> [--stable-id <id[,id]>] [--runner <id>] [--artifact-root <dir>] [--run-id-prefix <id>] [--tracker-ref <kind:id>] [--detach-after-handoff] [--component <id>] [--since <duration>] [--limit <n>] [--hotspot-limit <n>]
 homeboy fuzz run-campaign [<component>] [--rig <id>] [--campaign-manifest <path>] [--campaign-workload <id>] [--dry-run] [--resume] [fuzz run options]
@@ -41,6 +41,14 @@ homeboy fuzz list --rig <rig-id>
 Use the listed workload id in `fuzz run`, then use `runs show`, `runs evidence`,
 or run-backed replay/minimize to inspect the executable/proven state and recorded
 artifacts.
+
+Rig-backed `fuzz list` is bounded local metadata discovery. It reads the installed
+rig package, declared default component, extension provider, and workload paths
+without materializing a workspace, running prepare hooks, or handing off to Lab.
+The output includes package source/revision evidence, component mapping, and
+completeness/ambiguity diagnostics. Pass `--remote-discovery` only when
+runner-specific availability is required; that projection runs on the selected
+runner.
 
 Run one workload through the fuzz command surface:
 


### PR DESCRIPTION
## Summary
- keep `fuzz list --rig <id>` as bounded local metadata discovery without prepare hooks, workspace materialization, or Lab handoff
- add explicit `--remote-discovery` routing for runner-specific availability and structured package/component/provider/workload diagnostics
- cover absent global components, no-side-effect timing, ambiguous workloads, stale packages, and explicit remote routing

Closes #9919

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::fuzz::tests`
- `cargo test -p homeboy-cli commands::utils::resource_policy`

## AI assistance
OpenAI `gpt-5.6-terra` via OpenCode drafted the implementation and tests under Chris Huber direction. Chris remains responsible for every line.