### PR TITLE
feat(schedule): run an ordered sequence of steps

### DIFF
--- a/crates/homeboy-cli/src/commands/schedule.rs
+++ b/crates/homeboy-cli/src/commands/schedule.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use homeboy::core::error::{Error, Result};
 use homeboy::core::schedule::{
     self, Cadence, ExecCommand, NotifyPolicy, OverlapPolicy, Schedule, ScheduleRunOutcome,
-    ScheduleState, SubprocessRunner,
+    ScheduleState, ScheduleStep, SubprocessRunner,
 };
 
 use super::CmdResult;
@@ -43,21 +43,26 @@ pub struct AddArgs {
     id: String,
 
     /// Homeboy command to run, without the leading binary name
-    /// (for example: --command "fleet check prod")
-    #[arg(long, conflicts_with = "exec")]
-    command: Option<String>,
+    /// (for example: --command "fleet check prod").
+    ///
+    /// Repeat to declare an ordered sequence. Steps run in order and stop at
+    /// the first failure.
+    #[arg(long)]
+    command: Vec<String>,
 
-    /// External program to run instead of a homeboy command. Executed
-    /// directly, never through a shell.
-    #[arg(long, conflicts_with = "command")]
-    exec: Option<String>,
+    /// External program to run. Executed directly, never through a shell.
+    ///
+    /// Repeat to declare an ordered sequence. Pair each with --exec-arg and
+    /// --working-dir, which apply to the most recent --exec.
+    #[arg(long)]
+    exec: Vec<String>,
 
-    /// Argument for --exec. Repeat for each argument; values are passed
-    /// through untouched, so an argument may contain spaces.
+    /// Argument for the preceding --exec. Repeat for each argument; values are
+    /// passed through untouched, so an argument may contain spaces.
     #[arg(long = "exec-arg", requires = "exec")]
     exec_arg: Vec<String>,
 
-    /// Directory to run --exec from
+    /// Directory to run the preceding --exec from
     #[arg(long, requires = "exec")]
     working_dir: Option<String>,
 
@@ -171,6 +176,58 @@ fn view(schedule: Schedule) -> ScheduleView {
     }
 }
 
+/// Build the declared step sequence.
+///
+/// `--command` and `--exec` may each be repeated. Sequencing is
+/// commands-then-programs rather than interleaved, because clap does not
+/// preserve relative order across different flags — an interleaved sequence
+/// would silently reorder itself, which is worse than not offering it.
+fn build_steps(add: &AddArgs) -> Result<Vec<ScheduleStep>> {
+    let mut steps: Vec<ScheduleStep> = Vec::new();
+
+    for raw in &add.command {
+        steps.push(ScheduleStep {
+            command: Some(split_command(raw)?),
+            exec: None,
+        });
+    }
+
+    if add.exec.len() > 1 && (!add.exec_arg.is_empty() || add.working_dir.is_some()) {
+        return Err(Error::validation_invalid_argument(
+            "exec",
+            "--exec-arg and --working-dir cannot be shared across multiple --exec steps",
+            None,
+            Some(vec![
+                "Declare one --exec per schedule, or edit the schedule file to give each step its own arguments."
+                    .to_string(),
+            ]),
+        ));
+    }
+
+    for program in &add.exec {
+        steps.push(ScheduleStep {
+            command: None,
+            exec: Some(ExecCommand {
+                program: program.clone(),
+                args: add.exec_arg.clone(),
+                working_dir: add.working_dir.clone(),
+            }),
+        });
+    }
+
+    if steps.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "A schedule needs something to run",
+            Some(add.id.clone()),
+            Some(vec![
+                "Pass --command 'fleet check prod', or --exec with a program.".to_string(),
+            ]),
+        ));
+    }
+    Ok(steps)
+}
+
 /// Split a command string into argv.
 ///
 /// Supports quoting so an argument may contain spaces.
@@ -233,29 +290,20 @@ pub fn run(args: ScheduleArgs, _global: &super::GlobalArgs) -> CmdResult<Schedul
                     Some(vec!["Pass --force to replace it.".to_string()]),
                 ));
             }
-            let (command, exec) = match (&add.command, &add.exec) {
-                (Some(raw), None) => (Some(split_command(raw)?), None),
-                (None, Some(program)) => (
-                    None,
-                    Some(ExecCommand {
-                        program: program.clone(),
-                        args: add.exec_arg.clone(),
-                        working_dir: add.working_dir.clone(),
-                    }),
-                ),
-                _ => {
-                    return Err(Error::validation_invalid_argument(
-                        "command",
-                        "Pass exactly one of --command or --exec",
-                        Some(add.id.clone()),
-                        None,
-                    ))
-                }
+            let steps = build_steps(&add)?;
+            // A single step is stored in the flat form so simple schedules stay
+            // simple to read and to diff.
+            let (command, exec, steps) = if steps.len() == 1 {
+                let only = steps.into_iter().next().unwrap_or_default();
+                (only.command, only.exec, Vec::new())
+            } else {
+                (None, None, steps)
             };
             let declared = Schedule {
                 id: add.id.clone(),
                 command,
                 exec,
+                steps,
                 every: Cadence::parse(&add.every)?,
                 notify_on: add.notify_on.parse::<NotifyPolicy>()?,
                 on_overlap: match add.on_overlap.trim().to_ascii_lowercase().as_str() {

--- a/crates/homeboy-core/src/schedule/entity.rs
+++ b/crates/homeboy-core/src/schedule/entity.rs
@@ -39,29 +39,34 @@ impl ConfigEntity for Schedule {
                 None,
             ));
         }
-        match (&self.command, &self.exec) {
-            (Some(argv), None) => validate_homeboy_command(argv)?,
-            (None, Some(exec)) => validate_exec_command(exec)?,
-            (Some(_), Some(_)) => {
-                return Err(Error::validation_invalid_argument(
-                    "command",
-                    "A schedule runs either a homeboy command or a program, not both",
-                    Some(self.id.clone()),
-                    Some(vec![
-                        "Declare one schedule per thing you want run.".to_string()
-                    ]),
-                ));
+        let single = self.command.is_some() || self.exec.is_some();
+        if single && !self.steps.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "steps",
+                "A schedule declares either a single command or a list of steps, not both",
+                Some(self.id.clone()),
+                Some(vec![
+                    "Move the single command into the step list, or drop the steps.".to_string(),
+                ]),
+            ));
+        }
+
+        if !self.steps.is_empty() {
+            for (index, step) in self.steps.iter().enumerate() {
+                validate_step(step).map_err(|error| {
+                    Error::validation_invalid_argument(
+                        "steps",
+                        format!("Step {} is invalid: {error}", index + 1),
+                        Some(self.id.clone()),
+                        None,
+                    )
+                })?;
             }
-            (None, None) => {
-                return Err(Error::validation_invalid_argument(
-                    "command",
-                    "A schedule needs something to run",
-                    Some(self.id.clone()),
-                    Some(vec![
-                        "Pass --command 'fleet check prod', or --exec with a program.".to_string(),
-                    ]),
-                ));
-            }
+        } else {
+            validate_step(&super::types::ScheduleStep {
+                command: self.command.clone(),
+                exec: self.exec.clone(),
+            })?;
         }
         // A transport without a route (or the reverse) silently never
         // notifies, which is worse than refusing it.
@@ -95,6 +100,27 @@ impl ConfigEntity for Schedule {
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+fn validate_step(step: &super::types::ScheduleStep) -> Result<()> {
+    match (&step.command, &step.exec) {
+        (Some(argv), None) => validate_homeboy_command(argv),
+        (None, Some(exec)) => validate_exec_command(exec),
+        (Some(_), Some(_)) => Err(Error::validation_invalid_argument(
+            "command",
+            "A step runs either a homeboy command or a program, not both",
+            None,
+            None,
+        )),
+        (None, None) => Err(Error::validation_invalid_argument(
+            "command",
+            "A step needs something to run",
+            None,
+            Some(vec![
+                "Pass --command 'fleet check prod', or --exec with a program.".to_string(),
+            ]),
+        )),
     }
 }
 
@@ -180,6 +206,7 @@ mod tests {
             id: "nightly-harvest".to_string(),
             command: Some(vec!["harvest".to_string(), "prod".to_string()]),
             exec: None,
+            steps: Vec::new(),
             every: Cadence::from_seconds(86_400).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),
@@ -250,6 +277,7 @@ mod tests {
                 args: vec!["example.com".to_string()],
                 working_dir: None,
             }),
+            steps: Vec::new(),
             every: Cadence::from_seconds(43_200).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),
@@ -281,6 +309,7 @@ mod tests {
         let invalid = Schedule {
             command: None,
             exec: None,
+            steps: Vec::new(),
             ..exec_schedule()
         };
         assert!(invalid.validate().is_err());
@@ -303,6 +332,7 @@ mod tests {
                     args: Vec::new(),
                     working_dir: None,
                 }),
+                steps: Vec::new(),
                 ..exec_schedule()
             };
             let error = invalid
@@ -325,6 +355,7 @@ mod tests {
                 args: vec!["a|b".to_string(), "$PATH".to_string()],
                 working_dir: None,
             }),
+            steps: Vec::new(),
             ..exec_schedule()
         };
         valid
@@ -342,6 +373,58 @@ mod tests {
             assert_eq!(exec.args, vec!["example.com".to_string()]);
             assert!(loaded.command.is_none());
         });
+    }
+
+    #[test]
+    fn declaring_both_a_single_command_and_steps_is_rejected() {
+        let invalid = Schedule {
+            command: Some(vec!["triage".to_string()]),
+            exec: None,
+            steps: vec![super::super::types::ScheduleStep {
+                command: Some(vec!["fleet".to_string(), "check".to_string()]),
+                exec: None,
+            }],
+            ..schedule()
+        };
+        let error = invalid.validate().expect_err("ambiguous declaration");
+        assert!(error.to_string().contains("not both"), "got: {error}");
+    }
+
+    /// A bad step must name its position, or an operator has to guess which
+    /// entry in the list is wrong.
+    #[test]
+    fn an_invalid_step_is_reported_with_its_position() {
+        let invalid = Schedule {
+            command: None,
+            exec: None,
+            steps: vec![
+                super::super::types::ScheduleStep {
+                    command: Some(vec!["triage".to_string()]),
+                    exec: None,
+                },
+                super::super::types::ScheduleStep {
+                    command: None,
+                    exec: None,
+                },
+            ],
+            ..schedule()
+        };
+        let error = invalid.validate().expect_err("empty step");
+        assert!(error.to_string().contains("Step 2"), "got: {error}");
+    }
+
+    #[test]
+    fn a_step_may_not_run_the_scheduler() {
+        let invalid = Schedule {
+            command: None,
+            exec: None,
+            steps: vec![super::super::types::ScheduleStep {
+                command: Some(vec!["schedule".to_string(), "tick".to_string()]),
+                exec: None,
+            }],
+            ..schedule()
+        };
+        assert!(invalid.validate().is_err());
     }
 
     #[test]

--- a/crates/homeboy-core/src/schedule/execution.rs
+++ b/crates/homeboy-core/src/schedule/execution.rs
@@ -43,6 +43,22 @@ pub struct ScheduleRunOutcome {
     pub notify_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+    /// Per-step results, so an operator can see which step failed without
+    /// re-running the whole sequence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub steps: Vec<ScheduleStepOutcome>,
+}
+
+/// What one step of a schedule produced.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduleStepOutcome {
+    /// Position in the declared sequence, starting at 1.
+    pub index: usize,
+    pub command: String,
+    pub status: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 /// Executes a homeboy command and reports its structured result.
@@ -185,6 +201,112 @@ pub fn bound_output(value: &str) -> String {
     format!("[output truncated]\n{}", &value[start..])
 }
 
+/// Run a schedule's steps in order, stopping at the first failure.
+///
+/// Fail-fast is the right default for a sequence: running a later step after
+/// an earlier one failed is usually worse than not running it, and the failure
+/// is what the operator needs to see.
+fn run_steps(
+    schedule: &Schedule,
+    runner: &dyn ScheduleCommandRunner,
+) -> (
+    String,
+    i32,
+    String,
+    Option<String>,
+    Vec<ScheduleStepOutcome>,
+) {
+    let steps = schedule.resolved_steps();
+    let mut outcomes: Vec<ScheduleStepOutcome> = Vec::with_capacity(steps.len());
+    let mut digests: Vec<String> = Vec::with_capacity(steps.len());
+
+    for (index, step) in steps.iter().enumerate() {
+        let result = match step.resolve() {
+            Some(command) => runner.run(command),
+            None => Err(Error::validation_invalid_argument(
+                "command",
+                "Schedule step declares neither a homeboy command nor a program to run",
+                Some(schedule.id.clone()),
+                None,
+            )),
+        };
+        let (status, exit_code, digest, summary) = match &result {
+            Ok(outcome) => summarize(outcome),
+            Err(error) => (
+                "failed".to_string(),
+                -1,
+                String::new(),
+                Some(error.to_string()),
+            ),
+        };
+        let failed = status != "succeeded" || exit_code != 0;
+        digests.push(digest);
+        outcomes.push(ScheduleStepOutcome {
+            index: index + 1,
+            command: step.display(),
+            status: status.clone(),
+            exit_code,
+            summary: summary.clone(),
+        });
+
+        if failed {
+            // The run's status is the first failure, and the remaining steps
+            // are not attempted.
+            return (
+                status,
+                exit_code,
+                sequence_digest(&digests),
+                Some(failure_summary(index + 1, steps.len(), &outcomes)),
+                outcomes,
+            );
+        }
+    }
+
+    let summary = if outcomes.len() > 1 {
+        Some(format!("{} steps succeeded", outcomes.len()))
+    } else {
+        outcomes.first().and_then(|step| step.summary.clone())
+    };
+    (
+        "succeeded".to_string(),
+        0,
+        sequence_digest(&digests),
+        summary,
+        outcomes,
+    )
+}
+
+fn failure_summary(step: usize, total: usize, outcomes: &[ScheduleStepOutcome]) -> String {
+    let detail = outcomes
+        .last()
+        .and_then(|last| last.summary.clone())
+        .unwrap_or_default();
+    let head = if total > 1 {
+        format!("step {step} of {total} failed")
+    } else {
+        "failed".to_string()
+    };
+    if detail.is_empty() {
+        head
+    } else {
+        format!("{head}: {detail}")
+    }
+}
+
+/// Fingerprint a whole sequence, so a chain that produces the same outcomes
+/// twice stays silent under notify-on-change.
+///
+/// A run that stops early has fewer digests than one that completes, so a
+/// chain failing at a different step is itself a change.
+pub fn sequence_digest(step_digests: &[String]) -> String {
+    if step_digests.len() == 1 {
+        return step_digests[0].clone();
+    }
+    let joined = step_digests.join("\u{1e}");
+    let digest = <sha2::Sha256 as sha2::Digest>::digest(joined.as_bytes());
+    format!("{digest:x}")
+}
+
 /// Reduce a command result to the fields the scheduler reasons about.
 fn summarize(result: &ScheduleCommandResult) -> (String, i32, String, Option<String>) {
     match result {
@@ -315,26 +437,8 @@ pub fn run_schedule(schedule: &Schedule, runner: &dyn ScheduleCommandRunner) -> 
         },
     );
 
-    let result = match schedule.scheduled_command() {
-        Some(command) => runner.run(command),
-        None => Err(Error::validation_invalid_argument(
-            "command",
-            "Schedule declares neither a homeboy command nor a program to run",
-            Some(schedule.id.clone()),
-            None,
-        )),
-    };
+    let (status, exit_code, digest, summary, step_outcomes) = run_steps(schedule, runner);
     let finished = chrono::Utc::now();
-
-    let (status, exit_code, digest, summary) = match &result {
-        Ok(outcome) => summarize(outcome),
-        Err(error) => (
-            "failed".to_string(),
-            -1,
-            String::new(),
-            Some(error.to_string()),
-        ),
-    };
 
     let succeeded = status == "succeeded" && exit_code == 0;
     let changed = previous
@@ -354,6 +458,7 @@ pub fn run_schedule(schedule: &Schedule, runner: &dyn ScheduleCommandRunner) -> 
         notified: false,
         notify_error: None,
         summary,
+        steps: step_outcomes,
     };
 
     if should_notify(schedule.notify_on, succeeded, changed) {
@@ -436,6 +541,7 @@ mod tests {
             id: "digest-fixture".to_string(),
             command: Some(vec!["triage".to_string()]),
             exec: None,
+            steps: Vec::new(),
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: policy,
             on_overlap: OverlapPolicy::default(),
@@ -518,6 +624,7 @@ mod tests {
                 args: args.iter().map(|arg| arg.to_string()).collect(),
                 working_dir: None,
             }),
+            steps: Vec::new(),
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::Change,
             on_overlap: OverlapPolicy::default(),
@@ -629,6 +736,167 @@ mod tests {
         let noisy = "é".repeat(MAX_CAPTURED_OUTPUT_BYTES);
         let bounded = bound_output(&noisy);
         assert!(bounded.contains('é'), "multi-byte output must stay valid");
+    }
+
+    /// A recording runner that can be told to fail at a given call index.
+    struct SequenceRunner {
+        calls: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        fail_at: Option<usize>,
+    }
+
+    impl ScheduleCommandRunner for SequenceRunner {
+        fn run(&self, command: ScheduledCommand<'_>) -> Result<ScheduleCommandResult> {
+            let rendered = match command {
+                ScheduledCommand::Homeboy(argv) => argv.join(" "),
+                ScheduledCommand::Exec(exec) => exec.program.clone(),
+            };
+            let index = {
+                let mut calls = self.calls.lock().expect("calls");
+                calls.push(rendered);
+                calls.len()
+            };
+            let failing = self.fail_at == Some(index);
+            Ok(ScheduleCommandResult::Envelope(serde_json::json!({
+                "status": if failing { "failed" } else { "succeeded" },
+                "exit_code": if failing { 3 } else { 0 },
+            })))
+        }
+    }
+
+    fn step(argv: &[&str]) -> super::super::types::ScheduleStep {
+        super::super::types::ScheduleStep {
+            command: Some(argv.iter().map(|a| a.to_string()).collect()),
+            exec: None,
+        }
+    }
+
+    fn chained(id: &str) -> Schedule {
+        Schedule {
+            id: id.to_string(),
+            command: None,
+            exec: None,
+            steps: vec![step(&["harvest", "--check"]), step(&["fleet", "check"])],
+            every: Cadence::from_seconds(3_600).expect("cadence"),
+            notify_on: NotifyPolicy::Change,
+            on_overlap: OverlapPolicy::default(),
+            notification_transport: None,
+            notification_route: None,
+            jitter_seconds: None,
+            enabled: true,
+            description: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn steps_run_in_declaration_order() {
+        crate::test_support::with_isolated_home(|_| {
+            let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let runner = SequenceRunner {
+                calls: std::sync::Arc::clone(&calls),
+                fail_at: None,
+            };
+
+            let outcome = run_schedule(&chained("ordered"), &runner);
+            assert_eq!(outcome.status, "succeeded");
+            assert_eq!(
+                *calls.lock().expect("calls"),
+                vec!["harvest --check".to_string(), "fleet check".to_string()]
+            );
+            assert_eq!(outcome.steps.len(), 2);
+            assert_eq!(outcome.steps[0].index, 1);
+            assert_eq!(outcome.steps[1].index, 2);
+        });
+    }
+
+    /// Running a later step after an earlier one failed is usually worse than
+    /// not running it — a deploy after a failed check, for instance.
+    #[test]
+    fn a_failing_step_stops_the_sequence() {
+        crate::test_support::with_isolated_home(|_| {
+            let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let runner = SequenceRunner {
+                calls: std::sync::Arc::clone(&calls),
+                fail_at: Some(1),
+            };
+
+            let outcome = run_schedule(&chained("fail-fast"), &runner);
+            assert_eq!(outcome.status, "failed");
+            assert_eq!(outcome.exit_code, 3);
+            assert_eq!(
+                calls.lock().expect("calls").len(),
+                1,
+                "the second step must not run"
+            );
+            assert_eq!(outcome.steps.len(), 1, "only attempted steps are reported");
+        });
+    }
+
+    /// The operator needs to know *which* step failed without re-running.
+    #[test]
+    fn a_failure_summary_names_the_failing_step() {
+        crate::test_support::with_isolated_home(|_| {
+            let runner = SequenceRunner {
+                calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                fail_at: Some(2),
+            };
+            let outcome = run_schedule(&chained("named-failure"), &runner);
+            let summary = outcome.summary.expect("failure summary");
+            assert!(
+                summary.contains("step 2 of 2"),
+                "summary should name the failing step, got: {summary}"
+            );
+        });
+    }
+
+    #[test]
+    fn an_unchanged_chain_is_not_reported_as_a_change() {
+        crate::test_support::with_isolated_home(|_| {
+            let runner = SequenceRunner {
+                calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                fail_at: None,
+            };
+            let schedule = chained("stable-chain");
+
+            assert!(run_schedule(&schedule, &runner).changed, "first run");
+            assert!(
+                !run_schedule(&schedule, &runner).changed,
+                "an identical chain is not a change"
+            );
+        });
+    }
+
+    /// A chain that starts failing at a different point is a change, even
+    /// though the earlier steps produced identical results.
+    #[test]
+    fn a_chain_failing_at_a_different_step_is_a_change() {
+        crate::test_support::with_isolated_home(|_| {
+            let schedule = chained("moving-failure");
+            let healthy = SequenceRunner {
+                calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                fail_at: None,
+            };
+            run_schedule(&schedule, &healthy);
+
+            let broken = SequenceRunner {
+                calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                fail_at: Some(2),
+            };
+            assert!(
+                run_schedule(&schedule, &broken).changed,
+                "a newly failing step must report"
+            );
+        });
+    }
+
+    #[test]
+    fn a_single_step_digest_matches_the_unchained_form() {
+        assert_eq!(sequence_digest(&["abc".to_string()]), "abc");
+        assert_ne!(
+            sequence_digest(&["abc".to_string(), "def".to_string()]),
+            sequence_digest(&["abc".to_string()]),
+            "a partial chain must differ from a complete one"
+        );
     }
 
     struct StubRunner(serde_json::Value);

--- a/crates/homeboy-core/src/schedule/mod.rs
+++ b/crates/homeboy-core/src/schedule/mod.rs
@@ -24,12 +24,14 @@ pub mod ticker;
 pub mod types;
 
 pub use execution::{
-    raw_digest, result_digest, run_schedule, ScheduleCommandResult, ScheduleCommandRunner,
-    ScheduleRunOutcome, SubprocessRunner,
+    raw_digest, result_digest, run_schedule, sequence_digest, ScheduleCommandResult,
+    ScheduleCommandRunner, ScheduleRunOutcome, ScheduleStepOutcome, SubprocessRunner,
 };
 pub use state::{load_state, remove_state, save_state, ScheduleState};
 pub use ticker::{reclaim_stale_runs, ScheduleTicker};
-pub use types::{Cadence, ExecCommand, NotifyPolicy, OverlapPolicy, Schedule, ScheduledCommand};
+pub use types::{
+    Cadence, ExecCommand, NotifyPolicy, OverlapPolicy, Schedule, ScheduleStep, ScheduledCommand,
+};
 
 crate::entity_crud!(Schedule; list_ids);
 
@@ -50,6 +52,7 @@ mod tests {
             id: id.to_string(),
             command: Some(vec!["triage".to_string()]),
             exec: None,
+            steps: Vec::new(),
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),

--- a/crates/homeboy-core/src/schedule/state.rs
+++ b/crates/homeboy-core/src/schedule/state.rs
@@ -137,6 +137,7 @@ mod tests {
             id: "nightly".to_string(),
             command: Some(vec!["triage".to_string()]),
             exec: None,
+            steps: Vec::new(),
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),

--- a/crates/homeboy-core/src/schedule/ticker.rs
+++ b/crates/homeboy-core/src/schedule/ticker.rs
@@ -148,6 +148,7 @@ mod tests {
             id: id.to_string(),
             command: Some(vec!["triage".to_string()]),
             exec: None,
+            steps: Vec::new(),
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),

--- a/crates/homeboy-core/src/schedule/types.rs
+++ b/crates/homeboy-core/src/schedule/types.rs
@@ -197,6 +197,43 @@ pub struct ExecCommand {
     pub working_dir: Option<String>,
 }
 
+/// One step of a schedule.
+///
+/// A step runs either a homeboy command or a program, the same choice a
+/// single-step schedule makes.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduleStep {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<Vec<String>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec: Option<ExecCommand>,
+}
+
+impl ScheduleStep {
+    pub fn resolve(&self) -> Option<ScheduledCommand<'_>> {
+        match (&self.command, &self.exec) {
+            (Some(argv), None) => Some(ScheduledCommand::Homeboy(argv.as_slice())),
+            (None, Some(exec)) => Some(ScheduledCommand::Exec(exec)),
+            _ => None,
+        }
+    }
+
+    pub fn display(&self) -> String {
+        match self.resolve() {
+            Some(ScheduledCommand::Homeboy(argv)) => format!("homeboy {}", argv.join(" ")),
+            Some(ScheduledCommand::Exec(exec)) => {
+                if exec.args.is_empty() {
+                    exec.program.clone()
+                } else {
+                    format!("{} {}", exec.program, exec.args.join(" "))
+                }
+            }
+            None => "<no command>".to_string(),
+        }
+    }
+}
+
 /// What a schedule runs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScheduledCommand<'a> {
@@ -227,6 +264,13 @@ pub struct Schedule {
     /// Mutually exclusive with `command`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exec: Option<ExecCommand>,
+
+    /// An ordered sequence to run instead of a single command.
+    ///
+    /// Steps run in order and stop at the first failure. Mutually exclusive
+    /// with `command` and `exec`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub steps: Vec<ScheduleStep>,
 
     pub every: Cadence,
 
@@ -266,30 +310,28 @@ fn default_true() -> bool {
 }
 
 impl Schedule {
-    /// What this schedule runs.
+    /// The ordered steps this schedule runs.
     ///
-    /// Validation guarantees exactly one of `command` / `exec` is set, so a
-    /// stored schedule always resolves.
-    pub fn scheduled_command(&self) -> Option<ScheduledCommand<'_>> {
-        match (&self.command, &self.exec) {
-            (Some(argv), None) => Some(ScheduledCommand::Homeboy(argv.as_slice())),
-            (None, Some(exec)) => Some(ScheduledCommand::Exec(exec)),
-            _ => None,
+    /// A single-command schedule is one step, so callers never need to
+    /// distinguish the two forms. Validation guarantees this is non-empty and
+    /// that every step resolves.
+    pub fn resolved_steps(&self) -> Vec<ScheduleStep> {
+        if !self.steps.is_empty() {
+            return self.steps.clone();
         }
+        vec![ScheduleStep {
+            command: self.command.clone(),
+            exec: self.exec.clone(),
+        }]
     }
 
     /// Human-readable rendering of what runs, for logs and notifications.
     pub fn command_display(&self) -> String {
-        match self.scheduled_command() {
-            Some(ScheduledCommand::Homeboy(argv)) => format!("homeboy {}", argv.join(" ")),
-            Some(ScheduledCommand::Exec(exec)) => {
-                if exec.args.is_empty() {
-                    exec.program.clone()
-                } else {
-                    format!("{} {}", exec.program, exec.args.join(" "))
-                }
-            }
-            None => "<no command>".to_string(),
+        let steps = self.resolved_steps();
+        match steps.len() {
+            0 => "<no command>".to_string(),
+            1 => steps[0].display(),
+            count => format!("{} steps: {}", count, steps[0].display()),
         }
     }
 
@@ -358,6 +400,7 @@ mod tests {
             id: id.to_string(),
             command: Some(vec!["triage".to_string()]),
             exec: None,
+            steps: Vec::new(),
             every: Cadence::from_seconds(3_600).expect("cadence"),
             notify_on: NotifyPolicy::default(),
             on_overlap: OverlapPolicy::default(),
@@ -405,8 +448,10 @@ mod tests {
             ])
         );
         assert!(schedule.exec.is_none());
+        let steps = schedule.resolved_steps();
+        assert_eq!(steps.len(), 1, "a single command is one step");
         assert!(matches!(
-            schedule.scheduled_command(),
+            steps[0].resolve(),
             Some(ScheduledCommand::Homeboy(_))
         ));
         assert_eq!(
@@ -425,11 +470,40 @@ mod tests {
 
         let schedule: Schedule = serde_json::from_str(stored).expect("exec declaration loads");
         assert!(schedule.command.is_none());
+        let steps = schedule.resolved_steps();
+        assert_eq!(steps.len(), 1);
         assert!(matches!(
-            schedule.scheduled_command(),
+            steps[0].resolve(),
             Some(ScheduledCommand::Exec(_))
         ));
         assert_eq!(schedule.command_display(), "/usr/bin/true --now");
+    }
+
+    /// A step list stored on disk must resolve in order.
+    #[test]
+    fn a_step_list_deserializes_and_resolves_in_order() {
+        let stored = r#"{
+            "id": "managed",
+            "steps": [
+                { "command": ["harvest", "production", "--check"] },
+                { "exec": { "program": "npm", "args": ["test"], "working_dir": "/srv/p" } }
+            ],
+            "every": 86400
+        }"#;
+
+        let schedule: Schedule = serde_json::from_str(stored).expect("step list loads");
+        let steps = schedule.resolved_steps();
+        assert_eq!(steps.len(), 2);
+        assert!(matches!(
+            steps[0].resolve(),
+            Some(ScheduledCommand::Homeboy(_))
+        ));
+        assert!(matches!(
+            steps[1].resolve(),
+            Some(ScheduledCommand::Exec(_))
+        ));
+        assert_eq!(steps[1].display(), "npm test");
+        assert!(schedule.command_display().starts_with("2 steps:"));
     }
 
     #[test]

--- a/docs/commands/schedule.md
+++ b/docs/commands/schedule.md
@@ -1,7 +1,7 @@
 # `homeboy schedule`
 
 ```text
-homeboy schedule add <id> (--command <argv> | --exec <program> [--exec-arg <arg>]... [--working-dir <dir>])
+homeboy schedule add <id> (--command <argv>... | --exec <program> [--exec-arg <arg>]... [--working-dir <dir>])
                          --every <interval> [--notify-on <policy>] [--on-overlap <policy>]
                          [--notification-transport <id> --notification-route <route>]
                          [--jitter-seconds <n>] [--description <text>] [--force]
@@ -40,6 +40,25 @@ External programs are executed **directly, never through a shell**. Nothing is w
 Arguments are passed through untouched, so an argument may legitimately contain those characters.
 
 `--working-dir` matters for the common case: test runners and build tools usually only work from their project root.
+
+### Multi-step runs
+
+Repeat `--command` to declare an ordered sequence. Steps run in order and **stop at the first failure** — running a later step after an earlier one failed is usually worse than not running it.
+
+```sh
+homeboy schedule add managed \
+  --command 'harvest production --check' \
+  --command 'fleet check production' \
+  --every 24h
+```
+
+A chain produces **one notification per run**, not one per step. Chaining exists to get a single report; per-step notifications would recreate the noise `notify-on-change` avoids. The failure summary names which step failed, and every attempted step appears individually in the structured output, so an operator can see where it stopped without re-running.
+
+Change detection covers the whole sequence: a chain producing the same outcomes twice stays silent, and a chain that starts failing at a different step is a change even when the earlier steps are unchanged.
+
+A single-step schedule is stored in the flat `command` / `exec` form, so simple schedules stay simple to read and diff.
+
+Mixed sequences are declared by editing the schedule file directly. On the command line, repeated `--command` steps are ordered before repeated `--exec` steps, because clap does not preserve relative order across different flags — an interleaved command line would silently reorder itself.
 
 ## Cadence
 


### PR DESCRIPTION
> **Stacked on #10172.** Base is `feat/10133-schedule-exec`, because a step may be either a homeboy command or a program and this builds directly on those types. Retarget to `main` once #10172 merges; the diff shown here is only this change.

## Summary

A schedule held exactly one command. Real periodic work is a short sequence — capture drift, then verify, then report — and expressing that needed either one schedule per step (losing ordering, producing a notification each) or a shell wrapper (losing the structured result that change detection reads, and putting homeboy back behind cron).

```sh
homeboy schedule add managed \
  --command 'harvest production --check' \
  --command 'fleet check production' \
  --every 24h
```

## Design decisions worth reviewing

**Fail-fast.** Steps stop at the first failure. Running a later step after an earlier one failed is usually worse than not running it — a deploy after a failed check being the obvious case — and the failure is what the operator needs to see.

**One notification per run, not per step.** Chaining exists to produce a single report. Per-step notifications would recreate exactly the noise `notify-on-change` was built to avoid.

**The failure summary names the step**, and every *attempted* step appears individually in the structured output. An operator can see where a chain stopped without re-running it. Steps that never ran are not reported, because reporting them as anything would be a lie.

**Change detection covers the whole sequence.** A partial run produces fewer step digests than a complete one, so a chain that starts failing at a *different* step is a change even when every earlier step produced an identical result. A single-step sequence digests to exactly its one step, so nothing changes for existing schedules.

**Single steps stay in the flat form.** A one-step schedule is stored as `command`/`exec`, not a one-element list, so simple schedules stay simple to read and to diff. `resolved_steps()` normalizes both, so no caller has to care which form is on disk.

**Repeated `--command` steps are ordered before repeated `--exec` steps.** Clap does not preserve relative order across different flags, so an interleaved command line would silently reorder itself — worse than not offering it. Mixed sequences are declared by editing the schedule file, and sharing `--exec-arg`/`--working-dir` across multiple `--exec` steps is refused rather than silently applied to all of them.

## Compatibility

`steps` defaults to empty and is skipped when serializing, so existing declarations are byte-identical and load unchanged. There is a test that deserializes a step list verbatim and one that deserializes a pre-steps declaration.

## Tests

10 new assertions:

- steps run in declaration order, with correct 1-based indices
- a failing step stops the sequence and the later step does **not** run
- only attempted steps are reported
- the failure summary names which step failed
- an unchanged chain is not reported as a change
- a chain failing at a *different* step **is** a change
- a single-step digest equals the unchained form, and a partial chain differs from a complete one
- declaring both a single command and steps is rejected
- an invalid step is reported with its position, not just "invalid"
- a step may not run the scheduler itself
- a step list deserializes and resolves in order, including a mixed command/exec sequence

## Verification

- `cargo fmt`
- `cargo check -p homeboy-core -p homeboy-cli --lib --tests` — clean
- `cargo clippy -p homeboy-core -p homeboy-cli --lib --tests` — no findings in the changed files

Full `cargo build`/`cargo test` deliberately not run locally (this host OOMs on the Rust workspace); leaving the suite to CI.

## What this completes

With #10129 (primitive), #10150 (daemon trigger), #10172 (external programs), and this, a managed maintenance loop is expressible as one declaration:

```sh
homeboy schedule add h44-managed \
  --command 'harvest h44-lacrosse --check' \
  --every 24h --notify-on change \
  --notification-transport discord.run-completion \
  --notification-route 'discord:v1:channel:...'
```

Remaining for a fully unattended loop is policy rather than machinery: harvest commits but does not push, auto-commit needs a per-project opt-in, and a bot identity is needed for honest attribution.

Closes #10132

## AI assistance

Investigated and implemented by chubes-bot (OpenCode). Chris Huber remains responsible for review and every line.