### PR TITLE
feat(schedule): run external programs, not just homeboy commands

### DIFF
--- a/crates/homeboy-cli/src/commands/schedule.rs
+++ b/crates/homeboy-cli/src/commands/schedule.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 
 use homeboy::core::error::{Error, Result};
 use homeboy::core::schedule::{
-    self, Cadence, NotifyPolicy, OverlapPolicy, Schedule, ScheduleRunOutcome, ScheduleState,
-    SubprocessRunner,
+    self, Cadence, ExecCommand, NotifyPolicy, OverlapPolicy, Schedule, ScheduleRunOutcome,
+    ScheduleState, SubprocessRunner,
 };
 
 use super::CmdResult;
@@ -20,7 +20,7 @@ pub struct ScheduleArgs {
 #[derive(Subcommand)]
 enum ScheduleCommand {
     /// Declare a scheduled run
-    Add(AddArgs),
+    Add(Box<AddArgs>),
     /// List declared schedules with their last and next run
     List,
     /// Show one schedule and its runtime state
@@ -44,8 +44,22 @@ pub struct AddArgs {
 
     /// Homeboy command to run, without the leading binary name
     /// (for example: --command "fleet check prod")
-    #[arg(long)]
-    command: String,
+    #[arg(long, conflicts_with = "exec")]
+    command: Option<String>,
+
+    /// External program to run instead of a homeboy command. Executed
+    /// directly, never through a shell.
+    #[arg(long, conflicts_with = "command")]
+    exec: Option<String>,
+
+    /// Argument for --exec. Repeat for each argument; values are passed
+    /// through untouched, so an argument may contain spaces.
+    #[arg(long = "exec-arg", requires = "exec")]
+    exec_arg: Vec<String>,
+
+    /// Directory to run --exec from
+    #[arg(long, requires = "exec")]
+    working_dir: Option<String>,
 
     /// How often to run: 30m, 24h, 1h30m, 7d
     #[arg(long)]
@@ -111,7 +125,7 @@ pub struct ScheduleView {
 #[derive(Serialize)]
 pub struct ScheduleSummary {
     id: String,
-    command: Vec<String>,
+    command: String,
     every: String,
     notify_on: String,
     on_overlap: String,
@@ -142,7 +156,7 @@ fn view(schedule: Schedule) -> ScheduleView {
     ScheduleView {
         schedule: ScheduleSummary {
             id: schedule.id.clone(),
-            command: schedule.command.clone(),
+            command: schedule.command_display(),
             every: schedule.every.to_string(),
             notify_on: schedule.notify_on.as_str().to_string(),
             on_overlap: schedule.on_overlap.as_str().to_string(),
@@ -219,9 +233,29 @@ pub fn run(args: ScheduleArgs, _global: &super::GlobalArgs) -> CmdResult<Schedul
                     Some(vec!["Pass --force to replace it.".to_string()]),
                 ));
             }
+            let (command, exec) = match (&add.command, &add.exec) {
+                (Some(raw), None) => (Some(split_command(raw)?), None),
+                (None, Some(program)) => (
+                    None,
+                    Some(ExecCommand {
+                        program: program.clone(),
+                        args: add.exec_arg.clone(),
+                        working_dir: add.working_dir.clone(),
+                    }),
+                ),
+                _ => {
+                    return Err(Error::validation_invalid_argument(
+                        "command",
+                        "Pass exactly one of --command or --exec",
+                        Some(add.id.clone()),
+                        None,
+                    ))
+                }
+            };
             let declared = Schedule {
                 id: add.id.clone(),
-                command: split_command(&add.command)?,
+                command,
+                exec,
                 every: Cadence::parse(&add.every)?,
                 notify_on: add.notify_on.parse::<NotifyPolicy>()?,
                 on_overlap: match add.on_overlap.trim().to_ascii_lowercase().as_str() {

--- a/crates/homeboy-core/src/schedule/entity.rs
+++ b/crates/homeboy-core/src/schedule/entity.rs
@@ -39,40 +39,29 @@ impl ConfigEntity for Schedule {
                 None,
             ));
         }
-        if self.command.is_empty() {
-            return Err(Error::validation_invalid_argument(
-                "command",
-                "A schedule needs a command to run",
-                Some(self.id.clone()),
-                Some(vec![
-                    "Pass the homeboy arguments to run, for example: --command 'fleet check prod'"
-                        .to_string(),
-                ]),
-            ));
-        }
-        if self.command.iter().any(|arg| arg.trim().is_empty()) {
-            return Err(Error::validation_invalid_argument(
-                "command",
-                "A schedule command cannot contain empty arguments",
-                Some(self.command.join(" ")),
-                None,
-            ));
-        }
-        // Scheduling a schedule command would let a tick mutate its own
-        // definitions, or recurse.
-        if self
-            .command
-            .first()
-            .is_some_and(|first| first.trim() == "schedule")
-        {
-            return Err(Error::validation_invalid_argument(
-                "command",
-                "A schedule cannot run the schedule command itself",
-                Some(self.command.join(" ")),
-                Some(vec![
-                    "Schedule the work you want repeated, not the scheduler.".to_string(),
-                ]),
-            ));
+        match (&self.command, &self.exec) {
+            (Some(argv), None) => validate_homeboy_command(argv)?,
+            (None, Some(exec)) => validate_exec_command(exec)?,
+            (Some(_), Some(_)) => {
+                return Err(Error::validation_invalid_argument(
+                    "command",
+                    "A schedule runs either a homeboy command or a program, not both",
+                    Some(self.id.clone()),
+                    Some(vec![
+                        "Declare one schedule per thing you want run.".to_string()
+                    ]),
+                ));
+            }
+            (None, None) => {
+                return Err(Error::validation_invalid_argument(
+                    "command",
+                    "A schedule needs something to run",
+                    Some(self.id.clone()),
+                    Some(vec![
+                        "Pass --command 'fleet check prod', or --exec with a program.".to_string(),
+                    ]),
+                ));
+            }
         }
         // A transport without a route (or the reverse) silently never
         // notifies, which is worse than refusing it.
@@ -109,6 +98,78 @@ impl ConfigEntity for Schedule {
     }
 }
 
+fn validate_homeboy_command(argv: &[String]) -> Result<()> {
+    if argv.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "A schedule needs a command to run",
+            None,
+            None,
+        ));
+    }
+    if argv.iter().any(|arg| arg.trim().is_empty()) {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "A schedule command cannot contain empty arguments",
+            Some(argv.join(" ")),
+            None,
+        ));
+    }
+    // Scheduling a schedule command would let a tick mutate its own
+    // definitions, or recurse.
+    if argv.first().is_some_and(|first| first.trim() == "schedule") {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "A schedule cannot run the schedule command itself",
+            Some(argv.join(" ")),
+            Some(vec![
+                "Schedule the work you want repeated, not the scheduler.".to_string(),
+            ]),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_exec_command(exec: &super::types::ExecCommand) -> Result<()> {
+    if exec.program.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "exec",
+            "A scheduled program needs a program to run",
+            None,
+            None,
+        ));
+    }
+    // The program is executed directly, never through a shell. Shell
+    // metacharacters in the program name almost always mean the operator
+    // expected shell semantics they are not getting, so say so rather than
+    // failing later with a confusing "no such file".
+    if exec
+        .program
+        .contains(['|', ';', '&', '>', '<', '$', '`', '\n'])
+    {
+        return Err(Error::validation_invalid_argument(
+            "exec",
+            "A scheduled program is run directly, not through a shell",
+            Some(exec.program.clone()),
+            Some(vec![
+                "Shell operators are not interpreted. To run a pipeline, put it in a script and schedule the script."
+                    .to_string(),
+            ]),
+        ));
+    }
+    if let Some(dir) = exec.working_dir.as_deref() {
+        if dir.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "working-dir",
+                "A scheduled program's working directory cannot be empty",
+                None,
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,7 +178,8 @@ mod tests {
     fn schedule() -> Schedule {
         Schedule {
             id: "nightly-harvest".to_string(),
-            command: vec!["harvest".to_string(), "prod".to_string()],
+            command: Some(vec!["harvest".to_string(), "prod".to_string()]),
+            exec: None,
             every: Cadence::from_seconds(86_400).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),
@@ -138,7 +200,7 @@ mod tests {
     #[test]
     fn a_schedule_without_a_command_is_rejected() {
         let invalid = Schedule {
-            command: Vec::new(),
+            command: Some(Vec::new()),
             ..schedule()
         };
         assert!(invalid.validate().is_err());
@@ -169,10 +231,117 @@ mod tests {
     #[test]
     fn scheduling_the_scheduler_is_rejected() {
         let invalid = Schedule {
-            command: vec!["schedule".to_string(), "run".to_string(), "x".to_string()],
+            command: Some(vec![
+                "schedule".to_string(),
+                "run".to_string(),
+                "x".to_string(),
+            ]),
             ..schedule()
         };
         assert!(invalid.validate().is_err());
+    }
+
+    fn exec_schedule() -> Schedule {
+        Schedule {
+            id: "cert-expiry".to_string(),
+            command: None,
+            exec: Some(super::super::types::ExecCommand {
+                program: "/usr/local/bin/check-cert.sh".to_string(),
+                args: vec!["example.com".to_string()],
+                working_dir: None,
+            }),
+            every: Cadence::from_seconds(43_200).expect("cadence"),
+            notify_on: NotifyPolicy::default(),
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn an_exec_schedule_validates() {
+        exec_schedule().validate().expect("valid exec schedule");
+    }
+
+    #[test]
+    fn declaring_both_a_command_and_a_program_is_rejected() {
+        let invalid = Schedule {
+            command: Some(vec!["triage".to_string()]),
+            ..exec_schedule()
+        };
+        assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn declaring_neither_is_rejected() {
+        let invalid = Schedule {
+            command: None,
+            exec: None,
+            ..exec_schedule()
+        };
+        assert!(invalid.validate().is_err());
+    }
+
+    /// Programs run directly, never through a shell. An operator writing a
+    /// pipeline is expecting semantics they will not get, so say so at
+    /// declaration time rather than failing later with "no such file".
+    #[test]
+    fn shell_metacharacters_in_the_program_are_rejected() {
+        for program in [
+            "backup.sh | tee log",
+            "a && b",
+            "echo $HOME",
+            "run > out.txt",
+        ] {
+            let invalid = Schedule {
+                exec: Some(super::super::types::ExecCommand {
+                    program: program.to_string(),
+                    args: Vec::new(),
+                    working_dir: None,
+                }),
+                ..exec_schedule()
+            };
+            let error = invalid
+                .validate()
+                .expect_err("shell syntax must be refused");
+            assert!(
+                error.to_string().contains("not through a shell"),
+                "error should explain why, got: {error}"
+            );
+        }
+    }
+
+    /// Arguments are passed through untouched — only the program is checked.
+    /// A legitimate argument may contain characters that look shell-ish.
+    #[test]
+    fn arguments_may_contain_shell_looking_characters() {
+        let valid = Schedule {
+            exec: Some(super::super::types::ExecCommand {
+                program: "grep".to_string(),
+                args: vec!["a|b".to_string(), "$PATH".to_string()],
+                working_dir: None,
+            }),
+            ..exec_schedule()
+        };
+        valid
+            .validate()
+            .expect("arguments are not shell-interpreted");
+    }
+
+    #[test]
+    fn exec_schedules_round_trip_through_config_storage() {
+        crate::test_support::with_isolated_home(|_| {
+            crate::config::save(&exec_schedule()).expect("save");
+            let loaded = crate::config::load::<Schedule>("cert-expiry").expect("load");
+            let exec = loaded.exec.expect("exec preserved");
+            assert_eq!(exec.program, "/usr/local/bin/check-cert.sh");
+            assert_eq!(exec.args, vec!["example.com".to_string()]);
+            assert!(loaded.command.is_none());
+        });
     }
 
     #[test]
@@ -182,7 +351,10 @@ mod tests {
             crate::config::save(&schedule).expect("save schedule");
 
             let loaded = crate::config::load::<Schedule>("nightly-harvest").expect("load");
-            assert_eq!(loaded.command, vec!["harvest", "prod"]);
+            assert_eq!(
+                loaded.command,
+                Some(vec!["harvest".to_string(), "prod".to_string()])
+            );
             assert_eq!(loaded.every.seconds(), 86_400);
             assert!(loaded.enabled);
 

--- a/crates/homeboy-core/src/schedule/execution.rs
+++ b/crates/homeboy-core/src/schedule/execution.rs
@@ -5,13 +5,33 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Error, Result};
 
 use super::state::{load_state, save_state, ScheduleState};
-use super::types::{NotifyPolicy, Schedule};
+use super::types::{NotifyPolicy, Schedule, ScheduledCommand};
+
+/// Largest amount of external-command output retained.
+///
+/// A chatty program must not be able to grow the runtime state file without
+/// bound, and only the tail is ever reported.
+pub const MAX_CAPTURED_OUTPUT_BYTES: usize = 64 * 1024;
+
+/// Longest summary carried into a notification.
+pub const MAX_SUMMARY_CHARS: usize = 500;
+
+/// What a scheduled command produced.
+///
+/// Homeboy commands emit a structured envelope; external programs do not, so
+/// their result is carried as raw output plus an exit code and fingerprinted
+/// differently.
+#[derive(Debug, Clone)]
+pub enum ScheduleCommandResult {
+    Envelope(serde_json::Value),
+    Raw { exit_code: i32, output: String },
+}
 
 /// What a single schedule run produced.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduleRunOutcome {
     pub schedule_id: String,
-    pub command: Vec<String>,
+    pub command: String,
     pub status: String,
     pub exit_code: i32,
     pub started_at: String,
@@ -31,9 +51,8 @@ pub struct ScheduleRunOutcome {
 /// CLI layer can later supply an in-process runner without core depending
 /// upward on the CLI crate.
 pub trait ScheduleCommandRunner: Send + Sync {
-    /// Run `argv` (without the leading binary name) and return the parsed
-    /// `homeboy/command-result/v3` envelope.
-    fn run(&self, argv: &[String]) -> Result<serde_json::Value>;
+    /// Run a scheduled command and return its result.
+    fn run(&self, command: ScheduledCommand<'_>) -> Result<ScheduleCommandResult>;
 }
 
 /// Runs schedules by re-executing the homeboy binary.
@@ -57,7 +76,16 @@ impl SubprocessRunner {
 }
 
 impl ScheduleCommandRunner for SubprocessRunner {
-    fn run(&self, argv: &[String]) -> Result<serde_json::Value> {
+    fn run(&self, command: ScheduledCommand<'_>) -> Result<ScheduleCommandResult> {
+        match command {
+            ScheduledCommand::Homeboy(argv) => self.run_homeboy(argv),
+            ScheduledCommand::Exec(exec) => run_external(exec),
+        }
+    }
+}
+
+impl SubprocessRunner {
+    fn run_homeboy(&self, argv: &[String]) -> Result<ScheduleCommandResult> {
         let output_file = tempfile::Builder::new()
             .prefix("homeboy-schedule-")
             .suffix(".json")
@@ -88,20 +116,133 @@ impl ScheduleCommandRunner for SubprocessRunner {
         if raw.trim().is_empty() {
             // The command produced no envelope — surface the exit code rather
             // than inventing a result.
-            return Ok(serde_json::json!({
+            return Ok(ScheduleCommandResult::Envelope(serde_json::json!({
                 "schema": "homeboy/command-result/v3",
                 "success": status.success(),
                 "exit_code": status.code().unwrap_or(-1),
                 "status": if status.success() { "succeeded" } else { "failed" },
-            }));
+            })));
         }
-        serde_json::from_str(&raw).map_err(|error| {
-            Error::internal_io(
-                format!("Scheduled command wrote output that is not valid JSON: {error}"),
-                Some(output_path.display().to_string()),
-            )
-        })
+        serde_json::from_str(&raw)
+            .map(ScheduleCommandResult::Envelope)
+            .map_err(|error| {
+                Error::internal_io(
+                    format!("Scheduled command wrote output that is not valid JSON: {error}"),
+                    Some(output_path.display().to_string()),
+                )
+            })
     }
+}
+
+/// Run an external program directly.
+///
+/// No shell: the program and its arguments are passed as an argument vector,
+/// so nothing is word-split and there is no quoting or injection surface.
+/// stdout and stderr are captured together, because a failing command usually
+/// explains itself on stderr and that is what an operator needs in the
+/// notification.
+fn run_external(exec: &super::types::ExecCommand) -> Result<ScheduleCommandResult> {
+    let mut command = std::process::Command::new(&exec.program);
+    command.args(&exec.args);
+    if let Some(dir) = exec.working_dir.as_deref() {
+        command.current_dir(dir);
+    }
+    let output = command.output().map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to run scheduled program '{}': {error}",
+                exec.program
+            ),
+            exec.working_dir.clone(),
+        )
+    })?;
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.stderr.is_empty() {
+        if !combined.is_empty() && !combined.ends_with('\n') {
+            combined.push('\n');
+        }
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    }
+
+    Ok(ScheduleCommandResult::Raw {
+        exit_code: output.status.code().unwrap_or(-1),
+        output: bound_output(&combined),
+    })
+}
+
+/// Keep the tail of oversized output. The end of a run is where failures and
+/// summaries appear; the beginning is usually setup noise.
+pub fn bound_output(value: &str) -> String {
+    if value.len() <= MAX_CAPTURED_OUTPUT_BYTES {
+        return value.to_string();
+    }
+    let start = value.len() - MAX_CAPTURED_OUTPUT_BYTES;
+    // Do not split a UTF-8 character.
+    let start = (start..value.len())
+        .find(|index| value.is_char_boundary(*index))
+        .unwrap_or(value.len());
+    format!("[output truncated]\n{}", &value[start..])
+}
+
+/// Reduce a command result to the fields the scheduler reasons about.
+fn summarize(result: &ScheduleCommandResult) -> (String, i32, String, Option<String>) {
+    match result {
+        ScheduleCommandResult::Envelope(value) => {
+            let exit_code = value
+                .get("exit_code")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(0) as i32;
+            let status = value
+                .get("status")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(if exit_code == 0 {
+                    "succeeded"
+                } else {
+                    "failed"
+                })
+                .to_string();
+            let summary = value
+                .get("summary")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            (status, exit_code, result_digest(value), summary)
+        }
+        ScheduleCommandResult::Raw { exit_code, output } => {
+            let status = if *exit_code == 0 {
+                "succeeded"
+            } else {
+                "failed"
+            };
+            // An external program has no envelope, so its output *is* the
+            // result: fingerprint the output together with the exit code so a
+            // probe whose output stops changing goes quiet, and one whose
+            // output changes reports.
+            let digest = raw_digest(*exit_code, output);
+            (status.to_string(), *exit_code, digest, summary_tail(output))
+        }
+    }
+}
+
+/// Fingerprint an external command's output and exit code.
+pub fn raw_digest(exit_code: i32, output: &str) -> String {
+    let rendered = format!("{exit_code}\u{1e}{output}");
+    let digest = <sha2::Sha256 as sha2::Digest>::digest(rendered.as_bytes());
+    format!("{digest:x}")
+}
+
+/// The tail of a command's output, bounded for a notification.
+fn summary_tail(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let chars: Vec<char> = trimmed.chars().collect();
+    if chars.len() <= MAX_SUMMARY_CHARS {
+        return Some(trimmed.to_string());
+    }
+    let tail: String = chars[chars.len() - MAX_SUMMARY_CHARS..].iter().collect();
+    Some(format!("…{tail}"))
 }
 
 /// Fingerprint the part of a result that indicates *what the world looks
@@ -174,30 +315,19 @@ pub fn run_schedule(schedule: &Schedule, runner: &dyn ScheduleCommandRunner) -> 
         },
     );
 
-    let result = runner.run(&schedule.command);
+    let result = match schedule.scheduled_command() {
+        Some(command) => runner.run(command),
+        None => Err(Error::validation_invalid_argument(
+            "command",
+            "Schedule declares neither a homeboy command nor a program to run",
+            Some(schedule.id.clone()),
+            None,
+        )),
+    };
     let finished = chrono::Utc::now();
 
     let (status, exit_code, digest, summary) = match &result {
-        Ok(value) => {
-            let exit_code = value
-                .get("exit_code")
-                .and_then(serde_json::Value::as_i64)
-                .unwrap_or(0) as i32;
-            let status = value
-                .get("status")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or(if exit_code == 0 {
-                    "succeeded"
-                } else {
-                    "failed"
-                })
-                .to_string();
-            let summary = value
-                .get("summary")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string);
-            (status, exit_code, result_digest(value), summary)
-        }
+        Ok(outcome) => summarize(outcome),
         Err(error) => (
             "failed".to_string(),
             -1,
@@ -215,7 +345,7 @@ pub fn run_schedule(schedule: &Schedule, runner: &dyn ScheduleCommandRunner) -> 
 
     let mut outcome = ScheduleRunOutcome {
         schedule_id: schedule.id.clone(),
-        command: schedule.command.clone(),
+        command: schedule.command_display(),
         status: status.clone(),
         exit_code,
         started_at: started.to_rfc3339(),
@@ -267,7 +397,7 @@ fn notify(schedule: &Schedule, outcome: &ScheduleRunOutcome) -> (bool, Option<St
     };
 
     let title = format!("schedule {} — {}", schedule.id, outcome.status);
-    let mut body = format!("Command: homeboy {}\n", schedule.command.join(" "));
+    let mut body = format!("Command: {}\n", schedule.command_display());
     body.push_str(&format!(
         "Status: {} (exit {})\n",
         outcome.status, outcome.exit_code
@@ -304,7 +434,8 @@ mod tests {
     fn schedule(policy: NotifyPolicy) -> Schedule {
         Schedule {
             id: "digest-fixture".to_string(),
-            command: vec!["triage".to_string()],
+            command: Some(vec!["triage".to_string()]),
+            exec: None,
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: policy,
             on_overlap: OverlapPolicy::default(),
@@ -378,11 +509,133 @@ mod tests {
         assert_eq!(result_digest(&first), result_digest(&second));
     }
 
+    fn exec_schedule(program: &str, args: &[&str]) -> Schedule {
+        Schedule {
+            id: format!("exec-{program}"),
+            command: None,
+            exec: Some(super::super::types::ExecCommand {
+                program: program.to_string(),
+                args: args.iter().map(|arg| arg.to_string()).collect(),
+                working_dir: None,
+            }),
+            every: Cadence::from_seconds(3_600).expect("cadence"),
+            notify_on: NotifyPolicy::Change,
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// An external program has no result envelope, so its output *is* the
+    /// result and has to be fingerprinted directly.
+    #[test]
+    fn an_external_program_reports_its_exit_code_and_output() {
+        crate::test_support::with_isolated_home(|_| {
+            let runner = SubprocessRunner::new().expect("runner");
+            let schedule = exec_schedule("echo", &["scheduled output"]);
+
+            let outcome = run_schedule(&schedule, &runner);
+            assert_eq!(outcome.status, "succeeded");
+            assert_eq!(outcome.exit_code, 0);
+            assert_eq!(outcome.summary.as_deref(), Some("scheduled output"));
+            assert!(outcome.changed, "the first run has nothing to compare to");
+
+            // Identical output must not be reported as a change.
+            let again = run_schedule(&schedule, &runner);
+            assert!(!again.changed, "identical output is not a change");
+        });
+    }
+
+    #[test]
+    fn a_failing_external_program_is_reported_as_failed() {
+        crate::test_support::with_isolated_home(|_| {
+            let runner = SubprocessRunner::new().expect("runner");
+            let mut schedule = exec_schedule("false", &[]);
+            schedule.id = "exec-failing".to_string();
+
+            let outcome = run_schedule(&schedule, &runner);
+            assert_eq!(outcome.status, "failed");
+            assert_ne!(outcome.exit_code, 0);
+            assert_eq!(load_state("exec-failing").consecutive_failures, 1);
+        });
+    }
+
+    /// A missing program must be a recorded failure, not a panic or a run that
+    /// silently looks successful.
+    #[test]
+    fn a_missing_program_fails_the_run() {
+        crate::test_support::with_isolated_home(|_| {
+            let runner = SubprocessRunner::new().expect("runner");
+            let mut schedule = exec_schedule("definitely-not-a-real-program-10133", &[]);
+            schedule.id = "exec-missing".to_string();
+
+            let outcome = run_schedule(&schedule, &runner);
+            assert_eq!(outcome.status, "failed");
+            assert!(!load_state("exec-missing").running, "state must settle");
+        });
+    }
+
+    /// Arguments are passed as a vector, so one containing spaces stays one
+    /// argument rather than being word-split as a shell would.
+    #[test]
+    fn arguments_are_not_word_split() {
+        crate::test_support::with_isolated_home(|_| {
+            let runner = SubprocessRunner::new().expect("runner");
+            let mut schedule = exec_schedule("echo", &["one two three"]);
+            schedule.id = "exec-spaces".to_string();
+
+            let outcome = run_schedule(&schedule, &runner);
+            assert_eq!(outcome.summary.as_deref(), Some("one two three"));
+        });
+    }
+
+    /// Changed output must report even though the exit code is unchanged —
+    /// that is the whole point of scheduling a probe.
+    #[test]
+    fn raw_digest_tracks_output_and_exit_code_independently() {
+        assert_eq!(raw_digest(0, "healthy"), raw_digest(0, "healthy"));
+        assert_ne!(
+            raw_digest(0, "healthy"),
+            raw_digest(0, "degraded"),
+            "changed output must change the digest"
+        );
+        assert_ne!(
+            raw_digest(0, "same"),
+            raw_digest(1, "same"),
+            "a changed exit code must change the digest even with identical output"
+        );
+    }
+
+    /// A chatty program must not be able to grow the state file without bound.
+    #[test]
+    fn oversized_output_is_bounded_and_keeps_the_tail() {
+        let noisy = format!("{}TAIL-MARKER", "x".repeat(MAX_CAPTURED_OUTPUT_BYTES * 2));
+        let bounded = bound_output(&noisy);
+
+        assert!(bounded.len() < noisy.len(), "output must be bounded");
+        assert!(
+            bounded.ends_with("TAIL-MARKER"),
+            "the tail is where failures appear and must survive"
+        );
+        assert!(bounded.starts_with("[output truncated]"));
+    }
+
+    #[test]
+    fn bounding_does_not_split_a_utf8_character() {
+        let noisy = "é".repeat(MAX_CAPTURED_OUTPUT_BYTES);
+        let bounded = bound_output(&noisy);
+        assert!(bounded.contains('é'), "multi-byte output must stay valid");
+    }
+
     struct StubRunner(serde_json::Value);
 
     impl ScheduleCommandRunner for StubRunner {
-        fn run(&self, _argv: &[String]) -> Result<serde_json::Value> {
-            Ok(self.0.clone())
+        fn run(&self, _command: ScheduledCommand<'_>) -> Result<ScheduleCommandResult> {
+            Ok(ScheduleCommandResult::Envelope(self.0.clone()))
         }
     }
 

--- a/crates/homeboy-core/src/schedule/mod.rs
+++ b/crates/homeboy-core/src/schedule/mod.rs
@@ -24,11 +24,12 @@ pub mod ticker;
 pub mod types;
 
 pub use execution::{
-    result_digest, run_schedule, ScheduleCommandRunner, ScheduleRunOutcome, SubprocessRunner,
+    raw_digest, result_digest, run_schedule, ScheduleCommandResult, ScheduleCommandRunner,
+    ScheduleRunOutcome, SubprocessRunner,
 };
 pub use state::{load_state, remove_state, save_state, ScheduleState};
 pub use ticker::{reclaim_stale_runs, ScheduleTicker};
-pub use types::{Cadence, NotifyPolicy, OverlapPolicy, Schedule};
+pub use types::{Cadence, ExecCommand, NotifyPolicy, OverlapPolicy, Schedule, ScheduledCommand};
 
 crate::entity_crud!(Schedule; list_ids);
 
@@ -47,7 +48,8 @@ mod tests {
     fn schedule(id: &str, enabled: bool) -> Schedule {
         Schedule {
             id: id.to_string(),
-            command: vec!["triage".to_string()],
+            command: Some(vec!["triage".to_string()]),
+            exec: None,
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),

--- a/crates/homeboy-core/src/schedule/state.rs
+++ b/crates/homeboy-core/src/schedule/state.rs
@@ -135,7 +135,8 @@ mod tests {
     fn schedule() -> Schedule {
         Schedule {
             id: "nightly".to_string(),
-            command: vec!["triage".to_string()],
+            command: Some(vec!["triage".to_string()]),
+            exec: None,
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),

--- a/crates/homeboy-core/src/schedule/ticker.rs
+++ b/crates/homeboy-core/src/schedule/ticker.rs
@@ -146,7 +146,8 @@ mod tests {
     fn schedule(id: &str) -> Schedule {
         Schedule {
             id: id.to_string(),
-            command: vec!["triage".to_string()],
+            command: Some(vec!["triage".to_string()]),
+            exec: None,
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),
@@ -160,19 +161,24 @@ mod tests {
     }
 
     struct CountingRunner {
-        calls: Arc<Mutex<Vec<Vec<String>>>>,
+        calls: Arc<Mutex<Vec<String>>>,
         block: Option<Arc<std::sync::Barrier>>,
     }
 
     impl ScheduleCommandRunner for CountingRunner {
-        fn run(&self, argv: &[String]) -> crate::Result<serde_json::Value> {
+        fn run(
+            &self,
+            command: crate::schedule::types::ScheduledCommand<'_>,
+        ) -> crate::Result<crate::schedule::execution::ScheduleCommandResult> {
             if let Ok(mut calls) = self.calls.lock() {
-                calls.push(argv.to_vec());
+                calls.push(format!("{command:?}"));
             }
             if let Some(barrier) = &self.block {
                 barrier.wait();
             }
-            Ok(serde_json::json!({ "status": "succeeded", "exit_code": 0 }))
+            Ok(crate::schedule::execution::ScheduleCommandResult::Envelope(
+                serde_json::json!({ "status": "succeeded", "exit_code": 0 }),
+            ))
         }
     }
 

--- a/crates/homeboy-core/src/schedule/types.rs
+++ b/crates/homeboy-core/src/schedule/types.rs
@@ -178,6 +178,34 @@ impl OverlapPolicy {
     }
 }
 
+/// An external program run by a schedule.
+///
+/// Program and arguments are kept separate and passed as an argument vector.
+/// There is deliberately no shell: nothing here is word-split, so an argument
+/// containing spaces stays one argument and there is no quoting or injection
+/// surface to reason about.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecCommand {
+    pub program: String,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+
+    /// Directory to run from. Many useful commands — test runners, build
+    /// tools — only work from their project root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+}
+
+/// What a schedule runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScheduledCommand<'a> {
+    /// Homeboy arguments, run through the homeboy binary.
+    Homeboy(&'a [String]),
+    /// An external program.
+    Exec(&'a ExecCommand),
+}
+
 /// A declared periodic run.
 ///
 /// The declaration is stable, reviewable configuration. Everything that
@@ -189,7 +217,16 @@ pub struct Schedule {
 
     /// Homeboy arguments to run, without the leading binary name.
     /// For example `["fleet", "check", "prod"]`.
-    pub command: Vec<String>,
+    ///
+    /// Mutually exclusive with `exec`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<Vec<String>>,
+
+    /// An external program to run instead of a homeboy command.
+    ///
+    /// Mutually exclusive with `command`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec: Option<ExecCommand>,
 
     pub every: Cadence,
 
@@ -229,6 +266,33 @@ fn default_true() -> bool {
 }
 
 impl Schedule {
+    /// What this schedule runs.
+    ///
+    /// Validation guarantees exactly one of `command` / `exec` is set, so a
+    /// stored schedule always resolves.
+    pub fn scheduled_command(&self) -> Option<ScheduledCommand<'_>> {
+        match (&self.command, &self.exec) {
+            (Some(argv), None) => Some(ScheduledCommand::Homeboy(argv.as_slice())),
+            (None, Some(exec)) => Some(ScheduledCommand::Exec(exec)),
+            _ => None,
+        }
+    }
+
+    /// Human-readable rendering of what runs, for logs and notifications.
+    pub fn command_display(&self) -> String {
+        match self.scheduled_command() {
+            Some(ScheduledCommand::Homeboy(argv)) => format!("homeboy {}", argv.join(" ")),
+            Some(ScheduledCommand::Exec(exec)) => {
+                if exec.args.is_empty() {
+                    exec.program.clone()
+                } else {
+                    format!("{} {}", exec.program, exec.args.join(" "))
+                }
+            }
+            None => "<no command>".to_string(),
+        }
+    }
+
     /// Deterministic per-schedule jitter offset, in seconds.
     ///
     /// Derived from the id so a given schedule always lands at the same offset
@@ -292,7 +356,8 @@ mod tests {
     fn jitter_is_stable_per_id_and_bounded_by_the_window() {
         let schedule = |id: &str| Schedule {
             id: id.to_string(),
-            command: vec!["triage".to_string()],
+            command: Some(vec!["triage".to_string()]),
+            exec: None,
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),
@@ -315,6 +380,56 @@ mod tests {
             }
             .jitter_offset_seconds()
         );
+    }
+
+    /// Schedules declared before `exec` existed stored `command` as a bare
+    /// array with no `exec` key. Those files must keep loading untouched.
+    #[test]
+    fn a_pre_exec_declaration_still_deserializes() {
+        let stored = r#"{
+            "id": "nightly",
+            "command": ["harvest", "production", "--check"],
+            "every": 86400,
+            "notify_on": "change",
+            "on_overlap": "skip",
+            "enabled": true
+        }"#;
+
+        let schedule: Schedule = serde_json::from_str(stored).expect("legacy declaration loads");
+        assert_eq!(
+            schedule.command,
+            Some(vec![
+                "harvest".to_string(),
+                "production".to_string(),
+                "--check".to_string()
+            ])
+        );
+        assert!(schedule.exec.is_none());
+        assert!(matches!(
+            schedule.scheduled_command(),
+            Some(ScheduledCommand::Homeboy(_))
+        ));
+        assert_eq!(
+            schedule.command_display(),
+            "homeboy harvest production --check"
+        );
+    }
+
+    #[test]
+    fn an_exec_declaration_resolves_to_a_program() {
+        let stored = r#"{
+            "id": "probe",
+            "exec": { "program": "/usr/bin/true", "args": ["--now"] },
+            "every": 3600
+        }"#;
+
+        let schedule: Schedule = serde_json::from_str(stored).expect("exec declaration loads");
+        assert!(schedule.command.is_none());
+        assert!(matches!(
+            schedule.scheduled_command(),
+            Some(ScheduledCommand::Exec(_))
+        ));
+        assert_eq!(schedule.command_display(), "/usr/bin/true --now");
     }
 
     #[test]

--- a/docs/commands/schedule.md
+++ b/docs/commands/schedule.md
@@ -1,7 +1,8 @@
 # `homeboy schedule`
 
 ```text
-homeboy schedule add <id> --command <argv> --every <interval> [--notify-on <policy>] [--on-overlap <policy>]
+homeboy schedule add <id> (--command <argv> | --exec <program> [--exec-arg <arg>]... [--working-dir <dir>])
+                         --every <interval> [--notify-on <policy>] [--on-overlap <policy>]
                          [--notification-transport <id> --notification-route <route>]
                          [--jitter-seconds <n>] [--description <text>] [--force]
 homeboy schedule list
@@ -18,6 +19,27 @@ A schedule is stored in two parts:
 
 - the **declaration** is reviewable configuration at `~/.config/homeboy/schedules/<id>.json`
 - the **runtime record** — last status, last result fingerprint, in-flight marker — lives separately under the data directory, so the declaration stays diffable
+
+## What a schedule runs
+
+A schedule runs **either** a homeboy command or an external program — one or the other, never both.
+
+```sh
+# a homeboy command
+homeboy schedule add fleet-drift --command 'fleet check prod' --every 1h
+
+# an external program
+homeboy schedule add e2e \
+  --exec npm --exec-arg run --exec-arg test \
+  --working-dir /srv/project \
+  --every 24h
+```
+
+External programs are executed **directly, never through a shell**. Nothing is word-split, so an argument containing spaces stays one argument, and there is no quoting or injection surface. Shell operators (`|`, `&&`, `>`, `$`) in the program are refused at declaration time rather than failing later with a confusing "no such file" — to run a pipeline, put it in a script and schedule the script.
+
+Arguments are passed through untouched, so an argument may legitimately contain those characters.
+
+`--working-dir` matters for the common case: test runners and build tools usually only work from their project root.
 
 ## Cadence
 
@@ -37,7 +59,12 @@ Cadence is measured from the previous run's **start**, so a slow run does not pu
 
 `change` is the default because the useful behavior for a periodic check is silence while healthy and a ping when something drifts — a notification should mean something needs attention.
 
-Change detection fingerprints the result envelope with volatile fields (timestamps, durations, run ids) removed. Without that, every run would look like a change and `change` would be indistinguishable from `always`.
+Change detection depends on what ran:
+
+- a **homeboy command** is fingerprinted from its result envelope, with volatile fields (timestamps, durations, run ids) removed — without that, every run would look like a change and `change` would be indistinguishable from `always`
+- an **external program** has no envelope, so its combined stdout/stderr is fingerprinted together with its exit code. A probe whose output stops changing goes quiet; one whose output changes reports, even if the exit code is unchanged.
+
+External output is captured up to 64 KiB and only the tail is kept, so a chatty program cannot grow the runtime state without bound. The notification carries a bounded tail of that output.
 
 A repeated **identical failure** still notifies. An ongoing outage that goes quiet because it is "unchanged" is the worst available outcome.
 


### PR DESCRIPTION
## Summary

A schedule could only run homeboy commands. That covered homeboy's own periodic work — harvest, fleet check, triage, cleanup — but not the adjacent automation an operator wants on the same cadence: a test suite, a backup, a certificate probe, a health check. Those stayed on separate systemd timers, which is exactly the fragmentation the scheduler was meant to end.

```sh
homeboy schedule add e2e \
  --exec npm --exec-arg run --exec-arg test \
  --working-dir /srv/project \
  --every 24h --notify-on change
```

A schedule now declares **either** a homeboy command or a program, never both.

## Design decisions worth reviewing

**No shell, ever.** The program and its arguments are passed as an argument vector. Nothing is word-split, so an argument containing spaces stays one argument and there is no quoting or injection surface to reason about.

**Shell operators in the program are refused at declaration time.** An operator writing `--exec 'backup.sh | tee log'` expects semantics they will not get, and finding that out three hours later via "no such file" is a poor experience. The error says plainly that programs run directly and suggests putting the pipeline in a script. Arguments are *not* checked this way — an argument may legitimately contain `|` or `$`, and it is passed through untouched.

**Change detection needed a second form.** A homeboy command is fingerprinted from its result envelope with volatile fields stripped. An external program has no envelope, so its combined stdout/stderr is fingerprinted together with its exit code. That keeps `notify-on-change` meaningful for a probe: unchanged output stays quiet, and changed output reports **even when the exit code did not move** — which is the usual shape of a health check that starts degrading.

**Output is bounded to 64 KiB, keeping the tail.** A chatty program must not be able to grow the runtime state file without limit, and the end of a run is where failures and summaries appear. Truncation respects UTF-8 boundaries rather than splitting a character.

**stdout and stderr are captured together.** A failing command usually explains itself on stderr, and that is what an operator needs in the notification.

**`--working-dir`** exists because the motivating commands — test runners, build tools — generally only work from their project root.

## Compatibility

`command` becomes `Option<Vec<String>>` to make room for `exec`. Declarations written before this change carry a bare `command` array and no `exec` key, and deserialize unchanged. There is a test that loads such a document verbatim and asserts it still resolves to a homeboy command.

## Tests

14 new assertions:

- an external program reports exit code and output, and identical output is not a change
- a failing program is recorded as failed and counts toward consecutive failures
- a **missing** program fails the run rather than panicking or looking successful, and state still settles
- arguments are not word-split (an argument with spaces survives intact)
- raw digest tracks output and exit code independently — changed output with an unchanged exit code still reports
- oversized output is bounded, keeps the tail, and does not split a UTF-8 character
- validation: both forms declared, neither declared, shell metacharacters in the program, shell-looking characters in *arguments* (allowed)
- exec declarations round-trip through config storage
- a pre-`exec` declaration still deserializes and resolves

## Verification

- `cargo fmt`
- `cargo check -p homeboy-core --lib --tests` — clean
- `cargo check -p homeboy-cli --lib --tests` — clean
- `cargo clippy -p homeboy-core -p homeboy-cli --lib --tests` — no findings in the changed files (boxed the large clap variant clippy flagged)

Full `cargo build`/`cargo test` deliberately not run locally (this host OOMs on the Rust workspace); leaving the suite to CI.

## Motivating case

A managed WordPress site with a 122-assertion end-to-end suite that runs through an external CLI. Those suites caught a broken API contract today purely because a human chose to run them — they are not reachable from homeboy at all, so nothing scheduled could verify a harvest. This makes the verification step of a managed harvest loop expressible.

Closes #10133. #10132 (multi-step runs) remains open and composes with this: a chain of steps where any step may be a homeboy command or a program.

## AI assistance

Investigated and implemented by chubes-bot (OpenCode). Chris Huber remains responsible for review and every line.