### PR TITLE
fix(lab): reuse prepared same-commit source views

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -48,7 +48,8 @@ pub(crate) struct LabWorkspaceHydrationStep {
 pub(crate) struct LabWorkspaceHydrationOutput {
     pub(crate) schema: &'static str,
     /// `hydrated` when at least one provider install ran, `skipped_no_provider`
-    /// when the workspace exposed no detected dependency provider.
+    /// when the workspace exposed no detected dependency provider, or
+    /// `reused_prepared_cache` when dependencies arrived in a private cached view.
     pub(crate) status: &'static str,
     pub(crate) workspace: String,
     pub(crate) steps: Vec<LabWorkspaceHydrationStep>,
@@ -59,6 +60,15 @@ impl LabWorkspaceHydrationOutput {
         Self {
             schema: HYDRATION_SCHEMA,
             status: "skipped_no_provider",
+            workspace: workspace.to_string(),
+            steps: Vec::new(),
+        }
+    }
+
+    fn reused_prepared_cache(workspace: &str) -> Self {
+        Self {
+            schema: HYDRATION_SCHEMA,
+            status: "reused_prepared_cache",
             workspace: workspace.to_string(),
             steps: Vec::new(),
         }
@@ -122,6 +132,11 @@ fn hydrate_lab_workspace_dependencies_for_run(
     remote_path: &str,
     parent_run_id: Option<&str>,
 ) -> Result<LabWorkspaceHydrationOutput> {
+    if prepared_source_view_is_ready(runner_id, remote_path)? {
+        return Ok(LabWorkspaceHydrationOutput::reused_prepared_cache(
+            remote_path,
+        ));
+    }
     let plan = deps::dependency_install_plan(std::path::Path::new(local_path))?;
     if plan.is_empty() {
         return Ok(LabWorkspaceHydrationOutput::skipped_no_provider(
@@ -165,6 +180,24 @@ fn hydrate_lab_workspace_dependencies_for_run(
         workspace: remote_path.to_string(),
         steps,
     })
+}
+
+fn prepared_source_view_is_ready(runner_id: &str, remote_path: &str) -> Result<bool> {
+    let (output, exit_code) = exec(
+        runner_id,
+        RunnerExecOptions::raw_command(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "test -f {}/.homeboy/prepared-source-ready",
+                shell::quote_arg(remote_path)
+            ),
+        ])
+        .with_cwd(remote_path)
+        .without_evidence_mirror(),
+    )?;
+    let _ = output;
+    Ok(exit_code == 0)
 }
 
 /// Convert the controller-created declaration into runner-owned argv. Extension
@@ -377,6 +410,12 @@ fn hydrate_for_lab_workspace_exec_internal(
             agent_task_run_id,
         )?)
     };
+
+    // Persist a source/dependency preparation only after hydration has completed.
+    // The next same-commit job receives a private view of this immutable cache.
+    if matches!(&record, LabWorkspaceHydrationRecord::Applied(_)) {
+        crate::workspace::save_prepared_source_cache(runner_id, local_path, remote_path)?;
+    }
 
     let plan = match &record {
         LabWorkspaceHydrationRecord::Applied(output) if !output.is_empty() => with_step(

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -653,7 +653,7 @@ pub(crate) fn exec_lab_context(
     );
     context
         .overhead
-        .record(LabOffloadPhase::RemoteExec, remote_exec_started.elapsed());
+        .record(LabOffloadPhase::Command, remote_exec_started.elapsed());
     let (exec_output, exit_code) = match exec_result {
         Ok(output) => output,
         Err(err) => {
@@ -849,7 +849,6 @@ pub(crate) fn exec_lab_context(
         });
     }
 
-    let output_parse_started = std::time::Instant::now();
     let mut applied_mutation_files = Vec::new();
     let promotion_intent = promotion_handoff_intent(request.normalized_args, &exec_output.stdout)?;
     if request.capture_patch && (exit_code == 0 || promotion_intent.is_some()) {
@@ -867,10 +866,6 @@ pub(crate) fn exec_lab_context(
         applied_mutation_files = apply_output.result.modified_files.clone();
         context.plan = with_lab_apply_patch_step(context.plan, Some(apply_output));
     }
-    context
-        .overhead
-        .record(LabOffloadPhase::OutputParse, output_parse_started.elapsed());
-
     let artifact_import_started = std::time::Instant::now();
     let mut output_file_content = match context.remote_output_file.as_deref() {
         Some(path) => Some(download_lab_output_file(runner_id, path)?),
@@ -1591,7 +1586,7 @@ pub(crate) fn run_lab_offload_inner(
             output_file_content: Some(format!("{stdout}\n")),
         });
     }
-    let workspace_sync_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
+    let workspace_sync_timer = overhead.phase(LabOffloadPhase::SourceMaterialization);
     let workspace_stage = match prepare_lab_offload_workspace_stage(
         &request,
         crate::lab::offload::workspace_stage::LabWorkspaceStageCommand::from(&contract),
@@ -1738,6 +1733,7 @@ pub(crate) fn run_lab_offload_inner(
         )?;
     }
 
+    let dependency_hydration_timer = overhead.phase(LabOffloadPhase::DependencyHydration);
     let recorded_dependency_hydration = hydrate_for_lab_workspace_exec_with_lifecycle(
         request.skip_deps_hydration,
         runner_id,
@@ -1746,6 +1742,7 @@ pub(crate) fn run_lab_offload_inner(
         plan,
         agent_task_run_id.as_deref(),
     )?;
+    dependency_hydration_timer.finish();
     let dependency_hydration = recorded_dependency_hydration.hydration;
     plan = dependency_hydration.plan;
     if let Some(run_id) = agent_task_run_id.as_deref() {
@@ -1953,6 +1950,7 @@ pub(crate) fn run_lab_offload_inner(
     // retry to repeat the entire prep sequence with new identities (#9469).
     // Preserve the prepared workspace so a retry can resume against the current
     // healthy daemon instead; a genuine terminal outcome still reaps as before.
+    let admission_started = std::time::Instant::now();
     let admission = match direct_daemon_admission_coordinates(
         runner_id,
         &selection.mode,
@@ -1988,6 +1986,7 @@ pub(crate) fn run_lab_offload_inner(
             return Err(error);
         }
     };
+    overhead.record(LabOffloadPhase::QueueAdmission, admission_started.elapsed());
     lab_metadata["execution_bundle"] = serde_json::json!({
         "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
         "binary": crate::execution_bundle::binary(

--- a/crates/homeboy-lab-runner/src/lab/offload/overhead.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/overhead.rs
@@ -17,8 +17,8 @@ use std::time::{Duration, Instant};
 
 /// The distinct phases of a Lab offload run that we time independently.
 ///
-/// All variants except [`LabOffloadPhase::RemoteExec`] are *overhead* (runner
-/// setup). `RemoteExec` is the *workload* and is tracked separately so reports
+/// All variants except [`LabOffloadPhase::Command`] are *overhead* (runner
+/// setup). `Command` is the *workload* and is tracked separately so reports
 /// can separate `lab_overhead_ms` from workload command duration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum LabOffloadPhase {
@@ -27,15 +27,19 @@ pub(crate) enum LabOffloadPhase {
     /// Connecting to / preflighting the chosen runner (capability, daemon
     /// health, version-skew checks).
     Preflight,
-    /// Synchronizing the workspace/source checkout to the runner.
-    WorkspaceSync,
+    /// Waiting for a daemon admission reservation after the runner is ready.
+    QueueAdmission,
+    /// Creating the job-owned source view, or reusing an immutable preparation.
+    SourceMaterialization,
+    /// Installing or restoring dependencies into the job-owned source view.
+    DependencyHydration,
     /// Executing the workload command on the runner. This is the WORKLOAD, not
     /// overhead; tracked separately so it stays subtractable from the total.
-    RemoteExec,
-    /// Parsing the remote command output/streams.
-    OutputParse,
+    Command,
     /// Importing artifacts / structured-output files back from the runner.
     ArtifactImport,
+    /// Reaping the job-owned view. Immutable preparation is never reaped here.
+    Cleanup,
 }
 
 impl LabOffloadPhase {
@@ -44,22 +48,26 @@ impl LabOffloadPhase {
         match self {
             LabOffloadPhase::Selection => "selection",
             LabOffloadPhase::Preflight => "preflight",
-            LabOffloadPhase::WorkspaceSync => "workspace_sync",
-            LabOffloadPhase::RemoteExec => "remote_exec",
-            LabOffloadPhase::OutputParse => "output_parse",
+            LabOffloadPhase::QueueAdmission => "queue_admission",
+            LabOffloadPhase::SourceMaterialization => "source_materialization",
+            LabOffloadPhase::DependencyHydration => "dependency_hydration",
+            LabOffloadPhase::Command => "command",
             LabOffloadPhase::ArtifactImport => "artifact_import",
+            LabOffloadPhase::Cleanup => "cleanup",
         }
     }
 
     /// The setup phases in canonical order, used to render a stable per-phase
     /// duration map even when some phases were never reached.
-    pub(crate) const fn overhead_phases() -> [LabOffloadPhase; 5] {
+    pub(crate) const fn overhead_phases() -> [LabOffloadPhase; 7] {
         [
             LabOffloadPhase::Selection,
             LabOffloadPhase::Preflight,
-            LabOffloadPhase::WorkspaceSync,
-            LabOffloadPhase::OutputParse,
+            LabOffloadPhase::QueueAdmission,
+            LabOffloadPhase::SourceMaterialization,
+            LabOffloadPhase::DependencyHydration,
             LabOffloadPhase::ArtifactImport,
+            LabOffloadPhase::Cleanup,
         ]
     }
 }
@@ -106,10 +114,12 @@ impl AttemptedSelection {
 pub(crate) struct LabOffloadOverhead {
     selection: Option<Duration>,
     preflight: Option<Duration>,
-    workspace_sync: Option<Duration>,
-    remote_exec: Option<Duration>,
-    output_parse: Option<Duration>,
+    queue_admission: Option<Duration>,
+    source_materialization: Option<Duration>,
+    dependency_hydration: Option<Duration>,
+    command: Option<Duration>,
     artifact_import: Option<Duration>,
+    cleanup: Option<Duration>,
     attempted: AttemptedSelection,
     fallback_reason: Option<String>,
 }
@@ -124,10 +134,12 @@ impl LabOffloadOverhead {
         match phase {
             LabOffloadPhase::Selection => &mut self.selection,
             LabOffloadPhase::Preflight => &mut self.preflight,
-            LabOffloadPhase::WorkspaceSync => &mut self.workspace_sync,
-            LabOffloadPhase::RemoteExec => &mut self.remote_exec,
-            LabOffloadPhase::OutputParse => &mut self.output_parse,
+            LabOffloadPhase::QueueAdmission => &mut self.queue_admission,
+            LabOffloadPhase::SourceMaterialization => &mut self.source_materialization,
+            LabOffloadPhase::DependencyHydration => &mut self.dependency_hydration,
+            LabOffloadPhase::Command => &mut self.command,
             LabOffloadPhase::ArtifactImport => &mut self.artifact_import,
+            LabOffloadPhase::Cleanup => &mut self.cleanup,
         }
     }
 
@@ -177,10 +189,12 @@ impl LabOffloadOverhead {
         match phase {
             LabOffloadPhase::Selection => &self.selection,
             LabOffloadPhase::Preflight => &self.preflight,
-            LabOffloadPhase::WorkspaceSync => &self.workspace_sync,
-            LabOffloadPhase::RemoteExec => &self.remote_exec,
-            LabOffloadPhase::OutputParse => &self.output_parse,
+            LabOffloadPhase::QueueAdmission => &self.queue_admission,
+            LabOffloadPhase::SourceMaterialization => &self.source_materialization,
+            LabOffloadPhase::DependencyHydration => &self.dependency_hydration,
+            LabOffloadPhase::Command => &self.command,
             LabOffloadPhase::ArtifactImport => &self.artifact_import,
+            LabOffloadPhase::Cleanup => &self.cleanup,
         }
     }
 
@@ -210,7 +224,7 @@ impl LabOffloadOverhead {
                 );
             }
         }
-        let workload_ms = self.remote_exec.map(Self::millis);
+        let workload_ms = self.command.map(Self::millis);
         serde_json::json!({
             "schema": "homeboy/lab-offload-overhead/v1",
             "phase_durations_ms": phase_durations,
@@ -275,16 +289,23 @@ mod tests {
         let mut overhead = LabOffloadOverhead::start();
         overhead.record(LabOffloadPhase::Selection, Duration::from_millis(5));
         overhead.record(LabOffloadPhase::Preflight, Duration::from_millis(10));
-        overhead.record(LabOffloadPhase::WorkspaceSync, Duration::from_millis(20));
-        overhead.record(LabOffloadPhase::OutputParse, Duration::from_millis(3));
+        overhead.record(LabOffloadPhase::QueueAdmission, Duration::from_millis(3));
+        overhead.record(
+            LabOffloadPhase::SourceMaterialization,
+            Duration::from_millis(20),
+        );
+        overhead.record(
+            LabOffloadPhase::DependencyHydration,
+            Duration::from_millis(3),
+        );
         overhead.record(LabOffloadPhase::ArtifactImport, Duration::from_millis(2));
         // Workload is NOT overhead and must not inflate the total.
-        overhead.record(LabOffloadPhase::RemoteExec, Duration::from_millis(1000));
+        overhead.record(LabOffloadPhase::Command, Duration::from_millis(1000));
 
-        assert_eq!(overhead.overhead_total(), Duration::from_millis(40));
+        assert_eq!(overhead.overhead_total(), Duration::from_millis(43));
 
         let metadata = overhead.to_metadata();
-        assert_eq!(metadata["lab_overhead_ms"], serde_json::json!(40));
+        assert_eq!(metadata["lab_overhead_ms"], serde_json::json!(43));
         assert_eq!(metadata["workload_ms"], serde_json::json!(1000));
         assert_eq!(
             metadata["schema"],
@@ -293,11 +314,11 @@ mod tests {
         let durations = metadata["phase_durations_ms"].as_object().unwrap();
         assert_eq!(durations["selection"], serde_json::json!(5));
         assert_eq!(durations["preflight"], serde_json::json!(10));
-        assert_eq!(durations["workspace_sync"], serde_json::json!(20));
-        assert_eq!(durations["output_parse"], serde_json::json!(3));
+        assert_eq!(durations["source_materialization"], serde_json::json!(20));
+        assert_eq!(durations["dependency_hydration"], serde_json::json!(3));
         assert_eq!(durations["artifact_import"], serde_json::json!(2));
         // The workload phase is not part of the overhead duration map.
-        assert!(!durations.contains_key("remote_exec"));
+        assert!(!durations.contains_key("command"));
     }
 
     #[test]
@@ -308,17 +329,18 @@ mod tests {
             let _selection = overhead.phase(LabOffloadPhase::Selection);
         }
         overhead.record(LabOffloadPhase::Preflight, Duration::from_millis(7));
-        overhead.record(LabOffloadPhase::WorkspaceSync, Duration::from_millis(11));
-        overhead.record(LabOffloadPhase::RemoteExec, Duration::from_millis(500));
-        overhead.record(LabOffloadPhase::OutputParse, Duration::from_millis(1));
+        overhead.record(
+            LabOffloadPhase::SourceMaterialization,
+            Duration::from_millis(11),
+        );
+        overhead.record(LabOffloadPhase::Command, Duration::from_millis(500));
 
         let metadata = overhead.to_metadata();
         // Per-phase map present for the setup phases that ran.
         let durations = metadata["phase_durations_ms"].as_object().unwrap();
         assert!(durations.contains_key("selection"));
         assert!(durations.contains_key("preflight"));
-        assert!(durations.contains_key("workspace_sync"));
-        assert!(durations.contains_key("output_parse"));
+        assert!(durations.contains_key("source_materialization"));
         // Total overhead present and workload separable.
         assert!(metadata["lab_overhead_ms"].as_u64().is_some());
         assert_eq!(metadata["workload_ms"], serde_json::json!(500));

--- a/crates/homeboy-lab-runner/src/lab/offload/resident.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/resident.rs
@@ -21,7 +21,7 @@ pub(crate) fn run_runner_resident_lab_offload(
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, runner_status);
-    let managed_sources_timer = overhead.phase(LabOffloadPhase::WorkspaceSync);
+    let managed_sources_timer = overhead.phase(LabOffloadPhase::SourceMaterialization);
     let source_syncs = refresh_managed_runner_sources(runner_id, runner_workspace_root)?;
     managed_sources_timer.finish();
     if source_syncs.is_empty() {

--- a/crates/homeboy-lab-runner/src/workspace/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/mod.rs
@@ -18,6 +18,7 @@ mod types;
 mod util;
 
 pub use pull::{plan_workspace_pull, pull_workspace};
+pub(crate) use sync::save_prepared_source_cache;
 pub(crate) use sync::update_workspace_resource_lifecycle;
 #[cfg(test)]
 pub(crate) use sync::workspace_resource_lifecycle;

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -341,11 +341,22 @@ pub fn sync_workspace(
                 &includes,
                 workspace_cleanliness,
             );
-            let materialized = if options.controller_routed_git
+            // A prepared source is immutable and keyed by the controller path
+            // plus exact commit. Jobs never execute from it: each receives a
+            // private copied view which preserves #10105's ownership boundary.
+            let prepared_cache = prepared_source_cache_path(workspace_root, &local_path, &git.head);
+            let reused_prepared_source =
+                materialize_prepared_source_view(&runner, &prepared_cache, &remote_path)?;
+            let materialized = if reused_prepared_source {
+                materialization_plan.actual_materialization_mode =
+                    Some("prepared_source_view".to_string());
+                Ok(None)
+            } else if options.controller_routed_git
                 || git.branch.is_none()
                 || source_materialization::requires_controller_routed_workspace_sync(
                     &git.remote_url,
-                ) {
+                )
+            {
                 materialize_git_from_controller_bundle(
                     &runner,
                     &local_path,
@@ -476,6 +487,89 @@ pub fn sync_workspace(
                 0,
             ))
         }
+    }
+}
+
+/// Cache only a source that has completed dependency hydration. The cache lives
+/// outside `_lab_workspaces`, is never handed to a job, and has no terminal-job
+/// cleanup owner. A private job view is copied from it on a same-commit hit.
+pub(crate) fn save_prepared_source_cache(
+    runner_id: &str,
+    local_path: &str,
+    remote_path: &str,
+) -> Result<()> {
+    let runner = load(runner_id)?;
+    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_root",
+            "runner workspace cache requires workspace_root",
+            Some(runner.id.clone()),
+            None,
+        )
+    })?;
+    let local_path = canonical_workspace_path(local_path)?;
+    let commit = git_output(&local_path, &["rev-parse", "HEAD"])?;
+    let cache = prepared_source_cache_path(workspace_root, &local_path, &commit);
+    let command = format!(
+        "cache={cache}; source={source}; lock=\"$cache.lock\"; mkdir -p \"$(dirname \"$cache\")\"; test -f \"$cache/.homeboy/prepared-source-ready\" && exit 0; mkdir \"$lock\" 2>/dev/null || exit 0; trap 'rmdir \"$lock\"' EXIT; tmp=\"$cache.tmp.$$\"; rm -rf \"$tmp\"; cp -a \"$source\" \"$tmp\"; mkdir -p \"$tmp/.homeboy\"; : > \"$tmp/.homeboy/prepared-source-ready\"; chmod -R a-w \"$tmp\"; mv \"$tmp\" \"$cache\"",
+        cache = shell::quote_arg(&cache),
+        source = shell::quote_arg(remote_path),
+    );
+    run_workspace_shell_command(&runner, &command, "save prepared Lab source cache")
+}
+
+fn prepared_source_cache_path(workspace_root: &str, local_path: &Path, commit: &str) -> String {
+    let view = deterministic_remote_path(workspace_root, local_path, commit, None);
+    let name = Path::new(&view)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("workspace");
+    format!(
+        "{}/_lab_prepared_sources/{name}",
+        workspace_root.trim_end_matches('/')
+    )
+}
+
+fn materialize_prepared_source_view(
+    runner: &super::super::Runner,
+    cache: &str,
+    remote_path: &str,
+) -> Result<bool> {
+    let command = format!(
+        "test -f {cache}/.homeboy/prepared-source-ready && test ! -e {destination} && mkdir -p $(dirname {destination}) && cp -a {cache} {destination} && chmod -R u+w {destination}",
+        cache = shell::quote_arg(cache),
+        destination = shell::quote_arg(remote_path),
+    );
+    run_workspace_shell_success(runner, &command, "materialize prepared Lab source view")
+}
+
+fn run_workspace_shell_success(
+    runner: &super::super::Runner,
+    command: &str,
+    action: &str,
+) -> Result<bool> {
+    match runner.kind {
+        RunnerKind::Local => Ok(std::process::Command::new("sh")
+            .args(["-c", command])
+            .status()
+            .map_err(|error| Error::internal_io(error.to_string(), Some(action.to_string())))?
+            .success()),
+        RunnerKind::Ssh => {
+            let (_server, client) = ssh_client_for_runner(runner)?;
+            Ok(client.execute(command).success)
+        }
+    }
+}
+
+fn run_workspace_shell_command(
+    runner: &super::super::Runner,
+    command: &str,
+    action: &str,
+) -> Result<()> {
+    if run_workspace_shell_success(runner, command, action)? {
+        Ok(())
+    } else {
+        Err(Error::internal_unexpected(format!("{action} failed")))
     }
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -4,8 +4,8 @@ use std::sync::{Mutex, OnceLock};
 use super::git;
 use crate::workspace::snapshot::{incremental_prepare_command_fits, snapshot_manifest_delta};
 use crate::workspace::sync::{
-    reuse_compatible_snapshot_workspace, sync_workspace, workspace_snapshot_scan_command,
-    workspace_snapshots,
+    reuse_compatible_snapshot_workspace, save_prepared_source_cache, sync_workspace,
+    workspace_snapshot_scan_command, workspace_snapshots,
 };
 use crate::workspace::types::{
     RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
@@ -382,6 +382,74 @@ fn clean_snapshot_reuse_preserves_exact_source_provenance_without_git_materializ
             "snapshot_reused_clean_workspace"
         );
         assert!(reused.materialization_plan.controller_git_bundle.is_none());
+    });
+}
+
+#[test]
+fn same_commit_prepared_source_cache_creates_private_job_views() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-prepared-cache", runner_root.path());
+        let source = git_source("homeboy@prepared-cache", "fix/prepared-cache", "source\n");
+        git(
+            source.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://example.test/prepared-cache.git",
+            ],
+        );
+        let mut options = sync_options(
+            source.path().display().to_string(),
+            Some("job-one".to_string()),
+        );
+        options.mode = RunnerWorkspaceSyncMode::Git;
+        options.controller_routed_git = true;
+        let (first, _) = sync_workspace("lab-local-prepared-cache", options.clone())
+            .expect("first job materializes source");
+        std::fs::write(
+            std::path::Path::new(&first.remote_path).join("dependency-marker"),
+            "hydrated\n",
+        )
+        .expect("simulate dependency hydration");
+        save_prepared_source_cache(
+            "lab-local-prepared-cache",
+            &first.local_path,
+            &first.remote_path,
+        )
+        .expect("save immutable prepared source");
+
+        options.run_isolation_token = Some("job-two".to_string());
+        let (second, _) = sync_workspace("lab-local-prepared-cache", options)
+            .expect("same commit receives private cached view");
+
+        assert_ne!(first.remote_path, second.remote_path);
+        assert_eq!(
+            second
+                .materialization_plan
+                .actual_materialization_mode
+                .as_deref(),
+            Some("prepared_source_view")
+        );
+        assert!(std::path::Path::new(&second.remote_path)
+            .join("dependency-marker")
+            .is_file());
+        std::fs::write(
+            std::path::Path::new(&second.remote_path).join("job-only"),
+            "private\n",
+        )
+        .expect("mutate private job view");
+        assert!(!std::path::Path::new(&first.remote_path)
+            .join("job-only")
+            .exists());
+        assert!(runner_root
+            .path()
+            .join("_lab_prepared_sources")
+            .read_dir()
+            .expect("prepared cache directory")
+            .next()
+            .is_some());
     });
 }
 


### PR DESCRIPTION
Fixes #10120

## Performance
- Reuses a content-addressed immutable prepared source tree after dependency hydration for an exact controller path and commit.
- Every execution copies that cache into a distinct job-owned view before it runs; the cache is outside `_lab_workspaces`, and terminal cleanup continues to reap only the job view.
- Reused views skip repeat dependency installation and expose `prepared_source_view` materialization evidence.

## Timing
- Expands #3001 Lab timing vocabulary to selection, preflight, queue/admission, source materialization, dependency hydration, command, artifact import, and cleanup.
- The setup total excludes command duration.

## Evidence
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner overhead_total_excludes_workload_and_sums_setup_phases`
- `cargo test -p homeboy-lab-runner same_commit_prepared_source_cache_creates_private_job_views`

The deterministic cache test proves the repeated same-commit path avoids Git/bundle materialization, preserves the hydrated marker, uses a different workspace identity, and cannot leak a job-local mutation back to the prior job.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the implementation and deterministic tests, traced the Lab workspace lifecycle, and ran focused verification. Chris Huber remains responsible for every line.
