### PR TITLE
Finalize adopted Cook candidates across run lineage

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -65,7 +65,16 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     if !options.manual_finalization {
         let lifecycle = backend.hydrate_run(&options.run_id)?;
         let gate_proof = backend.hydrate_gate_proof(&options.run_id)?;
-        if gate_proof.run_id != options.run_id {
+        let review_form_only_follow_up =
+            is_review_form_only_follow_up(&gate_proof.promotion, &gate_proof.run_id);
+        let authenticated_follow_up = review_form_only_follow_up
+            && gate_proof
+                .promotion
+                .provenance
+                .pointer("/cook_follow_up/source_run_id")
+                .and_then(serde_json::Value::as_str)
+                == Some(options.run_id.as_str());
+        if gate_proof.run_id != options.run_id && !authenticated_follow_up {
             return Err(Error::validation_invalid_argument(
                 "run_id",
                 "durable gate proof belongs to a different run",
@@ -76,8 +85,6 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
         validate_gate_proof_binding(&gate_proof, &options)?;
         let eligibility =
             validate_durable_publication_eligibility(&lifecycle, &gate_proof.promotion)?;
-        let review_form_only_follow_up =
-            is_review_form_only_follow_up(&gate_proof.promotion, &options.run_id);
         durable_changed_files = normalize_changed_files(&gate_proof.promotion.changed_files);
         if normalize_changed_files(&options.changed_files) != durable_changed_files {
             return Err(changed_files_mismatch_error(
@@ -419,7 +426,7 @@ fn validate_gate_proof_binding(
             None,
         ));
     }
-    if gate_proof.promotion.source.run_id.as_deref() != Some(options.run_id.as_str()) {
+    if gate_proof.promotion.source.run_id.as_deref() != Some(gate_proof.run_id.as_str()) {
         return Err(Error::validation_invalid_argument(
             "run_id",
             "durable gate proof promotion source belongs to a different run",

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -1026,6 +1026,26 @@ fn durable_finalization_requires_successful_provider_run_and_hydrates_model() {
     mismatched_options.manual_finalization = false;
     assert!(finalize_pr_with_backend(mismatched_options, &mut backend).is_err());
 
+    let mut follow_up = successful_gate_proof();
+    follow_up.run_id = "cook-review-form".to_string();
+    follow_up.promotion.source.run_id = Some("cook-review-form".to_string());
+    follow_up.promotion.provenance = json!({
+        "cook_follow_up": {
+            "kind": "review_form_only",
+            "source_run_id": "cook-3678"
+        }
+    });
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(successful_lifecycle("openai/gpt-5.6-terra")),
+        gate_proof: Some(follow_up),
+        ..Default::default()
+    };
+    let mut follow_up_options = options();
+    follow_up_options.manual_finalization = false;
+    finalize_pr_with_backend(follow_up_options, &mut backend)
+        .expect("authenticated review-form continuation finalizes");
+
     let mut failed = successful_lifecycle("openai/gpt-5.6-terra");
     failed.execution.state = RunExecutionState::Failed;
     let mut backend = MockBackend {


### PR DESCRIPTION
## Summary
Allow adopted Cook review-form continuations to finalize through authenticated run lineage.

## What changed
- Accept a distinct proof run only when review-form provenance binds it to the requested source run.
- Continue requiring the promotion source to match the proof-producing run.

## How to test
1. Run `cargo test -p homeboy-agents durable_finalization_requires_successful_provider_run_and_hydrates_model`; expect the authenticated continuation finalizes and unrelated proof remains rejected.

## Compatibility
Preserves exact run identity for normal proofs and adds only the existing review\_form\_only lineage exception.

## Evidence
- Base unchanged since verification: main remains at 73f9b37fb120cc5a22b11805d695c1cd9e44606e.
- CI expected: Homeboy CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/10165
- Verified finalization base: main at 73f9b37fb120cc5a22b11805d695c1cd9e44606e
- focused-test: passed (cargo test -p homeboy-agents durable\_finalization\_requires\_successful\_provider\_run\_and\_hydrates\_model) (Passed)
- format: passed (cargo fmt --all -- --check) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode with OpenAI gpt-5.6-terra and gpt-5.6-sol)
- **Model:** openai/gpt-5.6-sol
- **Used for:** gpt-5.6-terra investigated the recovery flow; gpt-5.6-sol implemented and verified the minimal lineage validation fix.

## Source relationships
- Closes #10165
