### PR TITLE
fix: bound persisted run reads

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/dossier.rs
+++ b/crates/homeboy-cli/src/commands/runs/dossier.rs
@@ -99,9 +99,7 @@ pub struct RunsDossierCommandHint {
 }
 
 pub fn runs_dossier(run_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
-    runs_service::refresh_mirrored_daemon_evidence_best_effort(run_id);
+    let store = ObservationStore::open_readonly()?;
     let run = runs_service::require_run(&store, run_id)?;
     let artifacts = runs_service::list_artifacts_for_run(&store, run_id)?;
     let artifact_index = evidence_report::evidence_artifact_index(&artifacts);

--- a/crates/homeboy-cli/src/commands/runs/dossier.rs
+++ b/crates/homeboy-cli/src/commands/runs/dossier.rs
@@ -101,7 +101,9 @@ pub struct RunsDossierCommandHint {
 pub fn runs_dossier(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_readonly()?;
     let run = runs_service::require_run(&store, run_id)?;
-    let artifacts = runs_service::list_artifacts_for_run(&store, run_id)?;
+    // A dossier is an inspection command. Avoid the service helper here because
+    // it refreshes and indexes remote evidence, both of which can write.
+    let artifacts = runs_service::enrich_artifact_links(store.list_artifacts(run_id)?);
     let artifact_index = evidence_report::evidence_artifact_index(&artifacts);
     let failure = evidence_report::evidence_failure_summary(&run);
     let stale_reason = reconcile::running_status_note(&run);

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -240,12 +240,8 @@ fn active_runner_job_run_summary_if_durable(
 }
 
 pub fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+    let store = ObservationStore::open_readonly()?;
     let run = runs_service::require_run(&store, run_id)?;
-    runs_service::refresh_selected_mirrored_daemon_evidence_best_effort(&store, &run);
-    let run = runs_service::require_run(&store, &run.id)?;
-    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
-    let run = runs_service::require_run(&store, &run.id)?;
     let run = run_detail(&store, run)?;
     let actionable = actionable_for_run_detail(&run);
     Ok((

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -475,7 +475,7 @@ fn runs_dossier_aggregates_failure_env_refs_artifacts_and_commands() {
 }
 
 #[test]
-fn run_show_reconciles_owned_dead_running_run_before_displaying() {
+fn run_show_reads_owned_dead_running_run_without_mutating_it() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");
@@ -486,11 +486,8 @@ fn run_show_reconciles_owned_dead_running_run_before_displaying() {
         let RunsOutput::Show(output) = output else {
             panic!("expected show output");
         };
-        assert_eq!(output.run.summary.status, "stale");
-        assert_eq!(
-            output.run.metadata["homeboy_reconciled"]["reason"],
-            "owner_process_not_running"
-        );
+        assert_eq!(output.run.summary.status, "running");
+        assert!(output.run.metadata.get("homeboy_reconciled").is_none());
     });
 }
 

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -425,6 +425,8 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::DeployUploadFailed
         | ErrorCode::GitCommandFailed => 20,
 
+        ErrorCode::ObservationStoreBusy => 20,
+
         // A contended runtime promotion (another owner holds the lease) is a
         // transient "busy" condition, not a hard failure — map it to the
         // general error code alongside the other internal/unexpected states.

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -543,22 +543,70 @@ impl ObservationStore {
 
     pub fn list_artifacts(&self, run_id: &str) -> Result<Vec<ArtifactRecord>> {
         validate_required("run_id", run_id)?;
+        let columns = self.artifact_columns_for_read()?;
+        let artifact_type = columns
+            .contains("artifact_type")
+            .then_some("artifact_type")
+            .unwrap_or("'file'");
+        let url = columns.contains("url").then_some("url").unwrap_or("NULL");
+        let public_url = columns
+            .contains("public_url")
+            .then_some("public_url")
+            .unwrap_or("NULL");
+        let viewer_url = columns
+            .contains("viewer_url")
+            .then_some("viewer_url")
+            .unwrap_or("NULL");
+        let viewer_links = columns
+            .contains("viewer_links_json")
+            .then_some("viewer_links_json")
+            .unwrap_or("'[]'");
+        let metadata = columns
+            .contains("metadata_json")
+            .then_some("metadata_json")
+            .unwrap_or("'{}'");
         let mut statement = self
             .connection
-            .prepare(
+            .prepare(&format!(
                 r#"
-                SELECT id, run_id, kind, artifact_type, path, url, public_url, viewer_url, viewer_links_json, sha256, size_bytes, mime, metadata_json, created_at
+                SELECT id, run_id, kind, {}, path, {}, {}, {}, {}, sha256, size_bytes, mime, {}, created_at
                 FROM artifacts
                 WHERE run_id = ?1
                 ORDER BY created_at ASC
                 "#,
-            )
-            .map_err(sqlite_error("prepare list artifact records"))?;
+                artifact_type,
+                url,
+                public_url,
+                viewer_url,
+                viewer_links,
+                metadata,
+            ))
+            .map_err(|error| self.read_error("prepare list artifact records", error))?;
         let rows = statement
             .query_map([run_id], row_to_artifact_record)
-            .map_err(sqlite_error("list artifact records"))?;
+            .map_err(|error| self.read_error("list artifact records", error))?;
 
-        collect_rows(rows, "collect artifact records")
+        let mut artifacts = Vec::new();
+        for row in rows {
+            artifacts
+                .push(row.map_err(|error| self.read_error("collect artifact records", error))?);
+        }
+        Ok(artifacts)
+    }
+
+    fn artifact_columns_for_read(&self) -> Result<HashSet<String>> {
+        let mut statement = self
+            .connection
+            .prepare("PRAGMA table_info(artifacts)")
+            .map_err(|error| self.read_error("prepare artifact schema inspection", error))?;
+        let rows = statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|error| self.read_error("inspect artifact schema", error))?;
+        let mut columns = HashSet::new();
+        for row in rows {
+            columns.insert(row.map_err(|error| self.read_error("collect artifact schema", error))?);
+        }
+        Ok(columns)
     }
 
     pub fn update_artifact_metadata(

--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -46,6 +46,7 @@ pub struct RunArtifactRecord {
 pub struct ObservationStore {
     connection: Connection,
     path: PathBuf,
+    readonly: bool,
 }
 
 pub fn database_path() -> Result<PathBuf> {

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -27,6 +27,31 @@ impl ObservationStore {
         Ok(Self { connection, path })
     }
 
+    /// Open an existing observation database without any initialization work.
+    /// Metadata readers use this so they never contend for the global writer
+    /// lock merely to inspect a persisted run.
+    pub fn open_readonly() -> Result<Self> {
+        Self::open_readonly_at(database_path()?)
+    }
+
+    pub fn open_readonly_at(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        if !path.exists() {
+            // Preserve the normal "run not found" contract without creating a
+            // database merely because a metadata reader was invoked first.
+            let connection = rusqlite::Connection::open_in_memory()
+                .map_err(sqlite_error("open empty read-only observation store"))?;
+            connection
+                .execute_batch(
+                    "CREATE TABLE runs (id TEXT PRIMARY KEY, kind TEXT NOT NULL, component_id TEXT, started_at TEXT NOT NULL, finished_at TEXT, status TEXT NOT NULL, command TEXT, cwd TEXT, homeboy_version TEXT, git_sha TEXT, rig_id TEXT, metadata_json TEXT NOT NULL DEFAULT '{}');",
+                )
+                .map_err(sqlite_error("create empty read-only observation store"))?;
+            return Ok(Self { connection, path });
+        }
+        let connection = schema::open_readonly_connection(&path)?;
+        Ok(Self { connection, path })
+    }
+
     pub fn status(&self) -> Result<ObservationDbStatus> {
         schema::status_for_open_connection(&self.connection, self.path.clone(), true)
     }
@@ -207,7 +232,17 @@ impl ObservationStore {
                 row_to_run_record,
             )
             .optional()
-            .map_err(sqlite_error("read run record"))
+            .map_err(|error| {
+                if is_transient_lock_error(&error) {
+                    Error::observation_store_busy(
+                        self.path.to_string_lossy(),
+                        "read run record",
+                        750,
+                    )
+                } else {
+                    sqlite_error("read run record")(error)
+                }
+            })
     }
 
     pub fn list_runs(&self, filter: RunListFilter) -> Result<Vec<RunRecord>> {

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -24,7 +24,11 @@ impl ObservationStore {
 
         let connection = schema::open_connection(&path)?;
         schema::apply_migrations(&connection)?;
-        Ok(Self { connection, path })
+        Ok(Self {
+            connection,
+            path,
+            readonly: false,
+        })
     }
 
     /// Open an existing observation database without any initialization work.
@@ -46,10 +50,18 @@ impl ObservationStore {
                     "CREATE TABLE runs (id TEXT PRIMARY KEY, kind TEXT NOT NULL, component_id TEXT, started_at TEXT NOT NULL, finished_at TEXT, status TEXT NOT NULL, command TEXT, cwd TEXT, homeboy_version TEXT, git_sha TEXT, rig_id TEXT, metadata_json TEXT NOT NULL DEFAULT '{}');",
                 )
                 .map_err(sqlite_error("create empty read-only observation store"))?;
-            return Ok(Self { connection, path });
+            return Ok(Self {
+                connection,
+                path,
+                readonly: true,
+            });
         }
         let connection = schema::open_readonly_connection(&path)?;
-        Ok(Self { connection, path })
+        Ok(Self {
+            connection,
+            path,
+            readonly: true,
+        })
     }
 
     pub fn status(&self) -> Result<ObservationDbStatus> {
@@ -232,17 +244,15 @@ impl ObservationStore {
                 row_to_run_record,
             )
             .optional()
-            .map_err(|error| {
-                if is_transient_lock_error(&error) {
-                    Error::observation_store_busy(
-                        self.path.to_string_lossy(),
-                        "read run record",
-                        750,
-                    )
-                } else {
-                    sqlite_error("read run record")(error)
-                }
-            })
+            .map_err(|error| self.read_error("read run record", error))
+    }
+
+    pub(crate) fn read_error(&self, operation: &'static str, error: rusqlite::Error) -> Error {
+        if self.readonly && is_transient_lock_error(&error) {
+            Error::observation_store_busy(self.path.to_string_lossy(), operation, 750)
+        } else {
+            sqlite_error(operation)(error)
+        }
     }
 
     pub fn list_runs(&self, filter: RunListFilter) -> Result<Vec<RunRecord>> {

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 use super::{sqlite_error, ObservationDbStatus};
 use crate::{paths, Result};
@@ -278,6 +278,27 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
     let _ = connection.pragma_update(None, "journal_mode", "WAL");
     let _ = connection.pragma_update(None, "synchronous", "NORMAL");
     Ok(connection)
+}
+
+/// Open an existing observation store for a bounded metadata read.
+///
+/// This deliberately skips migrations and journal-mode configuration: both can
+/// acquire writer locks even though the caller only needs persisted metadata.
+pub(crate) fn open_readonly_connection(path: &Path) -> Result<Connection> {
+    const READ_TIMEOUT: Duration = Duration::from_millis(750);
+    let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|error| read_store_error(path, "open read-only observation store", error))?;
+    connection
+        .busy_timeout(READ_TIMEOUT)
+        .map_err(|error| read_store_error(path, "configure read-only observation store", error))?;
+    Ok(connection)
+}
+
+fn read_store_error(path: &Path, operation: &str, error: rusqlite::Error) -> crate::Error {
+    if super::is_transient_lock_error(&error) {
+        return crate::Error::observation_store_busy(path.to_string_lossy(), operation, 750);
+    }
+    sqlite_error(format!("{operation} {}", path.display()))(error)
 }
 
 fn apply_migration_sql(connection: &Connection, migration: &Migration) -> Result<()> {

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -64,6 +64,8 @@ pub enum ErrorCode {
 
     GitCommandFailed,
 
+    ObservationStoreBusy,
+
     InternalIoError,
     InternalJsonError,
     InternalUnexpected,
@@ -124,6 +126,8 @@ impl ErrorCode {
             ErrorCode::DeployUploadFailed => "deploy.upload_failed",
 
             ErrorCode::GitCommandFailed => "git.command_failed",
+
+            ErrorCode::ObservationStoreBusy => "observation_store.busy",
 
             ErrorCode::InternalIoError => "internal.io_error",
             ErrorCode::InternalJsonError => "internal.json_error",
@@ -327,6 +331,17 @@ pub struct InternalIoErrorDetails {
 }
 
 #[derive(Debug, Serialize)]
+pub struct ObservationStoreBusyDetails {
+    pub path: String,
+    pub operation: String,
+    pub timeout_ms: u64,
+    /// SQLite does not expose the process owning its advisory lock.
+    pub lock_owner: String,
+    /// SQLite does not expose lock acquisition time.
+    pub lock_age_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
 
 pub struct InternalJsonErrorDetails {
     pub error: String,
@@ -413,6 +428,30 @@ impl Error {
             hints: Vec::new(),
             retryable: None,
         }
+    }
+
+    pub fn observation_store_busy(
+        path: impl Into<String>,
+        operation: impl Into<String>,
+        timeout_ms: u64,
+    ) -> Self {
+        let path = path.into();
+        let operation = operation.into();
+        Self::new(
+            ErrorCode::ObservationStoreBusy,
+            format!("Observation store remained locked while attempting {operation}"),
+            to_details(ObservationStoreBusyDetails {
+                path,
+                operation,
+                timeout_ms,
+                lock_owner: "unknown (SQLite does not expose lock ownership)".to_string(),
+                lock_age_ms: None,
+            }),
+        )
+        .with_retryable(true)
+        .with_hint(
+            "Retry `homeboy runs show <run-id>` after the active import or writer completes.",
+        )
     }
 
     pub fn validation_missing_argument(args: Vec<String>) -> Self {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -187,6 +187,9 @@ mod store_init_tests {
             let store = ObservationStore::open_initialized().expect("initialize store");
             let persisted = sample_import_run("terminal-run");
             store.import_run(&persisted).expect("persist terminal run");
+            store
+                .record_url_artifact(&persisted.id, "evidence", "https://example.test/evidence")
+                .expect("persist artifact");
             let path = store::database_path().expect("database path");
 
             let workers = 5;
@@ -219,6 +222,14 @@ mod store_init_tests {
                                 Some(expected.clone()),
                                 "readers retain a coherent terminal record while imports write"
                             );
+                            assert_eq!(
+                                reader
+                                    .list_artifacts(&expected.id)
+                                    .expect("read terminal artifacts")
+                                    .len(),
+                                1,
+                                "readers retain coherent artifacts while imports write"
+                            );
                         }
                     })
                 })
@@ -232,6 +243,26 @@ mod store_init_tests {
                 .get_run("import-99")
                 .expect("read imported run")
                 .is_some());
+        });
+    }
+
+    #[test]
+    fn readonly_artifact_lookup_reports_a_retryable_busy_envelope() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let _store = ObservationStore::open_initialized().expect("initialize store");
+            let path = store::database_path().expect("database path");
+            let reader = ObservationStore::open_readonly_at(&path).expect("read-only store");
+            let error = reader.read_error(
+                "list artifact records",
+                rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                    Some("database is locked".to_string()),
+                ),
+            );
+            assert_eq!(error.code.as_str(), "observation_store.busy");
+            assert_eq!(error.retryable, Some(true));
+            assert!(error.details.to_string().contains("list artifact records"));
         });
     }
 

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -181,6 +181,61 @@ mod store_init_tests {
     }
 
     #[test]
+    fn readonly_run_lookups_complete_while_import_writes_evidence() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("initialize store");
+            let persisted = sample_import_run("terminal-run");
+            store.import_run(&persisted).expect("persist terminal run");
+            let path = store::database_path().expect("database path");
+
+            let workers = 5;
+            let barrier = Arc::new(Barrier::new(workers));
+            let writer_path = path.clone();
+            let writer_barrier = Arc::clone(&barrier);
+            let writer = std::thread::spawn(move || {
+                let writer =
+                    ObservationStore::open_initialized_at(writer_path).expect("writer store");
+                writer_barrier.wait();
+                for index in 0..100 {
+                    let mut imported = sample_import_run(&format!("import-{index}"));
+                    imported.metadata_json["import_sequence"] = serde_json::json!(index);
+                    writer.import_run(&imported).expect("import evidence");
+                }
+            });
+
+            let readers = (0..workers - 1)
+                .map(|_| {
+                    let path = path.clone();
+                    let barrier = Arc::clone(&barrier);
+                    let expected = persisted.clone();
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        for _ in 0..100 {
+                            let reader = ObservationStore::open_readonly_at(&path)
+                                .expect("bounded read-only store");
+                            assert_eq!(
+                                reader.get_run(&expected.id).expect("read terminal run"),
+                                Some(expected.clone()),
+                                "readers retain a coherent terminal record while imports write"
+                            );
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            writer.join().expect("writer joined");
+            for reader in readers {
+                reader.join().expect("reader joined");
+            }
+            assert!(store
+                .get_run("import-99")
+                .expect("read imported run")
+                .is_some());
+        });
+    }
+
+    #[test]
     fn test_record_finding() {
         with_isolated_home(|_home| {
             let _xdg = XdgGuard::unset();


### PR DESCRIPTION
Fixes #10119

## Root Cause
`runs show` and `runs dossier` opened and initialized the SQLite store, refreshed runner evidence, and reconciled every stale running record before reading the selected run. Initialization rewrote SQLite journal settings and could acquire a writer lock; refresh/reconciliation also introduced global work and eager side effects into a metadata lookup.

## Behavior
- Uses a read-only, 750 ms-bounded SQLite connection for persisted run metadata.
- Skips migrations and journal-mode configuration on read paths, so metadata reads do not take a global writer lock.
- Keeps `runs show` and `runs dossier` read-only: reconciliation remains explicit via `runs reconcile`, and artifact bytes remain behind dedicated artifact commands.
- Returns retryable `observation_store.busy` diagnostics with the operation, store path, timeout, SQLite lock-owner availability, and actionable retry guidance.

## Verification
- `cargo fmt`
- `cargo test -p homeboy-core readonly_run_lookups_complete_while_import_writes_evidence`
- `cargo test -p homeboy-cli run_show_reads_owned_dead_running_run_without_mutating_it`
- `cargo test -p homeboy-cli run_show_includes_metadata_and_artifacts`
- `cargo test -p homeboy-cli runs_dossier_aggregates_failure_env_refs_artifacts_and_commands`
- `cargo check -p homeboy-cli`

The concurrent regression test runs four read-only terminal-run readers while a writer imports 100 evidence records and asserts every reader gets the coherent persisted record.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode provided substantive implementation and test assistance: it traced the locking and hydration path, implemented the bounded read-only store and typed diagnostics, and added concurrent regression coverage. Chris Huber reviewed and remains responsible for every line.