### PR TITLE
Fix accepted Lab runner reconciliation races

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -269,18 +269,10 @@ struct UnsupportedLiveCancellation {
 fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancellationOutcome> {
     let owner_pid = record.owner_pid();
 
-    // Local, live owner process: terminate its tree directly (SIGTERM then
-    // SIGKILL escalation handled inside terminate_process_tree).
-    if let Some(pid) = owner_pid {
-        if record.owner_process_is_running() {
-            let termination = homeboy_core::process::terminate_process_tree(pid)?;
-            return Ok(LiveCancellationOutcome::Terminated(termination));
-        }
-    }
-
     // Runner-backed run whose provider process tree lives on a different host:
-    // we cannot signal it from this controller. Emit deterministic recovery
-    // commands keyed on the recorded runner + pid instead of failing.
+    // its accepted daemon job is authoritative over any controller-local PID.
+    // A PID left by the caller can be stale or reused, so it must never be
+    // signalled instead of the owning runner job.
     if record.is_runner_backed() {
         let runner_id = record.runner_id().map(str::to_string);
         let runner_job_id = record.runner_job_id().map(str::to_string);
@@ -326,6 +318,15 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
                 recovery_commands,
             },
         ));
+    }
+
+    // Local, live owner process: terminate its tree directly (SIGTERM then
+    // SIGKILL escalation handled inside terminate_process_tree).
+    if let Some(pid) = owner_pid {
+        if record.owner_process_is_running() {
+            let termination = homeboy_core::process::terminate_process_tree(pid)?;
+            return Ok(LiveCancellationOutcome::Terminated(termination));
+        }
     }
 
     // No reachable live process (stale running record, or no recorded pid): the

--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -148,6 +148,21 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
     } else {
         LiveCancellationOutcome::NotRunning
     };
+    // A runner cancellation can race with the daemon publishing its terminal
+    // result. The daemon outcome is authoritative: project it rather than
+    // overwriting completed work with a controller-only cancellation.
+    if let LiveCancellationOutcome::RunnerJobCancelled { job, events } = &cancellation {
+        if job.status.is_terminal() && job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
+            reconcile_runner_job_snapshot(
+                &mut record,
+                &homeboy_core::api_jobs::RunnerJobLogSnapshot {
+                    job: job.clone(),
+                    events: events.clone(),
+                },
+            )?;
+            return Ok(record);
+        }
+    }
     let runner_id = record.runner_id().map(str::to_string);
     let runner_job_id = record.runner_job_id().map(str::to_string);
 
@@ -272,8 +287,15 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
         if let (Some(runner_id), Some(runner_job_id)) =
             (runner_id.as_deref(), runner_job_id.as_deref())
         {
-            if let Ok((job, events)) = cancel_runner_job(runner_id, runner_job_id, &record.run_id) {
-                return Ok(LiveCancellationOutcome::RunnerJobCancelled { job, events });
+            match cancel_runner_job(runner_id, runner_job_id, &record.run_id) {
+                Ok((job, events)) => {
+                    return Ok(LiveCancellationOutcome::RunnerJobCancelled { job, events });
+                }
+                // An accepted Lab handoff has an authoritative remote owner.
+                // Leaving it active while only cancelling this projection loses
+                // the result, so propagate the failure before mutating the run.
+                Err(error) if record.has_accepted_lab_handoff() => return Err(error),
+                Err(_) => {}
             }
         }
         let mut recovery_commands = Vec::new();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -931,6 +931,14 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
         let _ = expire_unaccepted_lab_handoff(&resolved_run_id)?;
         record = store::read_record(&resolved_run_id)?;
     }
+    // A daemon can evict a completed job from its active store before a restarted
+    // controller observes it. The terminal event log already mirrored into this
+    // observation record is sufficient to recover the aggregate and artifacts.
+    // Consume it before querying the live runner, which is no longer authority
+    // once its active entry has been evicted.
+    if project_persisted_terminal_runner_events(&mut record)? {
+        record = store::read_record(&resolved_run_id)?;
+    }
     if !record.state.is_terminal() {
         let controller_plan = store::read_controller_plan(&record.run_id)?;
         let controller_plan_path = store::controller_plan_path(&record.run_id)?

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -33,7 +33,8 @@ pub(crate) fn reconcile_runner_job_snapshot(
         // published the inner agent-task aggregate. Adopt that later evidence
         // when it proves the same controller run rather than losing its patch.
         if let Some(event) = terminal_runner_lifecycle_event(record, snapshot)? {
-            if store::read_aggregate(&record.run_id).ok().as_ref() != Some(&event.aggregate) {
+            let aggregate = projected_runner_aggregate(record, &event.aggregate);
+            if store::read_aggregate(&record.run_id).ok().as_ref() != Some(&aggregate) {
                 project_terminal_runner_lifecycle_event(record, snapshot, &event)?;
             }
         }
@@ -151,7 +152,8 @@ pub fn project_terminal_runner_result(
     bind_pending_lab_handoff_snapshot(&mut record, snapshot)?;
     validate_runner_job_snapshot(&record, snapshot)?;
     if let Some(event) = terminal_runner_lifecycle_event(&record, snapshot)? {
-        if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&event.aggregate) {
+        let aggregate = projected_runner_aggregate(&record, &event.aggregate);
+        if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
             return Ok(false);
         }
         project_terminal_runner_lifecycle_event(&mut record, snapshot, &event)?;
@@ -279,8 +281,7 @@ fn project_terminal_runner_lifecycle_event(
     preserve_terminal_runner_identity(record, event)?;
     validate_runner_job_snapshot(record, snapshot)?;
     validate_terminal_child_identity(record, snapshot, event)?;
-    let mut aggregate = event.aggregate.clone();
-    crate::agent_task_lifecycle::project_runner_evidence_refs(record, &mut aggregate);
+    let aggregate = projected_runner_aggregate(record, &event.aggregate);
     let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
     let aggregate_path = store::aggregate_path(&record.run_id)
         .map(|path| path.display().to_string())
@@ -336,11 +337,10 @@ pub(crate) fn project_persisted_terminal_runner_events(
         return Ok(false);
     };
     validate_terminal_child_event_identity(record, &event)?;
-    if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&event.aggregate) {
+    let aggregate = projected_runner_aggregate(record, &event.aggregate);
+    if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
         return Ok(false);
     }
-    let mut aggregate = event.aggregate.clone();
-    crate::agent_task_lifecycle::project_runner_evidence_refs(record, &mut aggregate);
     let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
     let aggregate_path = store::aggregate_path(&record.run_id)
         .map(|path| path.display().to_string())
@@ -353,6 +353,15 @@ pub(crate) fn project_persisted_terminal_runner_events(
     store::write_aggregate_and_record(record, &aggregate)?;
     crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &aggregate)?;
     Ok(true)
+}
+
+fn projected_runner_aggregate(
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> AgentTaskAggregate {
+    let mut aggregate = aggregate.clone();
+    crate::agent_task_lifecycle::project_runner_evidence_refs(record, &mut aggregate);
+    aggregate
 }
 
 fn preserve_terminal_runner_identity(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -323,15 +323,22 @@ pub(crate) fn project_persisted_terminal_runner_events(
     else {
         return Ok(false);
     };
-    let Some(event) = crate::agent_task_lifecycle::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_persisted_job_events(
+    let event = crate::agent_task_lifecycle::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_persisted_job_events(
         &events,
         record.runner_id().unwrap_or_default(),
         runner_job_id,
         &record.run_id,
-    )? else {
+    )?
+    .or_else(|| {
+        crate::agent_task_lifecycle::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(Some(&events))
+    });
+    let Some(event) = event else {
         return Ok(false);
     };
     validate_terminal_child_event_identity(record, &event)?;
+    if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&event.aggregate) {
+        return Ok(false);
+    }
     let mut aggregate = event.aggregate.clone();
     crate::agent_task_lifecycle::project_runner_evidence_refs(record, &mut aggregate);
     let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -856,6 +856,48 @@ fn stale_reconcile_imports_terminal_runner_aggregate_before_cancelling_controlle
 }
 
 #[test]
+fn status_recovers_evicted_terminal_runner_job_from_durable_observation_once() {
+    with_isolated_home(|_| {
+        let run_id = "cook-9969-evicted-terminal-observation";
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("accepted runner handoff");
+
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["run_id"] = json!(run_id);
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["persisted_run_id"] =
+            json!(run_id);
+        rewrite_record_for_test(run_id, |record| {
+            record.metadata["runner_job_status"] = json!(snapshot.job.status);
+            record.metadata["runner_job_events"] = json!(snapshot.events);
+        })
+        .expect("persist terminal daemon observation before controller restart");
+
+        // The active daemon store no longer has this job. Recovery must use the
+        // terminal observation persisted before eviction rather than terminalizing
+        // the controller projection as a missing live job.
+        let _provider = RunnerContinuationTestGuard::install(Box::new(ConnectedRunnerProvider));
+        let recovered = status(run_id).expect("recover terminal observation");
+        assert_eq!(recovered.state, AgentTaskRunState::Succeeded);
+        assert!(store::read_aggregate(run_id).is_ok());
+
+        let recovered_aggregate = store::read_aggregate(run_id).expect("recovered aggregate");
+        let repeated = status(run_id).expect("idempotent recovery");
+        assert_eq!(repeated.state, AgentTaskRunState::Succeeded);
+        assert_eq!(
+            store::read_aggregate(run_id).expect("recovered aggregate remains stable"),
+            recovered_aggregate
+        );
+    });
+}
+
+#[test]
 fn stale_reconcile_keeps_an_accepted_runner_job_active_after_controller_owner_exit() {
     with_isolated_home(|_| {
         let run_id = "cook-9969-active-runner-after-owner-exit";

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -855,6 +855,89 @@ fn stale_reconcile_imports_terminal_runner_aggregate_before_cancelling_controlle
 }
 
 #[test]
+fn stale_reconcile_keeps_an_accepted_runner_job_active_after_controller_owner_exit() {
+    with_isolated_home(|_| {
+        let run_id = "cook-9969-active-runner-after-owner-exit";
+        let plan = test_plan();
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000009969",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("daemon acceptance persists runner identity before owner exit");
+
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+        snapshot.job.id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000009969")
+            .expect("valid runner job id");
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+        snapshot.events.clear();
+        let _provider = RunnerContinuationTestGuard::install(Box::new(TerminalSnapshotProvider {
+            snapshot: Mutex::new(Some(snapshot)),
+        }));
+
+        rewrite_record_for_test(run_id, |record| {
+            record.metadata["runner_pid"] = json!(u32::MAX);
+            record.annotate_stale_running();
+        })
+        .expect("persist dead controller owner");
+
+        let report = reconcile_stale_active_runs(false).expect("reconcile active runner job");
+        assert_eq!(report.considered, 0);
+        assert_eq!(report.reconciled, 0);
+
+        let active = store::read_record(run_id).expect("active runner projection retained");
+        assert_eq!(active.state, AgentTaskRunState::Running);
+        assert_eq!(active.runner_id(), Some("homeboy-lab"));
+        assert_eq!(
+            active.runner_job_id(),
+            Some("00000000-0000-0000-0000-000000009969")
+        );
+        assert!(active.metadata.get(METADATA_KEY_STALE_RUNNING).is_none());
+    });
+}
+
+#[test]
+fn cancellation_race_projects_runner_success_instead_of_cancelling_controller_projection() {
+    with_isolated_home(|_| {
+        let run_id = "cook-9969-cancel-success-race";
+        let plan = test_plan();
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("accepted runner handoff");
+
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["run_id"] = json!(run_id);
+        snapshot.events[0].data.as_mut().expect("event data")["identity"]["persisted_run_id"] =
+            json!(run_id);
+        let expected_job_id = snapshot.job.id;
+        let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
+            move |runner_id, runner_job_id, durable_run_id| {
+                assert_eq!(runner_id, "homeboy-lab");
+                assert_eq!(runner_job_id, expected_job_id.to_string());
+                assert_eq!(durable_run_id, run_id);
+                Ok((snapshot.job.clone(), snapshot.events.clone()))
+            },
+        ));
+
+        let terminal = cancel_run(run_id, Some("operator cancellation"))
+            .expect("daemon terminal result wins cancellation race");
+        assert_eq!(terminal.state, AgentTaskRunState::Succeeded);
+        assert_eq!(terminal.tasks[0].state, AgentTaskState::Succeeded);
+        assert!(terminal.metadata.get("cancel_reason").is_none());
+        assert!(store::read_aggregate(run_id).is_ok());
+    });
+}
+
+#[test]
 fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
     with_isolated_home(|_| {
         let run_id = "cook-ssi-510-after-9849-v5-attempt-1-4f0b66a4";

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -3,10 +3,11 @@
 
 use super::*;
 use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor,
-    AgentTaskLimits, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
-    AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus,
-    AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
+    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskEvidenceRef,
+    AgentTaskExecutionHandle, AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcomeStatus,
+    AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkflowEvidence,
+    AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus, AgentTaskWorkspace,
+    AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
 };
 use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
@@ -869,7 +870,15 @@ fn status_recovers_evicted_terminal_runner_job_from_durable_observation_once() {
         })
         .expect("accepted runner handoff");
 
-        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        let mut aggregate = succeeded_aggregate(&test_plan());
+        aggregate.outcomes[0]
+            .evidence_refs
+            .push(AgentTaskEvidenceRef {
+                kind: "transcript".to_string(),
+                uri: "file:///runner/private/transcript.json".to_string(),
+                label: Some("Runner transcript".to_string()),
+            });
+        let mut snapshot = terminal_child_snapshot(&aggregate);
         snapshot.events[0].data.as_mut().expect("event data")["identity"]["run_id"] = json!(run_id);
         snapshot.events[0].data.as_mut().expect("event data")["identity"]["persisted_run_id"] =
             json!(run_id);
@@ -888,6 +897,14 @@ fn status_recovers_evicted_terminal_runner_job_from_durable_observation_once() {
         assert!(store::read_aggregate(run_id).is_ok());
 
         let recovered_aggregate = store::read_aggregate(run_id).expect("recovered aggregate");
+        assert!(recovered_aggregate.outcomes[0].evidence_refs[0]
+            .uri
+            .starts_with("homeboy://agent-task/run/"));
+        let mut repeated_record = store::read_record(run_id).expect("recovered record");
+        assert!(
+            !project_persisted_terminal_runner_events(&mut repeated_record)
+                .expect("terminal projection is exactly once")
+        );
         let repeated = status(run_id).expect("idempotent recovery");
         assert_eq!(repeated.state, AgentTaskRunState::Succeeded);
         assert_eq!(
@@ -977,6 +994,35 @@ fn cancellation_race_projects_runner_success_instead_of_cancelling_controller_pr
         assert_eq!(terminal.tasks[0].state, AgentTaskState::Succeeded);
         assert!(terminal.metadata.get("cancel_reason").is_none());
         assert!(store::read_aggregate(run_id).is_ok());
+    });
+}
+
+#[test]
+fn accepted_runner_cancellation_fails_closed_when_daemon_cannot_be_reached() {
+    with_isolated_home(|_| {
+        let run_id = "cook-9969-runner-cancellation-fails-closed";
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000009971",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("accepted runner handoff");
+
+        let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
+            |_runner_id, _runner_job_id, _durable_run_id| {
+                Err(Error::internal_unexpected("runner daemon is unavailable"))
+            },
+        ));
+
+        cancel_run(run_id, Some("operator cancellation"))
+            .expect_err("accepted runner cancellation must fail closed");
+        assert_eq!(
+            store::read_record(run_id).expect("durable record").state,
+            AgentTaskRunState::Running
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -16,6 +16,7 @@ use crate::agent_task_service::reconcile_stale_active_runs;
 use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 struct TerminalSnapshotProvider {
@@ -934,6 +935,60 @@ fn cancellation_race_projects_runner_success_instead_of_cancelling_controller_pr
         assert_eq!(terminal.tasks[0].state, AgentTaskState::Succeeded);
         assert!(terminal.metadata.get("cancel_reason").is_none());
         assert!(store::read_aggregate(run_id).is_ok());
+    });
+}
+
+#[test]
+fn accepted_runner_cancellation_does_not_signal_a_controller_local_pid() {
+    with_isolated_home(|_| {
+        let run_id = "cook-9969-runner-cancellation-authority";
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000009970",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("accepted runner handoff");
+
+        let mut local_controller = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("start controller-local sentinel");
+        rewrite_record_for_test(run_id, |record| {
+            record.metadata["runner_pid"] = json!(local_controller.id());
+        })
+        .expect("persist stale controller pid");
+
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000009970")
+            .expect("valid runner job id");
+        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Cancelled;
+        let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
+            move |runner_id, runner_job_id, durable_run_id| {
+                assert_eq!(runner_id, "homeboy-lab");
+                assert_eq!(runner_job_id, snapshot.job.id.to_string());
+                assert_eq!(durable_run_id, run_id);
+                Ok((snapshot.job.clone(), snapshot.events.clone()))
+            },
+        ));
+
+        let cancelled = cancel_run(run_id, Some("operator cancellation"))
+            .expect("runner cancellation succeeds");
+        let controller_was_not_signalled = local_controller
+            .try_wait()
+            .expect("inspect controller-local sentinel")
+            .is_none();
+        let _ = local_controller.kill();
+        let _ = local_controller.wait();
+
+        assert!(controller_was_not_signalled);
+        assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            cancelled.metadata["live_cancellation"]["cancellation"],
+            "runner_job_cancel"
+        );
     });
 }
 


### PR DESCRIPTION
Refs #9969

## Summary
- Preserve accepted runner ownership during stale controller reconciliation and fail closed when a runner-owned cancellation cannot be propagated.
- When runner cancellation races with a non-cancelled terminal result, project the authoritative aggregate instead of overwriting it with `cancelled`.
- Recover a terminal runner aggregate from persisted daemon observation events before querying the active store, so controller restart remains recoverable after daemon eviction.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents status_recovers_evicted_terminal_runner_job_from_durable_observation_once`
- `cargo test -p homeboy-agents stale_reconcile_imports_terminal_runner_aggregate_before_cancelling_controller_projection`
- `cargo test -p homeboy-agents cancellation_race_projects_runner_success_instead_of_cancelling_controller_projection`
- `cargo test -p homeboy-agents stale_reconcile_keeps_an_accepted_runner_job_active_after_controller_owner_exit`
- `cargo check -p homeboy-agents`

## Scope And Follow-Up
This PR owns accepted runner handoff, terminal projection, durable observation recovery, and cancellation authority. Bounded stale daemon-generation convergence is runner-session lifecycle work, tracked by #9406; it is deliberately not implemented here.

## AI Assistance
OpenAI GPT-5.6-terra using OpenCode drafted the lifecycle change and deterministic tests after source and issue inspection. Chris Huber is responsible for every line.