### PR TITLE
fix(agent-task): preflight Cook prompt sources

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -27,6 +27,56 @@ use prompt_spec::{
     read_text_spec, DispatchPromptSpec,
 };
 
+/// Cook owns one source prompt and one promotion lifecycle. Keep its input
+/// boundary separate from generic dispatch, which still carries wave inputs.
+pub fn validate_single_cook_prompt_source(
+    prompt: Option<&str>,
+    tasks: &[String],
+    tasks_json: Option<&str>,
+) -> Result<()> {
+    if tasks.len() > 1 {
+        return Err(Error::validation_invalid_argument(
+            "task",
+            "agent-task cook accepts one --prompt source; repeated --task creates an unsupported wave",
+            None,
+            Some(vec![
+                "Replace the repeated --task flags with one prompt: homeboy agent-task cook --prompt @task.txt --to-worktree sample-plugin@fix-issue --verify 'npm test'".to_string(),
+            ]),
+        ));
+    }
+    if !tasks.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "task",
+            "agent-task cook accepts work through --prompt; --task is reserved for future batch transport inputs",
+            None,
+            Some(vec![
+                "Replace --task with --prompt: homeboy agent-task cook --prompt @task.txt --to-worktree sample-plugin@fix-issue --verify 'npm test'".to_string(),
+            ]),
+        ));
+    }
+    if tasks_json.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "tasks",
+            "agent-task cook accepts one --prompt source; --tasks JSON creates an unsupported wave",
+            None,
+            Some(vec![
+                "Run independent cooks through fanout, or use one prompt: homeboy agent-task cook --prompt @task.txt --to-worktree sample-plugin@fix-issue --verify 'npm test'".to_string(),
+            ]),
+        ));
+    }
+    if prompt.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "prompt",
+            "agent-task cook requires one --prompt source",
+            None,
+            Some(vec![
+                "Example: homeboy agent-task cook --prompt @task.txt --to-worktree sample-plugin@fix-issue --verify 'npm test'".to_string(),
+            ]),
+        ));
+    }
+    Ok(())
+}
+
 mod provider_config;
 use provider_config::{
     dispatch_component_contracts, dispatch_provider_config, dispatch_request_inputs,
@@ -44,11 +94,11 @@ pub fn build_dispatch_plan_with_provider_requirements(
     if request.prompt.is_none() && request.tasks.is_empty() && request.core.tasks_json.is_none() {
         return Err(Error::validation_invalid_argument(
             "prompt",
-            "agent-task cook requires --prompt, --prompt @file, --prompt -, repeated --task inputs, or --tasks @tasks.json",
+            "agent-task dispatch requires --prompt, --prompt @file, --prompt -, repeated --task inputs, or --tasks @tasks.json",
             None,
             Some(vec![
-                "Example: homeboy agent-task cook --repo sample-plugin --cwd /path/to/worktree --to-worktree sample-plugin@fix-issue --verify 'npm test' --prompt @task.txt".to_string(),
-                "Wave input: homeboy agent-task cook --tasks @tasks.json --concurrency 8 --to-worktree sample-plugin@fix-issue --verify 'npm test'".to_string(),
+                "Example: homeboy agent-task dispatch --repo sample-plugin --cwd /path/to/worktree --prompt @task.txt".to_string(),
+                "Wave input: homeboy agent-task dispatch --tasks @tasks.json --concurrency 8".to_string(),
             ]),
         ));
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use crate::agent_task_cook_loop::{
     evaluate_cook_loop, AgentTaskCookLoopOptions, AgentTaskCookLoopReport, AgentTaskCookLoopStatus,
 };
-use crate::agent_task_dispatch_plan::build_dispatch_plan;
+use crate::agent_task_dispatch_plan::{build_dispatch_plan, validate_single_cook_prompt_source};
 use crate::agent_task_dispatch_service::{self, AgentTaskDispatchCommand};
 use crate::agent_task_gate::VerifyGateOptions;
 use crate::agent_task_lifecycle;
@@ -498,6 +498,11 @@ pub fn compile_cook_attempt(
     mut options: AgentTaskCookServiceOptions,
     dispatch: AgentTaskDispatchCommand,
 ) -> Result<AgentTaskCookServiceOptions> {
+    validate_single_cook_prompt_source(
+        dispatch.prompt.as_deref(),
+        &dispatch.tasks,
+        dispatch.core.tasks_json.as_deref(),
+    )?;
     let request = agent_task_dispatch_service::resolve_dispatch_request(dispatch.into())?;
     options.initial_plan = build_dispatch_plan(&request)?;
     Ok(options)

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -197,7 +197,7 @@ pub mod batch {
 pub mod dispatch_service {
     pub use super::super::agent_task_dispatch_plan::{
         build_dispatch_plan, build_dispatch_plan_with_provider_requirements,
-        preflight_dispatch_provider_secrets,
+        preflight_dispatch_provider_secrets, validate_single_cook_prompt_source,
     };
     pub use super::super::agent_task_dispatch_service::{
         build_controller_dispatch_plan, controller_resolved_execution_policy, dispatch,

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -392,6 +392,15 @@ impl CliRuntime {
             }
         }
 
+        if let Commands::AgentTask(agent_task) = &cli.command {
+            if let crate::commands::agent_task::AgentTaskCommand::Cook(cook) = &agent_task.command {
+                if let Err(err) = crate::commands::agent_task::run::validate_cook_request(cook) {
+                    output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                    return std::process::ExitCode::from(2);
+                }
+            }
+        }
+
         match delegate_agent_task_cook_to_pinned_runtime(&cli, &normalized) {
             Ok(Some(exit_code)) => return std::process::ExitCode::from(exit_code_to_u8(exit_code)),
             Ok(None) => {}

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -65,6 +65,9 @@ pub(crate) fn run_with_cook_progress(
     match args.command {
         AgentTaskCommand::Doctor(doctor_args) => doctor::doctor(doctor_args),
         AgentTaskCommand::Cook(cook_args) => {
+            // Reject unsupported Cook source shapes before discovering a provider
+            // or preparing the local/Lab execution route.
+            run::validate_cook_request(&cook_args)?;
             if progress.is_some() {
                 run::run_cook_with_executor_and_dispatcher_with_progress(
                     cook_args,

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -36,14 +36,15 @@ pub enum AgentTaskCommand {
     Doctor(AgentTaskDoctorArgs),
     /// Run an agent task end to end and open a pull request.
     ///
-    /// Provide the work with `--task`/`--tasks` and a `--goal`, point
+    /// Provide the work with one `--prompt` and optional `--goal` framing, point
     /// `--to-worktree` at the existing worktree to edit (that checkout is
     /// authoritative — the agent's changes, the `--verify` gates, and the PR all
     /// operate on it), and give one or more `--verify` commands that must pass in
     /// that worktree before promotion. Cook then commits, runs the deterministic
     /// gates, and finalizes a `--base`-targeted PR (use `--no-finalize` to stop
     /// before opening the PR). Repeatable `--verify` gates all run; the run
-    /// retries up to `--max-attempts` times.
+    /// retries up to `--max-attempts` times. Use `agent-task fanout cook-batch`
+    /// for independent task waves.
     Cook(AgentTaskCookArgs),
     /// Continue a detached Cook from its durable Cook ID or provider attempt ID.
     /// The persisted recipe supplies the original prompt, transport, gates,

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -227,6 +227,14 @@ mod tests {
         );
         assert!(help.contains("before opening the pull request"), "{help}");
     }
+
+    #[test]
+    fn cook_help_advertises_one_prompt_source_not_wave_inputs() {
+        let help = rendered_cook_help();
+        assert!(help.contains("--prompt"), "{help}");
+        assert!(!help.contains("--task <"), "{help}");
+        assert!(!help.contains("--tasks <"), "{help}");
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -238,8 +246,8 @@ pub struct AgentTaskCookArgs {
     #[arg(long, hide = true)]
     pub attempt_plan: Option<String>,
     /// One-line statement of what a successful cook must achieve. Recorded as
-    /// framing metadata for every provider cell and used for review. Without
-    /// --prompt, --task, or --tasks, it supplies the one provider task.
+    /// framing metadata for the provider task and used for review. Without
+    /// --prompt, it supplies the one provider task.
     #[arg(long, value_name = "TEXT")]
     pub goal: Option<String>,
     /// Workspace handle the cook edits, verifies, and finalizes into (e.g.

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -47,6 +47,7 @@ fn aggregate_value_with_failure_reasons(aggregate: &AgentTaskAggregate) -> Value
 }
 
 pub(crate) fn run_cook(args: AgentTaskCookArgs) -> CmdResult<Value> {
+    validate_cook_request(&args)?;
     run_cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
 }
 
@@ -328,6 +329,22 @@ pub(crate) fn record_cook_provision(plan: &mut AgentTaskPlan, provision: Value) 
 }
 
 pub(crate) fn validate_cook_request(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    if args.goal.is_some() && !args.dispatch.tasks.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "task",
+            "agent-task cook uses --goal as framing metadata and --prompt as its one source; --goal and --task conflict",
+            None,
+            Some(vec![
+                "Use: homeboy agent-task cook --goal 'Describe the outcome' --prompt @task.txt --to-worktree sample-plugin@fix-issue --verify 'npm test'".to_string(),
+            ]),
+        ));
+    }
+    let dispatch = dispatch_args_for_cook(args);
+    dispatch_service::validate_single_cook_prompt_source(
+        dispatch.prompt.as_deref(),
+        &dispatch.tasks,
+        dispatch.core.tasks_json.as_deref(),
+    )?;
     if !args.gates.has_deterministic_gate() && !args.no_finalize {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "verify",

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -7,7 +7,7 @@ use homeboy::agents::agent_task_service::{
 };
 use homeboy::core::{Error, Result};
 use sha2::{Digest, Sha256};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::cli_surface::{Cli, Commands};
 
@@ -16,6 +16,164 @@ use super::super::AgentTaskCommand;
 #[derive(Debug)]
 struct RecoverableRunnerDispatcher {
     unavailable: AtomicBool,
+}
+
+#[derive(Debug, Default)]
+struct CountingCookDispatcher {
+    prepared: AtomicUsize,
+    dispatched: AtomicUsize,
+}
+
+impl AgentTaskCookAttemptDispatcher for CountingCookDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(json!({ "kind": "counting-cook-dispatcher" }))
+    }
+
+    fn prepare_for_cook(&self) -> Result<()> {
+        self.prepared.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn dispatch_attempt(
+        &self,
+        _plan: AgentTaskPlan,
+        _run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        self.dispatched.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+struct CountingCookExecutor {
+    executions: Arc<AtomicUsize>,
+}
+
+impl AgentTaskExecutorAdapter for CountingCookExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("unexpected execution".to_string()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }
+    }
+}
+
+fn cook_args_from_cli(args: Vec<String>) -> AgentTaskCookArgs {
+    let cli = Cli::parse_from(args);
+    let Commands::AgentTask(agent_task) = cli.command else {
+        panic!("agent-task command");
+    };
+    let AgentTaskCommand::Cook(cook) = agent_task.command else {
+        panic!("cook command");
+    };
+    cook
+}
+
+#[test]
+fn invalid_cook_sources_stop_before_worktree_provider_runner_executor_or_budget() {
+    with_temp_home(|| {
+        let destination = tempfile::tempdir()
+            .expect("destination parent")
+            .path()
+            .join("missing");
+        let cases = [
+            (
+                vec!["--goal", "Frame the work", "--task", "Do the work"],
+                "--goal and --task conflict",
+            ),
+            (
+                vec!["--task", "First task", "--task", "Second task"],
+                "repeated --task",
+            ),
+            (vec!["--tasks", r#"["Wave task"]"#], "--tasks JSON"),
+        ];
+
+        for (index, (source, diagnostic)) in cases.into_iter().enumerate() {
+            let run_id = format!("invalid-cook-source-{index}");
+            let mut command = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ];
+            command.extend(source.into_iter().map(str::to_string));
+            command.extend([
+                "--to-worktree".to_string(),
+                destination.display().to_string(),
+                "--backend".to_string(),
+                "unconfigured-provider".to_string(),
+                "--run-id".to_string(),
+                run_id.clone(),
+                "--no-finalize".to_string(),
+            ]);
+            let executor = CountingCookExecutor::default();
+            let dispatcher = Arc::new(CountingCookDispatcher::default());
+
+            let error = run_cook_with_executor_and_dispatcher(
+                cook_args_from_cli(command),
+                executor.clone(),
+                Some(dispatcher.clone()),
+            )
+            .expect_err(diagnostic);
+
+            assert!(error.message.contains(diagnostic), "{error}");
+            assert!(
+                error.details["tried"].as_array().is_some_and(|hints| hints
+                    .iter()
+                    .any(|hint| hint
+                        .as_str()
+                        .is_some_and(|hint| hint.contains("homeboy agent-task cook")))),
+                "diagnostic must include a complete replacement command: {error}"
+            );
+            assert!(
+                !destination.exists(),
+                "invalid source must not materialize a worktree"
+            );
+            assert_eq!(dispatcher.prepared.load(Ordering::SeqCst), 0);
+            assert_eq!(dispatcher.dispatched.load(Ordering::SeqCst), 0);
+            assert_eq!(executor.executions.load(Ordering::SeqCst), 0);
+            assert!(
+                lifecycle_status(&run_id).is_err(),
+                "invalid source must not create a lifecycle record or consume budget"
+            );
+        }
+    });
+}
+
+#[test]
+fn goal_and_prompt_remain_a_valid_single_source_cook_shape() {
+    let args = cook_args_from_cli(vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--goal".to_string(),
+        "Frame the outcome".to_string(),
+        "--prompt".to_string(),
+        "Implement the outcome".to_string(),
+        "--to-worktree".to_string(),
+        "sample-plugin@fix-issue".to_string(),
+        "--backend".to_string(),
+        "fixture".to_string(),
+        "--no-finalize".to_string(),
+    ]);
+
+    validate_cook_request(&args).expect("goal plus prompt is one valid Cook source");
 }
 
 impl AgentTaskCookAttemptDispatcher for RecoverableRunnerDispatcher {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
@@ -25,7 +25,7 @@ pub(in crate::commands::agent_task) use super::super::controller::{
 pub(in crate::commands::agent_task) use super::super::run::{
     resume, retry, run_cook_with_executor, run_cook_with_executor_and_dispatcher, run_loaded_plan,
     run_next_with_executor, run_resume_with_executor, run_submitted, run_submitted_with_executor,
-    submit,
+    submit, validate_cook_request,
 };
 pub(in crate::commands::agent_task) use super::super::status::{
     cancel, diagnose, evidence, logs, replay_provider_boundary, status,

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -14,8 +14,8 @@ use homeboy::agents::agent_tasks::dispatch_service::{
 // (#5187).
 #[derive(Args, Debug, Clone)]
 pub struct DispatchCoreArgs {
-    /// JSON array/object of task prompts for waves. Supports @file and - for stdin.
-    #[arg(long = "tasks", value_name = "JSON")]
+    /// Reserved batch input. Use `agent-task fanout cook-batch` for task waves.
+    #[arg(long = "tasks", value_name = "JSON", hide = true)]
     pub tasks_json: Option<String>,
 
     /// Provider config JSON object, @file, or - for stdin. Merged with workspace metadata.
@@ -97,12 +97,12 @@ impl From<DispatchCoreArgs> for DispatchCoreInputs {
 
 #[derive(Args, Debug, Clone)]
 pub struct DispatchArgs {
-    /// Inline prompt, @file, or - for stdin. Repeat --task for waves.
+    /// Inline prompt, @file, or - for stdin.
     #[arg(long, value_name = "PROMPT")]
     pub prompt: Option<String>,
 
-    /// Additional task prompt, @file, or - for stdin. Each --task creates one minion cell.
-    #[arg(long = "task", value_name = "PROMPT")]
+    /// Reserved batch input retained for forward-compatible command decoding.
+    #[arg(long = "task", value_name = "PROMPT", hide = true)]
     pub tasks: Vec<String>,
 
     /// Existing local repo checkout or worktree path to cook in.

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -43,6 +43,7 @@ pub(super) fn agent_task_resource_behavior(
             AgentTaskResourceBehavior::LocalControl
         }
         agent_task::AgentTaskCommand::Cook(_)
+        | agent_task::AgentTaskCommand::CookContinue(_)
         | agent_task::AgentTaskCommand::RunPlan(_)
         | agent_task::AgentTaskCommand::Run(_)
         | agent_task::AgentTaskCommand::RunNext

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -317,9 +317,9 @@ homeboy agent-task prompts list
 homeboy agent-task cook --repo homeboy --prompt prompt:issue-123
 ```
 
-Existing prompt inputs remain compatible: `--prompt @file`, `--prompt -`, inline
-prompt text, repeated `--task`, and `--tasks @tasks.json` still use the existing
-resolution behavior unless the prompt string starts with `prompt:`.
+Cook accepts one source through `--prompt`: `--prompt @file`, `--prompt -`, inline
+prompt text, and `prompt:<id>` references all use the same resolution behavior.
+Use `agent-task fanout cook-batch` for independent task waves.
 
 ### Controller
 
@@ -528,10 +528,9 @@ promotes the selected patch into the target worktree, runs deterministic gates,
 retries red gates within the configured budget, then commits, pushes, and opens or
 updates a PR.
 
-`--goal` is one-line Cook framing metadata, recorded on the durable plan and each
-provider cell. When work is supplied with `--prompt`, repeated `--task`, or
-`--tasks`, those inputs alone determine the cell count; `--goal` never creates an
-additional cell. A goal without explicit work supplies one provider task.
+`--goal` is one-line Cook framing metadata, recorded on the durable plan and its
+single provider task. Pair explicit work with `--prompt`; `--goal` never creates
+an additional task. A goal without explicit work supplies the one provider task.
 
 ```bash
 homeboy agent-task cook \


### PR DESCRIPTION
## Summary
- enforce Cook's single `--prompt` source before executor discovery, workspace provisioning, or Lab dispatch
- reject `--goal` plus `--task`, repeated `--task`, and `--tasks` with flag-specific replacement commands
- hide unsupported Cook wave inputs while retaining parser compatibility, and align Cook documentation
- add side-effect instrumentation proving invalid shapes create no worktree or lifecycle record and invoke no runner or executor

## Verification
- `cargo fmt --all`
- `cargo test -p homeboy-cli invalid_cook_sources_stop_before_worktree_provider_runner_executor_or_budget -- --nocapture`
- `cargo test -p homeboy-cli goal_and_prompt_remain_a_valid_single_source_cook_shape -- --nocapture`
- `cargo test -p homeboy-cli cook_help_advertises_one_prompt_source_not_wave_inputs -- --nocapture`
- `cargo check -p homeboy-cli`

Closes #9996

## AI assistance
OpenAI `gpt-5.6-terra` using OpenCode drafted the validation, diagnostics, documentation, and tests. Chris Huber remains responsible for every line.