### PR TITLE
feat(daemon): fire due schedules without an external timer

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -903,9 +903,11 @@ where
 
     let (local_shutdown_tx, local_shutdown_rx) = mpsc::channel();
     let (completion_shutdown_tx, completion_shutdown_rx) = mpsc::channel();
+    let (schedule_shutdown_tx, schedule_shutdown_rx) = mpsc::channel();
     let local_child_reconciler =
         spawn_local_child_reservation_reconciler(job_store.clone(), local_shutdown_rx);
     let completion_notifier = spawn_completion_notifier(completion_shutdown_rx);
+    let schedule_ticker = spawn_schedule_ticker(schedule_shutdown_rx);
 
     let mut accepted = 0;
     let mut serve_result = Ok(());
@@ -931,8 +933,10 @@ where
 
     let _ = local_shutdown_tx.send(());
     let _ = completion_shutdown_tx.send(());
+    let _ = schedule_shutdown_tx.send(());
     let _ = local_child_reconciler.join();
     let _ = completion_notifier.join();
+    let _ = schedule_ticker.join();
     serve_result.map(|()| state)
 }
 
@@ -941,6 +945,68 @@ where
 const COMPLETION_NOTIFY_INTERVAL_ENV: &str = "HOMEBOY_DAEMON_NOTIFY_INTERVAL_SECS";
 const COMPLETION_NOTIFY_DEFAULT_INTERVAL_SECS: u64 = 5;
 const LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS: u64 = 5;
+
+/// Environment variable overriding how often the daemon checks for due
+/// schedules, in seconds. Defaults to [`SCHEDULE_TICK_DEFAULT_INTERVAL_SECS`].
+///
+/// This is the *polling* cadence, not a schedule's own cadence. Polling more
+/// often than the shortest declared interval is harmless — a schedule that is
+/// not due is skipped — and it bounds how late a due schedule can fire.
+const SCHEDULE_TICK_INTERVAL_ENV: &str = "HOMEBOY_DAEMON_SCHEDULE_TICK_SECS";
+const SCHEDULE_TICK_DEFAULT_INTERVAL_SECS: u64 = 30;
+
+/// Setting the tick interval to zero disables daemon-driven scheduling, for
+/// operators who would rather drive `homeboy schedule tick` themselves.
+fn schedule_tick_interval() -> Option<std::time::Duration> {
+    parse_schedule_tick_interval(std::env::var(SCHEDULE_TICK_INTERVAL_ENV).ok().as_deref())
+}
+
+/// Interval parsing, split from the environment read so it can be tested
+/// without mutating process-wide state under parallel tests.
+fn parse_schedule_tick_interval(configured: Option<&str>) -> Option<std::time::Duration> {
+    let seconds = configured
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(SCHEDULE_TICK_DEFAULT_INTERVAL_SECS);
+    (seconds > 0).then(|| std::time::Duration::from_secs(seconds))
+}
+
+/// Fire due schedules on a cadence so homeboy does not need an external timer
+/// to run its own periodic work (#10131).
+fn spawn_schedule_ticker(shutdown: mpsc::Receiver<()>) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let Some(interval) = schedule_tick_interval() else {
+            // Disabled: still consume the shutdown signal so the join at
+            // teardown returns promptly.
+            let _ = shutdown.recv();
+            return;
+        };
+        schedule_tick_loop(interval, shutdown)
+    })
+}
+
+/// Poll for due schedules and dispatch them.
+///
+/// Runs are dispatched onto their own threads by the ticker, so a slow
+/// scheduled command delays neither this loop nor daemon shutdown. Stale
+/// `running` markers left by a previous process are reclaimed once at start,
+/// matching how the job store reconciles expired reservations when it opens.
+fn schedule_tick_loop(interval: std::time::Duration, shutdown: mpsc::Receiver<()>) {
+    let _ = crate::schedule::reclaim_stale_runs(chrono::Utc::now());
+
+    let runner: std::sync::Arc<dyn crate::schedule::ScheduleCommandRunner> =
+        match crate::schedule::SubprocessRunner::new() {
+            Ok(runner) => std::sync::Arc::new(runner),
+            Err(_) => return,
+        };
+    let ticker = crate::schedule::ScheduleTicker::new();
+
+    loop {
+        let _ = ticker.dispatch_due(chrono::Utc::now(), std::sync::Arc::clone(&runner));
+        if shutdown.recv_timeout(interval).is_ok() {
+            return;
+        }
+    }
+}
 
 /// Reclaim capacity even when no controller polls the daemon after a failed
 /// handoff. The store owns the fail-closed child-identity check.
@@ -2571,6 +2637,59 @@ mod tests {
     use crate::daemon::runner_exec_driver::{
         self, DaemonExecOutput, PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
     };
+
+    /// Polling cadence is independent of any schedule's own cadence, and an
+    /// operator can opt out of daemon-driven scheduling entirely.
+    #[test]
+    fn schedule_tick_interval_defaults_and_can_be_disabled() {
+        assert_eq!(
+            super::parse_schedule_tick_interval(None),
+            Some(Duration::from_secs(
+                super::SCHEDULE_TICK_DEFAULT_INTERVAL_SECS
+            ))
+        );
+        assert_eq!(
+            super::parse_schedule_tick_interval(Some(" 5 ")),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            super::parse_schedule_tick_interval(Some("0")),
+            None,
+            "zero disables daemon-driven scheduling"
+        );
+        assert_eq!(
+            super::parse_schedule_tick_interval(Some("not-a-number")),
+            Some(Duration::from_secs(
+                super::SCHEDULE_TICK_DEFAULT_INTERVAL_SECS
+            )),
+            "an unparseable value falls back to the default rather than disabling"
+        );
+    }
+
+    /// The daemon must not wait a full poll interval to shut down. The loop
+    /// blocks on `recv_timeout`, so the shutdown signal has to win the race.
+    #[test]
+    fn schedule_tick_loop_exits_promptly_on_shutdown() {
+        crate::test_support::with_isolated_home(|_| {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let handle = std::thread::spawn(move || {
+                // A long poll interval: only the shutdown signal can end this
+                // loop in reasonable time.
+                super::schedule_tick_loop(Duration::from_secs(300), rx);
+            });
+
+            std::thread::sleep(Duration::from_millis(50));
+            tx.send(()).expect("send shutdown");
+
+            let start = Instant::now();
+            handle.join().expect("ticker thread joins");
+            assert!(
+                start.elapsed() < Duration::from_secs(10),
+                "shutdown must not wait out the poll interval, took {:?}",
+                start.elapsed()
+            );
+        });
+    }
 
     #[test]
     fn heartbeat_only_liveness_stalls_after_the_bounded_window() {

--- a/crates/homeboy-core/src/schedule/mod.rs
+++ b/crates/homeboy-core/src/schedule/mod.rs
@@ -20,12 +20,14 @@
 mod entity;
 pub mod execution;
 pub mod state;
+pub mod ticker;
 pub mod types;
 
 pub use execution::{
     result_digest, run_schedule, ScheduleCommandRunner, ScheduleRunOutcome, SubprocessRunner,
 };
 pub use state::{load_state, remove_state, save_state, ScheduleState};
+pub use ticker::{reclaim_stale_runs, ScheduleTicker};
 pub use types::{Cadence, NotifyPolicy, OverlapPolicy, Schedule};
 
 crate::entity_crud!(Schedule; list_ids);

--- a/crates/homeboy-core/src/schedule/ticker.rs
+++ b/crates/homeboy-core/src/schedule/ticker.rs
@@ -1,0 +1,353 @@
+//! Firing due schedules on a cadence.
+//!
+//! The ticker wakes on a fixed interval, claims whatever is due, and runs each
+//! claim on its own thread. It deliberately does **not** execute schedules
+//! inline: a scheduled command that takes ten minutes would otherwise hold the
+//! tick loop for ten minutes and starve every other schedule.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use super::execution::ScheduleCommandRunner;
+use super::state::{load_state, save_state};
+use super::types::Schedule;
+
+/// A run in flight for longer than this is treated as abandoned — almost
+/// always because the daemon was killed between marking a schedule running and
+/// recording its result. Without this, a single hard kill would leave a
+/// schedule permanently un-runnable under `OverlapPolicy::Skip`.
+pub const STALE_RUN_RECLAIM_SECS: i64 = 6 * 60 * 60;
+
+/// Tracks which schedules this process currently has in flight.
+///
+/// Disk state alone is not enough: a tick can fire again in the window between
+/// spawning a run and that run recording itself as running, which would
+/// dispatch the same schedule twice. An in-process claim closes that window;
+/// the on-disk `running` flag still guards against a second daemon.
+#[derive(Clone, Default)]
+pub struct ScheduleTicker {
+    in_flight: Arc<Mutex<HashSet<String>>>,
+}
+
+impl ScheduleTicker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of runs this process currently has in flight.
+    pub fn in_flight_count(&self) -> usize {
+        self.in_flight.lock().map(|set| set.len()).unwrap_or(0)
+    }
+
+    fn claim(&self, id: &str) -> bool {
+        self.in_flight
+            .lock()
+            .map(|mut set| set.insert(id.to_string()))
+            .unwrap_or(false)
+    }
+
+    fn release(&self, id: &str) {
+        if let Ok(mut set) = self.in_flight.lock() {
+            set.remove(id);
+        }
+    }
+
+    /// Schedules that are due now and not already running in this process.
+    pub fn claim_due(&self, now: chrono::DateTime<chrono::Utc>) -> Vec<Schedule> {
+        let due = match super::due_schedules(now) {
+            Ok(due) => due,
+            Err(_) => return Vec::new(),
+        };
+        due.into_iter()
+            .filter(|schedule| self.claim(&schedule.id))
+            .collect()
+    }
+
+    /// Claim everything due and run each on its own thread.
+    ///
+    /// Returns the ids dispatched. Run threads are intentionally not joined —
+    /// the daemon must be able to shut down promptly without waiting on an
+    /// arbitrarily long scheduled command. Each run records its own outcome, and
+    /// [`reclaim_stale_runs`] recovers state if the process dies mid-run.
+    pub fn dispatch_due(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+        runner: Arc<dyn ScheduleCommandRunner>,
+    ) -> Vec<String> {
+        let claimed = self.claim_due(now);
+        let mut dispatched = Vec::with_capacity(claimed.len());
+        for schedule in claimed {
+            let id = schedule.id.clone();
+            dispatched.push(id.clone());
+            let ticker = self.clone();
+            let runner = Arc::clone(&runner);
+            let spawned = std::thread::Builder::new()
+                .name(format!("homeboy-schedule-{id}"))
+                .spawn(move || {
+                    super::run_schedule(&schedule, runner.as_ref());
+                    ticker.release(&schedule.id);
+                });
+            if spawned.is_err() {
+                // Could not spawn — drop the claim so the next tick retries
+                // rather than wedging this schedule forever.
+                self.release(&id);
+                dispatched.pop();
+            }
+        }
+        dispatched
+    }
+}
+
+/// Clear `running` markers left behind by a process that died mid-run.
+///
+/// Runs once at ticker start, matching how the daemon reconciles expired
+/// reservations and admissions when it opens its job store.
+pub fn reclaim_stale_runs(now: chrono::DateTime<chrono::Utc>) -> Vec<String> {
+    let Ok(schedules) = super::list() else {
+        return Vec::new();
+    };
+    let mut reclaimed = Vec::new();
+    for schedule in schedules {
+        let state = load_state(&schedule.id);
+        if !state.running {
+            continue;
+        }
+        let stale = state
+            .started_at
+            .as_deref()
+            .and_then(|started| chrono::DateTime::parse_from_rfc3339(started).ok())
+            .map(|started| {
+                (now - started.with_timezone(&chrono::Utc)).num_seconds() > STALE_RUN_RECLAIM_SECS
+            })
+            // A running marker with no start time cannot be aged, and would
+            // otherwise block the schedule forever.
+            .unwrap_or(true);
+        if !stale {
+            continue;
+        }
+        let recovered = super::ScheduleState {
+            running: false,
+            started_at: None,
+            ..state
+        };
+        if save_state(&schedule.id, &recovered).is_ok() {
+            reclaimed.push(schedule.id);
+        }
+    }
+    reclaimed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::types::{Cadence, NotifyPolicy, OverlapPolicy};
+    use crate::schedule::ScheduleState;
+
+    fn schedule(id: &str) -> Schedule {
+        Schedule {
+            id: id.to_string(),
+            command: vec!["triage".to_string()],
+            every: Cadence::from_seconds(3_600).expect("cadence"),
+            notify_on: NotifyPolicy::default(),
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    struct CountingRunner {
+        calls: Arc<Mutex<Vec<Vec<String>>>>,
+        block: Option<Arc<std::sync::Barrier>>,
+    }
+
+    impl ScheduleCommandRunner for CountingRunner {
+        fn run(&self, argv: &[String]) -> crate::Result<serde_json::Value> {
+            if let Ok(mut calls) = self.calls.lock() {
+                calls.push(argv.to_vec());
+            }
+            if let Some(barrier) = &self.block {
+                barrier.wait();
+            }
+            Ok(serde_json::json!({ "status": "succeeded", "exit_code": 0 }))
+        }
+    }
+
+    #[test]
+    fn dispatches_a_due_schedule() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::save(&schedule("due-now")).expect("save");
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            let runner = Arc::new(CountingRunner {
+                calls: Arc::clone(&calls),
+                block: None,
+            });
+
+            let ticker = ScheduleTicker::new();
+            let dispatched = ticker.dispatch_due(chrono::Utc::now(), runner);
+            assert_eq!(dispatched, vec!["due-now".to_string()]);
+
+            // Let the run thread finish before asserting on its effects.
+            for _ in 0..200 {
+                if ticker.in_flight_count() == 0 {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            assert_eq!(calls.lock().expect("calls").len(), 1);
+            assert!(!load_state("due-now").running, "state must be settled");
+        });
+    }
+
+    #[test]
+    fn skips_a_schedule_that_is_not_due() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::save(&schedule("just-ran")).expect("save");
+            save_state(
+                "just-ran",
+                &ScheduleState {
+                    last_run_at: Some(chrono::Utc::now().to_rfc3339()),
+                    ..Default::default()
+                },
+            )
+            .expect("save state");
+
+            let runner = Arc::new(CountingRunner {
+                calls: Arc::new(Mutex::new(Vec::new())),
+                block: None,
+            });
+            let dispatched = ScheduleTicker::new().dispatch_due(chrono::Utc::now(), runner);
+            assert!(dispatched.is_empty());
+        });
+    }
+
+    /// The window this closes: a second tick firing before the first run has
+    /// written its `running` marker to disk would otherwise dispatch the same
+    /// schedule twice.
+    #[test]
+    fn a_second_tick_does_not_dispatch_a_run_already_in_flight() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::save(&schedule("slow")).expect("save");
+
+            let barrier = Arc::new(std::sync::Barrier::new(2));
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            let runner = Arc::new(CountingRunner {
+                calls: Arc::clone(&calls),
+                block: Some(Arc::clone(&barrier)),
+            });
+
+            let ticker = ScheduleTicker::new();
+            let first = ticker.dispatch_due(chrono::Utc::now(), Arc::clone(&runner) as Arc<_>);
+            assert_eq!(first.len(), 1, "the first tick dispatches");
+
+            let second = ticker.dispatch_due(chrono::Utc::now(), Arc::clone(&runner) as Arc<_>);
+            assert!(
+                second.is_empty(),
+                "a tick must not dispatch a schedule already running in this process"
+            );
+
+            barrier.wait(); // release the blocked run
+            for _ in 0..200 {
+                if ticker.in_flight_count() == 0 {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            assert_eq!(calls.lock().expect("calls").len(), 1, "exactly one run");
+        });
+    }
+
+    /// Once a run completes, its claim is released so the schedule can fire
+    /// again on a later tick.
+    #[test]
+    fn a_completed_run_releases_its_claim() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::save(&schedule("repeatable")).expect("save");
+            let runner = Arc::new(CountingRunner {
+                calls: Arc::new(Mutex::new(Vec::new())),
+                block: None,
+            });
+
+            let ticker = ScheduleTicker::new();
+            ticker.dispatch_due(chrono::Utc::now(), runner);
+            for _ in 0..200 {
+                if ticker.in_flight_count() == 0 {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            assert_eq!(ticker.in_flight_count(), 0, "claim must be released");
+        });
+    }
+
+    /// A hard kill between "marked running" and "recorded result" would
+    /// otherwise leave the schedule permanently blocked under skip-on-overlap.
+    #[test]
+    fn reclaims_a_run_abandoned_by_a_dead_process() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::save(&schedule("abandoned")).expect("save");
+            let now = chrono::Utc::now();
+            save_state(
+                "abandoned",
+                &ScheduleState {
+                    running: true,
+                    started_at: Some(
+                        (now - chrono::Duration::seconds(STALE_RUN_RECLAIM_SECS + 60)).to_rfc3339(),
+                    ),
+                    ..Default::default()
+                },
+            )
+            .expect("save state");
+
+            let reclaimed = reclaim_stale_runs(now);
+            assert_eq!(reclaimed, vec!["abandoned".to_string()]);
+            assert!(!load_state("abandoned").running);
+        });
+    }
+
+    #[test]
+    fn does_not_reclaim_a_run_that_is_merely_slow() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::save(&schedule("still-going")).expect("save");
+            let now = chrono::Utc::now();
+            save_state(
+                "still-going",
+                &ScheduleState {
+                    running: true,
+                    started_at: Some((now - chrono::Duration::minutes(5)).to_rfc3339()),
+                    ..Default::default()
+                },
+            )
+            .expect("save state");
+
+            assert!(reclaim_stale_runs(now).is_empty());
+            assert!(load_state("still-going").running, "slow is not abandoned");
+        });
+    }
+
+    /// A running marker with no start time cannot be aged out, so it is
+    /// reclaimed rather than blocking the schedule forever.
+    #[test]
+    fn reclaims_a_running_marker_with_no_start_time() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::save(&schedule("no-start")).expect("save");
+            save_state(
+                "no-start",
+                &ScheduleState {
+                    running: true,
+                    started_at: None,
+                    ..Default::default()
+                },
+            )
+            .expect("save state");
+
+            assert_eq!(
+                reclaim_stale_runs(chrono::Utc::now()),
+                vec!["no-start".to_string()]
+            );
+        });
+    }
+}

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -213,3 +213,9 @@ preview/apply rules for future write endpoints.
 
 - [self](self.md)
 - [status](status.md)
+
+## Scheduled runs
+
+A running daemon fires due [schedules](schedule.md) without an external timer. It polls every 30 seconds by default; override with `HOMEBOY_DAEMON_SCHEDULE_TICK_SECS`, or set it to `0` to disable daemon-driven scheduling and drive `homeboy schedule tick` yourself.
+
+Each due schedule runs on its own thread, so a slow scheduled command delays neither the poll loop nor daemon shutdown. Markers left by a run the daemon did not finish are reclaimed at start.

--- a/docs/commands/schedule.md
+++ b/docs/commands/schedule.md
@@ -74,11 +74,26 @@ homeboy schedule tick --dry-run
 
 ## Triggering
 
-`schedule tick` is the trigger surface. Point any external timer at it:
+A running daemon fires due schedules itself — `homeboy daemon start` is all that is required for declared schedules to run.
 
 ```sh
-# systemd timer, cron, or any supervisor
+homeboy daemon start
+homeboy schedule add nightly --command 'harvest production --check' --every 24h
+```
+
+The daemon polls every 30 seconds by default. That is the *polling* cadence, not a schedule's own cadence: it bounds how late a due schedule can fire, and polling more often than the shortest declared interval is harmless because a schedule that is not due is skipped. Override with `HOMEBOY_DAEMON_SCHEDULE_TICK_SECS`, or set it to `0` to turn daemon-driven scheduling off entirely.
+
+Each due schedule runs on its own thread, so a slow scheduled command delays neither the poll loop nor daemon shutdown.
+
+`homeboy schedule tick` remains available for operators who would rather drive scheduling from systemd, cron, or another supervisor — pair it with `HOMEBOY_DAEMON_SCHEDULE_TICK_SECS=0` so the two do not both fire.
+
+```sh
+# external trigger, with daemon-driven scheduling disabled
 homeboy schedule tick
 ```
 
-Running the tick more often than the shortest cadence is safe — a schedule that is not due is skipped, and `--on-overlap skip` prevents pile-up.
+## Recovering an interrupted run
+
+A schedule is marked in flight while it runs so an overlapping tick declines it. If the process is killed between that marker and the recorded result, the marker would otherwise block the schedule forever under `--on-overlap skip`.
+
+The daemon clears markers older than six hours when it starts, in the same way it reconciles expired job reservations. A marker with no recorded start time cannot be aged and is cleared as well.


### PR DESCRIPTION
## Summary

The scheduling primitive shipped without a trigger. Homeboy could declare a schedule, but something still had to call `schedule tick` — cron or a systemd timer — which is exactly the external dependency #10073 set out to remove. A declared schedule on a host with a running daemon silently never ran.

This adds a third daemon background thread beside the completion notifier and the reservation reconciler, using the same `spawn_* / recv_timeout / shutdown-channel / join` idiom already used twice in `daemon::serve`.

```sh
homeboy daemon start
homeboy schedule add nightly --command 'harvest production --check' --every 24h
# that is the whole setup
```

## Design decisions worth reviewing

**Runs are dispatched onto their own threads, not executed inline.** A scheduled command that takes ten minutes would otherwise hold the poll loop for ten minutes and starve every other schedule. It also means daemon shutdown never waits on an arbitrarily long command.

**Dispatch is claim-based, and the claim is in-process.** The on-disk `running` marker is not sufficient on its own: a tick can fire in the window between spawning a run and that run writing its marker, which would dispatch the same schedule twice. An in-process claim closes that window; the disk marker still guards against a second daemon. There is a test that fails without the claim.

**Run threads are deliberately not joined.** Joining them would reintroduce the shutdown stall this avoids. Each run records its own outcome, and stale markers are reclaimed rather than leaked.

**Stale markers are reclaimed at start.** A process killed between "marked running" and "recorded result" would otherwise leave the schedule permanently un-runnable under `--on-overlap skip`. Markers older than six hours are cleared when the ticker starts, matching how the job store reconciles expired reservations when it opens. A marker with *no* recorded start time cannot be aged, so it is reclaimed too — otherwise it would block forever.

**Polling cadence is independent of schedule cadence.** It bounds how late a due schedule can fire; polling more often than the shortest declared interval is harmless because a not-due schedule is skipped. Default 30s, `HOMEBOY_DAEMON_SCHEDULE_TICK_SECS` overrides, and `0` disables daemon-driven scheduling entirely for operators who would rather keep driving `schedule tick` from a supervisor.

**Interval parsing is split from the environment read.** `set_var` is racy under parallel tests, so `parse_schedule_tick_interval` takes the configured value and is tested directly rather than mutating process-wide state.

## Tests

Nine assertions covering the reasoning above:

- a due schedule dispatches, and its state settles
- a not-due schedule is skipped
- **a second tick does not dispatch a run already in flight** — blocks a run on a barrier, ticks again, asserts exactly one execution
- a completed run releases its claim so it can fire again
- an abandoned run (older than the reclaim window) is reclaimed
- a merely slow run is **not** reclaimed
- a running marker with no start time is reclaimed
- tick interval defaults, explicit override, `0` disabling, and an unparseable value falling back to the default rather than silently disabling
- the tick loop exits promptly on shutdown rather than waiting out a 300s poll interval

## Verification

- `cargo fmt`
- `cargo check -p homeboy-core --lib --tests` — clean
- `cargo clippy -p homeboy-core --lib --tests` — no findings in `schedule/ticker.rs` or the changed regions of `daemon/mod.rs`; remaining warnings are pre-existing elsewhere

Full `cargo build`/`cargo test` deliberately not run locally (this host OOMs on the Rust workspace); leaving the suite to CI.

## Docs

`docs/commands/schedule.md` now leads with daemon-driven triggering and keeps `schedule tick` documented for external supervisors, with the pairing note to disable one when using the other. `docs/commands/daemon.md` gains a scheduled-runs section.

Closes #10131. With this, #10073 is met as originally stated — homeboy triggers its own periodic work. #10132 (multi-step runs) and #10133 (non-homeboy commands) remain open as separate extensions.

## AI assistance

Investigated and implemented by chubes-bot (OpenCode). Chris Huber remains responsible for review and every line.