### PR TITLE
fix(cook): retain durable failure identity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -616,6 +616,33 @@ pub struct AgentTaskCookReport {
     pub terminal_failure_classification: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub moving_base_recovery: Option<MovingBaseCookRecovery>,
+    /// Generic durable recovery coordinates for a Cook that stopped after its
+    /// recipe was materialized. This intentionally contains no provider or gate
+    /// evidence; operators retrieve that through the listed diagnose command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_context: Option<AgentTaskCookFailureContext>,
+}
+
+/// Durable identity and legal recovery surface for a failed Cook.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentTaskCookFailureContext {
+    pub cook_id: String,
+    pub latest_run_id: String,
+    pub durable_recipe_ref: String,
+    pub lifecycle_state: String,
+    pub provider_budget_consumed: bool,
+    pub provider_executions_consumed: u64,
+    pub recovery_legal: bool,
+    pub recovery_reason: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub legal_actions: Vec<AgentTaskCookRecoveryAction>,
+}
+
+/// An exact command that is legal for the durable Cook state.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentTaskCookRecoveryAction {
+    pub action: String,
+    pub command: String,
 }
 
 /// A bounded collection of independently durable cooks. Each cook retains the
@@ -1409,8 +1436,16 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
-    let result =
-        run_cook_with_boundaries_observed_inner(options, executor, side_effects, durable_observer)?;
+    let failure_options = options.clone();
+    let result = match run_cook_with_boundaries_observed_inner(
+        options,
+        executor,
+        side_effects,
+        durable_observer,
+    ) {
+        Ok(result) => result,
+        Err(error) => return durable_cook_error_report(&failure_options, error),
+    };
     if let Some(run_id) = result.value.latest_run_id.as_deref() {
         let attempt = result
             .value
@@ -1422,16 +1457,39 @@ where
             "queued" | "running" | "in_flight" => "in_flight",
             _ => "terminal",
         };
-        report_cook_progress(
+        if let Err(error) = report_cook_progress(
             durable_observer,
             &result.value.cook_id,
             run_id,
             phase,
             attempt,
             Some(&result.value.status),
-        )?;
+        ) {
+            return durable_cook_error_report(&failure_options, error);
+        }
     }
     Ok(result)
+}
+
+/// Convert an error that occurs after recipe materialization into the normal
+/// Cook result contract. Errors before materialization still return unchanged:
+/// they have no durable identity and therefore no legal recovery command.
+fn durable_cook_error_report(
+    options: &AgentTaskCookServiceOptions,
+    error: Error,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+    if super::recipe_exists(&options.cook_id)? {
+        return Ok(cook_report(
+            options.cook_id.clone(),
+            "durable_failure",
+            Vec::new(),
+            None,
+            Some("Cook stopped after durable creation; use the recovery actions in failure_context to inspect or continue it.".to_string()),
+            1,
+            None,
+        ));
+    }
+    Err(error)
 }
 
 fn run_cook_with_boundaries_observed_inner<E, S>(
@@ -2048,7 +2106,7 @@ where
         )?;
         let promotion = match side_effects.promote(&options, &run_id) {
             Ok(report) => report,
-            Err(error) => {
+            Err(_error) => {
                 attempts.push(AgentTaskCookAttemptReport {
                     attempt,
                     run_id: run_id.clone(),
@@ -2057,9 +2115,7 @@ where
                     promotion: None,
                     feedback: None,
                 });
-                let recovery = format!(
-                    "promotion provider response was rejected: {error}. The successful candidate remains durable on run {run_id}; inspect it and generate a corrected apply-provider retry with `homeboy agent-task review {run_id} --to-worktree <handle>`. To replace it with an externally prepared candidate, use `homeboy agent-task adopt {cook_id} --candidate-ref <sha> --ai-model <model>`.",
-                );
+                let recovery = "promotion provider response was rejected. The successful candidate remains durable; use failure_context to inspect or continue the Cook.".to_string();
                 return Ok(cook_report(
                     cook_id,
                     "policy_failure",

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1265,11 +1265,21 @@ pub(crate) fn cook_report(
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    let latest_run_id = invocation_latest_run_id.map(str::to_string).or_else(|| {
-        agent_task_lifecycle::cook_index(&cook_id)
-            .ok()
-            .map(|index| index.latest_run_id)
-    });
+    let latest_run_id = invocation_latest_run_id
+        .map(str::to_string)
+        .or_else(|| {
+            agent_task_lifecycle::cook_index(&cook_id)
+                .ok()
+                .map(|index| index.latest_run_id)
+        })
+        .or_else(|| {
+            // A recipe is persisted before its lifecycle record and Cook index. If
+            // materialization fails in that window, its final immutable attempt is
+            // still the only durable identity we can safely report.
+            super::load_recipe(&cook_id)
+                .ok()
+                .and_then(|recipe| recipe.attempts.last().map(|attempt| attempt.run_id.clone()))
+        });
     let invocation_run_ids: Vec<String> = attempts
         .iter()
         .map(|attempt| attempt.run_id.clone())
@@ -1305,11 +1315,14 @@ fn cook_failure_context(
     latest_run_id: Option<&str>,
 ) -> Option<super::AgentTaskCookFailureContext> {
     let recipe = super::load_recipe(cook_id).ok()?;
-    let latest_run_id = latest_run_id.map(str::to_string).or_else(|| {
-        agent_task_lifecycle::cook_index(cook_id)
-            .ok()
-            .map(|index| index.latest_run_id)
-    })?;
+    let latest_run_id = latest_run_id
+        .map(str::to_string)
+        .or_else(|| {
+            agent_task_lifecycle::cook_index(cook_id)
+                .ok()
+                .map(|index| index.latest_run_id)
+        })
+        .or_else(|| recipe.attempts.last().map(|attempt| attempt.run_id.clone()))?;
     let record = agent_task_lifecycle::status(&latest_run_id).ok();
     let provider_executions_consumed = recipe
         .attempts

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1274,6 +1274,9 @@ pub(crate) fn cook_report(
         .iter()
         .map(|attempt| attempt.run_id.clone())
         .collect();
+    let failure_context = (exit_code != 0)
+        .then(|| cook_failure_context(&cook_id, latest_run_id.as_deref()))
+        .flatten();
     AgentTaskRunResult {
         value: AgentTaskCookReport {
             schema: "homeboy/agent-task-cook/v1",
@@ -1288,9 +1291,79 @@ pub(crate) fn cook_report(
             terminal_phase: None,
             terminal_failure_classification: None,
             moving_base_recovery: None,
+            failure_context,
         },
         exit_code,
     }
+}
+
+/// Build recovery coordinates from durable controller records only. Provider
+/// output, gate output, and filesystem paths stay behind `diagnose` so a failed
+/// command envelope cannot disclose private evidence.
+fn cook_failure_context(
+    cook_id: &str,
+    latest_run_id: Option<&str>,
+) -> Option<super::AgentTaskCookFailureContext> {
+    let recipe = super::load_recipe(cook_id).ok()?;
+    let latest_run_id = latest_run_id.map(str::to_string).or_else(|| {
+        agent_task_lifecycle::cook_index(cook_id)
+            .ok()
+            .map(|index| index.latest_run_id)
+    })?;
+    let record = agent_task_lifecycle::status(&latest_run_id).ok();
+    let provider_executions_consumed = recipe
+        .attempts
+        .iter()
+        .filter_map(|attempt| agent_task_lifecycle::status(&attempt.run_id).ok())
+        .map(|record| {
+            record.metadata["provider_executions_consumed"]
+                .as_u64()
+                .unwrap_or_else(|| {
+                    record.metadata["provider_executions"]
+                        .as_array()
+                        .map(|executions| executions.len() as u64)
+                        .unwrap_or_default()
+                })
+        })
+        .sum();
+    let lifecycle_state = record
+        .as_ref()
+        .map(|record| format!("{:?}", record.state))
+        .unwrap_or_else(|| "recipe_persisted_without_lifecycle_record".to_string());
+    let recovery_legal = record.is_some();
+    let legal_actions = recovery_legal
+        .then(|| {
+            vec![
+                super::AgentTaskCookRecoveryAction {
+                    action: "status".to_string(),
+                    command: format!("homeboy agent-task status {latest_run_id} --full"),
+                },
+                super::AgentTaskCookRecoveryAction {
+                    action: "diagnose".to_string(),
+                    command: format!("homeboy agent-task diagnose {latest_run_id}"),
+                },
+                super::AgentTaskCookRecoveryAction {
+                    action: "resume".to_string(),
+                    command: format!("homeboy agent-task cook-continue {cook_id}"),
+                },
+            ]
+        })
+        .unwrap_or_default();
+    Some(super::AgentTaskCookFailureContext {
+        cook_id: cook_id.to_string(),
+        latest_run_id,
+        durable_recipe_ref: format!("homeboy://agent-task/cooks/{cook_id}/recipe"),
+        lifecycle_state,
+        provider_budget_consumed: provider_executions_consumed > 0,
+        provider_executions_consumed,
+        recovery_legal,
+        recovery_reason: if recovery_legal {
+            "Only status, diagnose, and cook-continue are legal automatic recovery actions for this Cook state; retry and adopt require an explicit operator decision after diagnosis.".to_string()
+        } else {
+            "No recovery command is legal because the durable recipe has no lifecycle record. Start a fresh Cook after preserving the recipe reference for investigation.".to_string()
+        },
+        legal_actions,
+    })
 }
 
 pub(crate) fn source_spec_path(spec: &str) -> Option<PathBuf> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5617,6 +5617,44 @@ fn post_materialization_failure_families_expose_only_durable_identity_and_legal_
 }
 
 #[test]
+fn post_recipe_failure_without_lifecycle_retains_identity_but_offers_no_recovery_command() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-9655-recipe-only";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        persist_initial_recipe(&options).expect("persist durable recipe");
+
+        let report = durable_cook_error_report(
+            &options,
+            Error::internal_unexpected("lifecycle materialization failed"),
+        )
+        .expect("convert post-recipe error");
+
+        assert_eq!(
+            report.value.latest_run_id.as_deref(),
+            Some(options.initial_run_id.as_str())
+        );
+        let context = report
+            .value
+            .failure_context
+            .expect("durable failure context");
+        assert_eq!(context.cook_id, cook_id);
+        assert_eq!(context.latest_run_id, options.initial_run_id);
+        assert_eq!(
+            context.durable_recipe_ref,
+            format!("homeboy://agent-task/cooks/{cook_id}/recipe")
+        );
+        assert_eq!(
+            context.lifecycle_state,
+            "recipe_persisted_without_lifecycle_record"
+        );
+        assert!(!context.recovery_legal);
+        assert!(context.legal_actions.is_empty());
+        assert!(!context.provider_budget_consumed);
+        assert_eq!(context.provider_executions_consumed, 0);
+    });
+}
+
+#[test]
 fn re_materialize_follow_up_baseline_recovers_after_worktree_deletion() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = &temp.path().join("repo");

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5554,6 +5554,69 @@ fn cook_report_latest_run_id_prefers_invocation_over_stale_cook_index() {
 }
 
 #[test]
+fn post_materialization_failure_families_expose_only_durable_identity_and_legal_recovery() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-9655";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        persist_initial_recipe(&options).expect("persist durable recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .expect("materialize durable run");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, &options.initial_run_id)
+            .expect("index durable run");
+        agent_task_lifecycle::rewrite_record_for_test(&options.initial_run_id, |record| {
+            record.metadata["provider_executions_consumed"] = serde_json::json!(1);
+        })
+        .expect("record provider budget consumption");
+
+        // Promotion, deterministic-gate, follow-up materialization, and
+        // finalization all return through cook_report after this point.
+        for status in [
+            "promotion_failure",
+            "deterministic_gate_failure",
+            "follow_up_materialization_failure",
+            "finalization_failure",
+        ] {
+            let report = cook_report(
+                cook_id.to_string(),
+                status,
+                Vec::new(),
+                None,
+                Some("private provider evidence remains in durable diagnostics".to_string()),
+                1,
+                Some(&options.initial_run_id),
+            );
+            let value = serde_json::to_value(report.value).expect("serialize command data");
+            let context = &value["failure_context"];
+
+            assert_eq!(context["cook_id"], cook_id, "{status}");
+            assert_eq!(context["latest_run_id"], options.initial_run_id, "{status}");
+            assert_eq!(
+                context["durable_recipe_ref"],
+                format!("homeboy://agent-task/cooks/{cook_id}/recipe"),
+                "{status}"
+            );
+            assert_eq!(context["lifecycle_state"], "Queued", "{status}");
+            assert_eq!(context["provider_budget_consumed"], true, "{status}");
+            assert_eq!(context["provider_executions_consumed"], 1, "{status}");
+            assert_eq!(context["recovery_legal"], true, "{status}");
+            assert_eq!(
+                context["legal_actions"],
+                serde_json::json!([
+                    { "action": "status", "command": format!("homeboy agent-task status {} --full", options.initial_run_id) },
+                    { "action": "diagnose", "command": format!("homeboy agent-task diagnose {}", options.initial_run_id) },
+                    { "action": "resume", "command": format!("homeboy agent-task cook-continue {cook_id}") },
+                ]),
+                "{status}"
+            );
+            assert!(
+                !context.to_string().contains("private provider evidence"),
+                "{status} must not copy private evidence into failure_context"
+            );
+        }
+    });
+}
+
+#[test]
 fn re_materialize_follow_up_baseline_recovers_after_worktree_deletion() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = &temp.path().join("repo");


### PR DESCRIPTION
Fixes #9655

## Root cause
Cook persisted a recipe and lifecycle record before provider dispatch, but several later errors still escaped the generic `Result` boundary. The CLI then produced a bare error envelope without the durable Cook or run identity. Promotion had a separate conversion, while deterministic-gate, follow-up materialization, finalization, and post-result progress errors could bypass it.

## Behavior
- Adds an additive `failure_context` to failed Cook reports with `cook_id`, `latest_run_id`, a durable recipe ref, lifecycle state, and provider-budget consumption.
- Derives safe recovery coordinates only from durable recipe and lifecycle metadata, without copying provider, gate, or filesystem evidence into the command envelope.
- Lists exact legal `status`, `diagnose`, and `cook-continue` commands. It explicitly states that adopt/retry require an operator decision after diagnosis, and states when no recovery command is legal.
- Converts all errors crossing the post-materialization Cook boundary into this durable report contract, including promotion, deterministic gate, follow-up materialization, finalization, and terminal progress reporting.

## Evidence
- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents post_materialization_failure_families_expose_only_durable_identity_and_legal_recovery --lib -- --test-threads=1`

The focused regression test covers promotion, deterministic-gate, follow-up materialization, and finalization report families; it verifies durable identity, budget accounting, legal recovery commands, and evidence redaction.

## Known Test Limitation
The full `agent_task_service::cook::tests` suite is not parallel-safe in this checkout and timed out with concurrent isolated-home collisions. A pre-existing serial test, `cook_report_latest_run_id_prefers_invocation_over_stale_cook_index`, also fails because it expects an unrecorded run to appear in the durable history index; this change does not alter that history behavior.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to trace the Cook lifecycle/error boundary, implement the generic durable failure context and conversion, and draft the focused regression test. Chris reviewed the change and remains responsible for every line.