### PR TITLE
Fix Rust test wiring audit source scope

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/test_wiring.rs
+++ b/crates/homeboy-code-audit/src/detectors/test_wiring.rs
@@ -294,4 +294,25 @@ mod tests {
 
         assert!(findings.is_empty());
     }
+
+    #[test]
+    fn accepts_nested_repository_test_path_when_crate_source_references_it() {
+        let dir = TempDir::new().expect("tempdir");
+        let mut config = nested_repository_policy();
+        config.test_wiring.policies[0]
+            .source_path_globs
+            .push("crates/**/*.rs".to_string());
+        write(
+            &dir.path().join("crates/homeboy-core/src/http_api.rs"),
+            "#[path = \"../../../tests/core/http_api_test.rs\"]\nmod http_api_test;\n",
+        );
+        write(
+            &dir.path().join("tests/core/http_api_test.rs"),
+            "#[test] fn works() {}\n",
+        );
+
+        let findings = run(dir.path(), &config);
+
+        assert!(findings.is_empty());
+    }
 }

--- a/crates/homeboy-rig/src/expand.rs
+++ b/crates/homeboy-rig/src/expand.rs
@@ -267,3 +267,7 @@ fn sanitize_env_segment(value: &str) -> String {
         })
         .collect()
 }
+
+#[cfg(test)]
+#[path = "../../../tests/core/rig/expand_test.rs"]
+mod expand_test;

--- a/homeboy.json
+++ b/homeboy.json
@@ -389,7 +389,8 @@
           "require_explicit_wiring": true,
           "severity": "warning",
           "source_path_globs": [
-            "src/**/*.rs"
+            "src/**/*.rs",
+            "crates/**/*.rs"
           ],
           "suggestion": "Wire `{test_path}` from the covered source module with an explicit path include, or move it to a top-level auto-discovered test path.",
           "support_test_path_globs": [],

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -3,13 +3,11 @@
 //! Audit convention requires a `test_expand_vars` method matching the sole
 //! public function of the module; additional cases cover edge conditions.
 
-use homeboy_core::paths;
 use crate::expand::{
     expand_resources, expand_resources_with_settings, expand_vars, expand_vars_with_settings,
 };
-use crate::spec::{
-    ComponentSpec, DiscoverSpec, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec,
-};
+use crate::spec::{ComponentSpec, DiscoverSpec, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec};
+use homeboy_core::paths;
 use homeboy_core::test_support::with_isolated_home;
 use std::collections::HashMap;
 use std::fs;


### PR DESCRIPTION
## Summary
- scan crate source files when validating nested Rust test harness wiring
- recognize the existing `http_api_test.rs` path module and eliminate the #10074 audit finding

Closes #10074

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core --lib http_api_test:: -- --list`
- `cargo test -p homeboy-core --lib http_api_test::`
- `target/debug/homeboy review audit --path . --only unwired_nested_rust_test --json-summary`
- `cargo check --workspace`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode diagnosed the harness/audit mismatch, made the configuration change, and ran verification. Chris Huber remains responsible for every line.