### PR TITLE
fix(cook): attest Lab runner source snapshots

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -44,30 +44,49 @@ fn linked_cook_source(temp: &tempfile::TempDir) -> std::path::PathBuf {
     source
 }
 
+fn remapped_cook_source(temp: &tempfile::TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+    let controller = linked_cook_source(temp);
+    let runner = temp.path().join("runner-snapshot");
+    git(
+        &controller,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            runner.to_str().expect("runner path"),
+            "HEAD",
+        ],
+    );
+    (controller, runner)
+}
+
 #[test]
-fn isolated_cook_attempt_spawns_a_real_provider_against_its_own_attestation() {
+fn remapped_lab_cook_spawns_and_harvests_from_runner_snapshot_identity() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let source = linked_cook_source(&temp);
+    let (controller, source) = remapped_cook_source(&temp);
     let marker = temp.path().join("provider-started");
     let command = format!(
         "node {}",
         script(&format!(
-            "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); fs.writeFileSync({:?}, JSON.stringify({{cwd:process.cwd(),workspace:req.workspace.root,attestation:req.metadata.cook_attempt_workspace_identity}})); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'provider spawned'}}));",
+            "let cp=require('child_process'),fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); fs.writeFileSync('provider-change.txt','changed\\n'); cp.execFileSync('git',['add','provider-change.txt']); cp.execFileSync('git',['-c','user.name=Homeboy','-c','user.email=homeboy@example.test','commit','-m','provider change']); fs.writeFileSync({:?}, JSON.stringify({{cwd:process.cwd(),workspace:req.workspace.root,attestation:req.metadata.cook_attempt_workspace_identity}})); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'provider spawned'}}));",
             marker.display().to_string()
         ))
     );
     let (mut request, provider) = request("cook-provider", command);
     request.workspace.root = Some(source.display().to_string());
     request.metadata = serde_json::json!({
-        "cook_workspace_identity": crate::agent_task_workspace_identity::attest_workspace(&source)
+        "cook_workspace_identity": crate::agent_task_workspace_identity::attest_workspace(&controller)
             .expect("attest source"),
     });
+    let mut plan = AgentTaskPlan::new("remapped-lab-cook-provider", vec![request]);
+    crate::agent_task_service::bind_runner_snapshot_workspace_attestations(&mut plan)
+        .expect("bind runner snapshot");
 
     let aggregate =
         AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
             provider,
         ]))
-        .run(AgentTaskPlan::new("isolated-cook-provider", vec![request]));
+        .run(plan);
 
     assert_eq!(aggregate.totals.succeeded, 1, "{aggregate:?}");
     let provider_observation: serde_json::Value =
@@ -86,6 +105,59 @@ fn isolated_cook_attempt_spawns_a_real_provider_against_its_own_attestation() {
     assert_eq!(
         provider_observation["attestation"]["canonical_path"], provider_cwd,
         "the spawned provider must receive the attestation for its isolated cwd"
+    );
+    let patch = aggregate.outcomes[0]
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.kind == "patch")
+        .expect("committed change harvest patch");
+    assert!(
+        std::fs::read_to_string(patch.path.as_deref().expect("patch path"))
+            .expect("read patch")
+            .contains("provider-change.txt")
+    );
+}
+
+#[test]
+fn remapped_lab_cook_rejects_runner_snapshot_drift_before_provider_spawn() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (controller, runner) = remapped_cook_source(&temp);
+    let marker = temp.path().join("provider-started");
+    let (mut request, provider) = request(
+        "cook-provider",
+        format!(
+            "node {}",
+            script(&format!(
+                "let fs=require('fs'); fs.writeFileSync({:?}, 'started'); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:'cook-provider',status:'succeeded'}}));",
+                marker.display().to_string()
+            ))
+        ),
+    );
+    request.workspace.root = Some(runner.display().to_string());
+    request.metadata = serde_json::json!({
+        "cook_workspace_identity": crate::agent_task_workspace_identity::attest_workspace(&controller)
+            .expect("attest controller source"),
+    });
+    let mut plan = AgentTaskPlan::new("runner-drift-cook", vec![request]);
+    crate::agent_task_service::bind_runner_snapshot_workspace_attestations(&mut plan)
+        .expect("bind runner snapshot");
+    std::fs::write(runner.join(".git"), "gitdir: ../replaced-gitdir\n")
+        .expect("replace runner gitdir reference");
+
+    let aggregate =
+        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+            provider,
+        ]))
+        .run(plan);
+
+    assert_eq!(aggregate.totals.failed, 1);
+    assert_eq!(
+        aggregate.outcomes[0].diagnostics[0].class,
+        "agent_task.committed_harvest_git_failed"
+    );
+    assert!(
+        !marker.exists(),
+        "provider must not start after runner drift"
     );
 }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -75,7 +75,7 @@ impl HarvestExecutionContext {
         }
     }
 
-    fn snapshot_signaled(&self) -> bool {
+    pub fn snapshot_signaled(&self) -> bool {
         self.source_snapshot.is_some() || self.lab_offload.is_some()
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -96,7 +96,6 @@ where
             )?;
             return Err(error);
         }
-        agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
         let harvest_context = match supplied_harvest_context.clone().map(Ok).unwrap_or_else(
             crate::agent_task_scheduler::HarvestExecutionContext::from_current_process,
         ) {
@@ -111,6 +110,10 @@ where
                 return Err(error);
             }
         };
+        if harvest_context.snapshot_signaled() {
+            bind_runner_snapshot_workspace_attestations(&mut plan)?;
+        }
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
         agent_task_lifecycle::mark_running(run_id)?;
         let aggregate = run_plan_with_scheduler(
             plan.clone(),
@@ -130,6 +133,9 @@ where
 
     let harvest_context = supplied_harvest_context
         .unwrap_or(crate::agent_task_scheduler::HarvestExecutionContext::from_current_process()?);
+    if harvest_context.snapshot_signaled() {
+        bind_runner_snapshot_workspace_attestations(&mut plan)?;
+    }
     let aggregate = run_plan_with_scheduler(
         plan.clone(),
         record_run_id,
@@ -141,6 +147,31 @@ where
         exit_code: aggregate_exit_code(&aggregate),
         value: crate::agent_task_artifacts::reviewer_facing_aggregate(&aggregate),
     })
+}
+
+/// A Lab plan carries its controller admission identity until its paths are
+/// materialized on the runner. Bind that concrete runner snapshot before the
+/// plan is persisted or executed; the predecessor remains audit provenance.
+pub fn bind_runner_snapshot_workspace_attestations(plan: &mut AgentTaskPlan) -> Result<()> {
+    for task in &mut plan.tasks {
+        let Some(controller_identity) = task.metadata.get("cook_workspace_identity").cloned()
+        else {
+            continue;
+        };
+        let root = task.workspace.root.as_deref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "workspace",
+                "Cook runner snapshot identity requires a workspace root",
+                Some(task.task_id.clone()),
+                None,
+            )
+        })?;
+        let runner_identity =
+            crate::agent_task_workspace_identity::attest_workspace(std::path::Path::new(root))?;
+        task.metadata["cook_workspace_identity"] = runner_identity;
+        task.metadata["cook_workspace_identity_predecessor"] = controller_identity;
+    }
+    Ok(())
 }
 
 pub fn submit_plan_spec(spec: &str, run_id: Option<&str>) -> Result<AgentTaskRunRecord> {

--- a/crates/homeboy-agents/src/agent_task_workspace_identity.rs
+++ b/crates/homeboy-agents/src/agent_task_workspace_identity.rs
@@ -59,7 +59,7 @@ pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
 }
 
 #[cfg(unix)]
-pub(crate) fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
+pub fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
     use std::os::unix::fs::MetadataExt;
 
     let Ok(supplied_metadata) = std::fs::symlink_metadata(path) else {
@@ -104,7 +104,7 @@ fn linked_git_metadata_matches(worktree: &Path, attestation: &Value) -> bool {
 }
 
 #[cfg(not(unix))]
-pub(crate) fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
+pub fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
     std::fs::canonicalize(path)
         .ok()
         .and_then(|path| path.to_str().map(str::to_string))

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -39,7 +39,7 @@ pub mod agent_task_secrets;
 pub mod agent_task_service;
 pub mod agent_task_timeout;
 pub mod agent_task_timeout_artifacts;
-pub(crate) mod agent_task_workspace_identity;
+pub mod agent_task_workspace_identity;
 pub mod agent_tasks;
 pub mod agent_tool_control_plane;
 pub mod api_jobs_terminal_recovery;

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1,6 +1,7 @@
 //! Workspace sync / remap staging for the standard (non-resident) offload path.
 
 use super::*;
+use crate::lab_args::verify_cook_workspace_attestations_in_args;
 use crate::lab_workspaces::workspace_mapping_entry_for_materialized_file;
 use crate::offload_changed_since::{
     degrade_changed_since_to_full_scope, remove_controller_changed_since_args,
@@ -233,6 +234,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         request.allow_dirty_lab_workspace,
     )?;
     let mut offload_args = materialization_planner.args;
+    verify_cook_workspace_attestations_in_args(&offload_args, source_path)?;
     let extra_workspaces = materialization_planner.extra_workspaces;
     // Isolate the primary workspace per cook/dispatch run. Without a per-run
     // token the git-mode remote path is keyed only on (source path, HEAD), so a

--- a/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
@@ -58,6 +58,66 @@ pub(crate) fn materialize_agent_task_specs_in_args<T>(
     })
 }
 
+/// Verify controller-authored Cook workspace attestations before the primary
+/// workspace is snapshotted for Lab. The runner cannot re-check this local
+/// identity after path materialization, so rejecting drift here is mandatory.
+pub(crate) fn verify_cook_workspace_attestations_in_args(
+    args: &[String],
+    source_path: &Path,
+) -> Result<()> {
+    let mut specs = Vec::new();
+    let mut iter = args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        for flag in ["--plan", "--attempt-plan"] {
+            if arg == flag {
+                if let Some(spec) = iter.next() {
+                    specs.push(spec.as_str());
+                }
+                break;
+            }
+            if let Some(spec) = arg.strip_prefix(&format!("{flag}=")) {
+                specs.push(spec);
+                break;
+            }
+        }
+    }
+    for spec in specs {
+        let raw = read_agent_task_plan_spec_to_string(spec, source_path)?;
+        let plan: homeboy_agents::agent_task_scheduler::AgentTaskPlan = serde_json::from_str(&raw)
+            .map_err(|error| {
+                Error::validation_invalid_json(error, Some(format!("parse Cook plan {spec}")), None)
+            })?;
+        for task in plan.tasks {
+            let Some(attestation) = task.metadata.get("cook_workspace_identity") else {
+                continue;
+            };
+            let root = task.workspace.root.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace",
+                    "Cook source identity attestation requires a workspace root",
+                    Some(task.task_id.clone()),
+                    None,
+                )
+            })?;
+            if !homeboy_agents::agent_task_workspace_identity::workspace_matches_attestation(
+                Path::new(root),
+                attestation,
+            ) {
+                return Err(Error::validation_invalid_argument(
+                    "workspace",
+                    "Cook source workspace no longer matches its admission identity attestation before Lab snapshotting",
+                    Some(root.to_string()),
+                    Some(vec![
+                        "Restore the admitted worktree or start a new Cook so Lab can snapshot the verified source."
+                            .to_string(),
+                    ]),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn remap_agent_task_fanout_input_in_args(
     args: &[String],
     mappings: &[LabPathRemap],

--- a/crates/homeboy-lab-runner/src/lab_args/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/mod.rs
@@ -27,12 +27,14 @@ mod workspace_contract_tests;
 /// Lab offload rewriting can distinguish it from synthesized passthrough args.
 pub(super) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
 
-pub(super) use agent_task_specs::materialize_agent_task_specs_in_args;
 #[cfg(test)]
 pub(super) use agent_task_specs::materialize_inline_agent_task_json_specs_in_args;
 #[cfg(test)]
 pub(super) use agent_task_specs::{
     inline_agent_task_prompt_files_in_args, remap_agent_task_plan_in_args,
+};
+pub(super) use agent_task_specs::{
+    materialize_agent_task_specs_in_args, verify_cook_workspace_attestations_in_args,
 };
 pub(super) use at_files::{lab_at_file_specs, remap_lab_at_file_args, LabAtFileSpec};
 pub(super) use offload::{


### PR DESCRIPTION
## Summary
- verifies each Cook plan's controller workspace attestation immediately before Lab snapshotting
- replaces the controller attestation with an attestation of the materialized runner snapshot before detached `run-plan` persistence/execution, retaining the controller identity as predecessor provenance
- continues using the bound runner identity for committed-change harvest and provider preflight

## Reproduction
Reproduced #10127 against the reported current-main lineage: a clean DMC worktree remapped from controller to Lab failed committed-change harvest before provider spawn because its runner path/inode/gitdir was compared to the controller admission attestation.

## Behavior
- Controller-side source drift now fails before Lab snapshots.
- A clean remapped runner snapshot receives its own attestation and can spawn a provider and harvest its committed patch.
- Runner snapshot git metadata drift fails closed before provider spawn.
- The existing isolated-provider attempt attestation from #10085 remains unchanged.

## Evidence
- Source relationship: controller admission workspace -> Lab materialized runner snapshot -> isolated provider attempt workspace.
- Change kind: bounded Cook/Lab identity handoff correction; no provider, repository, or path-specific exception.
- Verification capability: deterministic linked-worktree tests execute a real provider, commit a change, and assert harvested patch contents; drift tests assert zero provider starts.
- Runtime scope: rebinding occurs only when paired Lab snapshot transport is signaled and only for plans already carrying a Cook attestation.

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-agents remapped_lab_cook --lib -- --test-threads=1`
- `cargo check -p homeboy-agents -p homeboy-lab-runner`

The broader scheduler test module was also run and has unrelated environment-sensitive failures; the focused new tests pass serially.

## AI Assistance
Implemented with OpenAI GPT-5.6 Terra (OpenCode): issue/recent-fix inspection, code changes, tests, and this PR description were AI-assisted with human-directed task requirements.