### PR TITLE
fix(fuzz): provision declared runtime helpers

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/fuzz_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/fuzz_config.rs
@@ -2,6 +2,7 @@
 
 use homeboy_lifecycle_contract::LifecycleContract;
 use serde::{Deserialize, Serialize};
+use crate::runtime_helper::RuntimeHelperRequirement;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct FuzzConfig {
@@ -9,6 +10,9 @@ pub struct FuzzConfig {
     pub extension_script: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub env: Vec<String>,
+    /// Core-owned helper capabilities required by this fuzz runner.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_helpers: Vec<RuntimeHelperRequirement>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workloads: Vec<FuzzWorkloadConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -97,6 +97,7 @@ pub mod manifest_test_config;
 pub mod manifest_toolchain_config;
 pub mod notification_transport_config;
 pub mod runner_contract;
+pub mod runtime_helper;
 pub mod sidecar_config;
 pub use manifest::ExtensionManifest;
 pub use manifest_artifact_cleanup::{
@@ -123,5 +124,6 @@ pub use runner_contract::{
     PhaseFailure, PhaseFailureCategory, PhaseReport, PhaseStatus, RunnerStepFilter,
     VerificationPhase, GENERIC_INFRASTRUCTURE_FAILURE_MARKERS,
 };
+pub use runtime_helper::RuntimeHelperRequirement;
 pub use test_drift::TestDriftConfig;
 pub use version::{parse_extension_version, VersionConstraint};

--- a/crates/contracts/homeboy-extension-contract/src/runtime_helper.rs
+++ b/crates/contracts/homeboy-extension-contract/src/runtime_helper.rs
@@ -1,0 +1,15 @@
+//! Extension declarations for core-owned runtime helpers.
+
+use serde::{Deserialize, Serialize};
+
+/// A helper capability an extension requires for one execution capability.
+///
+/// `id` is resolved by Homeboy's core registry. `revision`, when supplied,
+/// pins the declaration to the helper content revision the extension supports.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeHelperRequirement {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+}

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -1234,15 +1234,31 @@ fn run_fuzz_extension_script(
         Some(execution_request_path),
         sequence_plan_path,
     )?;
+    let helper_provenance = homeboy_extension::provision_declared_helpers(runtime_helpers)?;
+    let mut helper_env = helper_provenance
+        .iter()
+        .map(|helper| (helper.env_var.clone(), helper.path.clone()))
+        .collect::<Vec<_>>();
+    if !helper_provenance.is_empty() {
+        let provenance = serde_json::to_string(&helper_provenance).map_err(|error| {
+            homeboy::core::Error::internal_json(
+                error.to_string(),
+                Some("serialize runtime helper provenance".to_string()),
+            )
+        })?;
+        helper_env.push(("HOMEBOY_RUNTIME_HELPERS_PROVENANCE".to_string(), provenance));
+    }
 
     if ctx.component.has_script(ExtensionCapability::Fuzz) {
+        let mut component_env = env;
+        component_env.extend(helper_env);
         let output = homeboy_extension::component_script::run_component_scripts_with_run_dir(
             &ctx.component,
             ExtensionCapability::Fuzz,
             &ctx.source_path,
             run_dir,
             false,
-            &env,
+            &component_env,
             &args.args,
         )?;
         return Ok(output.into());
@@ -1275,21 +1291,10 @@ fn run_fuzz_extension_script(
         .timeout(fuzz_max_duration(args.max_duration.as_deref())?)
         .script_args(&args.args);
 
-    let helper_provenance = homeboy_extension::provision_declared_helpers(runtime_helpers)?;
-    for helper in &helper_provenance {
-        runner = runner.env(&helper.env_var, &helper.path);
-    }
-    if !helper_provenance.is_empty() {
-        let provenance = serde_json::to_string(&helper_provenance).map_err(|error| {
-            homeboy::core::Error::internal_json(
-                error.to_string(),
-                Some("serialize runtime helper provenance".to_string()),
-            )
-        })?;
-        runner = runner.env("HOMEBOY_RUNTIME_HELPERS_PROVENANCE", &provenance);
-    }
-
     for (key, value) in env {
+        runner = runner.env(&key, &value);
+    }
+    for (key, value) in helper_env {
         runner = runner.env(&key, &value);
     }
 

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -113,6 +113,10 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         &run_dir,
         &execution_request_path,
         sequence_plan_path.as_deref(),
+        fuzz_config
+            .as_ref()
+            .map(|config| config.runtime_helpers.as_slice())
+            .unwrap_or_default(),
     )?;
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
     let artifacts_dir =
@@ -1194,6 +1198,11 @@ pub(super) fn fuzz_runner_contract(config: Option<&FuzzConfig>) -> FuzzRunnerCon
                 env.push(key.to_string());
             }
         }
+        for key in homeboy_extension::declared_helper_env_names(&config.runtime_helpers) {
+            if !env.iter().any(|existing| existing == &key) {
+                env.push(key);
+            }
+        }
     }
 
     FuzzRunnerContract {
@@ -1213,6 +1222,7 @@ fn run_fuzz_extension_script(
     run_dir: &RunDir,
     execution_request_path: &Path,
     sequence_plan_path: Option<&Path>,
+    runtime_helpers: &[homeboy_extension::RuntimeHelperRequirement],
 ) -> homeboy::core::Result<homeboy_extension::RunnerOutput> {
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
     let env = fuzz_runner_env(
@@ -1264,6 +1274,20 @@ fn run_fuzz_extension_script(
         .invocation_requirements(invocation_requirements)
         .timeout(fuzz_max_duration(args.max_duration.as_deref())?)
         .script_args(&args.args);
+
+    let helper_provenance = homeboy_extension::provision_declared_helpers(runtime_helpers)?;
+    for helper in &helper_provenance {
+        runner = runner.env(&helper.env_var, &helper.path);
+    }
+    if !helper_provenance.is_empty() {
+        let provenance = serde_json::to_string(&helper_provenance).map_err(|error| {
+            homeboy::core::Error::internal_json(
+                error.to_string(),
+                Some("serialize runtime helper provenance".to_string()),
+            )
+        })?;
+        runner = runner.env("HOMEBOY_RUNTIME_HELPERS_PROVENANCE", &provenance);
+    }
 
     for (key, value) in env {
         runner = runner.env(&key, &value);

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -43,6 +43,25 @@ fn auto_run_ids_scope_identical_payloads_while_explicit_ids_remain_stable() {
 }
 
 #[test]
+fn fuzz_contract_exposes_only_declared_core_helper_environment() {
+    let config = FuzzConfig {
+        runtime_helpers: vec![homeboy_extension::RuntimeHelperRequirement {
+            id: homeboy_extension::RUNTIME_SETTINGS_HELPER_ID.to_string(),
+            revision: None,
+        }],
+        ..Default::default()
+    };
+    let contract = fuzz_runner_contract(Some(&config));
+
+    assert!(contract
+        .env
+        .contains(&homeboy_extension::RUNTIME_SETTINGS_HELPER_ENV.to_string()));
+    assert!(!contract
+        .env
+        .contains(&"HOMEBOY_RUNTIME_HELPERS_PROVENANCE".to_string()));
+}
+
+#[test]
 fn fuzz_run_persists_requested_run_id_and_results_artifact() {
     with_isolated_home(|home| {
         let args = FuzzRunArgs {

--- a/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
@@ -95,6 +95,7 @@ fn fuzz_campaign_contract_surfaces_extension_metadata() {
     let config = FuzzConfig {
         extension_script: Some("fuzz.sh".to_string()),
         env: Vec::new(),
+        runtime_helpers: Vec::new(),
         workloads: Vec::new(),
         case_artifact: Some("failing-case".to_string()),
         corpus_artifacts: vec!["corpus".to_string()],

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -136,7 +136,9 @@ pub use refactor_protocol::{
 pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
 pub use runner::{ExtensionRunner, RunnerOutput, STRICT_VALIDATION_DEPENDENCIES_ENV};
 pub use runtime_helper::{
-    helper_path, BASH_PREFLIGHT_ENV, COMMAND_CAPTURE_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV,
+    declared_helper_env_names, helper_path, provision_declared_helpers, RuntimeHelperProvision,
+    BASH_PREFLIGHT_ENV, COMMAND_CAPTURE_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV,
+    RUNTIME_SETTINGS_HELPER_ENV, RUNTIME_SETTINGS_HELPER_ID,
 };
 pub use summary::{list_summaries, ActionSummary, ExtensionSummary};
 pub use validation::{
@@ -145,6 +147,7 @@ pub use validation::{
 
 pub use homeboy_extension_contract::{
     core_compat, exec_context, runner_contract, source_metadata_repair, update_output, version,
+    RuntimeHelperRequirement,
 };
 
 #[cfg(test)]

--- a/crates/homeboy-extension/src/runtime/settings.sh
+++ b/crates/homeboy-extension/src/runtime/settings.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Safe accessors for Homeboy's merged extension settings payload.
+
+homeboy_settings_json() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    if [ -z "$settings_json" ]; then
+        printf '{}'
+        return 0
+    fi
+    if printf '%s' "$settings_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '%s' "$settings_json"
+    else
+        printf '{}'
+    fi
+}
+
+homeboy_setting_json() {
+    local setting_name="${1:?setting name is required}"
+    local default_json="${2:-null}"
+    local expression="${3:-.$setting_name}"
+    printf '%s' "$(homeboy_settings_json)" | jq -c "$expression" 2>/dev/null || printf '%s' "$default_json"
+}
+
+homeboy_setting() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_value="${3:-}"
+    local value
+    value=$(printf '%s' "$(homeboy_settings_json)" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in ""|null) printf '%s' "$default_value" ;; *) printf '%s' "$value" ;; esac
+}
+
+homeboy_setting_bool() {
+    local setting_name="${1:?setting name is required}"
+    local default_value="${2:-false}"
+    local expression="${3:-.$setting_name}"
+    local value
+    value=$(printf '%s' "$(homeboy_settings_json)" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in true|TRUE|1|yes|YES|on|ON) printf 'true' ;; false|FALSE|0|no|NO|off|OFF) printf 'false' ;; *) case "$default_value" in true|TRUE|1|yes|YES|on|ON) printf 'true' ;; *) printf 'false' ;; esac ;; esac
+}
+
+homeboy_setting_array() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_json="${3:-[]}"
+    local value
+    value=$(printf '%s' "$(homeboy_settings_json)" | jq -c "$expression" 2>/dev/null || true)
+    if printf '%s' "$value" | jq -e 'type == "array"' >/dev/null 2>&1; then printf '%s' "$value"; else printf '%s' "$default_json"; fi
+}

--- a/crates/homeboy-extension/src/runtime_helper.rs
+++ b/crates/homeboy-extension/src/runtime_helper.rs
@@ -1,7 +1,9 @@
 use homeboy_core::error::{Error, Result};
 use homeboy_core::paths;
 use homeboy_engine_primitives::local_files;
+use homeboy_extension_contract::RuntimeHelperRequirement;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -21,8 +23,11 @@ pub const RESOLVE_CONTEXT_ENV: &str = "HOMEBOY_RUNTIME_RESOLVE_CONTEXT";
 pub const DISPOSABLE_LOCAL_DB_ENV: &str = "HOMEBOY_RUNTIME_DISPOSABLE_LOCAL_DB";
 pub const BENCH_HELPER_SH_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_SH";
 pub const BENCH_HELPER_JS_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_JS";
+pub const RUNTIME_SETTINGS_HELPER_ID: &str = "runtime-settings";
+pub const RUNTIME_SETTINGS_HELPER_ENV: &str = "HOMEBOY_RUNTIME_SETTINGS_HELPER";
 
 struct RuntimeHelper {
+    id: &'static str,
     filename: &'static str,
     content: &'static str,
     env_var: &'static str,
@@ -30,71 +35,100 @@ struct RuntimeHelper {
 
 const HELPERS: &[RuntimeHelper] = &[
     RuntimeHelper {
+        id: "runner-steps",
         filename: "runner-steps.sh",
         content: assets::RUNNER_STEPS_SH,
         env_var: RUNNER_STEPS_ENV,
     },
     RuntimeHelper {
+        id: "runner-prelude",
         filename: "runner-prelude.sh",
         content: assets::RUNNER_PRELUDE_SH,
         env_var: RUNNER_PRELUDE_ENV,
     },
     RuntimeHelper {
+        id: "command-capture",
         filename: "command-capture.sh",
         content: assets::COMMAND_CAPTURE_SH,
         env_var: COMMAND_CAPTURE_ENV,
     },
     RuntimeHelper {
+        id: "bash-preflight",
         filename: "bash-preflight.sh",
         content: assets::BASH_PREFLIGHT_SH,
         env_var: BASH_PREFLIGHT_ENV,
     },
     RuntimeHelper {
+        id: "failure-trap",
         filename: "failure-trap.sh",
         content: assets::FAILURE_TRAP_SH,
         env_var: FAILURE_TRAP_ENV,
     },
     RuntimeHelper {
+        id: "write-test-results",
         filename: "write-test-results.sh",
         content: assets::WRITE_TEST_RESULTS_SH,
         env_var: WRITE_TEST_RESULTS_ENV,
     },
     RuntimeHelper {
+        id: "emit-lint-finding",
         filename: "emit-lint-finding.sh",
         content: assets::EMIT_LINT_FINDING_SH,
         env_var: EMIT_LINT_FINDING_ENV,
     },
     RuntimeHelper {
+        id: "emit-test-failure",
         filename: "emit-test-failure.sh",
         content: assets::EMIT_TEST_FAILURE_SH,
         env_var: EMIT_TEST_FAILURE_ENV,
     },
     RuntimeHelper {
+        id: "sidecar-writer",
         filename: "sidecar-writer.sh",
         content: assets::SIDECAR_WRITER_SH,
         env_var: SIDECAR_WRITER_ENV,
     },
     RuntimeHelper {
+        id: "resolve-context",
         filename: "resolve-context.sh",
         content: assets::RESOLVE_CONTEXT_SH,
         env_var: RESOLVE_CONTEXT_ENV,
     },
     RuntimeHelper {
+        id: "disposable-local-db",
         filename: "disposable-local-db.sh",
         content: assets::DISPOSABLE_LOCAL_DB_SH,
         env_var: DISPOSABLE_LOCAL_DB_ENV,
     },
     RuntimeHelper {
+        id: "bench-helper-sh",
         filename: "bench-helper.sh",
         content: assets::BENCH_HELPER_SH,
         env_var: BENCH_HELPER_SH_ENV,
     },
     RuntimeHelper {
+        id: "bench-helper-js",
         filename: "bench-helper.mjs",
         content: assets::BENCH_HELPER_JS,
         env_var: BENCH_HELPER_JS_ENV,
     },
 ];
+
+const DECLARABLE_HELPERS: &[RuntimeHelper] = &[RuntimeHelper {
+    id: RUNTIME_SETTINGS_HELPER_ID,
+    filename: "settings.sh",
+    content: assets::SETTINGS_SH,
+    env_var: RUNTIME_SETTINGS_HELPER_ENV,
+}];
+
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct RuntimeHelperProvision {
+    pub id: String,
+    pub env_var: String,
+    pub path: String,
+    pub revision: String,
+    pub source: String,
+}
 
 #[derive(Debug, Deserialize)]
 struct DeclaredRuntimeHelper {
@@ -117,6 +151,98 @@ fn ensure_helper(runtime_dir: &std::path::Path, helper: &RuntimeHelper) -> Resul
     }
 
     Ok(helper_path)
+}
+
+fn helper_revision(helper: &RuntimeHelper) -> String {
+    format!("sha256:{:x}", Sha256::digest(helper.content.as_bytes()))
+}
+
+/// Materialize manifest-declared helpers under an identity-and-revision path.
+/// The content-addressed path keeps an admitted extension's helper immutable if
+/// another command later refreshes the core runtime helpers.
+pub fn provision_declared_helpers(
+    requirements: &[RuntimeHelperRequirement],
+) -> Result<Vec<RuntimeHelperProvision>> {
+    let runtime_dir = paths::homeboy()
+        .map(|path| path.join("runtime/helpers"))
+        .unwrap_or_else(|_| env::temp_dir().join("homeboy-runtime/helpers"));
+    let mut provisions = Vec::with_capacity(requirements.len());
+    for requirement in requirements {
+        let id = requirement.id.trim();
+        let helper = DECLARABLE_HELPERS
+            .iter()
+            .find(|helper| helper.id == id)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "runtime_helpers",
+                    format!("runtime helper identity `{id}` is not supplied by Homeboy core"),
+                    Some(id.to_string()),
+                    Some(vec![
+                        "Declare a helper identity supported by the installed Homeboy core."
+                            .to_string(),
+                    ]),
+                )
+            })?;
+        let revision = helper_revision(helper);
+        if let Some(expected) = requirement
+            .revision
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if expected != revision {
+                return Err(Error::validation_invalid_argument(
+                    "runtime_helpers.revision",
+                    format!("runtime helper `{id}` requires revision `{expected}`, but Homeboy core provides `{revision}`"),
+                    Some(expected.to_string()),
+                    Some(vec!["Install a compatible Homeboy core or update the extension helper declaration.".to_string()]),
+                ));
+            }
+        }
+        let path = runtime_dir.join(id).join(&revision).join(helper.filename);
+        if !path.is_file() {
+            let parent = path.parent().expect("helper path has a parent");
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "create runtime helper directory {}",
+                        parent.display()
+                    )),
+                )
+            })?;
+            local_files::write_file_atomic(
+                &path,
+                helper.content,
+                &format!("materialize runtime helper {id}"),
+            )?;
+        }
+        provisions.push(RuntimeHelperProvision {
+            id: id.to_string(),
+            env_var: helper.env_var.to_string(),
+            path: path.to_string_lossy().to_string(),
+            revision,
+            source: "homeboy-core-embedded".to_string(),
+        });
+    }
+    provisions.sort_by(|left, right| left.id.cmp(&right.id));
+    provisions.dedup_by(|left, right| left.id == right.id);
+    Ok(provisions)
+}
+
+pub fn declared_helper_env_names(requirements: &[RuntimeHelperRequirement]) -> Vec<String> {
+    let mut names = requirements
+        .iter()
+        .filter_map(|requirement| {
+            DECLARABLE_HELPERS
+                .iter()
+                .find(|helper| helper.id == requirement.id.trim())
+                .map(|helper| helper.env_var.to_string())
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
 }
 
 fn ensure_declared_helper(

--- a/crates/homeboy-extension/src/runtime_helper.rs
+++ b/crates/homeboy-extension/src/runtime_helper.rs
@@ -200,7 +200,8 @@ pub fn provision_declared_helpers(
             }
         }
         let path = runtime_dir.join(id).join(&revision).join(helper.filename);
-        if !path.is_file() {
+        let current = fs::read_to_string(&path).ok();
+        if current.as_deref() != Some(helper.content) {
             let parent = path.parent().expect("helper path has a parent");
             fs::create_dir_all(parent).map_err(|error| {
                 Error::internal_io(

--- a/crates/homeboy-extension/src/runtime_helper/assets.rs
+++ b/crates/homeboy-extension/src/runtime_helper/assets.rs
@@ -11,6 +11,7 @@ pub(super) const RESOLVE_CONTEXT_SH: &str = include_str!("../runtime/resolve-con
 pub(super) const DISPOSABLE_LOCAL_DB_SH: &str = include_str!("../runtime/disposable-local-db.sh");
 pub(super) const BENCH_HELPER_SH: &str = include_str!("../runtime/bench-helper.sh");
 pub(super) const BENCH_HELPER_JS: &str = include_str!("../runtime/bench-helper.mjs");
+pub(super) const SETTINGS_SH: &str = include_str!("../runtime/settings.sh");
 
 #[cfg(test)]
 mod tests {
@@ -32,6 +33,7 @@ mod tests {
             DISPOSABLE_LOCAL_DB_SH,
             BENCH_HELPER_SH,
             BENCH_HELPER_JS,
+            SETTINGS_SH,
         ] {
             assert!(!content.trim().is_empty());
         }

--- a/crates/homeboy-extension/src/runtime_helper/tests.rs
+++ b/crates/homeboy-extension/src/runtime_helper/tests.rs
@@ -90,6 +90,18 @@ fn declared_helper_is_content_addressed_and_reports_provenance() {
             std::fs::read_to_string(&provision[0].path).expect("helper contents"),
             assets::SETTINGS_SH
         );
+
+        std::fs::write(&provision[0].path, "tampered helper").expect("tamper helper");
+        let repaired = provision_declared_helpers(&[RuntimeHelperRequirement {
+            id: RUNTIME_SETTINGS_HELPER_ID.to_string(),
+            revision: Some(provision[0].revision.clone()),
+        }])
+        .expect("core replaces tampered content-addressed helper");
+        assert_eq!(repaired[0].path, provision[0].path);
+        assert_eq!(
+            std::fs::read_to_string(&repaired[0].path).expect("repaired helper contents"),
+            assets::SETTINGS_SH
+        );
     });
 }
 

--- a/crates/homeboy-extension/src/runtime_helper/tests.rs
+++ b/crates/homeboy-extension/src/runtime_helper/tests.rs
@@ -72,6 +72,48 @@ fn helper_path_resolves_by_filename_and_env_var() {
 }
 
 #[test]
+fn declared_helper_is_content_addressed_and_reports_provenance() {
+    with_isolated_home(|_| {
+        let requirement = RuntimeHelperRequirement {
+            id: RUNTIME_SETTINGS_HELPER_ID.to_string(),
+            revision: None,
+        };
+        let provision = provision_declared_helpers(&[requirement])
+            .expect("core materializes declared helper");
+
+        assert_eq!(provision.len(), 1);
+        assert_eq!(provision[0].env_var, RUNTIME_SETTINGS_HELPER_ENV);
+        assert_eq!(provision[0].source, "homeboy-core-embedded");
+        assert!(provision[0].revision.starts_with("sha256:"));
+        assert!(provision[0].path.contains(&provision[0].revision));
+        assert_eq!(
+            std::fs::read_to_string(&provision[0].path).expect("helper contents"),
+            assets::SETTINGS_SH
+        );
+    });
+}
+
+#[test]
+fn declared_helper_rejects_missing_or_incompatible_identity() {
+    with_isolated_home(|_| {
+        let missing = provision_declared_helpers(&[RuntimeHelperRequirement {
+            id: "missing-helper".to_string(),
+            revision: None,
+        }])
+        .expect_err("unknown identity must fail before execution");
+        assert!(missing.message.contains("not supplied by Homeboy core"));
+
+        let incompatible = provision_declared_helpers(&[RuntimeHelperRequirement {
+            id: RUNTIME_SETTINGS_HELPER_ID.to_string(),
+            revision: Some("sha256:incompatible".to_string()),
+        }])
+        .expect_err("revision mismatch must fail before execution");
+        assert!(incompatible.message.contains("requires revision"));
+        assert!(incompatible.message.contains("Homeboy core provides"));
+    });
+}
+
+#[test]
 fn runner_prelude_initializes_context_steps_trap_and_sidecar() {
     let dir = tempfile::tempdir().expect("tempdir");
     let runtime_dir = dir.path().join("runtime");


### PR DESCRIPTION
Fixes #9509

## Summary
- add a generic manifest-declared runtime helper contract for fuzz extensions
- materialize core helpers under immutable content-addressed paths and provide bounded path/provenance environment entries
- reject missing helper identities and incompatible pinned revisions before execution

## Verification
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `cargo test -p homeboy-extension runtime_helper`
- `cargo test -p homeboy-cli fuzz_` (145 passed; two existing shared-runner infrastructure-route tests failed outside this change)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode drafted substantive implementation and tests. Chris Huber remains responsible for review and every line.