### PR TITLE
Fix cleanup next action outside git checkouts

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1356,7 +1356,9 @@ fn cleanup_actionable(
         }
         actionable.next_actions.push(CommandNextAction::new(
             format!("{} cleanup", category.category.replace('_', " ")),
-            if apply || category.category == TASK_WORKTREES_METADATA.category {
+            if category.category == REPO_ARTIFACTS_METADATA.category {
+                apply_command(&category.canonical_cleanup_command)
+            } else if apply || category.category == TASK_WORKTREES_METADATA.category {
                 category.specialist_command.clone()
             } else {
                 apply_command(&category.specialist_command)

--- a/tests/cleanup_next_actions.rs
+++ b/tests/cleanup_next_actions.rs
@@ -1,0 +1,88 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[test]
+fn aggregate_repo_artifact_next_action_runs_outside_a_checkout() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let repository = fixture.path().join("repository");
+    let invocation_dir = fixture.path().join("operator-cwd");
+    let components_dir = fixture.path().join(".config/homeboy/components");
+    std::fs::create_dir_all(repository.join("target/debug")).expect("target directory");
+    std::fs::create_dir_all(&invocation_dir).expect("operator directory");
+    std::fs::create_dir_all(&components_dir).expect("components directory");
+    std::fs::write(repository.join("target/debug/app"), "artifact").expect("target artifact");
+    run_git(&repository, &["init", "-b", "main"]);
+    std::fs::write(
+        components_dir.join("fixture.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "local_path": repository,
+            "remote_path": "fixture"
+        }))
+        .expect("component JSON"),
+    )
+    .expect("component registration");
+
+    let inventory = run_cleanup(
+        fixture.path(),
+        &invocation_dir,
+        &["--include", "repo-artifacts"],
+    );
+    assert_eq!(inventory["success"], true, "{inventory:#}");
+    assert_eq!(
+        inventory["data"]["categories"][0]["specialist_command"],
+        "homeboy cleanup artifacts"
+    );
+    assert_eq!(
+        inventory["data"]["categories"][0]["canonical_cleanup_command"],
+        "homeboy cleanup --include repo-artifacts"
+    );
+
+    let next_command = inventory["next_actions"][0]["command"]
+        .as_str()
+        .expect("repo artifact next action");
+    assert_eq!(
+        next_command,
+        "homeboy cleanup --include repo-artifacts --apply"
+    );
+
+    let args: Vec<_> = next_command.split_whitespace().skip(2).collect();
+    let applied = run_cleanup(fixture.path(), &invocation_dir, &args);
+    assert_eq!(applied["success"], true, "{applied:#}");
+    assert!(!repository.join("target").exists());
+}
+
+fn run_cleanup(home: &Path, cwd: &Path, args: &[&str]) -> Value {
+    let output = Command::new(homeboy_bin())
+        .arg("cleanup")
+        .args(args)
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run cleanup");
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "cleanup output was not JSON ({error}); status={:?}; stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary

- emit the aggregate canonical repo-artifact cleanup command as actionable remediation
- preserve checkout-scoped `homeboy cleanup artifacts` specialist behavior and metadata
- add an end-to-end regression that runs aggregate cleanup and its emitted action from a non-repository directory

Fixes #10142

## Root Cause

Aggregate cleanup categories expose both a globally scoped `canonical_cleanup_command` and a narrower `specialist_command`, but `_homeboy_actionable.next_actions` was always constructed from the specialist command. For repo artifacts, that dropped the aggregate-owned component/source resolution and made the generated action depend on the caller being inside a Git checkout.

Before:

```text
homeboy cleanup artifacts --apply
```

After:

```text
homeboy cleanup --include repo-artifacts --apply
```

## Scoped Versus Aggregate Behavior

Aggregate repo-artifact remediation now uses the context-valid canonical command. The structured category still reports `homeboy cleanup artifacts` as its specialist command, and direct scoped cleanup continues to require a checkout or explicit `--path`.

## Tests

- `LD_LIBRARY_PATH=/mnt/extrachill-workspace/tmp/opencode/rustfmt-9579/usr/lib/x86_64-linux-gnu /mnt/extrachill-workspace/tmp/opencode/rustfmt-9579/usr/bin/rustfmt --edition 2021 --check crates/homeboy-cli/src/commands/cleanup.rs tests/cleanup_next_actions.rs` (passed)
- `CARGO_TARGET_DIR=/mnt/extrachill-workspace/tmp/opencode/homeboy-10142-target cargo test --test cleanup_next_actions` (passed: 1 test)
- `CARGO_TARGET_DIR=/mnt/extrachill-workspace/tmp/opencode/homeboy-10142-target cargo test -p homeboy-core cleanup_artifacts_outside_git_checkout_suggests_path_override` (passed: 1 test)
- `CARGO_TARGET_DIR=/mnt/extrachill-workspace/tmp/opencode/homeboy-10142-target cargo test -p homeboy-cli task_worktree_cleanup_next_actions_preserve_mode_specific_commands` (passed: 1 test)
- `git diff --check` (passed)

The Rust test runs the emitted apply action against a disposable registered repository from the same non-repository directory and verifies the fixture artifact is removed. Existing workspace warnings remain unchanged. The isolated Cargo target directory was removed after verification.

## Residual Risks

The change is intentionally limited to repo-artifact actionable remediation. Other cleanup categories retain their existing specialist next actions; no broader command-generation refactor was attempted.