### PR TITLE
fix(cli): register harvest in the command spec registry

### DIFF
--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -664,6 +664,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     crate::ops_command_spec!(logs),
     crate::ops_command_spec!(triage),
     crate::ops_command_spec!(deploy),
+    crate::ops_command_spec!(harvest),
     CommandSpec {
         subcommand_safety: COMPONENT_SUBCOMMAND_SAFETY,
         ..command_spec("component", CommandJsonFamily::Workspace)


### PR DESCRIPTION
## Summary

`homeboy harvest` panics on every invocation in the shipped release:

```
$ homeboy harvest <project> --check
thread 'main' panicked at crates/homeboy-cli/src/cli_surface/mod.rs:127:14:
built-in top-level command should be registered
```

Reproduced on `v0.318.0` (`homeboy 0.318.0+b7e26c3937ba`) against a real project.

`harvest` was added to the clap enum (`cli_surface/mod.rs`) and to the ops command descriptors (`command_contract/descriptors.rs`), but never to `COMMAND_SPECS`. `registered_command()` resolves a name against that array and `from_registered_arg_matches` `.expect()`s a hit, so dispatch panics before any harvest code runs.

`grep harvest crates/homeboy-cli/src/command_contract/spec.rs` returns nothing on `main`.

The fix is the missing registration, placed next to `deploy` — harvest's pull-side counterpart.

## Why this was not obvious

`homeboy harvest --help` works, because clap short-circuits `--help` before dispatch and never reaches the registry lookup. Only a real invocation hits it. Anything that exercised harvest by rendering its help — docs checks, surface tests, a human sanity check — would have looked fine.

## Verification

Before, on `main`:

```
COMMAND_SPECS entries: 39
clap variants:         39
missing from COMMAND_SPECS: ['harvest']
```

After:

```
COMMAND_SPECS entries: 40
clap variants:         39
missing from COMMAND_SPECS: none
```

- `cargo fmt`
- `cargo check -p homeboy-cli --lib --tests` — clean

Full `cargo build`/`cargo test` deliberately not run locally (this host OOMs on the Rust workspace); leaving the suite to CI.

## Open question worth a look

`command_registry_manifest_and_docs_metadata_align` in `cli_surface/mod.rs` already asserts exactly this invariant:

```rust
assert_eq!(registry_names, parser_names);
```

`harvest` is a visible, non-hidden subcommand, so that set comparison should have failed for every commit since harvest landed. It did not block the release, which suggests the test either is not reaching CI or is not in the differential test gate's scope for the PRs that touched these files — the same class of scoping gap as #10179.

I have not chased that down here, because the panic is blocking real use and the fix is independent. It is worth its own investigation: an invariant test that cannot fail the build is not protecting the invariant.

A second, smaller observation: an unregistered command produces a bare panic and a backtrace rather than an actionable error. Turning that `.expect()` into a proper `clap::Error` would make the next occurrence diagnosable by a user rather than only by someone reading the source. Left out of this PR to keep the fix minimal.

## AI assistance

Found and fixed by chubes-bot (OpenCode) while upgrading to 0.318.0 and running harvest against a live project. Chris Huber remains responsible for review and every line.