### PR TITLE
Fix capacity-relative resource severity

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/observation/tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/tests.rs
@@ -911,6 +911,7 @@ fn synthetic_resources(recommendation: ResourceRecommendation) -> DoctorOutput {
         },
         rig_leases: RigLeaseSummary {
             active_count: 0,
+            concurrency_limit: None,
             leases: Vec::new(),
             recommendation: ResourceRecommendation::Ok,
         },

--- a/crates/homeboy-cli/src/commands/resources/classification.rs
+++ b/crates/homeboy-cli/src/commands/resources/classification.rs
@@ -34,27 +34,62 @@ pub(super) fn classify_memory(total_bytes: u64, available_bytes: u64) -> Resourc
     }
 }
 
-pub(super) fn classify_processes(rows: &[ProcessRow]) -> ResourceRecommendation {
-    if rows
-        .iter()
-        .any(|row| row.cpu_percent >= 200.0 || row.rss_mb >= 4096)
-    {
+const PROCESS_WARM_CPU_PER_CORE_PERCENT: f64 = 12.5;
+const PROCESS_HOT_CPU_PER_CORE_PERCENT: f64 = 25.0;
+const PROCESS_WARM_CPU_FLOOR_PERCENT: f64 = 50.0;
+const PROCESS_HOT_CPU_FLOOR_PERCENT: f64 = 100.0;
+const PROCESS_WARM_RSS_RATIO: f64 = 0.125;
+const PROCESS_HOT_RSS_RATIO: f64 = 0.25;
+const PROCESS_WARM_RSS_FLOOR_MB: u64 = 512;
+const PROCESS_HOT_RSS_FLOOR_MB: u64 = 1024;
+
+pub(super) fn classify_processes(
+    rows: &[ProcessRow],
+    cpu_count: usize,
+    total_memory_mb: Option<u64>,
+) -> ResourceRecommendation {
+    let warm_cpu_percent = (cpu_count.max(1) as f64 * PROCESS_WARM_CPU_PER_CORE_PERCENT)
+        .max(PROCESS_WARM_CPU_FLOOR_PERCENT);
+    let hot_cpu_percent = (cpu_count.max(1) as f64 * PROCESS_HOT_CPU_PER_CORE_PERCENT)
+        .max(PROCESS_HOT_CPU_FLOOR_PERCENT);
+    let warm_rss_mb = total_memory_mb.map(|total| (total as f64 * PROCESS_WARM_RSS_RATIO) as u64);
+    let hot_rss_mb = total_memory_mb.map(|total| (total as f64 * PROCESS_HOT_RSS_RATIO) as u64);
+
+    if rows.iter().any(|row| {
+        row.cpu_percent >= hot_cpu_percent
+            || hot_rss_mb
+                .is_some_and(|threshold| row.rss_mb >= threshold.max(PROCESS_HOT_RSS_FLOOR_MB))
+    }) {
         ResourceRecommendation::Hot
-    } else if rows
-        .iter()
-        .any(|row| row.cpu_percent >= 100.0 || row.rss_mb >= 2048)
-    {
+    } else if rows.iter().any(|row| {
+        row.cpu_percent >= warm_cpu_percent
+            || warm_rss_mb
+                .is_some_and(|threshold| row.rss_mb >= threshold.max(PROCESS_WARM_RSS_FLOOR_MB))
+    }) {
         ResourceRecommendation::Warm
     } else {
         ResourceRecommendation::Ok
     }
 }
 
-pub(super) fn classify_rig_leases(active_count: usize) -> ResourceRecommendation {
-    match active_count {
-        0 => ResourceRecommendation::Ok,
-        1 => ResourceRecommendation::Warm,
-        _ => ResourceRecommendation::Hot,
+pub(super) fn classify_rig_leases(
+    active_count: usize,
+    concurrency_limit: Option<usize>,
+) -> ResourceRecommendation {
+    let Some(limit) = concurrency_limit.filter(|limit| *limit > 0) else {
+        return match active_count {
+            0 => ResourceRecommendation::Ok,
+            1 => ResourceRecommendation::Warm,
+            _ => ResourceRecommendation::Hot,
+        };
+    };
+
+    if active_count >= limit {
+        ResourceRecommendation::Hot
+    } else if active_count.saturating_mul(4) >= limit.saturating_mul(3) {
+        ResourceRecommendation::Warm
+    } else {
+        ResourceRecommendation::Ok
     }
 }
 
@@ -94,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    fn classifies_processes_by_hot_cpu_or_rss_rows() {
+    fn classifies_processes_by_capacity_relative_cpu_and_rss() {
         let rows = vec![ProcessRow {
             pid: 1,
             cpu_percent: 25.0,
@@ -102,26 +137,59 @@ mod tests {
             command: "homeboy".to_string(),
             args: "homeboy bench".to_string(),
         }];
-        assert_eq!(classify_processes(&rows), ResourceRecommendation::Ok);
+        assert_eq!(
+            classify_processes(&rows, 4, Some(8 * 1024)),
+            ResourceRecommendation::Ok
+        );
+
+        let rows = vec![ProcessRow {
+            cpu_percent: 51.0,
+            ..rows[0].clone()
+        }];
+        assert_eq!(
+            classify_processes(&rows, 4, Some(8 * 1024)),
+            ResourceRecommendation::Warm
+        );
 
         let rows = vec![ProcessRow {
             cpu_percent: 101.0,
             ..rows[0].clone()
         }];
-        assert_eq!(classify_processes(&rows), ResourceRecommendation::Warm);
+        assert_eq!(
+            classify_processes(&rows, 4, Some(8 * 1024)),
+            ResourceRecommendation::Hot
+        );
 
         let rows = vec![ProcessRow {
-            cpu_percent: 201.0,
+            rss_mb: 2 * 1024,
             ..rows[0].clone()
         }];
-        assert_eq!(classify_processes(&rows), ResourceRecommendation::Hot);
+        assert_eq!(
+            classify_processes(&rows, 4, Some(8 * 1024)),
+            ResourceRecommendation::Hot
+        );
+
+        let rows = vec![ProcessRow {
+            rss_mb: 4 * 1024,
+            ..rows[0].clone()
+        }];
+        assert_eq!(
+            classify_processes(&rows, 16, Some(128 * 1024)),
+            ResourceRecommendation::Ok
+        );
     }
 
     #[test]
-    fn classifies_rig_leases_by_active_count() {
-        assert_eq!(classify_rig_leases(0), ResourceRecommendation::Ok);
-        assert_eq!(classify_rig_leases(1), ResourceRecommendation::Warm);
-        assert_eq!(classify_rig_leases(2), ResourceRecommendation::Hot);
+    fn classifies_rig_leases_by_configured_concurrency_with_legacy_fallback() {
+        assert_eq!(classify_rig_leases(2, Some(8)), ResourceRecommendation::Ok);
+        assert_eq!(
+            classify_rig_leases(6, Some(8)),
+            ResourceRecommendation::Warm
+        );
+        assert_eq!(classify_rig_leases(8, Some(8)), ResourceRecommendation::Hot);
+        assert_eq!(classify_rig_leases(0, None), ResourceRecommendation::Ok);
+        assert_eq!(classify_rig_leases(1, None), ResourceRecommendation::Warm);
+        assert_eq!(classify_rig_leases(2, None), ResourceRecommendation::Hot);
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/resources/classification.rs
+++ b/crates/homeboy-cli/src/commands/resources/classification.rs
@@ -52,20 +52,26 @@ pub(super) fn classify_processes(
         .max(PROCESS_WARM_CPU_FLOOR_PERCENT);
     let hot_cpu_percent = (cpu_count.max(1) as f64 * PROCESS_HOT_CPU_PER_CORE_PERCENT)
         .max(PROCESS_HOT_CPU_FLOOR_PERCENT);
-    let warm_rss_mb = total_memory_mb.map(|total| (total as f64 * PROCESS_WARM_RSS_RATIO) as u64);
-    let hot_rss_mb = total_memory_mb.map(|total| (total as f64 * PROCESS_HOT_RSS_RATIO) as u64);
+    // Keep the absolute floors when memory capacity is unavailable: skipping
+    // RSS classification would make a failed probe hide real pressure.
+    let warm_rss_mb = total_memory_mb
+        .map(|total| (total as f64 * PROCESS_WARM_RSS_RATIO) as u64)
+        .unwrap_or(PROCESS_WARM_RSS_FLOOR_MB)
+        .max(PROCESS_WARM_RSS_FLOOR_MB);
+    let hot_rss_mb = total_memory_mb
+        .map(|total| (total as f64 * PROCESS_HOT_RSS_RATIO) as u64)
+        .unwrap_or(PROCESS_HOT_RSS_FLOOR_MB)
+        .max(PROCESS_HOT_RSS_FLOOR_MB);
 
-    if rows.iter().any(|row| {
-        row.cpu_percent >= hot_cpu_percent
-            || hot_rss_mb
-                .is_some_and(|threshold| row.rss_mb >= threshold.max(PROCESS_HOT_RSS_FLOOR_MB))
-    }) {
+    if rows
+        .iter()
+        .any(|row| row.cpu_percent >= hot_cpu_percent || row.rss_mb >= hot_rss_mb)
+    {
         ResourceRecommendation::Hot
-    } else if rows.iter().any(|row| {
-        row.cpu_percent >= warm_cpu_percent
-            || warm_rss_mb
-                .is_some_and(|threshold| row.rss_mb >= threshold.max(PROCESS_WARM_RSS_FLOOR_MB))
-    }) {
+    } else if rows
+        .iter()
+        .any(|row| row.cpu_percent >= warm_cpu_percent || row.rss_mb >= warm_rss_mb)
+    {
         ResourceRecommendation::Warm
     } else {
         ResourceRecommendation::Ok
@@ -176,6 +182,15 @@ mod tests {
         assert_eq!(
             classify_processes(&rows, 16, Some(128 * 1024)),
             ResourceRecommendation::Ok
+        );
+
+        let rows = vec![ProcessRow {
+            rss_mb: 1024,
+            ..rows[0].clone()
+        }];
+        assert_eq!(
+            classify_processes(&rows, 0, None),
+            ResourceRecommendation::Hot
         );
     }
 

--- a/crates/homeboy-cli/src/commands/resources/mod.rs
+++ b/crates/homeboy-cli/src/commands/resources/mod.rs
@@ -9,6 +9,7 @@ mod classification;
 mod load;
 mod memory;
 
+use crate::runner::runners::{self as runner, RunnerKind};
 use classification::{classify_processes, classify_rig_leases, overall_recommendation};
 
 const RELEVANT_PROCESS_EXECUTABLES: &[&str] = &["homeboy"];
@@ -78,6 +79,8 @@ pub struct ProcessRow {
 #[derive(Debug, Serialize)]
 pub struct RigLeaseSummary {
     pub active_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency_limit: Option<usize>,
     pub leases: Vec<RigLeaseRow>,
     pub recommendation: ResourceRecommendation,
 }
@@ -120,7 +123,10 @@ fn run_with_mode(mode: ResourceProbeMode) -> CmdResult<DoctorOutput> {
     };
 
     let processes = match mode {
-        ResourceProbeMode::Full => match collect_process_summary() {
+        ResourceProbeMode::Full => match collect_process_summary(
+            load.cpu_count,
+            memory.as_ref().map(|summary| summary.total_mb),
+        ) {
             Ok(summary) => summary,
             Err(note) => {
                 notes.push(note);
@@ -177,12 +183,16 @@ fn empty_process_summary() -> ProcessSummary {
 fn empty_rig_lease_summary() -> RigLeaseSummary {
     RigLeaseSummary {
         active_count: 0,
+        concurrency_limit: None,
         leases: Vec::new(),
         recommendation: ResourceRecommendation::Ok,
     }
 }
 
-fn collect_process_summary() -> Result<ProcessSummary, String> {
+fn collect_process_summary(
+    cpu_count: usize,
+    total_memory_mb: Option<u64>,
+) -> Result<ProcessSummary, String> {
     let output = Command::new("ps")
         .args(["-axo", "pid=,pcpu=,rss=,comm=,args="])
         .output()
@@ -197,7 +207,7 @@ fn collect_process_summary() -> Result<ProcessSummary, String> {
         .filter_map(parse_process_row)
         .filter(is_relevant_process)
         .collect();
-    let recommendation = classify_processes(&rows);
+    let recommendation = classify_processes(&rows, cpu_count, total_memory_mb);
     let relevant_count = rows.len();
 
     let mut top_cpu = rows.clone();
@@ -298,13 +308,24 @@ fn collect_rig_leases() -> Result<RigLeaseSummary, String> {
             started_at: lease.started_at,
         })
         .collect();
-    let recommendation = classify_rig_leases(rows.len());
+    let concurrency_limit = local_runner_concurrency_limit();
+    let recommendation = classify_rig_leases(rows.len(), concurrency_limit);
 
     Ok(RigLeaseSummary {
         active_count: rows.len(),
+        concurrency_limit,
         leases: rows,
         recommendation,
     })
+}
+
+fn local_runner_concurrency_limit() -> Option<usize> {
+    runner::list()
+        .ok()?
+        .into_iter()
+        .filter(|runner| runner.kind == RunnerKind::Local)
+        .filter_map(|runner| runner.settings.concurrency_limit)
+        .min()
 }
 
 fn round1(value: f64) -> f64 {

--- a/crates/homeboy-cli/src/commands/resources/mod.rs
+++ b/crates/homeboy-cli/src/commands/resources/mod.rs
@@ -9,7 +9,7 @@ mod classification;
 mod load;
 mod memory;
 
-use crate::runner::runners::{self as runner, RunnerKind};
+use crate::runner::runners::{self as runner, Runner};
 use classification::{classify_processes, classify_rig_leases, overall_recommendation};
 
 const RELEVANT_PROCESS_EXECUTABLES: &[&str] = &["homeboy"];
@@ -320,12 +320,18 @@ fn collect_rig_leases() -> Result<RigLeaseSummary, String> {
 }
 
 fn local_runner_concurrency_limit() -> Option<usize> {
-    runner::list()
-        .ok()?
+    let runner_id = homeboy::core::resource_policy_context::is_runner_hosted_exec()
+        .then(|| std::env::var(crate::runner::RUNNER_ID_ENV).ok())
+        .flatten();
+    runner_concurrency_limit(runner_id.as_deref(), runner::list().ok()?)
+}
+
+fn runner_concurrency_limit(runner_id: Option<&str>, runners: Vec<Runner>) -> Option<usize> {
+    let runner_id = runner_id?;
+    runners
         .into_iter()
-        .filter(|runner| runner.kind == RunnerKind::Local)
-        .filter_map(|runner| runner.settings.concurrency_limit)
-        .min()
+        .find(|runner| runner.id == runner_id)
+        .and_then(|runner| runner.settings.concurrency_limit)
 }
 
 fn round1(value: f64) -> f64 {
@@ -385,5 +391,33 @@ mod tests {
         assert!(output.processes.top_rss.is_empty());
         assert_eq!(output.rig_leases.active_count, 0);
         assert!(output.rig_leases.leases.is_empty());
+    }
+
+    #[test]
+    fn uses_only_the_hosted_runner_capacity() {
+        let configured = |id: &str, concurrency_limit| Runner {
+            id: id.to_string(),
+            kind: runner::RunnerKind::Local,
+            server_id: None,
+            workspace_root: None,
+            settings: homeboy::core::server::RunnerSettings {
+                concurrency_limit,
+                ..Default::default()
+            },
+            env: Default::default(),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: Default::default(),
+        };
+        let runners = vec![
+            configured("controller-local", Some(2)),
+            configured("lab-local", Some(8)),
+        ];
+
+        assert_eq!(runner_concurrency_limit(None, runners.clone()), None);
+        assert_eq!(
+            runner_concurrency_limit(Some("lab-local"), runners),
+            Some(8)
+        );
     }
 }

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -117,10 +117,12 @@ pub fn resource_policy_context_from_evaluation(
                 .map(|memory| severity_str(memory.recommendation).to_string()),
             memory_used_percent: resources.memory.as_ref().map(|memory| memory.used_percent),
             memory_available_mb: resources.memory.as_ref().map(|memory| memory.available_mb),
+            memory_total_mb: resources.memory.as_ref().map(|memory| memory.total_mb),
             relevant_process_count: resources.processes.relevant_count,
             process_severity: severity_str(resources.processes.recommendation).to_string(),
             active_rig_lease_count: resources.rig_leases.active_count,
             rig_lease_severity: severity_str(resources.rig_leases.recommendation).to_string(),
+            rig_lease_concurrency_limit: resources.rig_leases.concurrency_limit,
         },
     }
 }
@@ -423,6 +425,7 @@ mod tests {
             },
             rig_leases: RigLeaseSummary {
                 active_count: 0,
+                concurrency_limit: None,
                 leases: Vec::new(),
                 recommendation: ResourceRecommendation::Ok,
             },
@@ -1011,7 +1014,6 @@ mod tests {
             used_percent: 95.3,
             recommendation: ResourceRecommendation::Warm,
         });
-
         assert!(!admits_warm_runner_coordination(
             command,
             &resources,
@@ -1376,6 +1378,7 @@ mod tests {
             used_percent: 95.3,
             recommendation: ResourceRecommendation::Warm,
         });
+        resources.rig_leases.concurrency_limit = Some(8);
         let context = resource_policy_context_from_evaluation(
             lab_supported_hot("bench"),
             &resources,
@@ -1388,6 +1391,8 @@ mod tests {
         assert_eq!(context.host.memory_severity.as_deref(), Some("warm"));
         assert_eq!(context.host.memory_used_percent, Some(95.3));
         assert_eq!(context.host.memory_available_mb, Some(1_500));
+        assert_eq!(context.host.memory_total_mb, Some(32_000));
+        assert_eq!(context.host.rig_lease_concurrency_limit, Some(8));
     }
 
     #[test]
@@ -1421,6 +1426,7 @@ mod tests {
         assert_eq!(value["runner_selection"]["reason"], "default_lab_runner");
         assert_eq!(value["host"]["load_severity"], "hot");
         assert_eq!(value["host"]["cpu_count"], 4);
+        assert!(value["host"].get("rig_lease_concurrency_limit").is_none());
     }
 
     #[test]

--- a/crates/homeboy-core/src/resource_policy_context.rs
+++ b/crates/homeboy-core/src/resource_policy_context.rs
@@ -101,6 +101,27 @@ pub struct ResourcePolicyHostSnapshot {
     pub rig_lease_concurrency_limit: Option<usize>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_snapshot_accepts_observations_written_before_capacity_metadata() {
+        let snapshot: ResourcePolicyHostSnapshot = serde_json::from_value(serde_json::json!({
+            "load_severity": "ok",
+            "cpu_count": 4,
+            "relevant_process_count": 0,
+            "process_severity": "ok",
+            "active_rig_lease_count": 0,
+            "rig_lease_severity": "ok"
+        }))
+        .expect("older resource-policy host snapshots remain readable");
+
+        assert_eq!(snapshot.memory_total_mb, None);
+        assert_eq!(snapshot.rig_lease_concurrency_limit, None);
+    }
+}
+
 fn captured_storage() -> &'static RwLock<Option<ResourcePolicyContext>> {
     static STORAGE: OnceLock<RwLock<Option<ResourcePolicyContext>>> = OnceLock::new();
     STORAGE.get_or_init(|| RwLock::new(None))

--- a/crates/homeboy-core/src/resource_policy_context.rs
+++ b/crates/homeboy-core/src/resource_policy_context.rs
@@ -83,6 +83,10 @@ pub struct ResourcePolicyHostSnapshot {
     /// Memory available in MB if memory data was collected.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_available_mb: Option<u64>,
+    /// Total physical memory in MB if memory data was collected. This is the
+    /// capacity basis for relative process RSS classification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_total_mb: Option<u64>,
     /// Number of Homeboy-adjacent processes already active.
     pub relevant_process_count: usize,
     /// Severity classification of the active process set.
@@ -91,6 +95,10 @@ pub struct ResourcePolicyHostSnapshot {
     pub active_rig_lease_count: usize,
     /// Severity classification of the active rig lease set.
     pub rig_lease_severity: String,
+    /// Configured local runner concurrency used to classify rig leases, when
+    /// available. Absent values use the legacy count-based fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_lease_concurrency_limit: Option<usize>,
 }
 
 fn captured_storage() -> &'static RwLock<Option<ResourcePolicyContext>> {


### PR DESCRIPTION
## Summary
- Classify Homeboy process CPU and RSS relative to host cores and RAM, with conservative small-host floors.
- Classify active rig leases against configured local-runner concurrency, retaining the legacy count thresholds when no local concurrency is configured.
- Persist total RAM and the lease concurrency basis in additive resource-policy metadata.

Fixes #7585

## Related
- Relates to #10122: its 4.1 GB idle controller evidence is no longer automatically hot on a high-capacity host; abnormal growth remains a separate concern.

## Evidence
- Deterministic profiles cover a 4-core/8 GB laptop, a 16-core/128 GB runner, healthy leases below an 8-way configured limit, near-limit and full-limit leases, and the no-concurrency legacy fallback.
- `cargo fmt --check`
- `cargo test -p homeboy-cli resources::classification`
- `cargo test -p homeboy-cli resource_policy::tests`
- `cargo check --workspace`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the capacity-relative classification, persisted metadata, and deterministic tests. Chris Huber reviewed and remains responsible for every line.