### PR TITLE
fix: emit review run id before stages

### DIFF
--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -381,14 +381,14 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
         let message = format!("No files changed {} — skipping review", scope_label);
         println!("{}", message);
 
-        let review_observation = observation::start(observation::ReviewObservationStart {
+        let review_observation = Some(observation::start(observation::ReviewObservationStart {
             component_id: &component.id,
             component_label: &component_label,
             source_path: Path::new(&source_path),
             args: &args,
             scope: &scope,
             changed_file_count: Some(0),
-        });
+        })?);
         let observation_metadata = review_observation.as_ref().map(|o| o.output_metadata());
 
         let mut output = ReviewService::skipped_output(
@@ -413,14 +413,14 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
         return Ok((output, 0));
     }
 
-    let review_observation = observation::start(observation::ReviewObservationStart {
+    let review_observation = Some(observation::start(observation::ReviewObservationStart {
         component_id: &component.id,
         component_label: &component_label,
         source_path: Path::new(&source_path),
         args: &args,
         scope: &scope,
         changed_file_count,
-    });
+    })?);
     observation::emit_early_lifecycle(&review_observation);
 
     let mut top_hints: Vec<String> = Vec::new();
@@ -485,51 +485,68 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
     let audit_stage = audit_stage.expect("review quality plan must include audit stage");
     let lint_stage = lint_stage.expect("review quality plan must include lint stage");
     let test_stage = test_stage.expect("review quality plan must include test stage");
-    let ci_profile_stage = match args.ci_profile.as_ref() {
-        Some(profile) => {
-            let ctx = execution_context::resolve(&ResolveOptions {
-                component_id: args.comp.component.clone(),
-                path_override: args.comp.path.clone(),
-                capability: None,
-                settings_overrides: Vec::new(),
-                settings_profile_json_overrides: Vec::new(),
-                settings_json_overrides: Vec::new(),
-                extension_overrides: args.extension_override.extensions.clone(),
-            })?;
-            let extension_ids = ctx
-                .component
-                .extensions
-                .as_ref()
-                .map(|extensions| {
-                    let mut ids: Vec<String> = extensions.keys().cloned().collect();
-                    ids.sort();
-                    ids
-                })
-                .unwrap_or_default();
-            let extension_id = ci_profile::select_extension_id(&extension_ids)?;
-            let output = ci_profile::run_for_extension(
-                &ctx.source_path,
-                &extension_id,
-                CiRunSelection::Profile(profile.clone()),
-            )?;
-            let exit_code = output.exit_code;
-            let finding_count = output.jobs.iter().filter(|job| !job.success).count();
-            let stage = ReviewStage {
-                stage: "ci".to_string(),
-                ran: true,
-                passed: exit_code == 0,
-                exit_code,
-                finding_count,
-                hint: format!(
-                    "Deep dive: homeboy review ci run {} --profile {}",
-                    component_label, profile
-                ),
-                skipped_reason: None,
-                output: Some(output),
-            };
-            Some(stage)
+    let ci_profile_stage = match (|| -> homeboy::core::Result<Option<ReviewStage<_>>> {
+        let Some(profile) = args.ci_profile.as_ref() else {
+            return Ok(None);
+        };
+        if review_run_id
+            .as_deref()
+            .is_some_and(observation::is_cancelled)
+        {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "run-id",
+                "review was cancelled before the CI stage started",
+                review_run_id.clone(),
+                None,
+            ));
         }
-        None => None,
+        let ctx = execution_context::resolve(&ResolveOptions {
+            component_id: args.comp.component.clone(),
+            path_override: args.comp.path.clone(),
+            capability: None,
+            settings_overrides: Vec::new(),
+            settings_profile_json_overrides: Vec::new(),
+            settings_json_overrides: Vec::new(),
+            extension_overrides: args.extension_override.extensions.clone(),
+        })?;
+        let extension_ids = ctx
+            .component
+            .extensions
+            .as_ref()
+            .map(|extensions| {
+                let mut ids: Vec<String> = extensions.keys().cloned().collect();
+                ids.sort();
+                ids
+            })
+            .unwrap_or_default();
+        let extension_id = ci_profile::select_extension_id(&extension_ids)?;
+        let output = ci_profile::run_for_extension(
+            &ctx.source_path,
+            &extension_id,
+            CiRunSelection::Profile(profile.clone()),
+        )?;
+        let exit_code = output.exit_code;
+        let finding_count = output.jobs.iter().filter(|job| !job.success).count();
+        let stage = ReviewStage {
+            stage: "ci".to_string(),
+            ran: true,
+            passed: exit_code == 0,
+            exit_code,
+            finding_count,
+            hint: format!(
+                "Deep dive: homeboy review ci run {} --profile {}",
+                component_label, profile
+            ),
+            skipped_reason: None,
+            output: Some(output),
+        };
+        Ok(Some(stage))
+    })() {
+        Ok(stage) => stage,
+        Err(error) => {
+            observation::finish_error(review_observation, &error);
+            return Err(error);
+        }
     };
 
     if args.changed_only {

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -17,6 +17,7 @@ use homeboy::core::ci_profile::{self, CiRunSelection};
 use homeboy::core::code_audit::AuditCommandOutput;
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::git;
+use homeboy::core::observation::ObservationStore;
 use homeboy::core::plan::PlanStep;
 use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
 use homeboy_extension::lint::LintCommandOutput;
@@ -44,6 +45,11 @@ pub(super) mod raw_output;
 pub struct ReviewArgs {
     #[command(subcommand)]
     pub command: Option<ReviewCommand>,
+
+    /// Attach to an already-persisted review run instead of starting another
+    /// audit/lint/test execution.
+    #[arg(long, value_name = "RUN_ID")]
+    pub run_id: Option<String>,
 
     #[command(flatten)]
     pub comp: PositionalComponentArgs,
@@ -349,6 +355,10 @@ fn review_lint_args(mut args: lint::LintArgs) -> lint::LintArgs {
 }
 
 pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutput> {
+    if let Some(run_id) = args.run_id.as_deref() {
+        return attach_to_persisted_review(run_id);
+    }
+
     // Resolve component ID (auto-discovers from CWD when omitted) and source
     // path so we can probe git for the changed-file set ourselves.
     let component_args = args.effective_component_args();
@@ -411,6 +421,7 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
         scope: &scope,
         changed_file_count,
     });
+    observation::emit_early_lifecycle(&review_observation);
 
     let mut top_hints: Vec<String> = Vec::new();
 
@@ -430,8 +441,22 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
     let mut audit_stage = None;
     let mut lint_stage = None;
     let mut test_stage = None;
+    let review_run_id = review_observation
+        .as_ref()
+        .map(|observation| observation.run_id().to_string());
 
     let stage_run = match review::execute_review_plan_steps(&quality_plan.steps, |step| {
+        if review_run_id
+            .as_deref()
+            .is_some_and(observation::is_cancelled)
+        {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "run-id",
+                "review was cancelled before the next stage started",
+                review_run_id.clone(),
+                None,
+            ));
+        }
         // homeboy-audit: allow-thin-command-adapter
         dispatch_review_plan_step(step, &args, global, &component_label, &review_context)
         // homeboy-audit: allow-thin-command-adapter
@@ -547,6 +572,55 @@ pub fn run_umbrella(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCo
     observation::finish_success(review_observation, &output, overall_exit);
 
     Ok((output, overall_exit))
+}
+
+/// Return the persisted record rather than silently starting another expensive
+/// review when an interrupted foreground client retries by ID.
+fn attach_to_persisted_review(run_id: &str) -> CmdResult<ReviewCommandOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let run = store.get_run(run_id)?.ok_or_else(|| {
+        homeboy::core::Error::validation_invalid_argument(
+            "run-id",
+            "review run was not found",
+            Some(run_id.to_string()),
+            Some(vec![format!(
+                "Run `homeboy runs show {run_id}` to inspect persisted runs."
+            )]),
+        )
+    })?;
+    if run.kind != "review" {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "run-id",
+            "run-id must identify a review run",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+
+    let component = run
+        .component_id
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    let observation = homeboy::core::ObservationOutputMetadata::for_run("review", run_id);
+    let mut output = ReviewService::skipped_output(
+        ReviewOutputInput {
+            component: component.clone(),
+            plan: build_quality_plan(QualityPlanOptions::review(&component)),
+            observation: Some(observation),
+            scope: run.metadata_json.get("scope").and_then(Value::as_str).unwrap_or("full").to_string(),
+            changed_since: run.metadata_json.get("changed_since").and_then(Value::as_str).map(str::to_string),
+            changed_file_count: run.metadata_json.get("changed_file_count").and_then(Value::as_u64).and_then(|count| usize::try_from(count).ok()),
+            head_ref: run.git_sha.unwrap_or_default(),
+            hints: vec![format!(
+                "Attached to persisted review run {run_id} (status {}); no new review was started. Watch it with: homeboy runs watch {run_id}",
+                run.status
+            )],
+        },
+        "attached to persisted run",
+        false,
+    );
+    attach_review_actionable(&mut output);
+    Ok((output, 0))
 }
 
 fn manual_changelog_edit(
@@ -1094,6 +1168,7 @@ mod tests {
     fn scope_flag_suffix_renders_changed_since() {
         let args = ReviewArgs {
             command: None,
+            run_id: None,
             comp: PositionalComponentArgs {
                 component: None,
                 path: None,
@@ -1117,6 +1192,7 @@ mod tests {
     fn scope_flag_suffix_renders_changed_only_only_when_allowed() {
         let args = ReviewArgs {
             command: None,
+            run_id: None,
             comp: PositionalComponentArgs {
                 component: None,
                 path: None,
@@ -1142,6 +1218,7 @@ mod tests {
     fn scope_flag_suffix_empty_for_full_run() {
         let args = ReviewArgs {
             command: None,
+            run_id: None,
             comp: PositionalComponentArgs {
                 component: None,
                 path: None,
@@ -1285,6 +1362,7 @@ mod tests {
     fn review_args_fixture() -> ReviewArgs {
         ReviewArgs {
             command: None,
+            run_id: None,
             comp: PositionalComponentArgs {
                 component: Some("fixture".to_string()),
                 path: None,

--- a/crates/homeboy-cli/src/commands/review/observation.rs
+++ b/crates/homeboy-cli/src/commands/review/observation.rs
@@ -44,14 +44,14 @@ pub(super) struct ReviewObservationStart<'a> {
     pub changed_file_count: Option<usize>,
 }
 
-pub(super) fn start(start: ReviewObservationStart<'_>) -> Option<ReviewObservation> {
+pub(super) fn start(start: ReviewObservationStart<'_>) -> homeboy::core::Result<ReviewObservation> {
     let metadata = review_observation_initial_metadata(
         start.component_label,
         start.args,
         start.scope,
         start.changed_file_count,
     );
-    ActiveObservation::start_best_effort(
+    ActiveObservation::start(
         NewRunRecord::builder("review")
             .component_id(start.component_id)
             .command(review_observation_command(start.component_id, start.args))
@@ -136,13 +136,9 @@ fn finish_if_running(
     status: RunStatus,
     metadata: Option<serde_json::Value>,
 ) {
-    let still_running = ObservationStore::open_initialized()
-        .ok()
-        .and_then(|store| store.get_run(observation.run_id()).ok().flatten())
-        .is_some_and(|run| run.status == RunStatus::Running.as_str());
-    if still_running {
-        observation.finish(status, metadata);
-    }
+    let _ = observation
+        .store()
+        .finish_running_run(observation.run_id(), status, metadata);
 }
 
 fn review_observation_command(component_id: &str, args: &ReviewArgs) -> String {
@@ -291,11 +287,9 @@ mod tests {
                 args: &args,
                 scope: "changed-since",
                 changed_file_count: Some(3),
-            });
-            let run_id = observation
-                .expect("persisted observation")
-                .run_id()
-                .to_string();
+            })
+            .expect("persisted observation");
+            let run_id = observation.run_id().to_string();
 
             // No terminal cleanup runs after this point, as if the caller timed out.
             let run = ObservationStore::open_initialized()

--- a/crates/homeboy-cli/src/commands/review/observation.rs
+++ b/crates/homeboy-cli/src/commands/review/observation.rs
@@ -1,11 +1,14 @@
 use std::path::Path;
 
 use homeboy::core::git::short_head_revision_at;
-use homeboy::core::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
+use homeboy::core::observation::{
+    merge_metadata, ActiveObservation, NewRunRecord, ObservationStore, RunStatus,
+};
 use homeboy::core::ObservationOutputMetadata;
 use homeboy_review::review::{
     artifact_command, ReviewArtifactFindings, ReviewCommandOutput, ReviewStage,
 };
+use serde::Serialize;
 
 use super::ReviewArgs;
 
@@ -15,6 +18,21 @@ impl ReviewObservation {
     pub(super) fn output_metadata(&self) -> ObservationOutputMetadata {
         ObservationOutputMetadata::for_run(&self.0.run().kind, self.0.run_id())
     }
+
+    pub(super) fn run_id(&self) -> &str {
+        self.0.run_id()
+    }
+}
+
+#[derive(Serialize)]
+struct EarlyReviewLifecycle<'a> {
+    schema: &'static str,
+    event: &'static str,
+    run_id: &'a str,
+    status: &'static str,
+    show_command: String,
+    watch_command: String,
+    cancel_command: String,
 }
 
 pub(super) struct ReviewObservationStart<'a> {
@@ -46,6 +64,33 @@ pub(super) fn start(start: ReviewObservationStart<'_>) -> Option<ReviewObservati
     .map(ReviewObservation)
 }
 
+/// Emit a JSONL lifecycle event after persistence. The final stdout envelope is unchanged.
+pub(super) fn emit_early_lifecycle(observation: &Option<ReviewObservation>) {
+    let Some(observation) = observation else {
+        return;
+    };
+    let run_id = observation.0.run_id();
+    let lifecycle = EarlyReviewLifecycle {
+        schema: "homeboy/review-lifecycle/v1",
+        event: "persisted",
+        run_id,
+        status: "running",
+        show_command: format!("homeboy runs show {run_id}"),
+        watch_command: format!("homeboy runs watch {run_id}"),
+        cancel_command: format!("homeboy runs cancel {run_id}"),
+    };
+    if let Ok(json) = serde_json::to_string(&lifecycle) {
+        eprintln!("{json}");
+    }
+}
+
+pub(super) fn is_cancelled(run_id: &str) -> bool {
+    ObservationStore::open_initialized()
+        .ok()
+        .and_then(|store| store.get_run(run_id).ok().flatten())
+        .is_some_and(|run| run.status == RunStatus::Skipped.as_str())
+}
+
 pub(super) fn finish_success(
     observation: Option<ReviewObservation>,
     output: &ReviewCommandOutput,
@@ -68,7 +113,7 @@ pub(super) fn finish_success(
         exit_code,
         None,
     );
-    observation.0.finish(status, Some(metadata));
+    finish_if_running(&observation.0, status, Some(metadata));
 }
 
 pub(super) fn finish_error(observation: Option<ReviewObservation>, error: &homeboy::core::Error) {
@@ -83,7 +128,21 @@ pub(super) fn finish_error(observation: Option<ReviewObservation>, error: &homeb
             "error": error.to_string(),
         }),
     );
-    observation.0.finish_error(Some(metadata));
+    finish_if_running(&observation.0, RunStatus::Error, Some(metadata));
+}
+
+fn finish_if_running(
+    observation: &ActiveObservation,
+    status: RunStatus,
+    metadata: Option<serde_json::Value>,
+) {
+    let still_running = ObservationStore::open_initialized()
+        .ok()
+        .and_then(|store| store.get_run(observation.run_id()).ok().flatten())
+        .is_some_and(|run| run.status == RunStatus::Running.as_str());
+    if still_running {
+        observation.finish(status, metadata);
+    }
 }
 
 fn review_observation_command(component_id: &str, args: &ReviewArgs) -> String {
@@ -189,6 +248,7 @@ mod tests {
     fn review_args() -> ReviewArgs {
         ReviewArgs {
             command: None,
+            run_id: None,
             comp: PositionalComponentArgs {
                 component: None,
                 path: None,
@@ -218,6 +278,75 @@ mod tests {
         assert_eq!(metadata["changed_since"], "origin/main");
         assert_eq!(metadata["changed_file_count"], 3);
         assert_eq!(metadata["observation_status"], "running");
+    }
+
+    #[test]
+    fn persisted_lifecycle_survives_an_interrupted_foreground_client() {
+        homeboy::test_support::with_isolated_home(|_| {
+            let args = review_args();
+            let observation = start(ReviewObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: Path::new("/tmp/homeboy"),
+                args: &args,
+                scope: "changed-since",
+                changed_file_count: Some(3),
+            });
+            let run_id = observation
+                .expect("persisted observation")
+                .run_id()
+                .to_string();
+
+            // No terminal cleanup runs after this point, as if the caller timed out.
+            let run = ObservationStore::open_initialized()
+                .expect("store")
+                .get_run(&run_id)
+                .expect("read")
+                .expect("run");
+            assert_eq!(run.kind, "review");
+            assert_eq!(run.status, "running");
+
+            let lifecycle = serde_json::to_value(EarlyReviewLifecycle {
+                schema: "homeboy/review-lifecycle/v1",
+                event: "persisted",
+                run_id: &run_id,
+                status: "running",
+                show_command: format!("homeboy runs show {run_id}"),
+                watch_command: format!("homeboy runs watch {run_id}"),
+                cancel_command: format!("homeboy runs cancel {run_id}"),
+            })
+            .expect("lifecycle JSON");
+            assert_eq!(lifecycle["run_id"], run_id);
+            assert_eq!(
+                lifecycle["show_command"],
+                format!("homeboy runs show {run_id}")
+            );
+            assert_eq!(
+                lifecycle["watch_command"],
+                format!("homeboy runs watch {run_id}")
+            );
+            assert_eq!(
+                lifecycle["cancel_command"],
+                format!("homeboy runs cancel {run_id}")
+            );
+
+            let (attached, exit_code) = super::super::attach_to_persisted_review(&run_id)
+                .expect("attach to existing review");
+            assert_eq!(exit_code, 0);
+            assert_eq!(attached.observation.expect("observation").run_id, run_id);
+            let review_runs = ObservationStore::open_initialized()
+                .expect("store")
+                .list_runs(homeboy::core::observation::RunListFilter {
+                    kind: Some("review".to_string()),
+                    ..Default::default()
+                })
+                .expect("review runs");
+            assert_eq!(
+                review_runs.len(),
+                1,
+                "attaching must not create duplicate work"
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/runs/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runs/dispatch.rs
@@ -174,6 +174,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Reconcile(args) => reconcile::reconcile_runs(args),
         RunsCommand::Retention(args) => retention::retain_terminal_runs(args),
         RunsCommand::Watch(args) => watch::watch_run(args),
+        RunsCommand::Cancel { run_id } => handlers::cancel_run(&run_id),
         RunsCommand::Show {
             run_id,
             json: _,

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -12,7 +12,9 @@ use homeboy::core::api_jobs;
 use homeboy::core::artifact_address::ArtifactAddress;
 use homeboy::core::observation::evidence_report::directory_publication_guidance;
 use homeboy::core::observation::runs_service;
-use homeboy::core::observation::{FindingListFilter, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::observation::{
+    merge_metadata, FindingListFilter, ObservationStore, RunListFilter, RunRecord, RunStatus,
+};
 use homeboy::core::resource_lifecycle_index::resource_lifecycle_index_from_artifacts;
 use homeboy::core::validation_progress::ValidationProgressLedger;
 use homeboy::core::Error;
@@ -24,9 +26,10 @@ use super::types::{
     actionable_for_run_detail, actionable_for_run_list, RunDetail, RunsArtifactArgs,
     RunsArtifactCommand, RunsArtifactCommandHint, RunsArtifactGetArgs, RunsArtifactGetOutput,
     RunsArtifactPathGuide, RunsArtifactPullEntry, RunsArtifactPullSummary, RunsArtifactsArgs,
-    RunsArtifactsOutput, RunsDirectoryArtifactPublicationGuidance, RunsEnvKeyOutput, RunsEnvOutput,
-    RunsEnvSourceLayerOutput, RunsEnvSummary, RunsFieldSelectionOutput, RunsListArgs,
-    RunsListOutput, RunsOutput, RunsResumePlanOutput, RunsSelectedField, RunsShowOutput,
+    RunsArtifactsOutput, RunsCancelOutput, RunsDirectoryArtifactPublicationGuidance,
+    RunsEnvKeyOutput, RunsEnvOutput, RunsEnvSourceLayerOutput, RunsEnvSummary,
+    RunsFieldSelectionOutput, RunsListArgs, RunsListOutput, RunsOutput, RunsResumePlanOutput,
+    RunsSelectedField, RunsShowOutput,
 };
 use super::{reconcile, remote, remote_artifact, CmdResult};
 
@@ -98,6 +101,38 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
             runs,
             matched_runs,
             hidden_mirrors,
+            actionable,
+        }),
+        0,
+    ))
+}
+
+pub fn cancel_run(run_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let run = runs_service::require_run(&store, run_id)?;
+    if run.status != RunStatus::Running.as_str() {
+        return Err(Error::validation_invalid_argument(
+            "run-id",
+            "only running observation runs can be cancelled",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    let metadata = merge_metadata(
+        run.metadata_json,
+        serde_json::json!({
+            "cancellation": { "requested": true, "requested_at": chrono::Utc::now().to_rfc3339() }
+        }),
+    );
+    let cancelled = store.finish_run(run_id, RunStatus::Skipped, Some(metadata))?;
+    let actionable =
+        super::types::actionable_for_run_summary(&super::run_summary(cancelled.clone()));
+    Ok((
+        RunsOutput::Cancel(RunsCancelOutput {
+            command: "runs.cancel",
+            run_id: cancelled.id.clone(),
+            status: cancelled.status,
+            cancellation: "cooperative; the foreground owner stops before its next stage",
             actionable,
         }),
         0,

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -124,7 +124,16 @@ pub fn cancel_run(run_id: &str) -> CmdResult<RunsOutput> {
             "cancellation": { "requested": true, "requested_at": chrono::Utc::now().to_rfc3339() }
         }),
     );
-    let cancelled = store.finish_run(run_id, RunStatus::Skipped, Some(metadata))?;
+    let cancelled = store
+        .finish_running_run(run_id, RunStatus::Skipped, Some(metadata))?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run-id",
+                "run completed before cancellation could be recorded",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
     let actionable =
         super::types::actionable_for_run_summary(&super::run_summary(cancelled.clone()));
     Ok((
@@ -1130,5 +1139,35 @@ mod pull_tests {
             panic!("--pull with --runner should fail");
         };
         assert!(err.to_string().contains("local mirrored observation store"));
+    }
+
+    #[test]
+    fn cancel_marks_a_running_run_skipped_without_changing_its_identity() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(
+                    NewRunRecord::builder("review")
+                        .component_id("homeboy")
+                        .build(),
+                )
+                .expect("run");
+
+            let (output, exit_code) = cancel_run(&run.id).expect("cancel run");
+
+            assert_eq!(exit_code, 0);
+            let RunsOutput::Cancel(output) = output else {
+                panic!("expected cancel output");
+            };
+            assert_eq!(output.command, "runs.cancel");
+            assert_eq!(output.run_id, run.id);
+            assert_eq!(output.status, "skipped");
+            let persisted = store
+                .get_run(&run.id)
+                .expect("get run")
+                .expect("run exists");
+            assert_eq!(persisted.status, "skipped");
+            assert_eq!(persisted.metadata_json["cancellation"]["requested"], true);
+        });
     }
 }

--- a/crates/homeboy-cli/src/commands/runs/types.rs
+++ b/crates/homeboy-cli/src/commands/runs/types.rs
@@ -91,6 +91,8 @@ pub(super) enum RunsCommand {
     /// detached/offloaded runs.
     #[command(visible_aliases = ["follow", "tail"])]
     Watch(RunsWatchArgs),
+    /// Cooperatively cancel a persisted foreground run before its next stage.
+    Cancel { run_id: String },
     /// Show one persisted observation run
     Show {
         run_id: String,
@@ -268,6 +270,7 @@ pub enum RunsOutput {
     Reconcile(RunsReconcileOutput),
     Retention(RunsRetentionOutput),
     Watch(RunsWatchOutput),
+    Cancel(RunsCancelOutput),
     Export(RunsExportOutput),
     Import(RunsImportOutput),
     ImportFromGhActions(GhActionsImportOutput),
@@ -276,6 +279,19 @@ pub enum RunsOutput {
     Resources(RunsResourcesOutput),
     Drift(RunsDriftOutput),
     LoopSync(RunsLoopSyncOutput),
+}
+
+#[derive(Serialize)]
+pub struct RunsCancelOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub status: String,
+    pub cancellation: &'static str,
+    #[serde(
+        rename = "_homeboy_actionable",
+        skip_serializing_if = "CommandActionableMetadata::is_empty"
+    )]
+    pub actionable: CommandActionableMetadata,
 }
 
 #[derive(Serialize)]

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -159,6 +159,73 @@ impl ObservationStore {
         })
     }
 
+    /// Finish a run only while it is still active. This prevents concurrent
+    /// lifecycle owners from replacing an already-recorded terminal outcome.
+    pub fn finish_running_run(
+        &self,
+        run_id: &str,
+        status: RunStatus,
+        metadata_json: Option<serde_json::Value>,
+    ) -> Result<Option<RunRecord>> {
+        validate_required("run_id", run_id)?;
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let rows = match metadata_json {
+            Some(mut metadata_json) => {
+                if crate::notification_route::NotificationRoute::from_metadata(&metadata_json)
+                    .is_none()
+                {
+                    if let Some(existing) = self.get_run(run_id)? {
+                        if let Some(route) =
+                            crate::notification_route::NotificationRoute::from_metadata(
+                                &existing.metadata_json,
+                            )
+                        {
+                            route.insert_into_metadata(&mut metadata_json);
+                        }
+                    }
+                }
+                let serialized = serialize_metadata(&metadata_json)?;
+                execute_with_retry("finish running run record with metadata", || {
+                    self.connection.execute(
+                        r#"
+                        UPDATE runs
+                        SET finished_at = ?1, status = ?2, metadata_json = ?3
+                        WHERE id = ?4 AND status = ?5
+                        "#,
+                        params![
+                            finished_at,
+                            status.as_str(),
+                            serialized,
+                            run_id,
+                            RunStatus::Running.as_str(),
+                        ],
+                    )
+                })?
+            }
+            None => execute_with_retry("finish running run record", || {
+                self.connection.execute(
+                    r#"
+                    UPDATE runs
+                    SET finished_at = ?1, status = ?2
+                    WHERE id = ?3 AND status = ?4
+                    "#,
+                    params![
+                        finished_at,
+                        status.as_str(),
+                        run_id,
+                        RunStatus::Running.as_str(),
+                    ],
+                )
+            })?,
+        };
+
+        if rows == 0 {
+            return Ok(None);
+        }
+
+        Ok(self.get_run(run_id)?)
+    }
+
     pub fn update_run_metadata(
         &self,
         run_id: &str,

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -4,6 +4,17 @@ Run scoped audit + lint + test in a single invocation against PR-style changes.
 `review` also owns the individual quality gates: `review audit`, `review lint`,
 `review test`, `review build`, and `review ci`.
 
+Before audit, lint, or test starts, review persists its observation and writes a
+newline-delimited `homeboy/review-lifecycle/v1` JSON event to stderr. The event
+contains the canonical `run_id` and exact `runs show`, `runs watch`, and `runs
+cancel` commands. Stdout remains the existing final result envelope. If the
+foreground client is interrupted, attach without starting duplicate work:
+
+```bash
+homeboy review --run-id <run-id>
+homeboy runs watch <run-id>
+```
+
 ## Synopsis
 
 ```bash

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -503,6 +503,43 @@ fn test_finish_run() {
 }
 
 #[test]
+fn finish_running_run_preserves_an_existing_terminal_outcome() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let started = store
+            .start_run(sample_run("review", "homeboy"))
+            .expect("start run");
+
+        let cancelled = store
+            .finish_running_run(
+                &started.id,
+                RunStatus::Skipped,
+                Some(serde_json::json!({ "cancellation": { "requested": true } })),
+            )
+            .expect("cancel running run")
+            .expect("running run was cancelled");
+        let late_completion = store
+            .finish_running_run(
+                &started.id,
+                RunStatus::Pass,
+                Some(serde_json::json!({ "passed": true })),
+            )
+            .expect("late completion query");
+
+        assert_eq!(cancelled.status, "skipped");
+        assert!(late_completion.is_none());
+        let persisted = store
+            .get_run(&started.id)
+            .expect("get run")
+            .expect("run exists");
+        assert_eq!(persisted.status, "skipped");
+        assert_eq!(persisted.metadata_json["cancellation"]["requested"], true);
+        assert!(persisted.metadata_json.get("passed").is_none());
+    });
+}
+
+#[test]
 fn test_list_runs() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
Fixes #10121

## Root cause
`homeboy review` persisted its observation run before quality stages, but withheld that durable identity until the final foreground envelope. A client timeout during audit, lint, or test therefore left no authoritative recovery handle in the initial output.

## Behavior
- Emits a `homeboy/review-lifecycle/v1` JSONL event on stderr immediately after persistence, with the canonical run ID and exact `runs show`, `runs watch`, and `runs cancel` commands.
- Keeps existing final stdout envelopes and `--output` artifacts unchanged.
- Adds `homeboy review --run-id <id>` to attach to a persisted review rather than create duplicate audit/lint/test work.
- Adds cooperative `homeboy runs cancel <id>` handling; foreground review checks for cancellation between stages and does not overwrite the terminal cancellation record.

## Evidence
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli commands::review:: -- --nocapture` (24 passed)
- Deterministic lifecycle coverage persists a review, simulates client interruption before terminal cleanup, verifies show/watch/cancel command fields and run discoverability, then attaches by ID and proves no duplicate review record is created.

## AI assistance
OpenAI GPT-5.6 Sol using OpenCode drafted and tested the implementation. Chris Huber remains responsible for every line.