### PR TITLE
Index compacted daemon replay tombstones

### DIFF
--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
@@ -45,6 +46,15 @@ pub(super) enum ReplayTombstoneKind {
 
 pub(super) fn tombstone_path(path: &Path) -> std::path::PathBuf {
     path.with_file_name(format!(
+        "{}.replay-tombstones.sqlite",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("jobs.json")
+    ))
+}
+
+fn legacy_tombstone_path(path: &Path) -> std::path::PathBuf {
+    path.with_file_name(format!(
         "{}.replay-tombstones.jsonl",
         path.file_name()
             .and_then(|name| name.to_str())
@@ -52,41 +62,230 @@ pub(super) fn tombstone_path(path: &Path) -> std::path::PathBuf {
     ))
 }
 
-/// Stream the sidecar so permanent identities do not become daemon-resident
-/// state. A malformed record is a fail-closed store corruption, never absence.
+fn tombstone_kind_name(kind: ReplayTombstoneKind) -> &'static str {
+    match kind {
+        ReplayTombstoneKind::RemoteRunner => "remote_runner",
+        ReplayTombstoneKind::Controller => "controller",
+    }
+}
+
+fn tombstone_error(path: &Path, operation: &str, error: rusqlite::Error) -> Error {
+    Error::internal_io(
+        error.to_string(),
+        Some(format!("{operation} {}", path.display())),
+    )
+}
+
+fn open_tombstone_store(path: &Path) -> Result<Connection> {
+    let journal = tombstone_path(path);
+    if let Some(parent) = journal.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    let connection = Connection::open(&journal)
+        .map_err(|error| tombstone_error(&journal, "open replay tombstone index", error))?;
+    connection
+        .busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(|error| tombstone_error(&journal, "configure replay tombstone index", error))?;
+    connection
+        .execute_batch(
+            "PRAGMA journal_mode=DELETE; PRAGMA synchronous=FULL;
+             CREATE TABLE IF NOT EXISTS replay_tombstones (
+                 kind TEXT NOT NULL,
+                 key TEXT NOT NULL,
+                 fingerprint TEXT NOT NULL,
+                 job_id TEXT NOT NULL,
+                 terminal_job TEXT,
+                 PRIMARY KEY (kind, key)
+             );",
+        )
+        .map_err(|error| tombstone_error(&journal, "initialize replay tombstone index", error))?;
+    Ok(connection)
+}
+
+fn insert_tombstone(
+    connection: &Connection,
+    path: &Path,
+    tombstone: &ReplayTombstone,
+) -> Result<()> {
+    let journal = tombstone_path(path);
+    let terminal_job = tombstone
+        .terminal_job
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize replay tombstone".to_string()),
+            )
+        })?;
+    let changed = connection
+        .execute(
+            "INSERT OR IGNORE INTO replay_tombstones (kind, key, fingerprint, job_id, terminal_job)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                tombstone_kind_name(tombstone.kind),
+                tombstone.key,
+                tombstone.fingerprint,
+                tombstone.job_id.to_string(),
+                terminal_job,
+            ],
+        )
+        .map_err(|error| tombstone_error(&journal, "insert replay tombstone", error))?;
+    if changed == 0 {
+        let existing =
+            lookup_tombstone_in_connection(connection, path, tombstone.kind, &tombstone.key)?
+                .expect("existing replay tombstone must be readable");
+        let expected = serde_json::to_value(tombstone).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize replay tombstone".to_string()),
+            )
+        })?;
+        let actual = serde_json::to_value(existing).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize replay tombstone".to_string()),
+            )
+        })?;
+        if actual != expected {
+            return Err(Error::internal_unexpected(
+                "replay tombstone index contains conflicting exactly-once evidence",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Migrate the short-lived JSONL format introduced by this branch before any
+/// lookup. Renaming only after the SQLite transaction commits makes a crash
+/// repeat migration safely instead of ever treating an accepted key as absent.
+pub(super) fn prepare_tombstone_store(path: &Path) -> Result<()> {
+    let legacy = legacy_tombstone_path(path);
+    if !legacy.exists() {
+        return Ok(());
+    }
+    let connection = open_tombstone_store(path)?;
+    let transaction = connection.unchecked_transaction().map_err(|error| {
+        tombstone_error(
+            &tombstone_path(path),
+            "begin replay tombstone migration",
+            error,
+        )
+    })?;
+    let file = fs::File::open(&legacy).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read {}", legacy.display())),
+        )
+    })?;
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", legacy.display())),
+            )
+        })?;
+        let tombstone: ReplayTombstone = serde_json::from_str(&line)
+            .map_err(|error| Error::config_invalid_json(legacy.display().to_string(), error))?;
+        insert_tombstone(&transaction, path, &tombstone)?;
+    }
+    transaction.commit().map_err(|error| {
+        tombstone_error(
+            &tombstone_path(path),
+            "commit replay tombstone migration",
+            error,
+        )
+    })?;
+    fs::rename(&legacy, legacy.with_extension("jsonl.migrated")).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("migrate {}", legacy.display())),
+        )
+    })
+}
+
+fn lookup_tombstone_in_connection(
+    connection: &Connection,
+    path: &Path,
+    kind: ReplayTombstoneKind,
+    key: &str,
+) -> Result<Option<ReplayTombstone>> {
+    let journal = tombstone_path(path);
+    let row = connection
+        .query_row(
+            "SELECT fingerprint, job_id, terminal_job FROM replay_tombstones WHERE kind = ?1 AND key = ?2",
+            params![tombstone_kind_name(kind), key],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, Option<String>>(2)?)),
+        )
+        .optional()
+        .map_err(|error| tombstone_error(&journal, "lookup replay tombstone", error))?;
+    row.map(|(fingerprint, job_id, terminal_job)| {
+        Ok(ReplayTombstone {
+            kind,
+            key: key.to_string(),
+            fingerprint,
+            job_id: Uuid::parse_str(&job_id).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read {}", journal.display())),
+                )
+            })?,
+            terminal_job: terminal_job
+                .map(|value| {
+                    serde_json::from_str(&value).map_err(|error| {
+                        Error::config_invalid_json(journal.display().to_string(), error)
+                    })
+                })
+                .transpose()?,
+        })
+    })
+    .transpose()
+}
+
+/// SQLite's primary key provides bounded indexed lookup and an atomic durable
+/// commit. A damaged index is a fail-closed store corruption, never absence.
 pub(super) fn lookup_tombstone(
     path: &Path,
     kind: ReplayTombstoneKind,
     key: &str,
 ) -> Result<Option<ReplayTombstone>> {
-    let path = tombstone_path(path);
-    let file = match fs::File::open(&path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => {
-            return Err(Error::internal_io(
-                error.to_string(),
-                Some(format!("read {}", path.display())),
-            ))
-        }
-    };
-    let mut found = None;
-    for line in BufReader::new(file).lines() {
-        let line = line.map_err(|error| {
-            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
-        })?;
-        let tombstone: ReplayTombstone = serde_json::from_str(&line)
-            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
-        if tombstone.kind == kind && tombstone.key == key {
-            found = Some(tombstone);
-        }
-    }
-    Ok(found)
+    prepare_tombstone_store(path)?;
+    let connection = open_tombstone_store(path)?;
+    lookup_tombstone_in_connection(&connection, path, kind, key)
 }
 
-/// The journal is synced before the compacted primary store is atomically
-/// replaced. A crash can retain an extra rejection, but can never forget an
-/// accepted key and replay it as new work.
+pub(super) fn tombstone_store_report(path: &Path) -> Result<(usize, u64)> {
+    prepare_tombstone_store(path)?;
+    let journal = tombstone_path(path);
+    if !journal.exists() {
+        return Ok((0, 0));
+    }
+    let connection = open_tombstone_store(path)?;
+    let count = connection
+        .query_row("SELECT COUNT(*) FROM replay_tombstones", [], |row| {
+            row.get(0)
+        })
+        .map_err(|error| tombstone_error(&journal, "count replay tombstones", error))?;
+    let bytes = fs::metadata(&journal)
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", journal.display())),
+            )
+        })?
+        .len();
+    Ok((count, bytes))
+}
+
+/// The indexed tombstone transaction commits before the compacted primary store
+/// is atomically replaced. A crash can retain an extra rejection, but can never
+/// forget an accepted key and replay it as new work.
 pub(super) fn write_durable_store_with_tombstones(
     path: &Path,
     durable: &mut DurableJobStore,
@@ -111,8 +310,7 @@ pub(super) fn write_durable_store_with_tombstones(
         });
     }
     if !tombstones.is_empty() {
-        let journal = tombstone_path(path);
-        if let Some(parent) = journal.parent() {
+        if let Some(parent) = tombstone_path(path).parent() {
             fs::create_dir_all(parent).map_err(|error| {
                 Error::internal_io(
                     error.to_string(),
@@ -120,34 +318,23 @@ pub(super) fn write_durable_store_with_tombstones(
                 )
             })?;
         }
-        let mut file = fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&journal)
-            .map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some(format!("open {}", journal.display())),
-                )
-            })?;
+        prepare_tombstone_store(path)?;
+        let connection = open_tombstone_store(path)?;
+        let transaction = connection.unchecked_transaction().map_err(|error| {
+            tombstone_error(
+                &tombstone_path(path),
+                "begin replay tombstone commit",
+                error,
+            )
+        })?;
         for tombstone in tombstones {
-            serde_json::to_writer(&mut file, &tombstone).map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("serialize replay tombstone".to_string()),
-                )
-            })?;
-            file.write_all(b"\n").map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some(format!("write {}", journal.display())),
-                )
-            })?;
+            insert_tombstone(&transaction, path, &tombstone)?;
         }
-        file.sync_all().map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some(format!("sync {}", journal.display())),
+        transaction.commit().map_err(|error| {
+            tombstone_error(
+                &tombstone_path(path),
+                "commit replay tombstone index",
+                error,
             )
         })?;
     }
@@ -253,7 +440,19 @@ pub(super) fn write_durable_store(path: &Path, durable: &DurableJobStore) -> Res
                 path.display()
             )),
         )
-    })
+    })?;
+    // The file contents are synced above; syncing the directory makes the
+    // rename itself durable across a power loss on filesystems that require it.
+    #[cfg(unix)]
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("sync {}", parent.display())),
+            )
+        })?;
+    Ok(())
 }
 
 pub(super) fn compact_terminal_jobs(

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -584,7 +584,7 @@ impl JobStore {
                 ));
             }
         }
-        let job = Job {
+        let mut job = Job {
             id: Uuid::new_v4(),
             operation: request.operation.clone(),
             status: JobStatus::Queued,
@@ -639,6 +639,7 @@ impl JobStore {
             );
         }
         let mut evidence = run_ref_metadata.unwrap_or_else(|| serde_json::json!({}));
+        evidence["status"] = serde_json::json!("queued");
         if let (Some(submission_key), Some(fingerprint)) =
             (request.submission_key(), submission_fingerprint.as_deref())
         {
@@ -661,6 +662,8 @@ impl JobStore {
             data: Some(evidence),
         });
         stored.job.event_count = stored.events.len();
+        // Return the admitted projection, including the durable queued event.
+        job = stored.job.clone();
         // Persist job creation, queue evidence, and key index as one locked
         // snapshot. This is the admission commit point used by lost-response
         // recovery and daemon restart replay.

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -11,9 +11,10 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::persistence::{
-    apply_event_retention, compact_terminal_jobs, job_not_found, lookup_tombstone, timestamp_ms,
-    validate_transition, write_durable_store_with_tombstones, JobStoreCompactionEvidence,
-    ReplayTombstoneKind, DEFAULT_EVENT_RETENTION_LIMIT, DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
+    apply_event_retention, compact_terminal_jobs, job_not_found, lookup_tombstone,
+    prepare_tombstone_store, timestamp_ms, tombstone_store_report, validate_transition,
+    write_durable_store_with_tombstones, JobStoreCompactionEvidence, ReplayTombstoneKind,
+    DEFAULT_EVENT_RETENTION_LIMIT, DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
     DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
 };
 #[cfg(test)]
@@ -295,26 +296,7 @@ impl JobStore {
             + serde_json::to_vec(&durable.expired_controller_submissions)
                 .unwrap_or_default()
                 .len();
-        let journal = super::persistence::tombstone_path(&path);
-        let (journal_count, journal_bytes) = match fs::File::open(&journal) {
-            Ok(file) => {
-                use std::io::BufRead;
-                let count = std::io::BufReader::new(file).lines().count();
-                (
-                    count,
-                    fs::metadata(&journal)
-                        .map(|metadata| metadata.len())
-                        .unwrap_or(0),
-                )
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => (0, 0),
-            Err(error) => {
-                return Err(Error::internal_io(
-                    error.to_string(),
-                    Some(format!("read {}", journal.display())),
-                ))
-            }
-        };
+        let (journal_count, journal_bytes) = tombstone_store_report(&path)?;
         Ok(serde_json::json!({
             "jobs": { "count": durable.jobs.len(), "bytes": job_bytes, "active_count": active_count, "terminal_count": terminal_count },
             "live_submission_keys": { "count": live_submission_keys, "bytes": live_submission_bytes },
@@ -366,6 +348,7 @@ impl JobStore {
         terminal_job_retention_bytes: usize,
     ) -> Result<Self> {
         let path = path.into();
+        prepare_tombstone_store(&path)?;
         let mut durable = read_durable_store(&path)?;
         let event_retention_limit = event_retention_limit.max(1);
         let terminal_job_retention_limit = terminal_job_retention_limit.max(1);
@@ -410,6 +393,7 @@ impl JobStore {
     /// restart. Daemon lifecycle recovery must select ownership explicitly.
     pub fn open_without_reconciliation(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
+        prepare_tombstone_store(&path)?;
         let raw = fs::read(&path).unwrap_or_else(|error| {
             if error.kind() == std::io::ErrorKind::NotFound {
                 b"{\"jobs\":[]}".to_vec()
@@ -491,6 +475,7 @@ impl JobStore {
         terminal_job_retention_bytes: usize,
     ) -> Result<Self> {
         let path = path.into();
+        prepare_tombstone_store(&path)?;
         let mut durable: DurableJobStore = serde_json::from_slice(raw)
             .map_err(|err| Error::config_invalid_json(path.display().to_string(), err))?;
         let event_retention_limit = event_retention_limit.max(1);

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1478,6 +1478,39 @@ fn corrupt_replay_tombstone_journal_fails_closed() {
 }
 
 #[test]
+fn jsonl_replay_tombstones_migrate_before_restart_lookup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let legacy = path.with_file_name("jobs.json.replay-tombstones.jsonl");
+    let job_id = Uuid::new_v4();
+    let tombstone = super::super::persistence::ReplayTombstone {
+        kind: super::super::persistence::ReplayTombstoneKind::RemoteRunner,
+        key: "agent-task:v1:legacy".to_string(),
+        fingerprint: "sha256:legacy".to_string(),
+        job_id,
+        terminal_job: None,
+    };
+    fs::write(
+        &legacy,
+        format!(
+            "{}\n",
+            serde_json::to_string(&tombstone).expect("serialize legacy tombstone")
+        ),
+    )
+    .expect("write legacy journal");
+
+    let store = JobStore::open_with_retention(&path, 3, 1).expect("migrate legacy journal");
+    assert!(super::super::persistence::tombstone_path(&path).exists());
+    assert!(legacy.with_extension("jsonl.migrated").exists());
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({ "submission_key": "agent-task:v1:legacy" }));
+    let error = store
+        .submit_remote_runner_job(request)
+        .expect_err("migrated key remains exactly-once evidence");
+    assert_eq!(error.details["expired_job_id"], json!(job_id));
+}
+
+#[test]
 fn remote_runner_job_env_is_scoped_to_submitted_job() {
     let store = JobStore::default();
     let mut first = remote_runner_request("homeboy-lab", Some("extrachill"));

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1421,6 +1421,13 @@ fn replay_tombstones_keep_terminal_payload_memory_bounded_across_restart() {
         .expired_submission_keys
         .is_empty());
     assert!(fs::metadata(&path).expect("jobs metadata").len() < 40_000);
+    assert!(
+        fs::metadata(super::super::persistence::tombstone_path(&path))
+            .expect("tombstone index metadata")
+            .len()
+            < 128_000,
+        "128 compacted 32 KiB requests retain identity records, not 4 MiB of payloads"
+    );
 
     let restarted = JobStore::open_with_retention(&path, 3, 1).expect("restart");
     assert_eq!(restarted.list().len(), 1);


### PR DESCRIPTION
## Summary

Follow-up to merged #10204 and issue #10122 after independent persistence review.

- replaces the append-only JSONL replay journal with a SQLite primary-key tombstone index
- provides transactional writes, `synchronous=FULL`, bounded indexed lookup, corruption fail-closed behavior, and crash-safe one-time JSONL migration
- commits tombstones before atomic `jobs.json` replacement and fsyncs the parent directory
- reports exact indexed tombstone count/bytes without scanning history
- preserves terminal replay projections and remote duplicate rejection

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-core api_jobs --no-fail-fast`
- controller compaction/replay tests
- 128 x 32 KiB soak: one resident terminal job, `jobs.json < 40 KB`, tombstone index `< 128 KB`, old keys rejected after restart

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode independently reviewed the daemon compaction persistence design, identified critical linear lookup, disk growth, partial-write, fsync, projection, and diagnostics defects, implemented the indexed durable correction, and strengthened high-volume coverage. Chris Huber remains responsible for the change.