### PR TITLE
fix(rig): cache dependency materialization outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,16 +1211,19 @@ name = "homeboy-rig"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "fs4",
  "homeboy-core",
  "homeboy-extension",
  "homeboy-lab-runner-contract",
  "homeboy-lifecycle-contract",
+ "homeboy-paths",
  "homeboy-product-identity",
  "homeboy-rig-contract",
  "homeboy-stack",
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "shellexpand",
  "tempfile",
 ]

--- a/crates/homeboy-cli/src/commands/runs/resources.rs
+++ b/crates/homeboy-cli/src/commands/runs/resources.rs
@@ -1397,6 +1397,38 @@ mod tests {
     }
 
     #[test]
+    fn apply_deletes_expired_cache_lifecycle_record() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let cache_root = tempdir.path().join("cache");
+        std::fs::create_dir_all(&cache_root).expect("cache root");
+        std::fs::write(cache_root.join("entry"), "cached").expect("cache entry");
+        let resource = ResourceLifecycleRecord {
+            owner: "homeboy.rig.dependency_materialization_cache".to_string(),
+            path: cache_root.display().to_string(),
+            root_bound: Some(tempdir.path().display().to_string()),
+            kind: "dependency_materialization_cache".to_string(),
+            ttl: Some("0s".to_string()),
+            cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
+            cleanup_intent: ResourceCleanupIntent::Apply,
+            ..record(ResourceLifecycleResourceStatus::Active)
+        };
+
+        let cleanup = build_cleanup_output(
+            &[resource],
+            &RunsResourcesArgs {
+                apply: true,
+                cleanup_root: Some(tempdir.path().to_path_buf()),
+                limit: 1,
+                ..Default::default()
+            },
+        )
+        .expect("cleanup apply");
+
+        assert_eq!(cleanup.applied_count, 1);
+        assert!(!cache_root.exists());
+    }
+
+    #[test]
     fn apply_reaps_runner_workspace_through_runner_transport() {
         crate::test_support::with_isolated_home(|_| {
             let workspace_root = tempfile::tempdir().expect("workspace root");

--- a/crates/homeboy-rig/Cargo.toml
+++ b/crates/homeboy-rig/Cargo.toml
@@ -18,12 +18,15 @@ homeboy-rig-contract = { version = "0.1.0", path = "../contracts/homeboy-rig-con
 homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-runner-contract" }
 homeboy-lifecycle-contract = { version = "0.1.0", path = "../contracts/homeboy-lifecycle-contract" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
+homeboy-paths = { version = "0.1.0", path = "../homeboy-paths" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
 shellexpand = "3.1"
 libc = "0.2"
 tempfile = "3.14"
+sha2 = "0.10.9"
+fs4 = "0.13"
 
 [dev-dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -55,12 +55,14 @@ struct Output {
 pub(crate) enum CacheResult {
     Hit { bytes: u64 },
     Miss { reason: String },
+    Saved { bytes: u64 },
 }
 
 pub(crate) struct DependencyMaterializationCache {
     root: PathBuf,
     entry: PathBuf,
     key: String,
+    workspace: PathBuf,
     outputs: Vec<(String, PathBuf, DependencyMaterializationOutputKind)>,
     provenance: Provenance,
 }
@@ -183,6 +185,7 @@ impl DependencyMaterializationCache {
             entry: root.join(&key),
             root,
             key,
+            workspace,
             outputs,
             provenance,
         }))
@@ -210,14 +213,14 @@ impl DependencyMaterializationCache {
                 })
             }
         };
-        if manifest.outputs.len() != self.outputs.len() {
+        if !self.manifest_outputs_match(&manifest.outputs) {
             return self.evidence(CacheResult::Miss {
-                reason: "partial_entry".to_string(),
+                reason: "manifest_outputs_mismatch".to_string(),
             });
         }
         for output in &manifest.outputs {
             let source = self.entry.join("outputs").join(&output.path);
-            if !output_matches(&source, &output.kind, &output.sha256)? {
+            if !output_matches(&source, &output.kind, &output.sha256) {
                 return self.evidence(CacheResult::Miss {
                     reason: "corrupt_entry".to_string(),
                 });
@@ -235,8 +238,9 @@ impl DependencyMaterializationCache {
                     )
                 })?;
             let source = self.entry.join("outputs").join(&output.path);
-            copy_replace(&source, destination)?;
-            if !kind_matches(destination, *kind) || hash_path(destination)? != output.sha256 {
+            let destination = contained_path(&self.workspace, destination)?;
+            copy_replace(&source, &destination)?;
+            if !kind_matches(&destination, *kind) || hash_path(&destination)? != output.sha256 {
                 return self.evidence(CacheResult::Miss {
                     reason: "restore_verification_failed".to_string(),
                 });
@@ -256,7 +260,8 @@ impl DependencyMaterializationCache {
             .map_err(|error| io_error("create dependency cache staging", error))?;
         let mut outputs = Vec::new();
         for (relative, source, kind) in &self.outputs {
-            if !kind_matches(source, *kind) {
+            let source = contained_path(&self.workspace, source)?;
+            if !kind_matches(&source, *kind) {
                 return Err(Error::validation_invalid_argument(
                     "dependency_materialization",
                     "declared cache output is missing or has the wrong kind",
@@ -265,12 +270,12 @@ impl DependencyMaterializationCache {
                 ));
             }
             let destination = staging.join("outputs").join(relative);
-            copy_replace(source, &destination)?;
+            copy_replace(&source, &destination)?;
             outputs.push(Output {
                 path: relative.clone(),
                 kind: kind_name(*kind).to_string(),
-                sha256: hash_path(source)?,
-                bytes: path_bytes(source)?,
+                sha256: hash_path(&source)?,
+                bytes: path_bytes(&source)?,
             });
         }
         let manifest = Manifest {
@@ -287,8 +292,23 @@ impl DependencyMaterializationCache {
         fs::rename(&staging, &self.entry)
             .map_err(|error| io_error("publish dependency cache entry", error))?;
         let bytes = manifest.outputs.iter().map(|output| output.bytes).sum();
-        let _ = self.evidence(CacheResult::Hit { bytes });
+        self.evidence(CacheResult::Saved { bytes })?;
         Ok(())
+    }
+
+    fn manifest_outputs_match(&self, manifest_outputs: &[Output]) -> bool {
+        let mut expected = self
+            .outputs
+            .iter()
+            .map(|(path, _, kind)| (path.as_str(), kind_name(*kind)))
+            .collect::<Vec<_>>();
+        let mut actual = manifest_outputs
+            .iter()
+            .map(|output| (output.path.as_str(), output.kind.as_str()))
+            .collect::<Vec<_>>();
+        expected.sort_unstable();
+        actual.sort_unstable();
+        expected == actual
     }
 
     fn lock(&self) -> Result<File> {
@@ -309,11 +329,19 @@ impl DependencyMaterializationCache {
         let (status, reason, bytes) = match &result {
             CacheResult::Hit { bytes } => ("hit", None, *bytes),
             CacheResult::Miss { reason } => ("miss", Some(reason.as_str()), 0),
+            CacheResult::Saved { bytes } => ("saved", None, *bytes),
         };
         let evidence = serde_json::json!({ "schema": SCHEMA, "key": self.key, "status": status, "reason": reason, "bytes": bytes, "provenance": self.provenance, "cache_root": self.root });
-        let path = self
-            .root
-            .join(format!("evidence-{}-{}.json", self.key, std::process::id()));
+        let event_id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let path = self.root.join(format!(
+            "evidence-{}-{}-{}.json",
+            self.key,
+            std::process::id(),
+            event_id
+        ));
         if fs::write(&path, serde_json::to_vec(&evidence).unwrap_or_default()).is_ok() {
             let _ = crate::local_artifact::register_current_run_artifact(
                 "dependency_materialization_cache",
@@ -325,8 +353,38 @@ impl DependencyMaterializationCache {
 }
 
 fn contained_path(root: &Path, path: impl AsRef<Path>) -> Result<PathBuf> {
-    homeboy_paths::resolve_contained_local_path(root, path, "dependency_materialization")
-        .map_err(Into::into)
+    let path =
+        homeboy_paths::resolve_contained_local_path(root, path, "dependency_materialization")
+            .map_err(Into::into)?;
+    let root =
+        fs::canonicalize(root).map_err(|error| io_error("resolve dependency workspace", error))?;
+    let mut ancestor = path.as_path();
+    loop {
+        match fs::canonicalize(ancestor) {
+            Ok(resolved) => {
+                if resolved.starts_with(&root) {
+                    return Ok(path);
+                }
+                return Err(Error::validation_invalid_argument(
+                    "dependency_materialization",
+                    "cache path resolves outside the dependency workspace",
+                    Some(path.display().to_string()),
+                    None,
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                ancestor = ancestor.parent().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "dependency_materialization",
+                        "cache path has no existing ancestor in the dependency workspace",
+                        Some(path.display().to_string()),
+                        None,
+                    )
+                })?;
+            }
+            Err(error) => return Err(io_error("resolve dependency cache path", error)),
+        }
+    }
 }
 fn read_json<T: for<'a> Deserialize<'a>>(path: &Path) -> Result<T> {
     serde_json::from_slice(
@@ -448,15 +506,28 @@ fn kind_matches(path: &Path, kind: DependencyMaterializationOutputKind) -> bool 
         DependencyMaterializationOutputKind::Path => path.exists(),
     }
 }
-fn output_matches(path: &Path, kind: &str, sha256: &str) -> Result<bool> {
+fn output_matches(path: &Path, kind: &str, sha256: &str) -> bool {
     let kind = match kind {
         "file" => DependencyMaterializationOutputKind::File,
         "dir" => DependencyMaterializationOutputKind::Dir,
-        _ => DependencyMaterializationOutputKind::Path,
+        "path" => DependencyMaterializationOutputKind::Path,
+        _ => return false,
     };
-    Ok(kind_matches(path, kind) && hash_path(path)? == sha256)
+    kind_matches(path, kind) && hash_path(path).is_ok_and(|hash| hash == sha256)
 }
 fn copy_replace(source: &Path, destination: &Path) -> Result<()> {
+    if fs::symlink_metadata(source)
+        .map_err(|error| io_error("inspect dependency cache output", error))?
+        .file_type()
+        .is_symlink()
+    {
+        return Err(Error::validation_invalid_argument(
+            "dependency_materialization",
+            "cache outputs must not contain symbolic links",
+            Some(source.display().to_string()),
+            None,
+        ));
+    }
     if let Some(parent) = destination.parent() {
         fs::create_dir_all(parent)
             .map_err(|error| io_error("create dependency cache output parent", error))?;
@@ -492,12 +563,29 @@ fn copy_directory(source: &Path, destination: &Path) -> Result<()> {
         fs::read_dir(source).map_err(|error| io_error("read dependency cache directory", error))?
     {
         let entry = entry.map_err(|error| io_error("read dependency cache entry", error))?;
+        let metadata = fs::symlink_metadata(entry.path())
+            .map_err(|error| io_error("inspect dependency cache entry", error))?;
+        if metadata.file_type().is_symlink() {
+            return Err(Error::validation_invalid_argument(
+                "dependency_materialization",
+                "cache outputs must not contain symbolic links",
+                Some(entry.path().display().to_string()),
+                None,
+            ));
+        }
         let target = destination.join(entry.file_name());
-        if entry.path().is_dir() {
+        if metadata.is_dir() {
             copy_directory(&entry.path(), &target)?;
-        } else {
+        } else if metadata.is_file() {
             fs::copy(entry.path(), target)
                 .map_err(|error| io_error("copy dependency cache file", error))?;
+        } else {
+            return Err(Error::validation_invalid_argument(
+                "dependency_materialization",
+                "cache outputs must be regular files or directories",
+                Some(entry.path().display().to_string()),
+                None,
+            ));
         }
     }
     Ok(())

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -4,7 +4,9 @@ use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
@@ -19,6 +21,7 @@ use homeboy_core::error::{Error, Result};
 
 const SCHEMA: &str = "homeboy/dependency-materialization-cache/v1";
 const MAX_TOOL_VERSION_BYTES: usize = 4096;
+const TOOL_VERSION_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Manifest {
@@ -415,17 +418,7 @@ fn resolved_tool_identities(step: &DependencyMaterializationStepSpec) -> Result<
         .unwrap_or_else(|| command.to_string());
     let version = resolved
         .as_ref()
-        .and_then(|path| Command::new(path).arg("--version").output().ok())
-        .map(|output| {
-            let bytes = if output.stdout.is_empty() {
-                output.stderr
-            } else {
-                output.stdout
-            };
-            String::from_utf8_lossy(&bytes[..bytes.len().min(MAX_TOOL_VERSION_BYTES)])
-                .trim()
-                .to_string()
-        })
+        .and_then(|path| bounded_tool_version(path))
         .filter(|version| !version.is_empty())
         .unwrap_or_else(|| "unavailable".to_string());
     Ok(vec![ToolIdentity {
@@ -433,6 +426,56 @@ fn resolved_tool_identities(step: &DependencyMaterializationStepSpec) -> Result<
         executable,
         version,
     }])
+}
+
+fn bounded_tool_version(path: &Path) -> Option<String> {
+    let mut child = Command::new(path)
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    let mut stdout = child.stdout.take()?;
+    let mut stderr = child.stderr.take()?;
+    let (stdout_tx, stdout_rx) = mpsc::sync_channel(1);
+    let (stderr_tx, stderr_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = stdout_tx.send(read_limited(&mut stdout));
+    });
+    std::thread::spawn(move || {
+        let _ = stderr_tx.send(read_limited(&mut stderr));
+    });
+    let deadline = Instant::now() + TOOL_VERSION_TIMEOUT;
+    loop {
+        if child.try_wait().ok()?.is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    // Descendants can inherit a pipe after the probed process exits. Never let
+    // that keep cache-key construction blocked; readers are byte-bounded.
+    let stdout = stdout_rx.recv_timeout(TOOL_VERSION_TIMEOUT).ok()?;
+    let stderr = stderr_rx.recv_timeout(TOOL_VERSION_TIMEOUT).ok()?;
+    let bytes = if stdout.is_empty() { stderr } else { stdout };
+    String::from_utf8_lossy(&bytes).trim().to_string().into()
+}
+
+fn read_limited(reader: &mut impl Read) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(MAX_TOOL_VERSION_BYTES);
+    let mut chunk = [0; 1024];
+    while bytes.len() < MAX_TOOL_VERSION_BYTES {
+        let limit = (MAX_TOOL_VERSION_BYTES - bytes.len()).min(chunk.len());
+        match reader.read(&mut chunk[..limit]) {
+            Ok(0) | Err(_) => break,
+            Ok(read) => bytes.extend_from_slice(&chunk[..read]),
+        }
+    }
+    bytes
 }
 
 fn publish_restore_transaction(
@@ -466,6 +509,11 @@ fn publish_restore_transaction(
             }
             fs::rename(staging.join(relative), destination)
                 .map_err(|error| io_error("publish dependency cache restore", error))?;
+            if should_fail_restore_publish() {
+                return Err(Error::internal_unexpected(
+                    "injected dependency cache restore publish failure".to_string(),
+                ));
+            }
         }
         Ok(())
     })();
@@ -482,6 +530,27 @@ fn publish_restore_transaction(
     let _ = clear_path(&backup);
     let _ = clear_path(staging);
     result
+}
+
+#[cfg(test)]
+static RESTORE_PUBLISH_FAILURE_AFTER: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(usize::MAX);
+
+#[cfg(test)]
+pub fn inject_restore_publish_failure_after(publishes: usize) {
+    RESTORE_PUBLISH_FAILURE_AFTER.store(publishes, std::sync::atomic::Ordering::SeqCst);
+}
+
+fn should_fail_restore_publish() -> bool {
+    #[cfg(test)]
+    {
+        let remaining = RESTORE_PUBLISH_FAILURE_AFTER.load(std::sync::atomic::Ordering::SeqCst);
+        if remaining == 0 {
+            return true;
+        }
+        RESTORE_PUBLISH_FAILURE_AFTER.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+    false
 }
 
 fn clear_path(path: &Path) -> Result<()> {

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,7 @@ use crate::spec::{
 use homeboy_core::error::{Error, Result};
 
 const SCHEMA: &str = "homeboy/dependency-materialization-cache/v1";
+const MAX_TOOL_VERSION_BYTES: usize = 4096;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Manifest {
@@ -34,7 +36,15 @@ struct Provenance {
     source: String,
     platform: String,
     environment_sha256: String,
+    tools: Vec<ToolIdentity>,
     inputs: Vec<Input>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ToolIdentity {
+    command: String,
+    executable: String,
+    version: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -52,13 +62,13 @@ struct Output {
     bytes: u64,
 }
 
-pub(crate) enum CacheResult {
+pub enum CacheResult {
     Hit { bytes: u64 },
     Miss { reason: String },
     Saved { bytes: u64 },
 }
 
-pub(crate) struct DependencyMaterializationCache {
+pub struct DependencyMaterializationCache {
     root: PathBuf,
     entry: PathBuf,
     key: String,
@@ -68,7 +78,7 @@ pub(crate) struct DependencyMaterializationCache {
 }
 
 impl DependencyMaterializationCache {
-    pub(crate) fn new(
+    pub fn new(
         rig: &RigSpec,
         step: &DependencyMaterializationStepSpec,
         settings: &[(String, String)],
@@ -159,6 +169,7 @@ impl DependencyMaterializationCache {
             source,
             platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
             environment_sha256,
+            tools: resolved_tool_identities(step)?,
             inputs,
         };
         let key = hash_bytes(
@@ -177,10 +188,7 @@ impl DependencyMaterializationCache {
                 )
             })?,
         );
-        let root = homeboy_paths::homeboy_data()?
-            .join("cache")
-            .join("dependency-materialization")
-            .join("v1");
+        let root = cache_root()?;
         Ok(Some(Self {
             entry: root.join(&key),
             root,
@@ -191,7 +199,7 @@ impl DependencyMaterializationCache {
         }))
     }
 
-    pub(crate) fn restore(&self) -> Result<CacheResult> {
+    pub fn restore(&self) -> Result<CacheResult> {
         let _lock = self.lock()?;
         let manifest_path = self.entry.join("manifest.json");
         let manifest: Manifest = match read_json::<Manifest>(&manifest_path) {
@@ -226,6 +234,14 @@ impl DependencyMaterializationCache {
                 });
             }
         }
+        let staging = self.workspace.join(format!(
+            ".homeboy-cache-restore-{}-{}",
+            self.key,
+            std::process::id()
+        ));
+        clear_path(&staging)?;
+        fs::create_dir_all(&staging)
+            .map_err(|error| io_error("create dependency cache restore staging", error))?;
         let mut bytes = 0;
         for output in &manifest.outputs {
             let (_, destination, kind) = self
@@ -238,19 +254,26 @@ impl DependencyMaterializationCache {
                     )
                 })?;
             let source = self.entry.join("outputs").join(&output.path);
-            let destination = contained_path(&self.workspace, destination)?;
-            copy_replace(&source, &destination)?;
-            if !kind_matches(&destination, *kind) || hash_path(&destination)? != output.sha256 {
+            let _destination = contained_path(&self.workspace, destination)?;
+            let staged = staging.join(&output.path);
+            copy_replace(&source, &staged)?;
+            if !kind_matches(&staged, *kind) || hash_path(&staged)? != output.sha256 {
+                let _ = clear_path(&staging);
                 return self.evidence(CacheResult::Miss {
                     reason: "restore_verification_failed".to_string(),
                 });
             }
             bytes += output.bytes;
         }
+        publish_restore_transaction(&self.workspace, &staging, &self.outputs)?;
         self.evidence(CacheResult::Hit { bytes })
     }
 
-    pub(crate) fn save(&self) -> Result<()> {
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn save(&self) -> Result<()> {
         let _lock = self.lock()?;
         let staging = self
             .root
@@ -350,6 +373,127 @@ impl DependencyMaterializationCache {
         }
         Ok(result)
     }
+}
+
+/// Durable root shared by local and runner-side Homeboy processes. Lab invokes
+/// the same rig materialization contract on the runner outside its workspace.
+pub fn cache_root() -> Result<PathBuf> {
+    Ok(homeboy_paths::homeboy_data()?
+        .join("cache")
+        .join("dependency-materialization")
+        .join("v1"))
+}
+
+fn resolved_tool_identities(step: &DependencyMaterializationStepSpec) -> Result<Vec<ToolIdentity>> {
+    let Some(command) = step.command.as_deref() else {
+        return Ok(step
+            .provider
+            .as_ref()
+            .map(|provider| {
+                vec![ToolIdentity {
+                    command: format!("provider:{provider}"),
+                    executable: format!("provider:{provider}"),
+                    version: "provider-contract-v1".to_string(),
+                }]
+            })
+            .unwrap_or_default());
+    };
+    let command = command.split_whitespace().next().unwrap_or_default();
+    if command.is_empty() {
+        return Ok(Vec::new());
+    }
+    let resolved = crate::toolchain::command_step_path()
+        .as_deref()
+        .and_then(|path| {
+            std::env::split_paths(path)
+                .map(|directory| directory.join(command))
+                .find(|path| path.is_file())
+        });
+    let executable = resolved
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| command.to_string());
+    let version = resolved
+        .as_ref()
+        .and_then(|path| Command::new(path).arg("--version").output().ok())
+        .map(|output| {
+            let bytes = if output.stdout.is_empty() {
+                output.stderr
+            } else {
+                output.stdout
+            };
+            String::from_utf8_lossy(&bytes[..bytes.len().min(MAX_TOOL_VERSION_BYTES)])
+                .trim()
+                .to_string()
+        })
+        .filter(|version| !version.is_empty())
+        .unwrap_or_else(|| "unavailable".to_string());
+    Ok(vec![ToolIdentity {
+        command: command.to_string(),
+        executable,
+        version,
+    }])
+}
+
+fn publish_restore_transaction(
+    workspace: &Path,
+    staging: &Path,
+    outputs: &[(String, PathBuf, DependencyMaterializationOutputKind)],
+) -> Result<()> {
+    let backup = workspace.join(format!(".homeboy-cache-backup-{}", std::process::id()));
+    clear_path(&backup)?;
+    fs::create_dir_all(&backup)
+        .map_err(|error| io_error("create dependency cache rollback staging", error))?;
+    let result = (|| {
+        for (relative, destination, _) in outputs {
+            let destination = contained_path(workspace, destination)?;
+            if destination.exists() {
+                let prior = backup.join(relative);
+                if let Some(parent) = prior.parent() {
+                    fs::create_dir_all(parent).map_err(|error| {
+                        io_error("create dependency cache rollback parent", error)
+                    })?;
+                }
+                fs::rename(&destination, prior)
+                    .map_err(|error| io_error("stage dependency cache rollback", error))?;
+            }
+        }
+        for (relative, destination, _) in outputs {
+            let destination = contained_path(workspace, destination)?;
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| io_error("create dependency cache output parent", error))?;
+            }
+            fs::rename(staging.join(relative), destination)
+                .map_err(|error| io_error("publish dependency cache restore", error))?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        for (relative, destination, _) in outputs {
+            let destination = contained_path(workspace, destination)?;
+            let _ = clear_path(&destination);
+            let prior = backup.join(relative);
+            if prior.exists() {
+                let _ = fs::rename(prior, destination);
+            }
+        }
+    }
+    let _ = clear_path(&backup);
+    let _ = clear_path(staging);
+    result
+}
+
+fn clear_path(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            fs::remove_dir_all(path)
+        }
+        Ok(_) => fs::remove_file(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(io_error("inspect dependency cache staging", error)),
+    }
+    .map_err(|error| io_error("clear dependency cache staging", error))
 }
 
 fn contained_path(root: &Path, path: impl AsRef<Path>) -> Result<PathBuf> {

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -487,6 +487,8 @@ fn publish_restore_transaction(
     clear_path(&backup)?;
     fs::create_dir_all(&backup)
         .map_err(|error| io_error("create dependency cache rollback staging", error))?;
+    let mut backed_up = Vec::new();
+    let mut published = Vec::new();
     let result = (|| {
         for (relative, destination, _) in outputs {
             let destination = contained_path(workspace, destination)?;
@@ -499,6 +501,7 @@ fn publish_restore_transaction(
                 }
                 fs::rename(&destination, prior)
                     .map_err(|error| io_error("stage dependency cache rollback", error))?;
+                backed_up.push(destination);
             }
         }
         for (relative, destination, _) in outputs {
@@ -507,8 +510,9 @@ fn publish_restore_transaction(
                 fs::create_dir_all(parent)
                     .map_err(|error| io_error("create dependency cache output parent", error))?;
             }
-            fs::rename(staging.join(relative), destination)
+            fs::rename(staging.join(relative), &destination)
                 .map_err(|error| io_error("publish dependency cache restore", error))?;
+            published.push(destination);
             if should_fail_restore_publish() {
                 return Err(Error::internal_unexpected(
                     "injected dependency cache restore publish failure".to_string(),
@@ -518,9 +522,15 @@ fn publish_restore_transaction(
         Ok(())
     })();
     if result.is_err() {
-        for (relative, destination, _) in outputs {
-            let destination = contained_path(workspace, destination)?;
+        for destination in published {
             let _ = clear_path(&destination);
+        }
+        for destination in backed_up {
+            let relative = destination.strip_prefix(workspace).map_err(|error| {
+                Error::internal_unexpected(format!(
+                    "derive dependency cache rollback path: {error}"
+                ))
+            })?;
             let prior = backup.join(relative);
             if prior.exists() {
                 let _ = fs::rename(prior, destination);

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -457,10 +457,12 @@ fn bounded_tool_version(path: &Path) -> Option<String> {
         }
         std::thread::sleep(Duration::from_millis(10));
     }
-    // Descendants can inherit a pipe after the probed process exits. Never let
-    // that keep cache-key construction blocked; readers are byte-bounded.
-    let stdout = stdout_rx.recv_timeout(TOOL_VERSION_TIMEOUT).ok()?;
-    let stderr = stderr_rx.recv_timeout(TOOL_VERSION_TIMEOUT).ok()?;
+    // Descendants can inherit a pipe after the probed process exits. Preserve
+    // the process deadline for both readers rather than extending it per pipe.
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let stdout = stdout_rx.recv_timeout(remaining).ok()?;
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let stderr = stderr_rx.recv_timeout(remaining).ok()?;
     let bytes = if stdout.is_empty() { stderr } else { stdout };
     String::from_utf8_lossy(&bytes).trim().to_string().into()
 }
@@ -815,4 +817,40 @@ fn copy_directory(source: &Path, destination: &Path) -> Result<()> {
 }
 fn io_error(context: &str, error: std::io::Error) -> Error {
     Error::internal_io(error.to_string(), Some(context.to_string()))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn tool(script: &str) -> tempfile::TempPath {
+        let file = tempfile::NamedTempFile::new().expect("tool");
+        std::fs::write(file.path(), script).expect("tool script");
+        std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o755))
+            .expect("tool mode");
+        file.into_temp_path()
+    }
+
+    #[test]
+    fn tool_version_probe_limits_captured_output() {
+        let tool = tool("#!/bin/sh\nyes x | head -c 8192\n");
+
+        let version = bounded_tool_version(&tool).expect("version");
+
+        assert_eq!(version.len(), MAX_TOOL_VERSION_BYTES - 1);
+    }
+
+    #[test]
+    fn tool_version_probe_times_out() {
+        let tool = tool("#!/bin/sh\nsleep 30\n");
+        let started = Instant::now();
+
+        let _ = bounded_tool_version(&tool);
+
+        assert!(
+            started.elapsed() < TOOL_VERSION_TIMEOUT + Duration::from_secs(2),
+            "version probe must terminate within its timeout"
+        );
+    }
 }

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -1,0 +1,507 @@
+//! Content-addressed dependency materialization cache shared by local and Lab rig runs.
+
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use fs4::fs_std::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::expand::expand_vars_with_settings;
+use crate::runner::{dependency_step_cwd, resolve_dependency_output_path};
+use crate::spec::{
+    DependencyMaterializationOutputKind, DependencyMaterializationStepSpec, RigSpec,
+};
+use homeboy_core::error::{Error, Result};
+
+const SCHEMA: &str = "homeboy/dependency-materialization-cache/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Manifest {
+    schema: String,
+    key: String,
+    provenance: Provenance,
+    outputs: Vec<Output>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Provenance {
+    rig_id: String,
+    step_id: String,
+    executor: String,
+    source: String,
+    platform: String,
+    environment_sha256: String,
+    inputs: Vec<Input>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Input {
+    path: String,
+    status: String,
+    sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Output {
+    path: String,
+    kind: String,
+    sha256: String,
+    bytes: u64,
+}
+
+pub(crate) enum CacheResult {
+    Hit { bytes: u64 },
+    Miss { reason: String },
+}
+
+pub(crate) struct DependencyMaterializationCache {
+    root: PathBuf,
+    entry: PathBuf,
+    key: String,
+    outputs: Vec<(String, PathBuf, DependencyMaterializationOutputKind)>,
+    provenance: Provenance,
+}
+
+impl DependencyMaterializationCache {
+    pub(crate) fn new(
+        rig: &RigSpec,
+        step: &DependencyMaterializationStepSpec,
+        settings: &[(String, String)],
+    ) -> Result<Option<Self>> {
+        if step.cache_key_inputs.is_empty() || step.expected_outputs.is_empty() {
+            return Ok(None);
+        }
+        let workspace = dependency_step_cwd(rig, step).map(PathBuf::from).unwrap_or(
+            std::env::current_dir().map_err(|error| io_error("read current directory", error))?,
+        );
+        let mut inputs = step
+            .cache_key_inputs
+            .iter()
+            .map(|input| {
+                let path =
+                    contained_path(&workspace, &expand_vars_with_settings(rig, input, settings))?;
+                let relative = path.strip_prefix(&workspace).unwrap().display().to_string();
+                Ok(Input {
+                    path: relative,
+                    status: if path.is_file() {
+                        "present".to_string()
+                    } else {
+                        "missing".to_string()
+                    },
+                    sha256: path.is_file().then(|| hash_file(&path)).transpose()?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        inputs.sort_by(|left, right| left.path.cmp(&right.path));
+        inputs.dedup_by(|left, right| left.path == right.path);
+        let mut outputs = Vec::new();
+        for output in &step.expected_outputs {
+            if !output.required {
+                continue;
+            }
+            let path = resolve_dependency_output_path(
+                rig,
+                step,
+                &expand_vars_with_settings(rig, &output.path, settings),
+            );
+            let path = contained_path(&workspace, path)?;
+            let relative = path.strip_prefix(&workspace).unwrap().display().to_string();
+            outputs.push((relative, path, output.kind));
+        }
+        outputs.sort_by(|left, right| left.0.cmp(&right.0));
+        let executor = step
+            .command
+            .as_ref()
+            .map(|command| format!("command:{command}"))
+            .or_else(|| {
+                step.provider
+                    .as_ref()
+                    .map(|provider| format!("provider:{provider}"))
+            })
+            .unwrap_or_default();
+        let source = crate::runner::head_sha_and_branch(&workspace.display().to_string())
+            .0
+            .unwrap_or_else(|| hash_directory(&workspace).unwrap_or_default());
+        let mut environment = BTreeMap::new();
+        for (key, value) in &step.env {
+            environment.insert(key.clone(), expand_vars_with_settings(rig, value, settings));
+        }
+        for (key, value) in settings {
+            environment.insert(format!("setting:{key}"), value.clone());
+        }
+        environment.insert(
+            "PATH".to_string(),
+            crate::toolchain::command_step_path()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned(),
+        );
+        environment.insert(
+            "homeboy".to_string(),
+            homeboy_product_identity::product_version().to_string(),
+        );
+        let environment_sha256 =
+            hash_bytes(&serde_json::to_vec(&environment).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize dependency cache environment".to_string()),
+                )
+            })?);
+        let provenance = Provenance {
+            rig_id: rig.id.clone(),
+            step_id: step.id.clone(),
+            executor,
+            source,
+            platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+            environment_sha256,
+            inputs,
+        };
+        let key = hash_bytes(
+            &serde_json::to_vec(&(
+                SCHEMA,
+                &provenance,
+                outputs
+                    .iter()
+                    .map(|(path, _, kind)| (path, format!("{kind:?}")))
+                    .collect::<Vec<_>>(),
+            ))
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize dependency cache key".to_string()),
+                )
+            })?,
+        );
+        let root = homeboy_paths::homeboy_data()?
+            .join("cache")
+            .join("dependency-materialization")
+            .join("v1");
+        Ok(Some(Self {
+            entry: root.join(&key),
+            root,
+            key,
+            outputs,
+            provenance,
+        }))
+    }
+
+    pub(crate) fn restore(&self) -> Result<CacheResult> {
+        let _lock = self.lock()?;
+        let manifest_path = self.entry.join("manifest.json");
+        let manifest: Manifest = match read_json::<Manifest>(&manifest_path) {
+            Ok(manifest)
+                if manifest.schema == SCHEMA
+                    && manifest.key == self.key
+                    && manifest.provenance == self.provenance =>
+            {
+                manifest
+            }
+            Ok(_) => {
+                return self.evidence(CacheResult::Miss {
+                    reason: "manifest_mismatch".to_string(),
+                })
+            }
+            Err(_) => {
+                return self.evidence(CacheResult::Miss {
+                    reason: "entry_missing_or_invalid".to_string(),
+                })
+            }
+        };
+        if manifest.outputs.len() != self.outputs.len() {
+            return self.evidence(CacheResult::Miss {
+                reason: "partial_entry".to_string(),
+            });
+        }
+        for output in &manifest.outputs {
+            let source = self.entry.join("outputs").join(&output.path);
+            if !output_matches(&source, &output.kind, &output.sha256)? {
+                return self.evidence(CacheResult::Miss {
+                    reason: "corrupt_entry".to_string(),
+                });
+            }
+        }
+        let mut bytes = 0;
+        for output in &manifest.outputs {
+            let (_, destination, kind) = self
+                .outputs
+                .iter()
+                .find(|(path, _, _)| path == &output.path)
+                .ok_or_else(|| {
+                    Error::internal_unexpected(
+                        "dependency cache manifest output not declared".to_string(),
+                    )
+                })?;
+            let source = self.entry.join("outputs").join(&output.path);
+            copy_replace(&source, destination)?;
+            if !kind_matches(destination, *kind) || hash_path(destination)? != output.sha256 {
+                return self.evidence(CacheResult::Miss {
+                    reason: "restore_verification_failed".to_string(),
+                });
+            }
+            bytes += output.bytes;
+        }
+        self.evidence(CacheResult::Hit { bytes })
+    }
+
+    pub(crate) fn save(&self) -> Result<()> {
+        let _lock = self.lock()?;
+        let staging = self
+            .root
+            .join(format!(".{}-{}.tmp", self.key, std::process::id()));
+        let _ = fs::remove_dir_all(&staging);
+        fs::create_dir_all(staging.join("outputs"))
+            .map_err(|error| io_error("create dependency cache staging", error))?;
+        let mut outputs = Vec::new();
+        for (relative, source, kind) in &self.outputs {
+            if !kind_matches(source, *kind) {
+                return Err(Error::validation_invalid_argument(
+                    "dependency_materialization",
+                    "declared cache output is missing or has the wrong kind",
+                    Some(source.display().to_string()),
+                    None,
+                ));
+            }
+            let destination = staging.join("outputs").join(relative);
+            copy_replace(source, &destination)?;
+            outputs.push(Output {
+                path: relative.clone(),
+                kind: kind_name(*kind).to_string(),
+                sha256: hash_path(source)?,
+                bytes: path_bytes(source)?,
+            });
+        }
+        let manifest = Manifest {
+            schema: SCHEMA.to_string(),
+            key: self.key.clone(),
+            provenance: self.provenance.clone(),
+            outputs,
+        };
+        write_json(&staging.join("manifest.json"), &manifest)?;
+        if self.entry.exists() {
+            fs::remove_dir_all(&self.entry)
+                .map_err(|error| io_error("replace dependency cache entry", error))?;
+        }
+        fs::rename(&staging, &self.entry)
+            .map_err(|error| io_error("publish dependency cache entry", error))?;
+        let bytes = manifest.outputs.iter().map(|output| output.bytes).sum();
+        let _ = self.evidence(CacheResult::Hit { bytes });
+        Ok(())
+    }
+
+    fn lock(&self) -> Result<File> {
+        fs::create_dir_all(&self.root)
+            .map_err(|error| io_error("create dependency cache root", error))?;
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(self.root.join(format!(".{}.lock", self.key)))
+            .map_err(|error| io_error("open dependency cache lock", error))?;
+        file.lock_exclusive()
+            .map_err(|error| io_error("lock dependency cache entry", error))?;
+        Ok(file)
+    }
+
+    fn evidence(&self, result: CacheResult) -> Result<CacheResult> {
+        let (status, reason, bytes) = match &result {
+            CacheResult::Hit { bytes } => ("hit", None, *bytes),
+            CacheResult::Miss { reason } => ("miss", Some(reason.as_str()), 0),
+        };
+        let evidence = serde_json::json!({ "schema": SCHEMA, "key": self.key, "status": status, "reason": reason, "bytes": bytes, "provenance": self.provenance, "cache_root": self.root });
+        let path = self
+            .root
+            .join(format!("evidence-{}-{}.json", self.key, std::process::id()));
+        if fs::write(&path, serde_json::to_vec(&evidence).unwrap_or_default()).is_ok() {
+            let _ = crate::local_artifact::register_current_run_artifact(
+                "dependency_materialization_cache",
+                &path,
+            );
+        }
+        Ok(result)
+    }
+}
+
+fn contained_path(root: &Path, path: impl AsRef<Path>) -> Result<PathBuf> {
+    homeboy_paths::resolve_contained_local_path(root, path, "dependency_materialization")
+        .map_err(Into::into)
+}
+fn read_json<T: for<'a> Deserialize<'a>>(path: &Path) -> Result<T> {
+    serde_json::from_slice(
+        &fs::read(path).map_err(|error| io_error("read dependency cache manifest", error))?,
+    )
+    .map_err(|error| {
+        Error::validation_invalid_argument(
+            "dependency_materialization",
+            format!("invalid dependency cache manifest: {error}"),
+            Some(path.display().to_string()),
+            None,
+        )
+    })
+}
+fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(value).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize dependency cache manifest".to_string()),
+            )
+        })?,
+    )
+    .map_err(|error| io_error("write dependency cache manifest", error))
+}
+fn hash_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+fn hash_file(path: &Path) -> Result<String> {
+    let mut file =
+        File::open(path).map_err(|error| io_error("read dependency cache file", error))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| io_error("hash dependency cache file", error))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+fn hash_path(path: &Path) -> Result<String> {
+    if path.is_file() {
+        return hash_file(path);
+    }
+    hash_directory(path)
+}
+fn hash_directory(root: &Path) -> Result<String> {
+    let mut files = Vec::new();
+    collect_files(root, root, &mut files)?;
+    files.sort();
+    let mut hasher = Sha256::new();
+    for file in files {
+        hasher.update(
+            file.strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .as_bytes(),
+        );
+        hasher.update(hash_file(&file)?.as_bytes());
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(directory)
+        .map_err(|error| io_error("read dependency cache directory", error))?
+    {
+        let path = entry
+            .map_err(|error| io_error("read dependency cache entry", error))?
+            .path();
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| io_error("inspect dependency cache entry", error))?;
+        if metadata.file_type().is_symlink() {
+            return Err(Error::validation_invalid_argument(
+                "dependency_materialization",
+                "cache outputs must not contain symbolic links",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+        if metadata.is_dir() {
+            collect_files(root, &path, files)?;
+        } else if metadata.is_file() {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+fn path_bytes(path: &Path) -> Result<u64> {
+    if path.is_file() {
+        return Ok(fs::metadata(path)
+            .map_err(|error| io_error("inspect dependency cache file", error))?
+            .len());
+    }
+    let mut files = Vec::new();
+    collect_files(path, path, &mut files)?;
+    files.into_iter().try_fold(0, |total, file| {
+        Ok(total
+            + fs::metadata(file)
+                .map_err(|error| io_error("inspect dependency cache file", error))?
+                .len())
+    })
+}
+fn kind_name(kind: DependencyMaterializationOutputKind) -> &'static str {
+    match kind {
+        DependencyMaterializationOutputKind::File => "file",
+        DependencyMaterializationOutputKind::Dir => "dir",
+        DependencyMaterializationOutputKind::Path => "path",
+    }
+}
+fn kind_matches(path: &Path, kind: DependencyMaterializationOutputKind) -> bool {
+    match kind {
+        DependencyMaterializationOutputKind::File => path.is_file(),
+        DependencyMaterializationOutputKind::Dir => path.is_dir(),
+        DependencyMaterializationOutputKind::Path => path.exists(),
+    }
+}
+fn output_matches(path: &Path, kind: &str, sha256: &str) -> Result<bool> {
+    let kind = match kind {
+        "file" => DependencyMaterializationOutputKind::File,
+        "dir" => DependencyMaterializationOutputKind::Dir,
+        _ => DependencyMaterializationOutputKind::Path,
+    };
+    Ok(kind_matches(path, kind) && hash_path(path)? == sha256)
+}
+fn copy_replace(source: &Path, destination: &Path) -> Result<()> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| io_error("create dependency cache output parent", error))?;
+    }
+    let staging = destination.with_extension(format!("homeboy-cache-{}", std::process::id()));
+    if staging.exists() {
+        fs::remove_dir_all(&staging)
+            .or_else(|_| fs::remove_file(&staging))
+            .map_err(|error| io_error("clear dependency cache restore staging", error))?;
+    }
+    if source.is_file() {
+        fs::copy(source, &staging)
+            .map_err(|error| io_error("stage dependency cache file", error))?;
+    } else {
+        copy_directory(source, &staging)?;
+    }
+    if destination.exists() {
+        if destination.is_dir() {
+            fs::remove_dir_all(destination)
+        } else {
+            fs::remove_file(destination)
+        }
+        .map_err(|error| io_error("replace dependency cache output", error))?;
+    }
+    fs::rename(staging, destination)
+        .map_err(|error| io_error("publish dependency cache output", error))?;
+    Ok(())
+}
+fn copy_directory(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)
+        .map_err(|error| io_error("create dependency cache directory", error))?;
+    for entry in
+        fs::read_dir(source).map_err(|error| io_error("read dependency cache directory", error))?
+    {
+        let entry = entry.map_err(|error| io_error("read dependency cache entry", error))?;
+        let target = destination.join(entry.file_name());
+        if entry.path().is_dir() {
+            copy_directory(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), target)
+                .map_err(|error| io_error("copy dependency cache file", error))?;
+        }
+    }
+    Ok(())
+}
+fn io_error(context: &str, error: std::io::Error) -> Error {
+    Error::internal_io(error.to_string(), Some(context.to_string()))
+}

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -22,6 +22,7 @@ pub mod artifact_index;
 pub mod capabilities;
 pub mod check;
 pub mod component_resolution;
+mod dependency_materialization_cache;
 mod discovery;
 pub mod expand;
 pub mod install;

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -22,7 +22,7 @@ pub mod artifact_index;
 pub mod capabilities;
 pub mod check;
 pub mod component_resolution;
-mod dependency_materialization_cache;
+pub mod dependency_materialization_cache;
 mod discovery;
 pub mod expand;
 pub mod install;

--- a/crates/homeboy-rig/src/local_artifact.rs
+++ b/crates/homeboy-rig/src/local_artifact.rs
@@ -91,8 +91,19 @@ pub fn register_current_run_artifact(
     path: impl AsRef<Path>,
 ) -> Result<LocalArtifactRegistration> {
     validate_kind(kind)?;
-    let run_id = required_env(homeboy_core::observation::ACTIVE_RUN_ID_ENV)?;
-    let manifest_path = required_env(RIG_ARTIFACT_MANIFEST_ENV)?;
+    let (run_id, manifest_path) = REGISTRATION_CONTEXT
+        .with(|slot| {
+            slot.borrow()
+                .as_ref()
+                .map(|context| (context.run_id.clone(), context.manifest_path.clone()))
+        })
+        .map(Ok)
+        .unwrap_or_else(|| {
+            Ok((
+                required_env(homeboy_core::observation::ACTIVE_RUN_ID_ENV)?,
+                required_env(RIG_ARTIFACT_MANIFEST_ENV)?,
+            ))
+        })?;
     let manifest_path = Path::new(&manifest_path);
     if !manifest_path.is_absolute() || !manifest_path.is_file() {
         return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-rig/src/resource_lifecycle.rs
+++ b/crates/homeboy-rig/src/resource_lifecycle.rs
@@ -92,7 +92,9 @@ pub fn dependency_materialization_cache_lifecycle_record(
         ttl: Some("P30D".to_string()),
         cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
         evidence_retention: ResourceEvidenceRetention::Manifest,
-        cleanup_intent: options.cleanup_intent,
+        // Cache ownership is explicit: dry-run commands still only plan, while
+        // an operator's --apply may reclaim expired content-addressed entries.
+        cleanup_intent: ResourceCleanupIntent::Apply,
         cleanup_command: Some(format!(
             "homeboy runs resources --run-id {} --cleanup-plan",
             options.run_id

--- a/crates/homeboy-rig/src/resource_lifecycle.rs
+++ b/crates/homeboy-rig/src/resource_lifecycle.rs
@@ -73,6 +73,34 @@ pub fn rig_resource_lifecycle_records(
     records
 }
 
+/// Add durable dependency-cache storage to the same lifecycle index as rig
+/// resources. Entries are content addressed and independent of a run workspace,
+/// so retention is TTL based rather than terminal-run cleanup.
+pub fn dependency_materialization_cache_lifecycle_record(
+    options: &RigResourceLifecycleOptions,
+    root: &std::path::Path,
+) -> ResourceLifecycleRecord {
+    ResourceLifecycleRecord {
+        owner: "homeboy.rig.dependency_materialization_cache".to_string(),
+        run_id: options.run_id.clone(),
+        runner_id: options.runner_id.clone(),
+        path: root.display().to_string(),
+        // The cache root itself is the removable owned resource; bind cleanup
+        // to its parent so lifecycle cleanup cannot escape Homeboy cache space.
+        root_bound: root.parent().map(|parent| parent.display().to_string()),
+        kind: "dependency_materialization_cache".to_string(),
+        ttl: Some("P30D".to_string()),
+        cleanup_policy: ResourceCleanupPolicy::DeleteAfterTtl,
+        evidence_retention: ResourceEvidenceRetention::Manifest,
+        cleanup_intent: options.cleanup_intent,
+        cleanup_command: Some(format!(
+            "homeboy runs resources --run-id {} --cleanup-plan",
+            options.run_id
+        )),
+        status: options.status,
+    }
+}
+
 fn record(
     options: &RigResourceLifecycleOptions,
     kind: &str,
@@ -169,6 +197,23 @@ mod tests {
         assert_eq!(
             index.resources[0].cleanup_intent,
             ResourceCleanupIntent::Apply
+        );
+    }
+
+    #[test]
+    fn dependency_cache_is_retained_through_the_lifecycle_contract() {
+        let root = tempfile::tempdir().expect("cache root");
+        let record = dependency_materialization_cache_lifecycle_record(
+            &RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active),
+            root.path(),
+        );
+
+        record.validate(0).expect("valid cache lifecycle record");
+        assert_eq!(record.cleanup_policy, ResourceCleanupPolicy::DeleteAfterTtl);
+        assert_eq!(record.ttl.as_deref(), Some("P30D"));
+        assert_eq!(
+            record.evidence_retention,
+            ResourceEvidenceRetention::Manifest
         );
     }
 }

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use super::artifact_index::{self, RigRunArtifactIndex};
 
 use super::capabilities::evaluate_requirements;
+use super::dependency_materialization_cache::{CacheResult, DependencyMaterializationCache};
 use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
 use super::lint::run_package_lint;
@@ -447,6 +448,13 @@ fn materialize_dependency_step(
         return Ok(());
     }
 
+    let cache = DependencyMaterializationCache::new(rig, step, settings)?;
+    if let Some(cache) = cache.as_ref() {
+        if matches!(cache.restore()?, CacheResult::Hit { .. }) {
+            return Ok(());
+        }
+    }
+
     if let Some(command) = step.command.as_deref() {
         let env: HashMap<String, String> = step
             .env
@@ -502,6 +510,10 @@ fn materialize_dependency_step(
         ));
     }
 
+    if let Some(cache) = cache.as_ref() {
+        cache.save()?;
+    }
+
     Ok(())
 }
 
@@ -537,7 +549,7 @@ fn missing_dependency_outputs(
         .collect()
 }
 
-fn resolve_dependency_output_path(
+pub(crate) fn resolve_dependency_output_path(
     rig: &RigSpec,
     step: &super::DependencyMaterializationStepSpec,
     path: &str,
@@ -553,7 +565,7 @@ fn resolve_dependency_output_path(
     output_path
 }
 
-fn dependency_step_cwd(
+pub(crate) fn dependency_step_cwd(
     rig: &RigSpec,
     step: &super::DependencyMaterializationStepSpec,
 ) -> Option<String> {

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -22,7 +22,10 @@ use super::pipeline::{
     run_pipeline_with_settings, run_prepare_requirement_steps, PipelineOutcome,
     PipelineStepOutcome,
 };
-use super::resource_lifecycle::{rig_resource_lifecycle_index, RigResourceLifecycleOptions};
+use super::resource_lifecycle::{
+    dependency_materialization_cache_lifecycle_record, rig_resource_lifecycle_index,
+    RigResourceLifecycleOptions,
+};
 use super::service::{self, ServiceStatus};
 use super::spec::{DependencyMaterializationOutputKind, RigSpec, ServiceKind, SymlinkSpec};
 use super::state::{
@@ -1044,7 +1047,12 @@ impl RigRunObserver {
                 .unwrap_or_else(|| super::expand::expand_resources(rig)),
             _ => return,
         };
-        if resources.is_empty() {
+        let cache_enabled = rig
+            .requirements
+            .dependency_materialization
+            .iter()
+            .any(|step| !step.cache_key_inputs.is_empty() && !step.expected_outputs.is_empty());
+        if resources.is_empty() && !cache_enabled {
             return;
         }
 
@@ -1060,7 +1068,16 @@ impl RigRunObserver {
         if let Some(cleanup) = &rig.lifecycle.cleanup {
             options.cleanup_intent = cleanup.resource_cleanup_intent();
         }
-        let index = rig_resource_lifecycle_index(&rig.id, &resources, options);
+        let mut index = rig_resource_lifecycle_index(&rig.id, &resources, options.clone());
+        if cache_enabled {
+            if let Ok(root) = super::dependency_materialization_cache::cache_root() {
+                index
+                    .resources
+                    .push(dependency_materialization_cache_lifecycle_record(
+                        &options, &root,
+                    ));
+            }
+        }
         if index.resources.is_empty() || index.validate().is_err() {
             return;
         }

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -74,8 +74,12 @@ pub struct BenchPrepareReport {
 #[derive(Debug, Clone, Serialize)]
 pub struct FuzzPrepareReport {
     pub rig_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
     pub pipeline: PipelineOutcome,
     pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_index: Option<RigRunArtifactIndex>,
 }
 
 /// Report from `rig down`.
@@ -375,24 +379,47 @@ pub fn run_fuzz_prepare(
         return Ok(None);
     }
 
-    let dependency_outcome = run_dependency_materialization_steps(rig, "fuzz_prepare", settings)?;
-    let pipeline_outcome =
-        if dependency_outcome.is_success() && rig.pipeline.contains_key("fuzz_prepare") {
-            run_pipeline_with_settings(rig, "fuzz_prepare", true, settings)?
-        } else {
-            PipelineOutcome {
-                name: "fuzz_prepare".to_string(),
-                steps: Vec::new(),
-                passed: 0,
-                failed: 0,
-            }
-        };
-    let outcome = merge_prepare_outcomes("fuzz_prepare", dependency_outcome, pipeline_outcome);
-    Ok(Some(FuzzPrepareReport {
-        rig_id: rig.id.clone(),
-        success: outcome.is_success(),
-        pipeline: outcome,
-    }))
+    // Dependency-cache evidence must belong to a real, completed run rather
+    // than depending on a caller to have installed a rig observer.
+    let observer = RigRunObserver::start(rig, "fuzz_prepare");
+    let execute = || {
+        let dependency_outcome =
+            run_dependency_materialization_steps(rig, "fuzz_prepare", settings)?;
+        let pipeline_outcome =
+            if dependency_outcome.is_success() && rig.pipeline.contains_key("fuzz_prepare") {
+                run_pipeline_with_settings(rig, "fuzz_prepare", true, settings)?
+            } else {
+                PipelineOutcome {
+                    name: "fuzz_prepare".to_string(),
+                    steps: Vec::new(),
+                    passed: 0,
+                    failed: 0,
+                }
+            };
+        let outcome = merge_prepare_outcomes("fuzz_prepare", dependency_outcome, pipeline_outcome);
+        Ok(FuzzPrepareReport {
+            rig_id: rig.id.clone(),
+            run_id: None,
+            success: outcome.is_success(),
+            pipeline: outcome,
+            artifact_index: None,
+        })
+    };
+    let mut result = match observer.as_ref() {
+        Some(observer) => observer.with_command_context(execute),
+        None => execute(),
+    };
+    let artifact_index = RigRunObserver::finish(
+        observer.as_ref(),
+        rig,
+        result.as_ref().ok().map(|report| &report.pipeline),
+        &result,
+    );
+    if let Ok(report) = result.as_mut() {
+        report.run_id = observer.as_ref().map(|observer| observer.run_id.clone());
+        report.artifact_index = artifact_index;
+    }
+    result.map(Some)
 }
 
 fn run_dependency_materialization_steps(
@@ -1036,7 +1063,7 @@ impl RigRunObserver {
         let resources = match self.command.as_str() {
             "up" if status == RunStatus::Pass => super::expand::expand_resources(rig),
             "up" => super::expand::expand_resources(rig),
-            "check" => super::expand::expand_resources(rig),
+            "check" | "fuzz_prepare" => super::expand::expand_resources(rig),
             "down" => RigState::load(&rig.id)
                 .ok()
                 .and_then(|state| {
@@ -1060,6 +1087,8 @@ impl RigRunObserver {
             "up" if status == RunStatus::Pass => ResourceLifecycleResourceStatus::Active,
             "up" => ResourceLifecycleResourceStatus::Failed,
             "check" => ResourceLifecycleResourceStatus::Declared,
+            "fuzz_prepare" if status == RunStatus::Pass => ResourceLifecycleResourceStatus::Active,
+            "fuzz_prepare" => ResourceLifecycleResourceStatus::Failed,
             "down" if status == RunStatus::Pass => ResourceLifecycleResourceStatus::Cleaned,
             "down" => ResourceLifecycleResourceStatus::CleanupPending,
             _ => return,

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -3,8 +3,12 @@
 use std::collections::HashMap;
 use std::process::Command;
 
-use crate::runner::{run_check, run_up};
-use crate::spec::{ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec};
+use crate::runner::{run_check, run_fuzz_prepare, run_up};
+use crate::spec::{
+    ComponentSpec, DependencyMaterializationOutputKind, DependencyMaterializationOutputSpec,
+    DependencyMaterializationSafety, DependencyMaterializationStepSpec, PipelineStep,
+    RigRequirementsSpec, RigResourcesSpec, RigSpec,
+};
 use crate::{RigSourceMetadata, RigState};
 use homeboy_core::observation::{ObservationStore, RunListFilter};
 use homeboy_core::paths;
@@ -398,6 +402,52 @@ fn test_observation_store_failure_does_not_fail_rig_check() {
                 .as_deref(),
             Some("pass")
         );
+    });
+}
+
+#[test]
+fn fuzz_prepare_registers_dependency_cache_evidence_and_lifecycle_index() {
+    with_isolated_home(|home| {
+        let _xdg = XdgDataHomeGuard::unset();
+        let workspace = home.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::write(workspace.join("lock"), "input").expect("lock");
+        let mut rig = observation_spec("observed-fuzz-cache");
+        rig.requirements = RigRequirementsSpec {
+            dependency_materialization: vec![DependencyMaterializationStepSpec {
+                id: "install".to_string(),
+                command: Some("printf output > output".to_string()),
+                cwd: Some(workspace.display().to_string()),
+                cache_key_inputs: vec!["lock".to_string()],
+                expected_outputs: vec![DependencyMaterializationOutputSpec {
+                    path: "output".to_string(),
+                    kind: DependencyMaterializationOutputKind::File,
+                    required: true,
+                }],
+                safety: DependencyMaterializationSafety::WritesCache,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let report = run_fuzz_prepare(&rig, &[])
+            .expect("prepare")
+            .expect("declared prepare");
+        assert!(report.success);
+        let run_id = report.run_id.expect("fuzz prepare observation id");
+        let artifacts = ObservationStore::open_initialized()
+            .expect("store")
+            .list_artifacts(&run_id)
+            .expect("artifacts");
+        assert!(artifacts
+            .iter()
+            .any(|artifact| artifact.kind == "dependency_materialization_cache"));
+        let index = resource_lifecycle_index_from_artifacts(&artifacts)
+            .expect("lifecycle index")
+            .expect("cache lifecycle index");
+        assert!(index.resources.iter().any(|record| {
+            record.kind == "dependency_materialization_cache" && record.cleanup_intent.is_apply()
+        }));
     });
 }
 

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -17,14 +17,15 @@ use std::collections::HashMap;
 
 use crate::pipeline::PipelineOutcome;
 use crate::runner::{
-    head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings, run_repair,
-    run_status, run_up, snapshot_state, CheckReport, RigStatusReport, ServiceStatusReport,
-    SymlinkStatusState, UpReport,
+    head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings,
+    run_fuzz_prepare, run_repair, run_status, run_up, snapshot_state, CheckReport, RigStatusReport,
+    ServiceStatusReport, SymlinkStatusState, UpReport,
 };
 use crate::spec::{
-    ComponentSpec, ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec,
-    PipelineStep, RigRequirementsSpec, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec,
-    SharedPathOp, SharedPathSpec, SymlinkSpec,
+    ComponentSpec, DependencyMaterializationOutputKind, DependencyMaterializationOutputSpec,
+    DependencyMaterializationSafety, DependencyMaterializationStepSpec, ExecutableRequirementSpec,
+    FilesystemAssertionKind, FilesystemAssertionSpec, PipelineStep, RigRequirementsSpec,
+    RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, SymlinkSpec,
 };
 use crate::state::RigState;
 use homeboy_core::test_support::with_isolated_home;
@@ -977,4 +978,88 @@ fn test_head_sha_and_branch_returns_sha_and_branch_for_git_repo() {
         "HEAD SHA is hex: {sha}"
     );
     assert_eq!(branch.as_deref(), Some("fixture-main"));
+}
+
+#[test]
+fn dependency_materialization_cache_restores_verified_outputs_in_a_fresh_workspace() {
+    with_isolated_home(|root| {
+        let first = root.path().join("first");
+        let second = root.path().join("second");
+        let third = root.path().join("third");
+        let count = root.path().join("materializations");
+        for workspace in [&first, &second, &third] {
+            std::fs::create_dir_all(workspace).expect("workspace");
+            std::fs::write(workspace.join("lock"), "same input\n").expect("lock input");
+        }
+        let command = format!(
+            "printf materialized >> '{}'; mkdir -p output; cp lock output/value",
+            count.display()
+        );
+        let rig_for = |workspace: &std::path::Path| RigSpec {
+            id: "dependency-cache-fixture".to_string(),
+            requirements: RigRequirementsSpec {
+                dependency_materialization: vec![DependencyMaterializationStepSpec {
+                    id: "install".to_string(),
+                    command: Some(command.clone()),
+                    cwd: Some(workspace.display().to_string()),
+                    cache_key_inputs: vec!["lock".to_string()],
+                    expected_outputs: vec![DependencyMaterializationOutputSpec {
+                        path: "output/value".to_string(),
+                        kind: DependencyMaterializationOutputKind::File,
+                        required: true,
+                    }],
+                    safety: DependencyMaterializationSafety::WritesCache,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..minimal_spec("dependency-cache-fixture")
+        };
+
+        let first_report = run_fuzz_prepare(&rig_for(&first), &[])
+            .expect("first materialization")
+            .expect("prepare report");
+        assert!(first_report.success, "{:?}", first_report.pipeline.steps);
+        assert_eq!(
+            std::fs::read_to_string(&count).expect("first command"),
+            "materialized"
+        );
+
+        let second_report = run_fuzz_prepare(&rig_for(&second), &[])
+            .expect("cache restore")
+            .expect("prepare report");
+        assert!(second_report.success);
+        assert_eq!(
+            std::fs::read_to_string(&count).expect("cache skipped command"),
+            "materialized"
+        );
+        assert_eq!(
+            std::fs::read_to_string(second.join("output/value")).expect("restored output"),
+            "same input\n"
+        );
+
+        let cache_root = homeboy_paths::homeboy_data()
+            .expect("data root")
+            .join("cache/dependency-materialization/v1");
+        let entry = std::fs::read_dir(&cache_root)
+            .expect("cache entries")
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .find(|path| path.is_dir())
+            .expect("published cache entry");
+        std::fs::write(entry.join("outputs/output/value"), "corrupt")
+            .expect("corrupt cache output");
+
+        let third_report = run_fuzz_prepare(&rig_for(&third), &[])
+            .expect("corrupt entry is a safe miss")
+            .expect("prepare report");
+        assert!(third_report.success);
+        assert_eq!(
+            std::fs::read_to_string(&count).expect("materializer reran"),
+            "materializedmaterialized"
+        );
+        assert_eq!(
+            std::fs::read_to_string(third.join("output/value")).expect("rematerialized output"),
+            "same input\n"
+        );
+    });
 }

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -1061,5 +1061,77 @@ fn dependency_materialization_cache_restores_verified_outputs_in_a_fresh_workspa
             std::fs::read_to_string(third.join("output/value")).expect("rematerialized output"),
             "same input\n"
         );
+
+        let evidence = std::fs::read_dir(&cache_root)
+            .expect("cache evidence")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with("evidence-"))
+            .map(|entry| {
+                serde_json::from_slice::<serde_json::Value>(
+                    &std::fs::read(entry.path()).expect("read cache evidence"),
+                )
+                .expect("parse cache evidence")
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            evidence.iter().any(|event| event["status"] == "miss"),
+            "cache miss must be retained as structured evidence: {evidence:?}"
+        );
+        assert!(
+            evidence.iter().any(|event| event["status"] == "hit"),
+            "cache hit must be retained as structured evidence: {evidence:?}"
+        );
+        assert!(
+            evidence.iter().any(|event| event["status"] == "saved"),
+            "cache save must be retained as structured evidence: {evidence:?}"
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn dependency_materialization_cache_rejects_output_symlink_escapes() {
+    with_isolated_home(|root| {
+        let workspace = root.path().join("workspace");
+        let outside = root.path().join("outside");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::create_dir_all(&outside).expect("outside");
+        std::fs::write(workspace.join("lock"), "input\n").expect("lock input");
+        unix_symlink(&outside, &workspace.join("output"));
+
+        let rig = RigSpec {
+            id: "dependency-cache-symlink-escape".to_string(),
+            requirements: RigRequirementsSpec {
+                dependency_materialization: vec![DependencyMaterializationStepSpec {
+                    id: "install".to_string(),
+                    command: Some("touch output/value".to_string()),
+                    cwd: Some(workspace.display().to_string()),
+                    cache_key_inputs: vec!["lock".to_string()],
+                    expected_outputs: vec![DependencyMaterializationOutputSpec {
+                        path: "output/value".to_string(),
+                        kind: DependencyMaterializationOutputKind::File,
+                        required: true,
+                    }],
+                    safety: DependencyMaterializationSafety::WritesCache,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..minimal_spec("dependency-cache-symlink-escape")
+        };
+
+        let report = run_fuzz_prepare(&rig, &[])
+            .expect("symlink escape is reported as a failed prepare")
+            .expect("prepare report");
+        assert!(!report.success);
+        assert!(report.pipeline.steps[0]
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("resolves outside the dependency workspace"));
+        assert!(
+            !outside.join("value").exists(),
+            "the materializer must not run through an output symlink"
+        );
     });
 }

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -15,6 +15,7 @@
 
 use std::collections::HashMap;
 
+use crate::dependency_materialization_cache::{CacheResult, DependencyMaterializationCache};
 use crate::pipeline::PipelineOutcome;
 use crate::runner::{
     head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings,
@@ -1084,6 +1085,149 @@ fn dependency_materialization_cache_restores_verified_outputs_in_a_fresh_workspa
         assert!(
             evidence.iter().any(|event| event["status"] == "saved"),
             "cache save must be retained as structured evidence: {evidence:?}"
+        );
+    });
+}
+
+#[test]
+fn dependency_materialization_cache_rolls_back_all_outputs_when_a_restore_is_invalid() {
+    with_isolated_home(|root| {
+        let first = root.path().join("first");
+        let second = root.path().join("second");
+        for workspace in [&first, &second] {
+            std::fs::create_dir_all(workspace.join("output")).expect("workspace");
+            std::fs::write(workspace.join("lock"), "same input\n").expect("lock");
+        }
+        std::fs::write(first.join("output/one"), "new one").expect("first one");
+        std::fs::write(first.join("output/two"), "new two").expect("first two");
+        std::fs::write(second.join("output/one"), "old one").expect("second one");
+        std::fs::write(second.join("output/two"), "old two").expect("second two");
+        let rig_for = |workspace: &std::path::Path| RigSpec {
+            id: "dependency-cache-rollback".to_string(),
+            requirements: RigRequirementsSpec {
+                dependency_materialization: vec![DependencyMaterializationStepSpec {
+                    id: "install".to_string(),
+                    command: Some("printf ignored".to_string()),
+                    cwd: Some(workspace.display().to_string()),
+                    cache_key_inputs: vec!["lock".to_string()],
+                    expected_outputs: vec![
+                        DependencyMaterializationOutputSpec {
+                            path: "output/one".to_string(),
+                            kind: DependencyMaterializationOutputKind::File,
+                            required: true,
+                        },
+                        DependencyMaterializationOutputSpec {
+                            path: "output/two".to_string(),
+                            kind: DependencyMaterializationOutputKind::File,
+                            required: true,
+                        },
+                    ],
+                    safety: DependencyMaterializationSafety::WritesCache,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..minimal_spec("dependency-cache-rollback")
+        };
+        let first_rig = rig_for(&first);
+        let first_step = &first_rig.requirements.dependency_materialization[0];
+        let cache = DependencyMaterializationCache::new(&first_rig, first_step, &[])
+            .expect("cache")
+            .expect("enabled cache");
+        cache.save().expect("save cache");
+        let cache_root = homeboy_paths::homeboy_data()
+            .expect("data root")
+            .join("cache/dependency-materialization/v1");
+        let entry = std::fs::read_dir(cache_root)
+            .expect("entries")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| path.is_dir())
+            .expect("entry");
+        std::fs::write(entry.join("outputs/output/two"), "corrupt").expect("corrupt second output");
+
+        let second_rig = rig_for(&second);
+        let second_step = &second_rig.requirements.dependency_materialization[0];
+        let restore = DependencyMaterializationCache::new(&second_rig, second_step, &[])
+            .expect("cache")
+            .expect("enabled cache")
+            .restore()
+            .expect("safe miss");
+        assert!(matches!(restore, CacheResult::Miss { .. }));
+        assert_eq!(
+            std::fs::read_to_string(second.join("output/one")).unwrap(),
+            "old one"
+        );
+        assert_eq!(
+            std::fs::read_to_string(second.join("output/two")).unwrap(),
+            "old two"
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn dependency_materialization_cache_key_includes_resolved_tool_version() {
+    with_isolated_home(|root| {
+        let bin = root.path().join(".local/bin");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(&bin).expect("bin");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::write(workspace.join("lock"), "same input\n").expect("lock");
+        let tool = bin.join("cache-tool");
+        std::fs::write(
+            &tool,
+            "#!/bin/sh\nif [ \"$1\" = --version ]; then echo tool-v1; fi\n",
+        )
+        .expect("tool");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).expect("tool mode");
+        let rig = RigSpec {
+            id: "dependency-cache-tool-version".to_string(),
+            requirements: RigRequirementsSpec {
+                dependency_materialization: vec![DependencyMaterializationStepSpec {
+                    id: "install".to_string(),
+                    command: Some("cache-tool install".to_string()),
+                    cwd: Some(workspace.display().to_string()),
+                    cache_key_inputs: vec!["lock".to_string()],
+                    expected_outputs: vec![DependencyMaterializationOutputSpec {
+                        path: "output".to_string(),
+                        kind: DependencyMaterializationOutputKind::File,
+                        required: true,
+                    }],
+                    safety: DependencyMaterializationSafety::WritesCache,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..minimal_spec("dependency-cache-tool-version")
+        };
+        let key_v1 = DependencyMaterializationCache::new(
+            &rig,
+            &rig.requirements.dependency_materialization[0],
+            &[],
+        )
+        .expect("cache")
+        .expect("enabled")
+        .key()
+        .to_string();
+        std::fs::write(
+            &tool,
+            "#!/bin/sh\nif [ \"$1\" = --version ]; then echo tool-v2; fi\n",
+        )
+        .expect("replace tool");
+        let key_v2 = DependencyMaterializationCache::new(
+            &rig,
+            &rig.requirements.dependency_materialization[0],
+            &[],
+        )
+        .expect("cache")
+        .expect("enabled")
+        .key()
+        .to_string();
+        assert_ne!(
+            key_v1, key_v2,
+            "a resolved tool version change invalidates the cache"
         );
     });
 }

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -15,7 +15,9 @@
 
 use std::collections::HashMap;
 
-use crate::dependency_materialization_cache::{CacheResult, DependencyMaterializationCache};
+use crate::dependency_materialization_cache::{
+    inject_restore_publish_failure_after, CacheResult, DependencyMaterializationCache,
+};
 use crate::pipeline::PipelineOutcome;
 use crate::runner::{
     head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings,
@@ -1161,6 +1163,79 @@ fn dependency_materialization_cache_rolls_back_all_outputs_when_a_restore_is_inv
         assert_eq!(
             std::fs::read_to_string(second.join("output/two")).unwrap(),
             "old two"
+        );
+    });
+}
+
+#[test]
+fn dependency_materialization_cache_rolls_back_published_and_absent_outputs_on_publish_failure() {
+    with_isolated_home(|root| {
+        let source = root.path().join("source");
+        let destination = root.path().join("destination");
+        for workspace in [&source, &destination] {
+            std::fs::create_dir_all(workspace.join("output")).expect("workspace");
+            std::fs::write(workspace.join("lock"), "same input\n").expect("lock");
+        }
+        let rig_for = |workspace: &std::path::Path| RigSpec {
+            id: "dependency-cache-publish-rollback".to_string(),
+            requirements: RigRequirementsSpec {
+                dependency_materialization: vec![DependencyMaterializationStepSpec {
+                    id: "install".to_string(),
+                    command: Some("printf ignored".to_string()),
+                    cwd: Some(workspace.display().to_string()),
+                    cache_key_inputs: vec!["lock".to_string()],
+                    expected_outputs: vec![
+                        DependencyMaterializationOutputSpec {
+                            path: "output/one".to_string(),
+                            kind: DependencyMaterializationOutputKind::File,
+                            required: true,
+                        },
+                        DependencyMaterializationOutputSpec {
+                            path: "output/two".to_string(),
+                            kind: DependencyMaterializationOutputKind::File,
+                            required: true,
+                        },
+                    ],
+                    safety: DependencyMaterializationSafety::WritesCache,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..minimal_spec("dependency-cache-publish-rollback")
+        };
+        let source_rig = rig_for(&source);
+        let cache = DependencyMaterializationCache::new(
+            &source_rig,
+            &source_rig.requirements.dependency_materialization[0],
+            &[],
+        )
+        .expect("cache")
+        .expect("enabled cache");
+        let destination_rig = rig_for(&destination);
+        let restore_cache = DependencyMaterializationCache::new(
+            &destination_rig,
+            &destination_rig.requirements.dependency_materialization[0],
+            &[],
+        )
+        .expect("cache")
+        .expect("enabled cache");
+        std::fs::write(source.join("output/one"), "new one").expect("source one");
+        std::fs::write(source.join("output/two"), "new two").expect("source two");
+        std::fs::write(destination.join("output/one"), "old one").expect("destination one");
+        cache.save().expect("save cache");
+
+        inject_restore_publish_failure_after(1);
+        let restore = restore_cache.restore();
+        inject_restore_publish_failure_after(usize::MAX);
+
+        assert!(restore.is_err(), "injected failure must abort restore");
+        assert_eq!(
+            std::fs::read_to_string(destination.join("output/one")).unwrap(),
+            "old one"
+        );
+        assert!(
+            !destination.join("output/two").exists(),
+            "an output absent before restore remains absent after rollback"
         );
     });
 }


### PR DESCRIPTION
Closes #9904

## Summary
- add a content-addressed cache for rig dependency materialization steps that declare `cache_key_inputs` and required `expected_outputs`
- use the same owning `homeboy-rig` cache primitive in local execution and runner-side Lab commands, with durable data-root storage outside fresh run workspaces
- key entries by input content, source identity, command/provider identity, resolved tool executable/version identity, environment, platform, and Homeboy version
- stage and verify every restored output before a rollback-capable publish; preserve prior outputs on any invalid or failed restore
- publish staged entries behind per-key exclusive locks; validate manifest, output kinds, SHA-256 digests, contained paths, and symlink-free trees
- register cache evidence with structured observations when a rig run context exists and retain cache storage through the resource lifecycle index with a 30-day TTL

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-rig dependency_materialization_cache --lib`
- `cargo check --workspace`

## AI assistance
OpenAI GPT-5.6 Terra was used through OpenCode to inspect materialization and Lab execution paths, implement the cache lifecycle and transactional restore contracts, add focused tests, and run verification. Chris Huber remains responsible for every line.