### PR TITLE
fix(agent-task): hydrate nested promotion dependencies

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -224,6 +224,8 @@ pub struct AgentTaskGateSetupEvidence {
     pub output: String,
 }
 
+const MAX_GATE_DEPENDENCY_ROOTS: usize = 64;
+
 /// Discover only the checkout root and direct child roots. Provider resolution,
 /// package-manager detection, and install commands remain outside Homeboy core.
 pub(crate) fn hydrate_gate_dependency_roots(
@@ -240,24 +242,52 @@ pub(crate) fn hydrate_gate_dependency_roots(
             Some("read candidate dependency roots".to_string()),
         )
     })? {
-        let path = entry
-            .map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some("read candidate dependency root".to_string()),
-                )
-            })?
-            .path();
-        if path.is_dir() && path.file_name().is_none_or(|name| name != ".git") {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read candidate dependency root".to_string()),
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read candidate dependency root type".to_string()),
+            )
+        })?;
+        // A linked directory can escape the detached candidate checkout. Setup
+        // is allowed only in the candidate root or a real direct child.
+        if file_type.is_dir() && path.file_name().is_none_or(|name| name != ".git") {
             roots.push(path);
         }
     }
     roots.sort();
+    if roots.len() > MAX_GATE_DEPENDENCY_ROOTS {
+        return Err(Error::validation_invalid_argument(
+            "promotion.gate_setup",
+            format!(
+                "candidate declares more than {MAX_GATE_DEPENDENCY_ROOTS} dependency roots at the supported depth"
+            ),
+            Some(checkout.display().to_string()),
+            None,
+        ));
+    }
     let mut evidence = Vec::new();
     for root in roots {
+        // The identity is an input to setup, not a post-setup cache key. A
+        // provider that rewrites it has not verified the declared candidate.
+        let lock_identity = dependency_root_identity(&root)?;
         let started = std::time::Instant::now();
         if !homeboy_core::hygiene::materialize_worktree_dependencies(&root)? {
             continue;
+        }
+        if dependency_root_identity(&root)? != lock_identity {
+            return Err(Error::validation_invalid_argument(
+                "promotion.gate_setup",
+                "dependency setup changed its declared lock identity",
+                Some(root.display().to_string()),
+                None,
+            ));
         }
         let relative = root
             .strip_prefix(checkout)
@@ -271,7 +301,7 @@ pub(crate) fn hydrate_gate_dependency_roots(
             } else {
                 relative
             },
-            lock_identity: dependency_root_identity(&root)?,
+            lock_identity,
             setup_capability: "dependency.install".to_string(),
             duration_ms: started.elapsed().as_millis(),
             status: "succeeded".to_string(),

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 use homeboy_core::gate::{
     HomeboyGateKind, HomeboyGateResult, HomeboyGateRevealPolicy, HomeboyGateStatus,
@@ -80,6 +81,14 @@ pub struct VerifyGateOptions {
     /// consumes declared schemas and paths; producer semantics remain opaque.
     #[serde(default)]
     pub gate_diagnostic_sidecars: Vec<AgentTaskGateDiagnosticSidecarMapping>,
+    /// Hydrate provider-declared dependency roots in the isolated candidate
+    /// checkout before deterministic verification.
+    #[serde(default = "default_hydrate_dependencies")]
+    pub hydrate_dependencies: bool,
+}
+
+fn default_hydrate_dependencies() -> bool {
+    true
 }
 
 /// Scheduling policy for a declared sequence of deterministic gates.
@@ -199,8 +208,115 @@ impl Default for VerifyGateOptions {
             gate_environment: AgentTaskGateEnvironmentPolicy::default(),
             gate_toolchains: Vec::new(),
             gate_diagnostic_sidecars: Vec::new(),
+            hydrate_dependencies: default_hydrate_dependencies(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateSetupEvidence {
+    pub schema: String,
+    pub package_root: String,
+    pub lock_identity: String,
+    pub setup_capability: String,
+    pub duration_ms: u128,
+    pub status: String,
+    pub output: String,
+}
+
+/// Discover only the checkout root and direct child roots. Provider resolution,
+/// package-manager detection, and install commands remain outside Homeboy core.
+pub(crate) fn hydrate_gate_dependency_roots(
+    checkout: &Path,
+    enabled: bool,
+) -> Result<Vec<AgentTaskGateSetupEvidence>> {
+    if !enabled {
+        return Ok(Vec::new());
+    }
+    let mut roots = vec![checkout.to_path_buf()];
+    for entry in fs::read_dir(checkout).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read candidate dependency roots".to_string()),
+        )
+    })? {
+        let path = entry
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("read candidate dependency root".to_string()),
+                )
+            })?
+            .path();
+        if path.is_dir() && path.file_name().is_none_or(|name| name != ".git") {
+            roots.push(path);
+        }
+    }
+    roots.sort();
+    let mut evidence = Vec::new();
+    for root in roots {
+        let started = std::time::Instant::now();
+        if !homeboy_core::hygiene::materialize_worktree_dependencies(&root)? {
+            continue;
+        }
+        let relative = root
+            .strip_prefix(checkout)
+            .unwrap_or(&root)
+            .display()
+            .to_string();
+        evidence.push(AgentTaskGateSetupEvidence {
+            schema: "homeboy/agent-task-gate-setup/v1".to_string(),
+            package_root: if relative.is_empty() {
+                ".".to_string()
+            } else {
+                relative
+            },
+            lock_identity: dependency_root_identity(&root)?,
+            setup_capability: "dependency.install".to_string(),
+            duration_ms: started.elapsed().as_millis(),
+            status: "succeeded".to_string(),
+            output: "provider-declared dependency setup completed".to_string(),
+        });
+    }
+    Ok(evidence)
+}
+
+fn dependency_root_identity(root: &Path) -> Result<String> {
+    let mut inputs = Vec::new();
+    for entry in fs::read_dir(root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read dependency root identity".to_string()),
+        )
+    })? {
+        let path = entry
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("read dependency root identity entry".to_string()),
+                )
+            })?
+            .path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if path.is_file() && (name.ends_with(".lock") || name == "homeboy-deps.json") {
+            inputs.push((
+                name.to_string(),
+                fs::read(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?,
+            ));
+        }
+    }
+    inputs.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut hasher = Sha256::new();
+    for (name, bytes) in inputs {
+        hasher.update(name.as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1397,6 +1397,17 @@ fn run_promotion_gates(
         options.gates.hydrate_dependencies,
     )
     .map_err(|error| {
+        let mut cause = serde_json::json!({
+            "classification": "candidate_setup",
+            "code": error.code.as_str(),
+            "message": bounded_setup_error_text(&error.message),
+        });
+        if let Some(details) = cause.as_object_mut() {
+            details.insert(
+                "details".to_string(),
+                serde_json::Value::String(bounded_setup_error_text(&error.details.to_string())),
+            );
+        }
         Error::dependency_step_failed(
             "promotion.gate_setup",
             "candidate_checkout".to_string(),
@@ -1404,10 +1415,7 @@ fn run_promotion_gates(
             Vec::new(),
             Vec::new(),
             None,
-            Some(serde_json::json!({
-                "classification": "infrastructure",
-                "message": error.message,
-            })),
+            Some(cause),
         )
     })?;
     let declared_gates = options
@@ -1481,6 +1489,18 @@ fn run_promotion_gates(
         setup,
         candidate_checkout,
     })
+}
+
+fn bounded_setup_error_text(value: &str) -> String {
+    const MAX_BYTES: usize = 4096;
+    let mut result = String::new();
+    for character in value.chars() {
+        if result.len() + character.len_utf8() > MAX_BYTES {
+            break;
+        }
+        result.push(character);
+    }
+    result
 }
 
 /// A run-scoped detached worktree whose commit tree is exactly the promoted

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -193,6 +193,7 @@ pub fn resume_promoted_patch(
             "artifact_metadata": artifact.metadata,
             "worktree_path": target_path,
             "dependencies_materialized": gates.dependencies_materialized,
+            "gate_setup": gates.setup,
             "candidate_checkout": gates.candidate_checkout,
             "candidate": candidate,
             "resumed_post_apply_promotion": true,
@@ -621,6 +622,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
                 "worktree_path": worktree_path,
                 "verified_revision": verified_revision,
                 "dependencies_materialized": gates.dependencies_materialized,
+                "gate_setup": gates.setup,
                 "candidate_checkout": gates.candidate_checkout,
                 "candidate": candidate,
             }),
@@ -777,6 +779,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             "artifact_metadata": artifact.metadata,
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
+            "gate_setup": gates.setup,
             "candidate_checkout": gates.candidate_checkout,
             "candidate": candidate,
             "destination_baseline": candidate,
@@ -1348,6 +1351,7 @@ fn promote_committed_changes(
             "artifact_metadata": artifact.map(|artifact| artifact.metadata.clone()).unwrap_or(Value::Null),
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
+            "gate_setup": gates.setup,
             "candidate_checkout": gates.candidate_checkout,
             "change_source": "local_commits",
             "base_ref": committed_patch.base_ref,
@@ -1388,7 +1392,24 @@ fn run_promotion_gates(
     // Materialize dependencies in the immutable checkout so repository-owned
     // verification sees the candidate as committed content, never the dirty
     // promotion target that finalization still owns.
-    homeboy_core::hygiene::materialize_worktree_dependencies(gate_path)?;
+    let setup = crate::agent_task_gate::hydrate_gate_dependency_roots(
+        gate_path,
+        options.gates.hydrate_dependencies,
+    )
+    .map_err(|error| {
+        Error::dependency_step_failed(
+            "promotion.gate_setup",
+            "candidate_checkout".to_string(),
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            Some(serde_json::json!({
+                "classification": "infrastructure",
+                "message": error.message,
+            })),
+        )
+    })?;
     let declared_gates = options
         .gates
         .verify
@@ -1456,7 +1477,8 @@ fn run_promotion_gates(
         status: status_for_report(options.dry_run, has_gate_failure),
         deterministic_gates,
         gate_results,
-        dependencies_materialized: true,
+        dependencies_materialized: !setup.is_empty(),
+        setup,
         candidate_checkout,
     })
 }

--- a/crates/homeboy-agents/src/agent_task_promotion/promote/gate_run.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote/gate_run.rs
@@ -1,4 +1,6 @@
-use crate::agent_task_gate::{AgentTaskGateCandidateCheckout, AgentTaskGateReport};
+use crate::agent_task_gate::{
+    AgentTaskGateCandidateCheckout, AgentTaskGateReport, AgentTaskGateSetupEvidence,
+};
 use crate::agent_task_promotion::AgentTaskPromotionStatus;
 use homeboy_core::gate::HomeboyGateResult;
 
@@ -7,6 +9,7 @@ pub(super) struct PromotionGateRun {
     pub(super) deterministic_gates: Vec<AgentTaskGateReport>,
     pub(super) gate_results: Vec<HomeboyGateResult>,
     pub(super) dependencies_materialized: bool,
+    pub(super) setup: Vec<AgentTaskGateSetupEvidence>,
     pub(super) candidate_checkout: Option<AgentTaskGateCandidateCheckout>,
 }
 
@@ -21,6 +24,7 @@ impl PromotionGateRun {
             deterministic_gates: Vec::new(),
             gate_results: Vec::new(),
             dependencies_materialized: false,
+            setup: Vec::new(),
             candidate_checkout: None,
         }
     }

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1249,6 +1249,128 @@ fn promotion_runs_clean_checkout_gate_against_immutable_candidate() {
 }
 
 #[test]
+fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        git(&workspace, &["init", "-b", "main"]);
+        git(&workspace, &["config", "user.email", "test@example.com"]);
+        git(&workspace, &["config", "user.name", "Homeboy Test"]);
+        std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+        std::fs::create_dir_all(workspace.join("php-transformer")).expect("nested package");
+        std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+        std::fs::write(
+            workspace.join("php-transformer/homeboy.json"),
+            r#"{"id":"nested-php-transformer"}"#,
+        )
+        .expect("component manifest");
+        std::fs::write(
+            workspace.join("php-transformer/composer.lock"),
+            "fixture-lock\n",
+        )
+        .expect("composer lock fixture");
+        std::fs::write(
+            workspace.join("php-transformer/homeboy-deps.json"),
+            r#"{"provider":"fixture-composer","commands":{"install":{"argv":["sh","-c","mkdir -p vendor && printf fixture > vendor/autoload.php"]}}}"#,
+        )
+        .expect("provider declaration");
+        git(&workspace, &["add", "."]);
+        git(&workspace, &["commit", "-m", "base"]);
+        let (source_path, source) = write_patch_source(&temp);
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(workspace.clone()),
+            apply_to_git: true,
+            run_verify_command: true,
+            ..Default::default()
+        };
+
+        let report = promote_with_provider(
+            AgentTaskPromotionOptions {
+                source,
+                source_run_id: Some("nested-dependency-hydration".to_string()),
+                source_path: Some(source_path),
+                source_worktree_path: None,
+                base_ref: None,
+                task_base_sha: None,
+                candidate_ref: None,
+                to_worktree: "fixture@target".to_string(),
+                task_id: None,
+                artifact_id: None,
+                dry_run: false,
+                gates: VerifyGateOptions {
+                    verify: vec!["test -f php-transformer/vendor/autoload.php".to_string()],
+                    ..Default::default()
+                },
+                provider_command: None,
+                provider_invocation: None,
+            },
+            &mut provider,
+        )
+        .expect("nested dependency setup makes the gate runnable");
+
+        assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+        assert_eq!(
+            report.provenance["gate_setup"][0]["package_root"],
+            "php-transformer"
+        );
+        assert_eq!(
+            report.provenance["gate_setup"][0]["setup_capability"],
+            "dependency.install"
+        );
+        assert!(
+            !workspace.join("php-transformer/vendor").exists(),
+            "setup writes only to the candidate checkout"
+        );
+    });
+}
+
+#[test]
+fn promotion_can_disable_candidate_dependency_hydration() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init", "-b", "main"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Homeboy Test"]);
+    std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+    std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+    git(&workspace, &["add", "."]);
+    git(&workspace, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(workspace),
+        apply_to_git: true,
+        ..Default::default()
+    };
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("disable-dependency-hydration".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                hydrate_dependencies: false,
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("disabled setup still runs gates");
+    assert_eq!(report.provenance["gate_setup"], serde_json::json!([]));
+}
+
+#[test]
 fn promotion_rejects_mutation_after_checkpoint_before_gate_materialization() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path().join("workspace");

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1258,21 +1258,21 @@ fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
         git(&workspace, &["config", "user.email", "test@example.com"]);
         git(&workspace, &["config", "user.name", "Homeboy Test"]);
         std::fs::create_dir_all(workspace.join("src")).expect("source directory");
-        std::fs::create_dir_all(workspace.join("php-transformer")).expect("nested package");
+        std::fs::create_dir_all(workspace.join("transformer")).expect("nested package");
         std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
         std::fs::write(
-            workspace.join("php-transformer/homeboy.json"),
-            r#"{"id":"nested-php-transformer"}"#,
+            workspace.join("transformer/homeboy.json"),
+            r#"{"id":"nested-transformer"}"#,
         )
         .expect("component manifest");
         std::fs::write(
-            workspace.join("php-transformer/composer.lock"),
+            workspace.join("transformer/dependency.lock"),
             "fixture-lock\n",
         )
-        .expect("composer lock fixture");
+        .expect("dependency lock fixture");
         std::fs::write(
-            workspace.join("php-transformer/homeboy-deps.json"),
-            r#"{"provider":"fixture-composer","commands":{"install":{"argv":["sh","-c","mkdir -p vendor && printf fixture > vendor/autoload.php"]}}}"#,
+            workspace.join("transformer/homeboy-deps.json"),
+            r#"{"provider":"fixture-provider","commands":{"install":{"argv":["sh","-c","printf fixture > installed.marker"]}}}"#,
         )
         .expect("provider declaration");
         git(&workspace, &["add", "."]);
@@ -1299,7 +1299,7 @@ fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
                 artifact_id: None,
                 dry_run: false,
                 gates: VerifyGateOptions {
-                    verify: vec!["test -f php-transformer/vendor/autoload.php".to_string()],
+                    verify: vec!["test -f transformer/installed.marker".to_string()],
                     ..Default::default()
                 },
                 provider_command: None,
@@ -1312,14 +1312,14 @@ fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
         assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
         assert_eq!(
             report.provenance["gate_setup"][0]["package_root"],
-            "php-transformer"
+            "transformer"
         );
         assert_eq!(
             report.provenance["gate_setup"][0]["setup_capability"],
             "dependency.install"
         );
         assert!(
-            !workspace.join("php-transformer/vendor").exists(),
+            !workspace.join("transformer/installed.marker").exists(),
             "setup writes only to the candidate checkout"
         );
     });
@@ -1368,6 +1368,72 @@ fn promotion_can_disable_candidate_dependency_hydration() {
     )
     .expect("disabled setup still runs gates");
     assert_eq!(report.provenance["gate_setup"], serde_json::json!([]));
+}
+
+#[test]
+fn promotion_setup_failure_is_bounded_and_never_dispatches_a_gate() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        git(&workspace, &["init", "-b", "main"]);
+        git(&workspace, &["config", "user.email", "test@example.com"]);
+        git(&workspace, &["config", "user.name", "Homeboy Test"]);
+        std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+        std::fs::create_dir_all(workspace.join("component")).expect("component directory");
+        std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+        std::fs::write(
+            workspace.join("component/homeboy-deps.json"),
+            r#"{"provider":"fixture-provider","commands":{"install":{"argv":["sh","-c","exit 23"]}}}"#,
+        )
+        .expect("provider declaration");
+        git(&workspace, &["add", "."]);
+        git(&workspace, &["commit", "-m", "base"]);
+        let (source_path, source) = write_patch_source(&temp);
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(workspace),
+            apply_to_git: true,
+            ..Default::default()
+        };
+
+        let error = promote_with_provider(
+            AgentTaskPromotionOptions {
+                source,
+                source_run_id: Some("setup-failure-no-gate-dispatch".to_string()),
+                source_path: Some(source_path),
+                source_worktree_path: None,
+                base_ref: None,
+                task_base_sha: None,
+                candidate_ref: None,
+                to_worktree: "fixture@target".to_string(),
+                task_id: None,
+                artifact_id: None,
+                dry_run: false,
+                gates: VerifyGateOptions {
+                    verify: vec!["false".to_string()],
+                    ..Default::default()
+                },
+                provider_command: None,
+                provider_invocation: None,
+            },
+            &mut provider,
+        )
+        .expect_err("failed setup stops before a gate can spend repair capacity");
+
+        assert_eq!(error.code.as_str(), "dependency_step_failed");
+        assert_eq!(error.details["cause"]["classification"], "candidate_setup");
+        assert!(
+            error.details["cause"]["details"]
+                .as_str()
+                .expect("bounded setup details")
+                .len()
+                <= 20 * 1024
+        );
+        assert!(
+            provider.verify_calls.is_empty(),
+            "no gate/provider dispatch occurs"
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- hydrate provider-declared dependency roots at the candidate root and one bounded nested level before promotion gates
- retain setup evidence with root, lock identity, capability, duration, and status
- keep setup writes in the detached candidate checkout and allow an explicit hydration disable policy

## Testing
- `cargo test -p homeboy-agents agent_task_promotion::tests::part_b::promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate -- --exact`
- `cargo test -p homeboy-agents agent_task_promotion::tests::part_b::promotion_can_disable_candidate_dependency_hydration -- --exact`
- `cargo fmt --check`
- `cargo check -p homeboy-agents`

Fixes #10143

## AI assistance
OpenCode using OpenAI GPT-5.6 Terra drafted the implementation and regression tests. Chris Huber remains responsible for review and every line.