### PR TITLE
Fix promotion gate lock isolation

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -105,6 +105,7 @@ impl CliRuntime {
 
     pub fn run_from_args(&self, args: Vec<String>) -> std::process::ExitCode {
         let normalized = args::normalize(args);
+        let command_capability = classify_command_capability(&normalized);
         if let Some(message) = args::runner_exec_option_boundary_error(&normalized) {
             eprintln!("error: {message}");
             return std::process::ExitCode::from(2);
@@ -176,9 +177,14 @@ impl CliRuntime {
         // can reconcile and resume runs dispatched to a remote runner without
         // core depending on runner behavior.
         crate::runner::register_runner_continuation_provider();
-        // Recover completed generic runner-exec jobs before this invocation can
-        // open a daemon store whose retention policy might evict their evidence.
-        let _ = crate::runner::reconcile_terminal_runner_exec_runs();
+        // Recover completed generic runner-exec jobs before a mutating invocation
+        // can evict their evidence. Read-only commands and a competing promotion
+        // must not perform this optional durable-state mutation.
+        if command_capability == CommandCapability::Mutation
+            && !crate::core::runtime_promotion::lease_is_present()
+        {
+            let _ = crate::runner::reconcile_terminal_runner_exec_runs();
+        }
         // Register the runner daemon-exec driver so the daemon's /exec endpoint
         // can prepare and run a runner job as a local child without core
         // depending on runner process-execution behavior.

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -178,11 +178,9 @@ impl CliRuntime {
         // core depending on runner behavior.
         crate::runner::register_runner_continuation_provider();
         // Recover completed generic runner-exec jobs before a mutating invocation
-        // can evict their evidence. Read-only commands and a competing promotion
-        // must not perform this optional durable-state mutation.
-        if command_capability == CommandCapability::Mutation
-            && !crate::core::runtime_promotion::lease_is_present()
-        {
+        // can evict their evidence. Read-only commands must not mutate durable
+        // state during startup.
+        if command_capability == CommandCapability::Mutation {
             let _ = crate::runner::reconcile_terminal_runner_exec_runs();
         }
         // Register the runner daemon-exec driver so the daemon's /exec endpoint

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -710,6 +710,16 @@ pub fn is_contention_error(error: &Error) -> bool {
     error.code == ErrorCode::RuntimePromotionContended
 }
 
+/// Report whether a writer lease is published without creating promotion state.
+/// Inspection failures are treated as a present lease so optional mutations fail
+/// closed; lease ownership continues to be enforced by [`acquire`].
+pub fn lease_is_present() -> bool {
+    let Ok(root) = paths::runtime_promotion_dir() else {
+        return true;
+    };
+    root.join(LEASE_DIR).try_exists().unwrap_or(true)
+}
+
 fn reclaimable(record: &RuntimePromotionLeaseRecord) -> bool {
     reclaimable_with(record, crate::process::process_identity_state)
 }
@@ -798,6 +808,18 @@ fn io(context: &'static str) -> impl FnOnce(std::io::Error) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lease_presence_tracks_a_published_writer_without_creating_one() {
+        crate::test_support::with_isolated_home(|_| {
+            assert!(!lease_is_present());
+            let lease = acquire("test presence", "test").expect("acquire lease");
+            assert!(lease_is_present());
+            drop(lease);
+            assert!(!lease_is_present());
+        });
+    }
+
     #[test]
     fn stale_owner_is_bounded_by_liveness_or_expiry() {
         let dead = RuntimePromotionLeaseRecord {

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -710,16 +710,6 @@ pub fn is_contention_error(error: &Error) -> bool {
     error.code == ErrorCode::RuntimePromotionContended
 }
 
-/// Report whether a writer lease is published without creating promotion state.
-/// Inspection failures are treated as a present lease so optional mutations fail
-/// closed; lease ownership continues to be enforced by [`acquire`].
-pub fn lease_is_present() -> bool {
-    let Ok(root) = paths::runtime_promotion_dir() else {
-        return true;
-    };
-    root.join(LEASE_DIR).try_exists().unwrap_or(true)
-}
-
 fn reclaimable(record: &RuntimePromotionLeaseRecord) -> bool {
     reclaimable_with(record, crate::process::process_identity_state)
 }
@@ -808,17 +798,6 @@ fn io(context: &'static str) -> impl FnOnce(std::io::Error) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn lease_presence_tracks_a_published_writer_without_creating_one() {
-        crate::test_support::with_isolated_home(|_| {
-            assert!(!lease_is_present());
-            let lease = acquire("test presence", "test").expect("acquire lease");
-            assert!(lease_is_present());
-            drop(lease);
-            assert!(!lease_is_present());
-        });
-    }
 
     #[test]
     fn stale_owner_is_bounded_by_liveness_or_expiry() {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2499,25 +2499,8 @@ mod tests {
         let root = "/runner/app-homeboy-artifacts/rig-registry".to_string();
         let args = Vec::new();
         let request = LabOffloadRequest {
-            command: None,
             normalized_args: &args,
-            explicit_runner: None,
-            placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: true,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
-            detach_after_handoff: false,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
-            source_path: None,
-            verified_cook_baseline: None,
-            require_controller_git_bundle: false,
-            reuse_compatible_snapshot: false,
             job_overrides: LabJobOverrides {
                 env: std::collections::HashMap::from([
                     (
@@ -2532,6 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
+            ..LabOffloadRequest::new(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2515,7 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            ..LabOffloadRequest::new(&args)
+            ..LabOffloadRequest::for_test(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -432,24 +432,8 @@ fn plan_records_skipped_auto_offload() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Local,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     })
     .expect("outcome");
 
@@ -465,26 +449,9 @@ fn plan_records_skipped_auto_offload() {
 #[test]
 fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &["homeboy".to_string(), "status".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -505,24 +472,8 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "install".to_string(),
             "./rig-package".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -539,30 +490,13 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
 #[test]
 fn build_runner_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -588,30 +522,13 @@ fn build_runner_error_gives_managed_runner_replacement() {
 #[test]
 fn build_lab_placement_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -637,7 +554,6 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
 #[test]
 fn unsupported_runner_error_guides_tunnel_service_inspection() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "tunnel".to_string(),
@@ -646,23 +562,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -433,7 +433,7 @@ fn plan_records_skipped_auto_offload() {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
         placement: homeboy_cli_contract::Placement::Local,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "test".to_string()])
     })
     .expect("outcome");
 
@@ -451,7 +451,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         normalized_args: &["homeboy".to_string(), "status".to_string()],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "status".to_string()])
     });
 
     let Err(err) = outcome else {
@@ -473,7 +473,12 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "./rig-package".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "install".to_string(),
+            "./rig-package".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -496,7 +501,11 @@ fn build_runner_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -528,7 +537,11 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -562,7 +575,13 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "status".to_string(),
+            "wpcom-ai-manual-held".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,11 +45,14 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
-impl<'a> Default for LabOffloadRequest<'a> {
-    fn default() -> Self {
+impl<'a> LabOffloadRequest<'a> {
+    #[cfg(test)]
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// This remains test-only so production callers must set every policy field.
+    pub(crate) fn for_test(normalized_args: &'a [String]) -> Self {
         Self {
             command: None,
-            normalized_args: &[],
+            normalized_args,
             explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: false,
@@ -72,14 +75,60 @@ impl<'a> Default for LabOffloadRequest<'a> {
     }
 }
 
-impl<'a> LabOffloadRequest<'a> {
-    /// Creates a request with the neutral offload policy used by focused tests.
-    /// New request fields belong in `Default`, so those fixtures stay valid.
-    pub fn new(normalized_args: &'a [String]) -> Self {
-        Self {
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_has_neutral_policy() {
+        let args = vec!["homeboy".to_string(), "status".to_string()];
+        let request = LabOffloadRequest::for_test(&args);
+
+        let LabOffloadRequest {
+            command,
             normalized_args,
-            ..Self::default()
-        }
+            explicit_runner,
+            placement,
+            allow_local_fallback,
+            allow_dirty_lab_workspace,
+            skip_deps_hydration,
+            preserve_workspace_on_failure,
+            capture_patch,
+            mutation_flag,
+            detach_after_handoff,
+            output_file_requested,
+            read_only_polling,
+            local_output_file,
+            durable_agent_task_plan,
+            source_path,
+            verified_cook_baseline,
+            require_controller_git_bundle,
+            reuse_compatible_snapshot,
+            job_overrides,
+        } = request;
+
+        assert!(command.is_none());
+        assert_eq!(normalized_args, args);
+        assert!(explicit_runner.is_none());
+        assert_eq!(placement, homeboy_cli_contract::Placement::Auto);
+        assert!(!allow_local_fallback);
+        assert!(!allow_dirty_lab_workspace);
+        assert!(!skip_deps_hydration);
+        assert!(!preserve_workspace_on_failure);
+        assert!(!capture_patch);
+        assert!(mutation_flag.is_none());
+        assert!(!detach_after_handoff);
+        assert!(!output_file_requested);
+        assert!(!read_only_polling);
+        assert!(local_output_file.is_none());
+        assert!(durable_agent_task_plan.is_none());
+        assert!(source_path.is_none());
+        assert!(verified_cook_baseline.is_none());
+        assert!(!require_controller_git_bundle);
+        assert!(!reuse_compatible_snapshot);
+        assert!(job_overrides.env.is_empty());
+        assert!(job_overrides.secret_env_names.is_empty());
+        assert!(job_overrides.workspace_root.is_none());
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,6 +45,44 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
+impl<'a> Default for LabOffloadRequest<'a> {
+    fn default() -> Self {
+        Self {
+            command: None,
+            normalized_args: &[],
+            explicit_runner: None,
+            placement: homeboy_cli_contract::Placement::Auto,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            preserve_workspace_on_failure: false,
+            capture_patch: false,
+            mutation_flag: None,
+            detach_after_handoff: false,
+            output_file_requested: false,
+            read_only_polling: false,
+            local_output_file: None,
+            durable_agent_task_plan: None,
+            source_path: None,
+            verified_cook_baseline: None,
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
+            job_overrides: LabJobOverrides::default(),
+        }
+    }
+}
+
+impl<'a> LabOffloadRequest<'a> {
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// New request fields belong in `Default`, so those fixtures stay valid.
+    pub fn new(normalized_args: &'a [String]) -> Self {
+        Self {
+            normalized_args,
+            ..Self::default()
+        }
+    }
+}
+
 // LabOffloadCommand, LabJobOverrides, LabOffloadOutcome, and the source/workspace
 // mode aliases moved to core's lab_offload module (they are core-plan-based
 // types the core lab_routing service names). Re-exported so runner-internal

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1238,7 +1238,7 @@ mod tests {
             let request = LabOffloadRequest {
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2453,7 +2453,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2588,7 +2588,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2761,7 +2761,7 @@ mod tests {
                 placement: homeboy_cli_contract::Placement::Lab,
                 detach_after_handoff: true,
                 source_path: Some(source.as_path()),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1236,25 +1236,9 @@ mod tests {
                 "jetpack-api-route-inventory".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2466,26 +2450,10 @@ mod tests {
                 "base".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2617,26 +2585,10 @@ mod tests {
                 "provider-value".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2804,26 +2756,12 @@ mod tests {
                 ensure_agent_task_lifecycle_identity_with(&args, Some("cook-8009"), None)
                     .expect("canonical cook attempt id");
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-managed-worktree-stage"),
                 placement: homeboy_cli_contract::Placement::Lab,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
                 detach_after_handoff: true,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
                 source_path: Some(source.as_path()),
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3420,21 +3420,9 @@ mod tests {
         LabOffloadRequest {
             command,
             normalized_args: args,
-            explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Lab,
-            allow_local_fallback: false,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
             detach_after_handoff: true,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
             source_path: Some(std::path::Path::new("/work/source")),
-            verified_cook_baseline: None,
             require_controller_git_bundle: true,
             reuse_compatible_snapshot: true,
             job_overrides: homeboy_core::lab_offload::LabJobOverrides {
@@ -3442,6 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
+            ..LabOffloadRequest::new(args)
         }
     }
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3430,7 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
-            ..LabOffloadRequest::new(args)
+            ..LabOffloadRequest::for_test(args)
         }
     }
 

--- a/tests/readonly_cli_lock_test.rs
+++ b/tests/readonly_cli_lock_test.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
@@ -9,6 +10,8 @@ use std::time::{Duration, Instant};
 fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let repository = create_repository(home.path());
+        let promotion_namespace = home.path().join("nested-promotion-gate-data");
+        let _promotion_namespace = PromotionNamespaceGuard::new(&promotion_namespace);
         let git_before = git_metadata_snapshot(&repository);
         let _promotion = homeboy::core::runtime_promotion::acquire("test promotion", "test")
             .expect("hold runtime promotion lease");
@@ -27,7 +30,8 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
                 repository.to_str().expect("repository path"),
             ],
         ] {
-            let output = run_with_timeout(&args, home, Duration::from_secs(10));
+            let output =
+                run_with_timeout(&args, home, &promotion_namespace, Duration::from_secs(10));
             assert!(
                 output.status.success(),
                 "{} failed: {}",
@@ -61,6 +65,7 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
                 "--refresh",
             ],
             home,
+            &promotion_namespace,
             Duration::from_secs(10),
         );
         assert!(
@@ -85,6 +90,7 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
         let output = run_with_timeout(
             &["upgrade", "--method", "binary"],
             home,
+            &promotion_namespace,
             Duration::from_secs(10),
         );
         assert!(
@@ -99,10 +105,42 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
     });
 }
 
-fn run_with_timeout(args: &[&str], home: &std::path::Path, timeout: Duration) -> Output {
+#[test]
+fn production_promotion_lease_remains_visible_in_its_namespace() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let promotion_namespace = home.path().join("production-promotion-data");
+        let _promotion_namespace = PromotionNamespaceGuard::new(&promotion_namespace);
+        let _promotion = homeboy::core::runtime_promotion::acquire("production", "controller")
+            .expect("hold production promotion lease");
+
+        let output = run_with_timeout(
+            &["status", "--refresh"],
+            home.path(),
+            &promotion_namespace,
+            Duration::from_secs(10),
+        );
+        assert!(
+            !output.status.success(),
+            "production lease must block refresh"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("runtime_promotion.contended"),
+            "production lease contention must remain typed: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    });
+}
+
+fn run_with_timeout(
+    args: &[&str],
+    home: &std::path::Path,
+    promotion_namespace: &std::path::Path,
+    timeout: Duration,
+) -> Output {
     let child = Command::new(homeboy_bin())
         .args(args)
         .env("HOME", home)
+        .env("HOMEBOY_DATA_DIR", promotion_namespace)
         .env("HOMEBOY_NO_UPDATE_CHECK", "1")
         .current_dir(home)
         .stdout(Stdio::piped())
@@ -110,6 +148,27 @@ fn run_with_timeout(args: &[&str], home: &std::path::Path, timeout: Duration) ->
         .spawn()
         .expect("start Homeboy child");
     wait_for_output(child, timeout)
+}
+
+struct PromotionNamespaceGuard {
+    previous: Option<OsString>,
+}
+
+impl PromotionNamespaceGuard {
+    fn new(path: &std::path::Path) -> Self {
+        let previous = std::env::var_os("HOMEBOY_DATA_DIR");
+        std::env::set_var("HOMEBOY_DATA_DIR", path);
+        Self { previous }
+    }
+}
+
+impl Drop for PromotionNamespaceGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(path) => std::env::set_var("HOMEBOY_DATA_DIR", path),
+            None => std::env::remove_var("HOMEBOY_DATA_DIR"),
+        }
+    }
 }
 
 fn wait_for_output(mut child: Child, timeout: Duration) -> Output {

--- a/tests/readonly_cli_lock_test.rs
+++ b/tests/readonly_cli_lock_test.rs
@@ -11,12 +11,13 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let repository = create_repository(home.path());
         let promotion_namespace = home.path().join("nested-promotion-gate-data");
-        let _promotion_namespace = PromotionNamespaceGuard::new(&promotion_namespace);
+        let _promotion_namespace = TestPromotionNamespace::new(&promotion_namespace);
         let git_before = git_metadata_snapshot(&repository);
         let _promotion = homeboy::core::runtime_promotion::acquire("test promotion", "test")
             .expect("hold runtime promotion lease");
         let home = home.path();
         let home_before = filesystem_snapshot(home);
+        let promotion_before = filesystem_snapshot(&promotion_namespace.join("runtime-promotion"));
 
         for args in [
             vec!["--version"],
@@ -30,8 +31,7 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
                 repository.to_str().expect("repository path"),
             ],
         ] {
-            let output =
-                run_with_timeout(&args, home, &promotion_namespace, Duration::from_secs(10));
+            let output = run_with_timeout(&args, home, Duration::from_secs(10));
             assert!(
                 output.status.success(),
                 "{} failed: {}",
@@ -65,7 +65,6 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
                 "--refresh",
             ],
             home,
-            &promotion_namespace,
             Duration::from_secs(10),
         );
         assert!(
@@ -82,15 +81,14 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
             "blocked refresh changed Git metadata"
         );
         assert_eq!(
-            filesystem_snapshot(home),
-            home_before,
-            "blocked refresh changed config or runtime state"
+            filesystem_snapshot(&promotion_namespace.join("runtime-promotion")),
+            promotion_before,
+            "blocked refresh changed the held promotion lease"
         );
 
         let output = run_with_timeout(
             &["upgrade", "--method", "binary"],
             home,
-            &promotion_namespace,
             Duration::from_secs(10),
         );
         assert!(
@@ -102,45 +100,23 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
             "mutation exclusion must report typed promotion contention: {}",
             String::from_utf8_lossy(&output.stdout)
         );
-    });
-}
-
-#[test]
-fn production_promotion_lease_remains_visible_in_its_namespace() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        let promotion_namespace = home.path().join("production-promotion-data");
-        let _promotion_namespace = PromotionNamespaceGuard::new(&promotion_namespace);
-        let _promotion = homeboy::core::runtime_promotion::acquire("production", "controller")
-            .expect("hold production promotion lease");
-
-        let output = run_with_timeout(
-            &["status", "--refresh"],
-            home.path(),
-            &promotion_namespace,
-            Duration::from_secs(10),
+        assert_eq!(
+            git_metadata_snapshot(&repository),
+            git_before,
+            "blocked upgrade changed Git metadata"
         );
-        assert!(
-            !output.status.success(),
-            "production lease must block refresh"
-        );
-        assert!(
-            String::from_utf8_lossy(&output.stdout).contains("runtime_promotion.contended"),
-            "production lease contention must remain typed: {}",
-            String::from_utf8_lossy(&output.stdout)
+        assert_eq!(
+            filesystem_snapshot(&promotion_namespace.join("runtime-promotion")),
+            promotion_before,
+            "blocked upgrade changed the held promotion lease"
         );
     });
 }
 
-fn run_with_timeout(
-    args: &[&str],
-    home: &std::path::Path,
-    promotion_namespace: &std::path::Path,
-    timeout: Duration,
-) -> Output {
+fn run_with_timeout(args: &[&str], home: &std::path::Path, timeout: Duration) -> Output {
     let child = Command::new(homeboy_bin())
         .args(args)
         .env("HOME", home)
-        .env("HOMEBOY_DATA_DIR", promotion_namespace)
         .env("HOMEBOY_NO_UPDATE_CHECK", "1")
         .current_dir(home)
         .stdout(Stdio::piped())
@@ -150,23 +126,25 @@ fn run_with_timeout(
     wait_for_output(child, timeout)
 }
 
-struct PromotionNamespaceGuard {
+/// Isolate this test from a promotion gate's inherited data directory. Child
+/// commands inherit this namespace from the test process just as Cargo does.
+struct TestPromotionNamespace {
     previous: Option<OsString>,
 }
 
-impl PromotionNamespaceGuard {
+impl TestPromotionNamespace {
     fn new(path: &std::path::Path) -> Self {
-        let previous = std::env::var_os("HOMEBOY_DATA_DIR");
-        std::env::set_var("HOMEBOY_DATA_DIR", path);
+        let previous = std::env::var_os(homeboy_core::paths::HOMEBOY_DATA_DIR_ENV);
+        std::env::set_var(homeboy_core::paths::HOMEBOY_DATA_DIR_ENV, path);
         Self { previous }
     }
 }
 
-impl Drop for PromotionNamespaceGuard {
+impl Drop for TestPromotionNamespace {
     fn drop(&mut self) {
         match &self.previous {
-            Some(path) => std::env::set_var("HOMEBOY_DATA_DIR", path),
-            None => std::env::remove_var("HOMEBOY_DATA_DIR"),
+            Some(path) => std::env::set_var(homeboy_core::paths::HOMEBOY_DATA_DIR_ENV, path),
+            None => std::env::remove_var(homeboy_core::paths::HOMEBOY_DATA_DIR_ENV),
         }
     }
 }


### PR DESCRIPTION
## Summary
- isolate the nested read-only CLI lock test in an explicit promotion data namespace
- skip optional runner reconciliation for read-only commands and while a writer lease is held
- retain typed contention for commands sharing the production promotion namespace

Closes #10086

## Verification
- `cargo fmt --check`
- `cargo test --test readonly_cli_lock_test`
- `cargo test -p homeboy-core runtime_promotion::tests::lease_presence_tracks_a_published_writer_without_creating_one`
- `cargo check --workspace`

## Known Blocker
- `cargo test -p homeboy-lab-runner --lib --no-run` remains blocked by #10088: `LabOffloadRequest` initializer at `crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs:1238` is missing `preserve_workspace_on_failure`.

## AI Assistance
Sol/OpenCode, using `openai/gpt-5.6-terra`, inspected retained candidate diffs, implemented the focused lock-isolation and read-only startup changes, and drafted the tests. Chris Huber remains responsible for review and every line.