### PR TITLE
fix(lab): default offload test requests

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2499,25 +2499,8 @@ mod tests {
         let root = "/runner/app-homeboy-artifacts/rig-registry".to_string();
         let args = Vec::new();
         let request = LabOffloadRequest {
-            command: None,
             normalized_args: &args,
-            explicit_runner: None,
-            placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: true,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
-            detach_after_handoff: false,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
-            source_path: None,
-            verified_cook_baseline: None,
-            require_controller_git_bundle: false,
-            reuse_compatible_snapshot: false,
             job_overrides: LabJobOverrides {
                 env: std::collections::HashMap::from([
                     (
@@ -2532,6 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
+            ..LabOffloadRequest::new(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2515,7 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            ..LabOffloadRequest::new(&args)
+            ..LabOffloadRequest::for_test(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -432,24 +432,8 @@ fn plan_records_skipped_auto_offload() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Local,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     })
     .expect("outcome");
 
@@ -465,26 +449,9 @@ fn plan_records_skipped_auto_offload() {
 #[test]
 fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &["homeboy".to_string(), "status".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -505,24 +472,8 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "install".to_string(),
             "./rig-package".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -539,30 +490,13 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
 #[test]
 fn build_runner_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -588,30 +522,13 @@ fn build_runner_error_gives_managed_runner_replacement() {
 #[test]
 fn build_lab_placement_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -637,7 +554,6 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
 #[test]
 fn unsupported_runner_error_guides_tunnel_service_inspection() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "tunnel".to_string(),
@@ -646,23 +562,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -433,7 +433,7 @@ fn plan_records_skipped_auto_offload() {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
         placement: homeboy_cli_contract::Placement::Local,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "test".to_string()])
     })
     .expect("outcome");
 
@@ -451,7 +451,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         normalized_args: &["homeboy".to_string(), "status".to_string()],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "status".to_string()])
     });
 
     let Err(err) = outcome else {
@@ -473,7 +473,12 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "./rig-package".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "install".to_string(),
+            "./rig-package".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -496,7 +501,11 @@ fn build_runner_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -528,7 +537,11 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -562,7 +575,13 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "status".to_string(),
+            "wpcom-ai-manual-held".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,11 +45,14 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
-impl<'a> Default for LabOffloadRequest<'a> {
-    fn default() -> Self {
+impl<'a> LabOffloadRequest<'a> {
+    #[cfg(test)]
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// This remains test-only so production callers must set every policy field.
+    pub(crate) fn for_test(normalized_args: &'a [String]) -> Self {
         Self {
             command: None,
-            normalized_args: &[],
+            normalized_args,
             explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: false,
@@ -72,14 +75,60 @@ impl<'a> Default for LabOffloadRequest<'a> {
     }
 }
 
-impl<'a> LabOffloadRequest<'a> {
-    /// Creates a request with the neutral offload policy used by focused tests.
-    /// New request fields belong in `Default`, so those fixtures stay valid.
-    pub fn new(normalized_args: &'a [String]) -> Self {
-        Self {
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_has_neutral_policy() {
+        let args = vec!["homeboy".to_string(), "status".to_string()];
+        let request = LabOffloadRequest::for_test(&args);
+
+        let LabOffloadRequest {
+            command,
             normalized_args,
-            ..Self::default()
-        }
+            explicit_runner,
+            placement,
+            allow_local_fallback,
+            allow_dirty_lab_workspace,
+            skip_deps_hydration,
+            preserve_workspace_on_failure,
+            capture_patch,
+            mutation_flag,
+            detach_after_handoff,
+            output_file_requested,
+            read_only_polling,
+            local_output_file,
+            durable_agent_task_plan,
+            source_path,
+            verified_cook_baseline,
+            require_controller_git_bundle,
+            reuse_compatible_snapshot,
+            job_overrides,
+        } = request;
+
+        assert!(command.is_none());
+        assert_eq!(normalized_args, args);
+        assert!(explicit_runner.is_none());
+        assert_eq!(placement, homeboy_cli_contract::Placement::Auto);
+        assert!(!allow_local_fallback);
+        assert!(!allow_dirty_lab_workspace);
+        assert!(!skip_deps_hydration);
+        assert!(!preserve_workspace_on_failure);
+        assert!(!capture_patch);
+        assert!(mutation_flag.is_none());
+        assert!(!detach_after_handoff);
+        assert!(!output_file_requested);
+        assert!(!read_only_polling);
+        assert!(local_output_file.is_none());
+        assert!(durable_agent_task_plan.is_none());
+        assert!(source_path.is_none());
+        assert!(verified_cook_baseline.is_none());
+        assert!(!require_controller_git_bundle);
+        assert!(!reuse_compatible_snapshot);
+        assert!(job_overrides.env.is_empty());
+        assert!(job_overrides.secret_env_names.is_empty());
+        assert!(job_overrides.workspace_root.is_none());
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,6 +45,44 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
+impl<'a> Default for LabOffloadRequest<'a> {
+    fn default() -> Self {
+        Self {
+            command: None,
+            normalized_args: &[],
+            explicit_runner: None,
+            placement: homeboy_cli_contract::Placement::Auto,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            preserve_workspace_on_failure: false,
+            capture_patch: false,
+            mutation_flag: None,
+            detach_after_handoff: false,
+            output_file_requested: false,
+            read_only_polling: false,
+            local_output_file: None,
+            durable_agent_task_plan: None,
+            source_path: None,
+            verified_cook_baseline: None,
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
+            job_overrides: LabJobOverrides::default(),
+        }
+    }
+}
+
+impl<'a> LabOffloadRequest<'a> {
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// New request fields belong in `Default`, so those fixtures stay valid.
+    pub fn new(normalized_args: &'a [String]) -> Self {
+        Self {
+            normalized_args,
+            ..Self::default()
+        }
+    }
+}
+
 // LabOffloadCommand, LabJobOverrides, LabOffloadOutcome, and the source/workspace
 // mode aliases moved to core's lab_offload module (they are core-plan-based
 // types the core lab_routing service names). Re-exported so runner-internal

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1238,7 +1238,7 @@ mod tests {
             let request = LabOffloadRequest {
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2453,7 +2453,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2588,7 +2588,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2761,7 +2761,7 @@ mod tests {
                 placement: homeboy_cli_contract::Placement::Lab,
                 detach_after_handoff: true,
                 source_path: Some(source.as_path()),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1236,25 +1236,9 @@ mod tests {
                 "jetpack-api-route-inventory".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2466,26 +2450,10 @@ mod tests {
                 "base".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2617,26 +2585,10 @@ mod tests {
                 "provider-value".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2804,26 +2756,12 @@ mod tests {
                 ensure_agent_task_lifecycle_identity_with(&args, Some("cook-8009"), None)
                     .expect("canonical cook attempt id");
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-managed-worktree-stage"),
                 placement: homeboy_cli_contract::Placement::Lab,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
                 detach_after_handoff: true,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
                 source_path: Some(source.as_path()),
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3420,21 +3420,9 @@ mod tests {
         LabOffloadRequest {
             command,
             normalized_args: args,
-            explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Lab,
-            allow_local_fallback: false,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
             detach_after_handoff: true,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
             source_path: Some(std::path::Path::new("/work/source")),
-            verified_cook_baseline: None,
             require_controller_git_bundle: true,
             reuse_compatible_snapshot: true,
             job_overrides: homeboy_core::lab_offload::LabJobOverrides {
@@ -3442,6 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
+            ..LabOffloadRequest::new(args)
         }
     }
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3430,7 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
-            ..LabOffloadRequest::new(args)
+            ..LabOffloadRequest::for_test(args)
         }
     }
 


### PR DESCRIPTION
## Summary
- add a neutral `LabOffloadRequest` default and constructor that own all baseline fields
- migrate every test-only request initializer to struct-update syntax
- keep production core-to-runner and durable-recipe mappings explicit

Closes #10088.

## Verification
- `cargo fmt --all`
- `cargo test --workspace --no-run`
- `cargo test -p homeboy-lab-runner stage_materializes_rig_package_and_nested_component_as_distinct_sources`
- `cargo test -p homeboy-lab-runner plan_records_skipped_auto_offload`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the implementation, performed the initializer audit, and ran the listed verification. Chris Huber remains responsible for every line and for review/merge decisions.