### PR TITLE
Bound prepared Lab source cache retention

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -131,7 +131,8 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     )?;
 
     // Begin runner-agnostic overhead accounting (#3001). Each setup phase
-    // (selection, preflight, workspace sync, output parse, artifact import) is
+    // (selection, preflight, source materialization, dependency hydration,
+    // admission, artifact import) is
     // timed independently so reports can separate `lab_overhead_ms` from the
     // workload command duration, regardless of runner transport.
     let mut overhead = LabOffloadOverhead::start();

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1926,7 +1926,6 @@ pub(crate) fn run_lab_offload_inner(
         "status": synced.workspace_cleanliness,
         "allow_dirty_lab_workspace": request.allow_dirty_lab_workspace,
     });
-    attach_lab_offload_overhead(&mut lab_metadata, &overhead);
     lab_metadata["lab_host_telemetry"] = host_telemetry.before_metadata();
     let secret_env_delta = secret_env_handoff
         .env_delta
@@ -2031,6 +2030,9 @@ pub(crate) fn run_lab_offload_inner(
             },
         },
     });
+    // Admission is the final setup step before handing metadata to the runner.
+    // Attach now so the published setup total includes every completed phase.
+    attach_lab_offload_overhead(&mut lab_metadata, &overhead);
     exec_lab_context(LabDispatchExecutionContext {
         request: &request,
         selection: &selection,

--- a/crates/homeboy-lab-runner/src/lab/offload/overhead.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/overhead.rs
@@ -38,8 +38,6 @@ pub(crate) enum LabOffloadPhase {
     Command,
     /// Importing artifacts / structured-output files back from the runner.
     ArtifactImport,
-    /// Reaping the job-owned view. Immutable preparation is never reaped here.
-    Cleanup,
 }
 
 impl LabOffloadPhase {
@@ -53,13 +51,12 @@ impl LabOffloadPhase {
             LabOffloadPhase::DependencyHydration => "dependency_hydration",
             LabOffloadPhase::Command => "command",
             LabOffloadPhase::ArtifactImport => "artifact_import",
-            LabOffloadPhase::Cleanup => "cleanup",
         }
     }
 
     /// The setup phases in canonical order, used to render a stable per-phase
     /// duration map even when some phases were never reached.
-    pub(crate) const fn overhead_phases() -> [LabOffloadPhase; 7] {
+    pub(crate) const fn overhead_phases() -> [LabOffloadPhase; 6] {
         [
             LabOffloadPhase::Selection,
             LabOffloadPhase::Preflight,
@@ -67,7 +64,6 @@ impl LabOffloadPhase {
             LabOffloadPhase::SourceMaterialization,
             LabOffloadPhase::DependencyHydration,
             LabOffloadPhase::ArtifactImport,
-            LabOffloadPhase::Cleanup,
         ]
     }
 }
@@ -119,7 +115,6 @@ pub(crate) struct LabOffloadOverhead {
     dependency_hydration: Option<Duration>,
     command: Option<Duration>,
     artifact_import: Option<Duration>,
-    cleanup: Option<Duration>,
     attempted: AttemptedSelection,
     fallback_reason: Option<String>,
 }
@@ -139,7 +134,6 @@ impl LabOffloadOverhead {
             LabOffloadPhase::DependencyHydration => &mut self.dependency_hydration,
             LabOffloadPhase::Command => &mut self.command,
             LabOffloadPhase::ArtifactImport => &mut self.artifact_import,
-            LabOffloadPhase::Cleanup => &mut self.cleanup,
         }
     }
 
@@ -194,7 +188,6 @@ impl LabOffloadOverhead {
             LabOffloadPhase::DependencyHydration => &self.dependency_hydration,
             LabOffloadPhase::Command => &self.command,
             LabOffloadPhase::ArtifactImport => &self.artifact_import,
-            LabOffloadPhase::Cleanup => &self.cleanup,
         }
     }
 

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -57,6 +57,9 @@ const METADATA_SSH_RECOVERY_ATTEMPTS: usize = 2;
 const WORKSPACE_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_METADATA_OUTPUT_LIMIT: usize = 4 * 1024;
 const WORKSPACE_PRUNE_TIMEOUT: Duration = Duration::from_secs(30);
+// Prepared sources include hydrated dependency trees, so retain a small fixed
+// working set instead of making every historical commit permanent runner state.
+const PREPARED_SOURCE_CACHE_MAX_ENTRIES: usize = 8;
 
 pub fn sync_workspace(
     runner_id: &str,
@@ -427,8 +430,8 @@ pub fn sync_workspace(
                 &local_path,
                 &remote_path,
                 RunnerWorkspaceSyncMode::Git,
-                None,
-                None,
+                materialization_plan.actual_materialization_mode.as_deref(),
+                materialization_plan.fallback_reason.as_deref(),
                 &git.head,
                 &excludes,
                 None,
@@ -510,10 +513,13 @@ pub(crate) fn save_prepared_source_cache(
     let local_path = canonical_workspace_path(local_path)?;
     let commit = git_output(&local_path, &["rev-parse", "HEAD"])?;
     let cache = prepared_source_cache_path(workspace_root, &local_path, &commit);
+    let cache_root = prepared_source_cache_root(workspace_root);
     let command = format!(
-        "cache={cache}; source={source}; lock=\"$cache.lock\"; mkdir -p \"$(dirname \"$cache\")\"; test -f \"$cache/.homeboy/prepared-source-ready\" && exit 0; mkdir \"$lock\" 2>/dev/null || exit 0; trap 'rmdir \"$lock\"' EXIT; tmp=\"$cache.tmp.$$\"; rm -rf \"$tmp\"; cp -a \"$source\" \"$tmp\"; mkdir -p \"$tmp/.homeboy\"; : > \"$tmp/.homeboy/prepared-source-ready\"; chmod -R a-w \"$tmp\"; mv \"$tmp\" \"$cache\"",
+        "cache={cache}; cache_root={cache_root}; source={source}; lock=\"$cache.lock\"; mkdir -p \"$cache_root\"; test -f \"$cache/.homeboy/prepared-source-ready\" || {{ mkdir \"$lock\" 2>/dev/null || exit 0; trap 'rmdir \"$lock\"' EXIT; tmp=\"$cache.tmp.$$\"; rm -rf \"$tmp\"; cp -a \"$source\" \"$tmp\"; mkdir -p \"$tmp/.homeboy\"; : > \"$tmp/.homeboy/prepared-source-ready\"; chmod -R a-w \"$tmp\"; mv \"$tmp\" \"$cache\"; }}; kept=0; ls -1dt \"$cache_root\"/* 2>/dev/null | while IFS= read -r candidate; do test -f \"$candidate/.homeboy/prepared-source-ready\" || continue; if [ \"$kept\" -lt {max_entries} ]; then kept=$((kept + 1)); continue; fi; test -e \"$candidate.lock\" && continue; ls \"$candidate\".lease.* >/dev/null 2>&1 && continue; chmod -R u+w \"$candidate\" && rm -rf \"$candidate\"; done",
         cache = shell::quote_arg(&cache),
+        cache_root = shell::quote_arg(&cache_root),
         source = shell::quote_arg(remote_path),
+        max_entries = PREPARED_SOURCE_CACHE_MAX_ENTRIES,
     );
     run_workspace_shell_command(&runner, &command, "save prepared Lab source cache")
 }
@@ -524,8 +530,12 @@ fn prepared_source_cache_path(workspace_root: &str, local_path: &Path, commit: &
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("workspace");
+    format!("{}/{name}", prepared_source_cache_root(workspace_root))
+}
+
+fn prepared_source_cache_root(workspace_root: &str) -> String {
     format!(
-        "{}/_lab_prepared_sources/{name}",
+        "{}/_lab_prepared_sources",
         workspace_root.trim_end_matches('/')
     )
 }
@@ -536,7 +546,7 @@ fn materialize_prepared_source_view(
     remote_path: &str,
 ) -> Result<bool> {
     let command = format!(
-        "test -f {cache}/.homeboy/prepared-source-ready && test ! -e {destination} && mkdir -p $(dirname {destination}) && cp -a {cache} {destination} && chmod -R u+w {destination}",
+        "cache={cache}; destination={destination}; test -f \"$cache/.homeboy/prepared-source-ready\" && test ! -e \"$destination\" || exit 1; lease=\"$cache.lease.$$\"; : > \"$lease\" || exit 1; trap 'rm -f \"$lease\"' EXIT HUP INT TERM; test -f \"$cache/.homeboy/prepared-source-ready\" && mkdir -p \"$(dirname \"$destination\")\" && cp -a \"$cache\" \"$destination\" && chmod -R u+w \"$destination\" || {{ rm -rf \"$destination\"; exit 1; }}",
         cache = shell::quote_arg(cache),
         destination = shell::quote_arg(remote_path),
     );

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -432,6 +432,18 @@ fn same_commit_prepared_source_cache_creates_private_job_views() {
                 .as_deref(),
             Some("prepared_source_view")
         );
+        assert!(second.materialization_plan.controller_git_bundle.is_none());
+        let second_metadata: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(
+                std::path::Path::new(&second.remote_path).join(".homeboy/runner-workspace.json"),
+            )
+            .expect("second workspace metadata"),
+        )
+        .expect("parse second workspace metadata");
+        assert_eq!(
+            second_metadata["actual_materialization_mode"],
+            "prepared_source_view"
+        );
         assert!(std::path::Path::new(&second.remote_path)
             .join("dependency-marker")
             .is_file());
@@ -450,6 +462,64 @@ fn same_commit_prepared_source_cache_creates_private_job_views() {
             .expect("prepared cache directory")
             .next()
             .is_some());
+    });
+}
+
+#[test]
+fn prepared_source_cache_retains_a_bounded_completed_working_set() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root");
+        create_local_runner("lab-local-prepared-cache-retention", runner_root.path());
+        let source = git_source(
+            "homeboy@prepared-cache-retention",
+            "fix/prepared-cache",
+            "one\n",
+        );
+        git(
+            source.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://example.test/prepared-cache-retention.git",
+            ],
+        );
+        let mut options = sync_options(
+            source.path().display().to_string(),
+            Some("job-0".to_string()),
+        );
+        options.mode = RunnerWorkspaceSyncMode::Git;
+        options.controller_routed_git = true;
+
+        for index in 0..=8 {
+            fs::write(source.path().join("file.txt"), format!("source-{index}\n"))
+                .expect("update source");
+            git(source.path(), &["add", "."]);
+            git(source.path(), &["commit", "-m", &format!("source {index}")]);
+            options.run_isolation_token = Some(format!("job-{index}"));
+            let (synced, _) = sync_workspace("lab-local-prepared-cache-retention", options.clone())
+                .expect("materialize source");
+            save_prepared_source_cache(
+                "lab-local-prepared-cache-retention",
+                &synced.local_path,
+                &synced.remote_path,
+            )
+            .expect("save prepared cache");
+        }
+
+        let cache_root = runner_root.path().join("_lab_prepared_sources");
+        let completed = cache_root
+            .read_dir()
+            .expect("prepared cache root")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .path()
+                    .join(".homeboy/prepared-source-ready")
+                    .is_file()
+            })
+            .count();
+        assert_eq!(completed, 8);
     });
 }
 


### PR DESCRIPTION
## Summary

Follow-up to merged #10200 and issue #10120 after independent review.

- bounds completed prepared-source caches to eight entries per runner workspace root
- preserves active copy leases during pruning and evicts only inactive entries
- cleans partial destination views after failed cache copies
- records `prepared_source_view` provenance in workspace metadata
- publishes setup timing after admission without claiming an unmeasured cleanup phase

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner prepared_source_cache`
- `cargo test -p homeboy-lab-runner overhead_total_excludes_workload_and_sums_setup_phases`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode independently reviewed the Lab cache implementation, identified unbounded retention, lease, partial-copy, metadata, and timing defects, implemented corrections, and added deterministic coverage. Chris Huber remains responsible for the change.