### PR TITLE
fix(cook): attest normal Git directories

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -365,15 +365,29 @@ pub(super) fn run_materialized_provider_command_once(
             .get("cook_attempt_workspace_identity")
             .or_else(|| request.request.metadata.get("cook_workspace_identity"))
         {
-            if !crate::agent_task_workspace_identity::workspace_matches_attestation(
+            let identity_match = crate::agent_task_workspace_identity::workspace_attestation_match(
                 &cwd,
                 attestation,
-            ) {
+            );
+            if identity_match
+                != crate::agent_task_workspace_identity::WorkspaceAttestationMatch::Matched
+            {
+                let representation_drift = identity_match
+                    == crate::agent_task_workspace_identity::WorkspaceAttestationMatch::GitRepresentationDrift;
                 return failure_outcome(
-                    request, AgentTaskOutcomeStatus::ProviderError,
+                    request,
+                    AgentTaskOutcomeStatus::ProviderError,
                     AgentTaskFailureClassification::InvalidInput,
-                    "agent_task.workspace_identity_changed",
-                    "provider workspace no longer matches its Cook attempt identity attestation; refusing execution".to_string(),
+                    if representation_drift {
+                        "agent_task.workspace_git_representation_changed"
+                    } else {
+                        "agent_task.workspace_identity_changed"
+                    },
+                    if representation_drift {
+                        "provider workspace .git representation no longer matches its Cook attempt identity attestation; refusing execution".to_string()
+                    } else {
+                        "provider workspace no longer matches its Cook attempt identity attestation; refusing execution".to_string()
+                    },
                     json!({ "provider": provider.id, "workspace": cwd }),
                 );
             }

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -469,7 +469,7 @@ fn provider_refuses_legacy_source_attestation_git_file_replaced_before_spawn() {
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
     assert_eq!(
         outcome.diagnostics[0].class,
-        "agent_task.workspace_identity_changed"
+        "agent_task.workspace_git_representation_changed"
     );
     assert!(!marker.exists(), "provider command must not start");
 }

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -50,11 +50,10 @@ fn remapped_cook_source(temp: &tempfile::TempDir) -> (std::path::PathBuf, std::p
     git(
         &controller,
         &[
-            "worktree",
-            "add",
-            "--detach",
+            "clone",
+            "--quiet",
+            controller.to_str().expect("controller path"),
             runner.to_str().expect("runner path"),
-            "HEAD",
         ],
     );
     (controller, runner)
@@ -141,8 +140,9 @@ fn remapped_lab_cook_rejects_runner_snapshot_drift_before_provider_spawn() {
     let mut plan = AgentTaskPlan::new("runner-drift-cook", vec![request]);
     crate::agent_task_service::bind_runner_snapshot_workspace_attestations(&mut plan)
         .expect("bind runner snapshot");
-    std::fs::write(runner.join(".git"), "gitdir: ../replaced-gitdir\n")
-        .expect("replace runner gitdir reference");
+    std::fs::rename(runner.join(".git"), runner.join("replaced-git-directory"))
+        .expect("replace runner git directory");
+    std::fs::create_dir(runner.join(".git")).expect("new runner git directory");
 
     let aggregate =
         AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
@@ -158,6 +158,39 @@ fn remapped_lab_cook_rejects_runner_snapshot_drift_before_provider_spawn() {
     assert!(
         !marker.exists(),
         "provider must not start after runner drift"
+    );
+}
+
+#[test]
+fn remapped_lab_cook_retry_retains_controller_predecessor_and_rebinds_directory_identity() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (controller, runner) = remapped_cook_source(&temp);
+    let (mut request, _) = request("cook-provider", "true".to_string());
+    request.workspace.root = Some(runner.display().to_string());
+    let controller_identity = crate::agent_task_workspace_identity::attest_workspace(&controller)
+        .expect("attest controller source");
+    request.metadata = serde_json::json!({ "cook_workspace_identity": controller_identity });
+    let mut plan = AgentTaskPlan::new("remapped-lab-cook-retry", vec![request]);
+
+    crate::agent_task_service::bind_runner_snapshot_workspace_attestations(&mut plan)
+        .expect("bind runner snapshot");
+    crate::agent_task_service::bind_runner_snapshot_workspace_attestations(&mut plan)
+        .expect("rebind resumed runner snapshot");
+
+    let metadata = &plan.tasks[0].metadata;
+    assert_eq!(
+        metadata["cook_workspace_identity"]["git_representation"],
+        "directory"
+    );
+    assert_eq!(
+        metadata["cook_workspace_identity_predecessor"]["git_representation"], "pointer_file",
+        "resume must retain the controller attestation as provenance"
+    );
+    assert!(
+        crate::agent_task_workspace_identity::workspace_matches_attestation(
+            &runner,
+            &metadata["cook_workspace_identity"]
+        )
     );
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -154,8 +154,7 @@ where
 /// plan is persisted or executed; the predecessor remains audit provenance.
 pub fn bind_runner_snapshot_workspace_attestations(plan: &mut AgentTaskPlan) -> Result<()> {
     for task in &mut plan.tasks {
-        let Some(controller_identity) = task.metadata.get("cook_workspace_identity").cloned()
-        else {
+        let Some(current_identity) = task.metadata.get("cook_workspace_identity").cloned() else {
             continue;
         };
         let root = task.workspace.root.as_deref().ok_or_else(|| {
@@ -169,7 +168,13 @@ pub fn bind_runner_snapshot_workspace_attestations(plan: &mut AgentTaskPlan) -> 
         let runner_identity =
             crate::agent_task_workspace_identity::attest_workspace(std::path::Path::new(root))?;
         task.metadata["cook_workspace_identity"] = runner_identity;
-        task.metadata["cook_workspace_identity_predecessor"] = controller_identity;
+        if task
+            .metadata
+            .get("cook_workspace_identity_predecessor")
+            .is_none()
+        {
+            task.metadata["cook_workspace_identity_predecessor"] = current_identity;
+        }
     }
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_workspace_identity.rs
+++ b/crates/homeboy-agents/src/agent_task_workspace_identity.rs
@@ -3,6 +3,13 @@ use std::path::Path;
 use homeboy_core::{Error, Result};
 use serde_json::Value;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceAttestationMatch {
+    Matched,
+    Mismatched,
+    GitRepresentationDrift,
+}
+
 #[cfg(unix)]
 pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
     use std::os::unix::fs::MetadataExt;
@@ -34,21 +41,64 @@ pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
     let git_metadata = std::fs::symlink_metadata(&git_file).map_err(|error| {
         Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
     })?;
-    let git_content = std::fs::read_to_string(&git_file).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
-    })?;
-    let gitdir_target = git_content
-        .strip_prefix("gitdir: ")
-        .map(str::trim)
-        .and_then(|target| std::fs::canonicalize(canonical.join(target)).ok());
-    Ok(serde_json::json!({
+    let workspace_identity = serde_json::json!({
         "canonical_path": canonical,
         "device": metadata.dev(),
         "inode": metadata.ino(),
-        "git_file_is_file": git_metadata.file_type().is_file(),
-        "git_file_content": git_content,
-        "gitdir_target": gitdir_target,
-    }))
+    });
+    if git_metadata.file_type().is_file() {
+        let git_content = std::fs::read_to_string(&git_file).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
+        })?;
+        let gitdir_target = git_content
+            .strip_prefix("gitdir: ")
+            .map(str::trim)
+            .filter(|target| !target.is_empty())
+            .and_then(|target| std::fs::canonicalize(canonical.join(target)).ok())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace",
+                    "Cook workspace .git pointer must reference an existing Git directory",
+                    Some(git_file.display().to_string()),
+                    None,
+                )
+            })?;
+        return Ok(serde_json::json!({
+            "canonical_path": workspace_identity["canonical_path"],
+            "device": workspace_identity["device"],
+            "inode": workspace_identity["inode"],
+            "git_representation": "pointer_file",
+            // Retain these fields so persisted controller worktree attestations
+            // continue to verify after this representation discriminator lands.
+            "git_file_is_file": true,
+            "git_file_content": git_content,
+            "gitdir_target": gitdir_target,
+        }));
+    }
+    if git_metadata.file_type().is_dir() {
+        let git_directory = std::fs::canonicalize(&git_file).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(git_file.display().to_string()))
+        })?;
+        let git_directory_metadata =
+            std::fs::symlink_metadata(&git_directory).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(git_directory.display().to_string()))
+            })?;
+        return Ok(serde_json::json!({
+            "canonical_path": workspace_identity["canonical_path"],
+            "device": workspace_identity["device"],
+            "inode": workspace_identity["inode"],
+            "git_representation": "directory",
+            "git_dir_canonical_path": git_directory,
+            "git_dir_device": git_directory_metadata.dev(),
+            "git_dir_inode": git_directory_metadata.ino(),
+        }));
+    }
+    Err(Error::validation_invalid_argument(
+        "workspace",
+        "Cook workspace .git must be a regular pointer file or directory",
+        Some(git_file.display().to_string()),
+        None,
+    ))
 }
 
 #[cfg(not(unix))]
@@ -60,47 +110,93 @@ pub(crate) fn attest_workspace(path: &Path) -> Result<Value> {
 
 #[cfg(unix)]
 pub fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
-    use std::os::unix::fs::MetadataExt;
-
-    let Ok(supplied_metadata) = std::fs::symlink_metadata(path) else {
-        return false;
-    };
-    if supplied_metadata.file_type().is_symlink() || !supplied_metadata.is_dir() {
-        return false;
-    }
-    let Ok(canonical) = std::fs::canonicalize(path) else {
-        return false;
-    };
-    let Ok(metadata) = std::fs::symlink_metadata(&canonical) else {
-        return false;
-    };
-    !metadata.file_type().is_symlink()
-        && attestation["canonical_path"].as_str() == canonical.to_str()
-        && attestation["device"].as_u64() == Some(metadata.dev())
-        && attestation["inode"].as_u64() == Some(metadata.ino())
-        && linked_git_metadata_matches(&canonical, attestation)
+    workspace_attestation_match(path, attestation) == WorkspaceAttestationMatch::Matched
 }
 
 #[cfg(unix)]
-fn linked_git_metadata_matches(worktree: &Path, attestation: &Value) -> bool {
+pub fn workspace_attestation_match(path: &Path, attestation: &Value) -> WorkspaceAttestationMatch {
+    use std::os::unix::fs::MetadataExt;
+
+    let Ok(supplied_metadata) = std::fs::symlink_metadata(path) else {
+        return WorkspaceAttestationMatch::Mismatched;
+    };
+    if supplied_metadata.file_type().is_symlink() || !supplied_metadata.is_dir() {
+        return WorkspaceAttestationMatch::Mismatched;
+    }
+    let Ok(canonical) = std::fs::canonicalize(path) else {
+        return WorkspaceAttestationMatch::Mismatched;
+    };
+    let Ok(metadata) = std::fs::symlink_metadata(&canonical) else {
+        return WorkspaceAttestationMatch::Mismatched;
+    };
+    if metadata.file_type().is_symlink()
+        || attestation["canonical_path"].as_str() != canonical.to_str()
+        || attestation["device"].as_u64() != Some(metadata.dev())
+        || attestation["inode"].as_u64() != Some(metadata.ino())
+    {
+        return WorkspaceAttestationMatch::Mismatched;
+    }
+    git_metadata_match(&canonical, attestation)
+}
+
+#[cfg(unix)]
+fn git_metadata_match(worktree: &Path, attestation: &Value) -> WorkspaceAttestationMatch {
+    use std::os::unix::fs::MetadataExt;
+
     let git_file = worktree.join(".git");
     let Ok(metadata) = std::fs::symlink_metadata(&git_file) else {
-        return false;
+        return WorkspaceAttestationMatch::Mismatched;
     };
-    if !metadata.file_type().is_file() || attestation["git_file_is_file"] != true {
-        return false;
-    }
-    let Ok(content) = std::fs::read_to_string(&git_file) else {
-        return false;
+    let expected = attestation["git_representation"]
+        .as_str()
+        .or_else(|| (attestation["git_file_is_file"] == true).then_some("pointer_file"));
+    let actual = if metadata.file_type().is_file() {
+        "pointer_file"
+    } else if metadata.file_type().is_dir() {
+        "directory"
+    } else {
+        return WorkspaceAttestationMatch::Mismatched;
     };
-    if attestation["git_file_content"].as_str() != Some(content.as_str()) {
-        return false;
+    if expected != Some(actual) {
+        return WorkspaceAttestationMatch::GitRepresentationDrift;
     }
-    let target = content
-        .strip_prefix("gitdir: ")
-        .map(str::trim)
-        .and_then(|target| std::fs::canonicalize(worktree.join(target)).ok());
-    target.as_deref().and_then(|path| path.to_str()) == attestation["gitdir_target"].as_str()
+    if actual == "pointer_file" {
+        let Ok(content) = std::fs::read_to_string(&git_file) else {
+            return WorkspaceAttestationMatch::Mismatched;
+        };
+        if attestation["git_file_content"].as_str() != Some(content.as_str()) {
+            return WorkspaceAttestationMatch::Mismatched;
+        }
+        let target = content
+            .strip_prefix("gitdir: ")
+            .map(str::trim)
+            .filter(|target| !target.is_empty())
+            .and_then(|target| std::fs::canonicalize(worktree.join(target)).ok());
+        return if target.as_deref().and_then(|path| path.to_str())
+            == attestation["gitdir_target"].as_str()
+        {
+            WorkspaceAttestationMatch::Matched
+        } else {
+            WorkspaceAttestationMatch::Mismatched
+        };
+    }
+    let Ok(canonical) = std::fs::canonicalize(&git_file) else {
+        return WorkspaceAttestationMatch::Mismatched;
+    };
+    let Ok(directory_metadata) = std::fs::symlink_metadata(&canonical) else {
+        return WorkspaceAttestationMatch::Mismatched;
+    };
+    if directory_metadata.file_type().is_symlink() || !directory_metadata.is_dir() {
+        return WorkspaceAttestationMatch::Mismatched;
+    }
+    if attestation["git_dir_canonical_path"].as_str() == canonical.to_str()
+        && attestation["git_dir_device"].as_u64() == Some(directory_metadata.dev())
+        && attestation["git_dir_inode"].as_u64() == Some(directory_metadata.ino())
+    {
+        WorkspaceAttestationMatch::Matched
+    } else {
+        WorkspaceAttestationMatch::Mismatched
+    }
 }
 
 #[cfg(not(unix))]
@@ -110,6 +206,13 @@ pub fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
         .and_then(|path| path.to_str().map(str::to_string))
         .as_deref()
         == attestation["canonical_path"].as_str()
+}
+
+#[cfg(not(unix))]
+pub fn workspace_attestation_match(path: &Path, attestation: &Value) -> WorkspaceAttestationMatch {
+    workspace_matches_attestation(path, attestation)
+        .then_some(WorkspaceAttestationMatch::Matched)
+        .unwrap_or(WorkspaceAttestationMatch::Mismatched)
 }
 
 #[cfg(all(test, unix))]
@@ -131,5 +234,56 @@ mod tests {
 
         assert!(attest_workspace(&alias).is_err());
         assert!(!workspace_matches_attestation(&alias, &attestation));
+    }
+
+    #[test]
+    fn attests_and_rejects_replaced_normal_git_directories() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let git_directory = workspace.join(".git");
+        std::fs::create_dir_all(&git_directory).expect("git directory");
+        let attestation = attest_workspace(&workspace).expect("attest workspace");
+
+        assert_eq!(attestation["git_representation"], "directory");
+        assert!(workspace_matches_attestation(&workspace, &attestation));
+        std::fs::rename(&git_directory, workspace.join("replaced-git-directory"))
+            .expect("replace git directory");
+        std::fs::create_dir(&git_directory).expect("new git directory");
+        assert!(!workspace_matches_attestation(&workspace, &attestation));
+    }
+
+    #[test]
+    fn reports_pointer_to_directory_representation_drift() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let gitdir = temp.path().join("gitdir");
+        std::fs::create_dir(&workspace).expect("workspace");
+        std::fs::create_dir(&gitdir).expect("gitdir");
+        std::fs::write(workspace.join(".git"), "gitdir: ../gitdir\n").expect("git file");
+        let attestation = attest_workspace(&workspace).expect("attest workspace");
+        std::fs::remove_file(workspace.join(".git")).expect("remove git file");
+        std::fs::create_dir(workspace.join(".git")).expect("git directory");
+
+        assert_eq!(
+            workspace_attestation_match(&workspace, &attestation),
+            WorkspaceAttestationMatch::GitRepresentationDrift
+        );
+    }
+
+    #[test]
+    fn accepts_legacy_pointer_attestations_without_a_representation_discriminator() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let gitdir = temp.path().join("gitdir");
+        std::fs::create_dir(&workspace).expect("workspace");
+        std::fs::create_dir(&gitdir).expect("gitdir");
+        std::fs::write(workspace.join(".git"), "gitdir: ../gitdir\n").expect("git file");
+        let mut attestation = attest_workspace(&workspace).expect("attest workspace");
+        attestation
+            .as_object_mut()
+            .expect("attestation object")
+            .remove("git_representation");
+
+        assert!(workspace_matches_attestation(&workspace, &attestation));
     }
 }


### PR DESCRIPTION
Fixes #10146

## Summary
- Adds an explicit `.git` representation discriminator to Cook workspace attestations.
- Keeps linked-worktree pointer identities bound to pointer content plus canonical gitdir target.
- Supports normal checkout identities with canonical `.git` directory path and stable device/inode metadata.
- Returns `agent_task.workspace_git_representation_changed` when a pointer/file and directory representation drifts, instead of attempting directory text IO.
- Keeps the original controller identity as predecessor provenance across runner resume/rebinding.

## Concrete Reproduction
1. Create a clean controller Git worktree, whose `.git` is a `gitdir:` pointer file.
2. Materialize its Lab snapshot as a normal clone, whose `.git` is a directory.
3. Bind the runner snapshot identity and dispatch the Cook provider.

Before this change, identity capture called `read_to_string(.git)` on the normal checkout and failed with `Is a directory (os error 21)` before provider execution. The deterministic integration test now executes the provider and harvests its committed patch from that normal runner checkout.

## Compatibility Analysis
Existing controller worktree attestations remain compatible: attestations without `git_representation` and with the legacy `git_file_is_file: true`, pointer content, and canonical target are verified as pointer-file identities. New pointer attestations retain those legacy fields while adding `git_representation: pointer_file`. Runner-native normal-checkout attestations use `git_representation: directory` with independent directory identity fields. The controller attestation remains in `cook_workspace_identity_predecessor`, including on retry/resume rebinding.

## Evidence
- Source relationship: controller linked worktree pointer file -> Lab materialized normal checkout directory -> isolated provider attempt worktree.
- Change kind: bounded generic workspace-attestation contract correction; no Lab-only or repository/path-specific exception.
- Verification capability: deterministic tests cover unchanged normal-checkout provider dispatch and patch harvest, pointer and directory replacement rejection, legacy pointer metadata, and repeated runner rebinding for retry/resume.
- Runtime scope: only the existing Cook identity capture/verification and runner attestation replacement boundary changes. It does not alter snapshot transport, provider selection, or release behavior.

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-agents remapped_lab_cook --lib -- --test-threads=1`
- `cargo test -p homeboy-agents agent_task_workspace_identity --lib -- --test-threads=1`
- `cargo test -p homeboy-agents provider_refuses_legacy_source_attestation_git_file_replaced_before_spawn --lib -- --test-threads=1`
- `cargo check -p homeboy-agents -p homeboy-lab-runner`

## AI Assistance
Implemented with OpenAI GPT-5.6 Terra (OpenCode): issue and merged-boundary inspection, reproduction analysis, code and test changes, validation, and this PR description were AI-assisted with human-directed requirements.