### PR TITLE
fix(daemon): bound compacted replay memory

### DIFF
--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -2,6 +2,7 @@ use clap::{Args, Subcommand};
 use homeboy::cli_surface::current_command_surface_doctor_report;
 use homeboy::core::build_identity;
 use homeboy::core::engine;
+use homeboy::core::{api_jobs::JobStore, paths};
 use homeboy::runner::runners::{self as runner, Runner, RunnerKind, RunnerStatusReport};
 use homeboy_upgrade::self_status::{self, ControllerRuntimeInput, RunnerRuntimeInput};
 use serde_json::Value;
@@ -116,6 +117,13 @@ pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
                     serde_json::to_value(host_resources)
                         .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?,
                 );
+                let daemon_memory_owners = paths::daemon_jobs_file()
+                    .and_then(JobStore::retained_owner_report_at_path)
+                    .unwrap_or_else(|error| serde_json::json!({
+                        "error": error.to_string(),
+                        "guidance": "Inspect the daemon job store before restarting the controller."
+                    }));
+                object.insert("daemon_memory_owners".to_string(), daemon_memory_owners);
             }
             Ok((json, exit_code))
         }

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -9,7 +10,7 @@ use uuid::Uuid;
 
 use super::remote_runner::RemoteRunnerJobRequest;
 use super::store::{DurableJobStore, StoredJob};
-use super::types::{JobEvent, JobEventKind, JobStatus};
+use super::types::{Job, JobEvent, JobEventKind, JobStatus};
 use crate::error::{Error, Result};
 
 pub(super) const DEFAULT_EVENT_RETENTION_LIMIT: usize = 1000;
@@ -19,6 +20,139 @@ pub(super) const DEFAULT_TERMINAL_JOB_RETENTION_LIMIT: usize = 1000;
 /// Bound terminal history independently of active jobs, whose recovery records
 /// must remain durable until they reach a terminal state.
 pub(super) const DEFAULT_TERMINAL_JOB_RETENTION_BYTES: usize = 4 * 1024 * 1024;
+
+/// A compacted key is permanent exactly-once evidence. It intentionally carries
+/// no request or event payload. Controller tombstones retain only their existing
+/// safe terminal job projection so lost-response retries stay observable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ReplayTombstone {
+    pub(super) kind: ReplayTombstoneKind,
+    pub(super) key: String,
+    pub(super) fingerprint: String,
+    pub(super) job_id: Uuid,
+    /// Controller callers need the safe terminal status projection to make a
+    /// lost-response retry observable. Remote runner tombstones omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) terminal_job: Option<Job>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ReplayTombstoneKind {
+    RemoteRunner,
+    Controller,
+}
+
+pub(super) fn tombstone_path(path: &Path) -> std::path::PathBuf {
+    path.with_file_name(format!(
+        "{}.replay-tombstones.jsonl",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("jobs.json")
+    ))
+}
+
+/// Stream the sidecar so permanent identities do not become daemon-resident
+/// state. A malformed record is a fail-closed store corruption, never absence.
+pub(super) fn lookup_tombstone(
+    path: &Path,
+    kind: ReplayTombstoneKind,
+    key: &str,
+) -> Result<Option<ReplayTombstone>> {
+    let path = tombstone_path(path);
+    let file = match fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", path.display())),
+            ))
+        }
+    };
+    let mut found = None;
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        let tombstone: ReplayTombstone = serde_json::from_str(&line)
+            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+        if tombstone.kind == kind && tombstone.key == key {
+            found = Some(tombstone);
+        }
+    }
+    Ok(found)
+}
+
+/// The journal is synced before the compacted primary store is atomically
+/// replaced. A crash can retain an extra rejection, but can never forget an
+/// accepted key and replay it as new work.
+pub(super) fn write_durable_store_with_tombstones(
+    path: &Path,
+    durable: &mut DurableJobStore,
+) -> Result<()> {
+    let mut tombstones = Vec::new();
+    for (key, submission) in std::mem::take(&mut durable.expired_submission_keys) {
+        tombstones.push(ReplayTombstone {
+            kind: ReplayTombstoneKind::RemoteRunner,
+            key,
+            fingerprint: submission.fingerprint,
+            job_id: submission.job_id,
+            terminal_job: None,
+        });
+    }
+    for (key, submission) in std::mem::take(&mut durable.expired_controller_submissions) {
+        tombstones.push(ReplayTombstone {
+            kind: ReplayTombstoneKind::Controller,
+            key,
+            fingerprint: submission.fingerprint,
+            job_id: submission.job_id,
+            terminal_job: submission.terminal_job,
+        });
+    }
+    if !tombstones.is_empty() {
+        let journal = tombstone_path(path);
+        if let Some(parent) = journal.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("create {}", parent.display())),
+                )
+            })?;
+        }
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&journal)
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("open {}", journal.display())),
+                )
+            })?;
+        for tombstone in tombstones {
+            serde_json::to_writer(&mut file, &tombstone).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize replay tombstone".to_string()),
+                )
+            })?;
+            file.write_all(b"\n").map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("write {}", journal.display())),
+                )
+            })?;
+        }
+        file.sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("sync {}", journal.display())),
+            )
+        })?;
+    }
+    write_durable_store(path, durable)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct JobStoreCompactionEvidence {
@@ -235,7 +369,6 @@ pub(super) fn compact_terminal_jobs(
     );
     Some(evidence)
 }
-
 #[cfg(test)]
 pub(super) fn reconcile_stale_jobs(
     durable: &mut DurableJobStore,

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::persistence::{apply_event_retention, job_not_found, timestamp_ms, validate_transition};
+use super::persistence::{
+    apply_event_retention, job_not_found, lookup_tombstone, timestamp_ms, validate_transition,
+    write_durable_store_with_tombstones, ReplayTombstoneKind,
+};
 use super::store::{JobStore, RemoteRunnerSubmission, StoredJob};
 use super::types::{Job, JobEvent, JobEventKind, JobStatus};
 use crate::engine::command::CommandCaptureMetadata;
@@ -556,6 +559,30 @@ impl JobStore {
                     }),
                 ));
             }
+            if let Some(expired) = self
+                .persistence
+                .as_ref()
+                .map(|persistence| {
+                    lookup_tombstone(
+                        &persistence.path,
+                        ReplayTombstoneKind::RemoteRunner,
+                        submission_key,
+                    )
+                })
+                .transpose()?
+                .flatten()
+            {
+                return Err(Error::new(
+                    ErrorCode::ValidationInvalidArgument,
+                    "remote runner submission key has expired with its retained job evidence",
+                    serde_json::json!({
+                        "schema": "homeboy/remote-runner-submission-expired/v1",
+                        "submission_key": submission_key,
+                        "payload_fingerprint": expired.fingerprint,
+                        "expired_job_id": expired.job_id,
+                    }),
+                ));
+            }
         }
         let job = Job {
             id: Uuid::new_v4(),
@@ -638,7 +665,7 @@ impl JobStore {
         // snapshot. This is the admission commit point used by lost-response
         // recovery and daemon restart replay.
         if let Some(persistence) = &self.persistence {
-            let durable = super::store::DurableJobStore {
+            let mut durable = super::store::DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 submission_keys: inner.submission_keys.clone(),
                 expired_submission_keys: inner.expired_submission_keys.clone(),
@@ -646,7 +673,7 @@ impl JobStore {
                 expired_controller_submissions: inner.expired_controller_submissions.clone(),
                 compaction: inner.compaction.clone(),
             };
-            if let Err(error) = super::persistence::write_durable_store(&persistence.path, &durable)
+            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
             {
                 inner.jobs.remove(&job.id);
                 if let Some(submission_key) = request.submission_key() {

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -11,9 +11,10 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::persistence::{
-    apply_event_retention, compact_terminal_jobs, job_not_found, timestamp_ms, validate_transition,
-    write_durable_store, JobStoreCompactionEvidence, DEFAULT_EVENT_RETENTION_LIMIT,
-    DEFAULT_TERMINAL_JOB_RETENTION_BYTES, DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
+    apply_event_retention, compact_terminal_jobs, job_not_found, lookup_tombstone, timestamp_ms,
+    validate_transition, write_durable_store_with_tombstones, JobStoreCompactionEvidence,
+    ReplayTombstoneKind, DEFAULT_EVENT_RETENTION_LIMIT, DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
+    DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
 };
 #[cfg(test)]
 use super::persistence::{read_durable_store, reconcile_stale_jobs};
@@ -243,6 +244,83 @@ impl JobStore {
                         .is_none_or(|lease| lease.expires_at_ms > now)
             })
             .count())
+    }
+
+    /// Report the durable owners that a daemon would retain after opening this
+    /// store. Tombstone identities remain on disk and are deliberately excluded
+    /// from resident owner counts.
+    pub fn retained_owner_report_at_path(path: impl Into<PathBuf>) -> Result<Value> {
+        let path = path.into();
+        if !path.exists() {
+            return Ok(serde_json::json!({
+                "jobs": { "count": 0, "bytes": 0, "active_count": 0, "terminal_count": 0 },
+                "live_submission_keys": { "count": 0, "bytes": 0 },
+                "legacy_expired_submission_keys": { "count": 0, "bytes": 0 },
+                "replay_tombstone_journal": { "count": 0, "bytes": 0, "resident": false },
+            }));
+        }
+        let content = fs::read_to_string(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        let durable: DurableJobStore = serde_json::from_str(&content)
+            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+        let job_bytes = durable
+            .jobs
+            .iter()
+            .map(|job| {
+                serde_json::to_vec(job)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or(0)
+            })
+            .sum::<usize>();
+        let active_count = durable
+            .jobs
+            .iter()
+            .filter(|job| !job.job.status.is_terminal())
+            .count();
+        let terminal_count = durable.jobs.len() - active_count;
+        let live_submission_keys =
+            durable.submission_keys.len() + durable.controller_submissions.len();
+        let live_submission_bytes = serde_json::to_vec(&durable.submission_keys)
+            .unwrap_or_default()
+            .len()
+            + serde_json::to_vec(&durable.controller_submissions)
+                .unwrap_or_default()
+                .len();
+        let legacy_count =
+            durable.expired_submission_keys.len() + durable.expired_controller_submissions.len();
+        let legacy_bytes = serde_json::to_vec(&durable.expired_submission_keys)
+            .unwrap_or_default()
+            .len()
+            + serde_json::to_vec(&durable.expired_controller_submissions)
+                .unwrap_or_default()
+                .len();
+        let journal = super::persistence::tombstone_path(&path);
+        let (journal_count, journal_bytes) = match fs::File::open(&journal) {
+            Ok(file) => {
+                use std::io::BufRead;
+                let count = std::io::BufReader::new(file).lines().count();
+                (
+                    count,
+                    fs::metadata(&journal)
+                        .map(|metadata| metadata.len())
+                        .unwrap_or(0),
+                )
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => (0, 0),
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read {}", journal.display())),
+                ))
+            }
+        };
+        Ok(serde_json::json!({
+            "jobs": { "count": durable.jobs.len(), "bytes": job_bytes, "active_count": active_count, "terminal_count": terminal_count },
+            "live_submission_keys": { "count": live_submission_keys, "bytes": live_submission_bytes },
+            "legacy_expired_submission_keys": { "count": legacy_count, "bytes": legacy_bytes },
+            "replay_tombstone_journal": { "count": journal_count, "bytes": journal_bytes, "resident": false },
+        }))
     }
 
     #[cfg(test)]
@@ -1081,7 +1159,7 @@ impl JobStore {
             stored.job.finished_at_ms = Some(now);
         }
         if let Some(persistence) = &self.persistence {
-            let durable = DurableJobStore {
+            let mut durable = DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 submission_keys: inner.submission_keys.clone(),
                 expired_submission_keys: inner.expired_submission_keys.clone(),
@@ -1089,7 +1167,8 @@ impl JobStore {
                 expired_controller_submissions: inner.expired_controller_submissions.clone(),
                 compaction: inner.compaction.clone(),
             };
-            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
+            {
                 *inner.jobs.get_mut(&job_id).expect("controller job exists") = prior;
                 return Err(error);
             }
@@ -1284,7 +1363,8 @@ impl JobStore {
                 persistence.terminal_job_retention_limit,
                 persistence.terminal_job_retention_bytes,
             );
-            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
+            {
                 *inner = prior;
                 return Err(error);
             }
@@ -1392,6 +1472,32 @@ impl JobStore {
                 None,
             ));
         }
+        if let Some(tombstone) = self
+            .persistence
+            .as_ref()
+            .map(|persistence| {
+                lookup_tombstone(
+                    &persistence.path,
+                    ReplayTombstoneKind::Controller,
+                    &idempotency_key,
+                )
+            })
+            .transpose()?
+            .flatten()
+        {
+            if tombstone.fingerprint != fingerprint {
+                return Err(controller_idempotency_conflict(&idempotency_key));
+            }
+            if let Some(job) = tombstone.terminal_job {
+                return Ok(ControllerJobSubmissionOutcome::Existing(job));
+            }
+            return Err(Error::validation_invalid_argument(
+                "idempotency_key",
+                "controller idempotency key belongs to compacted terminal work; choose a new key for a new attempt",
+                Some(idempotency_key),
+                None,
+            ));
+        }
         let job = Job {
             id: Uuid::new_v4(),
             operation,
@@ -1446,7 +1552,7 @@ impl JobStore {
         // Persist the initial event, job, and submission index as one admission
         // commit. Roll back memory on failure so retries cannot observe a ghost.
         if let Some(persistence) = &self.persistence {
-            let durable = DurableJobStore {
+            let mut durable = DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 submission_keys: inner.submission_keys.clone(),
                 expired_submission_keys: inner.expired_submission_keys.clone(),
@@ -1454,7 +1560,8 @@ impl JobStore {
                 expired_controller_submissions: inner.expired_controller_submissions.clone(),
                 compaction: inner.compaction.clone(),
             };
-            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
+            {
                 inner.jobs.remove(&job_id);
                 inner.controller_submissions.remove(&idempotency_key);
                 return Err(error);
@@ -1542,7 +1649,7 @@ impl JobStore {
         stored.job.updated_at_ms = timestamp_ms();
         let controller = controller.clone();
         if let Some(persistence) = &self.persistence {
-            let durable = DurableJobStore {
+            let mut durable = DurableJobStore {
                 jobs: inner.jobs.values().cloned().collect(),
                 submission_keys: inner.submission_keys.clone(),
                 expired_submission_keys: inner.expired_submission_keys.clone(),
@@ -1550,7 +1657,8 @@ impl JobStore {
                 expired_controller_submissions: inner.expired_controller_submissions.clone(),
                 compaction: inner.compaction.clone(),
             };
-            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
+            {
                 *inner.jobs.get_mut(&job_id).expect("controller job exists") = prior;
                 return Err(error);
             }
@@ -2029,7 +2137,8 @@ impl JobStore {
                 persistence.terminal_job_retention_limit,
                 persistence.terminal_job_retention_bytes,
             );
-            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
+            {
                 inner.jobs.insert(job_id, prior);
                 return Err(error);
             }
@@ -2310,7 +2419,8 @@ impl JobStore {
                 persistence.terminal_job_retention_limit,
                 persistence.terminal_job_retention_bytes,
             );
-            if let Err(error) = write_durable_store(&persistence.path, &durable) {
+            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
+            {
                 *inner.jobs.get_mut(&job_id).expect("job exists") = prior;
                 return Err(error);
             }
@@ -2412,7 +2522,7 @@ impl JobStore {
             self.terminal_job_retention_limit(),
             self.terminal_job_retention_bytes(),
         );
-        write_durable_store(&persistence.path, &durable)?;
+        write_durable_store_with_tombstones(&persistence.path, &mut durable)?;
         inner.jobs = durable
             .jobs
             .iter()

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1356,15 +1356,17 @@ fn compacted_submission_key_expires_without_creating_a_duplicate() {
         requests.push((key.to_string(), request));
     }
     store.persist().expect("compact terminal jobs");
-    let expired_key = store
-        .inner
-        .lock()
-        .expect("store")
-        .expired_submission_keys
-        .keys()
-        .next()
-        .cloned()
-        .expect("compacted submission tombstone");
+    let expired_key = "agent-task:v1:compact-one".to_string();
+    assert!(super::super::persistence::tombstone_path(&path).exists());
+    assert!(
+        store
+            .inner
+            .lock()
+            .expect("store")
+            .expired_submission_keys
+            .is_empty(),
+        "expired identities are not daemon-resident"
+    );
     let request = requests
         .into_iter()
         .find_map(|(key, request)| (key == expired_key).then_some(request))
@@ -1377,6 +1379,102 @@ fn compacted_submission_key_expires_without_creating_a_duplicate() {
         json!("homeboy/remote-runner-submission-expired/v1")
     );
     assert_eq!(store.list().len(), 1);
+}
+
+#[test]
+fn replay_tombstones_keep_terminal_payload_memory_bounded_across_restart() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_with_retention(&path, 3, 1).expect("durable store");
+    let mut first = None;
+    for index in 0..128 {
+        let key = format!("agent-task:v1:soak-{index}");
+        let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+        request.metadata = Some(json!({ "submission_key": key }));
+        request.command.push("x".repeat(32_000));
+        let job = store
+            .submit_remote_runner_job(request.clone())
+            .expect("submit");
+        store
+            .inner
+            .lock()
+            .expect("store")
+            .jobs
+            .get_mut(&job.id)
+            .expect("job")
+            .job
+            .status = JobStatus::Succeeded;
+        store.persist().expect("compact terminal job");
+        if index == 0 {
+            first = Some(request);
+        }
+    }
+    assert_eq!(
+        store.list().len(),
+        1,
+        "only the retained payload stays resident"
+    );
+    assert!(store
+        .inner
+        .lock()
+        .expect("store")
+        .expired_submission_keys
+        .is_empty());
+    assert!(fs::metadata(&path).expect("jobs metadata").len() < 40_000);
+
+    let restarted = JobStore::open_with_retention(&path, 3, 1).expect("restart");
+    assert_eq!(restarted.list().len(), 1);
+    let error = restarted
+        .submit_remote_runner_job(first.expect("first request"))
+        .expect_err("compacted accepted key stays rejected after restart");
+    assert_eq!(
+        error.details["schema"],
+        json!("homeboy/remote-runner-submission-expired/v1")
+    );
+}
+
+#[test]
+fn corrupt_replay_tombstone_journal_fails_closed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_with_retention(&path, 3, 1).expect("durable store");
+    let mut first = remote_runner_request("homeboy-lab", Some("extrachill"));
+    first.metadata = Some(json!({ "submission_key": "agent-task:v1:corrupt-one" }));
+    let job = store.submit_remote_runner_job(first).expect("submit");
+    store
+        .inner
+        .lock()
+        .expect("store")
+        .jobs
+        .get_mut(&job.id)
+        .expect("job")
+        .job
+        .status = JobStatus::Succeeded;
+    store.persist().expect("persist first");
+    let mut second = remote_runner_request("homeboy-lab", Some("extrachill"));
+    second.metadata = Some(json!({ "submission_key": "agent-task:v1:corrupt-two" }));
+    let second_job = store
+        .submit_remote_runner_job(second)
+        .expect("submit second");
+    store
+        .inner
+        .lock()
+        .expect("store")
+        .jobs
+        .get_mut(&second_job.id)
+        .expect("job")
+        .job
+        .status = JobStatus::Succeeded;
+    store.persist().expect("compact first");
+    fs::write(
+        super::super::persistence::tombstone_path(&path),
+        "not json\n",
+    )
+    .expect("corrupt journal");
+    let restarted = JobStore::open_with_retention(&path, 3, 1).expect("restart");
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({ "submission_key": "agent-task:v1:any-key" }));
+    assert!(restarted.submit_remote_runner_job(request).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #10122.

- Move compacted idempotency identities out of the daemon-resident JobStore maps into a durable fsynced replay-tombstone journal.
- Preserve remote-runner exactly-once rejection and controller lost-response terminal projections after compaction and restart.
- Add `self doctor.daemon_memory_owners` counts/bytes for retained jobs, live keys, legacy maps, and the non-resident tombstone journal.

## Retention, Atomicity, And Compatibility

- Tombstone schema: `kind`, `key`, `fingerprint`, `job_id`, plus controller-only safe terminal job projection. Request and event payloads are omitted.
- Compaction appends and syncs tombstones before atomically replacing `jobs.json`; a crash may conservatively retain an extra rejection but cannot forget an accepted key.
- Existing `expired_*` JSON maps are read compatibly and migrated into the journal on the next durable write.
- A malformed journal fails submission closed rather than treating identities as absent.

## Evidence

Before: every compacted accepted key remained in `expired_submission_keys` / `expired_controller_submissions` in the in-memory daemon store, including controller terminal projections.

After: a 128-submission soak with an added 32 KB payload per submission retains one full terminal job in memory and keeps `jobs.json` below 40 KB; the first compacted key remains rejected after restart. Tombstone journal identities are explicitly asserted absent from the resident expired map.

## Tests

- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-core replay_tombstone --no-fail-fast`
- `cargo test -p homeboy-core controller_job_retry_after_compaction_returns_tombstoned_terminal_projection --no-fail-fast`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode drafted the tombstone journal, observability, and focused tests. Chris Huber remains responsible for every line.