### PR TITLE
Preserve promotion provider stdin during startup

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -180,7 +180,11 @@ impl CliRuntime {
         // Recover completed generic runner-exec jobs before a mutating invocation
         // can evict their evidence. Read-only commands must not mutate durable
         // state during startup.
-        if command_capability == CommandCapability::Mutation {
+        if command_capability == CommandCapability::Mutation
+            && !normalized
+                .windows(2)
+                .any(|args| args == ["agent-task", "promotion-provider"])
+        {
             let _ = crate::runner::reconcile_terminal_runner_exec_runs();
         }
         // Register the runner daemon-exec driver so the daemon's /exec endpoint
@@ -464,6 +468,14 @@ impl CliRuntime {
             }
         }
 
+        // This internal provider's request is carried on process stdin. Execute
+        // it before generic routing or startup work can consume that stream.
+        if let Some(exit_code) =
+            run_promotion_provider_dispatch(&cli.command, output_file.as_deref(), &command_identity)
+        {
+            return std::process::ExitCode::from(exit_code_to_u8(exit_code));
+        }
+
         // Capture controller pressure once before placement routing. The route
         // and persisted evidence reuse this preflight decision rather than
         // probing the host a second time.
@@ -661,6 +673,28 @@ fn run_raw_agent_tool_dispatch(command: &Commands) -> Option<i32> {
             ))
         }
     }
+}
+
+fn run_promotion_provider_dispatch(
+    command: &Commands,
+    output_file: Option<&str>,
+    identity: &output::CommandIdentity,
+) -> Option<i32> {
+    let Commands::AgentTask(args) = command else {
+        return None;
+    };
+    let crate::commands::agent_task::AgentTaskCommand::PromotionProvider(args) = &args.command
+    else {
+        return None;
+    };
+
+    let (result, exit_code) =
+        match crate::commands::agent_task::run::promotion_provider(args.clone()) {
+            Ok((value, exit_code)) => (Ok(value), exit_code),
+            Err(error) => (Err(error), 2),
+        };
+    output_runtime::emit_json_result_for_identity(result, output_file, exit_code, identity);
+    Some(exit_code)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -366,7 +366,7 @@ pub struct AgentTaskCookArgs {
     pub ai_used_for: String,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Clone, Debug)]
 pub struct PromotionProviderArgs {
     #[arg(long, value_name = "PATH")]
     pub workspace: String,

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -364,7 +364,7 @@ pub(crate) fn validate_cook_request(args: &AgentTaskCookArgs) -> homeboy::core::
     Ok(())
 }
 
-pub(super) fn promotion_provider(args: PromotionProviderArgs) -> CmdResult<Value> {
+pub(crate) fn promotion_provider(args: PromotionProviderArgs) -> CmdResult<Value> {
     let mut request = Vec::new();
     std::io::stdin()
         .take(MAX_PROMOTION_PROVIDER_REQUEST_BYTES + 1)

--- a/tests/promotion_provider_stdin.rs
+++ b/tests/promotion_provider_stdin.rs
@@ -1,0 +1,43 @@
+use serde_json::Value;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}
+
+#[test]
+fn promotion_provider_reads_its_request_from_process_stdin() {
+    let mut child = Command::new(homeboy_bin())
+        .args([
+            "agent-task",
+            "promotion-provider",
+            "--workspace",
+            "/unused-for-invalid-request",
+        ])
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn promotion provider");
+
+    child
+        .stdin
+        .take()
+        .expect("promotion provider stdin")
+        .write_all(b"{}")
+        .expect("write promotion provider request");
+
+    let output = child
+        .wait_with_output()
+        .expect("wait for promotion provider");
+    let response: Value = serde_json::from_slice(&output.stdout).expect("provider response JSON");
+
+    assert!(!output.status.success());
+    assert_eq!(
+        response["diagnostics"]["details"]["context"],
+        "agent-task promotion provider request"
+    );
+    assert_ne!(response["diagnostics"]["details"]["category"], "eof");
+}


### PR DESCRIPTION
## Summary

- preserve the bounded promotion-provider stdin request across CLI startup
- skip unrelated runner-exec recovery for this internal stdin-bound command
- dispatch the provider before generic routing and startup checks
- add process-level regression coverage for the EOF failure

Closes #10208.

## Verification

- `cargo fmt --check`
- `cargo test --test promotion_provider_stdin`
- `cargo test -p homeboy-cli commands::utils::resource_policy`
- real WP Codebox #2081 artifact dry-run through the patched binary and configured DMC provider; six expected files reported with artifact SHA-256 `0cf4855a1a645e902d67d0867e3ffdffe73803ec3ceff290d9a6c8a80c0063ef`

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: reproduced and isolated the stdin loss, implemented the startup-boundary repair and regression test, and verified the original promotion workflow end to end.