### PR TITLE
Format runtime helper contract import

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/fuzz_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/fuzz_config.rs
@@ -1,8 +1,8 @@
 //! Fuzz workload manifest config types.
 
+use crate::runtime_helper::RuntimeHelperRequirement;
 use homeboy_lifecycle_contract::LifecycleContract;
 use serde::{Deserialize, Serialize};
-use crate::runtime_helper::RuntimeHelperRequirement;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct FuzzConfig {


### PR DESCRIPTION
## Summary

Follow-up to merged #10202 after exact CI remediation.

- applies the required Rustfmt import order for the runtime-helper contract
- preserves the verified core/extension helper behavior unchanged

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-extension declared_helper_is_content_addressed_and_reports_provenance`
- `cargo test -p homeboy-cli fuzz_contract_exposes_only_declared_core_helper_environment`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the exact CI failure, reproduced it, applied the formatter correction, and reran focused interoperability tests. Chris Huber remains responsible for the change.