### PR TITLE
Scale Lab workspace pruning

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -1040,8 +1040,14 @@ pub fn prune_workspaces(
     let mut candidate_entries = Vec::new();
     let mut total_candidate_count = 0;
     let mut total_candidate_bytes = 0;
+    let mut scanned_workspace_count = 0;
+    let mut scan_complete = true;
+    let remaining_candidates: Vec<RunnerWorkspacePruneEntry> = Vec::new();
     for pass in 0..passes {
-        let candidates = prune_candidates_for_runner(&runner, &lab_workspaces_root, &options)?;
+        let scan = prune_candidates_for_runner(&runner, &lab_workspaces_root, &options, limit)?;
+        scanned_workspace_count += scan.scanned_workspace_count;
+        scan_complete = scan.scan_complete;
+        let candidates = scan.candidates;
         if pass == 0 {
             total_candidate_count = candidates.len();
             total_candidate_bytes = candidates.iter().map(|entry| entry.bytes).sum();
@@ -1049,7 +1055,7 @@ pub fn prune_workspaces(
         if candidates.is_empty() {
             break;
         }
-        for candidate in candidates.into_iter().take(limit) {
+        for candidate in candidates {
             if !options.apply {
                 candidate_entries.push(candidate);
                 continue;
@@ -1062,22 +1068,14 @@ pub fn prune_workspaces(
                 }),
             }
         }
-        if !options.apply || total_candidate_count <= limit {
+        if !options.apply || scan_complete {
             break;
         }
     }
 
-    let remaining_candidates = if options.apply {
-        prune_candidates_for_runner(&runner, &lab_workspaces_root, &options)?
-    } else {
-        prune_candidates_for_runner(&runner, &lab_workspaces_root, &options)?
-            .into_iter()
-            .skip(limit)
-            .collect()
-    };
     let remaining_candidate_count = remaining_candidates.len();
     let remaining_candidate_bytes = remaining_candidates.iter().map(|entry| entry.bytes).sum();
-    let has_more = remaining_candidate_count > 0;
+    let has_more = !scan_complete || remaining_candidate_count > 0 || !skipped.is_empty();
     let runner_arg = shell_arg(&runner.id);
     let next_command = has_more.then(|| {
         if options.apply {
@@ -1111,6 +1109,8 @@ pub fn prune_workspaces(
             candidates: candidate_entries,
             removed,
             skipped,
+            scanned_workspace_count,
+            scan_complete,
             total_candidate_count,
             total_candidate_bytes,
             total_removed_bytes,
@@ -1128,11 +1128,20 @@ fn prune_candidates_for_runner(
     runner: &super::super::Runner,
     lab_workspaces_root: &str,
     options: &RunnerWorkspacePruneOptions,
-) -> Result<Vec<RunnerWorkspacePruneEntry>> {
+    scan_limit: usize,
+) -> Result<PruneCandidateScan> {
     match runner.kind {
-        RunnerKind::Local => prune_candidates_local(Path::new(lab_workspaces_root), options),
-        RunnerKind::Ssh => prune_candidates_ssh(runner, lab_workspaces_root, options),
+        RunnerKind::Local => {
+            prune_candidates_local(Path::new(lab_workspaces_root), options, scan_limit)
+        }
+        RunnerKind::Ssh => prune_candidates_ssh(runner, lab_workspaces_root, options, scan_limit),
     }
+}
+
+struct PruneCandidateScan {
+    candidates: Vec<RunnerWorkspacePruneEntry>,
+    scanned_workspace_count: usize,
+    scan_complete: bool,
 }
 
 /// Reap a single run-scoped materialized workspace (and its sibling Homeboy
@@ -1811,17 +1820,25 @@ fn exclude_homeboy_metadata_from_git_status(workspace_path: &Path) -> Result<()>
 fn prune_candidates_local(
     root: &Path,
     options: &RunnerWorkspacePruneOptions,
-) -> Result<Vec<RunnerWorkspacePruneEntry>> {
+    scan_limit: usize,
+) -> Result<PruneCandidateScan> {
     if !root.is_dir() {
-        return Ok(Vec::new());
+        return Ok(PruneCandidateScan {
+            candidates: Vec::new(),
+            scanned_workspace_count: 0,
+            scan_complete: true,
+        });
     }
     let mut candidates = Vec::new();
-    for entry in fs::read_dir(root).map_err(|err| {
+    let mut entries = fs::read_dir(root).map_err(|err| {
         Error::internal_io(
             err.to_string(),
             Some("read runner workspace root".to_string()),
         )
-    })? {
+    })?;
+    let mut scanned_workspace_count = 0;
+    let mut scan_complete = true;
+    while let Some(entry) = entries.next() {
         let entry = entry.map_err(|err| {
             Error::internal_io(
                 err.to_string(),
@@ -1832,6 +1849,11 @@ fn prune_candidates_local(
         if !entry.file_type().map(|kind| kind.is_dir()).unwrap_or(false) {
             continue;
         }
+        if scanned_workspace_count == scan_limit {
+            scan_complete = false;
+            break;
+        }
+        scanned_workspace_count += 1;
         if let Some(candidate) = classify_local_candidate(root, &path, options)? {
             candidates.push(candidate);
         }
@@ -1840,8 +1862,13 @@ fn prune_candidates_local(
         b.bytes
             .cmp(&a.bytes)
             .then_with(|| b.age_seconds.cmp(&a.age_seconds))
+            .then_with(|| a.remote_path.cmp(&b.remote_path))
     });
-    Ok(candidates)
+    Ok(PruneCandidateScan {
+        candidates,
+        scanned_workspace_count,
+        scan_complete,
+    })
 }
 
 fn classify_local_candidate(
@@ -1944,11 +1971,12 @@ fn prune_candidates_ssh(
     runner: &super::super::Runner,
     root: &str,
     options: &RunnerWorkspacePruneOptions,
-) -> Result<Vec<RunnerWorkspacePruneEntry>> {
+    scan_limit: usize,
+) -> Result<PruneCandidateScan> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
     let min_age = options.min_age_hours.saturating_mul(3600);
-    let command = prune_scan_command(root, min_age);
+    let command = prune_scan_command(root, min_age, scan_limit);
     let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
@@ -1957,7 +1985,33 @@ fn prune_candidates_ssh(
         )));
     }
     let mut candidates = Vec::new();
+    let mut scan_status = None;
     for line in output.stdout.lines() {
+        if let Some(status) = line.strip_prefix("__homeboy_prune_scan__\t") {
+            let parts = status.split('\t').collect::<Vec<_>>();
+            let [scanned_workspace_count, completion] = parts.as_slice() else {
+                return Err(Error::internal_unexpected(
+                    "runner workspace prune scan returned an invalid completion status".to_string(),
+                ));
+            };
+            let scanned_workspace_count = scanned_workspace_count.parse().map_err(|err| {
+                Error::internal_unexpected(format!(
+                    "runner workspace prune scan returned an invalid inspected count: {err}"
+                ))
+            })?;
+            let scan_complete = match *completion {
+                "complete" => true,
+                "partial" => false,
+                _ => {
+                    return Err(Error::internal_unexpected(
+                        "runner workspace prune scan returned an invalid completion status"
+                            .to_string(),
+                    ));
+                }
+            };
+            scan_status = Some((scanned_workspace_count, scan_complete));
+            continue;
+        }
         let parts = line.splitn(4, '\t').collect::<Vec<_>>();
         if parts.len() != 4 {
             continue;
@@ -1970,6 +2024,11 @@ fn prune_candidates_ssh(
             .map_err(|err| Error::internal_json(err.to_string(), None))?;
         let metadata: serde_json::Value = serde_json::from_slice(&decoded)
             .map_err(|err| Error::internal_json(err.to_string(), Some(remote_path.clone())))?;
+        if metadata.get("schema").and_then(|value| value.as_str())
+            != Some("homeboy/runner-workspace/v1")
+        {
+            continue;
+        }
         let Some(source_path) = metadata.get("local_path").and_then(|value| value.as_str()) else {
             continue;
         };
@@ -2005,8 +2064,18 @@ fn prune_candidates_ssh(
         b.bytes
             .cmp(&a.bytes)
             .then_with(|| b.age_seconds.cmp(&a.age_seconds))
+            .then_with(|| a.remote_path.cmp(&b.remote_path))
     });
-    Ok(candidates)
+    let (scanned_workspace_count, scan_complete) = scan_status.ok_or_else(|| {
+        Error::internal_unexpected(
+            "runner workspace prune scan did not return a completion status".to_string(),
+        )
+    })?;
+    Ok(PruneCandidateScan {
+        candidates,
+        scanned_workspace_count,
+        scan_complete,
+    })
 }
 
 fn prune_candidate_reason_from_decoded_metadata(
@@ -2035,13 +2104,13 @@ fn prune_candidate_reason_from_decoded_metadata(
     (!Path::new(source_path).exists()).then(|| "source_path_missing".to_string())
 }
 
-pub(crate) fn prune_scan_command(root: &str, min_age: u64) -> String {
+pub(crate) fn prune_scan_command(root: &str, min_age: u64, scan_limit: usize) -> String {
     format!(
-        "root={root}; meta_rel={meta}; now=$(date +%s); if [ -d \"$root\" ]; then find \"$root\" -mindepth 1 -maxdepth 1 -type d -exec sh -c 'meta_rel=$1; now=$2; min_age=$3; shift 3; for dir do meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; mtime=$(stat -c %Y \"$dir\" 2>/dev/null || stat -f %m \"$dir\" 2>/dev/null || echo 0); age=$((now-mtime)); [ \"$age\" -ge \"$min_age\" ] || continue; if find \"$dir/.homeboy\" -type f \\( -name \"*.patch\" -o -name \"*.diff\" -o -name \"*patch*\" \\) 2>/dev/null | grep -q .; then continue; fi; blocks=$(du -sk \"$dir\" 2>/dev/null); blocks=${{blocks%%[!0-9]*}}; bytes=$((blocks * 1024)); printf \"%s\\t%s\\t%s\\t\" \"$age\" \"${{bytes:-0}}\" \"$dir\"; base64 < \"$meta\" | tr -d \"\\n\"; printf \"\\n\"; done' sh {meta_arg} \"$now\" {min_age_arg} {{}} +; fi",
+        "root={root}; meta_rel={meta}; min_age={min_age}; now=$(date +%s); if [ -d \"$root\" ]; then find \"$root\" -mindepth 1 -maxdepth 1 -type d -print | {{ scanned=0; complete=complete; while IFS= read -r dir; do if [ \"$scanned\" -ge {scan_limit} ]; then complete=partial; break; fi; scanned=$((scanned + 1)); meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; mtime=$(stat -c %Y \"$dir\" 2>/dev/null || stat -f %m \"$dir\" 2>/dev/null || echo 0); age=$((now-mtime)); [ \"$age\" -ge \"$min_age\" ] || continue; if find \"$dir/.homeboy\" -type f \\( -name \"*.patch\" -o -name \"*.diff\" -o -name \"*patch*\" \\) 2>/dev/null | grep -q .; then continue; fi; blocks=$(du -sk \"$dir\" 2>/dev/null); blocks=${{blocks%%[!0-9]*}}; bytes=$((blocks * 1024)); printf \"%s\\t%s\\t%s\\t\" \"$age\" \"${{bytes:-0}}\" \"$dir\"; base64 < \"$meta\" | tr -d \"\\n\"; printf \"\\n\"; done; printf \"__homeboy_prune_scan__\\t%s\\t%s\\n\" \"$scanned\" \"$complete\"; }}; else printf \"__homeboy_prune_scan__\\t0\\tcomplete\\n\"; fi",
         root = shell::quote_arg(root),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
-        meta_arg = shell::quote_arg(WORKSPACE_METADATA_FILE),
-        min_age_arg = shell::quote_arg(&min_age.to_string()),
+        min_age = shell::quote_arg(&min_age.to_string()),
+        scan_limit = scan_limit,
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -426,10 +426,11 @@ fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
         assert_eq!(exit_code, 0);
         assert!(output.dry_run);
         assert_eq!(output.candidates.len(), 1);
-        assert_eq!(output.total_candidate_count, 2);
-        assert!(output.total_candidate_bytes > output.candidates[0].bytes);
-        assert_eq!(output.remaining_candidate_count, 1);
-        assert!(output.remaining_candidate_bytes > 0);
+        assert_eq!(output.scanned_workspace_count, 1);
+        assert!(!output.scan_complete);
+        assert_eq!(output.total_candidate_count, 1);
+        assert_eq!(output.remaining_candidate_count, 0);
+        assert_eq!(output.remaining_candidate_bytes, 0);
         assert!(output.has_more);
         assert_eq!(
             output.next_command.as_deref(),
@@ -487,7 +488,8 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
 
         assert_eq!(exit_code, 0);
         assert!(!output.dry_run);
-        assert_eq!(output.total_candidate_count, 2);
+        assert_eq!(output.scanned_workspace_count, 2);
+        assert_eq!(output.total_candidate_count, 1);
         assert_eq!(output.removed.len(), 2);
         assert_eq!(output.remaining_candidate_count, 0);
         assert_eq!(output.remaining_candidate_bytes, 0);
@@ -496,6 +498,85 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
         assert!(!Path::new(&workspace_a.remote_path).exists());
         assert!(!Path::new(&workspace_b.remote_path).exists());
     });
+}
+
+#[test]
+fn prune_workspaces_bounds_thousands_of_entries_per_pass_and_drains_stably() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        const WORKSPACE_COUNT: usize = 5_214;
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let workspaces_root = runner_root.path().join("_lab_workspaces");
+        fs::create_dir_all(&workspaces_root).expect("workspaces root");
+        for index in 0..WORKSPACE_COUNT {
+            write_orphan_workspace(&workspaces_root.join(format!("workspace-{index:05}")));
+        }
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-thousands","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let options = RunnerWorkspacePruneOptions {
+            apply: true,
+            min_age_hours: 0,
+            limit: 5,
+            passes: 3,
+        };
+        let (first, _) = prune_workspaces("lab-local-prune-thousands", options.clone())
+            .expect("first bounded drain");
+        let (second, _) =
+            prune_workspaces("lab-local-prune-thousands", options).expect("second bounded drain");
+
+        assert_eq!(first.scanned_workspace_count, 15);
+        assert_eq!(first.removed.len(), 15);
+        assert_eq!(first.total_candidate_count, 5);
+        assert!(!first.scan_complete);
+        assert!(first.has_more);
+        assert_eq!(second.scanned_workspace_count, 15);
+        assert_eq!(second.removed.len(), 15);
+        assert!(first.removed.iter().all(|entry| !second
+            .removed
+            .iter()
+            .any(|next| next.remote_path == entry.remote_path)));
+        assert_eq!(
+            fs::read_dir(&workspaces_root)
+                .expect("remaining workspaces")
+                .count(),
+            WORKSPACE_COUNT - 30
+        );
+    });
+}
+
+#[test]
+fn ssh_prune_scan_command_bounds_thousands_of_entries() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    for index in 0..5_214 {
+        write_orphan_workspace(&temp.path().join(format!("workspace-{index:05}")));
+    }
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(prune_scan_command(&temp.path().display().to_string(), 0, 5))
+        .output()
+        .expect("run generated prune scan command");
+
+    assert!(output.status.success(), "{:?}", output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout
+            .lines()
+            .filter(|line| !line.starts_with("__homeboy_prune_scan__"))
+            .count(),
+        5,
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("__homeboy_prune_scan__\t5\tpartial"),
+        "{stdout}"
+    );
 }
 
 #[test]
@@ -522,7 +603,7 @@ fn ssh_prune_scan_command_handles_paths_that_need_shell_quoting() {
 
     let output = Command::new("sh")
         .arg("-c")
-        .arg(prune_scan_command(&root.display().to_string(), 0))
+        .arg(prune_scan_command(&root.display().to_string(), 0, 10))
         .output()
         .expect("run generated prune scan command");
 
@@ -537,7 +618,11 @@ fn ssh_prune_scan_command_handles_paths_that_need_shell_quoting() {
         "{stdout}"
     );
     assert!(stdout.contains('\t'), "{stdout}");
-    assert!(stdout.lines().count() == 1, "{stdout}");
+    assert!(stdout.lines().count() == 2, "{stdout}");
+    assert!(
+        stdout.contains("__homeboy_prune_scan__\t1\tcomplete"),
+        "{stdout}"
+    );
 }
 
 fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {
@@ -551,4 +636,18 @@ fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {
         allow_dirty_lab_workspace: false,
         run_isolation_token: None,
     }
+}
+
+fn write_orphan_workspace(path: &Path) {
+    fs::create_dir_all(path.join(".homeboy")).expect("workspace metadata dir");
+    fs::write(path.join("file.txt"), "orphan\n").expect("workspace file");
+    fs::write(
+        path.join(WORKSPACE_METADATA_FILE),
+        serde_json::json!({
+            "schema": "homeboy/runner-workspace/v1",
+            "local_path": path.join("missing-source").display().to_string(),
+        })
+        .to_string(),
+    )
+    .expect("workspace metadata");
 }

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -341,11 +341,17 @@ pub struct RunnerWorkspacePruneOutput {
     pub candidates: Vec<RunnerWorkspacePruneEntry>,
     pub removed: Vec<RunnerWorkspacePruneEntry>,
     pub skipped: Vec<RunnerWorkspacePruneSkippedEntry>,
+    /// Number of workspace directories inspected during this invocation.
+    pub scanned_workspace_count: usize,
+    /// Whether the inspected window reached the end of the workspace root.
+    pub scan_complete: bool,
+    /// Candidate totals are limited to the first bounded scan window.
     pub total_candidate_count: usize,
     pub total_candidate_bytes: u64,
     pub total_removed_bytes: u64,
     pub remaining_candidate_count: usize,
     pub remaining_candidate_bytes: u64,
+    /// `has_more` includes an incomplete scan, so remaining totals can be partial.
     pub has_more: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_command: Option<String>,

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -823,6 +823,17 @@ Safety rules:
 - Output includes `local_path`, `remote_path`, `sync_mode`, `snapshot_identity`, and snapshot `files` / `bytes` when available.
 - The runner workspace is execution-only; this command does not push branches, commit, or make the runner authoritative for source changes.
 
+### `workspace prune`
+
+```sh
+homeboy runner workspace prune <runner-id> --min-age-hours 24 --limit 5
+homeboy runner workspace prune <runner-id> --apply --min-age-hours 24 --limit 5 --passes 10
+```
+
+`workspace prune` only removes metadata-backed, inactive Lab workspaces that are old enough, have no pending patch or diff artifact, and are orphaned or have an expired lifecycle TTL. It never removes outside `_lab_workspaces`.
+
+`--limit` bounds the workspace directories inspected, sized, retained in memory, and removed in each pass. `--passes` bounds apply passes. Output now includes `scanned_workspace_count` and `scan_complete`: when `scan_complete` is false, `has_more` is true and `total_candidate_*` plus `remaining_candidate_*` describe only the inspected window, not every runner workspace. Use the emitted `next_command` or `drain_command` to continue safely.
+
 ### `workspace apply`
 
 ```sh


### PR DESCRIPTION
## Summary
Bound runner workspace prune work so large Lab backlogs can be inspected and drained incrementally without hitting the fixed SSH probe timeout.

## What changed
- Limits each local or SSH scan to the requested batch, reports whether the scan is partial, avoids the second full preview scan, and adds deterministic 5,214-entry drain coverage.

## How to test
1. Run `cargo test -p homeboy-lab-runner workspace::tests::prune`; expect 11 prune tests pass, including bounded 5,214-entry scan and drain behavior.

## Compatibility
Adds scanned\_workspace\_count and scan\_complete to prune output. Existing total and remaining fields now describe the bounded inspected window when scan\_complete is false; has\_more and emitted drain commands preserve iterative cleanup behavior.

## Evidence
- Base advanced after verification: verified main at 0861597086fb1ae8561e2a4a733056d783f7d5ba; publication observed 21e1859c370369566621becfc1564f32039c2dca. Candidate ancestry was validated against the verified snapshot.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/10141
- Verified finalization base: main at 0861597086fb1ae8561e2a4a733056d783f7d5ba
- deterministic gate passed: sh -lc cargo check -p homeboy-lab-runner -p homeboy-cli (Passed)
- deterministic gate passed: sh -lc cargo fmt --all -- --check (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-lab-runner workspace::tests::prune (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented bounded runner workspace scanning, output semantics, tests, and documentation; Homeboy deterministic promotion gates verified the candidate.

## Source relationships
- Closes Extra-Chill/homeboy#10141
