### PR TITLE
fix: clean release-owned package artifacts

### DIFF
--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -36,8 +36,15 @@ pub(super) fn run_deployment_step(
     expected_version: Option<&str>,
     released_tag: Option<&str>,
     artifacts: &[ReleaseArtifact],
+    package_owned_paths: &[String],
 ) -> ReleaseStepResult {
-    let deployment = execute_deployment(component, expected_version, released_tag, artifacts);
+    let deployment = execute_deployment(
+        component,
+        expected_version,
+        released_tag,
+        artifacts,
+        package_owned_paths,
+    );
     let deploy_failed = deployment.summary.failed > 0;
 
     ReleaseStepResult {
@@ -69,13 +76,14 @@ fn execute_deployment(
     expected_version: Option<&str>,
     released_tag: Option<&str>,
     artifacts: &[ReleaseArtifact],
+    package_owned_paths: &[String],
 ) -> ReleaseDeploymentResult {
     let component_id = &component.id;
     let local_path = &component.local_path;
     let projects = release_deploy_targets(component_id);
 
     if projects.is_empty() {
-        cleanup_release_artifacts(local_path, artifacts);
+        cleanup_release_artifacts(local_path, package_owned_paths);
         return ReleaseDeploymentResult {
             projects: vec![],
             summary: ReleaseDeploymentSummary::default(),
@@ -108,9 +116,14 @@ fn execute_deployment(
         Ok(result) => {
             if result.summary.failed > 0 {
                 if let Some(run_id) = result.deploy_run_id.as_deref() {
-                    if let Err(error) =
-                        save_recovery(component, expected_version, &projects, &config, run_id)
-                    {
+                    if let Err(error) = save_recovery(
+                        component,
+                        expected_version,
+                        &projects,
+                        &config,
+                        run_id,
+                        package_owned_paths,
+                    ) {
                         return failed_deployment(
                             &projects,
                             format!(
@@ -169,7 +182,7 @@ fn execute_deployment(
     };
 
     if should_cleanup_release_artifacts(&deployment) {
-        cleanup_release_artifacts(local_path, artifacts);
+        cleanup_release_artifacts(local_path, package_owned_paths);
     } else {
         homeboy_core::log_status!(
             "release",
@@ -385,6 +398,10 @@ struct DeploymentRecovery {
     artifact: PreparedDeployArtifact,
     projection: PreparedDeployProjection,
     deploy_run_id: String,
+    #[serde(default)]
+    component_path: String,
+    #[serde(default)]
+    package_owned_paths: Vec<String>,
 }
 
 fn recovery_path(component_id: &str) -> Result<std::path::PathBuf> {
@@ -399,6 +416,7 @@ fn save_recovery(
     projects: &[String],
     config: &DeployConfig,
     deploy_run_id: &str,
+    package_owned_paths: &[String],
 ) -> Result<()> {
     let record = DeploymentRecovery {
         component_id: component.id.clone(),
@@ -413,6 +431,8 @@ fn save_recovery(
             .clone()
             .expect("release deploy has projection"),
         deploy_run_id: deploy_run_id.to_string(),
+        component_path: component.local_path.clone(),
+        package_owned_paths: package_owned_paths.to_vec(),
     };
     let path = recovery_path(&component.id)?;
     fs::create_dir_all(path.parent().expect("recovery path parent"))
@@ -480,6 +500,9 @@ pub(super) fn resume_deployment(component_id: &str) -> Result<Option<ReleaseDepl
         },
     };
     if deployment.summary.failed == 0 {
+        if !record.component_path.is_empty() {
+            cleanup_release_artifacts(&record.component_path, &record.package_owned_paths);
+        }
         remove_recovery(component_id)?;
     }
     Ok(Some(deployment))
@@ -512,13 +535,20 @@ fn release_deploy_targets(component_id: &str) -> Vec<String> {
     }
 }
 
-fn cleanup_release_artifacts(local_path: &str, artifacts: &[ReleaseArtifact]) {
-    for path in release_cleanup_paths(local_path, artifacts) {
+fn cleanup_release_artifacts(local_path: &str, package_owned_paths: &[String]) {
+    for path in release_cleanup_paths(local_path, package_owned_paths) {
         if !path.exists() {
             continue;
         }
 
-        if let Err(error) = std::fs::remove_dir_all(&path) {
+        let result = std::fs::symlink_metadata(&path).and_then(|metadata| {
+            if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            }
+        });
+        if let Err(error) = result {
             homeboy_core::log_status!(
                 "release",
                 "Warning: failed to clean up {}: {}",
@@ -705,6 +735,7 @@ mod tests {
             None,
             None,
             &[],
+            &[],
         );
 
         assert_eq!(result.id, "deploy");
@@ -736,6 +767,7 @@ mod tests {
             None,
             None,
             &artifacts,
+            &["build".to_string()],
         );
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
@@ -851,6 +883,10 @@ mod tests {
                 artifact_type: None,
                 platform: None,
             };
+            std::fs::create_dir_all(source.join("build")).expect("package build directory");
+            std::fs::write(source.join("build/intermediate"), "build").expect("build output");
+            std::fs::write(source.join("fixture-1.2.4.tgz"), "package").expect("package output");
+            let package_owned_paths = vec!["build".to_string(), "fixture-1.2.4.tgz".to_string()];
             let component = Component {
                 id: "fixture".to_string(),
                 local_path: source.display().to_string(),
@@ -902,7 +938,13 @@ mod tests {
                 .expect("save project");
             }
 
-            let first = run_deployment_step(&component, Some("1.2.4"), None, &[artifact]);
+            let first = run_deployment_step(
+                &component,
+                Some("1.2.4"),
+                None,
+                &[artifact],
+                &package_owned_paths,
+            );
             assert_eq!(first.status, ReleaseStepStatus::Failed);
             let first_deployment = first
                 .data
@@ -924,6 +966,8 @@ mod tests {
             assert!(super::recovery_path("fixture")
                 .expect("recovery path")
                 .exists());
+            assert!(source.join("build/intermediate").is_file());
+            assert!(source.join("fixture-1.2.4.tgz").is_file());
 
             // A process restart reloads the checkpoint, not an in-memory release plan.
             // The completed target is now invalid: success proves the resumed lifecycle skips it.
@@ -985,6 +1029,8 @@ mod tests {
                 )
             );
             assert!(retry_target.join("plugins/retry/plugin.txt").exists());
+            assert!(!source.join("build").exists());
+            assert!(!source.join("fixture-1.2.4.tgz").exists());
             assert_eq!(run_git(&source, &["tag", "--list"]), "v1.2.4");
             assert_eq!(
                 run_git(&source, &["rev-parse", "v1.2.4^{commit}"]),

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -208,15 +208,10 @@ pub(super) fn execute_release_plan_step(
             )
             .unwrap_or_else(|err| failed_result("github.release", "github.release", err)),
         )),
-        "cleanup" => {
-            if context.publish_failed {
-                return Ok(None);
-            }
-            Ok(Some(
-                executor::run_cleanup(context.component, &context.state)
-                    .unwrap_or_else(|err| failed_result("cleanup", "cleanup", err)),
-            ))
-        }
+        "cleanup" => Ok(Some(
+            executor::run_cleanup(context.component, &context.state)
+                .unwrap_or_else(|err| failed_result("cleanup", "cleanup", err)),
+        )),
         "post_release" => {
             let commands = step_config_string_array(step, "commands");
             Ok(Some(
@@ -229,6 +224,7 @@ pub(super) fn execute_release_plan_step(
             context.state.version.as_deref(),
             context.state.tag.as_deref(),
             &context.state.artifacts,
+            &context.state.package_owned_paths,
         ))),
         step_kind if step_kind.starts_with("publish.") => {
             let target = step_kind.strip_prefix("publish.").unwrap_or_default();
@@ -977,6 +973,120 @@ mod tests {
     }
 
     #[test]
+    fn package_cleanup_uses_invocation_ownership_and_restores_clean_preflight() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let repo = tempfile::tempdir().expect("repo");
+            std::fs::write(repo.path().join("plugin.php"), "<?php\n").expect("plugin");
+            run_in(repo.path(), &["git", "init", "-q"]);
+            configure_git_user(repo.path());
+            run_in(repo.path(), &["git", "add", "plugin.php"]);
+            run_in(repo.path(), &["git", "commit", "-qm", "Initial commit"]);
+            let preexisting = repo.path().join("fixture-previous.tgz");
+            std::fs::write(&preexisting, "operator artifact").expect("preexisting artifact");
+            let package = package_extension(
+                "mkdir -p build/stage; printf intermediate > build/stage/file; \
+                 printf package > fixture-1.2.3.tgz; \
+                 printf '[{\"path\":\"fixture-1.2.3.tgz\",\"type\":\"archive\"}]'",
+            );
+            homeboy_extension::save_manifest(&package).expect("save package extension");
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: repo.path().to_string_lossy().to_string(),
+                ..Component::default()
+            };
+            let options = ReleaseOptions::default();
+            let extensions = vec![package];
+            let mut context = ReleaseExecutionContext {
+                component: &component,
+                extensions: &extensions,
+                component_id: "fixture",
+                options: &options,
+                state: ReleaseState {
+                    version: Some("1.2.3".to_string()),
+                    ..ReleaseState::default()
+                },
+                publish_failed: false,
+            };
+
+            let package_result = execute_release_plan_step(&plan_step("package"), &mut context)
+                .expect("package dispatch")
+                .expect("package result");
+            assert_eq!(package_result.status, ReleaseStepStatus::Success);
+            assert_eq!(
+                context.state.package_owned_paths,
+                vec!["build".to_string(), "fixture-1.2.3.tgz".to_string()]
+            );
+
+            let cleanup = execute_release_plan_step(&plan_step("cleanup"), &mut context)
+                .expect("cleanup dispatch")
+                .expect("cleanup result");
+            assert_eq!(cleanup.status, ReleaseStepStatus::Success);
+            assert!(!repo.path().join("build").exists());
+            assert!(!repo.path().join("fixture-1.2.3.tgz").exists());
+            assert_eq!(
+                std::fs::read_to_string(&preexisting).expect("preexisting remains"),
+                "operator artifact"
+            );
+
+            std::fs::remove_file(preexisting).expect("remove test fixture");
+            let preflight =
+                execute_release_plan_step(&plan_step("preflight.working_tree"), &mut context)
+                    .expect("preflight dispatch")
+                    .expect("preflight result");
+            assert_eq!(preflight.status, ReleaseStepStatus::Success);
+        });
+    }
+
+    #[test]
+    fn failed_package_retains_outputs_without_claiming_cleanup_ownership() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let repo = tempfile::tempdir().expect("repo");
+            std::fs::write(repo.path().join("plugin.php"), "<?php\n").expect("plugin");
+            run_in(repo.path(), &["git", "init", "-q"]);
+            configure_git_user(repo.path());
+            run_in(repo.path(), &["git", "add", "plugin.php"]);
+            run_in(repo.path(), &["git", "commit", "-qm", "Initial commit"]);
+            let package = package_extension(
+                "mkdir -p build; printf diagnostic > build/output; \
+                 printf partial > fixture-1.2.3.tgz; printf failed >&2; exit 1",
+            );
+            homeboy_extension::save_manifest(&package).expect("save package extension");
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: repo.path().to_string_lossy().to_string(),
+                ..Component::default()
+            };
+            let options = ReleaseOptions::default();
+            let extensions = vec![package];
+            let mut context = ReleaseExecutionContext {
+                component: &component,
+                extensions: &extensions,
+                component_id: "fixture",
+                options: &options,
+                state: ReleaseState {
+                    version: Some("1.2.3".to_string()),
+                    ..ReleaseState::default()
+                },
+                publish_failed: false,
+            };
+
+            let result = execute_release_plan_step(&plan_step("package"), &mut context)
+                .expect("package dispatch")
+                .expect("package result");
+
+            assert_eq!(result.status, ReleaseStepStatus::Failed);
+            assert!(result
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("failed"));
+            assert!(context.state.package_owned_paths.is_empty());
+            assert!(repo.path().join("build/output").is_file());
+            assert!(repo.path().join("fixture-1.2.3.tgz").is_file());
+        });
+    }
+
+    #[test]
     fn final_package_completeness_failure_stops_before_publication() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let repo = tempfile::tempdir().expect("repo");
@@ -1268,7 +1378,7 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_release_plan_step() {
+    fn cleanup_runs_after_publish_failure_because_durable_artifacts_are_recoverable() {
         let component = Component {
             id: "fixture".to_string(),
             local_path: "/tmp/fixture".to_string(),
@@ -1288,8 +1398,10 @@ mod tests {
         };
         let step = plan_step("cleanup");
 
-        let result = execute_release_plan_step(&step, &mut context).expect("dispatch");
-        assert!(result.is_none());
+        let result = execute_release_plan_step(&step, &mut context)
+            .expect("dispatch")
+            .expect("cleanup result");
+        assert_eq!(result.status, ReleaseStepStatus::Success);
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -146,6 +146,7 @@ fn initial_release_state(
         tag: Some(tag),
         notes,
         artifacts: Vec::new(),
+        package_owned_paths: Vec::new(),
         changelog_validation: None,
     })
 }

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -335,14 +335,14 @@ pub(crate) fn run_cleanup(
     component: &Component,
     state: &ReleaseState,
 ) -> Result<ReleaseStepResult> {
-    let cleanup_paths = release_cleanup_paths(&component.local_path, &state.artifacts);
+    let cleanup_paths = release_cleanup_paths(&component.local_path, &state.package_owned_paths);
     let mut removed_paths = Vec::new();
 
     for path in &cleanup_paths {
         if !path.exists() {
             continue;
         }
-        std::fs::remove_dir_all(path).map_err(|e| {
+        remove_release_cleanup_path(path).map_err(|e| {
             Error::internal_io(
                 format!("Failed to clean up {}: {}", path.display(), e),
                 Some(path.display().to_string()),
@@ -351,10 +351,9 @@ pub(crate) fn run_cleanup(
         removed_paths.push(path.display().to_string());
     }
 
-    let distrib_path = std::path::Path::new(&component.local_path).join("target/distrib");
     let data = serde_json::json!({
         "action": "cleanup",
-        "path": distrib_path.display().to_string(),
+        "path": cleanup_paths.first().map(|path| path.display().to_string()),
         "paths": cleanup_paths
             .iter()
             .map(|path| path.display().to_string())
@@ -368,28 +367,24 @@ pub(crate) fn run_cleanup(
 
 pub(crate) fn release_cleanup_paths(
     local_path: &str,
-    artifacts: &[ReleaseArtifact],
+    package_owned_paths: &[String],
 ) -> Vec<std::path::PathBuf> {
     let component_path = std::path::Path::new(local_path);
-    let mut paths = vec![component_path.join("target/distrib")];
+    package_owned_paths
+        .iter()
+        .filter(|path| homeboy_core::cleanup::is_safe_artifact_path(path))
+        .filter(|path| !homeboy_core::git::is_tracked_path(component_path, path))
+        .map(|path| component_path.join(path))
+        .collect()
+}
 
-    let build_path = component_path.join("build");
-    let has_build_artifact = artifacts.iter().any(|artifact| {
-        let artifact_path = std::path::Path::new(&artifact.path);
-        let artifact_path = if artifact_path.is_absolute() {
-            artifact_path.to_path_buf()
-        } else {
-            component_path.join(artifact_path)
-        };
-
-        artifact_path.starts_with(&build_path)
-    });
-
-    if has_build_artifact {
-        paths.push(build_path);
+fn remove_release_cleanup_path(path: &std::path::Path) -> std::io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
     }
-
-    paths
 }
 
 /// Run the component's `post_release` hook commands. Failures are non-fatal —
@@ -655,14 +650,14 @@ mod tests {
     }
 
     #[test]
-    fn cleanup_removes_build_dir_when_release_artifact_is_inside_build() {
+    fn cleanup_removes_only_release_owned_directory_and_file() {
         let temp = tempfile::tempdir().expect("tempdir");
         let build_dir = temp.path().join("build");
-        let distrib_dir = temp.path().join("target/distrib");
         std::fs::create_dir_all(&build_dir).expect("build dir");
-        std::fs::create_dir_all(&distrib_dir).expect("distrib dir");
         let artifact_path = build_dir.join("fixture.zip");
         std::fs::write(&artifact_path, "artifact").expect("artifact");
+        let package_path = temp.path().join("fixture-1.2.3.tgz");
+        std::fs::write(&package_path, "package").expect("package");
 
         let component = Component {
             id: "fixture".to_string(),
@@ -676,6 +671,7 @@ mod tests {
                 artifact_type: None,
                 platform: None,
             }],
+            package_owned_paths: vec!["build".to_string(), "fixture-1.2.3.tgz".to_string()],
             ..ReleaseState::default()
         };
 
@@ -683,7 +679,7 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         assert!(!build_dir.exists());
-        assert!(!distrib_dir.exists());
+        assert!(!package_path.exists());
     }
 
     #[test]
@@ -704,6 +700,24 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         assert!(build_dir.exists());
+    }
+
+    #[test]
+    fn cleanup_preserves_preexisting_matching_paths_not_owned_by_release() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path().join("build")).expect("build dir");
+        std::fs::write(temp.path().join("build/user.txt"), "user").expect("user file");
+        std::fs::write(temp.path().join("fixture-1.2.3.tgz"), "user").expect("user package");
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            ..Component::default()
+        };
+
+        run_cleanup(&component, &ReleaseState::default()).expect("cleanup");
+
+        assert!(temp.path().join("build/user.txt").is_file());
+        assert!(temp.path().join("fixture-1.2.3.tgz").is_file());
     }
 
     #[test]
@@ -850,6 +864,16 @@ mod tests {
                 "mkdir -p build; printf artifact > build/fixture.zip; printf '[{\"path\":\"build/fixture.zip\",\"type\":\"archive\"}]'",
             );
             homeboy_extension::save_manifest(&package).expect("save package extension");
+            let component_config = Component {
+                id: "fixture".to_string(),
+                local_path: component.path().to_string_lossy().to_string(),
+                cleanup_artifacts: vec![homeboy_core::component::CleanupArtifactDeclaration {
+                    label: "package build".to_string(),
+                    path: Some("build".to_string()),
+                    glob: None,
+                }],
+                ..Component::default()
+            };
 
             let mut state = crate::release::types::ReleaseState {
                 version: Some("1.2.3".to_string()),
@@ -858,7 +882,7 @@ mod tests {
             let result = run_package(
                 &[package],
                 &mut state,
-                &Component::default(),
+                &component_config,
                 "fixture",
                 &component.path().to_string_lossy(),
                 None,
@@ -888,12 +912,7 @@ mod tests {
             assert!(repair.create_command.contains(durable_path));
 
             let build_dir = component.path().join("build");
-            let component = Component {
-                id: "fixture".to_string(),
-                local_path: component.path().to_string_lossy().to_string(),
-                ..Component::default()
-            };
-            run_cleanup(&component, &state).expect("cleanup");
+            run_cleanup(&component_config, &state).expect("cleanup");
 
             assert!(!build_dir.exists());
             assert!(std::path::Path::new(durable_path).is_file());

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -9,6 +9,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_extension as extension;
 use homeboy_extension::ExtensionCapability;
 use homeboy_extension::{self, ExtensionManifest};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use super::super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult};
@@ -35,6 +36,7 @@ pub(crate) fn run_package(
     declared_build_artifact: Option<&str>,
     skip_build_validation: bool,
 ) -> Result<ReleaseStepResult> {
+    let cleanup_before = package_cleanup_snapshot(component)?;
     let package_extensions: Vec<&ExtensionManifest> = extensions
         .iter()
         .filter(|m| m.actions.iter().any(|a| a.id == "release.package"))
@@ -53,12 +55,14 @@ pub(crate) fn run_package(
 
     if package_extensions.is_empty() {
         if declared_artifact_built {
+            record_package_owned_paths(state, component, &cleanup_before)?;
             return Ok(step_success(
                 "package",
                 "package",
                 Some(serde_json::json!({
                     "action": "scripts.build",
                     "artifact": declared_build_artifact,
+                    "package_owned_paths": state.package_owned_paths,
                 })),
                 Vec::new(),
             ));
@@ -107,22 +111,77 @@ pub(crate) fn run_package(
         )?;
     }
 
+    record_package_owned_paths(state, component, &cleanup_before)?;
+
     let data = if responses.len() == 1 {
         let response = responses.pop().expect("single package response");
         serde_json::json!({
             "extension": response["extension"],
             "action": "release.package",
             "response": response["response"],
+            "package_owned_paths": state.package_owned_paths,
         })
     } else {
         serde_json::json!({
             "action": "release.package",
             "extensions": responses.iter().map(|response| response["extension"].clone()).collect::<Vec<_>>(),
             "responses": responses,
+            "package_owned_paths": state.package_owned_paths,
         })
     };
 
     Ok(step_success("package", "package", Some(data), Vec::new()))
+}
+
+fn record_package_owned_paths(
+    state: &mut ReleaseState,
+    component: &Component,
+    before: &BTreeSet<String>,
+) -> Result<()> {
+    let after = package_cleanup_snapshot(component)?;
+    state
+        .package_owned_paths
+        .extend(after.difference(before).cloned());
+    state.package_owned_paths.sort();
+    state.package_owned_paths.dedup();
+    Ok(())
+}
+
+/// Snapshot only checkout paths that can later be removed without guessing.
+/// Git supplies untracked outputs while component/extension declarations cover
+/// ignored build paths. Paths that existed before packaging never enter the
+/// ownership delta, even when their names match generated outputs.
+fn package_cleanup_snapshot(component: &Component) -> Result<BTreeSet<String>> {
+    let component_path = Path::new(&component.local_path);
+    let mut paths = BTreeSet::new();
+
+    if homeboy_core::git::is_git_repo(&component.local_path) {
+        let changes = homeboy_core::git::get_uncommitted_changes(&component.local_path)?;
+        for path in changes.untracked {
+            record_existing_cleanup_path(component_path, &path, &mut paths);
+        }
+    }
+
+    for path in homeboy_core::component::declared_cleanup_artifact_paths(component)? {
+        record_existing_cleanup_path(component_path, &path, &mut paths);
+    }
+
+    Ok(paths)
+}
+
+fn record_existing_cleanup_path(component_path: &Path, path: &str, paths: &mut BTreeSet<String>) {
+    let normalized = path.trim().trim_end_matches('/').replace('\\', "/");
+    let relative = Path::new(&normalized);
+    if normalized.is_empty()
+        || relative.is_absolute()
+        || relative
+            .components()
+            .any(|part| !matches!(part, std::path::Component::Normal(_)))
+        || !component_path.join(relative).exists()
+    {
+        return;
+    }
+    paths.insert(normalized);
 }
 
 /// Run the component-owned build contract before package providers when it is

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -110,6 +110,10 @@ pub fn package_existing_tag(
         )
     })?;
 
+    // The durable recovery directory now owns the deliverables. Remove only
+    // checkout paths proven to have been created by this package invocation.
+    super::executor::run_cleanup(&component, &state)?;
+
     homeboy_core::log_status!(
         "release",
         "Release package artifacts written to {}",

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -181,16 +181,6 @@ pub(in crate::release) fn build_release_steps(
                 StepConfig::new(),
             ));
         }
-
-        if !options.pipeline.deploy {
-            steps.push(ready_step(
-                "cleanup",
-                "cleanup",
-                "Clean up release artifacts",
-                publish_step_ids.clone(),
-                StepConfig::new(),
-            ));
-        }
     } else if options.pipeline.skip_publish && !publish_targets.is_empty() {
         homeboy_core::log_status!(
             "release",
@@ -198,16 +188,35 @@ pub(in crate::release) fn build_release_steps(
         );
     }
 
+    if package_step_needed && !options.pipeline.deploy {
+        let cleanup_needs = if !publish_step_ids.is_empty() {
+            publish_step_ids.clone()
+        } else if github_release_needed {
+            vec!["github.release".to_string()]
+        } else {
+            vec!["git.push".to_string()]
+        };
+        steps.push(ready_step(
+            "cleanup",
+            "cleanup",
+            "Clean up release artifacts",
+            cleanup_needs,
+            StepConfig::new(),
+        ));
+    }
+
     let post_release_hooks = homeboy_core::engine::hooks::resolve_hooks(
         component,
         homeboy_core::engine::hooks::events::POST_RELEASE,
     )?;
     if !post_release_hooks.is_empty() {
-        let post_release_needs = if !options.pipeline.skip_publish && !publish_targets.is_empty() {
+        let post_release_needs = if package_step_needed && !options.pipeline.deploy {
+            vec!["cleanup".to_string()]
+        } else if !options.pipeline.skip_publish && !publish_targets.is_empty() {
             if options.pipeline.deploy {
                 publish_step_ids.clone()
             } else {
-                vec!["cleanup".to_string()]
+                vec!["git.push".to_string()]
             }
         } else {
             vec!["git.push".to_string()]
@@ -254,6 +263,8 @@ fn build_head_release_steps(
 ) -> Result<Vec<PlanStep>> {
     let mut steps = Vec::new();
     let mut artifact_need = "preflight.remote_sync".to_string();
+    let package_step_needed = options.pipeline.from_artifacts.is_none()
+        && head_package_step_needed(component, extensions, publish_targets, options);
 
     if !publish_targets.is_empty()
         && !options.pipeline.skip_publish
@@ -276,7 +287,7 @@ fn build_head_release_steps(
             string_config("dir", dir),
         ));
         artifact_need = "artifacts.inventory".to_string();
-    } else if head_package_step_needed(component, extensions, publish_targets, options) {
+    } else if package_step_needed {
         steps.push(ready_step(
             "package",
             "package",
@@ -318,16 +329,23 @@ fn build_head_release_steps(
                 StepConfig::new(),
             ));
         }
+    }
 
-        if !options.pipeline.deploy {
-            steps.push(ready_step(
-                "cleanup",
-                "cleanup",
-                "Clean up release artifacts",
-                publish_step_ids.clone(),
-                StepConfig::new(),
-            ));
-        }
+    if package_step_needed && !options.pipeline.deploy {
+        let cleanup_needs = if !publish_step_ids.is_empty() {
+            publish_step_ids.clone()
+        } else if github_release_needed(component, options) {
+            vec!["github.release".to_string()]
+        } else {
+            vec![artifact_need.clone()]
+        };
+        steps.push(ready_step(
+            "cleanup",
+            "cleanup",
+            "Clean up release artifacts",
+            cleanup_needs,
+            StepConfig::new(),
+        ));
     }
 
     let post_release_hooks = homeboy_core::engine::hooks::resolve_hooks(
@@ -335,11 +353,13 @@ fn build_head_release_steps(
         homeboy_core::engine::hooks::events::POST_RELEASE,
     )?;
     if !post_release_hooks.is_empty() {
-        let post_release_needs = if !options.pipeline.skip_publish && !publish_targets.is_empty() {
+        let post_release_needs = if package_step_needed && !options.pipeline.deploy {
+            vec!["cleanup".to_string()]
+        } else if !options.pipeline.skip_publish && !publish_targets.is_empty() {
             if options.pipeline.deploy {
                 publish_step_ids.clone()
             } else {
-                vec!["cleanup".to_string()]
+                vec![artifact_need.clone()]
             }
         } else if github_release_needed(component, options) {
             vec!["github.release".to_string()]

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -556,7 +556,10 @@ fn skip_publish_with_package_provider_still_packages_before_github_release() {
     assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["package"]);
     assert_eq!(steps[github_release_index].needs, vec!["git.push"]);
     assert!(!ids.contains(&"publish.artifact-packager"));
-    assert!(!ids.contains(&"cleanup"));
+    assert_eq!(
+        steps[step_index(&ids, "cleanup")].needs,
+        vec!["github.release"]
+    );
 }
 
 #[test]
@@ -628,8 +631,9 @@ fn head_skip_publish_with_package_provider_still_packages_before_github_release(
     .expect("steps");
 
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
-    assert_eq!(ids, vec!["package", "github.release"]);
+    assert_eq!(ids, vec!["package", "github.release", "cleanup"]);
     assert_eq!(steps[1].needs, vec!["package"]);
+    assert_eq!(steps[2].needs, vec!["github.release"]);
 }
 
 #[test]
@@ -665,6 +669,10 @@ fn component_build_artifact_packages_before_github_release_without_extension() {
     assert!(step_index(&ids, "preflight.package") < step_index(&ids, "package"));
     assert!(step_index(&ids, "package") < step_index(&ids, "github.release"));
     assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["package"]);
+    assert_eq!(
+        steps[step_index(&ids, "cleanup")].needs,
+        vec!["github.release"]
+    );
 }
 
 #[test]
@@ -701,8 +709,9 @@ fn head_component_build_artifact_packages_before_github_release_without_extensio
     .expect("steps");
 
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
-    assert_eq!(ids, vec!["package", "github.release"]);
+    assert_eq!(ids, vec!["package", "github.release", "cleanup"]);
     assert_eq!(steps[1].needs, vec!["package"]);
+    assert_eq!(steps[2].needs, vec!["github.release"]);
 }
 
 #[test]
@@ -868,12 +877,7 @@ fn head_release_plan_skips_mutation_steps_and_uses_existing_artifacts() {
     assert!(!ids.contains(&"git.push"));
     assert_eq!(
         ids,
-        vec![
-            "artifacts.inventory",
-            "github.release",
-            "publish.wordpress",
-            "cleanup"
-        ]
+        vec!["artifacts.inventory", "github.release", "publish.wordpress"]
     );
     assert_eq!(
         steps[0].inputs.get("dir").and_then(|value| value.as_str()),

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -433,87 +433,91 @@ fn test_build_release_steps() {
 
 #[test]
 fn release_plan_runs_package_preflight_before_mutating_release_steps() {
-    let mut component = fixture_component();
-    component.extensions = Some(std::collections::HashMap::from([(
-        "fixture-packager".to_string(),
-        ScopedExtensionConfig::default(),
-    )]));
-    let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
-        "name": "Fixture Packager",
-        "version": "1.0.0",
-        "actions": [
-            {
-                "id": "release.package",
-                "label": "Package release",
-                "type": "command",
-                "command": "true"
-            },
-            {
-                "id": "release.publish",
-                "label": "Publish release",
-                "type": "command",
-                "command": "true"
-            }
-        ]
-    }))
-    .expect("extension manifest");
-    extension.id = "fixture-packager".to_string();
-    let mut warnings = Vec::new();
-    let mut hints = Vec::new();
-    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
-    let options = ReleaseOptions {
-        bump_type: "patch".to_string(),
-        ..Default::default()
-    };
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut component = fixture_component();
+        component.extensions = Some(std::collections::HashMap::from([(
+            "fixture-packager".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+        let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Fixture Packager",
+            "version": "1.0.0",
+            "actions": [
+                {
+                    "id": "release.package",
+                    "label": "Package release",
+                    "type": "command",
+                    "command": "true"
+                },
+                {
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": "true"
+                }
+            ]
+        }))
+        .expect("extension manifest");
+        extension.id = "fixture-packager".to_string();
+        homeboy_extension::save_manifest(&extension).expect("save extension manifest");
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let release_scope =
+            ReleaseScope::resolve(&component, &component.id).expect("release scope");
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
 
-    let steps = build_release_steps(
-        &component,
-        &[extension],
-        "1.0.0",
-        "1.0.1",
-        &fixture_changelog_plan(),
-        &options,
-        &release_scope,
-        &mut warnings,
-        &mut hints,
-    )
-    .expect("steps");
+        let steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.0",
+            "1.0.1",
+            &fixture_changelog_plan(),
+            &options,
+            &release_scope,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
 
-    let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
-    let package_preflight_index = step_index(&ids, "preflight.package");
-    let tag_preflight_index = step_index(&ids, "preflight.tag_availability");
-    let changelog_finalize_index = step_index(&ids, "changelog.finalize");
-    let version_index = step_index(&ids, "version");
-    let commit_index = step_index(&ids, "git.commit");
+        let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+        let package_preflight_index = step_index(&ids, "preflight.package");
+        let tag_preflight_index = step_index(&ids, "preflight.tag_availability");
+        let changelog_finalize_index = step_index(&ids, "changelog.finalize");
+        let version_index = step_index(&ids, "version");
+        let commit_index = step_index(&ids, "git.commit");
 
-    assert!(package_preflight_index < changelog_finalize_index);
-    assert!(tag_preflight_index < changelog_finalize_index);
-    assert!(package_preflight_index < version_index);
-    assert!(tag_preflight_index < version_index);
-    assert!(package_preflight_index < commit_index);
-    assert!(tag_preflight_index < commit_index);
+        assert!(package_preflight_index < changelog_finalize_index);
+        assert!(tag_preflight_index < changelog_finalize_index);
+        assert!(package_preflight_index < version_index);
+        assert!(tag_preflight_index < version_index);
+        assert!(package_preflight_index < commit_index);
+        assert!(tag_preflight_index < commit_index);
 
-    let package_preflight = &steps[package_preflight_index];
-    assert_eq!(
-        package_preflight.needs,
-        vec!["preflight.changelog_bootstrap"]
-    );
+        let package_preflight = &steps[package_preflight_index];
+        assert_eq!(
+            package_preflight.needs,
+            vec!["preflight.changelog_bootstrap"]
+        );
 
-    let changelog_policy = steps
-        .iter()
-        .find(|step| step.id == "changelog.policy")
-        .expect("changelog policy step");
-    assert_eq!(changelog_policy.needs, vec!["preflight.tag_availability"]);
+        let changelog_policy = steps
+            .iter()
+            .find(|step| step.id == "changelog.policy")
+            .expect("changelog policy step");
+        assert_eq!(changelog_policy.needs, vec!["preflight.tag_availability"]);
 
-    let tag_preflight = &steps[tag_preflight_index];
-    assert_eq!(tag_preflight.needs, vec!["preflight.package"]);
-    assert_eq!(
-        tag_preflight
-            .inputs
-            .get("name")
-            .and_then(|value| value.as_str()),
-        Some("v1.0.1")
-    );
+        let tag_preflight = &steps[tag_preflight_index];
+        assert_eq!(tag_preflight.needs, vec!["preflight.package"]);
+        assert_eq!(
+            tag_preflight
+                .inputs
+                .get("name")
+                .and_then(|value| value.as_str()),
+            Some("v1.0.1")
+        );
+    });
 }
 
 #[test]

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -298,6 +298,9 @@ pub struct ReleaseState {
     pub tag: Option<String>,
     pub notes: Option<String>,
     pub artifacts: Vec<ReleaseArtifact>,
+    /// Component-relative checkout paths proven absent before packaging and
+    /// created by the current package invocation.
+    pub package_owned_paths: Vec<String>,
     pub changelog_validation: Option<crate::release::version::ChangelogValidationResult>,
 }
 


### PR DESCRIPTION
## Summary

- snapshot untracked source-tree paths before and after package execution so release cleanup owns only paths created by that invocation
- preserve pre-existing matching files and external `--from-artifacts` inputs while cleaning durable package outputs after successful publication or recovery
- isolate the package-preflight plan fixture from ambient extension-store state

## Root cause

Release packaging durably copied emitted assets, but final cleanup inferred only legacy declared paths such as `target/distrib` and an artifact-containing build directory. Package-created sibling outputs such as WP Codebox's root tarball and intermediate `build/` directory had no invocation ownership record, so cleanup reported success while leaving the checkout dirty.

## Safety model

The release executor records only untracked paths absent before package execution and present afterward. Cleanup combines this invocation delta with explicit declarations, excludes tracked files, rejects unsafe paths, and runs only after durable artifact copies exist. Pre-existing paths are never claimed merely because their names match package output conventions.

Packaging failures retain source outputs for diagnosis. External `--from-artifacts` inputs are not treated as checkout-owned package outputs.

## Recovery semantics

Package-only runs clean source outputs only after writing durable recovery artifacts and their exact-digest manifest. Failed deployments persist the ownership list in recovery state, retain source outputs while recovery is needed, and remove them only after a successful resume. Publish failures may clean source outputs because the durable recovery copies remain available.

## Disk behavior

Successful package-producing flows remove only invocation-owned source-tree files and directories, including package-only and private/skip-publish flows. Durable recovery artifacts remain intact. The implementation adds no persistent build cache or duplicate artifact store; the task-only shared Cargo target was reclaimed after verification.

## Coverage

- package-created files and directories restore a clean working-tree preflight
- pre-existing matching files survive cleanup
- packaging failure retains diagnostics
- skip-publish/private plans still clean after durable publication
- `--head` and `--from-artifacts` plans preserve external inputs
- failed deployment recovery retains then cleans owned paths after successful resume
- package-preflight test fixtures no longer depend on ambient extension state

## Verification

- `cargo test -p homeboy-release cleanup -- --nocapture`
- `cargo test -p homeboy-release failed_package_retains_outputs_without_claiming_cleanup_ownership -- --nocapture`
- `cargo test -p homeboy-release release::executor::publish::tests -- --test-threads=1`
- `cargo test -p homeboy-release release::package_recovery::tests -- --test-threads=1`
- `cargo test -p homeboy-release release::deployment::tests -- --test-threads=1`
- `cargo test -p homeboy --test release_workflow_test -- --test-threads=1`
- `homeboy review --changed-since origin/main --summary` (post-rebase: audit and lint passed with zero introduced findings; 27 tests passed)
- `git diff --check origin/main...HEAD`

The repository currently emits unrelated compiler warnings. Broader host-dependent release test baselines are tracked in #10126.

Fixes #6853
Fixes #10125