### PR TITLE
Fix Lab daemon startup token recovery

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -108,6 +108,9 @@ enum DaemonCommand {
         /// Local bind address. Defaults to an OS-selected loopback port.
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
+        /// Exact startup admission identity, forwarded by the supervisor.
+        #[arg(long, hide = true)]
+        startup_token: Option<String>,
     },
     /// Supervise one daemon child and persist its termination evidence.
     #[command(hide = true)]
@@ -242,7 +245,12 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             DaemonOutput::RecoverMissingLeaseState(daemon::recover_missing_lease_state(&lease_id, recorded_pid, &recorded_endpoint, confirm_pid_dead, confirm_control_plane_lost, &addr)?),
             0,
         )),
-        DaemonCommand::Serve { addr } => serve(&addr),
+        DaemonCommand::Serve { addr, startup_token } => {
+            // Supervision supplies the token through the environment; the
+            // hidden argument is retained as the portable ownership proof.
+            let _ = startup_token;
+            serve(&addr)
+        }
         DaemonCommand::Supervise { addr, startup_token } => {
             daemon::supervise(&addr, &startup_token)?;
             Ok((DaemonOutput::Serve(DaemonStartResult { pid: std::process::id(), address: addr, state_path: String::new(), lease_id: String::new() }), 0))

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -66,7 +66,17 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
         )
     })?;
     let child = Command::new(exe)
-        .args(["daemon", "serve", "--addr", addr])
+        // The argument is the portable, exact ownership proof used when a
+        // platform cannot inspect a process environment. Keep it aligned with
+        // the persisted admission token for the lifetime of this daemon.
+        .args([
+            "daemon",
+            "serve",
+            "--addr",
+            addr,
+            "--startup-token",
+            startup_token,
+        ])
         .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -1829,9 +1839,8 @@ fn startup_timeout_error(
         "daemon process {pid} did not publish its isolated startup token before timeout"
     ))
     .with_hint("The daemon startup was not accepted because the expected token and PID did not match. Retry the Lab Cook; provider budget was not consumed.".to_string());
-    error.retryable = Some(true);
     error.details = serde_json::json!({
-        "classification": "retryable_pre_provider_startup",
+        "classification": "terminal_pre_provider_startup",
         "expected": { "pid": pid, "startup_token": startup_token },
         "observed": {
             "pid": observation.observed_pid,
@@ -1839,9 +1848,27 @@ fn startup_timeout_error(
             "startup_token": observation.observed_token,
         },
         "cleanup": cleanup,
+        "managed_recovery_actions": 1,
+        "provider_budget_consumed": false,
         "safe_next_action": "Retry the same Lab Cook. Inspect `homeboy daemon status` if the failure repeats.",
     });
     error
+}
+
+fn can_recover_startup_attempt(
+    allow_retry: bool,
+    startup_token: &str,
+    observation: &StartupLeaseObservation,
+    cleanup_evidence: &[String],
+) -> bool {
+    allow_retry
+        && observation
+            .observed_token
+            .as_deref()
+            .is_none_or(|token| token == startup_token)
+        && !cleanup_evidence
+            .iter()
+            .any(|entry| entry.contains("could not be proven"))
 }
 
 fn spawn_and_wait_for_lease(addr: &str, startup_token: &str) -> Result<DaemonStartResult> {
@@ -1891,13 +1918,19 @@ fn spawn_and_wait_for_lease_attempt(
         Err(observation) => {
             let cleanup = cleanup_startup_attempt(pid, startup_token)?;
             cleanup_evidence.extend(cleanup);
-            if allow_retry {
-                // A launcher can lose the first publication race during an SSH
-                // handoff. Retry once with a new token; never adopt another
-                // controller's lease as this attempt's daemon.
+            if can_recover_startup_attempt(
+                allow_retry,
+                startup_token,
+                &observation,
+                &cleanup_evidence,
+            ) {
+                // The token is the durable admission identity for this
+                // startup. A bounded recovery restarts only the same proven
+                // attempt, so receipt replay and concurrent callers can never
+                // mistake a replacement for a second daemon.
                 return spawn_and_wait_for_lease_attempt(
                     addr,
-                    &uuid::Uuid::new_v4().to_string(),
+                    startup_token,
                     false,
                     cleanup_evidence,
                 );

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -881,7 +881,18 @@ fn persist_lab_staging_recipe_for_transport(
 fn ensure_current_controller_daemon() -> Result<homeboy_core::daemon::DaemonStartResult> {
     let expected = homeboy_core::build_identity::current().display;
     for _ in 0..2 {
-        let daemon = homeboy_core::daemon::ensure_running(homeboy_core::daemon::DEFAULT_ADDR)?;
+        let daemon = homeboy_core::daemon::ensure_running(homeboy_core::daemon::DEFAULT_ADDR)
+            .map_err(|mut error| {
+                // Daemon admission happens before the controller job or any
+                // provider dispatch. Preserve the source invocation as the
+                // only safe replay after its one managed startup recovery.
+                error.details["lab_daemon_admission"] = json!({
+                    "phase": "pre_provider",
+                    "provider_budget_consumed": false,
+                    "preserved_invocation": preserved_invocation(),
+                });
+                error
+            })?;
         let status = homeboy_core::daemon::read_status()?;
         let Some(state) = status.state else {
             return Err(Error::internal_unexpected(

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -6,8 +6,9 @@ use std::time::Duration;
 use std::{os::unix::process::CommandExt, process::Command};
 
 use super::{
-    artifact_content_url, ensure_running_with_operations, fetch_artifact_to_path,
-    observe_startup_lease, reconcile_dead_lease_and_ensure_running_with_operations,
+    artifact_content_url, can_recover_startup_attempt, ensure_running_with_operations,
+    fetch_artifact_to_path, observe_startup_lease,
+    reconcile_dead_lease_and_ensure_running_with_operations,
     reconcile_leaseless_orphan_store_with_operations,
 };
 use crate::api_jobs::{JobEventKind, JobStatus, JobStore};
@@ -1364,6 +1365,45 @@ fn startup_observation_waits_for_delayed_token_without_provider_work() {
     .expect("observe delayed startup")
     .expect("matching delayed token is ready");
     assert_eq!(result.lease_id, "lease-new");
+}
+
+#[test]
+fn startup_recovery_reuses_only_the_authoritative_attempt_identity() {
+    let expected = "attempt-token";
+    let absent = super::StartupLeaseObservation {
+        observed_pid: None,
+        observed_lease_id: None,
+        observed_token: None,
+    };
+    assert!(can_recover_startup_attempt(true, expected, &absent, &[]));
+
+    let stale = super::StartupLeaseObservation {
+        observed_pid: Some(4242),
+        observed_lease_id: Some("stale-lease".to_string()),
+        observed_token: Some(expected.to_string()),
+    };
+    assert!(can_recover_startup_attempt(true, expected, &stale, &[]));
+
+    let competing = super::StartupLeaseObservation {
+        observed_pid: Some(4343),
+        observed_lease_id: Some("other-lease".to_string()),
+        observed_token: Some("other-token".to_string()),
+    };
+    assert!(!can_recover_startup_attempt(
+        true,
+        expected,
+        &competing,
+        &[]
+    ));
+    assert!(!can_recover_startup_attempt(
+        true,
+        expected,
+        &stale,
+        &[
+            "retained lease for pid 4242 because its token ownership could not be proven"
+                .to_string()
+        ],
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- retain one authoritative startup-token identity across the bounded daemon recovery instead of rotating it
- expose that token on the supervised daemon child for portable exact ownership proof, and fail closed when another token owns the observed lease
- terminalize final Lab daemon admission failures before provider dispatch with preserved invocation and zero provider budget

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-core daemon::control::control_test -- --nocapture`
- `cargo test -p homeboy-lab-runner lab_staging_controller --lib`
- `cargo check -p homeboy-cli -p homeboy-lab-runner`

Fixes #10022

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode drafted substantive implementation and tests. Chris Huber reviewed and remains responsible for every line.