### PR TITLE
test(runner): cover compact and full status

### DIFF
--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -103,12 +103,45 @@ fn command_owned_output_path_is_not_rejected_as_global_format() {
 }
 
 #[test]
-fn runner_status_includes_lab_diagnostics() {
+fn compact_runner_status_includes_summary_and_full_continuation() {
     let dir = tempfile::tempdir().expect("tempdir");
     register_local_runner(dir.path());
 
     let output = homeboy_command()
         .args(["runner", "status", "lab-local"])
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .output()
+        .expect("run homeboy");
+
+    assert!(
+        output.status.success(),
+        "runner status should succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
+    assert_eq!(stdout_json["success"], true);
+    assert_eq!(stdout_json["data"]["command"], "runner.status");
+    assert_eq!(
+        stdout_json["data"]["operator_summary"]["identity"],
+        "lab-local"
+    );
+    assert_eq!(
+        stdout_json["data"]["truncation"]["full_command"],
+        "homeboy runner status lab-local --full"
+    );
+    assert!(stdout_json["data"].get("selected_lab_runner").is_none());
+}
+
+#[test]
+fn full_runner_status_includes_lab_diagnostics() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    register_local_runner(dir.path());
+
+    let output = homeboy_command()
+        .args(["runner", "status", "lab-local", "--full"])
         .current_dir(dir.path())
         .env("HOME", dir.path())
         .output()


### PR DESCRIPTION
## Summary
- Run lab diagnostics assertions against `homeboy runner status lab-local --full`.
- Preserve compact status coverage for its operator summary, full continuation command, and omitted diagnostics expansion.

Closes #10071

## Verification
- `cargo test --test output_errors`
- `cargo fmt --check`
- `cargo test --workspace` reached the changed suite successfully but fails on the unrelated deterministic `readonly_cli_lock_test` mutation-lock assertion.

## AI Assistance
Drafted with OpenAI GPT-5.6 Sol using OpenCode to inspect the issue and status contracts, implement the test correction, and run verification. Chris Huber remains responsible for every line.