### PR TITLE
Recover committed adoption candidate baselines

### DIFF
--- a/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
@@ -124,6 +124,21 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
     Ok(current_diff)
 }
 
+/// Validate a committed adoption candidate when an interrupted pre-provider
+/// attempt has no dirty-worktree diff to replay.
+pub(crate) fn validate_immutable_candidate_tree(root: &Path, candidate_sha: &str) -> Result<()> {
+    if !valid_git_object_id(candidate_sha) {
+        return Err(invalid("adopted candidate has no valid immutable commit"));
+    }
+    let expected_tree = git(root, &["rev-parse", &format!("{candidate_sha}^{{tree}}")])?;
+    if workspace_tree(root)? != expected_tree {
+        return Err(invalid(
+            "candidate worktree differs from the adopted immutable commit",
+        ));
+    }
+    Ok(())
+}
+
 /// A follow-up candidate is allowed to reuse a dirty destination only when its
 /// complete tree is the controller-verified source tree used to cook that
 /// candidate. This works for materialized snapshots whose HEAD is synthetic.
@@ -205,6 +220,21 @@ fn workspace_tree(root: &Path) -> Result<String> {
     git_with_index(root, &["write-tree"], &index_path)
 }
 
+fn git(root: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .map_err(|error| invalid(&error.to_string()))?;
+    if !output.status.success() {
+        return Err(invalid(&format!(
+            "candidate baseline Git operation failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 fn git_with_index(root: &Path, args: &[&str], index_path: &str) -> Result<String> {
     let output = Command::new("git")
         .args(args)
@@ -233,6 +263,26 @@ fn invalid(message: &str) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn immutable_candidate_tree_accepts_exact_commit_and_rejects_dirty_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        git(temp.path(), &["init", "-b", "main"]);
+        git(temp.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            temp.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        std::fs::write(temp.path().join("tracked.txt"), "candidate\n").expect("candidate file");
+        git(temp.path(), &["add", "tracked.txt"]);
+        git(temp.path(), &["commit", "-m", "candidate"]);
+        let candidate_sha = git(temp.path(), &["rev-parse", "HEAD"]).trim().to_string();
+
+        validate_immutable_candidate_tree(temp.path(), &candidate_sha)
+            .expect("exact committed candidate");
+        std::fs::write(temp.path().join("tracked.txt"), "diverged\n").expect("dirty candidate");
+        assert!(validate_immutable_candidate_tree(temp.path(), &candidate_sha).is_err());
+    }
 
     #[test]
     fn layered_remediation_uses_complete_current_diff() {

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -764,6 +764,19 @@ fn reusable_applied_adoption_promotion(
             None,
         )));
     };
+    if baseline
+        .get("current_diff")
+        .and_then(Value::as_str)
+        .is_some_and(|diff| diff.trim().is_empty())
+    {
+        return Some(
+            crate::agent_task_candidate_baseline::validate_immutable_candidate_tree(
+                std::path::Path::new(worktree_path),
+                candidate_sha,
+            )
+            .map(|_| promotion),
+        );
+    }
     // The checkpoint records the complete candidate diff; bind it to the exact
     // promoted artifact before handing it to the shared dirty-destination check.
     baseline["patch_artifact"] = match serde_json::to_value(&promotion.patch_artifact) {


### PR DESCRIPTION
## Summary

- recover interrupted adoption baselines from the recorded immutable candidate commit
- accept only an exact complete workspace-tree match
- retain the existing patch-based validation for dirty gate-feedback candidates

Fixes #10181.

## Verification

- `cargo test -p homeboy-agents agent_task_candidate_baseline::tests`
- `cargo check -p homeboy-cli`
- `git diff --check`

## AI assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** Root-cause analysis, implementation, tests, and downstream recovery verification.

Chris Huber remains responsible for every line.
