### PR TITLE
fix: complete bounded output follow-up

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -109,13 +109,21 @@ pub struct CookContinueArgs {
 
 #[derive(Args, Debug)]
 pub struct ListArgs {
-    #[arg(long = "limit", value_name = "N")]
+    #[arg(long = "limit", value_name = "N", conflicts_with = "full")]
     pub limit: Option<usize>,
+    /// Return every matching record. This is intentionally explicit because
+    /// discovery defaults to a finite agent-facing page.
+    #[arg(long)]
+    pub full: bool,
 }
 #[derive(Args, Debug)]
 pub struct ActiveArgs {
-    #[arg(long = "limit", value_name = "N")]
+    #[arg(long = "limit", value_name = "N", conflicts_with = "full")]
     pub limit: Option<usize>,
+    /// Return every matching record. This is intentionally explicit because
+    /// discovery defaults to a finite agent-facing page.
+    #[arg(long, conflicts_with = "reconcile")]
+    pub full: bool,
     #[arg(long = "reconcile")]
     pub reconcile: bool,
     #[arg(long = "dry-run", requires = "reconcile", conflicts_with = "apply")]
@@ -144,14 +152,14 @@ pub struct LatestArgs {
 impl From<ListArgs> for AgentTaskDiscoveryOptions {
     fn from(args: ListArgs) -> Self {
         Self {
-            limit: Some(args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+            limit: (!args.full).then(|| args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
         }
     }
 }
 impl From<ActiveArgs> for AgentTaskDiscoveryOptions {
     fn from(args: ActiveArgs) -> Self {
         Self {
-            limit: Some(args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+            limit: (!args.full).then(|| args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -55,10 +55,16 @@ pub struct EvidenceArgs {
     pub task: Option<String>,
     #[arg(long = "failure-only")]
     pub failure_only: bool,
+    /// Return every matching evidence record rather than the bounded preview.
+    #[arg(long)]
+    pub full: bool,
 }
 #[derive(Args, Debug)]
 pub struct DiagnoseArgs {
     pub run_id: String,
+    /// Hydrate every available evidence summary rather than the bounded preview.
+    #[arg(long)]
+    pub full: bool,
 }
 #[derive(Args, Debug)]
 pub struct RuntimeRecoverArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/args/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/lifecycle.rs
@@ -61,12 +61,18 @@ pub struct EvidenceArgs {
     /// Only include evidence attached to failed/provider-error/timed-out task outcomes.
     #[arg(long = "failure-only")]
     pub failure_only: bool,
+    /// Return every matching evidence record rather than the bounded preview.
+    #[arg(long)]
+    pub full: bool,
 }
 
 #[derive(Args, Debug)]
 pub struct DiagnoseArgs {
     /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
     pub run_id: String,
+    /// Hydrate every available evidence summary rather than the bounded preview.
+    #[arg(long)]
+    pub full: bool,
 }
 
 #[derive(Args, Debug)]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -94,8 +94,8 @@ pub(super) fn list_runs(
     attach_collection_budget(
         &mut value,
         "runs",
-        "homeboy agent-task list --limit 20",
-        "homeboy agent-task list --output <path>",
+        "homeboy agent-task list --full",
+        "homeboy agent-task list --full --output <path>",
     );
     attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
@@ -129,8 +129,8 @@ pub(super) fn list_active(
     attach_collection_budget(
         &mut value,
         "runs",
-        "homeboy agent-task active --limit 20",
-        "homeboy agent-task active --output <path>",
+        "homeboy agent-task active --full",
+        "homeboy agent-task active --full --output <path>",
     );
     attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
@@ -464,17 +464,20 @@ pub(super) fn logs(args: LogsArgs) -> CmdResult<Value> {
 pub(super) fn artifacts(args: StatusArgs) -> CmdResult<Value> {
     let artifacts = agent_task_service::artifacts(&args.run_id)?;
     let mut value = serde_json::to_value(artifacts).unwrap_or(Value::Null);
-    // Artifact indexes are bounded before presentation; durable artifact files
-    // remain losslessly available through the global output artifact.
-    attach_collection_budget(
-        &mut value,
-        "artifacts",
-        &format!("homeboy agent-task artifacts {}", quote_arg(&args.run_id)),
-        &format!(
-            "homeboy agent-task artifacts {} --output <path>",
-            quote_arg(&args.run_id)
-        ),
-    );
+    if !args.full {
+        attach_collection_budget(
+            &mut value,
+            "artifacts",
+            &format!(
+                "homeboy agent-task artifacts {} --full",
+                quote_arg(&args.run_id)
+            ),
+            &format!(
+                "homeboy agent-task artifacts {} --full --output <path>",
+                quote_arg(&args.run_id)
+            ),
+        );
+    }
     Ok((value, 0))
 }
 
@@ -514,7 +517,7 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
         total += 1;
         // Count filtered refs without hydrating their payload once the shared
         // collection budget is full.
-        if hydrated.len() >= OutputBudget::COLLECTION.max_items {
+        if !args.full && hydrated.len() >= OutputBudget::COLLECTION.max_items {
             continue;
         }
         hydrated.push(agent_task_service::hydrate_evidence_ref(
@@ -539,15 +542,20 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
         evidence: hydrated,
     })
     .unwrap_or(Value::Null);
-    attach_collection_budget(
-        &mut value,
-        "evidence",
-        &format!("homeboy agent-task evidence {}", quote_arg(&args.run_id)),
-        &format!(
-            "homeboy agent-task evidence {} --output <path>",
-            quote_arg(&args.run_id)
-        ),
-    );
+    if !args.full {
+        attach_collection_budget(
+            &mut value,
+            "evidence",
+            &format!(
+                "homeboy agent-task evidence {} --full",
+                quote_arg(&args.run_id)
+            ),
+            &format!(
+                "homeboy agent-task evidence {} --full --output <path>",
+                quote_arg(&args.run_id)
+            ),
+        );
+    }
     Ok((value, 0))
 }
 
@@ -562,7 +570,7 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         for outcome in &aggregate.outcomes {
             for evidence in &outcome.evidence_refs {
                 total_hydrated_evidence += 1;
-                if hydrated_evidence.len() >= OutputBudget::COLLECTION.max_items {
+                if !args.full && hydrated_evidence.len() >= OutputBudget::COLLECTION.max_items {
                     continue;
                 }
                 if let Some(summary) =
@@ -611,15 +619,20 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         "hydrated_evidence_total": total_hydrated_evidence,
         "next_commands": next_commands,
     });
-    attach_collection_budget(
-        &mut value,
-        "hydrated_evidence",
-        &format!("homeboy agent-task diagnose {}", quote_arg(&args.run_id)),
-        &format!(
-            "homeboy agent-task diagnose {} --output <path>",
-            quote_arg(&args.run_id)
-        ),
-    );
+    if !args.full {
+        attach_collection_budget(
+            &mut value,
+            "hydrated_evidence",
+            &format!(
+                "homeboy agent-task diagnose {} --full",
+                quote_arg(&args.run_id)
+            ),
+            &format!(
+                "homeboy agent-task diagnose {} --full --output <path>",
+                quote_arg(&args.run_id)
+            ),
+        );
+    }
     Ok((value, 0))
 }
 
@@ -635,9 +648,9 @@ fn attach_collection_budget(
         return;
     };
     let values = map
-        .get(field)
-        .and_then(Value::as_array)
-        .cloned()
+        .get_mut(field)
+        .and_then(Value::as_array_mut)
+        .map(std::mem::take)
         .unwrap_or_default();
     let total = map
         .get(&format!("{field}_total"))

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -712,6 +712,7 @@ fn evidence_command_hydrates_homeboy_and_file_refs_with_filters_and_redaction() 
             kind: None,
             task: Some("task-a".to_string()),
             failure_only: true,
+            full: false,
         })
         .expect("evidence loaded");
 
@@ -774,6 +775,7 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 
         let (value, exit_code) = diagnose(DiagnoseArgs {
             run_id: "run-cli-diagnose-evidence".to_string(),
+            full: false,
         })
         .expect("diagnose loaded");
 
@@ -977,6 +979,7 @@ fn generic_contract_fixtures_surface_runtime_import_before_missing_artifact() {
 
         let (diagnose_value, diagnose_exit_code) = diagnose(DiagnoseArgs {
             run_id: run_id.to_string(),
+            full: false,
         })
         .expect("diagnose loaded");
         assert_eq!(diagnose_exit_code, 0);
@@ -1239,6 +1242,7 @@ fn generic_contract_fixtures_hydrate_local_file_and_path_evidence() {
             kind: None,
             task: Some("task-a".to_string()),
             failure_only: true,
+            full: false,
         })
         .expect("evidence loaded");
         assert_eq!(exit_code, 0);
@@ -1328,6 +1332,7 @@ fn evidence_command_hydrates_plain_local_path_refs_and_summarizes_unsupported_re
             kind: None,
             task: Some("task-a".to_string()),
             failure_only: true,
+            full: false,
         })
         .expect("evidence loaded");
 
@@ -1415,6 +1420,7 @@ fn evidence_command_truncates_large_file_evidence() {
             kind: Some("executor-result".to_string()),
             task: Some("task-a".to_string()),
             failure_only: false,
+            full: false,
         })
         .expect("evidence loaded");
 

--- a/crates/homeboy-cli/src/commands/logs.rs
+++ b/crates/homeboy-cli/src/commands/logs.rs
@@ -218,9 +218,10 @@ fn show_pinned(project_id: &str, lines: u32, follow: bool, local: bool) -> CmdRe
         total_bytes: content.returned_bytes + content.omitted_bytes,
         returned_bytes: content.returned_bytes,
         omitted_bytes: content.omitted_bytes,
+        total_bytes_known: true,
         truncated: content.omitted_logs > 0 || content.omitted_bytes > 0,
         continue_command: format!("homeboy logs list {project_id}"),
-        export_command: format!("homeboy logs show {project_id} --output <path>"),
+        export_command: format!("homeboy logs show {project_id} <path> --output <path>"),
     };
     Ok((
         LogsOutput {

--- a/crates/homeboy-core/src/project/logs.rs
+++ b/crates/homeboy-core/src/project/logs.rs
@@ -14,7 +14,8 @@ use crate::project::{self, Project};
 use serde::Serialize;
 
 const MAX_PINNED_LOGS: usize = 8;
-const MAX_PINNED_LOG_BYTES: usize = 8 * 1024;
+const MAX_PINNED_LOG_TOTAL_BYTES: usize = 48 * 1024;
+const MAX_PINNED_LOG_BYTES: usize = MAX_PINNED_LOG_TOTAL_BYTES / MAX_PINNED_LOGS;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogEntry {
@@ -141,10 +142,27 @@ pub fn show_pinned(project_id: &str, lines: u32, local: bool) -> Result<PinnedLo
         };
         let full_path = base_path::join_remote_path(Some(&base_path), &pinned_log.path)?;
 
-        let command = format!("tail -n {} {}", log_lines, shell::quote_path(&full_path));
+        // Limit inside the remote shell so the executor never buffers an
+        // arbitrarily large `tail` result before this reader can truncate it.
+        let command = format!(
+            "tail -n {} {} | head -c {}",
+            log_lines,
+            shell::quote_path(&full_path),
+            MAX_PINNED_LOG_BYTES
+        );
         let output = execute_for_project(&project, &command)?;
-        let (content, omitted) = truncate_utf8(&output.stdout, MAX_PINNED_LOG_BYTES);
-        omitted_bytes += omitted;
+        let content = output.stdout;
+        let size_command = format!(
+            "tail -n {} {} | wc -c",
+            log_lines,
+            shell::quote_path(&full_path)
+        );
+        let total_bytes = execute_for_project(&project, &size_command)?
+            .stdout
+            .trim()
+            .parse::<usize>()
+            .unwrap_or(content.len());
+        omitted_bytes += total_bytes.saturating_sub(content.len());
         let evidence =
             LogEvidenceMetadata::tail(&full_path, pinned_log.label.clone(), log_lines, &content);
 
@@ -167,17 +185,6 @@ pub fn show_pinned(project_id: &str, lines: u32, local: bool) -> Result<PinnedLo
         returned_bytes,
         omitted_bytes,
     })
-}
-
-fn truncate_utf8(value: &str, max_bytes: usize) -> (String, usize) {
-    if value.len() <= max_bytes {
-        return (value.to_string(), 0);
-    }
-    let mut end = max_bytes;
-    while !value.is_char_boundary(end) {
-        end -= 1;
-    }
-    (value[..end].to_string(), value.len() - end)
 }
 
 pub fn show(project_id: &str, path: &str, lines: u32, local: bool) -> Result<LogContent> {

--- a/crates/homeboy-output/src/lib.rs
+++ b/crates/homeboy-output/src/lib.rs
@@ -57,15 +57,24 @@ pub struct OutputTruncation {
     pub total_bytes: usize,
     pub returned_bytes: usize,
     pub omitted_bytes: usize,
+    /// Whether byte totals cover the complete source collection. A reader can
+    /// determine item totals without serializing an unbounded source, so byte
+    /// totals become partial when iteration stops at the output budget.
+    #[serde(default = "default_total_bytes_known")]
+    pub total_bytes_known: bool,
     pub truncated: bool,
     pub continue_command: String,
     pub export_command: String,
 }
 
+fn default_total_bytes_known() -> bool {
+    true
+}
+
 /// Apply an aggregate item and serialized-byte budget without changing the item
-/// schema. Callers can obtain `total_items` from indexed sources without
-/// hydrating every record, and use the exact continuation/export commands in the
-/// returned metadata.
+/// schema. Iteration stops at the first omitted item: callers must supply an
+/// indexed `total_items` rather than hydrating or serializing the remainder just
+/// to calculate byte metadata.
 pub fn budget_json_values(
     values: impl IntoIterator<Item = serde_json::Value>,
     total_items: usize,
@@ -76,22 +85,24 @@ pub fn budget_json_values(
     let mut returned = Vec::new();
     let mut returned_bytes: usize = 0;
     let mut observed_bytes: usize = 0;
+    let mut total_bytes_known = true;
     for value in values {
         let bytes = serde_json::to_vec(&value)
             .map(|value| value.len())
             .unwrap_or(0);
-        observed_bytes += bytes;
         if returned.len() >= budget.max_items
             || returned_bytes.saturating_add(bytes) > budget.max_bytes
         {
-            continue;
+            total_bytes_known = false;
+            break;
         }
+        observed_bytes += bytes;
         returned_bytes += bytes;
         returned.push(value);
     }
     let returned_items = returned.len();
     let omitted_items = total_items.saturating_sub(returned_items);
-    let total_bytes = observed_bytes.max(returned_bytes);
+    let total_bytes = observed_bytes;
     (
         returned,
         OutputTruncation {
@@ -101,8 +112,9 @@ pub fn budget_json_values(
             omitted_items,
             total_bytes,
             returned_bytes,
-            omitted_bytes: total_bytes.saturating_sub(returned_bytes),
-            truncated: omitted_items > 0 || total_bytes > returned_bytes,
+            omitted_bytes: 0,
+            total_bytes_known,
+            truncated: omitted_items > 0 || !total_bytes_known,
             continue_command: continue_command.into(),
             export_command: export_command.into(),
         },
@@ -509,11 +521,52 @@ mod tests {
         assert_eq!(metadata.returned_items, returned.len());
         assert_eq!(metadata.omitted_items, 100 - returned.len());
         assert!(metadata.truncated);
+        assert!(!metadata.total_bytes_known);
         assert_eq!(metadata.continue_command, "homeboy example list --limit 20");
         assert_eq!(
             metadata.export_command,
             "homeboy example list --output <path>"
         );
+    }
+
+    #[test]
+    fn collection_budget_stops_before_serializing_an_unbounded_remainder() {
+        let mut consumed = 0;
+        let values = std::iter::from_fn(|| {
+            consumed += 1;
+            Some(json!({ "id": consumed, "payload": "x".repeat(8 * 1024) }))
+        });
+
+        let (returned, metadata) = budget_json_values(
+            values,
+            usize::MAX,
+            OutputBudget::COLLECTION,
+            "homeboy example list --full",
+            "homeboy example list --full --output <path>",
+        );
+
+        assert_eq!(returned.len(), 7);
+        assert_eq!(consumed, 8);
+        assert!(!metadata.total_bytes_known);
+    }
+
+    #[test]
+    fn output_truncation_accepts_metadata_written_before_byte_totals_were_optional() {
+        let metadata: OutputTruncation = serde_json::from_value(json!({
+            "presentation": "bounded_collection",
+            "total_items": 20,
+            "returned_items": 20,
+            "omitted_items": 0,
+            "total_bytes": 1024,
+            "returned_bytes": 1024,
+            "omitted_bytes": 0,
+            "truncated": false,
+            "continue_command": "homeboy example list --limit 20",
+            "export_command": "homeboy example list --output <path>"
+        }))
+        .expect("metadata written before total_bytes_known remains readable");
+
+        assert!(metadata.total_bytes_known);
     }
 
     #[test]

--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -246,13 +246,14 @@ Agent-facing readers use one finite output contract from `homeboy-output`:
 - `compact_summary` returns fixed summary fields only.
 - `bounded_collection` defaults to 20 items and 64 KiB of serialized items.
 - `bounded_stream` defaults to 200 events, 64 KiB, and five minutes.
-- `lossless_export` is explicit through `--output <path>` or a command-specific
-  export artifact.
+- `lossless_export` is explicit through a command's `--full --output <path>`
+  pair or a command-specific export artifact.
 
 Bounded payloads add `output_budget` with stable `total_items`,
 `returned_items`, `omitted_items`, `total_bytes`, `returned_bytes`,
-`omitted_bytes`, `truncated`, `continue_command`, and `export_command` fields.
-The item payload schema remains unchanged. Continuations are focused commands;
+`omitted_bytes`, `total_bytes_known`, `truncated`, `continue_command`, and
+`export_command` fields. Byte totals are marked incomplete rather than forcing a
+reader to serialize an unbounded source merely to calculate metadata. The item payload schema remains unchanged. Continuations are focused commands;
 exports are the explicit lossless path rather than an unbounded stdout default.
 
 ## Observation-backed payloads


### PR DESCRIPTION
## Summary
- make lossless agent-task discovery, artifact, evidence, and diagnosis retrieval explicit with `--full`
- stop aggregate output budgeting at the first excluded value, report incomplete byte totals explicitly, and retain compatibility with prior metadata
- enforce pinned-log transfer limits before remote buffering and point export guidance at the valid single-log command

Follow-up to #10161.
Refs #10134.

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-output`
- `cargo test -p homeboy-cli commands::agent_task::tests::lifecycle::evidence_command_hydrates_homeboy_and_file_refs_with_filters_and_redaction --no-fail-fast`
- `cargo run --bin homeboy -- agent-task list --full --limit 1` (rejected conflicting arguments as expected)
- `cargo run --bin homeboy -- agent-task evidence --help`
- `cargo run --bin homeboy -- logs show --help`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode reviewed the interrupted follow-up, implemented the bounded-output fixes and compatibility test, and ran focused verification. Chris Huber remains responsible for the final change.