### PR TITLE
Fix stranded Cook retry recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -30,9 +30,9 @@ use super::cook_budget::{
     budget_remaining, execution_budget_usage, reserve_remediation_budget, ExecutionBudgetUsage,
 };
 use super::cook_pre_execution::{
-    materialize_initial_cook_attempt, pre_execution_failure_details, pre_execution_failure_phase,
-    pre_execution_failure_report, record_pre_execution_failure, retryable_pre_execution_failure,
-    terminal_executor_matches, with_pre_execution_phase,
+    materialize_cook_attempt, materialize_initial_cook_attempt, pre_execution_failure_details,
+    pre_execution_failure_phase, pre_execution_failure_report, record_pre_execution_failure,
+    retryable_pre_execution_failure, terminal_executor_matches, with_pre_execution_phase,
 };
 use super::cook_promotion::{
     attempt_needs_execution, cook_report, finalize_or_load_cook_pr,
@@ -1600,6 +1600,13 @@ where
     validate_cook_workspace(&options)?;
     validate_cook_candidate_group(&options.initial_plan)?;
     materialize_initial_cook_attempt(&options)?;
+    if let Some(latest_attempt) = recipe.attempts.last() {
+        materialize_cook_attempt(
+            &recipe.cook_id,
+            &latest_attempt.run_id,
+            &latest_attempt.plan,
+        )?;
+    }
     // The recipe alone is resumable input, not a status-addressable run. Publish
     // the run identity only after initial materialization and a lifecycle read
     // prove status/log recovery resolves for this exact attempt.
@@ -1920,6 +1927,7 @@ where
                 let next_attempt = attempt + 1;
                 let next_run_id = agent_task_lifecycle::cook_attempt_run_id(&cook_id, next_attempt);
                 super::record_recipe_attempt(&cook_id, next_attempt, &next_run_id, &plan)?;
+                materialize_cook_attempt(&cook_id, &next_run_id, &plan)?;
                 run_id = next_run_id;
                 next_plan = Some(plan);
                 continue;

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -31,15 +31,30 @@ use super::AgentTaskRunResult;
 pub(crate) fn materialize_initial_cook_attempt(
     options: &AgentTaskCookServiceOptions,
 ) -> Result<()> {
-    if agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
-        return ensure_initial_cook_attempt_index(options);
+    materialize_cook_attempt(
+        &options.cook_id,
+        &options.initial_run_id,
+        &options.initial_plan,
+    )
+}
+
+/// Complete recipe, run-record, and index registration for an attempt. Each
+/// write is independently durable, so replay must repair whichever suffix of
+/// the sequence was interrupted.
+pub(crate) fn materialize_cook_attempt(
+    cook_id: &str,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+) -> Result<()> {
+    if agent_task_lifecycle::run_record_exists(run_id)? {
+        return ensure_cook_attempt_index(cook_id, run_id);
     }
-    match agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id)) {
-        Ok(_) => ensure_initial_cook_attempt_index(options),
+    match agent_task_lifecycle::submit_plan(plan, Some(run_id)) {
+        Ok(_) => ensure_cook_attempt_index(cook_id, run_id),
         Err(error) => {
             // `submit_plan` persists admission failures before returning them.
-            if agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
-                ensure_initial_cook_attempt_index(options)?;
+            if agent_task_lifecycle::run_record_exists(run_id)? {
+                ensure_cook_attempt_index(cook_id, run_id)?;
             }
             Err(error)
         }
@@ -49,27 +64,27 @@ pub(crate) fn materialize_initial_cook_attempt(
 /// Complete the second half of initial-attempt materialization after a crash.
 /// The recipe and run record are independent durable writes, so their exact
 /// identities must agree before repairing the alias/index projection.
-fn ensure_initial_cook_attempt_index(options: &AgentTaskCookServiceOptions) -> Result<()> {
-    let recipe = super::cook_recipe::load_recipe(&options.cook_id)?;
+fn ensure_cook_attempt_index(cook_id: &str, run_id: &str) -> Result<()> {
+    let recipe = super::cook_recipe::load_recipe(cook_id)?;
     let attempt = recipe
         .attempts
         .iter()
-        .find(|attempt| attempt.run_id == options.initial_run_id)
+        .find(|attempt| attempt.run_id == run_id)
         .ok_or_else(|| {
             Error::validation_invalid_argument(
                 "cook_recipe.attempts",
-                "durable cook recipe does not declare the initial run id",
-                Some(options.initial_run_id.clone()),
+                "durable cook recipe does not declare the run id",
+                Some(run_id.to_string()),
                 None,
             )
         })?;
-    let record = agent_task_lifecycle::exact_record(&options.initial_run_id)?;
+    let record = agent_task_lifecycle::exact_record(run_id)?;
     if let Some(cook_id) = record.metadata.get("cook_id").and_then(Value::as_str) {
         if cook_id != recipe.cook_id {
             return Err(Error::validation_invalid_argument(
                 "cook_id",
                 "durable run record belongs to a different Cook",
-                Some(options.initial_run_id.clone()),
+                Some(run_id.to_string()),
                 None,
             ));
         }
@@ -79,7 +94,7 @@ fn ensure_initial_cook_attempt_index(options: &AgentTaskCookServiceOptions) -> R
             return Err(Error::validation_invalid_argument(
                 "cook_attempt",
                 "durable run record belongs to a different Cook attempt",
-                Some(options.initial_run_id.clone()),
+                Some(run_id.to_string()),
                 None,
             ));
         }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1854,6 +1854,144 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
 }
 
 #[test]
+fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("temporary destination");
+        let repository = temp.path().join("repository");
+        let destination = temp.path().join("destination");
+        std::fs::create_dir(&repository).expect("create repository");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .status()
+                .expect("run git")
+                .success());
+        };
+        git(&repository, &["init", "-b", "main"]);
+        std::fs::write(repository.join("fixture.txt"), "base\n").expect("write base");
+        git(&repository, &["add", "fixture.txt"]);
+        git(
+            &repository,
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "base",
+            ],
+        );
+        git(
+            &repository,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "fixture-candidate",
+                destination.to_str().expect("destination path"),
+                "HEAD",
+            ],
+        );
+        let cook_id = "cook-repair-recipe-only-retry";
+        let first_run_id = "cook-repair-recipe-only-retry-attempt-1";
+        let stranded_run_id = "cook-repair-recipe-only-retry-attempt-2-stranded";
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let mut options = batch_cook_options(
+            cook_id,
+            Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: Arc::clone(&dispatches),
+            }),
+        );
+        options.initial_run_id = first_run_id.to_string();
+        options.max_attempts = 2;
+        options.source_worktree_path = Some(destination.clone());
+        options.initial_plan.tasks[0].workspace.root = Some(destination.display().to_string());
+        options.initial_plan.tasks[0].workspace.kind = Some("homeboy-worktree".to_string());
+        options.initial_plan.tasks[0].workspace.materialization = serde_json::json!({
+            "kind": "homeboy-worktree",
+            "id": options.to_worktree.clone(),
+            "root": destination,
+            "branch": "fixture-candidate",
+        });
+        homeboy_core::worktree::adopt(homeboy_core::worktree::WorktreeAdoptOptions {
+            handle: options.to_worktree.clone(),
+            path: destination.display().to_string(),
+            kind: Some("test-fixture".to_string()),
+            provenance: None,
+        })
+        .expect("register destination workspace");
+        super::super::persist_initial_recipe(&options).expect("persist durable recipe");
+        super::super::materialize_initial_cook_attempt(&options)
+            .expect("materialize initial attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            first_run_id,
+            &options.initial_plan,
+            "lab_handoff_preacceptance",
+            &Error::new(
+                homeboy_core::error::ErrorCode::RunnerLabTransportFailure,
+                "fixture runner identity mismatch",
+                serde_json::json!({ "phase": "lab_handoff_preacceptance" }),
+            )
+            .with_retryable(true),
+        )
+        .expect("record retryable pre-acceptance failure");
+        super::super::record_recipe_attempt(cook_id, 2, stranded_run_id, &options.initial_plan)
+            .expect("persist recipe-only retry");
+
+        assert!(!agent_task_lifecycle::run_record_exists(stranded_run_id).unwrap());
+        assert_eq!(
+            agent_task_lifecycle::cook_index(cook_id)
+                .expect("initial Cook index")
+                .latest_run_id,
+            first_run_id
+        );
+
+        let result = run_cook_with_boundaries_observed_inner(
+            options.clone(),
+            UnusedExecutor,
+            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            None,
+        )
+        .expect("continuation repairs and dispatches recipe-bound retry");
+        let repeated = run_cook_with_boundaries_observed_inner(
+            options,
+            UnusedExecutor,
+            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            None,
+        )
+        .expect("repeated continuation remains idempotent");
+
+        assert_eq!(result.value.status, "in_flight", "{result:#?}");
+        assert_eq!(result.value.latest_run_id.as_deref(), Some(stranded_run_id));
+        assert_eq!(
+            repeated.value.latest_run_id.as_deref(),
+            Some(stranded_run_id)
+        );
+        assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+        let index = agent_task_lifecycle::cook_index(cook_id).expect("repaired Cook index");
+        assert_eq!(index.attempts.len(), 2);
+        assert_eq!(index.latest_run_id, stranded_run_id);
+        assert_eq!(
+            agent_task_lifecycle::status(stranded_run_id)
+                .expect("repaired retry record")
+                .runner_job_id(),
+            Some("recording-daemon-job")
+        );
+        assert_eq!(
+            super::super::load_recipe(cook_id)
+                .expect("stable recipe")
+                .attempts
+                .iter()
+                .filter(|attempt| attempt.attempt == 2)
+                .count(),
+            1
+        );
+    });
+}
+
+#[test]
 fn retry_after_admission_failure_restores_managed_workspace_after_baseline_cleanup() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("temp source root");


### PR DESCRIPTION
## Summary
Recover Cook retries interrupted between recipe, run-record, and index persistence.

## What changed
- Generalize durable Cook attempt materialization, repair recipe-bound retries during continuation, and register newly generated retries before they become observable.

## How to test
1. Run `cargo test -p homeboy-agents cook_continue_adopts_recipe_bound_retry_missing_run_and_index --lib`; expect The recipe-only retry is repaired under its original ID and repeated continuation dispatches it exactly once..

## Compatibility
Existing complete attempt records remain idempotent; recovery only materializes exact recipe-declared run IDs and rejects conflicting Cook or attempt metadata.

## Evidence
- Base unchanged since verification: main remains at faaeed867180c60a267fed0f14e5c284e3db5c54.
- \[operator-only reference omitted\]
- \[operator-only reference omitted\]
- \[operator-only reference omitted\]
- \[operator-only reference omitted\]
- \[operator-only reference omitted\]
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/10140
- Verified finalization base: main at faaeed867180c60a267fed0f14e5c284e3db5c54
- cargo-check: passed (Passed)
- focused-recovery-test: passed (Passed)
- format: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, deterministic regression coverage, and PR drafting

## Source relationships
- Closes #10140
