### PR TITLE
Harden local Cook owner reconciliation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -198,79 +198,109 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
     let runner_id = record.runner_id().map(str::to_string);
     let runner_job_id = record.runner_job_id().map(str::to_string);
 
-    let cancelled_at = now_timestamp();
-    let was_stale_running = record.state == AgentTaskRunState::Running;
-    record.updated_at = Some(cancelled_at.clone());
-    set_run_state(&mut record, AgentTaskRunState::Cancelled);
-    for task in &mut record.tasks {
-        if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
-            task.state = AgentTaskState::Cancelled;
+    // The provider can publish its terminal reservation after the initial read
+    // above. Make the final decision under the record mutation lock so a late
+    // success is either observed here or cancellation wins before it can be
+    // imported; never overwrite an already durable success.
+    let record = store::mutate_record(&record.run_id, |record| {
+        // An aggregate or runner projection may have finished after the live
+        // cancellation transport returned. Its terminal state is authoritative.
+        if record.state.is_terminal() {
+            return false;
         }
-    }
+        if record.state == AgentTaskRunState::Running
+            && !record.is_runner_backed()
+            && record.metadata["provider_executions"]
+                .as_array()
+                .is_some_and(|executions| {
+                    executions
+                        .iter()
+                        .any(|execution| execution["state"] == json!("succeeded"))
+                })
+        {
+            record.ensure_metadata_object().insert(
+                "cancellation_deferred_for_terminal_provider".to_string(),
+                json!({ "requested_at": now_timestamp(), "reason": reason.unwrap_or("cancel requested") }),
+            );
+            return true;
+        }
 
-    let metadata = record.ensure_metadata_object();
-    terminalize_running_provider_executions(metadata, &cancelled_at);
-    metadata.insert("cancelled_at".to_string(), json!(cancelled_at));
-    metadata.insert("cancelled_by_pid".to_string(), json!(std::process::id()));
-    metadata.insert(
-        "cancel_reason".to_string(),
-        json!(reason.unwrap_or("cancel requested")),
-    );
-    metadata.remove("live_cancellation");
-    metadata.remove("live_cancellation_unsupported");
-    match cancellation {
-        LiveCancellationOutcome::Terminated(termination) => {
-            metadata.insert(
-                "live_cancellation".to_string(),
-                json!({
-                    "owner_pid": termination.owner_pid,
-                    "descendant_pids": termination.descendant_pids,
-                    "signalled_pids": termination.signalled_pids,
-                    "signal": termination.signal,
-                    "killed_pids": termination.killed_pids,
-                    "surviving_pids": termination.surviving_pids,
-                    "recovery_commands": termination.recovery_commands,
-                }),
-            );
+        let cancelled_at = now_timestamp();
+        let was_stale_running = record.state == AgentTaskRunState::Running;
+        record.updated_at = Some(cancelled_at.clone());
+        set_run_state(record, AgentTaskRunState::Cancelled);
+        for task in &mut record.tasks {
+            if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+                task.state = AgentTaskState::Cancelled;
+            }
         }
-        LiveCancellationOutcome::RunnerJobCancelled { job, events } => {
-            metadata.insert(
-                "live_cancellation".to_string(),
-                json!({
-                    "runner_id": runner_id,
-                    "runner_job_id": runner_job_id,
-                    "runner_job_status": job.status,
-                    "runner_job_events": events,
-                    "cancellation": "runner_job_cancel",
-                }),
-            );
-        }
-        LiveCancellationOutcome::Unsupported(unsupported) => {
-            metadata.insert(
-                "live_cancellation_unsupported".to_string(),
-                json!({
-                    "reason": unsupported.reason,
-                    "owner_pid": unsupported.owner_pid,
-                    "runner_id": unsupported.runner_id,
-                    "runner_job_id": unsupported.runner_job_id,
-                    "recovery_commands": unsupported.recovery_commands,
-                }),
-            );
-        }
-        LiveCancellationOutcome::NotRunning => {}
-    }
-    if was_stale_running {
+
+        let metadata = record.ensure_metadata_object();
+        terminalize_running_provider_executions(metadata, &cancelled_at);
+        metadata.insert("cancelled_at".to_string(), json!(cancelled_at));
+        metadata.insert("cancelled_by_pid".to_string(), json!(std::process::id()));
         metadata.insert(
-            METADATA_KEY_CANCELLED_STALE_RUNNING.to_string(),
-            json!(true),
+            "cancel_reason".to_string(),
+            json!(reason.unwrap_or("cancel requested")),
         );
+        metadata.remove("live_cancellation");
+        metadata.remove("live_cancellation_unsupported");
+        match &cancellation {
+            LiveCancellationOutcome::Terminated(termination) => {
+                metadata.insert(
+                    "live_cancellation".to_string(),
+                    json!({
+                        "owner_pid": termination.owner_pid,
+                        "descendant_pids": termination.descendant_pids,
+                        "signalled_pids": termination.signalled_pids,
+                        "signal": termination.signal,
+                        "killed_pids": termination.killed_pids,
+                        "surviving_pids": termination.surviving_pids,
+                        "recovery_commands": termination.recovery_commands,
+                    }),
+                );
+            }
+            LiveCancellationOutcome::RunnerJobCancelled { job, events } => {
+                metadata.insert(
+                    "live_cancellation".to_string(),
+                    json!({
+                        "runner_id": runner_id,
+                        "runner_job_id": runner_job_id,
+                        "runner_job_status": job.status,
+                        "runner_job_events": events,
+                        "cancellation": "runner_job_cancel",
+                    }),
+                );
+            }
+            LiveCancellationOutcome::Unsupported(unsupported) => {
+                metadata.insert(
+                    "live_cancellation_unsupported".to_string(),
+                    json!({
+                        "reason": unsupported.reason,
+                        "owner_pid": unsupported.owner_pid,
+                        "runner_id": unsupported.runner_id,
+                        "runner_job_id": unsupported.runner_job_id,
+                        "recovery_commands": unsupported.recovery_commands,
+                    }),
+                );
+            }
+            LiveCancellationOutcome::NotRunning => {}
+        }
+        if was_stale_running {
+            metadata.insert(
+                METADATA_KEY_CANCELLED_STALE_RUNNING.to_string(),
+                json!(true),
+            );
+        }
+        metadata.remove(METADATA_KEY_STALE_RUNNING);
+        metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
+        true
+    })?
+    .unwrap_or(store::read_record(&record.run_id)?);
+    if record.state == AgentTaskRunState::Cancelled {
+        crate::controller_scratch::finalize_run(&record.run_id)?;
+        homeboy_core::controller_runtime::cancel_admission(&record.run_id)?;
     }
-    metadata.remove(METADATA_KEY_STALE_RUNNING);
-    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
-
-    store::write_record(&record)?;
-    crate::controller_scratch::finalize_run(&record.run_id)?;
-    homeboy_core::controller_runtime::cancel_admission(&record.run_id)?;
     Ok(record)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -893,14 +893,16 @@ fn reconcile_local_provider_ownership(record: &mut AgentTaskRunRecord) -> bool {
         return false;
     };
 
-    let mut has_running = false;
+    let mut has_reconcilable_execution = false;
     let mut has_live_owner = false;
+    let mut has_unverifiable_owner = false;
     let mut has_succeeded = false;
     let mut recovery_identity = Vec::new();
     for execution in executions.iter_mut() {
         match execution["state"].as_str() {
-            Some("running") => {
-                has_running = true;
+            Some("running") | Some("succeeded") => {
+                has_reconcilable_execution = true;
+                has_succeeded |= execution["state"] == json!("succeeded");
                 recovery_identity.push(execution["owner_identity"].clone());
                 let identity_state = execution
                     .get("owner_pid")
@@ -918,6 +920,14 @@ fn reconcile_local_provider_ownership(record: &mut AgentTaskRunRecord) -> bool {
                     identity_state,
                     Some(homeboy_core::process::ProcessIdentityState::Live)
                 );
+                has_unverifiable_owner |= !matches!(
+                    identity_state,
+                    Some(
+                        homeboy_core::process::ProcessIdentityState::Live
+                            | homeboy_core::process::ProcessIdentityState::Dead
+                            | homeboy_core::process::ProcessIdentityState::IdentityMismatch
+                    )
+                );
                 execution["owner_state"] = json!(match identity_state {
                     Some(homeboy_core::process::ProcessIdentityState::Live) => "live",
                     Some(homeboy_core::process::ProcessIdentityState::Dead) => "dead",
@@ -927,14 +937,16 @@ fn reconcile_local_provider_ownership(record: &mut AgentTaskRunRecord) -> bool {
                 });
                 has_live_owner |= live;
             }
-            Some("succeeded") => has_succeeded = true,
             _ => {}
         }
     }
-    if has_live_owner {
+    // Older records predate per-provider ownership, and non-Linux hosts can be
+    // unable to verify a persisted identity. Neither is proof that the owner
+    // died, so retain the joinable run instead of terminalizing it on a read.
+    if has_live_owner || has_unverifiable_owner {
         return true;
     }
-    if !has_running && !has_succeeded {
+    if !has_reconcilable_execution {
         return false;
     }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2059,16 +2059,69 @@ fn status_keeps_live_local_provider_owner_running_idempotently() {
 }
 
 #[test]
+fn status_does_not_terminalize_a_live_owner_after_provider_success() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("owner-live-late-import")).expect("submitted");
+        mark_running("owner-live-late-import").expect("running");
+        reserve_provider_execution("owner-live-late-import", &plan.tasks[0], 1).expect("reserved");
+        record_provider_execution_terminal("owner-live-late-import", "task-a", 1, "succeeded")
+            .expect("provider success recorded");
+
+        let record = status("owner-live-late-import").expect("status before aggregate import");
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(
+            record.metadata["provider_executions"][0]["owner_state"],
+            json!("live")
+        );
+    });
+}
+
+#[test]
+fn legacy_provider_reservation_without_owner_proof_remains_joinable() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("owner-legacy")).expect("submitted");
+        mark_running("owner-legacy").expect("running");
+        reserve_provider_execution("owner-legacy", &plan.tasks[0], 1).expect("reserved");
+        rewrite_record_for_test("owner-legacy", |record| {
+            let execution = record.metadata["provider_executions"][0]
+                .as_object_mut()
+                .expect("provider execution object");
+            execution.remove("owner_pid");
+            execution.remove("owner_linux_starttime_ticks");
+            execution.remove("owner_identity");
+        })
+        .expect("legacy reservation fixture");
+
+        let record = status("owner-legacy").expect("legacy status");
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(
+            record.metadata["provider_executions"][0]["owner_state"],
+            json!("unverifiable")
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
 fn dead_local_provider_owner_terminalizes_running_reservation_once() {
     with_isolated_home(|_| {
         let plan = test_plan();
         submit_plan(&plan, Some("owner-dead")).expect("submitted");
         mark_running("owner-dead").expect("running");
         reserve_provider_execution("owner-dead", &plan.tasks[0], 1).expect("reserved");
+        let mut owner = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("start provider owner");
         rewrite_record_for_test("owner-dead", |record| {
-            record.metadata["provider_executions"][0]["owner_pid"] = json!(u32::MAX);
+            record.metadata["provider_executions"][0]["owner_pid"] = json!(owner.id());
+            record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = Value::Null;
         })
-        .expect("dead owner fixture");
+        .expect("provider owner fixture");
+        owner.kill().expect("interrupt provider owner");
+        owner.wait().expect("reap provider owner");
 
         let terminal = status("owner-dead").expect("reconciled status");
         let replay = status("owner-dead").expect("idempotent status");
@@ -2085,6 +2138,7 @@ fn dead_local_provider_owner_terminalizes_running_reservation_once() {
     });
 }
 
+#[cfg(unix)]
 #[test]
 fn dead_owner_preserves_late_provider_success_as_recoverable_candidate() {
     with_isolated_home(|_| {
@@ -2094,10 +2148,17 @@ fn dead_owner_preserves_late_provider_success_as_recoverable_candidate() {
         reserve_provider_execution("owner-late-success", &plan.tasks[0], 1).expect("reserved");
         record_provider_execution_terminal("owner-late-success", "task-a", 1, "succeeded")
             .expect("provider success recorded");
+        let mut owner = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("start provider owner");
         rewrite_record_for_test("owner-late-success", |record| {
-            record.metadata["provider_executions"][0]["owner_pid"] = json!(u32::MAX);
+            record.metadata["provider_executions"][0]["owner_pid"] = json!(owner.id());
+            record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = Value::Null;
         })
-        .expect("dead owner fixture");
+        .expect("provider owner fixture");
+        owner.kill().expect("interrupt provider owner");
+        owner.wait().expect("reap provider owner");
 
         let recovered = status("owner-late-success").expect("recovered status");
         assert_eq!(recovered.state, AgentTaskRunState::CandidateRecoverable);

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2103,6 +2103,29 @@ fn legacy_provider_reservation_without_owner_proof_remains_joinable() {
     });
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn pid_starttime_mismatch_reclaims_a_reused_provider_pid_without_signalling_it() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("owner-pid-reused")).expect("submitted");
+        mark_running("owner-pid-reused").expect("running");
+        reserve_provider_execution("owner-pid-reused", &plan.tasks[0], 1).expect("reserved");
+        rewrite_record_for_test("owner-pid-reused", |record| {
+            record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = json!(0);
+        })
+        .expect("reused PID fixture");
+
+        let record = status("owner-pid-reused").expect("reconcile PID reuse");
+        assert_eq!(record.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            record.metadata["provider_executions"][0]["owner_state"],
+            json!("identity_mismatch")
+        );
+        assert!(homeboy_core::process::pid_is_running(std::process::id()));
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn dead_local_provider_owner_terminalizes_running_reservation_once() {


### PR DESCRIPTION
## Summary

Follow-up to merged #10201 and issue #10183 after independent review.

- fails closed for legacy records without verifiable owner proof
- preserves live owners while provider success awaits aggregate import
- makes cancellation terminalization atomic with durable provider state
- covers real killed/reaped child processes and Linux PID reuse

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents --lib owner -- --nocapture`
- `cargo test -p homeboy-agents --lib cancellation_race_defers_to_a_durable_provider_success -- --nocapture`
- `cargo check -p homeboy-agents -p homeboy-cli`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode independently reviewed the local Cook ownership implementation, identified legacy-proof, late-success, cancellation, and PID-reuse defects, implemented fixes, and strengthened behavioral tests. Chris Huber remains responsible for the change.