### PR TITLE
fix(fuzz): make planned Lab commands executable

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -378,6 +378,15 @@ impl CliRuntime {
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
         normalize_cook_runner_option(&mut cli, &normalized);
+        if let Commands::Fuzz(args) = &mut cli.command {
+            match args.absorb_planning_runner(cli.runner.take()) {
+                Ok(runner) => cli.runner = runner,
+                Err(err) => {
+                    output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                    return std::process::ExitCode::from(2);
+                }
+            }
+        }
 
         if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
             output_file = None;

--- a/crates/homeboy-cli/src/commands/fuzz/planning.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/planning.rs
@@ -50,15 +50,22 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         rig_context.as_ref(),
         ctx.extension_id.as_deref(),
     );
+    let campaign_workload_ids = requested_campaign_workload_ids(&args)?;
     let selected_workload_id = resolve_profile_workload_id(
         rig_context.as_ref().map(|context| &context.spec),
         args.run.rig_profile(),
         args.run.workload_id.as_deref(),
     )?;
-    let selected_workload = select_workload(&workloads, selected_workload_id.as_deref())?;
+    let selected_workload_id = selected_workload_id
+        .or_else(|| (campaign_workload_ids.len() == 1).then(|| campaign_workload_ids[0].clone()));
+    let selected_workload = if selected_workload_id.is_some() || !campaign_requested(&args) {
+        select_workload(&workloads, selected_workload_id.as_deref())?
+    } else {
+        None
+    };
     let workload_id = selected_workload
         .map(|workload| workload.id.clone())
-        .or(selected_workload_id);
+        .or(selected_workload_id.clone());
     let (required_artifacts, gates) =
         fuzz_gate_profile_contract(args.run.effective_gate_profile().as_core());
     let request_id = args
@@ -77,8 +84,10 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
     )?;
     let isolation_proof = load_or_default_isolation_proof(&args, &ctx.component_id)?;
     let sequence_plan = load_sequence_plan(args.run.sequence_plan.as_deref())?;
+    let mut planning_args = args.clone();
+    planning_args.run.workload_id = selected_workload_id.clone();
     let planning_metadata =
-        plan_inventory_selection(&args, &target_inventory, isolation_proof.as_ref())?;
+        plan_inventory_selection(&planning_args, &target_inventory, isolation_proof.as_ref())?;
     let planning_metadata = with_sequence_plan_metadata(
         planning_metadata,
         args.run.sequence_plan.as_deref(),
@@ -129,6 +138,24 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
         campaign_plan,
         runner_contract: fuzz_runner_contract(fuzz_config.as_ref()),
     })
+}
+
+fn campaign_requested(args: &FuzzPlanArgs) -> bool {
+    args.campaign_manifest.is_some()
+        || !args.campaign_workloads.is_empty()
+        || args.lab_runner.is_some()
+}
+
+fn requested_campaign_workload_ids(args: &FuzzPlanArgs) -> homeboy::core::Result<Vec<String>> {
+    let manifest = load_campaign_manifest(args.campaign_manifest.as_deref())?;
+    let mut workload_ids = manifest_workload_ids(manifest.as_ref());
+    workload_ids.extend(args.campaign_workloads.iter().cloned());
+    if campaign_requested(args) {
+        workload_ids.extend(args.run.workload_id.iter().cloned());
+    }
+    workload_ids.sort();
+    workload_ids.dedup();
+    Ok(workload_ids)
 }
 
 pub(super) fn run_campaign(
@@ -337,15 +364,12 @@ pub(super) fn build_campaign_plan(
     rig_id: Option<&str>,
     base_request: &FuzzExecutionRequest,
 ) -> homeboy::core::Result<Option<FuzzCampaignPlanOutput>> {
-    if args.campaign_manifest.is_none() && args.campaign_workloads.is_empty() {
+    if !campaign_requested(args) {
         return Ok(None);
     }
 
     let manifest = load_campaign_manifest(args.campaign_manifest.as_deref())?;
-    let mut workload_ids = manifest_workload_ids(manifest.as_ref());
-    workload_ids.extend(args.campaign_workloads.iter().cloned());
-    workload_ids.sort();
-    workload_ids.dedup();
+    let workload_ids = requested_campaign_workload_ids(args)?;
     if workload_ids.is_empty() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "campaign-workload",
@@ -651,14 +675,15 @@ fn lab_campaign_run_command(
     lab_runner.map(|runner| {
         let mut command = vec![
             "homeboy".to_string(),
+            "fuzz".to_string(),
+            "run".to_string(),
             "--runner".to_string(),
             runner.to_string(),
-            "--lab-only".to_string(),
         ];
         command.extend(
             campaign_run_command(args, component, workload_id, run_id)
                 .into_iter()
-                .skip(1),
+                .skip(3),
         );
         command
     })

--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -29,6 +29,7 @@ use super::workloads::{
     rig_component_for_fuzz, select_workload, FuzzRigContext,
 };
 use super::{run_contract, run_discover, FuzzArgs};
+use crate::cli_surface::{Cli, Commands};
 use clap::Parser;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::lifecycle::{

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -421,6 +421,7 @@ fn fuzz_campaign_plan_emits_deterministic_run_entries_from_manifest_and_cli_work
         .expect("generated Lab command must parse through the real CLI surface");
     let (cli, _) = Cli::from_registered_arg_matches(&matches)
         .expect("generated Lab command must deserialize through the real CLI surface");
+    assert_eq!(cli.runner.as_deref(), Some("lab-b"));
     assert!(cli.command.supports_lab_runner());
 }
 
@@ -439,17 +440,20 @@ fn fuzz_campaign_plan_uses_one_explicit_workload_as_one_entry() {
 
 #[test]
 fn fuzz_plan_absorbs_global_runner_as_its_campaign_runner() {
-    let mut cli = Cli::try_parse_from([
-        "homeboy",
-        "fuzz",
-        "plan",
-        "component-a",
-        "--workload",
-        "api-fuzz",
-        "--runner",
-        "lab-a",
-    ])
-    .expect("global runner alias should parse for fuzz planning");
+    let matches = Cli::command_with_scoped_lab_args()
+        .try_get_matches_from([
+            "homeboy",
+            "fuzz",
+            "plan",
+            "component-a",
+            "--workload",
+            "api-fuzz",
+            "--runner",
+            "lab-a",
+        ])
+        .expect("global runner alias should parse for fuzz planning");
+    let (mut cli, _) = Cli::from_registered_arg_matches(&matches)
+        .expect("global runner alias should deserialize for fuzz planning");
 
     let runner = cli.runner.take();
     let Commands::Fuzz(args) = &mut cli.command else {
@@ -467,6 +471,36 @@ fn fuzz_plan_absorbs_global_runner_as_its_campaign_runner() {
     assert!(error
         .to_string()
         .contains("--runner and --lab-runner select different Lab runners"));
+}
+
+#[test]
+fn fuzz_plan_dry_run_absorbs_global_runner_as_its_campaign_runner() {
+    let matches = Cli::command_with_scoped_lab_args()
+        .try_get_matches_from([
+            "homeboy",
+            "fuzz",
+            "plan",
+            "component-a",
+            "--workload",
+            "api-fuzz",
+            "--dry-run",
+            "--runner",
+            "lab-a",
+        ])
+        .expect("global runner alias should parse for a dry-run fuzz plan");
+    let (mut cli, _) = Cli::from_registered_arg_matches(&matches)
+        .expect("global runner alias should deserialize for a dry-run fuzz plan");
+
+    let runner = cli.runner.take();
+    let Commands::Fuzz(args) = &mut cli.command else {
+        panic!("expected fuzz command");
+    };
+    assert_eq!(args.absorb_planning_runner(runner).unwrap(), None);
+    let Some(FuzzCommand::Plan(plan)) = &args.command else {
+        panic!("expected fuzz plan command");
+    };
+    assert!(plan.dry_run);
+    assert_eq!(plan.lab_runner.as_deref(), Some("lab-a"));
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -397,11 +397,10 @@ fn fuzz_campaign_plan_emits_deterministic_run_entries_from_manifest_and_cli_work
             .collect::<Vec<_>>(),
         vec![
             "homeboy",
-            "--runner",
-            "lab-b",
-            "--lab-only",
             "fuzz",
             "run",
+            "--runner",
+            "lab-b",
             "component-a",
             "--workload",
             "api-fuzz",
@@ -415,6 +414,59 @@ fn fuzz_campaign_plan_emits_deterministic_run_entries_from_manifest_and_cli_work
             "measurement",
         ]
     );
+
+    let lab_command = plan.entries[0].lab_command.as_ref().expect("lab command");
+    let matches = Cli::command_with_scoped_lab_args()
+        .try_get_matches_from(lab_command)
+        .expect("generated Lab command must parse through the real CLI surface");
+    let (cli, _) = Cli::from_registered_arg_matches(&matches)
+        .expect("generated Lab command must deserialize through the real CLI surface");
+    assert!(cli.command.supports_lab_runner());
+}
+
+#[test]
+fn fuzz_campaign_plan_uses_one_explicit_workload_as_one_entry() {
+    let mut args = planner_args();
+    args.lab_runner = Some("lab-a".to_string());
+
+    let plan = build_campaign_plan(&args, "component-a", None, &campaign_base_request())
+        .expect("build campaign plan")
+        .expect("explicit workload creates a campaign entry");
+
+    assert_eq!(plan.entries.len(), 1);
+    assert_eq!(plan.entries[0].workload_id, "api-fuzz");
+}
+
+#[test]
+fn fuzz_plan_absorbs_global_runner_as_its_campaign_runner() {
+    let mut cli = Cli::try_parse_from([
+        "homeboy",
+        "fuzz",
+        "plan",
+        "component-a",
+        "--workload",
+        "api-fuzz",
+        "--runner",
+        "lab-a",
+    ])
+    .expect("global runner alias should parse for fuzz planning");
+
+    let runner = cli.runner.take();
+    let Commands::Fuzz(args) = &mut cli.command else {
+        panic!("expected fuzz command");
+    };
+    assert_eq!(args.absorb_planning_runner(runner).unwrap(), None);
+    let Some(FuzzCommand::Plan(plan)) = &args.command else {
+        panic!("expected fuzz plan command");
+    };
+    assert_eq!(plan.lab_runner.as_deref(), Some("lab-a"));
+
+    let error = args
+        .absorb_planning_runner(Some("lab-b".to_string()))
+        .expect_err("conflicting runner aliases should be reported together");
+    assert!(error
+        .to_string()
+        .contains("--runner and --lab-runner select different Lab runners"));
 }
 
 #[test]
@@ -520,7 +572,7 @@ fn fuzz_plan_lab_contract_explains_local_planning_path() {
     };
 
     assert!(reason.contains("`fuzz plan` is controller-local planning"));
-    assert!(reason.contains("--lab-runner <runner>"));
+    assert!(reason.contains("--runner <runner>"));
     assert!(reason.contains("--execute"));
 }
 

--- a/crates/homeboy-cli/src/commands/fuzz/types.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types.rs
@@ -139,7 +139,7 @@ impl FuzzArgs {
         let Some(FuzzCommand::Plan(plan)) = self.command.as_mut() else {
             return Ok(Some(runner));
         };
-        if plan.execute || plan.dry_run {
+        if plan.execute {
             return Ok(Some(runner));
         }
         if let Some(lab_runner) = plan.lab_runner.as_deref() {

--- a/crates/homeboy-cli/src/commands/fuzz/types.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types.rs
@@ -10,7 +10,7 @@ use crate::command_contract::{
 };
 use homeboy::fuzz::FuzzGateProfile;
 
-const FUZZ_PLAN_LAB_UNSUPPORTED_REASON: &str = "`fuzz plan` is controller-local planning so operators can inspect the generated request before execution. Use `homeboy fuzz plan --lab-runner <runner> ...` to emit exact Lab run commands, or pass `--execute` / use `fuzz run` with the global `--runner <runner> --lab-only` flags to execute on Lab.";
+const FUZZ_PLAN_LAB_UNSUPPORTED_REASON: &str = "`fuzz plan` is controller-local planning so operators can inspect the generated request before execution. Use `homeboy fuzz plan --runner <runner> ...` to emit exact Lab run commands, or pass `--execute` / use `fuzz run` with `--runner <runner>` to execute on Lab.";
 
 #[derive(Args)]
 pub struct FuzzArgs {
@@ -125,6 +125,36 @@ impl FuzzArgs {
         self.destructive_run_args().is_some_and(|run| {
             run.effective_allow_destructive() && !run.allow_local_destructive_fuzz
         })
+    }
+
+    /// A non-executing plan records its preferred runner rather than offloading
+    /// planning itself. Keep the global runner spelling usable on this surface.
+    pub(crate) fn absorb_planning_runner(
+        &mut self,
+        runner: Option<String>,
+    ) -> homeboy::core::Result<Option<String>> {
+        let Some(runner) = runner else {
+            return Ok(None);
+        };
+        let Some(FuzzCommand::Plan(plan)) = self.command.as_mut() else {
+            return Ok(Some(runner));
+        };
+        if plan.execute || plan.dry_run {
+            return Ok(Some(runner));
+        }
+        if let Some(lab_runner) = plan.lab_runner.as_deref() {
+            if lab_runner != runner {
+                return Err(homeboy::core::Error::validation_invalid_argument(
+                    "runner",
+                    "--runner and --lab-runner select different Lab runners; pass one runner selection".to_string(),
+                    Some(runner),
+                    Some(vec![lab_runner.to_string()]),
+                ));
+            }
+        } else {
+            plan.lab_runner = Some(runner);
+        }
+        Ok(None)
     }
 
     fn destructive_run_args(&self) -> Option<&FuzzRunArgs> {
@@ -441,6 +471,8 @@ pub(crate) struct FuzzPlanArgs {
     pub(crate) campaign_workloads: Vec<String>,
 
     /// Preferred Lab runner id to record in campaign plan entries without executing them.
+    /// Prefer the global `--runner` spelling; this alias remains compatible with
+    /// existing manifests and automation.
     #[arg(long = "lab-runner", value_name = "ID")]
     pub(crate) lab_runner: Option<String>,
 

--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -8,7 +8,7 @@ List and run generic fuzz workloads for a Homeboy component or rig.
 homeboy fuzz [<component>] [--rig <id>] [--workload <id>] [--profile <id|lab>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive [--isolation-proof <path>]] [--allow-local-destructive-fuzz] [-- <runner-args>]
 homeboy fuzz run [<component>] [--rig <id>] [--workload <id>] [--profile <id|lab>] [--run-id <id>] [--seed <seed>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--require-case-log] [--require-coverage-summary] [--require-result-envelope] [--max-duration <duration>] [--action-model <path>] [--exploration-policy <path>] [--allow-destructive [--isolation-proof <path>]] [--allow-local-destructive-fuzz] [-- <runner-args>]
 homeboy fuzz list [<component>] [--rig <id>] [--remote-discovery]
-homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--lab-runner <id>] [--required-artifact <id>] [--execute|--dry-run] [--resume] [--allow-destructive [--isolation-proof <path>]]
+homeboy fuzz plan [<component>] [--rig <id>] [--workload <id>] [--inventory <path>] [--sequence-plan <path>] [--gate-profile <measurement|evidence|coverage-complete|strict>] [--strategy <all|read-only|crud|coverage-gaps>] [--operation <filter>] [--operation-family <family>] [--case-budget <count>] [--duration-budget-seconds <seconds>] [--action-model <path>] [--exploration-policy <path>] [--campaign-manifest <path>] [--campaign-workload <id>] [--runner <id>] [--required-artifact <id>] [--execute|--dry-run] [--resume] [--allow-destructive [--isolation-proof <path>]]
 homeboy fuzz stable plan --manifest <path> [--stable-id <id[,id]>] [--runner <id>] [--artifact-root <dir>] [--run-id-prefix <id>] [--tracker-ref <kind:id>] [--detach-after-handoff] [--component <id>] [--since <duration>] [--limit <n>] [--hotspot-limit <n>]
 homeboy fuzz run-campaign [<component>] [--rig <id>] [--campaign-manifest <path>] [--campaign-workload <id>] [--dry-run] [--resume] [fuzz run options]
 homeboy fuzz validate <results-file>
@@ -174,7 +174,7 @@ a stricter profile is supplied, and requires case-log, coverage-summary, and
 result-envelope artifacts:
 
 ```bash
-homeboy --runner <runner-id> --lab-only fuzz run --workload <workload-id> --profile lab
+homeboy fuzz run --runner <runner-id> --workload <workload-id> --profile lab
 ```
 
 With `--rig`, `--profile` continues to select that rig's declared fuzz profile,
@@ -210,7 +210,7 @@ product-neutral and may contain `id`, `workloads`,
 `workload_ids`, `lab_runner`, and `required_artifacts`; product-specific details
 belong in manifest metadata that downstream runners consume, not in Homeboy core.
 Repeat `--campaign-workload <id>` to add workload ids without a manifest,
-`--tracker-ref KIND:ID` to anchor every entry, `--lab-runner <id>` to record the
+`--tracker-ref KIND:ID` to anchor every entry, `--runner <id>` to record the
 preferred offload target, and `--required-artifact <id>` for reviewer-facing
 artifacts each planned run must produce.
 
@@ -235,19 +235,19 @@ homeboy fuzz plan my-component \
   --campaign-manifest manifests/full-surface-fuzz.json \
   --campaign-workload browser-fuzz \
   --tracker-ref github_issue:owner/repo#123 \
-  --lab-runner lab-a \
+  --runner lab-a \
   --required-artifact fuzz-result-envelope
 ```
 
 The resulting `campaign_plan.entries[]` are sorted by workload id, deduplicated,
 and include `run_id`, `tracker_refs`, `artifact_requirements`, `lab_runner`, a
 request copy scoped to the workload, and a command vector suitable for a caller
-or Lab orchestration layer to schedule explicitly. When `--lab-runner <id>` is
-set, each entry also includes `lab_command`, the exact `homeboy --runner <id>
---lab-only fuzz run ...` vector for that workload.
+or Lab orchestration layer to schedule explicitly. When `--runner <id>` is set,
+each entry also includes `lab_command`, the exact `homeboy fuzz run --runner <id>
+...` vector for that workload.
 
-Plain `homeboy --runner <id> --lab-only fuzz plan ...` is unsupported because
-planning remains controller-local for operator inspection. Use `--lab-runner` to
+Plain `homeboy fuzz plan --runner <id> ...` records the requested runner while
+planning remains controller-local for operator inspection. Use `--runner` to
 emit Lab run commands, or execute through `fuzz run`, `fuzz run-campaign`, or
 `fuzz plan --execute`.
 


### PR DESCRIPTION
## Summary
- emit parser-valid `homeboy fuzz run --runner <id>` Lab commands
- accept `--runner` as the canonical non-executing planner runner selection while preserving `--lab-runner`
- let a single `--workload` create one deduplicated campaign entry and cover generated commands through the root CLI parser

Closes #9906

## Validation
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::fuzz::tests`
- `cargo check -p homeboy-cli`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the implementation, tests, and documentation after inspecting the issue and codebase. Chris Huber remains responsible for every line.