### PR TITLE
fix: preserve nested command identity in failures

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -331,6 +331,7 @@ impl CliRuntime {
 
     fn run_matches(&self, matches: ArgMatches, normalized: Vec<String>) -> std::process::ExitCode {
         let global = GlobalArgs {};
+        let command_identity = command_identity_from_matches(&matches);
 
         // Extract --output early so it's available for all code paths (including
         // extension CLI commands which exit before Cli::from_arg_matches).
@@ -349,7 +350,7 @@ impl CliRuntime {
 
         if let Some(extension_cmd) = self.try_parse_extension_cli_command(&matches) {
             if let Some(path) = output_file.as_deref() {
-                if let Some(exit) = output_file_path_exit_code(path) {
+                if let Some(exit) = output_file_path_exit_code(path, &command_identity) {
                     return exit;
                 }
             }
@@ -362,7 +363,12 @@ impl CliRuntime {
             let result = cli::run(cli_args, &global);
 
             let (json_result, exit_code) = output::map_cmd_result_to_json(result);
-            output_runtime::emit_json_result(json_result, output_file.as_deref(), exit_code);
+            output_runtime::emit_json_result_for_identity(
+                json_result,
+                output_file.as_deref(),
+                exit_code,
+                &command_identity,
+            );
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
 
@@ -376,7 +382,12 @@ impl CliRuntime {
         ) {
             Ok(route) => route,
             Err(err) => {
-                output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                output_runtime::emit_json_result_for_identity(
+                    Err(err),
+                    output_file.as_deref(),
+                    2,
+                    &command_identity,
+                );
                 return std::process::ExitCode::from(2);
             }
         };
@@ -387,7 +398,12 @@ impl CliRuntime {
             match args.absorb_planning_runner(cli.runner.take()) {
                 Ok(runner) => cli.runner = runner,
                 Err(err) => {
-                    output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                    output_runtime::emit_json_result_for_identity(
+                        Err(err),
+                        output_file.as_deref(),
+                        2,
+                        &command_identity,
+                    );
                     return std::process::ExitCode::from(2);
                 }
             }
@@ -401,7 +417,7 @@ impl CliRuntime {
             // This command owns `--output/-o`; it is not the global JSON envelope.
             output_file = None;
         } else if let Some(path) = output_file.as_deref() {
-            if let Some(exit) = output_file_path_exit_code(path) {
+            if let Some(exit) = output_file_path_exit_code(path, &command_identity) {
                 return exit;
             }
         }
@@ -409,7 +425,12 @@ impl CliRuntime {
         if let Commands::AgentTask(agent_task) = &cli.command {
             if let crate::commands::agent_task::AgentTaskCommand::Cook(cook) = &agent_task.command {
                 if let Err(err) = crate::commands::agent_task::run::validate_cook_request(cook) {
-                    output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                    output_runtime::emit_json_result_for_identity(
+                        Err(err),
+                        output_file.as_deref(),
+                        2,
+                        &command_identity,
+                    );
                     return std::process::ExitCode::from(2);
                 }
             }
@@ -419,7 +440,12 @@ impl CliRuntime {
             Ok(Some(exit_code)) => return std::process::ExitCode::from(exit_code_to_u8(exit_code)),
             Ok(None) => {}
             Err(err) => {
-                output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                output_runtime::emit_json_result_for_identity(
+                    Err(err),
+                    output_file.as_deref(),
+                    2,
+                    &command_identity,
+                );
                 return std::process::ExitCode::from(2);
             }
         }
@@ -428,7 +454,12 @@ impl CliRuntime {
             Ok(Some(exit_code)) => return std::process::ExitCode::from(exit_code_to_u8(exit_code)),
             Ok(None) => {}
             Err(err) => {
-                output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                output_runtime::emit_json_result_for_identity(
+                    Err(err),
+                    output_file.as_deref(),
+                    2,
+                    &command_identity,
+                );
                 return std::process::ExitCode::from(2);
             }
         }
@@ -437,7 +468,9 @@ impl CliRuntime {
         // and persisted evidence reuse this preflight decision rather than
         // probing the host a second time.
         let managed_runner_placement = resource_policy::is_managed_runner_placement_context();
-        if let Some(exit_code) = preflight_hot_command(&cli, output_file.as_deref()) {
+        if let Some(exit_code) =
+            preflight_hot_command(&cli, output_file.as_deref(), &command_identity)
+        {
             if managed_runner_placement {
                 resource_policy::clear_managed_runner_placement_context();
             }
@@ -459,7 +492,12 @@ impl CliRuntime {
                 return std::process::ExitCode::from(exit_code_to_u8(exit_code));
             }
             Err(err) => {
-                output_runtime::emit_json_result(Err(err), output_file.as_deref(), 2);
+                output_runtime::emit_json_result_for_identity(
+                    Err(err),
+                    output_file.as_deref(),
+                    2,
+                    &command_identity,
+                );
                 return std::process::ExitCode::from(exit_code_to_u8(2));
             }
         }
@@ -482,6 +520,7 @@ impl CliRuntime {
                 command_spec,
                 &global,
                 output_file.as_deref(),
+                &command_identity,
             )
         });
         std::process::ExitCode::from(exit_code_to_u8(exit_code))
@@ -916,7 +955,11 @@ fn is_builtin_subcommand(name: &str) -> bool {
     crate::command_contract::registered_command(name).is_some()
 }
 
-fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
+fn preflight_hot_command(
+    cli: &Cli,
+    output_file: Option<&str>,
+    command_identity: &output::CommandIdentity,
+) -> Option<i32> {
     if let Some(hot_command) = resource_policy::hot_command(&cli.command) {
         if let Ok((resources, _)) = crate::commands::resources::run_preflight() {
             let lab_readiness = if hot_command.lab_offload_supported {
@@ -1000,7 +1043,12 @@ fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
                     ),
                     runner_admits_offload,
                 ) {
-                    output_runtime::emit_json_result(Err(err), output_file, 2);
+                    output_runtime::emit_json_result_for_identity(
+                        Err(err),
+                        output_file,
+                        2,
+                        command_identity,
+                    );
                     return Some(2);
                 }
             }
@@ -1031,12 +1079,34 @@ fn run_startup_update_checks(command: &Commands) {
 /// Validate the JSON-envelope output-file path. When the path is invalid,
 /// emit the error envelope and return the process `ExitCode` the caller
 /// should return; otherwise return `None` to continue.
-fn output_file_path_exit_code(path: &str) -> Option<std::process::ExitCode> {
+fn output_file_path_exit_code(
+    path: &str,
+    command_identity: &output::CommandIdentity,
+) -> Option<std::process::ExitCode> {
     if let Some(err) = output_runtime::validate_output_file_path(path) {
-        output_runtime::emit_json_result(Err(err), None, 2);
+        output_runtime::emit_json_result_for_identity(Err(err), None, 2, command_identity);
         return Some(std::process::ExitCode::from(exit_code_to_u8(2)));
     }
     None
+}
+
+fn command_identity_from_matches(matches: &ArgMatches) -> output::CommandIdentity {
+    let mut current = matches;
+    let mut path = Vec::new();
+    while let Some((name, subcommand)) = current.subcommand() {
+        path.push(name.to_string());
+        current = subcommand;
+    }
+
+    let Some(command) = path.first() else {
+        return output::CommandIdentity::top_level("unknown");
+    };
+    let operation = path[1..].join(" ");
+    if operation.is_empty() {
+        output::CommandIdentity::top_level(command)
+    } else {
+        output::CommandIdentity::with_operation(command, operation)
+    }
 }
 
 fn exit_code_to_u8(code: i32) -> u8 {
@@ -1311,6 +1381,25 @@ mod tests {
     use super::*;
     use clap::Parser;
     use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    #[test]
+    fn command_identity_uses_the_resolved_top_level_and_nested_path() {
+        let matches = Cli::command_with_scoped_lab_args()
+            .try_get_matches_from(["homeboy", "agent-task", "cook", "--to-worktree", "fixture"])
+            .expect("parse nested command");
+        assert_eq!(
+            command_identity_from_matches(&matches),
+            output::CommandIdentity::with_operation("agent-task", "cook")
+        );
+
+        let matches = Cli::command_with_scoped_lab_args()
+            .try_get_matches_from(["homeboy", "runner", "status", "local"])
+            .expect("parse another nested command");
+        assert_eq!(
+            command_identity_from_matches(&matches),
+            output::CommandIdentity::with_operation("runner", "status")
+        );
+    }
 
     struct EnvGuard {
         name: &'static str,

--- a/crates/homeboy-cli/src/commands/infra/output_runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/output_runtime.rs
@@ -7,7 +7,7 @@ use std::sync::{Mutex, OnceLock};
 use crate::cli_surface::Commands;
 use crate::command_contract::CommandOutputFileMode;
 
-use crate::commands::utils::response as output;
+use crate::commands::utils::response::{self as output, CommandIdentity};
 use crate::commands::{review, trace, GlobalArgs};
 
 #[derive(Debug)]
@@ -56,13 +56,13 @@ impl CookOutputLease {
         &self,
         result: &homeboy::core::Result<Value>,
         exit_code: i32,
-        command: &str,
+        identity: &CommandIdentity,
         presentation: Option<output::CommandPresentationEnvelope>,
     ) -> homeboy::core::Result<()> {
-        let response = output::cli_response_for_json_result_for_command(
+        let response = output::cli_response_for_json_result_for_identity(
             result,
             exit_code,
-            command,
+            identity,
             presentation,
         );
         let contents = serde_json::to_string_pretty(&response).map_err(|error| {
@@ -280,6 +280,7 @@ fn output_io_error(path: &Path, error: std::io::Error) -> homeboy::core::Error {
 
 pub struct CommandRun {
     pub command: String,
+    pub operation: Option<String>,
     pub stdout_result: homeboy::core::Result<Value>,
     pub exit_code: i32,
     pub output_file_result: Option<homeboy::core::Result<Value>>,
@@ -306,6 +307,7 @@ impl CommandRun {
     ) -> Self {
         Self {
             command: command.into(),
+            operation: None,
             stdout_result,
             exit_code,
             output_file_result: None,
@@ -322,6 +324,12 @@ impl CommandRun {
 
     pub fn with_command(mut self, command: impl Into<String>) -> Self {
         self.command = command.into();
+        self
+    }
+
+    pub fn with_identity(mut self, identity: &CommandIdentity) -> Self {
+        self.command = identity.command.clone();
+        self.operation = identity.operation.clone();
         self
     }
 
@@ -346,6 +354,7 @@ impl CommandRun {
 
         Self {
             command: command.into(),
+            operation: None,
             stdout_result,
             exit_code,
             output_file_result,
@@ -379,8 +388,21 @@ impl<'a> OutputService<'a> {
     }
 
     pub fn emit_json_result(&self, result: homeboy::core::Result<Value>, exit_code: i32) {
+        self.emit_json_result_for_identity(
+            result,
+            exit_code,
+            &CommandIdentity::top_level("unknown"),
+        );
+    }
+
+    pub fn emit_json_result_for_identity(
+        &self,
+        result: homeboy::core::Result<Value>,
+        exit_code: i32,
+        identity: &CommandIdentity,
+    ) {
         self.emit_run(
-            CommandRun::from_stdout_result(result, exit_code),
+            CommandRun::from_stdout_result(result, exit_code).with_identity(identity),
             CommandOutputFileMode::GenericEnvelope,
         );
     }
@@ -391,10 +413,13 @@ impl<'a> OutputService<'a> {
             match raw_stdout {
                 Ok(content) => print!("{}", content),
                 Err(err) => {
-                    output::print_json_result_for_command(
+                    output::print_json_result_for_identity(
                         Err(err),
                         run.exit_code,
-                        &run.command,
+                        &CommandIdentity {
+                            command: run.command.clone(),
+                            operation: run.operation.clone(),
+                        },
                         None,
                     )
                     .ok();
@@ -407,10 +432,13 @@ impl<'a> OutputService<'a> {
         if let Some(stderr) = &run.presentation.stderr {
             eprint!("{}", stderr);
         }
-        output::print_json_result_for_command(
+        output::print_json_result_for_identity(
             run.stdout_result,
             run.exit_code,
-            &run.command,
+            &CommandIdentity {
+                command: run.command.clone(),
+                operation: run.operation.clone(),
+            },
             presentation_envelope(run.presentation),
         )
         .ok();
@@ -430,6 +458,7 @@ pub fn run_command(
     spec: &'static crate::command_contract::CommandSpec,
     global: &GlobalArgs,
     requested_output_file: Option<&str>,
+    identity: &CommandIdentity,
 ) -> i32 {
     let output_file = command_runtime_output_file(&command, requested_output_file);
     let plan = command.response_plan(spec, output_file.is_some());
@@ -439,13 +468,14 @@ pub fn run_command(
         crate::commands::raw_output::CommandRunPreparation::Handled(exit_code) => return exit_code,
         crate::commands::raw_output::CommandRunPreparation::Json(command) => {
             return output_service.emit_run(
-                run_json(*command, spec, global, plan.output_file, output_file),
+                run_json(*command, spec, global, plan.output_file, output_file)
+                    .with_identity(identity),
                 plan.output_file,
             );
         }
         crate::commands::raw_output::CommandRunPreparation::Raw(run) => run,
     };
-    output_service.emit_run(run, plan.output_file)
+    output_service.emit_run(run.with_identity(identity), plan.output_file)
 }
 
 pub fn emit_json_result(
@@ -454,6 +484,15 @@ pub fn emit_json_result(
     exit_code: i32,
 ) {
     OutputService::new(output_file).emit_json_result(result, exit_code);
+}
+
+pub fn emit_json_result_for_identity(
+    result: homeboy::core::Result<Value>,
+    output_file: Option<&str>,
+    exit_code: i32,
+    identity: &CommandIdentity,
+) {
+    OutputService::new(output_file).emit_json_result_for_identity(result, exit_code, identity);
 }
 
 pub fn validate_output_file_path(path: &str) -> Option<homeboy::core::Error> {
@@ -506,6 +545,7 @@ pub fn run_json(
 
             CommandRun {
                 command: "trace".to_string(),
+                operation: None,
                 stdout_result,
                 exit_code,
                 output_file_result,
@@ -534,11 +574,14 @@ pub fn write_output_file(run: &CommandRun, mode: CommandOutputFileMode, path: Op
         }
         CommandOutputFileMode::TraceJsonSummaryArtifact
         | CommandOutputFileMode::GenericEnvelope => {
-            output::write_json_to_file_for_command(
+            output::write_json_to_file_for_identity(
                 run.output_file_result(mode),
                 path,
                 run.exit_code,
-                &run.command,
+                &CommandIdentity {
+                    command: run.command.clone(),
+                    operation: run.operation.clone(),
+                },
                 presentation_envelope(run.presentation.clone()),
             );
         }
@@ -568,6 +611,7 @@ mod tests {
     ) -> CommandRun {
         CommandRun {
             command: "test".to_string(),
+            operation: None,
             stdout_result: Ok(json!({ "kind": "stdout" })),
             exit_code: 0,
             output_file_result,
@@ -761,7 +805,7 @@ mod tests {
             .finish(
                 &Ok(json!({ "status": "green_no_finalize", "latest_run_id": "run-current" })),
                 0,
-                "agent-task",
+                &CommandIdentity::with_operation("agent-task", "cook"),
                 None,
             )
             .expect("write terminal envelope");

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -56,7 +56,15 @@ pub fn run_command_output(
                     let (result, exit_code) = map(
                         crate::commands::agent_task::run_with_cook_progress(args, Some(&progress)),
                     );
-                    if let Err(error) = lease.finish(&result, exit_code, "agent-task", None) {
+                    if let Err(error) = lease.finish(
+                        &result,
+                        exit_code,
+                        &crate::commands::utils::response::CommandIdentity::with_operation(
+                            "agent-task",
+                            "cook",
+                        ),
+                        None,
+                    ) {
                         return CommandRun::from_stdout_result(Err(error), 2)
                             .with_command(spec.name);
                     }

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -16,6 +16,8 @@ pub const ACTIONABLE_METADATA_KEY: &str = "_homeboy_actionable";
 pub struct CommandResultEnvelope<T: Serialize> {
     pub schema: &'static str,
     pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
     pub success: bool,
     pub exit_code: i32,
     pub status: String,
@@ -37,6 +39,31 @@ pub struct CommandResultEnvelope<T: Serialize> {
     pub data: Option<T>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub presentation: Option<CommandPresentationEnvelope>,
+}
+
+/// The resolved CLI identity carried by command-result envelopes. `command` is
+/// always the top-level command; nested subcommands are represented by the
+/// optional operation without changing the v3 envelope's existing fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandIdentity {
+    pub command: String,
+    pub operation: Option<String>,
+}
+
+impl CommandIdentity {
+    pub fn top_level(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            operation: None,
+        }
+    }
+
+    pub fn with_operation(command: impl Into<String>, operation: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            operation: Some(operation.into()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -264,6 +291,7 @@ impl<T: Serialize> CommandResultEnvelope<T> {
         Self {
             schema: COMMAND_RESULT_SCHEMA,
             command: command.to_string(),
+            operation: None,
             success: true,
             exit_code: 0,
             status: "succeeded".to_string(),
@@ -287,10 +315,11 @@ impl<T: Serialize> CommandResultEnvelope<T> {
 }
 
 impl CommandResultEnvelope<()> {
-    fn from_error(command: &str, err: &Error, exit_code: i32) -> Self {
+    fn from_error(identity: &CommandIdentity, err: &Error, exit_code: i32) -> Self {
         Self {
             schema: COMMAND_RESULT_SCHEMA,
-            command: command.to_string(),
+            command: identity.command.clone(),
+            operation: identity.operation.clone(),
             success: false,
             exit_code,
             status: status_for_result(None, exit_code),
@@ -344,7 +373,7 @@ pub fn print_result<T: Serialize>(result: Result<T>) -> Result<()> {
     match result {
         Ok(data) => print_success(data),
         Err(err) => print_response(&CommandResultEnvelope::<()>::from_error(
-            "unknown",
+            &CommandIdentity::top_level("unknown"),
             &err,
             exit_code_for_error(err.code),
         )),
@@ -444,10 +473,24 @@ pub fn print_json_result_for_command(
     command: &str,
     presentation: Option<CommandPresentationEnvelope>,
 ) -> Result<()> {
-    print_response(&cli_response_for_json_result_for_command(
+    print_json_result_for_identity(
+        result,
+        exit_code,
+        &CommandIdentity::top_level(command),
+        presentation,
+    )
+}
+
+pub fn print_json_result_for_identity(
+    result: Result<Value>,
+    exit_code: i32,
+    identity: &CommandIdentity,
+    presentation: Option<CommandPresentationEnvelope>,
+) -> Result<()> {
+    print_response(&cli_response_for_json_result_for_identity(
         &result,
         exit_code,
-        command,
+        identity,
         presentation,
     ))
 }
@@ -465,9 +508,23 @@ pub fn cli_response_for_json_result_for_command(
     command: &str,
     presentation: Option<CommandPresentationEnvelope>,
 ) -> CommandResultEnvelope<serde_json::Value> {
+    cli_response_for_json_result_for_identity(
+        result,
+        exit_code,
+        &CommandIdentity::top_level(command),
+        presentation,
+    )
+}
+
+pub fn cli_response_for_json_result_for_identity(
+    result: &Result<serde_json::Value>,
+    exit_code: i32,
+    identity: &CommandIdentity,
+    presentation: Option<CommandPresentationEnvelope>,
+) -> CommandResultEnvelope<serde_json::Value> {
     match result {
-        Ok(data) => envelope_for_data(command, data.clone(), exit_code, presentation),
-        Err(err) => CommandResultEnvelope::<()>::from_error(command, err, exit_code).into_value(),
+        Ok(data) => envelope_for_data(identity, data.clone(), exit_code, presentation),
+        Err(err) => CommandResultEnvelope::<()>::from_error(identity, err, exit_code).into_value(),
     }
 }
 
@@ -476,6 +533,7 @@ impl CommandResultEnvelope<()> {
         CommandResultEnvelope {
             schema: self.schema,
             command: self.command,
+            operation: self.operation,
             success: self.success,
             exit_code: self.exit_code,
             status: self.status,
@@ -493,7 +551,7 @@ impl CommandResultEnvelope<()> {
 }
 
 fn envelope_for_data(
-    command: &str,
+    identity: &CommandIdentity,
     mut data: Value,
     exit_code: i32,
     presentation: Option<CommandPresentationEnvelope>,
@@ -537,7 +595,8 @@ fn envelope_for_data(
 
     CommandResultEnvelope {
         schema: COMMAND_RESULT_SCHEMA,
-        command: command.to_string(),
+        command: identity.command.clone(),
+        operation: identity.operation.clone(),
         success,
         exit_code,
         status: status_for_result(Some(&data), exit_code),
@@ -971,8 +1030,24 @@ pub fn write_json_to_file_for_command(
     command: &str,
     presentation: Option<CommandPresentationEnvelope>,
 ) {
+    write_json_to_file_for_identity(
+        result,
+        path,
+        exit_code,
+        &CommandIdentity::top_level(command),
+        presentation,
+    );
+}
+
+pub fn write_json_to_file_for_identity(
+    result: &Result<serde_json::Value>,
+    path: &str,
+    exit_code: i32,
+    identity: &CommandIdentity,
+    presentation: Option<CommandPresentationEnvelope>,
+) {
     let response =
-        cli_response_for_json_result_for_command(result, exit_code, command, presentation);
+        cli_response_for_json_result_for_identity(result, exit_code, identity, presentation);
 
     let json = match serde_json::to_string_pretty(&response) {
         Ok(j) => j,
@@ -991,6 +1066,23 @@ pub fn write_json_to_file_for_command(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn preflight_failures_keep_resolved_nested_command_identity() {
+        let identity = CommandIdentity::with_operation("agent-task", "cook");
+        for failure in [
+            "destination is dirty",
+            "destination has unpushed commits",
+            "base does not resolve",
+            "destination worktree is missing",
+        ] {
+            let error = Error::validation_invalid_argument("to_worktree", failure, None, None);
+            let result = cli_response_for_json_result_for_identity(&Err(error), 2, &identity, None);
+            let value = serde_json::to_value(result).expect("serialize result");
+            assert_eq!(value["command"], "agent-task", "{failure}");
+            assert_eq!(value["operation"], "cook", "{failure}");
+        }
+    }
 
     fn release_failure_payload(step_id: &str, step_type: &str) -> Value {
         json!({

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -63,6 +63,8 @@ fn validation_error_writes_json_output_file() {
 
     assert_eq!(file_json, stdout_json);
     assert_eq!(file_json["schema"], "homeboy/command-result/v3");
+    assert_eq!(file_json["command"], "runner");
+    assert_eq!(file_json["operation"], "exec");
     assert_eq!(file_json["success"], false);
     assert_eq!(
         file_json["diagnostics"]["code"],


### PR DESCRIPTION
## Summary
- preserve resolved top-level command and nested operation identity in command-result envelopes before command execution
- carry identity through validation, routing, output-file, and normal dispatch error paths
- cover Cook dirty destination, unpushed destination, invalid base, missing worktree, and generic nested command identities

Fixes #10103

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-cli command_identity_uses_the_resolved_top_level_and_nested_path --lib`
- `cargo test -p homeboy-cli preflight_failures_keep_resolved_nested_command_identity --lib`
- `cargo test -p homeboy --test output_errors`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the implementation and tests. Chris Huber reviewed the resulting change and remains responsible for every line.