### PR TITLE
fix(cook): attest isolated provider workspaces

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -347,13 +347,20 @@ pub(super) fn run_materialized_provider_command_once(
             .map(|(key, value)| (key.as_str(), value.as_str())),
     );
     if let Some(cwd) = cwd {
-        if let Some(attestation) = request.request.metadata.get("cook_workspace_identity") {
-            if !workspace_matches_attestation(&cwd, attestation) {
+        if let Some(attestation) = request
+            .request
+            .metadata
+            .get("cook_attempt_workspace_identity")
+        {
+            if !crate::agent_task_workspace_identity::workspace_matches_attestation(
+                &cwd,
+                attestation,
+            ) {
                 return failure_outcome(
                     request, AgentTaskOutcomeStatus::ProviderError,
                     AgentTaskFailureClassification::InvalidInput,
                     "agent_task.workspace_identity_changed",
-                    "provider workspace no longer matches the Cook identity attestation; refusing execution".to_string(),
+                    "provider workspace no longer matches its Cook attempt identity attestation; refusing execution".to_string(),
                     json!({ "provider": provider.id, "workspace": cwd }),
                 );
             }
@@ -591,56 +598,6 @@ pub(super) fn run_materialized_provider_command_once(
             ),
         ),
     }
-}
-
-#[cfg(unix)]
-fn workspace_matches_attestation(path: &std::path::Path, attestation: &serde_json::Value) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    let Ok(canonical) = std::fs::canonicalize(path) else {
-        return false;
-    };
-    let Ok(metadata) = std::fs::symlink_metadata(&canonical) else {
-        return false;
-    };
-    !metadata.file_type().is_symlink()
-        && attestation["canonical_path"].as_str() == canonical.to_str()
-        && attestation["device"].as_u64() == Some(metadata.dev())
-        && attestation["inode"].as_u64() == Some(metadata.ino())
-        && linked_git_metadata_matches(&canonical, attestation)
-}
-
-#[cfg(unix)]
-fn linked_git_metadata_matches(
-    worktree: &std::path::Path,
-    attestation: &serde_json::Value,
-) -> bool {
-    let git_file = worktree.join(".git");
-    let Ok(metadata) = std::fs::symlink_metadata(&git_file) else {
-        return false;
-    };
-    if !metadata.file_type().is_file() || attestation["git_file_is_file"] != true {
-        return false;
-    }
-    let Ok(content) = std::fs::read_to_string(&git_file) else {
-        return false;
-    };
-    if attestation["git_file_content"].as_str() != Some(content.as_str()) {
-        return false;
-    }
-    let target = content
-        .strip_prefix("gitdir: ")
-        .map(str::trim)
-        .and_then(|target| std::fs::canonicalize(worktree.join(target)).ok());
-    target.as_deref().and_then(|path| path.to_str()) == attestation["gitdir_target"].as_str()
-}
-
-#[cfg(not(unix))]
-fn workspace_matches_attestation(path: &std::path::Path, attestation: &serde_json::Value) -> bool {
-    std::fs::canonicalize(path)
-        .ok()
-        .and_then(|path| path.to_str().map(str::to_string))
-        .as_deref()
-        == attestation["canonical_path"].as_str()
 }
 
 #[cfg(unix)]

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -347,10 +347,13 @@ pub(super) fn run_materialized_provider_command_once(
             .map(|(key, value)| (key.as_str(), value.as_str())),
     );
     if let Some(cwd) = cwd {
+        // Old persisted Cook plans bind the source workspace. Newly materialized
+        // plans replace that with an attempt-specific binding before execution.
         if let Some(attestation) = request
             .request
             .metadata
             .get("cook_attempt_workspace_identity")
+            .or_else(|| request.request.metadata.get("cook_workspace_identity"))
         {
             if !crate::agent_task_workspace_identity::workspace_matches_attestation(
                 &cwd,

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -340,7 +340,7 @@ fn linked_workspace(temp: &tempfile::TempDir) -> (std::path::PathBuf, std::path:
 
 #[cfg(unix)]
 #[test]
-fn provider_refuses_git_file_replaced_by_directory_before_spawn() {
+fn provider_refuses_legacy_source_attestation_git_file_replaced_before_spawn() {
     let temp = tempfile::tempdir().expect("tempdir");
     let (workspace, _) = linked_workspace(&temp);
     let attestation = workspace_attestation(&workspace);
@@ -351,7 +351,7 @@ fn provider_refuses_git_file_replaced_by_directory_before_spawn() {
     ));
     let (mut request, provider) = request("attested-workspace", format!("node {script}"));
     request.workspace.root = Some(workspace.display().to_string());
-    request.metadata = serde_json::json!({ "cook_attempt_workspace_identity": attestation });
+    request.metadata = serde_json::json!({ "cook_workspace_identity": attestation });
 
     std::fs::remove_file(workspace.join(".git")).expect("remove linked git file");
     std::fs::create_dir(workspace.join(".git")).expect("replace with git directory");

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -351,7 +351,7 @@ fn provider_refuses_git_file_replaced_by_directory_before_spawn() {
     ));
     let (mut request, provider) = request("attested-workspace", format!("node {script}"));
     request.workspace.root = Some(workspace.display().to_string());
-    request.metadata = serde_json::json!({ "cook_workspace_identity": attestation });
+    request.metadata = serde_json::json!({ "cook_attempt_workspace_identity": attestation });
 
     std::fs::remove_file(workspace.join(".git")).expect("remove linked git file");
     std::fs::create_dir(workspace.join(".git")).expect("replace with git directory");
@@ -379,7 +379,7 @@ fn provider_refuses_linked_git_target_swap_before_spawn() {
     ));
     let (mut request, provider) = request("attested-workspace", format!("node {script}"));
     request.workspace.root = Some(workspace.display().to_string());
-    request.metadata = serde_json::json!({ "cook_workspace_identity": attestation });
+    request.metadata = serde_json::json!({ "cook_attempt_workspace_identity": attestation });
 
     std::fs::create_dir_all(temp.path().join("replacement-gitdir")).expect("replacement gitdir");
     std::fs::write(workspace.join(".git"), "gitdir: ../replacement-gitdir\n")

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -52,7 +52,7 @@ fn isolated_cook_attempt_spawns_a_real_provider_against_its_own_attestation() {
     let command = format!(
         "node {}",
         script(&format!(
-            "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); fs.writeFileSync({:?}, process.cwd()); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'provider spawned'}}));",
+            "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); fs.writeFileSync({:?}, JSON.stringify({{cwd:process.cwd(),workspace:req.workspace.root,attestation:req.metadata.cook_attempt_workspace_identity}})); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'provider spawned'}}));",
             marker.display().to_string()
         ))
     );
@@ -70,7 +70,10 @@ fn isolated_cook_attempt_spawns_a_real_provider_against_its_own_attestation() {
         .run(AgentTaskPlan::new("isolated-cook-provider", vec![request]));
 
     assert_eq!(aggregate.totals.succeeded, 1, "{aggregate:?}");
-    let provider_cwd = std::fs::read_to_string(&marker).expect("provider marker");
+    let provider_observation: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&marker).expect("provider marker"))
+            .expect("provider observation");
+    let provider_cwd = provider_observation["cwd"].as_str().expect("provider cwd");
     assert_ne!(
         provider_cwd,
         std::fs::canonicalize(&source)
@@ -78,6 +81,11 @@ fn isolated_cook_attempt_spawns_a_real_provider_against_its_own_attestation() {
             .display()
             .to_string(),
         "provider must run in the isolated attempt workspace"
+    );
+    assert_eq!(provider_observation["workspace"], provider_cwd);
+    assert_eq!(
+        provider_observation["attestation"]["canonical_path"], provider_cwd,
+        "the spawned provider must receive the attestation for its isolated cwd"
     );
 }
 

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -7,6 +7,118 @@ use std::sync::Mutex;
 
 static DEFAULT_TIMEOUT_ENV_LOCK: Mutex<()> = Mutex::new(());
 
+fn git(cwd: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn linked_cook_source(temp: &tempfile::TempDir) -> std::path::PathBuf {
+    let repository = temp.path().join("repository");
+    let source = temp.path().join("source");
+    std::fs::create_dir(&repository).expect("create repository");
+    git(&repository, &["init", "--quiet", "-b", "main"]);
+    git(&repository, &["config", "user.email", "test@example.com"]);
+    git(&repository, &["config", "user.name", "Homeboy Test"]);
+    std::fs::write(repository.join("base.txt"), "base\n").expect("write base");
+    git(&repository, &["add", "base.txt"]);
+    git(&repository, &["commit", "--quiet", "-m", "base"]);
+    git(
+        &repository,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            source.to_str().expect("source path"),
+            "HEAD",
+        ],
+    );
+    source
+}
+
+#[test]
+fn isolated_cook_attempt_spawns_a_real_provider_against_its_own_attestation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source = linked_cook_source(&temp);
+    let marker = temp.path().join("provider-started");
+    let command = format!(
+        "node {}",
+        script(&format!(
+            "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); fs.writeFileSync({:?}, process.cwd()); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'provider spawned'}}));",
+            marker.display().to_string()
+        ))
+    );
+    let (mut request, provider) = request("cook-provider", command);
+    request.workspace.root = Some(source.display().to_string());
+    request.metadata = serde_json::json!({
+        "cook_workspace_identity": crate::agent_task_workspace_identity::attest_workspace(&source)
+            .expect("attest source"),
+    });
+
+    let aggregate =
+        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+            provider,
+        ]))
+        .run(AgentTaskPlan::new("isolated-cook-provider", vec![request]));
+
+    assert_eq!(aggregate.totals.succeeded, 1, "{aggregate:?}");
+    let provider_cwd = std::fs::read_to_string(&marker).expect("provider marker");
+    assert_ne!(
+        provider_cwd,
+        std::fs::canonicalize(&source)
+            .expect("canonical source")
+            .display()
+            .to_string(),
+        "provider must run in the isolated attempt workspace"
+    );
+}
+
+#[test]
+fn isolated_cook_rejects_source_identity_drift_before_snapshotting() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source = linked_cook_source(&temp);
+    let marker = temp.path().join("provider-started");
+    let command = format!(
+        "node {}",
+        script(&format!(
+            "let fs=require('fs'); fs.writeFileSync({:?}, 'started'); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:'cook-provider',status:'succeeded'}}));",
+            marker.display().to_string()
+        ))
+    );
+    let (mut request, provider) = request("cook-provider", command);
+    request.workspace.root = Some(source.display().to_string());
+    request.metadata = serde_json::json!({
+        "cook_workspace_identity": crate::agent_task_workspace_identity::attest_workspace(&source)
+            .expect("attest source"),
+    });
+    std::fs::write(source.join(".git"), "gitdir: ../replaced-gitdir\n")
+        .expect("replace source gitdir reference");
+
+    let aggregate =
+        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+            provider,
+        ]))
+        .run(AgentTaskPlan::new("source-drift-cook", vec![request]));
+
+    assert_eq!(aggregate.totals.failed, 1);
+    assert_eq!(
+        aggregate.outcomes[0].diagnostics[0].class,
+        "agent_task.committed_harvest_git_failed"
+    );
+    assert!(
+        !marker.exists(),
+        "provider must not start after source drift"
+    );
+}
+
 #[test]
 fn scheduler_dispatches_extension_provider_command() {
     let command = format!(

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -592,6 +592,18 @@ pub(super) fn prepare_attempt_workspace(
     // scratch lease, never an untracked system-temporary worktree.
     let attempt_root = scratch_root.join("workspace");
     let attempt_root_string = attempt_root.display().to_string();
+    if let Some(attestation) = request.metadata.get("cook_workspace_identity") {
+        if !crate::agent_task_workspace_identity::workspace_matches_attestation(&root, attestation)
+        {
+            return Err(HarvestError::Git {
+                command: "verify Cook source workspace identity before snapshot".to_string(),
+                cwd: root,
+                message:
+                    "source workspace no longer matches its Cook admission identity attestation"
+                        .to_string(),
+            });
+        }
+    }
     git_output(
         &root,
         &["worktree", "add", "--detach", &attempt_root_string, base],

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -630,6 +630,14 @@ pub(super) fn prepare_attempt_workspace(
     let base_fingerprint = fingerprint(attempt_base.as_bytes());
     remap_workspace_config(&mut request.executor.config, &root, &attempt_root);
     request.workspace.root = Some(attempt_root.display().to_string());
+    request.metadata["cook_attempt_workspace_identity"] =
+        crate::agent_task_workspace_identity::attest_workspace(&attempt_root).map_err(|error| {
+            HarvestError::Git {
+                command: "attest Cook attempt workspace".to_string(),
+                cwd: attempt_root.clone(),
+                message: error.message,
+            }
+        })?;
     request.workspace.attempt = Some(crate::agent_task::AgentTaskAttemptWorkspace {
         identity,
         base_ref: attempt_base,

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -399,6 +399,37 @@ where
                     record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                     continue;
                 }
+                let source_identity_valid = request
+                    .metadata
+                    .get("cook_workspace_identity")
+                    .map(|attestation| {
+                        request.workspace.root.as_deref().is_some_and(|root| {
+                            crate::agent_task_workspace_identity::workspace_matches_attestation(
+                                Path::new(root),
+                                attestation,
+                            )
+                        })
+                    })
+                    .unwrap_or(true);
+                if !source_identity_valid {
+                    let root = request.workspace.root.as_deref().unwrap_or("<missing>");
+                    let outcome = committed_harvest_failure(
+                        committed_harvest_preflight_outcome(task_id.clone()),
+                        HarvestError::Git {
+                            command: "verify Cook source workspace identity".to_string(),
+                            cwd: Path::new(root).to_path_buf(),
+                            message: "source workspace no longer matches its Cook admission identity attestation".to_string(),
+                        },
+                    );
+                    events.push(event(
+                        &task_id,
+                        AgentTaskState::Failed,
+                        scheduled.attempt,
+                        outcome.summary.clone(),
+                    ));
+                    record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                    continue;
+                }
                 let harvest_preflight = match prepare_committed_harvest(
                     &request,
                     derived_cook_baseline,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2383,57 +2383,14 @@ fn bind_dispatch_workspace_attestations(plan: &mut AgentTaskPlan) -> Result<()> 
             )
         })?;
         let prior = task.metadata.get("cook_workspace_identity").cloned();
-        let identity = dispatch_workspace_identity(std::path::Path::new(root))?;
+        let identity =
+            crate::agent_task_workspace_identity::attest_workspace(std::path::Path::new(root))?;
         task.metadata["cook_workspace_identity"] = identity;
         if let Some(prior) = prior {
             task.metadata["cook_workspace_identity_predecessor"] = prior;
         }
     }
     Ok(())
-}
-
-#[cfg(unix)]
-fn dispatch_workspace_identity(path: &std::path::Path) -> Result<Value> {
-    use std::os::unix::fs::MetadataExt;
-    let canonical = std::fs::canonicalize(path)
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
-    let metadata = std::fs::symlink_metadata(&canonical).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(canonical.display().to_string()))
-    })?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        return Err(Error::validation_invalid_argument(
-            "workspace",
-            "Cook baseline workspace must be a non-symlink directory",
-            Some(canonical.display().to_string()),
-            None,
-        ));
-    }
-    let git_file = canonical.join(".git");
-    let git_metadata = std::fs::symlink_metadata(&git_file).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
-    })?;
-    let git_content = std::fs::read_to_string(&git_file).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
-    })?;
-    let gitdir_target = git_content
-        .strip_prefix("gitdir: ")
-        .map(str::trim)
-        .and_then(|target| std::fs::canonicalize(canonical.join(target)).ok());
-    Ok(serde_json::json!({
-        "canonical_path": canonical,
-        "device": metadata.dev(),
-        "inode": metadata.ino(),
-        "git_file_is_file": git_metadata.file_type().is_file(),
-        "git_file_content": git_content,
-        "gitdir_target": gitdir_target,
-    }))
-}
-
-#[cfg(not(unix))]
-fn dispatch_workspace_identity(path: &std::path::Path) -> Result<Value> {
-    let canonical = std::fs::canonicalize(path)
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
-    Ok(serde_json::json!({ "canonical_path": canonical }))
 }
 
 /// Re-resolve the declared Cook target before a provider can run. Durable

--- a/crates/homeboy-agents/src/agent_task_workspace_identity.rs
+++ b/crates/homeboy-agents/src/agent_task_workspace_identity.rs
@@ -7,6 +7,16 @@ use serde_json::Value;
 pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
     use std::os::unix::fs::MetadataExt;
 
+    let supplied_metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    if supplied_metadata.file_type().is_symlink() || !supplied_metadata.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "Cook workspace must be a non-symlink directory",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
     let canonical = std::fs::canonicalize(path)
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     let metadata = std::fs::symlink_metadata(&canonical).map_err(|error| {
@@ -52,6 +62,12 @@ pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
 pub(crate) fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
     use std::os::unix::fs::MetadataExt;
 
+    let Ok(supplied_metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    if supplied_metadata.file_type().is_symlink() || !supplied_metadata.is_dir() {
+        return false;
+    }
     let Ok(canonical) = std::fs::canonicalize(path) else {
         return false;
     };
@@ -94,4 +110,26 @@ pub(crate) fn workspace_matches_attestation(path: &Path, attestation: &Value) ->
         .and_then(|path| path.to_str().map(str::to_string))
         .as_deref()
         == attestation["canonical_path"].as_str()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn rejects_a_symlink_even_when_it_resolves_to_a_valid_workspace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let gitdir = temp.path().join("gitdir");
+        let alias = temp.path().join("workspace-alias");
+        std::fs::create_dir(&workspace).expect("workspace");
+        std::fs::create_dir(&gitdir).expect("gitdir");
+        std::fs::write(workspace.join(".git"), "gitdir: ../gitdir\n").expect("git file");
+        let attestation = attest_workspace(&workspace).expect("attest workspace");
+        symlink(&workspace, &alias).expect("workspace symlink");
+
+        assert!(attest_workspace(&alias).is_err());
+        assert!(!workspace_matches_attestation(&alias, &attestation));
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_workspace_identity.rs
+++ b/crates/homeboy-agents/src/agent_task_workspace_identity.rs
@@ -1,0 +1,97 @@
+use std::path::Path;
+
+use homeboy_core::{Error, Result};
+use serde_json::Value;
+
+#[cfg(unix)]
+pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
+    use std::os::unix::fs::MetadataExt;
+
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let metadata = std::fs::symlink_metadata(&canonical).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(canonical.display().to_string()))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "Cook workspace must be a non-symlink directory",
+            Some(canonical.display().to_string()),
+            None,
+        ));
+    }
+    let git_file = canonical.join(".git");
+    let git_metadata = std::fs::symlink_metadata(&git_file).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
+    })?;
+    let git_content = std::fs::read_to_string(&git_file).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
+    })?;
+    let gitdir_target = git_content
+        .strip_prefix("gitdir: ")
+        .map(str::trim)
+        .and_then(|target| std::fs::canonicalize(canonical.join(target)).ok());
+    Ok(serde_json::json!({
+        "canonical_path": canonical,
+        "device": metadata.dev(),
+        "inode": metadata.ino(),
+        "git_file_is_file": git_metadata.file_type().is_file(),
+        "git_file_content": git_content,
+        "gitdir_target": gitdir_target,
+    }))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    Ok(serde_json::json!({ "canonical_path": canonical }))
+}
+
+#[cfg(unix)]
+pub(crate) fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let Ok(canonical) = std::fs::canonicalize(path) else {
+        return false;
+    };
+    let Ok(metadata) = std::fs::symlink_metadata(&canonical) else {
+        return false;
+    };
+    !metadata.file_type().is_symlink()
+        && attestation["canonical_path"].as_str() == canonical.to_str()
+        && attestation["device"].as_u64() == Some(metadata.dev())
+        && attestation["inode"].as_u64() == Some(metadata.ino())
+        && linked_git_metadata_matches(&canonical, attestation)
+}
+
+#[cfg(unix)]
+fn linked_git_metadata_matches(worktree: &Path, attestation: &Value) -> bool {
+    let git_file = worktree.join(".git");
+    let Ok(metadata) = std::fs::symlink_metadata(&git_file) else {
+        return false;
+    };
+    if !metadata.file_type().is_file() || attestation["git_file_is_file"] != true {
+        return false;
+    }
+    let Ok(content) = std::fs::read_to_string(&git_file) else {
+        return false;
+    };
+    if attestation["git_file_content"].as_str() != Some(content.as_str()) {
+        return false;
+    }
+    let target = content
+        .strip_prefix("gitdir: ")
+        .map(str::trim)
+        .and_then(|target| std::fs::canonicalize(worktree.join(target)).ok());
+    target.as_deref().and_then(|path| path.to_str()) == attestation["gitdir_target"].as_str()
+}
+
+#[cfg(not(unix))]
+pub(crate) fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
+    std::fs::canonicalize(path)
+        .ok()
+        .and_then(|path| path.to_str().map(str::to_string))
+        .as_deref()
+        == attestation["canonical_path"].as_str()
+}

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -39,6 +39,7 @@ pub mod agent_task_secrets;
 pub mod agent_task_service;
 pub mod agent_task_timeout;
 pub mod agent_task_timeout_artifacts;
+pub(crate) mod agent_task_workspace_identity;
 pub mod agent_tasks;
 pub mod agent_tool_control_plane;
 pub mod api_jobs_terminal_recovery;

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2499,25 +2499,8 @@ mod tests {
         let root = "/runner/app-homeboy-artifacts/rig-registry".to_string();
         let args = Vec::new();
         let request = LabOffloadRequest {
-            command: None,
             normalized_args: &args,
-            explicit_runner: None,
-            placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: true,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
-            detach_after_handoff: false,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
-            source_path: None,
-            verified_cook_baseline: None,
-            require_controller_git_bundle: false,
-            reuse_compatible_snapshot: false,
             job_overrides: LabJobOverrides {
                 env: std::collections::HashMap::from([
                     (
@@ -2532,6 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
+            ..LabOffloadRequest::new(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2515,7 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            ..LabOffloadRequest::new(&args)
+            ..LabOffloadRequest::for_test(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -432,24 +432,8 @@ fn plan_records_skipped_auto_offload() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Local,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     })
     .expect("outcome");
 
@@ -465,26 +449,9 @@ fn plan_records_skipped_auto_offload() {
 #[test]
 fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &["homeboy".to_string(), "status".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -505,24 +472,8 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "install".to_string(),
             "./rig-package".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -539,30 +490,13 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
 #[test]
 fn build_runner_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -588,30 +522,13 @@ fn build_runner_error_gives_managed_runner_replacement() {
 #[test]
 fn build_lab_placement_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -637,7 +554,6 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
 #[test]
 fn unsupported_runner_error_guides_tunnel_service_inspection() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "tunnel".to_string(),
@@ -646,23 +562,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -433,7 +433,7 @@ fn plan_records_skipped_auto_offload() {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
         placement: homeboy_cli_contract::Placement::Local,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "test".to_string()])
     })
     .expect("outcome");
 
@@ -451,7 +451,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         normalized_args: &["homeboy".to_string(), "status".to_string()],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "status".to_string()])
     });
 
     let Err(err) = outcome else {
@@ -473,7 +473,12 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "./rig-package".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "install".to_string(),
+            "./rig-package".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -496,7 +501,11 @@ fn build_runner_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -528,7 +537,11 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -562,7 +575,13 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "status".to_string(),
+            "wpcom-ai-manual-held".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,11 +45,14 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
-impl<'a> Default for LabOffloadRequest<'a> {
-    fn default() -> Self {
+impl<'a> LabOffloadRequest<'a> {
+    #[cfg(test)]
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// This remains test-only so production callers must set every policy field.
+    pub(crate) fn for_test(normalized_args: &'a [String]) -> Self {
         Self {
             command: None,
-            normalized_args: &[],
+            normalized_args,
             explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: false,
@@ -72,14 +75,60 @@ impl<'a> Default for LabOffloadRequest<'a> {
     }
 }
 
-impl<'a> LabOffloadRequest<'a> {
-    /// Creates a request with the neutral offload policy used by focused tests.
-    /// New request fields belong in `Default`, so those fixtures stay valid.
-    pub fn new(normalized_args: &'a [String]) -> Self {
-        Self {
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_has_neutral_policy() {
+        let args = vec!["homeboy".to_string(), "status".to_string()];
+        let request = LabOffloadRequest::for_test(&args);
+
+        let LabOffloadRequest {
+            command,
             normalized_args,
-            ..Self::default()
-        }
+            explicit_runner,
+            placement,
+            allow_local_fallback,
+            allow_dirty_lab_workspace,
+            skip_deps_hydration,
+            preserve_workspace_on_failure,
+            capture_patch,
+            mutation_flag,
+            detach_after_handoff,
+            output_file_requested,
+            read_only_polling,
+            local_output_file,
+            durable_agent_task_plan,
+            source_path,
+            verified_cook_baseline,
+            require_controller_git_bundle,
+            reuse_compatible_snapshot,
+            job_overrides,
+        } = request;
+
+        assert!(command.is_none());
+        assert_eq!(normalized_args, args);
+        assert!(explicit_runner.is_none());
+        assert_eq!(placement, homeboy_cli_contract::Placement::Auto);
+        assert!(!allow_local_fallback);
+        assert!(!allow_dirty_lab_workspace);
+        assert!(!skip_deps_hydration);
+        assert!(!preserve_workspace_on_failure);
+        assert!(!capture_patch);
+        assert!(mutation_flag.is_none());
+        assert!(!detach_after_handoff);
+        assert!(!output_file_requested);
+        assert!(!read_only_polling);
+        assert!(local_output_file.is_none());
+        assert!(durable_agent_task_plan.is_none());
+        assert!(source_path.is_none());
+        assert!(verified_cook_baseline.is_none());
+        assert!(!require_controller_git_bundle);
+        assert!(!reuse_compatible_snapshot);
+        assert!(job_overrides.env.is_empty());
+        assert!(job_overrides.secret_env_names.is_empty());
+        assert!(job_overrides.workspace_root.is_none());
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,6 +45,44 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
+impl<'a> Default for LabOffloadRequest<'a> {
+    fn default() -> Self {
+        Self {
+            command: None,
+            normalized_args: &[],
+            explicit_runner: None,
+            placement: homeboy_cli_contract::Placement::Auto,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            preserve_workspace_on_failure: false,
+            capture_patch: false,
+            mutation_flag: None,
+            detach_after_handoff: false,
+            output_file_requested: false,
+            read_only_polling: false,
+            local_output_file: None,
+            durable_agent_task_plan: None,
+            source_path: None,
+            verified_cook_baseline: None,
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
+            job_overrides: LabJobOverrides::default(),
+        }
+    }
+}
+
+impl<'a> LabOffloadRequest<'a> {
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// New request fields belong in `Default`, so those fixtures stay valid.
+    pub fn new(normalized_args: &'a [String]) -> Self {
+        Self {
+            normalized_args,
+            ..Self::default()
+        }
+    }
+}
+
 // LabOffloadCommand, LabJobOverrides, LabOffloadOutcome, and the source/workspace
 // mode aliases moved to core's lab_offload module (they are core-plan-based
 // types the core lab_routing service names). Re-exported so runner-internal

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1238,7 +1238,7 @@ mod tests {
             let request = LabOffloadRequest {
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2453,7 +2453,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2588,7 +2588,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2761,7 +2761,7 @@ mod tests {
                 placement: homeboy_cli_contract::Placement::Lab,
                 detach_after_handoff: true,
                 source_path: Some(source.as_path()),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1236,25 +1236,9 @@ mod tests {
                 "jetpack-api-route-inventory".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2466,26 +2450,10 @@ mod tests {
                 "base".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2617,26 +2585,10 @@ mod tests {
                 "provider-value".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2804,26 +2756,12 @@ mod tests {
                 ensure_agent_task_lifecycle_identity_with(&args, Some("cook-8009"), None)
                     .expect("canonical cook attempt id");
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-managed-worktree-stage"),
                 placement: homeboy_cli_contract::Placement::Lab,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
                 detach_after_handoff: true,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
                 source_path: Some(source.as_path()),
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3420,21 +3420,9 @@ mod tests {
         LabOffloadRequest {
             command,
             normalized_args: args,
-            explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Lab,
-            allow_local_fallback: false,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
             detach_after_handoff: true,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
             source_path: Some(std::path::Path::new("/work/source")),
-            verified_cook_baseline: None,
             require_controller_git_bundle: true,
             reuse_compatible_snapshot: true,
             job_overrides: homeboy_core::lab_offload::LabJobOverrides {
@@ -3442,6 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
+            ..LabOffloadRequest::new(args)
         }
     }
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3430,7 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
-            ..LabOffloadRequest::new(args)
+            ..LabOffloadRequest::for_test(args)
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve the authoritative Cook source-worktree attestation for admission and revalidate it before snapshotting
- attest each materialized isolated attempt workspace and verify that identity immediately before provider spawn
- keep promotion source/destination binding unchanged while avoiding comparisons between intentionally distinct source and attempt worktree identities

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test -p homeboy-agents isolated_cook_attempt_spawns_a_real_provider_against_its_own_attestation -- --nocapture`
- `cargo test -p homeboy-agents isolated_cook_rejects_source_identity_drift_before_snapshotting -- --nocapture`
- `cargo test -p homeboy-agents agent_task_provider::tests::manifest_tests::provider_refuses_git_file_replaced_by_directory_before_spawn -- --exact`
- `cargo test -p homeboy-agents agent_task_provider::tests::manifest_tests::provider_refuses_linked_git_target_swap_before_spawn -- --exact`

Closes #10085

## AI Assistance
Substantive implementation and tests were drafted with OpenAI GPT-5.6 Sol using OpenCode. Chris Huber owns and is responsible for every line.