### PR TITLE
feat(schedule): declare homeboy commands that run on a cadence

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 use crate::commands::{
     activity, agent_task, api, bench, cleanup, component, config, contract, daemon, db, deploy,
     extension, file, fleet, fuzz, git, harvest, logs, observe, project, refactor, release, report,
-    review, rig, runner, runs, runtime, self_cmd, server, ssh, stack, status, trace, triage,
-    tunnel, upgrade, worktree,
+    review, rig, runner, runs, runtime, schedule, self_cmd, server, ssh, stack, status, trace,
+    triage, tunnel, upgrade, worktree,
 };
 
 const VERSION: &str = homeboy_product_identity::product_version();
@@ -179,6 +179,8 @@ pub enum Commands {
     Daemon(daemon::DaemonArgs),
     /// Execute CLI-compatible extensions
     Extension(extension::ExtensionArgs),
+    /// Declare homeboy commands that run on a cadence
+    Schedule(schedule::ScheduleArgs),
     /// Actionable component status overview
     Status(status::StatusArgs),
     /// Remove declared reconstructable artifacts from managed worktrees

--- a/crates/homeboy-cli/src/command_contract/descriptors.rs
+++ b/crates/homeboy-cli/src/command_contract/descriptors.rs
@@ -18,6 +18,7 @@ macro_rules! ops_command_descriptors {
             (deploy, Deploy, crate::commands::deploy::DeployArgs, command_spec_with_safety("deploy", CommandJsonFamily::Ops, operator_safety(Some("--dry-run"), DEPLOY_DANGEROUS_FLAGS)), crate::commands::deploy::run),
             (harvest, Harvest, crate::commands::harvest::HarvestArgs, command_spec_with_safety("harvest", CommandJsonFamily::Ops, operator_safety(Some("--dry-run"), &["--apply"])), crate::commands::harvest::run),
             (daemon, Daemon, crate::commands::daemon::DaemonArgs, command_spec("daemon", CommandJsonFamily::Ops), crate::commands::daemon::run),
+            (schedule, Schedule, crate::commands::schedule::ScheduleArgs, command_spec("schedule", CommandJsonFamily::Ops), crate::commands::schedule::run),
             (status, Status, crate::commands::status::StatusArgs, command_spec("status", CommandJsonFamily::Ops), crate::commands::status::run),
             (git, Git, crate::commands::git::GitArgs, command_spec("git", CommandJsonFamily::Ops), crate::commands::git::run),
             (self_cmd, SelfCmd, crate::commands::self_cmd::SelfArgs, command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation"), crate::commands::self_cmd::run),
@@ -45,6 +46,7 @@ macro_rules! ops_command_spec {
     (deploy) => { command_spec_with_safety("deploy", CommandJsonFamily::Ops, operator_safety(Some("--dry-run"), DEPLOY_DANGEROUS_FLAGS)) };
     (harvest) => { command_spec_with_safety("harvest", CommandJsonFamily::Ops, operator_safety(Some("--dry-run"), &["--apply"])) };
     (daemon) => { command_spec("daemon", CommandJsonFamily::Ops) };
+    (schedule) => { command_spec("schedule", CommandJsonFamily::Ops) };
     (status) => { command_spec("status", CommandJsonFamily::Ops) };
     (git) => { command_spec("git", CommandJsonFamily::Ops) };
     (self_cmd) => { command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") };

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -678,6 +678,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         "lists, shows, exports constants, exports schemas, validates, normalizes, and emits Homeboy-owned contract metadata and command manifests through the central contract surface",
     ),
     crate::ops_command_spec!(daemon),
+    crate::ops_command_spec!(schedule),
     command_spec_with_representative_argv(
         &["homeboy", "extension", "refresh", "."],
         lab_command_spec_with_summary(

--- a/crates/homeboy-cli/src/commands/schedule.rs
+++ b/crates/homeboy-cli/src/commands/schedule.rs
@@ -1,0 +1,356 @@
+//! `homeboy schedule` — declare homeboy commands that run on a cadence.
+
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use homeboy::core::error::{Error, Result};
+use homeboy::core::schedule::{
+    self, Cadence, NotifyPolicy, OverlapPolicy, Schedule, ScheduleRunOutcome, ScheduleState,
+    SubprocessRunner,
+};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct ScheduleArgs {
+    #[command(subcommand)]
+    command: ScheduleCommand,
+}
+
+#[derive(Subcommand)]
+enum ScheduleCommand {
+    /// Declare a scheduled run
+    Add(AddArgs),
+    /// List declared schedules with their last and next run
+    List,
+    /// Show one schedule and its runtime state
+    Show { id: String },
+    /// Remove a schedule and its runtime state
+    Remove { id: String },
+    /// Run a schedule now, regardless of whether it is due
+    Run { id: String },
+    /// Enable a disabled schedule
+    Enable { id: String },
+    /// Disable a schedule without deleting it
+    Disable { id: String },
+    /// Run every schedule that is currently due
+    Tick(TickArgs),
+}
+
+#[derive(Args)]
+pub struct AddArgs {
+    /// Schedule id
+    id: String,
+
+    /// Homeboy command to run, without the leading binary name
+    /// (for example: --command "fleet check prod")
+    #[arg(long)]
+    command: String,
+
+    /// How often to run: 30m, 24h, 1h30m, 7d
+    #[arg(long)]
+    every: String,
+
+    /// When to notify: change (default), failure, or always
+    #[arg(long, default_value = "change")]
+    notify_on: String,
+
+    /// What to do if the previous run is still going: skip (default) or allow
+    #[arg(long, default_value = "skip")]
+    on_overlap: String,
+
+    /// Notification transport id (requires --notification-route)
+    #[arg(long, requires = "notification_route")]
+    notification_transport: Option<String>,
+
+    /// Notification route (requires --notification-transport)
+    #[arg(long, requires = "notification_transport")]
+    notification_route: Option<String>,
+
+    /// Spread runs across a window, in seconds, so many schedules sharing a
+    /// cadence do not fire at the same instant
+    #[arg(long)]
+    jitter_seconds: Option<u64>,
+
+    /// Human-readable note about why this schedule exists
+    #[arg(long)]
+    description: Option<String>,
+
+    /// Replace an existing schedule with the same id
+    #[arg(long)]
+    force: bool,
+}
+
+#[derive(Args)]
+pub struct TickArgs {
+    /// Report what is due without running anything
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum ScheduleOutput {
+    One(Box<ScheduleView>),
+    Many(Vec<ScheduleView>),
+    Run(Box<ScheduleRunOutcome>),
+    Tick(TickReport),
+    Removed { id: String, removed: bool },
+}
+
+#[derive(Serialize)]
+pub struct ScheduleView {
+    #[serde(flatten)]
+    schedule: ScheduleSummary,
+    state: ScheduleState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_run_at: Option<String>,
+    due: bool,
+}
+
+#[derive(Serialize)]
+pub struct ScheduleSummary {
+    id: String,
+    command: Vec<String>,
+    every: String,
+    notify_on: String,
+    on_overlap: String,
+    enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    notification_transport: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jitter_seconds: Option<u64>,
+}
+
+#[derive(Serialize)]
+pub struct TickReport {
+    due: Vec<String>,
+    dry_run: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    runs: Vec<ScheduleRunOutcome>,
+}
+
+fn view(schedule: Schedule) -> ScheduleView {
+    let state = schedule::load_state(&schedule.id);
+    let next_run_at = state
+        .next_run_at(&schedule)
+        .map(|next| next.to_rfc3339())
+        .or_else(|| Some("due now".to_string()));
+    let due = state.is_due(&schedule, chrono::Utc::now());
+    ScheduleView {
+        schedule: ScheduleSummary {
+            id: schedule.id.clone(),
+            command: schedule.command.clone(),
+            every: schedule.every.to_string(),
+            notify_on: schedule.notify_on.as_str().to_string(),
+            on_overlap: schedule.on_overlap.as_str().to_string(),
+            enabled: schedule.enabled,
+            description: schedule.description.clone(),
+            notification_transport: schedule.notification_transport.clone(),
+            jitter_seconds: schedule.jitter_seconds,
+        },
+        state,
+        next_run_at,
+        due,
+    }
+}
+
+/// Split a command string into argv.
+///
+/// Supports quoting so an argument may contain spaces.
+fn split_command(raw: &str) -> Result<Vec<String>> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut has_current = false;
+
+    for ch in raw.chars() {
+        match quote {
+            Some(open) if ch == open => quote = None,
+            Some(_) => current.push(ch),
+            None if ch == '\'' || ch == '"' => {
+                quote = Some(ch);
+                has_current = true;
+            }
+            None if ch.is_whitespace() => {
+                if has_current {
+                    args.push(std::mem::take(&mut current));
+                    has_current = false;
+                }
+            }
+            None => {
+                current.push(ch);
+                has_current = true;
+            }
+        }
+    }
+    if quote.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "Unbalanced quote in the scheduled command",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    if has_current {
+        args.push(current);
+    }
+    if args.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "A schedule needs a command to run",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    Ok(args)
+}
+
+pub fn run(args: ScheduleArgs, _global: &super::GlobalArgs) -> CmdResult<ScheduleOutput> {
+    match args.command {
+        ScheduleCommand::Add(add) => {
+            if schedule::exists(&add.id) && !add.force {
+                return Err(Error::validation_invalid_argument(
+                    "id",
+                    format!("Schedule '{}' already exists", add.id),
+                    Some(add.id.clone()),
+                    Some(vec!["Pass --force to replace it.".to_string()]),
+                ));
+            }
+            let declared = Schedule {
+                id: add.id.clone(),
+                command: split_command(&add.command)?,
+                every: Cadence::parse(&add.every)?,
+                notify_on: add.notify_on.parse::<NotifyPolicy>()?,
+                on_overlap: match add.on_overlap.trim().to_ascii_lowercase().as_str() {
+                    "skip" => OverlapPolicy::Skip,
+                    "allow" => OverlapPolicy::Allow,
+                    other => {
+                        return Err(Error::validation_invalid_argument(
+                            "on-overlap",
+                            format!("Unknown overlap policy '{other}'"),
+                            Some(other.to_string()),
+                            Some(vec!["Use skip or allow.".to_string()]),
+                        ))
+                    }
+                },
+                notification_transport: add.notification_transport,
+                notification_route: add.notification_route,
+                jitter_seconds: add.jitter_seconds,
+                enabled: true,
+                description: add.description,
+                aliases: Vec::new(),
+            };
+            schedule::save(&declared)?;
+            Ok((ScheduleOutput::One(Box::new(view(declared))), 0))
+        }
+        ScheduleCommand::List => {
+            let mut all: Vec<Schedule> = schedule::list()?;
+            all.sort_by(|a, b| a.id.cmp(&b.id));
+            Ok((
+                ScheduleOutput::Many(all.into_iter().map(view).collect()),
+                0,
+            ))
+        }
+        ScheduleCommand::Show { id } => {
+            let declared = schedule::load(&id)?;
+            Ok((ScheduleOutput::One(Box::new(view(declared))), 0))
+        }
+        ScheduleCommand::Remove { id } => {
+            schedule::delete(&id)?;
+            schedule::remove_state(&id);
+            Ok((
+                ScheduleOutput::Removed {
+                    id,
+                    removed: true,
+                },
+                0,
+            ))
+        }
+        ScheduleCommand::Run { id } => {
+            let declared = schedule::load(&id)?;
+            let runner = SubprocessRunner::new()?;
+            let outcome = schedule::run_schedule(&declared, &runner);
+            // A scheduled run that failed should fail the invoking command, so
+            // an external trigger can react without parsing the payload.
+            let exit_code = i32::from(outcome.status != "succeeded");
+            Ok((ScheduleOutput::Run(Box::new(outcome)), exit_code))
+        }
+        ScheduleCommand::Enable { id } => set_enabled(&id, true),
+        ScheduleCommand::Disable { id } => set_enabled(&id, false),
+        ScheduleCommand::Tick(tick) => {
+            let due = schedule::due_schedules(chrono::Utc::now())?;
+            let ids: Vec<String> = due.iter().map(|s| s.id.clone()).collect();
+            if tick.dry_run {
+                return Ok((
+                    ScheduleOutput::Tick(TickReport {
+                        due: ids,
+                        dry_run: true,
+                        runs: Vec::new(),
+                    }),
+                    0,
+                ));
+            }
+            let runner = SubprocessRunner::new()?;
+            let runs: Vec<ScheduleRunOutcome> = due
+                .iter()
+                .map(|declared| schedule::run_schedule(declared, &runner))
+                .collect();
+            let failed = runs.iter().any(|run| run.status != "succeeded");
+            Ok((
+                ScheduleOutput::Tick(TickReport {
+                    due: ids,
+                    dry_run: false,
+                    runs,
+                }),
+                i32::from(failed),
+            ))
+        }
+    }
+}
+
+fn set_enabled(id: &str, enabled: bool) -> CmdResult<ScheduleOutput> {
+    let mut declared = schedule::load(id)?;
+    declared.enabled = enabled;
+    schedule::save(&declared)?;
+    Ok((ScheduleOutput::One(Box::new(view(declared))), 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_plain_and_quoted_commands() {
+        assert_eq!(
+            split_command("fleet check prod").expect("split"),
+            vec!["fleet", "check", "prod"]
+        );
+        assert_eq!(
+            split_command("  triage   --json  ").expect("split"),
+            vec!["triage", "--json"]
+        );
+        assert_eq!(
+            split_command(r#"deploy prod --note "nightly drift check""#).expect("split"),
+            vec!["deploy", "prod", "--note", "nightly drift check"]
+        );
+    }
+
+    /// An empty quoted argument is meaningful (it is still an argument), so it
+    /// must survive splitting rather than being dropped as whitespace.
+    #[test]
+    fn preserves_an_explicitly_empty_argument() {
+        assert_eq!(
+            split_command(r#"cmd "" tail"#).expect("split"),
+            vec!["cmd", "", "tail"]
+        );
+    }
+
+    #[test]
+    fn rejects_unbalanced_quotes_and_empty_commands() {
+        assert!(split_command(r#"deploy "unclosed"#).is_err());
+        assert!(split_command("   ").is_err());
+    }
+}

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -394,6 +394,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::DocsTopicNotFound
         | ErrorCode::RigNotFound
         | ErrorCode::RunnerNotFound
+        | ErrorCode::ScheduleNotFound
         | ErrorCode::ServiceTunnelNotFound
         | ErrorCode::StackNotFound
         | ErrorCode::ProjectNoActive => 4,

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -175,6 +175,7 @@ pub mod run_outcome_envelope;
 pub mod runner_execution_envelope;
 pub mod runtime_package;
 pub mod runtime_promotion;
+pub mod schedule;
 pub mod scope;
 pub mod stack_provider;
 pub use homeboy_lab_contract::secret_env_plan;

--- a/crates/homeboy-core/src/schedule/entity.rs
+++ b/crates/homeboy-core/src/schedule/entity.rs
@@ -1,0 +1,196 @@
+//! Schedules as reviewable configuration entities.
+
+use std::path::PathBuf;
+
+use crate::config::ConfigEntity;
+use crate::error::{Error, Result};
+use crate::paths;
+
+use super::types::Schedule;
+
+impl ConfigEntity for Schedule {
+    const ENTITY_TYPE: &'static str = "schedule";
+    const DIR_NAME: &'static str = "schedules";
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+
+    fn not_found_error(id: String, suggestions: Vec<String>) -> Error {
+        Error::schedule_not_found(id, suggestions)
+    }
+
+    fn config_path(id: &str) -> Result<PathBuf> {
+        Ok(paths::homeboy()?
+            .join("schedules")
+            .join(format!("{}.json", id)))
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.id.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "id",
+                "A schedule needs an id",
+                None,
+                None,
+            ));
+        }
+        if self.command.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "command",
+                "A schedule needs a command to run",
+                Some(self.id.clone()),
+                Some(vec![
+                    "Pass the homeboy arguments to run, for example: --command 'fleet check prod'"
+                        .to_string(),
+                ]),
+            ));
+        }
+        if self.command.iter().any(|arg| arg.trim().is_empty()) {
+            return Err(Error::validation_invalid_argument(
+                "command",
+                "A schedule command cannot contain empty arguments",
+                Some(self.command.join(" ")),
+                None,
+            ));
+        }
+        // Scheduling a schedule command would let a tick mutate its own
+        // definitions, or recurse.
+        if self
+            .command
+            .first()
+            .is_some_and(|first| first.trim() == "schedule")
+        {
+            return Err(Error::validation_invalid_argument(
+                "command",
+                "A schedule cannot run the schedule command itself",
+                Some(self.command.join(" ")),
+                Some(vec![
+                    "Schedule the work you want repeated, not the scheduler.".to_string(),
+                ]),
+            ));
+        }
+        // A transport without a route (or the reverse) silently never
+        // notifies, which is worse than refusing it.
+        match (
+            self.notification_transport.as_deref(),
+            self.notification_route.as_deref(),
+        ) {
+            (Some(transport), Some(route)) => {
+                crate::notification_route::NotificationRoute::new(transport, route)?;
+            }
+            (None, None) => {}
+            (Some(_), None) => {
+                return Err(Error::validation_invalid_argument(
+                    "notification-route",
+                    "A notification transport also needs a route",
+                    Some(self.id.clone()),
+                    None,
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(Error::validation_invalid_argument(
+                    "notification-transport",
+                    "A notification route also needs a transport",
+                    Some(self.id.clone()),
+                    None,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::types::{Cadence, NotifyPolicy, OverlapPolicy};
+
+    fn schedule() -> Schedule {
+        Schedule {
+            id: "nightly-harvest".to_string(),
+            command: vec!["harvest".to_string(), "prod".to_string()],
+            every: Cadence::from_seconds(86_400).expect("cadence"),
+            notify_on: NotifyPolicy::default(),
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_complete_schedule_validates() {
+        schedule().validate().expect("valid schedule");
+    }
+
+    #[test]
+    fn a_schedule_without_a_command_is_rejected() {
+        let invalid = Schedule {
+            command: Vec::new(),
+            ..schedule()
+        };
+        assert!(invalid.validate().is_err());
+    }
+
+    /// Half-configured notification silently never delivers, so it is refused
+    /// at declaration time rather than at 3am.
+    #[test]
+    fn a_transport_without_a_route_is_rejected() {
+        let invalid = Schedule {
+            notification_transport: Some("discord.run-completion".to_string()),
+            notification_route: None,
+            ..schedule()
+        };
+        let error = invalid
+            .validate()
+            .expect_err("half-configured notification");
+        assert!(error.to_string().contains("route"), "got: {error}");
+
+        let invalid = Schedule {
+            notification_transport: None,
+            notification_route: Some("discord:v1:channel:1".to_string()),
+            ..schedule()
+        };
+        assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn scheduling_the_scheduler_is_rejected() {
+        let invalid = Schedule {
+            command: vec!["schedule".to_string(), "run".to_string(), "x".to_string()],
+            ..schedule()
+        };
+        assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn schedules_round_trip_through_config_storage() {
+        crate::test_support::with_isolated_home(|_| {
+            let schedule = schedule();
+            crate::config::save(&schedule).expect("save schedule");
+
+            let loaded = crate::config::load::<Schedule>("nightly-harvest").expect("load");
+            assert_eq!(loaded.command, vec!["harvest", "prod"]);
+            assert_eq!(loaded.every.seconds(), 86_400);
+            assert!(loaded.enabled);
+
+            let all = crate::config::list::<Schedule>().expect("list");
+            assert_eq!(all.len(), 1);
+
+            crate::config::delete::<Schedule>("nightly-harvest").expect("delete");
+            assert!(!crate::config::exists::<Schedule>("nightly-harvest"));
+        });
+    }
+}

--- a/crates/homeboy-core/src/schedule/execution.rs
+++ b/crates/homeboy-core/src/schedule/execution.rs
@@ -1,0 +1,439 @@
+//! Running a schedule and deciding whether the result is worth reporting.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+use super::state::{load_state, save_state, ScheduleState};
+use super::types::{NotifyPolicy, Schedule};
+
+/// What a single schedule run produced.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduleRunOutcome {
+    pub schedule_id: String,
+    pub command: Vec<String>,
+    pub status: String,
+    pub exit_code: i32,
+    pub started_at: String,
+    pub finished_at: String,
+    /// Whether this run's reportable payload differs from the previous run's.
+    pub changed: bool,
+    pub notified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notify_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+/// Executes a homeboy command and reports its structured result.
+///
+/// A trait so the tick can be tested without spawning processes, and so the
+/// CLI layer can later supply an in-process runner without core depending
+/// upward on the CLI crate.
+pub trait ScheduleCommandRunner: Send + Sync {
+    /// Run `argv` (without the leading binary name) and return the parsed
+    /// `homeboy/command-result/v3` envelope.
+    fn run(&self, argv: &[String]) -> Result<serde_json::Value>;
+}
+
+/// Runs schedules by re-executing the homeboy binary.
+///
+/// Core cannot call into the CLI crate, and a subprocess additionally means a
+/// panicking or hanging command cannot take the daemon down with it.
+pub struct SubprocessRunner {
+    binary: std::path::PathBuf,
+}
+
+impl SubprocessRunner {
+    pub fn new() -> Result<Self> {
+        let binary = std::env::current_exe().map_err(|error| {
+            Error::internal_io(
+                format!("Failed to resolve the homeboy binary for scheduled runs: {error}"),
+                None,
+            )
+        })?;
+        Ok(Self { binary })
+    }
+}
+
+impl ScheduleCommandRunner for SubprocessRunner {
+    fn run(&self, argv: &[String]) -> Result<serde_json::Value> {
+        let output_file = tempfile::Builder::new()
+            .prefix("homeboy-schedule-")
+            .suffix(".json")
+            .tempfile()
+            .map_err(|error| {
+                Error::internal_io(
+                    format!("Failed to create a schedule output file: {error}"),
+                    None,
+                )
+            })?;
+        let output_path = output_file.path().to_path_buf();
+
+        let status = std::process::Command::new(&self.binary)
+            .arg("--output")
+            .arg(&output_path)
+            .args(argv)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map_err(|error| {
+                Error::internal_io(
+                    format!("Failed to run scheduled command: {error}"),
+                    Some(self.binary.display().to_string()),
+                )
+            })?;
+
+        let raw = std::fs::read_to_string(&output_path).unwrap_or_default();
+        if raw.trim().is_empty() {
+            // The command produced no envelope — surface the exit code rather
+            // than inventing a result.
+            return Ok(serde_json::json!({
+                "schema": "homeboy/command-result/v3",
+                "success": status.success(),
+                "exit_code": status.code().unwrap_or(-1),
+                "status": if status.success() { "succeeded" } else { "failed" },
+            }));
+        }
+        serde_json::from_str(&raw).map_err(|error| {
+            Error::internal_io(
+                format!("Scheduled command wrote output that is not valid JSON: {error}"),
+                Some(output_path.display().to_string()),
+            )
+        })
+    }
+}
+
+/// Fingerprint the part of a result that indicates *what the world looks
+/// like*, so an unchanged healthy run can stay quiet.
+///
+/// Volatile fields — timestamps, durations, run ids — are excluded, otherwise
+/// every run would look like a change and `NotifyPolicy::Change` would degrade
+/// into `Always`.
+pub fn result_digest(value: &serde_json::Value) -> String {
+    let mut normalized = value.clone();
+    strip_volatile(&mut normalized);
+    let rendered = serde_json::to_string(&normalized).unwrap_or_default();
+    let digest = <sha2::Sha256 as sha2::Digest>::digest(rendered.as_bytes());
+    format!("{digest:x}")
+}
+
+const VOLATILE_KEYS: &[&str] = &[
+    "duration_ms",
+    "elapsed_ms",
+    "finished_at",
+    "generated_at",
+    "run_id",
+    "started_at",
+    "timestamp",
+    "took_ms",
+];
+
+fn strip_volatile(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.retain(|key, _| !VOLATILE_KEYS.contains(&key.as_str()));
+            for entry in map.values_mut() {
+                strip_volatile(entry);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                strip_volatile(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Whether a completed run should notify, given the policy and whether the
+/// result changed.
+pub fn should_notify(policy: NotifyPolicy, succeeded: bool, changed: bool) -> bool {
+    match policy {
+        NotifyPolicy::Always => true,
+        NotifyPolicy::Failure => !succeeded,
+        // A failure is always a change worth reporting, even if it fails the
+        // same way twice: staying silent on a repeated failure would hide an
+        // ongoing outage.
+        NotifyPolicy::Change => changed || !succeeded,
+    }
+}
+
+/// Run one schedule now, record the outcome, and notify if the policy says so.
+pub fn run_schedule(schedule: &Schedule, runner: &dyn ScheduleCommandRunner) -> ScheduleRunOutcome {
+    let started = chrono::Utc::now();
+    let previous = load_state(&schedule.id);
+
+    // Mark in-flight before executing so an overlapping tick declines.
+    let _ = save_state(
+        &schedule.id,
+        &ScheduleState {
+            running: true,
+            started_at: Some(started.to_rfc3339()),
+            ..previous.clone()
+        },
+    );
+
+    let result = runner.run(&schedule.command);
+    let finished = chrono::Utc::now();
+
+    let (status, exit_code, digest, summary) = match &result {
+        Ok(value) => {
+            let exit_code = value
+                .get("exit_code")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(0) as i32;
+            let status = value
+                .get("status")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(if exit_code == 0 {
+                    "succeeded"
+                } else {
+                    "failed"
+                })
+                .to_string();
+            let summary = value
+                .get("summary")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            (status, exit_code, result_digest(value), summary)
+        }
+        Err(error) => (
+            "failed".to_string(),
+            -1,
+            String::new(),
+            Some(error.to_string()),
+        ),
+    };
+
+    let succeeded = status == "succeeded" && exit_code == 0;
+    let changed = previous
+        .last_digest
+        .as_deref()
+        .map(|last| last != digest)
+        .unwrap_or(true);
+
+    let mut outcome = ScheduleRunOutcome {
+        schedule_id: schedule.id.clone(),
+        command: schedule.command.clone(),
+        status: status.clone(),
+        exit_code,
+        started_at: started.to_rfc3339(),
+        finished_at: finished.to_rfc3339(),
+        changed,
+        notified: false,
+        notify_error: None,
+        summary,
+    };
+
+    if should_notify(schedule.notify_on, succeeded, changed) {
+        let (notified, error) = notify(schedule, &outcome);
+        outcome.notified = notified;
+        outcome.notify_error = error;
+    }
+
+    let _ = save_state(
+        &schedule.id,
+        &ScheduleState {
+            last_run_at: Some(started.to_rfc3339()),
+            last_status: Some(status),
+            last_exit_code: Some(exit_code),
+            last_digest: Some(digest),
+            running: false,
+            started_at: None,
+            consecutive_failures: if succeeded {
+                0
+            } else {
+                previous.consecutive_failures.saturating_add(1)
+            },
+        },
+    );
+
+    outcome
+}
+
+fn notify(schedule: &Schedule, outcome: &ScheduleRunOutcome) -> (bool, Option<String>) {
+    let route = match (
+        schedule.notification_transport.as_deref(),
+        schedule.notification_route.as_deref(),
+    ) {
+        (Some(transport), Some(route)) => {
+            match crate::notification_route::NotificationRoute::new(transport, route) {
+                Ok(route) => Some(route),
+                Err(error) => return (false, Some(error.to_string())),
+            }
+        }
+        _ => None,
+    };
+
+    let title = format!("schedule {} — {}", schedule.id, outcome.status);
+    let mut body = format!("Command: homeboy {}\n", schedule.command.join(" "));
+    body.push_str(&format!(
+        "Status: {} (exit {})\n",
+        outcome.status, outcome.exit_code
+    ));
+    body.push_str(&format!(
+        "Result: {}\n",
+        if outcome.changed {
+            "changed since the previous run"
+        } else {
+            "unchanged"
+        }
+    ));
+    if let Some(summary) = &outcome.summary {
+        body.push_str(&format!("Summary: {summary}\n"));
+    }
+
+    let event = crate::notify::NotifyEvent {
+        run_id: format!("schedule-{}-{}", schedule.id, outcome.started_at),
+        status: outcome.status.clone(),
+        title,
+        body,
+        transport: route.as_ref().map(|route| route.transport.clone()),
+        route: route.as_ref().map(|route| route.route.clone()),
+    };
+    let result = crate::notify::dispatch(&event);
+    (result.delivered, result.error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::types::{Cadence, OverlapPolicy};
+
+    fn schedule(policy: NotifyPolicy) -> Schedule {
+        Schedule {
+            id: "digest-fixture".to_string(),
+            command: vec!["triage".to_string()],
+            every: Cadence::from_seconds(3_600).expect("cadence"),
+            notify_on: policy,
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// The point of `change`: a fleet that is healthy and unchanged stays
+    /// silent, so a notification always means something needs a human.
+    #[test]
+    fn change_policy_is_silent_only_when_healthy_and_unchanged() {
+        assert!(!should_notify(NotifyPolicy::Change, true, false));
+        assert!(should_notify(NotifyPolicy::Change, true, true));
+    }
+
+    /// A repeated identical failure must keep reporting — an ongoing outage
+    /// that goes quiet because it is "unchanged" is the worst outcome here.
+    #[test]
+    fn change_policy_still_reports_a_repeated_failure() {
+        assert!(should_notify(NotifyPolicy::Change, false, false));
+    }
+
+    #[test]
+    fn failure_policy_ignores_changed_successes() {
+        assert!(!should_notify(NotifyPolicy::Failure, true, true));
+        assert!(should_notify(NotifyPolicy::Failure, false, false));
+    }
+
+    #[test]
+    fn always_policy_reports_everything() {
+        assert!(should_notify(NotifyPolicy::Always, true, false));
+        assert!(should_notify(NotifyPolicy::Always, false, true));
+    }
+
+    /// Timestamps and run ids change on every single run. If they fed the
+    /// digest, `change` would fire every time and be indistinguishable from
+    /// `always`.
+    #[test]
+    fn digest_ignores_volatile_fields() {
+        let first = serde_json::json!({
+            "data": { "drifted": 0, "components": ["a", "b"] },
+            "run_id": "run-1",
+            "duration_ms": 12,
+            "generated_at": "2026-07-26T00:00:00Z",
+        });
+        let second = serde_json::json!({
+            "data": { "drifted": 0, "components": ["a", "b"] },
+            "run_id": "run-2",
+            "duration_ms": 9_999,
+            "generated_at": "2026-07-27T00:00:00Z",
+        });
+        assert_eq!(result_digest(&first), result_digest(&second));
+    }
+
+    #[test]
+    fn digest_reflects_a_real_change() {
+        let healthy = serde_json::json!({ "data": { "drifted": 0 } });
+        let drifted = serde_json::json!({ "data": { "drifted": 1 } });
+        assert_ne!(result_digest(&healthy), result_digest(&drifted));
+    }
+
+    #[test]
+    fn nested_volatile_fields_are_stripped_too() {
+        let first = serde_json::json!({ "data": { "runs": [{ "ok": true, "took_ms": 1 }] } });
+        let second = serde_json::json!({ "data": { "runs": [{ "ok": true, "took_ms": 900 }] } });
+        assert_eq!(result_digest(&first), result_digest(&second));
+    }
+
+    struct StubRunner(serde_json::Value);
+
+    impl ScheduleCommandRunner for StubRunner {
+        fn run(&self, _argv: &[String]) -> Result<serde_json::Value> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn a_run_records_state_and_reports_change_against_the_previous_run() {
+        crate::test_support::with_isolated_home(|_| {
+            let schedule = schedule(NotifyPolicy::Change);
+            let runner = StubRunner(serde_json::json!({
+                "status": "succeeded",
+                "exit_code": 0,
+                "data": { "drifted": 0 },
+            }));
+
+            let first = run_schedule(&schedule, &runner);
+            assert_eq!(first.status, "succeeded");
+            assert!(
+                first.changed,
+                "the first run has nothing to compare against"
+            );
+
+            let second = run_schedule(&schedule, &runner);
+            assert!(
+                !second.changed,
+                "an identical result must not be reported as a change"
+            );
+
+            let state = load_state(&schedule.id);
+            assert!(!state.running, "state must not stay marked in-flight");
+            assert_eq!(state.last_exit_code, Some(0));
+            assert_eq!(state.consecutive_failures, 0);
+        });
+    }
+
+    #[test]
+    fn a_failing_run_counts_consecutive_failures() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut schedule = schedule(NotifyPolicy::Failure);
+            schedule.id = "failing-fixture".to_string();
+            let runner = StubRunner(serde_json::json!({
+                "status": "failed",
+                "exit_code": 2,
+                "data": { "drifted": 3 },
+            }));
+
+            run_schedule(&schedule, &runner);
+            run_schedule(&schedule, &runner);
+
+            let state = load_state(&schedule.id);
+            assert_eq!(state.consecutive_failures, 2);
+            assert_eq!(state.last_exit_code, Some(2));
+            assert!(!state.running);
+        });
+    }
+}

--- a/crates/homeboy-core/src/schedule/mod.rs
+++ b/crates/homeboy-core/src/schedule/mod.rs
@@ -1,0 +1,85 @@
+//! Scheduled runs — declared homeboy commands that execute on a cadence.
+//!
+//! Homeboy already owns durable jobs, typed notification transports, and a
+//! structured result envelope. What it lacked was a time trigger, so every
+//! operator bolted periodic work onto external cron or systemd timers and
+//! re-solved notification wiring, overlap, and change detection themselves
+//! (#10073).
+//!
+//! A schedule is split deliberately in two:
+//!
+//! - the **declaration** (`Schedule`) is reviewable configuration under
+//!   `~/.config/homeboy/schedules/{id}.json`
+//! - the **runtime record** (`ScheduleState`) churns on every run and lives
+//!   apart, so the declaration stays diffable
+//!
+//! The default reporting policy is *notify on change*. A fleet check that
+//! keeps returning "healthy" should be silent; a notification should mean
+//! something needs a human.
+
+mod entity;
+pub mod execution;
+pub mod state;
+pub mod types;
+
+pub use execution::{
+    result_digest, run_schedule, ScheduleCommandRunner, ScheduleRunOutcome, SubprocessRunner,
+};
+pub use state::{load_state, remove_state, save_state, ScheduleState};
+pub use types::{Cadence, NotifyPolicy, OverlapPolicy, Schedule};
+
+crate::entity_crud!(Schedule; list_ids);
+
+/// Schedules that are due at `now`, in declaration order.
+pub fn due_schedules(now: chrono::DateTime<chrono::Utc>) -> crate::Result<Vec<Schedule>> {
+    Ok(list()?
+        .into_iter()
+        .filter(|schedule| load_state(&schedule.id).is_due(schedule, now))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schedule(id: &str, enabled: bool) -> Schedule {
+        Schedule {
+            id: id.to_string(),
+            command: vec!["triage".to_string()],
+            every: Cadence::from_seconds(3_600).expect("cadence"),
+            notify_on: NotifyPolicy::default(),
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn due_schedules_skips_disabled_and_recently_run_definitions() {
+        crate::test_support::with_isolated_home(|_| {
+            save(&schedule("never-run", true)).expect("save");
+            save(&schedule("disabled", false)).expect("save");
+            save(&schedule("just-ran", true)).expect("save");
+
+            save_state(
+                "just-ran",
+                &ScheduleState {
+                    last_run_at: Some(chrono::Utc::now().to_rfc3339()),
+                    ..Default::default()
+                },
+            )
+            .expect("save state");
+
+            let due = due_schedules(chrono::Utc::now()).expect("due schedules");
+            let ids: Vec<&str> = due.iter().map(|s| s.id.as_str()).collect();
+
+            assert!(ids.contains(&"never-run"));
+            assert!(!ids.contains(&"disabled"));
+            assert!(!ids.contains(&"just-ran"));
+        });
+    }
+}

--- a/crates/homeboy-core/src/schedule/state.rs
+++ b/crates/homeboy-core/src/schedule/state.rs
@@ -1,0 +1,246 @@
+//! Mutable per-schedule runtime state.
+//!
+//! Deliberately stored apart from the declaration. The declaration is
+//! reviewable configuration a human writes; this record churns on every run
+//! and would make that file useless to diff.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::paths;
+
+use super::types::Schedule;
+
+/// The outcome of the most recent run, and enough context to decide whether
+/// the next one is worth reporting.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScheduleState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_status: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_exit_code: Option<i32>,
+
+    /// Fingerprint of the last run's reportable payload. Drives
+    /// `NotifyPolicy::Change` — a run whose fingerprint matches the previous
+    /// one is healthy-and-unchanged, and stays silent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_digest: Option<String>,
+
+    /// Set while a run is in flight so an overlapping tick can decline.
+    #[serde(default)]
+    pub running: bool,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+
+    #[serde(default)]
+    pub consecutive_failures: u32,
+}
+
+impl ScheduleState {
+    /// Whether `schedule` is due at `now`, given this state.
+    ///
+    /// Uses the recorded start time rather than completion so a long run does
+    /// not push the cadence out by its own duration.
+    pub fn is_due(&self, schedule: &Schedule, now: chrono::DateTime<chrono::Utc>) -> bool {
+        if !schedule.enabled {
+            return false;
+        }
+        if self.running && matches!(schedule.on_overlap, super::types::OverlapPolicy::Skip) {
+            return false;
+        }
+        let Some(next) = self.next_run_at(schedule) else {
+            // Never run: due immediately.
+            return true;
+        };
+        now >= next
+    }
+
+    /// When this schedule next becomes due, or `None` if it has never run.
+    pub fn next_run_at(&self, schedule: &Schedule) -> Option<chrono::DateTime<chrono::Utc>> {
+        let last = self.last_run_at.as_ref()?;
+        let parsed = chrono::DateTime::parse_from_rfc3339(last).ok()?;
+        let interval =
+            chrono::Duration::try_seconds(schedule.every.seconds() as i64).unwrap_or_default();
+        let jitter = chrono::Duration::try_seconds(schedule.jitter_offset_seconds() as i64)
+            .unwrap_or_default();
+        Some(parsed.with_timezone(&chrono::Utc) + interval + jitter)
+    }
+}
+
+fn state_path(id: &str) -> Result<std::path::PathBuf> {
+    let segment = paths::sanitize_path_segment(id);
+    Ok(paths::homeboy_data()?
+        .join("schedules")
+        .join(segment)
+        .join("state.json"))
+}
+
+/// Read a schedule's runtime state, treating absent or unreadable state as
+/// "never run" rather than an error — a missing record must not stop a
+/// schedule from running for the first time.
+pub fn load_state(id: &str) -> ScheduleState {
+    let Ok(path) = state_path(id) else {
+        return ScheduleState::default();
+    };
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return ScheduleState::default();
+    };
+    serde_json::from_str(&raw).unwrap_or_default()
+}
+
+pub fn save_state(id: &str, state: &ScheduleState) -> Result<()> {
+    let path = state_path(id)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            crate::error::Error::internal_io(
+                format!("Failed to create schedule state directory: {error}"),
+                Some(parent.display().to_string()),
+            )
+        })?;
+    }
+    let body = serde_json::to_string_pretty(state).map_err(|error| {
+        crate::error::Error::internal_io(
+            format!("Failed to serialize schedule state: {error}"),
+            Some(path.display().to_string()),
+        )
+    })?;
+    std::fs::write(&path, body).map_err(|error| {
+        crate::error::Error::internal_io(
+            format!("Failed to write schedule state: {error}"),
+            Some(path.display().to_string()),
+        )
+    })
+}
+
+/// Drop a schedule's runtime state. Best effort: removing a schedule must not
+/// fail because its state was already gone.
+pub fn remove_state(id: &str) {
+    if let Ok(path) = state_path(id) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::types::{Cadence, NotifyPolicy, OverlapPolicy};
+
+    fn schedule() -> Schedule {
+        Schedule {
+            id: "nightly".to_string(),
+            command: vec!["triage".to_string()],
+            every: Cadence::from_seconds(3_600).expect("cadence"),
+            notify_on: NotifyPolicy::default(),
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_schedule_that_never_ran_is_due_immediately() {
+        assert!(ScheduleState::default().is_due(&schedule(), chrono::Utc::now()));
+    }
+
+    #[test]
+    fn a_schedule_is_not_due_until_its_interval_elapses() {
+        let now = chrono::Utc::now();
+        let state = ScheduleState {
+            last_run_at: Some((now - chrono::Duration::minutes(30)).to_rfc3339()),
+            ..Default::default()
+        };
+        assert!(!state.is_due(&schedule(), now), "30m into a 1h cadence");
+
+        let state = ScheduleState {
+            last_run_at: Some((now - chrono::Duration::minutes(61)).to_rfc3339()),
+            ..Default::default()
+        };
+        assert!(state.is_due(&schedule(), now), "61m into a 1h cadence");
+    }
+
+    #[test]
+    fn a_disabled_schedule_is_never_due() {
+        let disabled = Schedule {
+            enabled: false,
+            ..schedule()
+        };
+        assert!(!ScheduleState::default().is_due(&disabled, chrono::Utc::now()));
+    }
+
+    /// A slow run must not stack copies of itself.
+    #[test]
+    fn an_in_flight_run_blocks_the_next_one_under_skip() {
+        let state = ScheduleState {
+            running: true,
+            ..Default::default()
+        };
+        assert!(!state.is_due(&schedule(), chrono::Utc::now()));
+
+        let allow = Schedule {
+            on_overlap: OverlapPolicy::Allow,
+            ..schedule()
+        };
+        assert!(state.is_due(&allow, chrono::Utc::now()));
+    }
+
+    /// Cadence is measured from the previous start, so a run that takes longer
+    /// than usual does not push every later run out by its own duration.
+    #[test]
+    fn next_run_is_measured_from_the_last_start_plus_jitter() {
+        let base = chrono::Utc::now();
+        let state = ScheduleState {
+            last_run_at: Some(base.to_rfc3339()),
+            ..Default::default()
+        };
+        let jittered = Schedule {
+            jitter_seconds: Some(600),
+            ..schedule()
+        };
+        let expected = base
+            + chrono::Duration::seconds(3_600)
+            + chrono::Duration::seconds(jittered.jitter_offset_seconds() as i64);
+        assert_eq!(state.next_run_at(&jittered), Some(expected));
+    }
+
+    #[test]
+    fn unreadable_state_reads_as_never_run_rather_than_failing() {
+        crate::test_support::with_isolated_home(|_| {
+            let state = load_state("definitely-absent-schedule");
+            assert!(state.last_run_at.is_none());
+            assert!(!state.running);
+        });
+    }
+
+    #[test]
+    fn state_round_trips_through_disk() {
+        crate::test_support::with_isolated_home(|_| {
+            let state = ScheduleState {
+                last_run_at: Some("2026-07-26T00:00:00+00:00".to_string()),
+                last_status: Some("succeeded".to_string()),
+                last_exit_code: Some(0),
+                last_digest: Some("abc123".to_string()),
+                running: false,
+                started_at: None,
+                consecutive_failures: 0,
+            };
+            save_state("round-trip", &state).expect("save state");
+            let loaded = load_state("round-trip");
+            assert_eq!(loaded.last_status.as_deref(), Some("succeeded"));
+            assert_eq!(loaded.last_digest.as_deref(), Some("abc123"));
+
+            remove_state("round-trip");
+            assert!(load_state("round-trip").last_status.is_none());
+        });
+    }
+}

--- a/crates/homeboy-core/src/schedule/types.rs
+++ b/crates/homeboy-core/src/schedule/types.rs
@@ -1,0 +1,332 @@
+//! Schedule declarations: what to run, how often, and when to say something.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// How often a schedule is due.
+///
+/// Interval only, deliberately. Cron expressions would be the first cron
+/// parser in the tree; an interval covers "check this periodically", which is
+/// what every current caller wants, and can be extended later without
+/// changing the stored shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Cadence {
+    /// Seconds between runs.
+    seconds: u64,
+}
+
+impl Cadence {
+    pub fn from_seconds(seconds: u64) -> Result<Self> {
+        if seconds == 0 {
+            return Err(Error::validation_invalid_argument(
+                "every",
+                "A schedule interval must be greater than zero",
+                Some(seconds.to_string()),
+                None,
+            ));
+        }
+        Ok(Self { seconds })
+    }
+
+    pub fn seconds(&self) -> u64 {
+        self.seconds
+    }
+
+    /// Parse a compact duration such as `30m`, `24h`, `1h30m`, or `7d`.
+    ///
+    /// A bare number is rejected rather than assumed: `--every 30` is
+    /// ambiguous between seconds and minutes, and guessing would silently run
+    /// something 60x more often than intended.
+    pub fn parse(value: &str) -> Result<Self> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(Self::invalid(value, "an interval is required"));
+        }
+
+        let mut total: u64 = 0;
+        let mut digits = String::new();
+        let mut saw_unit = false;
+
+        for ch in trimmed.chars() {
+            if ch.is_ascii_digit() {
+                digits.push(ch);
+                continue;
+            }
+            let unit_seconds = match ch {
+                's' => 1,
+                'm' => 60,
+                'h' => 60 * 60,
+                'd' => 24 * 60 * 60,
+                _ => {
+                    return Err(Self::invalid(
+                        value,
+                        "use s, m, h, or d — for example 30m, 24h, or 1h30m",
+                    ))
+                }
+            };
+            if digits.is_empty() {
+                return Err(Self::invalid(value, "each unit needs a number before it"));
+            }
+            let amount: u64 = digits
+                .parse()
+                .map_err(|_| Self::invalid(value, "the number is too large"))?;
+            total = total
+                .checked_add(amount.saturating_mul(unit_seconds))
+                .ok_or_else(|| Self::invalid(value, "the interval is too large"))?;
+            digits.clear();
+            saw_unit = true;
+        }
+
+        if !digits.is_empty() || !saw_unit {
+            return Err(Self::invalid(
+                value,
+                "add a unit — s, m, h, or d — for example 30m rather than 30",
+            ));
+        }
+
+        Self::from_seconds(total)
+    }
+
+    fn invalid(value: &str, problem: &str) -> Error {
+        Error::validation_invalid_argument(
+            "every",
+            format!("Invalid interval '{value}': {problem}"),
+            Some(value.to_string()),
+            None,
+        )
+    }
+}
+
+impl std::fmt::Display for Cadence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut remaining = self.seconds;
+        let mut rendered = String::new();
+        for (unit, size) in [("d", 86_400u64), ("h", 3_600), ("m", 60), ("s", 1)] {
+            let count = remaining / size;
+            if count > 0 {
+                rendered.push_str(&format!("{count}{unit}"));
+                remaining -= count * size;
+            }
+        }
+        write!(f, "{rendered}")
+    }
+}
+
+/// When a completed run is worth interrupting a human for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotifyPolicy {
+    /// Notify only when the result differs from the previous run. The useful
+    /// default for fleet-shaped checks: silence while healthy, a ping when
+    /// something drifts.
+    #[default]
+    Change,
+    /// Notify only when the run fails.
+    Failure,
+    /// Notify on every run.
+    Always,
+}
+
+impl NotifyPolicy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Change => "change",
+            Self::Failure => "failure",
+            Self::Always => "always",
+        }
+    }
+}
+
+impl std::str::FromStr for NotifyPolicy {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "change" => Ok(Self::Change),
+            "failure" => Ok(Self::Failure),
+            "always" => Ok(Self::Always),
+            other => Err(Error::validation_invalid_argument(
+                "notify-on",
+                format!("Unknown notify policy '{other}'"),
+                Some(other.to_string()),
+                Some(vec!["Use change, failure, or always.".to_string()]),
+            )),
+        }
+    }
+}
+
+/// What to do when a schedule comes due while its previous run is still going.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OverlapPolicy {
+    /// Leave the in-flight run alone and try again next tick. Prevents a slow
+    /// check from stacking copies of itself.
+    #[default]
+    Skip,
+    /// Start the run regardless.
+    Allow,
+}
+
+impl OverlapPolicy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Skip => "skip",
+            Self::Allow => "allow",
+        }
+    }
+}
+
+/// A declared periodic run.
+///
+/// The declaration is stable, reviewable configuration. Everything that
+/// changes as it runs — last status, next due time, in-flight marker — lives
+/// in a separate runtime record so this file stays diffable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Schedule {
+    pub id: String,
+
+    /// Homeboy arguments to run, without the leading binary name.
+    /// For example `["fleet", "check", "prod"]`.
+    pub command: Vec<String>,
+
+    pub every: Cadence,
+
+    #[serde(default)]
+    pub notify_on: NotifyPolicy,
+
+    #[serde(default)]
+    pub on_overlap: OverlapPolicy,
+
+    /// Notification transport id, paired with `notification_route`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notification_transport: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notification_route: Option<String>,
+
+    /// Spread load when many schedules share a cadence. Each run is delayed by
+    /// a deterministic offset derived from the schedule id, up to this many
+    /// seconds, so a fleet does not stampede on the hour.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jitter_seconds: Option<u64>,
+
+    /// A disabled schedule is never due, but is kept so it can be re-enabled
+    /// without re-deriving its definition.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Schedule {
+    /// Deterministic per-schedule jitter offset, in seconds.
+    ///
+    /// Derived from the id so a given schedule always lands at the same offset
+    /// rather than walking across the window on every restart.
+    pub fn jitter_offset_seconds(&self) -> u64 {
+        let Some(window) = self.jitter_seconds.filter(|window| *window > 0) else {
+            return 0;
+        };
+        let mut hash: u64 = 1469598103934665603;
+        for byte in self.id.as_bytes() {
+            hash ^= *byte as u64;
+            hash = hash.wrapping_mul(1099511628211);
+        }
+        hash % window
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_compound_and_single_unit_intervals() {
+        assert_eq!(Cadence::parse("30m").expect("30m").seconds(), 1_800);
+        assert_eq!(Cadence::parse("24h").expect("24h").seconds(), 86_400);
+        assert_eq!(Cadence::parse("1h30m").expect("1h30m").seconds(), 5_400);
+        assert_eq!(Cadence::parse("7d").expect("7d").seconds(), 604_800);
+        assert_eq!(Cadence::parse(" 45s ").expect("45s").seconds(), 45);
+    }
+
+    /// A bare number is ambiguous between seconds and minutes. Guessing wrong
+    /// runs the command 60x more often than intended, so it is rejected.
+    #[test]
+    fn rejects_a_unitless_interval_rather_than_guessing() {
+        let error = Cadence::parse("30").expect_err("unitless must be rejected");
+        assert!(
+            error.to_string().contains("add a unit"),
+            "error should name the fix, got: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_zero_and_unknown_units() {
+        assert!(Cadence::parse("0s").is_err());
+        assert!(Cadence::parse("5w").is_err());
+        assert!(Cadence::parse("h").is_err());
+        assert!(Cadence::parse("").is_err());
+    }
+
+    #[test]
+    fn renders_intervals_in_the_form_it_accepts() {
+        let rendered = Cadence::from_seconds(5_400).expect("cadence").to_string();
+        assert_eq!(rendered, "1h30m");
+        assert_eq!(
+            Cadence::parse(&rendered).expect("round trip").seconds(),
+            5_400
+        );
+    }
+
+    #[test]
+    fn jitter_is_stable_per_id_and_bounded_by_the_window() {
+        let schedule = |id: &str| Schedule {
+            id: id.to_string(),
+            command: vec!["triage".to_string()],
+            every: Cadence::from_seconds(3_600).expect("cadence"),
+            notify_on: NotifyPolicy::default(),
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: Some(300),
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        };
+
+        let first = schedule("nightly-harvest").jitter_offset_seconds();
+        assert_eq!(first, schedule("nightly-harvest").jitter_offset_seconds());
+        assert!(first < 300);
+        assert_eq!(
+            0,
+            Schedule {
+                jitter_seconds: None,
+                ..schedule("no-jitter")
+            }
+            .jitter_offset_seconds()
+        );
+    }
+
+    #[test]
+    fn notify_policy_round_trips_through_its_string_form() {
+        for policy in [
+            NotifyPolicy::Change,
+            NotifyPolicy::Failure,
+            NotifyPolicy::Always,
+        ] {
+            let parsed: NotifyPolicy = policy.as_str().parse().expect("parse policy");
+            assert_eq!(parsed, policy);
+        }
+        assert!("hourly".parse::<NotifyPolicy>().is_err());
+    }
+}

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -35,6 +35,7 @@ pub enum ErrorCode {
     RunnerPolicyDenied,
     RunnerCapabilityMissing,
     BrokerAuthDenied,
+    ScheduleNotFound,
     ServiceTunnelNotFound,
     RigPipelineFailed,
     RigServiceFailed,
@@ -95,6 +96,7 @@ impl ErrorCode {
             ErrorCode::RunnerPolicyDenied => "runner.policy_denied",
             ErrorCode::RunnerCapabilityMissing => "runner.capability_missing",
             ErrorCode::BrokerAuthDenied => "broker.auth_denied",
+            ErrorCode::ScheduleNotFound => "schedule.not_found",
             ErrorCode::ServiceTunnelNotFound => "service_tunnel.not_found",
             ErrorCode::RigPipelineFailed => "rig.pipeline_failed",
             ErrorCode::RigServiceFailed => "rig.service_failed",
@@ -804,6 +806,10 @@ impl Error {
             error = error.with_hint(hint);
         }
         error
+    }
+
+    pub fn schedule_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {
+        Self::entity_not_found(ErrorCode::ScheduleNotFound, "Schedule", id, suggestions)
     }
 
     pub fn service_tunnel_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -32,6 +32,7 @@
 - [runtime](runtime.md) — narrow lookup for bundled core runtime helpers
 - [runs](runs.md) — persisted observation runs, artifacts, postprocessing, and findings
 - [server](server.md)
+- [schedule](schedule.md) — declare homeboy commands that run on a cadence
 - [self](self.md) — active binary, install-signal, runtime drift, host resource inspection, and embedded docs
 - [ssh](ssh.md)
 - [stack](stack.md) — combined-fixes branches from base refs plus cherry-picked PRs

--- a/docs/commands/schedule.md
+++ b/docs/commands/schedule.md
@@ -1,0 +1,84 @@
+# `homeboy schedule`
+
+```text
+homeboy schedule add <id> --command <argv> --every <interval> [--notify-on <policy>] [--on-overlap <policy>]
+                         [--notification-transport <id> --notification-route <route>]
+                         [--jitter-seconds <n>] [--description <text>] [--force]
+homeboy schedule list
+homeboy schedule show <id>
+homeboy schedule run <id>
+homeboy schedule enable|disable <id>
+homeboy schedule remove <id>
+homeboy schedule tick [--dry-run]
+```
+
+`schedule` declares homeboy commands that run on a cadence. Homeboy already owned durable jobs, typed notification transports, and a structured result envelope; what it lacked was a time trigger, so periodic work had to be bolted onto external cron or systemd timers that each re-solved notification wiring, overlap, and change detection ([issue #10073](https://github.com/Extra-Chill/homeboy/issues/10073)).
+
+A schedule is stored in two parts:
+
+- the **declaration** is reviewable configuration at `~/.config/homeboy/schedules/<id>.json`
+- the **runtime record** — last status, last result fingerprint, in-flight marker — lives separately under the data directory, so the declaration stays diffable
+
+## Cadence
+
+`--every` takes a compact interval: `45s`, `30m`, `24h`, `1h30m`, `7d`. A bare number is rejected rather than guessed, because `--every 30` is ambiguous between seconds and minutes and guessing wrong runs a command sixty times more often than intended.
+
+Cadence is measured from the previous run's **start**, so a slow run does not push every later run out by its own duration.
+
+## Reporting
+
+`--notify-on` decides when a completed run is worth interrupting a human for:
+
+| Policy | Notifies |
+|---|---|
+| `change` (default) | when the result differs from the previous run, **and** on every failure |
+| `failure` | only when the run fails |
+| `always` | every run |
+
+`change` is the default because the useful behavior for a periodic check is silence while healthy and a ping when something drifts — a notification should mean something needs attention.
+
+Change detection fingerprints the result envelope with volatile fields (timestamps, durations, run ids) removed. Without that, every run would look like a change and `change` would be indistinguishable from `always`.
+
+A repeated **identical failure** still notifies. An ongoing outage that goes quiet because it is "unchanged" is the worst available outcome.
+
+Notifications are delivered through the same installed transports as `--notification-transport` / `--notification-route`, stored on the schedule so a triggered run does not need them passed again.
+
+## Overlap and jitter
+
+`--on-overlap skip` (default) declines to start a run while the previous one is still in flight, so a slow check cannot stack copies of itself. `--on-overlap allow` starts it anyway.
+
+`--jitter-seconds` spreads runs across a window so that many schedules sharing a cadence do not all fire on the hour. The offset is derived from the schedule id, so a given schedule always lands at the same point in the window rather than walking across it on every restart.
+
+## Running
+
+`homeboy schedule run <id>` runs one schedule immediately, whether or not it is due. `homeboy schedule tick` runs everything currently due, and `--dry-run` reports what would run without running it.
+
+Both exit non-zero when a scheduled run fails, so an external trigger can react without parsing the payload.
+
+Scheduled commands execute as a subprocess of the homeboy binary and are read back through their `homeboy/command-result/v3` envelope. A scheduled command therefore cannot take its caller down with it.
+
+Scheduling the `schedule` command itself is refused.
+
+```sh
+homeboy schedule add nightly-harvest \
+  --command 'harvest production --check' \
+  --every 24h \
+  --notification-transport discord.run-completion \
+  --notification-route 'discord:v1:channel:123456789012345678'
+
+homeboy schedule add fleet-drift --command 'fleet check prod' --every 1h --jitter-seconds 300
+
+homeboy schedule list
+homeboy schedule tick --dry-run
+```
+
+## Triggering
+
+`schedule tick` is the trigger surface. Point any external timer at it:
+
+```sh
+# systemd timer, cron, or any supervisor
+homeboy schedule tick
+```
+
+Running the tick more often than the shortest cadence is safe — a schedule that is not due is skipped, and `--on-overlap skip` prevents pile-up.


### PR DESCRIPTION
## Summary

Homeboy has no scheduling primitive, so every operation that is naturally periodic gets bolted onto external cron or systemd timers, and each operator re-solves notification wiring, overlap prevention, and change detection themselves.

The hard parts already existed — durable jobs, typed notification transports, a structured result envelope. The missing piece was a time trigger. This adds it.

```sh
homeboy schedule add nightly-harvest \
  --command 'harvest production --check' \
  --every 24h \
  --notification-transport discord.run-completion \
  --notification-route 'discord:v1:channel:123456789012345678'

homeboy schedule list
homeboy schedule tick --dry-run
```

## Shape

A schedule is split in two on purpose:

- the **declaration** is reviewable configuration at `~/.config/homeboy/schedules/<id>.json`, stored through `ConfigEntity` / `entity_crud!` like every other declared entity
- the **runtime record** — last status, result fingerprint, in-flight marker, consecutive failures — lives separately under the data directory, mirroring how `ServiceTunnel` splits declaration from runtime state

That keeps the declaration diffable instead of churning on every run.

## Design decisions worth reviewing

**Notify on change is the default.** For a periodic fleet check the useful behavior is silence while healthy and a ping when something drifts — a notification should mean something needs a human. `failure` and `always` are available.

**Change detection strips volatile fields** (timestamps, durations, run ids) before fingerprinting the result envelope. Without that every run reads as a change and `change` collapses into `always`, which is exactly the noise this is meant to avoid.

**A repeated identical failure still notifies.** Staying silent on an ongoing outage because it is "unchanged" is the worst available outcome, so failure short-circuits the change check.

**Cadence is measured from the previous start, not completion**, so a slow run does not push every later run out by its own duration.

**A bare `--every 30` is rejected rather than guessed.** Seconds vs minutes is a 60x difference in how often a command runs; guessing is not worth the convenience.

**Overlap skips by default** so a slow check cannot stack copies of itself. **Jitter is deterministic per id**, so a schedule always lands at the same offset rather than walking across the window on every restart.

**Execution is a subprocess** of the homeboy binary, read back through its `homeboy/command-result/v3` envelope. Core cannot depend upward on `homeboy-cli`, and a subprocess additionally means a panicking or hanging scheduled command cannot take its caller down. A `ScheduleCommandRunner` trait is the seam if an in-process runner is registered later, in the style of `set_command_label_resolver`.

**Scheduling the `schedule` command itself is refused**, so a tick cannot mutate its own definitions or recurse.

**Half-configured notification is refused at declaration time** — a transport without a route silently never delivers, and finding that out at 3am is worse than failing the `add`.

## Scope

**Interval only.** There is no cron parser anywhere in this tree today; adding one would be the first, and an interval covers every current caller. The stored shape can gain a cron variant later without breaking existing declarations.

**`schedule tick` is the trigger surface for now.** It runs everything due and is safe to call more often than the shortest cadence. Driving it from the daemon is a deliberate follow-up: `daemon::serve` already runs two background threads with the exact shutdown-channel idiom this needs, so it is a small, separately reviewable addition rather than something to bury in this PR.

This means the feature is usable immediately with any external timer, and the follow-up removes the external dependency.

## Tests

25 assertions across the new modules, covering the reasoning above rather than just the happy path:

- cadence parsing, compound units, round-tripping through its own `Display`, and the deliberate rejection of unitless intervals
- due-ness: never-run, mid-interval, elapsed, disabled, and in-flight-under-skip
- next run measured from last start plus jitter
- notify policy matrix, including the repeated-failure case
- digest stability across volatile fields (top-level and nested) and sensitivity to a real change
- run bookkeeping: state cleared after a run, consecutive failure counting, change detection against the previous run
- validation: missing command, half-configured notification, scheduling the scheduler
- config round-trip through storage
- command splitting including quoted arguments and an explicitly empty argument

## Verification

- `cargo fmt`
- `cargo check -p homeboy-core --lib --tests` — clean
- `cargo check -p homeboy-cli --lib --tests` — clean
- `cargo clippy -p homeboy-core -p homeboy-cli --lib --tests` — no findings in the new code

Full `cargo build`/`cargo test` deliberately not run locally (this host OOMs on the Rust workspace); leaving the suite to CI.

## Motivating case

A managed WordPress install where an AI agent edits live files at the site owner's request. Three separate changes existed only on the remote and were each caught by a human running a manual diff; a fourth was a required API field added without updating the test suite. A daily `harvest --check` that pings on drift catches all of them. Today that needs a hand-rolled systemd timer plus a notification script, despite homeboy already having both a durable job runner and a working Discord transport.

Refs #10073

## AI assistance

Investigated and implemented by chubes-bot (OpenCode). Chris Huber remains responsible for review and every line.