### PR TITLE
Fix bounded output for agent readers

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -1,6 +1,11 @@
 use clap::{Args, Subcommand, ValueEnum};
 use homeboy::agents::agent_task_service::AgentTaskDiscoveryOptions;
 
+/// Agent-facing discovery defaults to a finite page. A caller can request a
+/// different page with `--limit`; full durable records remain available through
+/// focused status/artifact commands and `--output` artifacts.
+const DEFAULT_DISCOVERY_LIMIT: usize = 20;
+
 use super::super::super::prompts::AgentTaskPromptsArgs;
 use super::super::super::tool::AgentTaskToolArgs;
 use super::cook::{AgentTaskCookArgs, AgentTaskLoopArgs, PromotionProviderArgs};
@@ -138,17 +143,23 @@ pub struct LatestArgs {
 }
 impl From<ListArgs> for AgentTaskDiscoveryOptions {
     fn from(args: ListArgs) -> Self {
-        Self { limit: args.limit }
+        Self {
+            limit: Some(args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+        }
     }
 }
 impl From<ActiveArgs> for AgentTaskDiscoveryOptions {
     fn from(args: ActiveArgs) -> Self {
-        Self { limit: args.limit }
+        Self {
+            limit: Some(args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+        }
     }
 }
 impl From<LatestArgs> for AgentTaskDiscoveryOptions {
     fn from(args: LatestArgs) -> Self {
-        Self { limit: args.limit }
+        Self {
+            limit: Some(args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+        }
     }
 }
 #[derive(Args, Debug)]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -16,6 +16,7 @@ use homeboy::agents::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskPlan}
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::agents::agent_tasks::{AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
 use homeboy::core::engine::shell::quote_arg;
+use homeboy::core::output::{budget_json_values, OutputBudget};
 use homeboy::runner::runners::{self as runner, RunnerKind};
 
 use super::super::CmdResult;
@@ -90,6 +91,12 @@ pub(super) fn list_runs(
 ) -> CmdResult<Value> {
     let report = agent_task_service_direct::discover_runs_with_options(filter, options)?;
     let mut value = serde_json::to_value(report).unwrap_or(Value::Null);
+    attach_collection_budget(
+        &mut value,
+        "runs",
+        "homeboy agent-task list --limit 20",
+        "homeboy agent-task list --output <path>",
+    );
     attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
 }
@@ -119,6 +126,12 @@ pub(super) fn list_active(
             json!("run the per-run `commands.reconcile` preview, then repeat it with `--apply` after reviewing authoritative provider state"),
         );
     }
+    attach_collection_budget(
+        &mut value,
+        "runs",
+        "homeboy agent-task active --limit 20",
+        "homeboy agent-task active --output <path>",
+    );
     attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
 }
@@ -450,7 +463,19 @@ pub(super) fn logs(args: LogsArgs) -> CmdResult<Value> {
 
 pub(super) fn artifacts(args: StatusArgs) -> CmdResult<Value> {
     let artifacts = agent_task_service::artifacts(&args.run_id)?;
-    Ok((serde_json::to_value(artifacts).unwrap_or(Value::Null), 0))
+    let mut value = serde_json::to_value(artifacts).unwrap_or(Value::Null);
+    // Artifact indexes are bounded before presentation; durable artifact files
+    // remain losslessly available through the global output artifact.
+    attach_collection_budget(
+        &mut value,
+        "artifacts",
+        &format!("homeboy agent-task artifacts {}", quote_arg(&args.run_id)),
+        &format!(
+            "homeboy agent-task artifacts {} --output <path>",
+            quote_arg(&args.run_id)
+        ),
+    );
+    Ok((value, 0))
 }
 
 pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
@@ -460,6 +485,7 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
     let plan = agent_task_lifecycle::load_plan(&args.run_id).ok();
 
     let mut hydrated = Vec::new();
+    let mut total = 0;
     for (evidence_ref, task_id) in
         evidence_refs_with_tasks(&artifacts.evidence_refs, aggregate.as_ref())
     {
@@ -485,6 +511,12 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
             continue;
         }
 
+        total += 1;
+        // Count filtered refs without hydrating their payload once the shared
+        // collection budget is full.
+        if hydrated.len() >= OutputBudget::COLLECTION.max_items {
+            continue;
+        }
         hydrated.push(agent_task_service::hydrate_evidence_ref(
             &args.run_id,
             &evidence_ref,
@@ -494,32 +526,45 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
         ));
     }
 
-    Ok((
-        serde_json::to_value(AgentTaskEvidenceReport {
-            schema: "homeboy/agent-task-evidence/v1",
-            run_id: args.run_id,
-            filters: AgentTaskEvidenceFilters {
-                kind: args.kind,
-                task: args.task,
-                failure_only: args.failure_only,
-            },
-            count: hydrated.len(),
-            evidence: hydrated,
-        })
-        .unwrap_or(Value::Null),
-        0,
-    ))
+    let mut value = serde_json::to_value(AgentTaskEvidenceReport {
+        schema: "homeboy/agent-task-evidence/v1",
+        run_id: args.run_id.clone(),
+        filters: AgentTaskEvidenceFilters {
+            kind: args.kind,
+            task: args.task,
+            failure_only: args.failure_only,
+        },
+        count: total,
+        evidence_total: total,
+        evidence: hydrated,
+    })
+    .unwrap_or(Value::Null);
+    attach_collection_budget(
+        &mut value,
+        "evidence",
+        &format!("homeboy agent-task evidence {}", quote_arg(&args.run_id)),
+        &format!(
+            "homeboy agent-task evidence {} --output <path>",
+            quote_arg(&args.run_id)
+        ),
+    );
+    Ok((value, 0))
 }
 
 pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
     let record = agent_task_service::status(&args.run_id)?;
     let aggregate = completed_run_aggregate(&args.run_id).transpose()?;
     let mut hydrated_evidence = Vec::new();
+    let mut total_hydrated_evidence = 0;
     let mut nested_reasons = Vec::new();
 
     if let Some(aggregate) = aggregate.as_ref() {
         for outcome in &aggregate.outcomes {
             for evidence in &outcome.evidence_refs {
+                total_hydrated_evidence += 1;
+                if hydrated_evidence.len() >= OutputBudget::COLLECTION.max_items {
+                    continue;
+                }
                 if let Some(summary) =
                     agent_task_service::hydrate_evidence_summary(&outcome.task_id, evidence)
                 {
@@ -555,19 +600,63 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         .unwrap_or_default();
     let next_commands = diagnose_next_commands(&args.run_id);
 
-    Ok((
-        json!({
-            "schema": "homeboy/agent-task-diagnose/v1",
-            "run_id": record.run_id,
-            "state": record.state,
-            "root_cause": root_cause,
-            "causal_chain": causal_chain,
-            "missing_artifacts": missing_artifacts,
-            "hydrated_evidence": hydrated_evidence,
-            "next_commands": next_commands,
-        }),
-        0,
-    ))
+    let mut value = json!({
+        "schema": "homeboy/agent-task-diagnose/v1",
+        "run_id": record.run_id,
+        "state": record.state,
+        "root_cause": root_cause,
+        "causal_chain": causal_chain,
+        "missing_artifacts": missing_artifacts,
+        "hydrated_evidence": hydrated_evidence,
+        "hydrated_evidence_total": total_hydrated_evidence,
+        "next_commands": next_commands,
+    });
+    attach_collection_budget(
+        &mut value,
+        "hydrated_evidence",
+        &format!("homeboy agent-task diagnose {}", quote_arg(&args.run_id)),
+        &format!(
+            "homeboy agent-task diagnose {} --output <path>",
+            quote_arg(&args.run_id)
+        ),
+    );
+    Ok((value, 0))
+}
+
+/// Apply the shared output primitive to a JSON collection while retaining every
+/// command's established field names and schema.
+fn attach_collection_budget(
+    value: &mut Value,
+    field: &str,
+    continue_command: &str,
+    export_command: &str,
+) {
+    let Some(map) = value.as_object_mut() else {
+        return;
+    };
+    let values = map
+        .get(field)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let total = map
+        .get(&format!("{field}_total"))
+        .or_else(|| map.get("total"))
+        .and_then(Value::as_u64)
+        .map(|count| count as usize)
+        .unwrap_or(values.len());
+    let (bounded, metadata) = budget_json_values(
+        values,
+        total,
+        OutputBudget::COLLECTION,
+        continue_command,
+        export_command,
+    );
+    map.insert(field.to_string(), Value::Array(bounded));
+    map.insert(
+        "output_budget".to_string(),
+        serde_json::to_value(metadata).unwrap_or(Value::Null),
+    );
 }
 
 pub(super) fn recover_runtime(args: RuntimeRecoverArgs) -> CmdResult<Value> {
@@ -827,6 +916,7 @@ struct AgentTaskEvidenceReport {
     run_id: String,
     filters: AgentTaskEvidenceFilters,
     count: usize,
+    evidence_total: usize,
     evidence: Vec<agent_task_service::AgentTaskHydratedEvidence>,
 }
 

--- a/crates/homeboy-cli/src/commands/logs.rs
+++ b/crates/homeboy-cli/src/commands/logs.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use homeboy::core::project::logs::{
     self, LogContent, LogEntry, LogSearchResult, PinnedLogsContent,
 };
+use homeboy::core::output::{OutputPresentation, OutputTruncation};
 
 use crate::commands::CmdResult;
 
@@ -130,6 +131,8 @@ pub struct LogsOutput {
     pub cleared_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search_result: Option<LogSearchResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_budget: Option<OutputTruncation>,
 }
 
 fn list(project_id: &str) -> CmdResult<LogsOutput> {
@@ -144,6 +147,7 @@ fn list(project_id: &str) -> CmdResult<LogsOutput> {
             pinned_logs: None,
             cleared_path: None,
             search_result: None,
+            output_budget: None,
         },
         0,
     ))
@@ -168,6 +172,7 @@ fn show(
                 pinned_logs: None,
                 cleared_path: None,
                 search_result: None,
+                output_budget: None,
             },
             code,
         ))
@@ -183,6 +188,7 @@ fn show(
                 pinned_logs: None,
                 cleared_path: None,
                 search_result: None,
+                output_budget: None,
             },
             0,
         ))
@@ -204,6 +210,18 @@ fn show_pinned(project_id: &str, lines: u32, follow: bool, local: bool) -> CmdRe
 
     let content = logs::show_pinned(project_id, lines, local)?;
 
+    let output_budget = OutputTruncation {
+        presentation: OutputPresentation::BoundedCollection,
+        total_items: content.total_logs,
+        returned_items: content.returned_logs,
+        omitted_items: content.omitted_logs,
+        total_bytes: content.returned_bytes + content.omitted_bytes,
+        returned_bytes: content.returned_bytes,
+        omitted_bytes: content.omitted_bytes,
+        truncated: content.omitted_logs > 0 || content.omitted_bytes > 0,
+        continue_command: format!("homeboy logs list {project_id}"),
+        export_command: format!("homeboy logs show {project_id} --output <path>"),
+    };
     Ok((
         LogsOutput {
             command: "logs.show_pinned".to_string(),
@@ -213,6 +231,7 @@ fn show_pinned(project_id: &str, lines: u32, follow: bool, local: bool) -> CmdRe
             pinned_logs: Some(content),
             cleared_path: None,
             search_result: None,
+            output_budget: Some(output_budget),
         },
         0,
     ))
@@ -230,6 +249,7 @@ fn clear(project_id: &str, path: &str, local: bool) -> CmdResult<LogsOutput> {
             pinned_logs: None,
             cleared_path: Some(cleared_path),
             search_result: None,
+            output_budget: None,
         },
         0,
     ))
@@ -263,6 +283,7 @@ fn search(
             pinned_logs: None,
             cleared_path: None,
             search_result: Some(result),
+            output_budget: None,
         },
         0,
     ))

--- a/crates/homeboy-cli/src/commands/runs/watch.rs
+++ b/crates/homeboy-cli/src/commands/runs/watch.rs
@@ -37,9 +37,13 @@ pub struct RunsWatchArgs {
     /// Observation run id to watch until it reaches a terminal state.
     pub run_id: String,
     /// Maximum time to wait before giving up (e.g. `30m`, `2h`, `7d`).
-    /// Unbounded when omitted.
-    #[arg(long)]
-    pub timeout: Option<String>,
+    /// Defaults to five minutes; use `--forever` for an intentional indefinite watch.
+    #[arg(long, default_value = "5m", conflicts_with = "forever")]
+    pub timeout: String,
+    /// Keep watching without a time bound. This is explicit because streams are
+    /// otherwise finite by default.
+    #[arg(long, conflicts_with = "timeout")]
+    pub forever: bool,
     /// Delay between status polls (e.g. `2s`, `1m`).
     #[arg(long, default_value = "2s")]
     pub interval: String,
@@ -112,7 +116,9 @@ pub(super) struct WatchResult {
 
 pub fn watch_run(args: RunsWatchArgs) -> CmdResult<RunsOutput> {
     let interval = parse_duration(&args.interval)?;
-    let timeout = args.timeout.as_deref().map(parse_duration).transpose()?;
+    let timeout = (!args.forever)
+        .then(|| parse_duration(&args.timeout))
+        .transpose()?;
     let config = WatchConfig { interval, timeout };
 
     let store = ObservationStore::open_initialized()?;

--- a/crates/homeboy-core/src/project/logs.rs
+++ b/crates/homeboy-core/src/project/logs.rs
@@ -13,6 +13,9 @@ use crate::paths as base_path;
 use crate::project::{self, Project};
 use serde::Serialize;
 
+const MAX_PINNED_LOGS: usize = 8;
+const MAX_PINNED_LOG_BYTES: usize = 8 * 1024;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct LogEntry {
     pub path: String,
@@ -78,6 +81,10 @@ pub struct PinnedLogContent {
 pub struct PinnedLogsContent {
     pub logs: Vec<PinnedLogContent>,
     pub total_logs: usize,
+    pub returned_logs: usize,
+    pub omitted_logs: usize,
+    pub returned_bytes: usize,
+    pub omitted_bytes: usize,
 }
 
 fn load_project(project_id: &str, local: bool) -> Result<Project> {
@@ -124,7 +131,9 @@ pub fn show_pinned(project_id: &str, lines: u32, local: bool) -> Result<PinnedLo
     let base_path = require_project_base_path(project_id, &project)?;
 
     let mut logs = Vec::new();
-    for pinned_log in &project.remote_logs.pinned_logs {
+    let total_logs = project.remote_logs.pinned_logs.len();
+    let mut omitted_bytes = 0;
+    for pinned_log in project.remote_logs.pinned_logs.iter().take(MAX_PINNED_LOGS) {
         let log_lines = if lines > 0 {
             lines
         } else {
@@ -134,24 +143,41 @@ pub fn show_pinned(project_id: &str, lines: u32, local: bool) -> Result<PinnedLo
 
         let command = format!("tail -n {} {}", log_lines, shell::quote_path(&full_path));
         let output = execute_for_project(&project, &command)?;
-        let evidence = LogEvidenceMetadata::tail(
-            &full_path,
-            pinned_log.label.clone(),
-            log_lines,
-            &output.stdout,
-        );
+        let (content, omitted) = truncate_utf8(&output.stdout, MAX_PINNED_LOG_BYTES);
+        omitted_bytes += omitted;
+        let evidence =
+            LogEvidenceMetadata::tail(&full_path, pinned_log.label.clone(), log_lines, &content);
 
         logs.push(PinnedLogContent {
             path: full_path,
             label: pinned_log.label.clone(),
             lines: log_lines,
             evidence,
-            content: output.stdout,
+            content,
         });
     }
 
-    let total_logs = logs.len();
-    Ok(PinnedLogsContent { logs, total_logs })
+    let returned_logs = logs.len();
+    let returned_bytes = logs.iter().map(|log| log.content.len()).sum();
+    Ok(PinnedLogsContent {
+        logs,
+        total_logs,
+        returned_logs,
+        omitted_logs: total_logs.saturating_sub(returned_logs),
+        returned_bytes,
+        omitted_bytes,
+    })
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> (String, usize) {
+    if value.len() <= max_bytes {
+        return (value.to_string(), 0);
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_string(), value.len() - end)
 }
 
 pub fn show(project_id: &str, path: &str, lines: u32, local: bool) -> Result<LogContent> {

--- a/crates/homeboy-output/src/lib.rs
+++ b/crates/homeboy-output/src/lib.rs
@@ -7,6 +7,109 @@
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
+// Progressive-disclosure output budgets
+// ============================================================================
+
+/// Stable presentation classes for read-side command output.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputPresentation {
+    CompactSummary,
+    BoundedCollection,
+    BoundedStream,
+    LosslessExport,
+}
+
+/// Finite defaults used by agent-facing readers unless an explicit export is
+/// requested. Commands may lower these values, but may not make defaults infinite.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OutputBudget {
+    pub max_items: usize,
+    pub max_bytes: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_events: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_seconds: Option<u64>,
+}
+
+impl OutputBudget {
+    pub const COLLECTION: Self = Self {
+        max_items: 20,
+        max_bytes: 64 * 1024,
+        max_events: None,
+        max_seconds: None,
+    };
+    pub const STREAM: Self = Self {
+        max_items: 0,
+        max_bytes: 64 * 1024,
+        max_events: Some(200),
+        max_seconds: Some(300),
+    };
+}
+
+/// Additive, schema-stable disclosure metadata attached to a bounded payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OutputTruncation {
+    pub presentation: OutputPresentation,
+    pub total_items: usize,
+    pub returned_items: usize,
+    pub omitted_items: usize,
+    pub total_bytes: usize,
+    pub returned_bytes: usize,
+    pub omitted_bytes: usize,
+    pub truncated: bool,
+    pub continue_command: String,
+    pub export_command: String,
+}
+
+/// Apply an aggregate item and serialized-byte budget without changing the item
+/// schema. Callers can obtain `total_items` from indexed sources without
+/// hydrating every record, and use the exact continuation/export commands in the
+/// returned metadata.
+pub fn budget_json_values(
+    values: impl IntoIterator<Item = serde_json::Value>,
+    total_items: usize,
+    budget: OutputBudget,
+    continue_command: impl Into<String>,
+    export_command: impl Into<String>,
+) -> (Vec<serde_json::Value>, OutputTruncation) {
+    let mut returned = Vec::new();
+    let mut returned_bytes: usize = 0;
+    let mut observed_bytes: usize = 0;
+    for value in values {
+        let bytes = serde_json::to_vec(&value)
+            .map(|value| value.len())
+            .unwrap_or(0);
+        observed_bytes += bytes;
+        if returned.len() >= budget.max_items
+            || returned_bytes.saturating_add(bytes) > budget.max_bytes
+        {
+            continue;
+        }
+        returned_bytes += bytes;
+        returned.push(value);
+    }
+    let returned_items = returned.len();
+    let omitted_items = total_items.saturating_sub(returned_items);
+    let total_bytes = observed_bytes.max(returned_bytes);
+    (
+        returned,
+        OutputTruncation {
+            presentation: OutputPresentation::BoundedCollection,
+            total_items,
+            returned_items,
+            omitted_items,
+            total_bytes,
+            returned_bytes,
+            omitted_bytes: total_bytes.saturating_sub(returned_bytes),
+            truncated: omitted_items > 0 || total_bytes > returned_bytes,
+            continue_command: continue_command.into(),
+            export_command: export_command.into(),
+        },
+    )
+}
+
+// ============================================================================
 // Observation-backed Outputs
 // ============================================================================
 
@@ -387,6 +490,31 @@ impl<T: Serialize, E: Serialize + Default> Default for EntityCrudOutput<T, E> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn collection_budget_reports_adversarial_item_and_byte_truncation() {
+        let values = (0..100)
+            .map(|index| json!({ "id": index, "payload": "x".repeat(8 * 1024) }))
+            .collect::<Vec<_>>();
+        let (returned, metadata) = budget_json_values(
+            values,
+            100,
+            OutputBudget::COLLECTION,
+            "homeboy example list --limit 20",
+            "homeboy example list --output <path>",
+        );
+
+        assert!(returned.len() < 20);
+        assert_eq!(metadata.total_items, 100);
+        assert_eq!(metadata.returned_items, returned.len());
+        assert_eq!(metadata.omitted_items, 100 - returned.len());
+        assert!(metadata.truncated);
+        assert_eq!(metadata.continue_command, "homeboy example list --limit 20");
+        assert_eq!(
+            metadata.export_command,
+            "homeboy example list --output <path>"
+        );
+    }
 
     #[test]
     fn test_for_run() {

--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -239,6 +239,22 @@ envelope semantics, and public variant discrimination. Prefer command execution 
 focused contract assertions over golden fixtures that only serialize hand-built
 payload structs and compare them with checked-in JSON produced from the same code.
 
+## Progressive Disclosure Budgets
+
+Agent-facing readers use one finite output contract from `homeboy-output`:
+
+- `compact_summary` returns fixed summary fields only.
+- `bounded_collection` defaults to 20 items and 64 KiB of serialized items.
+- `bounded_stream` defaults to 200 events, 64 KiB, and five minutes.
+- `lossless_export` is explicit through `--output <path>` or a command-specific
+  export artifact.
+
+Bounded payloads add `output_budget` with stable `total_items`,
+`returned_items`, `omitted_items`, `total_bytes`, `returned_bytes`,
+`omitted_bytes`, `truncated`, `continue_command`, and `export_command` fields.
+The item payload schema remains unchanged. Continuations are focused commands;
+exports are the explicit lossless path rather than an unbounded stdout default.
+
 ## Observation-backed payloads
 
 `--output` remains the per-invocation command-result artifact. It must continue


### PR DESCRIPTION
## Summary
- add the reusable output-budget/progressive-disclosure metadata contract
- bound agent-task discovery, artifacts, evidence, diagnostics, pinned logs, and run watches
- document finite collection and stream defaults with continuation/export metadata

Fixes #10134

## Verification
- 
- 
- 
running 11 tests
test tests::batch_outcome_totals_cover_success_partial_failure_skipped_and_empty ... ok
test tests::bulk_result_builds_summary_without_changing_json_shape ... ok
test tests::bulk_result_handles_empty_results ... ok
test tests::bulk_builder_counts_failed_results_without_changing_item_shape ... ok
test tests::test_for_run ... ok
test tests::test_exit_code ... ok
test tests::test_record_error ... ok
test tests::test_record_updated ... ok
test tests::test_record_created ... ok
test tests::test_record_skipped ... ok
test tests::collection_budget_reports_adversarial_item_and_byte_truncation ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
running 6 tests
test commands::runs::watch::tests::skipped_status_exits_zero ... ok
test commands::runs::watch::tests::unknown_status_is_treated_as_terminal_failure ... ok
test commands::runs::watch::tests::watch_fail_status_exits_nonzero ... ok
test commands::runs::watch::tests::watch_reaches_terminal_pass_with_zero_exit ... ok
test commands::runs::watch::tests::watch_surfaces_stale_ghost_as_terminal_failure ... ok
test commands::runs::watch::tests::watch_times_out_when_run_never_settles ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1536 filtered out; finished in 0.01s

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the output-budget primitive, integrated the bounded reader changes, and ran the focused verification commands. Chris Huber remains responsible for the final change.