### PR TITLE
Fix local Cook owner reconciliation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -103,6 +103,29 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         ));
     }
 
+    // A provider can return in the narrow window before its scheduler persists
+    // the aggregate. Its terminal reservation is durable proof that cancelling
+    // now would overwrite completed work; leave the run joinable so the late
+    // aggregate import is authoritative.
+    if record.state == AgentTaskRunState::Running
+        && !record.is_runner_backed()
+        && record.metadata["provider_executions"]
+            .as_array()
+            .is_some_and(|executions| {
+                executions
+                    .iter()
+                    .any(|execution| execution["state"] == json!("succeeded"))
+            })
+    {
+        let now = now_timestamp();
+        record.ensure_metadata_object().insert(
+            "cancellation_deferred_for_terminal_provider".to_string(),
+            json!({ "requested_at": now, "reason": reason.unwrap_or("cancel requested") }),
+        );
+        store::write_record(&record)?;
+        return Ok(record);
+    }
+
     // Staging is controller-local work, not a runner child. Its terminal
     // confirmation is required before this parent can become Cancelled.
     let controller_cancelled = if let Some(controller_job_id) = record

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -757,6 +757,11 @@ pub fn reserve_provider_execution(
                 "model": task.executor.model(),
                 "state": "running",
                 "started_at": started_at.clone(),
+                // This is the process that owns the synchronous local provider
+                // boundary, captured before the scheduler can block on it.
+                "owner_pid": std::process::id(),
+                "owner_linux_starttime_ticks": homeboy_core::process::linux_process_starttime_ticks(std::process::id()).ok().flatten(),
+                "owner_identity": format!("{run_id}:{execution_key}"),
             }));
             let consumed = executions.len();
             metadata.insert("provider_executions_consumed".to_string(), json!(consumed));
@@ -822,6 +827,7 @@ pub fn record_provider_execution_terminal(
     let execution_key = format!("{task_id}:{attempt}");
     let mut found = false;
     let record = store::mutate_record(&run_id, |record| {
+        let cancelled = record.state == AgentTaskRunState::Cancelled;
         let Some(execution) = record
             .ensure_metadata_object()
             .get_mut("provider_executions")
@@ -834,6 +840,18 @@ pub fn record_provider_execution_terminal(
         else {
             return false;
         };
+        // A confirmed cancellation wins over a provider return that raced with
+        // it. Conversely, cancellation observes a terminal provider state
+        // before it mutates the run, allowing an already-completed result to be
+        // imported instead of being discarded.
+        if cancelled {
+            found = true;
+            return false;
+        }
+        if execution["state"] != json!("running") {
+            found = true;
+            return false;
+        }
         execution["state"] = json!(state);
         execution["finished_at"] = json!(now_timestamp());
         found = true;
@@ -858,6 +876,114 @@ where
     rewrite(&mut record);
     store::write_record(&record)?;
     Ok(record)
+}
+
+/// Reconcile the ownership captured at the local provider boundary. A local
+/// provider has no opaque remote handle, so its reserving process is the only
+/// durable authority that can prove the reservation is still executing.
+fn reconcile_local_provider_ownership(record: &mut AgentTaskRunRecord) -> bool {
+    if record.state != AgentTaskRunState::Running || record.is_runner_backed() {
+        return false;
+    }
+    let Some(executions) = record
+        .metadata
+        .get_mut("provider_executions")
+        .and_then(Value::as_array_mut)
+    else {
+        return false;
+    };
+
+    let mut has_running = false;
+    let mut has_live_owner = false;
+    let mut has_succeeded = false;
+    let mut recovery_identity = Vec::new();
+    for execution in executions.iter_mut() {
+        match execution["state"].as_str() {
+            Some("running") => {
+                has_running = true;
+                recovery_identity.push(execution["owner_identity"].clone());
+                let identity_state = execution
+                    .get("owner_pid")
+                    .and_then(Value::as_u64)
+                    .and_then(|pid| u32::try_from(pid).ok())
+                    .map(|pid| {
+                        homeboy_core::process::process_identity_state(
+                            pid,
+                            execution
+                                .get("owner_linux_starttime_ticks")
+                                .and_then(Value::as_u64),
+                        )
+                    });
+                let live = matches!(
+                    identity_state,
+                    Some(homeboy_core::process::ProcessIdentityState::Live)
+                );
+                execution["owner_state"] = json!(match identity_state {
+                    Some(homeboy_core::process::ProcessIdentityState::Live) => "live",
+                    Some(homeboy_core::process::ProcessIdentityState::Dead) => "dead",
+                    Some(homeboy_core::process::ProcessIdentityState::IdentityMismatch) =>
+                        "identity_mismatch",
+                    _ => "unverifiable",
+                });
+                has_live_owner |= live;
+            }
+            Some("succeeded") => has_succeeded = true,
+            _ => {}
+        }
+    }
+    if has_live_owner {
+        return true;
+    }
+    if !has_running && !has_succeeded {
+        return false;
+    }
+
+    let now = now_timestamp();
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "local_provider_ownership".to_string(),
+        json!({
+            "state": "owner_dead",
+            "recovery_identity": recovery_identity,
+            "reconciled_at": now,
+        }),
+    );
+    if has_succeeded {
+        // The provider reported completion before the foreground owner died,
+        // but the aggregate was not yet persisted. Preserve that fact and the
+        // workspace as a recoverable candidate instead of erasing it.
+        record.updated_at = Some(now);
+        set_run_state(record, AgentTaskRunState::CandidateRecoverable);
+        for task in &mut record.tasks {
+            if task.state == AgentTaskState::Running {
+                task.state = AgentTaskState::CandidateRecoverable;
+            }
+        }
+    } else {
+        let executions = record
+            .ensure_metadata_object()
+            .get_mut("provider_executions")
+            .and_then(Value::as_array_mut)
+            .expect("provider executions were checked above");
+        for execution in executions.iter_mut() {
+            if execution["state"] == json!("running") {
+                execution["state"] = json!("cancelled");
+                execution["finished_at"] = json!(now.clone());
+            }
+        }
+        record.updated_at = Some(now.clone());
+        set_run_state(record, AgentTaskRunState::Cancelled);
+        for task in &mut record.tasks {
+            if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+                task.state = AgentTaskState::Cancelled;
+            }
+        }
+        record.ensure_metadata_object().insert(
+            "cancel_reason".to_string(),
+            json!("local provider owner process is not running"),
+        );
+    }
+    true
 }
 
 pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
@@ -971,6 +1097,9 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
                 record = reconciled;
             }
         }
+    }
+    if reconcile_local_provider_ownership(&mut record) {
+        store::write_record(&record)?;
     }
     let before_liveness_reconciliation = record.clone();
     reconcile_runner_job_state(&mut record)?;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2022,6 +2022,116 @@ fn replaying_cancel_repairs_stale_provider_execution() {
 }
 
 #[test]
+fn local_provider_reservation_persists_reusable_owner_identity_before_execution() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("owner-identity")).expect("submitted");
+        reserve_provider_execution("owner-identity", &plan.tasks[0], 1).expect("reserved");
+
+        let record = store::read_record("owner-identity").expect("record");
+        let execution = &record.metadata["provider_executions"][0];
+        assert_eq!(execution["owner_pid"], json!(std::process::id()));
+        assert_eq!(
+            execution["owner_identity"],
+            json!("owner-identity:task-a:1")
+        );
+        assert_eq!(execution["state"], json!("running"));
+    });
+}
+
+#[test]
+fn status_keeps_live_local_provider_owner_running_idempotently() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("owner-live")).expect("submitted");
+        mark_running("owner-live").expect("running");
+        reserve_provider_execution("owner-live", &plan.tasks[0], 1).expect("reserved");
+
+        let first = status("owner-live").expect("first status");
+        let second = status("owner-live").expect("second status");
+        assert_eq!(first.state, AgentTaskRunState::Running);
+        assert_eq!(second.state, AgentTaskRunState::Running);
+        assert_eq!(
+            second.metadata["provider_executions"][0]["owner_state"],
+            json!("live")
+        );
+    });
+}
+
+#[test]
+fn dead_local_provider_owner_terminalizes_running_reservation_once() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("owner-dead")).expect("submitted");
+        mark_running("owner-dead").expect("running");
+        reserve_provider_execution("owner-dead", &plan.tasks[0], 1).expect("reserved");
+        rewrite_record_for_test("owner-dead", |record| {
+            record.metadata["provider_executions"][0]["owner_pid"] = json!(u32::MAX);
+        })
+        .expect("dead owner fixture");
+
+        let terminal = status("owner-dead").expect("reconciled status");
+        let replay = status("owner-dead").expect("idempotent status");
+        assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
+        assert_eq!(replay.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            replay.metadata["provider_executions"][0]["state"],
+            json!("cancelled")
+        );
+        assert_eq!(
+            replay.metadata["local_provider_ownership"]["state"],
+            json!("owner_dead")
+        );
+    });
+}
+
+#[test]
+fn dead_owner_preserves_late_provider_success_as_recoverable_candidate() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("owner-late-success")).expect("submitted");
+        mark_running("owner-late-success").expect("running");
+        reserve_provider_execution("owner-late-success", &plan.tasks[0], 1).expect("reserved");
+        record_provider_execution_terminal("owner-late-success", "task-a", 1, "succeeded")
+            .expect("provider success recorded");
+        rewrite_record_for_test("owner-late-success", |record| {
+            record.metadata["provider_executions"][0]["owner_pid"] = json!(u32::MAX);
+        })
+        .expect("dead owner fixture");
+
+        let recovered = status("owner-late-success").expect("recovered status");
+        assert_eq!(recovered.state, AgentTaskRunState::CandidateRecoverable);
+        assert_eq!(
+            recovered.metadata["provider_executions"][0]["state"],
+            json!("succeeded")
+        );
+    });
+}
+
+#[test]
+fn cancellation_race_defers_to_a_durable_provider_success() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("cancel-race")).expect("submitted");
+        mark_running("cancel-race").expect("running");
+        reserve_provider_execution("cancel-race", &plan.tasks[0], 1).expect("reserved");
+        record_provider_execution_terminal("cancel-race", "task-a", 1, "succeeded")
+            .expect("provider success recorded");
+
+        let deferred = cancel_run("cancel-race", Some("operator cancel"))
+            .expect("cancellation defers to terminal provider");
+        let replay = cancel_run("cancel-race", Some("operator cancel"))
+            .expect("idempotent cancellation deferral");
+        assert_eq!(deferred.state, AgentTaskRunState::Running);
+        assert_eq!(replay.state, AgentTaskRunState::Running);
+        assert_eq!(
+            replay.metadata["provider_executions"][0]["state"],
+            json!("succeeded")
+        );
+    });
+}
+
+#[test]
 fn record_health_reconciles_plan_backed_missing_metadata_idempotently() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1603,6 +1603,7 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
     let has_active_provider_execution = !active_provider_executions.is_empty();
     let provider_boundary_recorded =
         provider_handle_count > 0 || runner_job_id.is_some() || has_active_provider_execution;
+    let local_provider_ownership = metadata.get("local_provider_ownership");
 
     json!({
         "status": if terminal { "terminal" } else if stale { "stale" } else if waiting_for_capacity { "waiting_for_capacity" } else { "active" },
@@ -1615,6 +1616,7 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
             "runner_job_id": runner_job_id,
             "active_execution_count": active_provider_executions.len(),
             "active_executions": active_provider_executions,
+            "local_owner": local_provider_ownership,
         },
         "stale_reason": metadata.get("stale_running_reason"),
         "runner_queue": metadata.get("runner_queue"),


### PR DESCRIPTION
## Summary
- Persist a local provider reservation owner PID, process-start identity, and reusable execution identity before scheduler dispatch.
- Reconcile live versus dead local owners on status reads, terminalizing orphaned running providers and preserving a recorded late success as recoverable.
- Make cancellation defer to a terminal provider reservation so a success/cancel race cannot discard the late aggregate.

## Testing
- `cargo test -p homeboy-agents local_provider -- --nocapture`
- `cargo test -p homeboy-agents dead_owner_preserves_late_provider_success -- --nocapture`
- `cargo test -p homeboy-agents cancellation_race_defers_to_a_durable_provider_success -- --nocapture`
- `cargo fmt --check`
- `cargo check -p homeboy-agents -p homeboy-cli`

Fixes #10183

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to trace the local provider lifecycle, implement durable ownership/reconciliation, and add deterministic lifecycle coverage. Chris remains responsible for every line.