### PR TITLE
Fix runner generation convergence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -383,6 +383,14 @@ pub(crate) fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
     );
     metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     metadata.insert(
+        "managed_recovery".to_string(),
+        json!({
+            "action": "agent_task_retry",
+            "command": format!("homeboy agent-task retry {record_run_id} --run"),
+            "reason": EXPIRED_LAB_HANDOFF_REASON,
+        }),
+    );
+    metadata.insert(
         "runner_execution_record".to_string(),
         serde_json::to_value(
             homeboy_core::runner_execution_envelope::RunnerExecutionRecord::terminal(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -484,6 +484,10 @@ fn status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins() {
         assert_eq!(expired.state, AgentTaskRunState::Cancelled);
         assert_eq!(expired.metadata["handoff_acceptance"]["state"], "expired");
         assert_eq!(expired.metadata["retryable"], true);
+        assert_eq!(
+            expired.metadata["managed_recovery"]["command"],
+            "homeboy agent-task retry expired-handoff-late-acceptance --run"
+        );
 
         let accepted = record_detached_lab_run(DetachedLabRunRecord {
             run_id: "expired-handoff-late-acceptance",

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -271,6 +271,28 @@ pub(super) fn authoritative_idle_lease_for_stale_generations(
     Ok(Some(lease_id.to_string()))
 }
 
+/// A stale generation registry may be retired only after the remote authority
+/// proves there is no process left that could own its recorded work. A missing
+/// lease is sufficient only when the authoritative jobs view is also zero.
+pub(super) fn authoritative_stale_generations_are_dead(
+    status: &RemoteDaemonStatus,
+    persisted_leases: &[String],
+) -> bool {
+    if persisted_leases.is_empty() || status.reachable || status.active_jobs != 0 {
+        return false;
+    }
+    match status.daemon.as_ref() {
+        Some(daemon) => {
+            status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
+                && daemon.lease_id.as_deref().is_some_and(|lease| {
+                    persisted_leases.iter().any(|persisted| persisted == lease)
+                })
+                && daemon.pid.is_some()
+        }
+        None => status.stale_reason_code == Some(DaemonStaleReasonCode::LeaseMissing),
+    }
+}
+
 /// A stop is complete only when the remote state is absent or explicitly proves
 /// the exact stopped lease is dead. A new lease is a recovery race, not success.
 pub(super) fn authoritative_lease_stop_confirmed(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -273,7 +273,9 @@ pub(super) fn authoritative_idle_lease_for_stale_generations(
 
 /// A stale generation registry may be retired only after the remote authority
 /// proves there is no process left that could own its recorded work. A missing
-/// lease is sufficient only when the authoritative jobs view is also zero.
+/// lease is sufficient only when the authoritative jobs view is also zero. A
+/// PID-dead result is specific to one lease, so it cannot retire an inventory
+/// containing any other lease.
 pub(super) fn authoritative_stale_generations_are_dead(
     status: &RemoteDaemonStatus,
     persisted_leases: &[String],
@@ -285,7 +287,7 @@ pub(super) fn authoritative_stale_generations_are_dead(
         Some(daemon) => {
             status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
                 && daemon.lease_id.as_deref().is_some_and(|lease| {
-                    persisted_leases.iter().any(|persisted| persisted == lease)
+                    persisted_leases.iter().all(|persisted| persisted == lease)
                 })
                 && daemon.pid.is_some()
         }

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -243,6 +243,28 @@ fn stale_generation_reconciliation_refuses_a_lease_change_after_stop() {
 }
 
 #[test]
+fn authoritative_dead_lease_allows_stale_generation_tombstoning() {
+    let dead = remote_daemon_status_for_test_with_reason(
+        false,
+        false,
+        0,
+        "lease-dead",
+        4444,
+        Some(DaemonStaleReasonCode::PidDead),
+    );
+    let live = remote_daemon_status_for_test(true, true, 0, "lease-live", 5555);
+
+    assert!(authoritative_stale_generations_are_dead(
+        &dead,
+        &["lease-old".to_string(), "lease-dead".to_string()],
+    ));
+    assert!(!authoritative_stale_generations_are_dead(
+        &live,
+        &["lease-old".to_string(), "lease-dead".to_string()],
+    ));
+}
+
+#[test]
 fn idle_stale_replacement_fails_closed_for_active_or_inconsistent_typed_jobs() {
     let configured = "homeboy 0.289.0+configured";
     let mut freshness_active = idle_stale_status(RemoteDaemonWorkEvidence::AuthoritativelyIdle);

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -254,9 +254,13 @@ fn authoritative_dead_lease_allows_stale_generation_tombstoning() {
     );
     let live = remote_daemon_status_for_test(true, true, 0, "lease-live", 5555);
 
-    assert!(authoritative_stale_generations_are_dead(
+    assert!(!authoritative_stale_generations_are_dead(
         &dead,
         &["lease-old".to_string(), "lease-dead".to_string()],
+    ));
+    assert!(authoritative_stale_generations_are_dead(
+        &dead,
+        &["lease-dead".to_string()],
     ));
     assert!(!authoritative_stale_generations_are_dead(
         &live,

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -72,11 +72,7 @@ pub(crate) fn disconnect_with_session(
         ) {
             let leases =
                 eligible_stale_generation_leases(&retained_generations).unwrap_or_default();
-            for pid in super::super::generation_store::tombstone_dead_direct_generations(
-                runner_id, &leases,
-            )? {
-                terminate_pid(pid);
-            }
+            super::super::generation_store::tombstone_dead_direct_generations(runner_id, &leases)?;
             remove_session(runner_id)?;
             remove_ownership(runner_id)?;
             return Ok(RunnerDisconnectReport {
@@ -146,11 +142,7 @@ pub(crate) fn disconnect_with_session(
                 &leases,
             )
         {
-            for pid in super::super::generation_store::tombstone_dead_direct_generations(
-                runner_id, &leases,
-            )? {
-                terminate_pid(pid);
-            }
+            super::super::generation_store::tombstone_dead_direct_generations(runner_id, &leases)?;
             remove_ownership(runner_id)?;
         }
     }

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -66,6 +66,26 @@ pub(crate) fn disconnect_with_session(
         // SSH and clean up stale local tunnel processes only after its stop.
         let retained_generations =
             super::super::generation_store::live_sessions(runner_id, Some(session))?;
+        if remote_daemon::authoritative_stale_generations_are_dead(
+            &probe_authoritative_daemon_status(runner_id)?,
+            &eligible_stale_generation_leases(&retained_generations).unwrap_or_default(),
+        ) {
+            let leases =
+                eligible_stale_generation_leases(&retained_generations).unwrap_or_default();
+            for pid in super::super::generation_store::tombstone_dead_direct_generations(
+                runner_id, &leases,
+            )? {
+                terminate_pid(pid);
+            }
+            remove_session(runner_id)?;
+            remove_ownership(runner_id)?;
+            return Ok(RunnerDisconnectReport {
+                runner_id: runner_id.to_string(),
+                disconnected: true,
+                session: None,
+                session_path: session_path(runner_id)?.display().to_string(),
+            });
+        }
         if let Some(authoritative_session) =
             reconcile_authoritative_idle_stale_generations(runner_id, &retained_generations)?
         {
@@ -114,6 +134,25 @@ pub(crate) fn disconnect_with_session(
         if should_stop_remote_daemon(session, ownership.as_ref(), has_live_peer_session(session)?) {
             remove_ownership(runner_id)?;
         }
+    } else {
+        // A prior lease-safe stop can remove the controller session before the
+        // historical registry is reconciled. Do not make reconnect create a
+        // new generation merely to clean that already-dead inventory.
+        let retained_generations = super::super::generation_store::live_sessions(runner_id, None)?;
+        let leases = eligible_stale_generation_leases(&retained_generations).unwrap_or_default();
+        if !leases.is_empty()
+            && remote_daemon::authoritative_stale_generations_are_dead(
+                &probe_authoritative_daemon_status(runner_id)?,
+                &leases,
+            )
+        {
+            for pid in super::super::generation_store::tombstone_dead_direct_generations(
+                runner_id, &leases,
+            )? {
+                terminate_pid(pid);
+            }
+            remove_ownership(runner_id)?;
+        }
     }
     remove_session(runner_id)?;
     Ok(RunnerDisconnectReport {
@@ -122,6 +161,29 @@ pub(crate) fn disconnect_with_session(
         session,
         session_path: session_path(runner_id)?.display().to_string(),
     })
+}
+
+fn probe_authoritative_daemon_status(runner_id: &str) -> Result<remote_daemon::RemoteDaemonStatus> {
+    let runner = load(runner_id)?;
+    let homeboy = remote_runner_homeboy_path(&runner, "runner stale-generation reconciliation")?;
+    let Some((_, _, client)) = remote_daemon::resolve_ssh_runner(&runner)? else {
+        return Err(Error::validation_invalid_argument(
+            "disconnect",
+            "runner stale-generation reconciliation requires an SSH authority",
+            Some(runner_id.to_string()),
+            None,
+        ));
+    };
+    let mut status = remote_daemon::remote_daemon_status(&client, homeboy).map_err(|error| {
+        Error::validation_invalid_argument(
+            "disconnect",
+            format!("authoritative daemon reconciliation probe failed: {error}"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    remote_daemon::probe_remote_daemon_endpoint(&client, &mut status);
+    Ok(status)
 }
 
 /// A refresh can inherit a ledger from interrupted rotations while the remote
@@ -137,20 +199,7 @@ fn reconcile_authoritative_idle_stale_generations(
     if persisted_leases.is_empty() {
         return Ok(None);
     }
-    let runner = load(runner_id)?;
-    let homeboy = remote_runner_homeboy_path(&runner, "runner stale-generation reconciliation")?;
-    let Some((_, _, client)) = remote_daemon::resolve_ssh_runner(&runner)? else {
-        return Ok(None);
-    };
-    let mut status = remote_daemon::remote_daemon_status(&client, homeboy).map_err(|error| {
-        Error::validation_invalid_argument(
-            "disconnect",
-            format!("authoritative daemon reconciliation probe failed: {error}"),
-            Some(runner_id.to_string()),
-            None,
-        )
-    })?;
-    remote_daemon::probe_remote_daemon_endpoint(&client, &mut status);
+    let status = probe_authoritative_daemon_status(runner_id)?;
     let Some(lease_id) =
         remote_daemon::authoritative_idle_lease_for_stale_generations(&status, &persisted_leases)
             .map_err(|error| {

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -526,14 +526,14 @@ pub(crate) fn clear(runner_id: &str) -> Result<()> {
 pub(crate) fn tombstone_dead_direct_generations(
     runner_id: &str,
     expected_leases: &[String],
-) -> Result<Vec<u32>> {
+) -> Result<()> {
     let expected_leases = expected_leases
         .iter()
         .map(String::as_str)
         .collect::<std::collections::BTreeSet<_>>();
     with_registry_lock(runner_id, || {
         let Some(generations) = read_locked(runner_id, None)? else {
-            return Ok(Vec::new());
+            return Ok(());
         };
         let current_leases = generations
             .generations
@@ -553,11 +553,6 @@ pub(crate) fn tombstone_dead_direct_generations(
                 None,
             ));
         }
-        let tunnel_pids = generations
-            .generations
-            .values()
-            .filter_map(|entry| entry.endpoint.tunnel_pid)
-            .collect::<Vec<_>>();
         let path = path(runner_id)?;
         if path.exists() {
             std::fs::remove_file(&path).map_err(|error| {
@@ -567,7 +562,10 @@ pub(crate) fn tombstone_dead_direct_generations(
                 )
             })?;
         }
-        Ok(tunnel_pids)
+        // The registry only persists a numeric local tunnel PID, not a process
+        // identity. It may have been reused since this stale generation was
+        // recorded, so convergence must not signal it.
+        Ok(())
     })
 }
 
@@ -1122,10 +1120,9 @@ mod tests {
             let leases = (0..58)
                 .map(|index| format!("lease-{index}"))
                 .collect::<Vec<_>>();
-            let pids = tombstone_dead_direct_generations("runner-a", &leases)
+            tombstone_dead_direct_generations("runner-a", &leases)
                 .expect("dead authoritative daemon tombstones stale inventory");
 
-            assert_eq!(pids.len(), 58);
             assert!(read("runner-a", None)
                 .expect("read tombstoned registry")
                 .is_none());

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -519,6 +519,58 @@ pub(crate) fn clear(runner_id: &str) -> Result<()> {
     })
 }
 
+/// Remove a registry only after its caller has obtained authoritative remote
+/// proof that every recorded direct daemon generation is dead and idle. Check
+/// the exact lease set again under the registry lock so a concurrent reconnect
+/// cannot lose a newly admitted generation.
+pub(crate) fn tombstone_dead_direct_generations(
+    runner_id: &str,
+    expected_leases: &[String],
+) -> Result<Vec<u32>> {
+    let expected_leases = expected_leases
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    with_registry_lock(runner_id, || {
+        let Some(generations) = read_locked(runner_id, None)? else {
+            return Ok(Vec::new());
+        };
+        let current_leases = generations
+            .generations
+            .values()
+            .map(|entry| {
+                (entry.endpoint.mode == crate::RunnerTunnelMode::DirectSsh)
+                    .then_some(entry.endpoint.remote_daemon_lease_id.as_deref())
+                    .flatten()
+                    .filter(|lease| !lease.is_empty())
+            })
+            .collect::<Option<std::collections::BTreeSet<_>>>();
+        if current_leases.as_ref() != Some(&expected_leases) {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                "runner generation registry changed while dead-daemon evidence was being reconciled; retained all generations",
+                Some(runner_id.to_string()),
+                None,
+            ));
+        }
+        let tunnel_pids = generations
+            .generations
+            .values()
+            .filter_map(|entry| entry.endpoint.tunnel_pid)
+            .collect::<Vec<_>>();
+        let path = path(runner_id)?;
+        if path.exists() {
+            std::fs::remove_file(&path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("delete {}", path.display())),
+                )
+            })?;
+        }
+        Ok(tunnel_pids)
+    })
+}
+
 trait GenerationEndpointOperations {
     /// Terminal linked handoffs can survive a controller restart in a daemon's
     /// job store. Settle them before treating its active count as ownership.
@@ -1051,6 +1103,33 @@ mod tests {
         let raw = std::fs::read_to_string(path(runner_id).expect("registry path"))
             .expect("read registry");
         serde_json::from_str(&raw).expect("parse registry")
+    }
+
+    #[test]
+    fn tombstones_a_large_dead_direct_generation_inventory_without_accepting_new_work() {
+        test_support::with_isolated_home(|_| {
+            let mut generations =
+                RollingGenerations::new("lease-0", session("lease-0", "daemon-0", Some(1000)));
+            for index in 1..58 {
+                let lease = format!("lease-{index}");
+                generations.begin(
+                    lease.clone(),
+                    session(&lease, &format!("daemon-{index}"), Some(1000 + index)),
+                );
+            }
+            write("runner-a", &generations).expect("persist stale inventory");
+
+            let leases = (0..58)
+                .map(|index| format!("lease-{index}"))
+                .collect::<Vec<_>>();
+            let pids = tombstone_dead_direct_generations("runner-a", &leases)
+                .expect("dead authoritative daemon tombstones stale inventory");
+
+            assert_eq!(pids.len(), 58);
+            assert!(read("runner-a", None)
+                .expect("read tombstoned registry")
+                .is_none());
+        });
     }
 
     const PROCESS_SYNC_DIR_ENV: &str = "HOMEBOY_GENERATION_STORE_PROCESS_SYNC_DIR";


### PR DESCRIPTION
Fixes #9406

## Root Cause
Runner disconnect treated retained historical generation leases as live mutation targets. When the authoritative SSH daemon had already proven the lease dead or absent with zero active jobs, the stale ledger could not converge. Separately, expired pre-acceptance handoffs lacked a single durable recovery action.

## Behavior And Evidence
- Tombstones an all-direct, lease-bound generation registry only after authoritative SSH status proves zero jobs and either the matching PID is dead or the lease is absent. The locked lease-set recheck fails closed if reconnect changes the registry.
- Disconnect also converges an already-sessionless stale registry, preventing a reconnect from creating another historical generation.
- Expired handoffs remain zero-provider-budget pre-execution failures and persist one retry recovery command; a late accepted runner job still takes ownership.
- Coverage: 58-generation tombstone inventory, dead authoritative lease gating, handoff deadline expiry, zero provider budget, managed recovery command, and late acceptance.

## Verification
- `cargo test -p homeboy-lab-runner 'authoritative_dead_lease_allows_stale_generation_tombstoning|tombstones_a_large_dead_direct_generation_inventory_without_accepting_new_work' --lib`\n- `cargo test -p homeboy-agents status_expires_an_unaccepted_handoff_but_late_runner_acceptance_wins --lib`\n- `cargo check -p homeboy-lab-runner -p homeboy-agents`\n- `cargo fmt --check`\n\n## AI Assistance\nOpenAI GPT-5.6 Sol via OpenCode was used to inspect the lifecycle, draft the Rust implementation and deterministic tests, and run verification. Chris Huber reviewed and remains responsible for every line.