### PR TITLE
Fix durable Lab artifact import before reap

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_lifecycle_event.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_lifecycle_event.rs
@@ -54,14 +54,17 @@ pub fn is_agent_task_run_plan_envelope(value: &serde_json::Value) -> bool {
     let Some(data) = value.get("data") else {
         return false;
     };
-    data.get("schema").and_then(serde_json::Value::as_str)
-        == Some("homeboy/agent-task-aggregate/v1")
-        || data.get("plan_id").is_some()
-        || data.get("aggregate").is_some_and(|aggregate| {
-            aggregate.get("schema").and_then(serde_json::Value::as_str)
-                == Some("homeboy/agent-task-aggregate/v1")
-                || aggregate.get("plan_id").is_some()
-        })
+    is_authoritative_agent_task_aggregate(data)
+        || data
+            .get("aggregate")
+            .is_some_and(is_authoritative_agent_task_aggregate)
+}
+
+fn is_authoritative_agent_task_aggregate(value: &serde_json::Value) -> bool {
+    value.get("view").and_then(serde_json::Value::as_str) != Some("summary")
+        && (value.get("schema").and_then(serde_json::Value::as_str)
+            == Some("homeboy/agent-task-aggregate/v1")
+            || value.get("plan_id").is_some())
 }
 
 pub fn agent_task_run_plan_lifecycle_event_from_job_events(
@@ -208,28 +211,19 @@ pub fn agent_task_run_plan_lifecycle_event_from_workload_result(
 /// instead of treating a valid aggregate as opaque terminal metadata.
 fn agent_task_aggregate_from_terminal_result(
     value: &serde_json::Value,
-    allow_compact_summary: bool,
+    _allow_compact_summary: bool,
 ) -> Result<Option<AgentTaskAggregate>> {
     const MAX_ENVELOPE_DEPTH: usize = 8;
 
     let mut current = value;
     for _ in 0..MAX_ENVELOPE_DEPTH {
         if current.get("view").and_then(serde_json::Value::as_str) == Some("summary") {
-            if allow_compact_summary {
-                if let Some(aggregate) = agent_task_aggregate_from_compact_summary(current)? {
-                    return Ok(Some(aggregate));
-                }
-            } else {
-                return Ok(None);
-            }
+            return Ok(None);
         }
         if let Some(aggregate) = agent_task_aggregate_from_value(current) {
             return Ok(Some(aggregate));
         }
-        if current.get("schema").and_then(serde_json::Value::as_str)
-            == Some("homeboy/agent-task-aggregate/v1")
-            || current.get("plan_id").is_some()
-        {
+        if is_authoritative_agent_task_aggregate(current) {
             return serde_json::from_value(current.clone())
                 .map(Some)
                 .map_err(|error| {
@@ -289,96 +283,8 @@ fn persisted_result_matches_run_plan(result: &serde_json::Value, run_id: &str) -
             .any(|args| args[0] == "--record-run-id" && args[1] == run_id)
 }
 
-fn agent_task_aggregate_from_compact_summary(
-    value: &serde_json::Value,
-) -> Result<Option<AgentTaskAggregate>> {
-    const COMPACT_REF_LIMIT: usize = 12;
-    const COMPACT_TEXT_LIMIT: usize = 512;
-
-    if value.get("schema").and_then(serde_json::Value::as_str)
-        != Some("homeboy/agent-task-aggregate/v1")
-        || value.get("view").and_then(serde_json::Value::as_str) != Some("summary")
-    {
-        return Ok(None);
-    }
-    if value
-        .get("tasks_omitted")
-        .and_then(serde_json::Value::as_u64)
-        != Some(0)
-    {
-        return Err(Error::internal_unexpected(
-            "cannot recover a truncated Lab terminal agent-task summary",
-        ));
-    }
-    let Some(tasks) = value.get("tasks").and_then(serde_json::Value::as_array) else {
-        return Ok(None);
-    };
-    for task in tasks {
-        let refs_are_bounded = ["artifacts", "evidence_refs"].into_iter().all(|field| {
-            task.get(field)
-                .and_then(serde_json::Value::as_array)
-                .is_none_or(|items| items.len() < COMPACT_REF_LIMIT)
-        });
-        let retained_text_is_bounded = task
-            .get("summary")
-            .and_then(serde_json::Value::as_str)
-            .is_none_or(|text| text.chars().count() <= COMPACT_TEXT_LIMIT)
-            && ["artifacts", "evidence_refs"].into_iter().all(|field| {
-                task.get(field)
-                    .and_then(serde_json::Value::as_array)
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|item| item.as_object().into_iter().flat_map(|item| item.values()))
-                    .filter_map(serde_json::Value::as_str)
-                    .all(|text| text.chars().count() <= COMPACT_TEXT_LIMIT)
-            });
-        if !refs_are_bounded || !retained_text_is_bounded {
-            return Err(Error::internal_unexpected(
-                "cannot recover a potentially truncated Lab terminal agent-task summary",
-            ));
-        }
-    }
-    let mut canonical = value.clone();
-    let Some(canonical) = canonical.as_object_mut() else {
-        return Ok(None);
-    };
-    canonical.insert(
-        "outcomes".to_string(),
-        serde_json::Value::Array(tasks.clone()),
-    );
-    for key in [
-        "view",
-        "tasks",
-        "tasks_omitted",
-        "failure_reasons",
-        "run_id",
-        "full_command",
-        "evidence_command",
-    ] {
-        canonical.remove(key);
-    }
-    serde_json::from_value::<AgentTaskAggregate>(serde_json::Value::Object(canonical.clone()))
-        .map(|mut aggregate| {
-            for outcome in &mut aggregate.outcomes {
-                outcome.metadata = serde_json::json!({
-                    "terminal_recovery": "authenticated_compact_summary",
-                });
-            }
-            Some(aggregate)
-        })
-        .map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("hydrate authenticated compact Lab terminal agent-task aggregate".to_string()),
-            )
-        })
-}
-
 fn agent_task_aggregate_from_value(value: &serde_json::Value) -> Option<AgentTaskAggregate> {
-    if value.get("schema").and_then(serde_json::Value::as_str)
-        == Some("homeboy/agent-task-aggregate/v1")
-        || value.get("plan_id").is_some()
-    {
+    if is_authoritative_agent_task_aggregate(value) {
         return serde_json::from_value(value.clone()).ok();
     }
     None
@@ -592,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_command_result_stdout_recovers_authenticated_compact_aggregate() {
+    fn persisted_compact_aggregate_is_not_an_authoritative_terminal_result() {
         let stdout = format!(
             "HOMEBOY_RUNNER_PROGRESS {{\"phase\":\"finished\"}}\n{}",
             serde_json::json!({
@@ -637,16 +543,9 @@ mod tests {
             "fc3215cb-e657-485b-9887-96deaf0d5c5a",
             "cook-ssi-510-after-9849-v5-attempt-1-4f0b66a4",
         )
-        .expect("command-result stdout recovery")
-        .expect("agent-task lifecycle event");
+        .expect("compact summary detection");
 
-        assert_eq!(event.aggregate.outcomes.len(), 1);
-        let patch = &event.aggregate.outcomes[0].artifacts[0];
-        assert_eq!(patch.size_bytes, Some(12_704));
-        assert_eq!(
-            patch.sha256.as_deref(),
-            Some("b86157f2c3735b453880c486455b263dfdbd8e77541cb5846b89754065fc9d9a")
-        );
+        assert!(event.is_none());
     }
 
     #[test]
@@ -682,61 +581,5 @@ mod tests {
         .expect("mismatched compact aggregate is ignored");
 
         assert!(event.is_none());
-    }
-
-    #[test]
-    fn authenticated_compact_aggregate_rejects_ambiguous_reference_truncation() {
-        let artifacts = (0..12)
-            .map(|index| {
-                serde_json::json!({
-                    "id": format!("artifact-{index}"),
-                    "kind": "patch",
-                })
-            })
-            .collect::<Vec<_>>();
-        let summary = serde_json::json!({
-            "schema": "homeboy/agent-task-aggregate/v1",
-            "view": "summary",
-            "plan_id": "plan-x",
-            "status": "succeeded",
-            "totals": { "skipped": 0, "succeeded": 1, "failed": 0 },
-            "tasks": [{
-                "task_id": "task-x",
-                "status": "succeeded",
-                "artifacts": artifacts,
-            }],
-            "tasks_omitted": 0,
-        });
-
-        let error = agent_task_aggregate_from_terminal_result(&summary, true)
-            .expect_err("a list at the compact cap may have omitted references");
-
-        assert!(error.message.contains("potentially truncated"));
-    }
-
-    #[test]
-    fn authenticated_compact_aggregate_rejects_bounded_reference_text() {
-        let summary = serde_json::json!({
-            "schema": "homeboy/agent-task-aggregate/v1",
-            "view": "summary",
-            "plan_id": "plan-x",
-            "status": "succeeded",
-            "totals": { "skipped": 0, "succeeded": 1, "failed": 0 },
-            "tasks": [{
-                "task_id": "task-x",
-                "status": "succeeded",
-                "artifacts": [{
-                    "id": "patch",
-                    "kind": "patch",
-                    "url": format!("{}...", "x".repeat(512)),
-                }],
-            }],
-            "tasks_omitted": 0,
-        });
-
-        let error = agent_task_aggregate_from_terminal_result(&summary, true)
-            .expect_err("bounded artifact text is not authoritative evidence");
-
-        assert!(error.message.contains("potentially truncated"));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -654,6 +654,7 @@ pub(crate) fn record_terminal_artifact_projection(
     record: &mut AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<()> {
+    let recovery_command = format!("homeboy agent-task status {}", record.run_id);
     if record.runner_id().is_none() && aggregate_has_runner_backed_actionable_patch(aggregate) {
         match runner_id_from_artifact_provenance(aggregate) {
             Ok(runner_id) => {
@@ -664,7 +665,14 @@ pub(crate) fn record_terminal_artifact_projection(
             Err(error) => {
                 record.ensure_metadata_object().insert(
                     "artifact_projection".to_string(),
-                    json!({ "status": "pending", "error": error.message }),
+                    json!({
+                        "status": "pending",
+                        "error": error.message,
+                        "recovery_action": {
+                            "kind": "fetch_and_reconcile",
+                            "command": recovery_command,
+                        },
+                    }),
                 );
                 return store::write_record(record);
             }
@@ -680,7 +688,14 @@ pub(crate) fn record_terminal_artifact_projection(
         Err(error) => {
             record.ensure_metadata_object().insert(
                 "artifact_projection".to_string(),
-                json!({ "status": "pending", "error": error.message }),
+                json!({
+                    "status": "pending",
+                    "error": error.message,
+                    "recovery_action": {
+                        "kind": "fetch_and_reconcile",
+                        "command": recovery_command,
+                    },
+                }),
             );
         }
     }
@@ -882,7 +897,7 @@ pub(crate) fn terminal_artifact_projection_is_verified(
 ) -> Result<bool> {
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
-            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact) {
+            if requires_durable_lab_projection(artifact) {
                 if artifact.path.is_none()
                     || artifact.size_bytes.is_none()
                     || artifact.sha256.is_none()
@@ -1191,21 +1206,15 @@ pub(crate) fn project_terminal_artifacts(
                         let remote_ref = homeboy_core::execution_contract::EXECUTION_CONTRACT
                             .artifacts
                             .runner_artifact_ref(runner_id, &record.run_id, &logical_id);
-                        let mirror_result =
-                            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(
-                                artifact,
-                            ) {
-                                (|| -> Result<()> {
-                                    let mirror =
-                                        tempfile::NamedTempFile::new().map_err(|error| {
-                                            Error::internal_io(
-                                                error.to_string(),
-                                                Some(
-                                                    "create controller artifact mirror".to_string(),
-                                                ),
-                                            )
-                                        })?;
-                                    let download =
+                        let mirror_result = if requires_durable_lab_projection(artifact) {
+                            (|| -> Result<()> {
+                                let mirror = tempfile::NamedTempFile::new().map_err(|error| {
+                                    Error::internal_io(
+                                        error.to_string(),
+                                        Some("create controller artifact mirror".to_string()),
+                                    )
+                                })?;
+                                let download =
                                 homeboy_core::observation::runs_service::runner_evidence::with_runner_evidence(
                                     |p| {
                                         p.download_remote_artifact(
@@ -1214,28 +1223,23 @@ pub(crate) fn project_terminal_artifacts(
                                         )
                                     },
                                 )?;
-                                    let expected_size = artifact.size_bytes.expect("checked above");
-                                    let expected_sha256 =
-                                        artifact.sha256.as_deref().expect("checked above");
-                                    let actual_size = std::fs::metadata(&download.output_path)
-                                        .map_err(|error| {
-                                            Error::internal_io(
-                                                error.to_string(),
-                                                Some(
-                                                    "inspect controller artifact mirror"
-                                                        .to_string(),
-                                                ),
-                                            )
-                                        })?
-                                        .len();
-                                    let actual_sha256 =
-                                        homeboy_core::artifact_metadata::sha256_file(
-                                            &download.output_path,
-                                        )?;
-                                    if actual_size != expected_size
-                                        || actual_sha256 != expected_sha256
-                                    {
-                                        return Err(Error::validation_invalid_argument(
+                                let expected_size = artifact.size_bytes.expect("checked above");
+                                let expected_sha256 =
+                                    artifact.sha256.as_deref().expect("checked above");
+                                let actual_size = std::fs::metadata(&download.output_path)
+                                    .map_err(|error| {
+                                        Error::internal_io(
+                                            error.to_string(),
+                                            Some("inspect controller artifact mirror".to_string()),
+                                        )
+                                    })?
+                                    .len();
+                                let actual_sha256 = homeboy_core::artifact_metadata::sha256_file(
+                                    &download.output_path,
+                                )?;
+                                if actual_size != expected_size || actual_sha256 != expected_sha256
+                                {
+                                    return Err(Error::validation_invalid_argument(
                                     "artifact_id",
                                     format!(
                                         "runner artifact mirror for run '{}', task '{}', and artifact '{}' does not match the aggregate SHA-256 and size",
@@ -1244,33 +1248,30 @@ pub(crate) fn project_terminal_artifacts(
                                     Some(artifact.id.clone()),
                                     None,
                                 ));
-                                    }
-                                    let mut controller_hash = sha2::Sha256::new();
-                                    sha2::Digest::update(&mut controller_hash, b"controller");
-                                    sha2::Digest::update(&mut controller_hash, [0]);
-                                    sha2::Digest::update(
-                                        &mut controller_hash,
-                                        artifact_id.as_bytes(),
-                                    );
-                                    let controller_artifact_id =
-                                        format!("agent-task-{:x}", controller_hash.finalize());
-                                    let mut controller_metadata = metadata.clone();
-                                    controller_metadata["agent_task"]["projection"] =
-                                        json!("runner_mirrored");
-                                    store.record_verified_artifact_with_id(
-                                        &record.run_id,
-                                        &artifact.kind,
-                                        &download.output_path,
-                                        &controller_artifact_id,
-                                        Some(expected_size as i64),
-                                        Some(expected_sha256),
-                                        controller_metadata,
-                                    )?;
-                                    Ok(())
-                                })()
-                            } else {
+                                }
+                                let mut controller_hash = sha2::Sha256::new();
+                                sha2::Digest::update(&mut controller_hash, b"controller");
+                                sha2::Digest::update(&mut controller_hash, [0]);
+                                sha2::Digest::update(&mut controller_hash, artifact_id.as_bytes());
+                                let controller_artifact_id =
+                                    format!("agent-task-{:x}", controller_hash.finalize());
+                                let mut controller_metadata = metadata.clone();
+                                controller_metadata["agent_task"]["projection"] =
+                                    json!("runner_mirrored");
+                                store.record_verified_artifact_with_id(
+                                    &record.run_id,
+                                    &artifact.kind,
+                                    &download.output_path,
+                                    &controller_artifact_id,
+                                    Some(expected_size as i64),
+                                    Some(expected_sha256),
+                                    controller_metadata,
+                                )?;
                                 Ok(())
-                            };
+                            })()
+                        } else {
+                            Ok(())
+                        };
 
                         // Preserve the canonical runner retrieval alias even when
                         // the controller also materializes verified bytes.
@@ -1313,6 +1314,14 @@ pub(crate) fn project_terminal_artifacts(
         }
     }
     projection_error.map_or(Ok(()), Err)
+}
+
+fn requires_durable_lab_projection(artifact: &AgentTaskArtifact) -> bool {
+    crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
+        || matches!(
+            artifact.kind.as_str(),
+            "transcript" | "agent-result" | "agent_result"
+        )
 }
 
 /// A direct artifact import can retain the same deterministic lifecycle id

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1112,7 +1112,7 @@ pub(crate) fn project_terminal_artifacts(
         metadata_json: existing_metadata,
     })?;
 
-    let mut used_ids = std::collections::BTreeSet::new();
+    validate_unique_terminal_artifact_ids(aggregate)?;
     let mut projection_error = None;
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
@@ -1141,7 +1141,7 @@ pub(crate) fn project_terminal_artifacts(
             validate_projection_token("artifact.id", &artifact.id)?;
             validate_projection_token("artifact.kind", &artifact.kind)?;
             let base_id = artifact.id.trim();
-            let logical_id = unique_logical_artifact_id(&mut used_ids, base_id, &outcome.task_id);
+            let logical_id = base_id;
             // Observation artifact ids are globally unique. Keep the lifecycle
             // logical id as the per-run lookup token exposed by runs artifact.
             let mut id_hash = sha2::Sha256::new();
@@ -1618,26 +1618,28 @@ pub fn verified_controller_artifact_projection(
     Ok(Some((candidate.id.clone(), bytes)))
 }
 
-fn unique_logical_artifact_id(
-    used_ids: &mut std::collections::BTreeSet<String>,
-    base_id: &str,
-    task_id: &str,
-) -> String {
-    if used_ids.insert(base_id.to_string()) {
-        return base_id.to_string();
-    }
-    let prefix = format!("{task_id}-{base_id}");
-    for suffix in 1_u64.. {
-        let candidate = if suffix == 1 {
-            prefix.clone()
-        } else {
-            format!("{prefix}-{suffix}")
-        };
-        if used_ids.insert(candidate.clone()) {
-            return candidate;
+/// Runner artifact retrieval is keyed only by artifact id. Reject duplicates
+/// rather than inventing a controller-only alias that cannot be retried safely.
+fn validate_unique_terminal_artifact_ids(aggregate: &AgentTaskAggregate) -> Result<()> {
+    let mut identities = std::collections::BTreeMap::new();
+    for outcome in &aggregate.outcomes {
+        for artifact in &outcome.artifacts {
+            validate_projection_token("artifact.id", &artifact.id)?;
+            let Some(previous_task_id) = identities.insert(&artifact.id, &outcome.task_id) else {
+                continue;
+            };
+            return Err(Error::validation_invalid_argument(
+                "artifact.id",
+                format!(
+                    "terminal aggregate reuses artifact id '{}' for tasks '{}' and '{}'; runner artifact ids must be unique",
+                    artifact.id, previous_task_id, outcome.task_id
+                ),
+                Some(artifact.id.clone()),
+                None,
+            ));
         }
     }
-    unreachable!("unbounded artifact aliases cannot exhaust u64")
+    Ok(())
 }
 
 fn validate_projection_token(field: &str, value: &str) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -325,7 +325,12 @@ pub fn run_owes_candidate_follow_up(run_id: &str) -> Result<bool> {
                 .metadata
                 .get("candidate_preserved")
                 .and_then(Value::as_bool)
-                == Some(true)),
+                == Some(true)
+            || record
+                .metadata
+                .pointer("/artifact_projection/status")
+                .and_then(Value::as_str)
+                == Some("pending")),
         Err(_) => Ok(false),
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1415,6 +1415,12 @@ fn controller_leaves_runner_artifact_projection_pending_when_it_cannot_mirror_by
         assert!(record.metadata["artifact_projection"]["error"]
             .as_str()
             .is_some_and(|error| !error.is_empty()));
+        assert_eq!(
+            record.metadata["artifact_projection"]["recovery_action"]["command"],
+            format!("homeboy agent-task status {}", submitted.run_id)
+        );
+        assert!(run_owes_candidate_follow_up(&submitted.run_id)
+            .expect("pending import retains the runner workspace"));
         let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let remote_alias = homeboy_core::observation::runs_service::resolve_artifact_for_run(
             &store,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1445,6 +1445,56 @@ fn controller_leaves_runner_artifact_projection_pending_when_it_cannot_mirror_by
 }
 
 #[test]
+fn duplicate_runner_artifact_ids_fail_closed_before_projection() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let mut aggregate = succeeded_aggregate(&plan);
+        let bytes = b"runner patch";
+        let artifact = AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "patch".to_string(),
+            kind: "patch".to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: Some("/runner/private/patch.diff".to_string()),
+            url: None,
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some(bytes.len() as u64),
+            sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+            metadata: json!({ "executor_artifact_finalized": true }),
+        };
+        aggregate.outcomes[0].artifacts.push(artifact.clone());
+        let mut duplicate_outcome = aggregate.outcomes[0].clone();
+        duplicate_outcome.task_id = "task-b".to_string();
+        duplicate_outcome.artifacts = vec![artifact];
+        aggregate.outcomes.push(duplicate_outcome);
+
+        let submitted = submit_plan(&plan, Some("duplicate-runner-artifact")).expect("submit");
+        record_runner_job_identity(&submitted.run_id, "homeboy-lab", "job-1")
+            .expect("runner identity");
+        record_run_aggregate(&submitted.run_id, &plan, &aggregate).expect("record aggregate");
+
+        let record = status(&submitted.run_id).expect("terminal record");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert!(record.metadata["artifact_projection"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("reuses artifact id 'patch'")));
+        assert!(run_owes_candidate_follow_up(&submitted.run_id)
+            .expect("duplicate identity retains the runner workspace"));
+        let artifacts = homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("store")
+            .list_artifacts(&submitted.run_id)
+            .expect("artifact records");
+        assert!(
+            artifacts.is_empty(),
+            "no ambiguous artifact may be imported"
+        );
+    });
+}
+
+#[test]
 fn corrected_promotion_replaces_gate_failed_latest_proof() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -198,7 +198,11 @@ fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_ide
         );
         let record = crate::agent_task_lifecycle::status(run_id).expect("recovered status");
         assert_eq!(record.metadata["runner_id"], "homeboy-lab");
-        assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert_eq!(
+            record.metadata["artifact_projection"]["recovery_action"]["kind"],
+            "fetch_and_reconcile"
+        );
 
         let remote_id = "runner-patch-reference";
         store

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2499,25 +2499,8 @@ mod tests {
         let root = "/runner/app-homeboy-artifacts/rig-registry".to_string();
         let args = Vec::new();
         let request = LabOffloadRequest {
-            command: None,
             normalized_args: &args,
-            explicit_runner: None,
-            placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: true,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
-            detach_after_handoff: false,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
-            source_path: None,
-            verified_cook_baseline: None,
-            require_controller_git_bundle: false,
-            reuse_compatible_snapshot: false,
             job_overrides: LabJobOverrides {
                 env: std::collections::HashMap::from([
                     (
@@ -2532,6 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
+            ..LabOffloadRequest::new(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2515,7 +2515,7 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            ..LabOffloadRequest::new(&args)
+            ..LabOffloadRequest::for_test(&args)
         };
         let selection = LabRunnerSelection {
             runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -432,24 +432,8 @@ fn plan_records_skipped_auto_offload() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Local,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     })
     .expect("outcome");
 
@@ -465,26 +449,9 @@ fn plan_records_skipped_auto_offload() {
 #[test]
 fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &["homeboy".to_string(), "status".to_string()],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -505,24 +472,8 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "install".to_string(),
             "./rig-package".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -539,30 +490,13 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
 #[test]
 fn build_runner_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -588,30 +522,13 @@ fn build_runner_error_gives_managed_runner_replacement() {
 #[test]
 fn build_lab_placement_error_gives_managed_runner_replacement() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "build".to_string(),
             "homeboy".to_string(),
         ],
-        explicit_runner: None,
         placement: homeboy_cli_contract::Placement::Lab,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {
@@ -637,7 +554,6 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
 #[test]
 fn unsupported_runner_error_guides_tunnel_service_inspection() {
     let outcome = execute_lab_offload(LabOffloadRequest {
-        command: None,
         normalized_args: &[
             "homeboy".to_string(),
             "tunnel".to_string(),
@@ -646,23 +562,7 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        placement: homeboy_cli_contract::Placement::Auto,
-        allow_local_fallback: false,
-        allow_dirty_lab_workspace: false,
-        skip_deps_hydration: false,
-        preserve_workspace_on_failure: false,
-        capture_patch: false,
-        mutation_flag: None,
-        detach_after_handoff: false,
-        output_file_requested: false,
-        read_only_polling: false,
-        local_output_file: None,
-        durable_agent_task_plan: None,
-        source_path: None,
-        verified_cook_baseline: None,
-        require_controller_git_bundle: false,
-        reuse_compatible_snapshot: false,
-        job_overrides: LabJobOverrides::default(),
+        ..LabOffloadRequest::default()
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -433,7 +433,7 @@ fn plan_records_skipped_auto_offload() {
         command: Some(portable_lab_command("test")),
         normalized_args: &["homeboy".to_string(), "test".to_string()],
         placement: homeboy_cli_contract::Placement::Local,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "test".to_string()])
     })
     .expect("outcome");
 
@@ -451,7 +451,7 @@ fn lab_placement_refuses_local_execution_without_lab_contract() {
     let outcome = execute_lab_offload(LabOffloadRequest {
         normalized_args: &["homeboy".to_string(), "status".to_string()],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&["homeboy".to_string(), "status".to_string()])
     });
 
     let Err(err) = outcome else {
@@ -473,7 +473,12 @@ fn lab_placement_refuses_local_only_rig_install_with_actionable_boundary() {
             "./rig-package".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "install".to_string(),
+            "./rig-package".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -496,7 +501,11 @@ fn build_runner_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -528,7 +537,11 @@ fn build_lab_placement_error_gives_managed_runner_replacement() {
             "homeboy".to_string(),
         ],
         placement: homeboy_cli_contract::Placement::Lab,
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "build".to_string(),
+            "homeboy".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {
@@ -562,7 +575,13 @@ fn unsupported_runner_error_guides_tunnel_service_inspection() {
             "wpcom-ai-manual-held".to_string(),
         ],
         explicit_runner: Some("homeboy-lab"),
-        ..LabOffloadRequest::default()
+        ..LabOffloadRequest::for_test(&[
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "status".to_string(),
+            "wpcom-ai-manual-held".to_string(),
+        ])
     });
 
     let Err(err) = outcome else {

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,11 +45,14 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
-impl<'a> Default for LabOffloadRequest<'a> {
-    fn default() -> Self {
+impl<'a> LabOffloadRequest<'a> {
+    #[cfg(test)]
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// This remains test-only so production callers must set every policy field.
+    pub(crate) fn for_test(normalized_args: &'a [String]) -> Self {
         Self {
             command: None,
-            normalized_args: &[],
+            normalized_args,
             explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Auto,
             allow_local_fallback: false,
@@ -72,14 +75,60 @@ impl<'a> Default for LabOffloadRequest<'a> {
     }
 }
 
-impl<'a> LabOffloadRequest<'a> {
-    /// Creates a request with the neutral offload policy used by focused tests.
-    /// New request fields belong in `Default`, so those fixtures stay valid.
-    pub fn new(normalized_args: &'a [String]) -> Self {
-        Self {
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_has_neutral_policy() {
+        let args = vec!["homeboy".to_string(), "status".to_string()];
+        let request = LabOffloadRequest::for_test(&args);
+
+        let LabOffloadRequest {
+            command,
             normalized_args,
-            ..Self::default()
-        }
+            explicit_runner,
+            placement,
+            allow_local_fallback,
+            allow_dirty_lab_workspace,
+            skip_deps_hydration,
+            preserve_workspace_on_failure,
+            capture_patch,
+            mutation_flag,
+            detach_after_handoff,
+            output_file_requested,
+            read_only_polling,
+            local_output_file,
+            durable_agent_task_plan,
+            source_path,
+            verified_cook_baseline,
+            require_controller_git_bundle,
+            reuse_compatible_snapshot,
+            job_overrides,
+        } = request;
+
+        assert!(command.is_none());
+        assert_eq!(normalized_args, args);
+        assert!(explicit_runner.is_none());
+        assert_eq!(placement, homeboy_cli_contract::Placement::Auto);
+        assert!(!allow_local_fallback);
+        assert!(!allow_dirty_lab_workspace);
+        assert!(!skip_deps_hydration);
+        assert!(!preserve_workspace_on_failure);
+        assert!(!capture_patch);
+        assert!(mutation_flag.is_none());
+        assert!(!detach_after_handoff);
+        assert!(!output_file_requested);
+        assert!(!read_only_polling);
+        assert!(local_output_file.is_none());
+        assert!(durable_agent_task_plan.is_none());
+        assert!(source_path.is_none());
+        assert!(verified_cook_baseline.is_none());
+        assert!(!require_controller_git_bundle);
+        assert!(!reuse_compatible_snapshot);
+        assert!(job_overrides.env.is_empty());
+        assert!(job_overrides.secret_env_names.is_empty());
+        assert!(job_overrides.workspace_root.is_none());
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -45,6 +45,44 @@ pub struct LabOffloadRequest<'a> {
     pub job_overrides: LabJobOverrides,
 }
 
+impl<'a> Default for LabOffloadRequest<'a> {
+    fn default() -> Self {
+        Self {
+            command: None,
+            normalized_args: &[],
+            explicit_runner: None,
+            placement: homeboy_cli_contract::Placement::Auto,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            skip_deps_hydration: false,
+            preserve_workspace_on_failure: false,
+            capture_patch: false,
+            mutation_flag: None,
+            detach_after_handoff: false,
+            output_file_requested: false,
+            read_only_polling: false,
+            local_output_file: None,
+            durable_agent_task_plan: None,
+            source_path: None,
+            verified_cook_baseline: None,
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
+            job_overrides: LabJobOverrides::default(),
+        }
+    }
+}
+
+impl<'a> LabOffloadRequest<'a> {
+    /// Creates a request with the neutral offload policy used by focused tests.
+    /// New request fields belong in `Default`, so those fixtures stay valid.
+    pub fn new(normalized_args: &'a [String]) -> Self {
+        Self {
+            normalized_args,
+            ..Self::default()
+        }
+    }
+}
+
 // LabOffloadCommand, LabJobOverrides, LabOffloadOutcome, and the source/workspace
 // mode aliases moved to core's lab_offload module (they are core-plan-based
 // types the core lab_routing service names). Re-exported so runner-internal

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1238,7 +1238,7 @@ mod tests {
             let request = LabOffloadRequest {
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2453,7 +2453,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2588,7 +2588,7 @@ mod tests {
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
                 require_controller_git_bundle: true,
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2761,7 +2761,7 @@ mod tests {
                 placement: homeboy_cli_contract::Placement::Lab,
                 detach_after_handoff: true,
                 source_path: Some(source.as_path()),
-                ..LabOffloadRequest::new(&args)
+                ..LabOffloadRequest::for_test(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1236,25 +1236,9 @@ mod tests {
                 "jetpack-api-route-inventory".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-rig-component-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2466,26 +2450,10 @@ mod tests {
                 "base".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-controller-bundle-stage"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract {
@@ -2617,26 +2585,10 @@ mod tests {
                 "provider-value".to_string(),
             ];
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-review-test-snapshot"),
-                placement: homeboy_cli_contract::Placement::Auto,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                detach_after_handoff: false,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
-                source_path: None,
-                verified_cook_baseline: None,
                 require_controller_git_bundle: true,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(
@@ -2804,26 +2756,12 @@ mod tests {
                 ensure_agent_task_lifecycle_identity_with(&args, Some("cook-8009"), None)
                     .expect("canonical cook attempt id");
             let request = LabOffloadRequest {
-                command: None,
                 normalized_args: &args,
                 explicit_runner: Some("lab-managed-worktree-stage"),
                 placement: homeboy_cli_contract::Placement::Lab,
-                allow_local_fallback: false,
-                allow_dirty_lab_workspace: false,
-                skip_deps_hydration: false,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
                 detach_after_handoff: true,
-                output_file_requested: false,
-                read_only_polling: false,
-                local_output_file: None,
-                durable_agent_task_plan: None,
                 source_path: Some(source.as_path()),
-                verified_cook_baseline: None,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                job_overrides: LabJobOverrides::default(),
+                ..LabOffloadRequest::new(&args)
             };
             let mut contract = LabOffloadCommand {
                 command: homeboy_core::lab_contract::LabCommandContract::portable(

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3420,21 +3420,9 @@ mod tests {
         LabOffloadRequest {
             command,
             normalized_args: args,
-            explicit_runner: None,
             placement: homeboy_cli_contract::Placement::Lab,
-            allow_local_fallback: false,
-            allow_dirty_lab_workspace: false,
-            skip_deps_hydration: false,
-            preserve_workspace_on_failure: false,
-            capture_patch: false,
-            mutation_flag: None,
             detach_after_handoff: true,
-            output_file_requested: false,
-            read_only_polling: false,
-            local_output_file: None,
-            durable_agent_task_plan: None,
             source_path: Some(std::path::Path::new("/work/source")),
-            verified_cook_baseline: None,
             require_controller_git_bundle: true,
             reuse_compatible_snapshot: true,
             job_overrides: homeboy_core::lab_offload::LabJobOverrides {
@@ -3442,6 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
+            ..LabOffloadRequest::new(args)
         }
     }
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3430,7 +3430,7 @@ mod tests {
                 secret_env_names: vec!["AGENT_TOKEN".to_string()],
                 workspace_root: Some("/runner/workspaces".to_string()),
             },
-            ..LabOffloadRequest::new(args)
+            ..LabOffloadRequest::for_test(args)
         }
     }
 


### PR DESCRIPTION
Closes #9817\n\n## Summary\n- reject compact Lab summaries as durable task outcomes\n- require verified controller projection of patches, transcripts, and agent results before Lab success cleanup\n- retain pending-import workspaces and expose a fetch/reconcile action\n\n## Verification\n- cargo fmt\n- cargo check -p homeboy-agents\n- cargo test -p homeboy-agents persisted_compact_aggregate_is_not_an_authoritative_terminal_result --lib\n- cargo test -p homeboy-agents bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_idempotently --lib\n\n## AI assistance\nOpenAI GPT-5.6 Sol via OpenCode drafted and verified the implementation. Chris remains responsible for every line.