### PR TITLE
fix(agent-task): preflight isolated gate toolchains

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -72,6 +72,10 @@ pub struct VerifyGateOptions {
     /// Declarative, non-secret process environment policy for every gate.
     #[serde(default)]
     pub gate_environment: AgentTaskGateEnvironmentPolicy,
+    /// Required tools initialized in the final isolated environment before a
+    /// provider can spend an execution budget.
+    #[serde(default)]
+    pub gate_toolchains: Vec<AgentTaskGateToolchainRequirement>,
     /// Explicit mappings for producer-owned diagnostic sidecars. Homeboy only
     /// consumes declared schemas and paths; producer semantics remain opaque.
     #[serde(default)]
@@ -106,10 +110,26 @@ pub struct AgentTaskGateEnvironmentPolicy {
     pub mode: AgentTaskGateEnvironmentMode,
     #[serde(default)]
     pub variables: BTreeMap<String, String>,
+    /// Explicit host environment sources retained for a required toolchain.
+    /// A source may include a relative suffix, for example `HOME/.toolchain`.
+    #[serde(default)]
+    pub preserve: BTreeMap<String, String>,
     #[serde(default)]
     pub isolate_home: bool,
     #[serde(default)]
     pub isolate_xdg: bool,
+}
+
+/// A required executable and its non-mutating initialization probe.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateToolchainRequirement {
+    pub command: String,
+    #[serde(default = "default_toolchain_probe_arguments")]
+    pub probe_arguments: Vec<String>,
+}
+
+fn default_toolchain_probe_arguments() -> Vec<String> {
+    vec!["--version".to_string()]
 }
 
 impl Default for AgentTaskGateEnvironmentPolicy {
@@ -117,6 +137,7 @@ impl Default for AgentTaskGateEnvironmentPolicy {
         Self {
             mode: AgentTaskGateEnvironmentMode::Inherit,
             variables: BTreeMap::new(),
+            preserve: BTreeMap::new(),
             isolate_home: true,
             isolate_xdg: true,
         }
@@ -155,6 +176,7 @@ impl Default for VerifyGateOptions {
             gate_heartbeat_interval_seconds: default_gate_heartbeat_interval_seconds(),
             rerun_completed_gates: false,
             gate_environment: AgentTaskGateEnvironmentPolicy::default(),
+            gate_toolchains: Vec::new(),
             gate_diagnostic_sidecars: Vec::new(),
         }
     }
@@ -218,6 +240,9 @@ pub struct AgentTaskGateEnvironment {
     pub mode: AgentTaskGateEnvironmentMode,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inherited: Vec<AgentTaskGateEnvironmentVariable>,
+    /// Explicit source mappings retained from the host for required tools.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub preserved: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sanitized: Vec<AgentTaskGateEnvironmentVariable>,
 }
@@ -232,6 +257,7 @@ impl AgentTaskGateEnvironment {
     fn is_empty(&self) -> bool {
         self.mode == AgentTaskGateEnvironmentMode::Inherit
             && self.inherited.is_empty()
+            && self.preserved.is_empty()
             && self.sanitized.is_empty()
     }
 
@@ -244,6 +270,7 @@ impl AgentTaskGateEnvironment {
         AgentTaskGateEnvironmentPolicy {
             mode: self.mode,
             variables,
+            preserve: self.preserved.clone(),
             isolate_home: self
                 .sanitized
                 .iter()
@@ -957,6 +984,11 @@ fn selected_gate_environment(
             value: value.clone(),
         });
     }
+    for (name, source) in &policy.preserve {
+        let value = preserved_environment_value(source)?;
+        values.insert(name.clone(), value);
+        report.preserved.insert(name.clone(), source.clone());
+    }
 
     let needs_scratch = policy.isolate_home || policy.isolate_xdg;
     let scratch = if needs_scratch && runtime_tmpdir.is_none() {
@@ -999,6 +1031,70 @@ fn selected_gate_environment(
         values,
         _scratch: scratch,
     })
+}
+
+fn preserved_environment_value(source: &str) -> Result<String> {
+    let (source_name, suffix) = source.split_once('/').unwrap_or((source, ""));
+    let value = std::env::var(source_name).map_err(|_| {
+        Error::validation_invalid_argument(
+            "gate_environment.preserve",
+            format!("declared gate environment source {source_name} is unavailable"),
+            Some(source.to_string()),
+            Some(vec![format!(
+                "Set {source_name} before Cook or replace this mapping with an available toolchain home."
+            )]),
+        )
+    })?;
+    Ok(if suffix.is_empty() {
+        value
+    } else {
+        PathBuf::from(value).join(suffix).display().to_string()
+    })
+}
+
+/// Validate declared tools in the exact environment candidate gates will use.
+/// This is deliberately generic: callers declare executables and environment
+/// mappings while extensions own language-specific discovery.
+pub(crate) fn preflight_gate_toolchains(
+    cwd: &Path,
+    policy: &AgentTaskGateEnvironmentPolicy,
+    requirements: &[AgentTaskGateToolchainRequirement],
+) -> Result<()> {
+    let selected_environment = selected_gate_environment(policy, None)?;
+    for requirement in requirements {
+        let mut process = Command::new(&requirement.command);
+        process
+            .args(&requirement.probe_arguments)
+            .current_dir(cwd)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        selected_environment.apply(&mut process);
+        let output = process.output().map_err(|error| {
+            Error::validation_invalid_argument(
+                "gate_toolchains",
+                format!(
+                    "gate toolchain preflight could not resolve or initialize `{}`: {error}",
+                    requirement.command
+                ),
+                Some(requirement.command.clone()),
+                Some(vec!["Declare the required toolchain environment with --gate-env-from NAME=SOURCE[/suffix], then retry Cook.".to_string()]),
+            )
+        })?;
+        if !output.status.success() {
+            return Err(Error::validation_invalid_argument(
+                "gate_toolchains",
+                format!(
+                    "gate toolchain preflight could not initialize `{}` (exit {}): {}",
+                    requirement.command,
+                    output.status.code().unwrap_or(1),
+                    text_tail(&String::from_utf8_lossy(&output.stderr), 5),
+                ),
+                Some(requirement.command.clone()),
+                Some(vec!["Declare the required toolchain environment with --gate-env-from NAME=SOURCE[/suffix], then retry Cook.".to_string()]),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn set_isolated_environment_variable(
@@ -1644,6 +1740,7 @@ mod tests {
         let policy = AgentTaskGateEnvironmentPolicy {
             mode: AgentTaskGateEnvironmentMode::Replace,
             variables: BTreeMap::from([("DECLARED_INPUT".to_string(), "kept".to_string())]),
+            preserve: BTreeMap::new(),
             isolate_home: false,
             isolate_xdg: false,
         };
@@ -1666,5 +1763,94 @@ mod tests {
         assert_eq!(report.environment.inherited.len(), 1);
         assert_eq!(report.environment.inherited[0].name, "DECLARED_INPUT");
         assert_eq!(report.environment.inherited[0].value, "kept");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn toolchain_preflight_preserves_only_declared_homes_for_cargo_on_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_MUTEX.lock().expect("env lock");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let original_home = tempfile::tempdir().expect("original home");
+        let cargo_bin = original_home.path().join(".cargo/bin");
+        fs::create_dir_all(&cargo_bin).expect("cargo bin");
+        let cargo = cargo_bin.join("cargo");
+        fs::write(
+            &cargo,
+            format!(
+                "#!/bin/sh\ntest \"$RUSTUP_HOME\" = \"{}/.rustup\" && test \"$CARGO_HOME\" = \"{}/.cargo\"\n",
+                original_home.path().display(),
+                original_home.path().display(),
+            ),
+        )
+        .expect("cargo probe");
+        let mut permissions = fs::metadata(&cargo).expect("cargo metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&cargo, permissions).expect("cargo executable");
+        let prior_home = std::env::var_os("HOME");
+        let prior_path = std::env::var_os("PATH");
+        std::env::set_var("HOME", original_home.path());
+        std::env::set_var("PATH", &cargo_bin);
+
+        let policy = AgentTaskGateEnvironmentPolicy {
+            preserve: BTreeMap::from([
+                ("RUSTUP_HOME".to_string(), "HOME/.rustup".to_string()),
+                ("CARGO_HOME".to_string(), "HOME/.cargo".to_string()),
+            ]),
+            ..AgentTaskGateEnvironmentPolicy::default()
+        };
+        let result = preflight_gate_toolchains(
+            workspace.path(),
+            &policy,
+            &[AgentTaskGateToolchainRequirement {
+                command: "cargo".to_string(),
+                probe_arguments: vec!["--version".to_string()],
+            }],
+        );
+
+        match prior_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match prior_path {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+        result.expect("declared cargo homes initialize the toolchain");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn toolchain_preflight_reports_generic_initialization_failures_without_code_feedback() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = ENV_MUTEX.lock().expect("env lock");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let bin = tempfile::tempdir().expect("bin");
+        let tool = bin.path().join("other-tool");
+        fs::write(&tool, "#!/bin/sh\necho unavailable >&2\nexit 7\n").expect("tool");
+        let mut permissions = fs::metadata(&tool).expect("tool metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tool, permissions).expect("tool executable");
+        let prior_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", bin.path());
+
+        let error = preflight_gate_toolchains(
+            workspace.path(),
+            &AgentTaskGateEnvironmentPolicy::default(),
+            &[AgentTaskGateToolchainRequirement {
+                command: "other-tool".to_string(),
+                probe_arguments: vec!["initialize".to_string()],
+            }],
+        )
+        .expect_err("unusable declared toolchain fails preflight");
+
+        match prior_path {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+        assert!(error.message.contains("gate toolchain preflight"));
+        assert!(!error.message.contains("Fix the code"));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -163,6 +163,27 @@ impl VerifyGateOptions {
     pub fn gate_heartbeat_interval(&self) -> Duration {
         Duration::from_secs(self.gate_heartbeat_interval_seconds.max(1))
     }
+
+    /// Commands already declared as gates are toolchain requirements too. This
+    /// protects existing Cook invocations without duplicate CLI ceremony.
+    pub(crate) fn required_toolchains(&self) -> Vec<AgentTaskGateToolchainRequirement> {
+        let mut requirements = self.gate_toolchains.clone();
+        for gate in self.verify.iter().chain(&self.private_verify) {
+            let Some(command) = gate.split_whitespace().next() else {
+                continue;
+            };
+            if !requirements
+                .iter()
+                .any(|requirement| requirement.command == command)
+            {
+                requirements.push(AgentTaskGateToolchainRequirement {
+                    command: command.to_string(),
+                    probe_arguments: default_toolchain_probe_arguments(),
+                });
+            }
+        }
+        requirements
+    }
 }
 
 impl Default for VerifyGateOptions {
@@ -1059,8 +1080,9 @@ pub(crate) fn preflight_gate_toolchains(
     cwd: &Path,
     policy: &AgentTaskGateEnvironmentPolicy,
     requirements: &[AgentTaskGateToolchainRequirement],
+    runtime_tmpdir: Option<&Path>,
 ) -> Result<()> {
-    let selected_environment = selected_gate_environment(policy, None)?;
+    let selected_environment = selected_gate_environment(policy, runtime_tmpdir)?;
     for requirement in requirements {
         let mut process = Command::new(&requirement.command);
         process
@@ -1765,6 +1787,33 @@ mod tests {
         assert_eq!(report.environment.inherited[0].value, "kept");
     }
 
+    #[test]
+    fn existing_gate_commands_are_automatic_toolchain_requirements() {
+        let options = VerifyGateOptions {
+            verify: vec!["cargo test --lib".to_string()],
+            private_verify: vec!["npm test".to_string()],
+            gate_toolchains: vec![AgentTaskGateToolchainRequirement {
+                command: "cargo".to_string(),
+                probe_arguments: vec!["metadata".to_string()],
+            }],
+            ..VerifyGateOptions::default()
+        };
+
+        assert_eq!(
+            options.required_toolchains(),
+            vec![
+                AgentTaskGateToolchainRequirement {
+                    command: "cargo".to_string(),
+                    probe_arguments: vec!["metadata".to_string()],
+                },
+                AgentTaskGateToolchainRequirement {
+                    command: "npm".to_string(),
+                    probe_arguments: vec!["--version".to_string()],
+                },
+            ]
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn toolchain_preflight_preserves_only_declared_homes_for_cargo_on_path() {
@@ -1807,6 +1856,7 @@ mod tests {
                 command: "cargo".to_string(),
                 probe_arguments: vec!["--version".to_string()],
             }],
+            None,
         );
 
         match prior_home {
@@ -1843,6 +1893,7 @@ mod tests {
                 command: "other-tool".to_string(),
                 probe_arguments: vec!["initialize".to_string()],
             }],
+            None,
         )
         .expect_err("unusable declared toolchain fails preflight");
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -206,6 +206,9 @@ fn candidate_adoption_recovery(phase: &str) -> Option<serde_json::Value> {
 }
 
 fn pre_execution_failure_classification(error: &Error) -> AgentTaskFailureClassification {
+    if error.details["pre_execution_phase"] == "gate_toolchain_preflight" {
+        return AgentTaskFailureClassification::CapabilityMissing;
+    }
     if error.retryable == Some(true) {
         AgentTaskFailureClassification::Transient
     } else {

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1655,7 +1655,16 @@ fn run_promotion_gate(
         }
     };
     let supervision = GATE_SUPERVISION.with(|slot| slot.borrow().clone());
-    let result = if let Some(supervision) = supervision.as_deref() {
+    // Pre-dispatch validation protects provider budget. Recheck in this exact
+    // runtime because every gate receives its own isolated HOME/XDG directory.
+    let result = if let Err(error) = crate::agent_task_gate::preflight_gate_toolchains(
+        worktree_path,
+        &options.gates.gate_environment,
+        &options.gates.required_toolchains(),
+        Some(&runtime_tmpdir.context().tmp_dir),
+    ) {
+        Err(error)
+    } else if let Some(supervision) = supervision.as_deref() {
         crate::agent_task_gate::run_gate_command_with_supervision(
             worktree_path,
             index,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1600,6 +1600,28 @@ where
     validate_cook_workspace(&options)?;
     validate_cook_candidate_group(&options.initial_plan)?;
     materialize_initial_cook_attempt(&options)?;
+    let gate_workspace = options.source_worktree_path.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace",
+            "Cook requires a workspace before gate toolchain preflight",
+            Some(options.to_worktree.clone()),
+            None,
+        )
+    })?;
+    if let Err(error) = crate::agent_task_gate::preflight_gate_toolchains(
+        gate_workspace,
+        &options.gates.gate_environment,
+        &options.gates.gate_toolchains,
+    ) {
+        let error = with_pre_execution_phase(error, "gate_toolchain_preflight");
+        record_pre_execution_failure(
+            &options.initial_plan,
+            &options.initial_run_id,
+            &error,
+            "gate_toolchain_preflight",
+        )?;
+        return Err(error);
+    }
     if let Some(latest_attempt) = recipe.attempts.last() {
         materialize_cook_attempt(
             &recipe.cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1600,19 +1600,27 @@ where
     validate_cook_workspace(&options)?;
     validate_cook_candidate_group(&options.initial_plan)?;
     materialize_initial_cook_attempt(&options)?;
-    let gate_workspace = options.source_worktree_path.as_deref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "workspace",
-            "Cook requires a workspace before gate toolchain preflight",
-            Some(options.to_worktree.clone()),
-            None,
-        )
-    })?;
-    if let Err(error) = crate::agent_task_gate::preflight_gate_toolchains(
-        gate_workspace,
-        &options.gates.gate_environment,
-        &options.gates.gate_toolchains,
-    ) {
+    let required_toolchains = options.gates.required_toolchains();
+    let preflight = required_toolchains
+        .is_empty()
+        .then_some(Ok(()))
+        .unwrap_or_else(|| {
+            let gate_workspace = options.source_worktree_path.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace",
+                    "Cook requires a workspace before gate toolchain preflight",
+                    Some(options.to_worktree.clone()),
+                    None,
+                )
+            })?;
+            crate::agent_task_gate::preflight_gate_toolchains(
+                gate_workspace,
+                &options.gates.gate_environment,
+                &required_toolchains,
+                None,
+            )
+        });
+    if let Err(error) = preflight {
         let error = with_pre_execution_phase(error, "gate_toolchain_preflight");
         record_pre_execution_failure(
             &options.initial_plan,
@@ -1620,7 +1628,18 @@ where
             &error,
             "gate_toolchain_preflight",
         )?;
-        return Err(error);
+        return Ok(pre_execution_failure_report(
+            options.cook_id.clone(),
+            Vec::new(),
+            pre_execution_failure_details(
+                agent_task_lifecycle::exact_record(&options.initial_run_id)
+                    .ok()
+                    .as_ref(),
+                &error,
+            ),
+            error,
+            Some(&options.initial_run_id),
+        ));
     }
     if let Some(latest_attempt) = recipe.attempts.last() {
         materialize_cook_attempt(

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -245,8 +245,8 @@ pub mod gate {
         AgentTaskGateEnvironment, AgentTaskGateEnvironmentMode, AgentTaskGateEnvironmentPolicy,
         AgentTaskGateEnvironmentVariable, AgentTaskGateExecutionPolicy,
         AgentTaskGateFailureEvidence, AgentTaskGateReport, AgentTaskGateRevealPolicy,
-        AgentTaskGateStatus, AgentTaskGateVisibility, VerifyGateOptions,
-        AGENT_TASK_GATE_REPORT_SCHEMA,
+        AgentTaskGateStatus, AgentTaskGateToolchainRequirement, AgentTaskGateVisibility,
+        VerifyGateOptions, AGENT_TASK_GATE_REPORT_SCHEMA,
     };
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use homeboy::agents::agent_task_scheduler::AgentTaskCandidateCompletionPolicy;
 use homeboy::agents::agent_tasks::gate::{
     AgentTaskGateEnvironmentMode, AgentTaskGateEnvironmentPolicy, AgentTaskGateExecutionPolicy,
-    AgentTaskGateRevealPolicy, VerifyGateOptions,
+    AgentTaskGateRevealPolicy, AgentTaskGateToolchainRequirement, VerifyGateOptions,
 };
 
 use super::super::super::super::agent_task_dispatch::DispatchArgs;
@@ -68,6 +68,14 @@ pub struct VerifyGateArgs {
     /// Extra environment variable for gate commands, as `NAME=VALUE`. Repeatable.
     #[arg(long = "gate-env", value_name = "NAME=VALUE", value_parser = parse_gate_environment)]
     pub gate_environment: Vec<(String, String)>,
+    /// Preserve a required toolchain setting from the host as `NAME=SOURCE` or
+    /// `NAME=SOURCE/relative/path`. The mapping is retained in gate evidence.
+    #[arg(long = "gate-env-from", value_name = "NAME=SOURCE[/PATH]", value_parser = parse_gate_environment)]
+    pub gate_environment_preserve: Vec<(String, String)>,
+    /// Required executable to initialize before provider execution. Its probe is
+    /// `COMMAND --version` in the final isolated gate environment. Repeatable.
+    #[arg(long = "gate-toolchain", value_name = "COMMAND")]
+    pub gate_toolchains: Vec<String>,
     /// Run gates with an isolated `$HOME` so gate side effects do not touch the
     /// operator's home directory (default true).
     #[arg(
@@ -112,9 +120,21 @@ impl From<VerifyGateArgs> for VerifyGateOptions {
                     .gate_environment
                     .into_iter()
                     .collect::<BTreeMap<_, _>>(),
+                preserve: args
+                    .gate_environment_preserve
+                    .into_iter()
+                    .collect::<BTreeMap<_, _>>(),
                 isolate_home: args.isolate_gate_home,
                 isolate_xdg: args.isolate_gate_xdg,
             },
+            gate_toolchains: args
+                .gate_toolchains
+                .into_iter()
+                .map(|command| AgentTaskGateToolchainRequirement {
+                    command,
+                    probe_arguments: vec!["--version".to_string()],
+                })
+                .collect(),
             gate_diagnostic_sidecars: Vec::new(),
         }
     }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -678,6 +678,8 @@ struct BatchCookSpec {
     rerun_completed_gates: bool,
     #[serde(default)]
     gate_environment: AgentTaskGateEnvironmentPolicy,
+    #[serde(default)]
+    gate_toolchains: Vec<homeboy::agents::agent_tasks::gate::AgentTaskGateToolchainRequirement>,
     #[serde(default = "default_max_attempts")]
     max_attempts: u32,
     #[serde(default)]
@@ -822,6 +824,7 @@ impl BatchCookSpec {
                     gate_heartbeat_interval_seconds: self.gate_heartbeat_interval_seconds,
                     rerun_completed_gates: self.rerun_completed_gates,
                     gate_environment: self.gate_environment.clone(),
+                    gate_toolchains: self.gate_toolchains.clone(),
                     gate_diagnostic_sidecars: Vec::new(),
                 },
                 max_attempts: self.max_attempts,
@@ -979,6 +982,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
             gate_heartbeat_interval_seconds: args.gates.gate_heartbeat_interval_seconds,
             rerun_completed_gates: args.gates.rerun_completed_gates,
             gate_environment: VerifyGateOptions::from(args.gates.clone()).gate_environment,
+            gate_toolchains: VerifyGateOptions::from(args.gates.clone()).gate_toolchains,
             max_attempts: default_max_attempts(),
             no_finalize: false,
             base: args.base.clone(),


### PR DESCRIPTION
## Summary
- preflight declared and existing verification commands before provider dispatch, without requiring duplicate `--gate-toolchain` flags
- record unavailable toolchains as non-retryable `CapabilityMissing` pre-execution failures with zero provider executions consumed
- rerun command initialization in each final isolated promotion-gate runtime
- retain explicit host environment mappings for toolchain homes; Rust-owned mappings are supplied by https://github.com/Extra-Chill/homeboy-extensions/pull/2426

Fixes #9840

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents agent_task_gate::tests::toolchain_preflight --lib`
- `cargo test -p homeboy-agents existing_gate_commands_are_automatic_toolchain_requirements --lib`

## AI assistance
- Model: OpenAI gpt-5.6-terra
- Tool: OpenCode via Kimaki
- Used for: independent PR review, implementation of identified defects, and focused test coverage. Chris remains responsible for every line.