### PR TITLE
Recover stale terminal scratch during cancellation replay

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2022,6 +2022,139 @@ fn replaying_cancel_repairs_stale_provider_execution() {
 }
 
 #[test]
+fn replaying_cancel_recovers_stale_released_and_orphaned_scratch_before_bounded_cleanup() {
+    with_isolated_home(|_| {
+        let run_id = "run-cancel-scratch-replay";
+        let plan = test_plan();
+        submit_plan(&plan, Some(run_id)).expect("submitted");
+        reserve_provider_execution(run_id, &plan.tasks[0], 1).expect("provider execution reserved");
+
+        let released = crate::controller_scratch::allocate_attempt(
+            run_id,
+            &plan.plan_id,
+            &plan.tasks[0].task_id,
+            1,
+        )
+        .expect("released scratch");
+        let orphaned = crate::controller_scratch::allocate_attempt(
+            run_id,
+            &plan.plan_id,
+            &plan.tasks[0].task_id,
+            2,
+        )
+        .expect("orphaned scratch");
+        prepare_dirty_scheduler_workspace(&released.path);
+        prepare_dirty_scheduler_workspace(&orphaned.path);
+        crate::controller_scratch::abandon_attempt_for_test(&released)
+            .expect("dead released owner");
+        crate::controller_scratch::abandon_attempt_for_test(&orphaned).expect("dead orphan owner");
+        crate::controller_scratch::release_attempt(
+            &released,
+            "legacy_provider_release",
+            json!({ "legacy": true }),
+        )
+        .expect("record stale released resource");
+
+        let mut record = store::read_record(run_id).expect("record");
+        record.state = AgentTaskRunState::Cancelled;
+        record.tasks[0].state = AgentTaskState::Cancelled;
+        store::write_record(&record).expect("legacy cancelled record");
+
+        // A terminal cleanup pass made this dead allocation look orphaned before
+        // cancellation replay could project its tracked source state.
+        let orphaned_preview = crate::controller_scratch::cleanup(
+            crate::controller_scratch::ControllerScratchCleanupOptions {
+                apply: false,
+                limit: 1,
+                retention_override_seconds: Some(0),
+            },
+        )
+        .expect("orphan stale resource");
+        assert_eq!(orphaned_preview.candidate_count, 0);
+
+        let repaired = cancel_run(run_id, None).expect("replayed cancellation");
+        assert_eq!(
+            repaired.metadata["provider_executions"][0]["state"],
+            "cancelled"
+        );
+
+        let preview = crate::controller_scratch::cleanup(
+            crate::controller_scratch::ControllerScratchCleanupOptions {
+                apply: false,
+                limit: 1,
+                retention_override_seconds: Some(0),
+            },
+        )
+        .expect("recovery-backed cleanup preview");
+        assert_eq!(preview.candidate_count, 2);
+        assert_eq!(preview.candidates.len(), 1);
+        assert_eq!(preview.remaining_candidate_count, 1);
+        assert!(preview.estimated_bytes > 0);
+
+        let first = crate::controller_scratch::cleanup(
+            crate::controller_scratch::ControllerScratchCleanupOptions {
+                apply: true,
+                limit: 1,
+                retention_override_seconds: Some(0),
+            },
+        )
+        .expect("first bounded cleanup");
+        assert_eq!(first.applied_count, 1);
+        let second = crate::controller_scratch::cleanup(
+            crate::controller_scratch::ControllerScratchCleanupOptions {
+                apply: true,
+                limit: 1,
+                retention_override_seconds: Some(0),
+            },
+        )
+        .expect("second bounded cleanup");
+        assert_eq!(second.applied_count, 1);
+        assert!(!released.path.exists());
+        assert!(!orphaned.path.exists());
+    });
+}
+
+fn prepare_dirty_scheduler_workspace(scratch: &std::path::Path) {
+    let workspace = scratch.join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    run_git(&workspace, &["init", "-b", "main"]);
+    std::fs::write(workspace.join("tracked.txt"), "base\n").expect("base file");
+    run_git(&workspace, &["add", "."]);
+    run_git(
+        &workspace,
+        &[
+            "-c",
+            "user.name=Homeboy",
+            "-c",
+            "user.email=homeboy@example.test",
+            "commit",
+            "-m",
+            "base",
+        ],
+    );
+    std::fs::write(workspace.join("tracked.txt"), "candidate\n").expect("tracked candidate");
+
+    let fixture = scratch.join("hb-test-generated-fixture");
+    std::fs::create_dir(&fixture).expect("generated fixture");
+    run_git(&fixture, &["init", "-b", "main"]);
+    std::fs::write(fixture.join("untracked.txt"), "generated\n").expect("fixture state");
+}
+
+fn run_git(cwd: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn local_provider_reservation_persists_reusable_owner_identity_before_execution() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2045,6 +2045,12 @@ fn replaying_cancel_recovers_stale_released_and_orphaned_scratch_before_bounded_
         .expect("orphaned scratch");
         prepare_dirty_scheduler_workspace(&released.path);
         prepare_dirty_scheduler_workspace(&orphaned.path);
+        // Model the reported retained-byte incident without allocating physical
+        // disk. `path_size` reports this logical sparse-file size.
+        std::fs::File::create(released.path.join("retained-scratch.bin"))
+            .expect("retained scratch")
+            .set_len(178_650_000_000)
+            .expect("sparse retained scratch");
         crate::controller_scratch::abandon_attempt_for_test(&released)
             .expect("dead released owner");
         crate::controller_scratch::abandon_attempt_for_test(&orphaned).expect("dead orphan owner");
@@ -2089,7 +2095,7 @@ fn replaying_cancel_recovers_stale_released_and_orphaned_scratch_before_bounded_
         assert_eq!(preview.candidate_count, 2);
         assert_eq!(preview.candidates.len(), 1);
         assert_eq!(preview.remaining_candidate_count, 1);
-        assert!(preview.estimated_bytes > 0);
+        assert!(preview.estimated_bytes >= 178_650_000_000);
 
         let first = crate::controller_scratch::cleanup(
             crate::controller_scratch::ControllerScratchCleanupOptions {

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -520,19 +520,23 @@ fn finalize_run_unlocked(run_id: &str) -> Result<()> {
                 resource.finalized_at = Some(now.clone());
                 changed = true;
             }
-            let recovery_state = resource
-                .terminal_evidence
-                .as_ref()
-                .and_then(|evidence| evidence.pointer("/workspace_recovery/state"))
-                .and_then(serde_json::Value::as_str);
-            let needs_recovery = matches!(
-                resource.lifecycle_state.as_str(),
-                "active" | "provider_registered"
-            ) || (resource.lifecycle_state == "interrupted"
-                && !matches!(
-                    recovery_state,
-                    Some("recovered" | "explicitly_ephemeral" | "authoritative_checkout_absent")
-                ));
+            let has_recovery_evidence = matches!(
+                resource
+                    .terminal_evidence
+                    .as_ref()
+                    .and_then(|evidence| evidence.pointer("/workspace_recovery/state"))
+                    .and_then(serde_json::Value::as_str),
+                Some("recovered" | "explicitly_ephemeral" | "authoritative_checkout_absent")
+            );
+            let stale_dirty_workspace = !resource.ephemeral
+                && git_safety_path(resource, Path::new(&resource.path))
+                    .is_some_and(|workspace| git_dirty_or_unpushed(&workspace));
+            let needs_recovery = !has_recovery_evidence
+                && (matches!(
+                    resource.lifecycle_state.as_str(),
+                    "active" | "provider_registered"
+                ) || resource.lifecycle_state == "interrupted"
+                    || stale_dirty_workspace);
             if needs_recovery {
                 let workspace_recovery = recover_authoritative_workspace(resource);
                 resource.lifecycle_state = "interrupted".to_string();

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -520,14 +520,7 @@ fn finalize_run_unlocked(run_id: &str) -> Result<()> {
                 resource.finalized_at = Some(now.clone());
                 changed = true;
             }
-            let has_recovery_evidence = matches!(
-                resource
-                    .terminal_evidence
-                    .as_ref()
-                    .and_then(|evidence| evidence.pointer("/workspace_recovery/state"))
-                    .and_then(serde_json::Value::as_str),
-                Some("recovered" | "explicitly_ephemeral" | "authoritative_checkout_absent")
-            );
+            let has_recovery_evidence = recovery_evidence_is_current(resource);
             let stale_dirty_workspace = !resource.ephemeral
                 && git_safety_path(resource, Path::new(&resource.path))
                     .is_some_and(|workspace| git_dirty_or_unpushed(&workspace));
@@ -925,7 +918,13 @@ fn cleanup_command(options: ControllerScratchCleanupOptions) -> String {
 }
 
 fn git_dirty_or_unpushed(path: &Path) -> bool {
-    let status = git::run_git(path, &["status", "--porcelain=v1"], "git status");
+    // Include ignored files. They are still local source state and therefore
+    // must be retained unless the terminal recovery path has preserved it.
+    let status = git::run_git(
+        path,
+        &["status", "--porcelain=v1", "--ignored"],
+        "git status",
+    );
     let Ok(status) = status else {
         return true;
     };
@@ -959,6 +958,26 @@ fn git_safety_path(resource: &ControllerScratchResource, path: &Path) -> Option<
     None
 }
 
+fn recovery_evidence_is_current(resource: &ControllerScratchResource) -> bool {
+    let recovery = resource
+        .terminal_evidence
+        .as_ref()
+        .and_then(|evidence| evidence.get("workspace_recovery"));
+    match recovery
+        .and_then(|recovery| recovery.get("state"))
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("recovered") => git_safety_path(resource, Path::new(&resource.path))
+            .is_some_and(|workspace| recovered_workspace_matches(resource, &workspace)),
+        Some("explicitly_ephemeral") => resource.ephemeral,
+        Some("authoritative_checkout_absent") => {
+            !resource.plan_id.is_empty()
+                && git_safety_path(resource, Path::new(&resource.path)).is_none()
+        }
+        _ => false,
+    }
+}
+
 fn recover_authoritative_workspace(resource: &ControllerScratchResource) -> serde_json::Value {
     recover_authoritative_workspace_inner(resource).unwrap_or_else(|error| {
         serde_json::json!({
@@ -984,8 +1003,15 @@ fn recover_authoritative_workspace_inner(
             },
         }));
     };
-    let status = git::run_git(&workspace, &["status", "--porcelain=v1"], "git status")?;
-    if status.lines().any(|line| line.starts_with("??")) {
+    let status = git::run_git(
+        &workspace,
+        &["status", "--porcelain=v1", "--ignored"],
+        "git status",
+    )?;
+    if status
+        .lines()
+        .any(|line| line.starts_with("??") || line.starts_with("!!"))
+    {
         return Ok(serde_json::json!({
             "state": "untracked_changes_retained",
             "workspace": workspace,
@@ -1094,7 +1120,12 @@ fn recovered_workspace_matches(resource: &ControllerScratchResource, workspace: 
     let expected_head = recovery.get("head").and_then(serde_json::Value::as_str);
     let expected_status = recovery.get("status").and_then(serde_json::Value::as_str);
     let current_head = git::run_git(workspace, &["rev-parse", "HEAD"], "git rev-parse HEAD").ok();
-    let current_status = git::run_git(workspace, &["status", "--porcelain=v1"], "git status").ok();
+    let current_status = git::run_git(
+        workspace,
+        &["status", "--porcelain=v1", "--ignored"],
+        "git status",
+    )
+    .ok();
     let current_patch = git::run_git(
         workspace,
         &[
@@ -1998,6 +2029,43 @@ mod tests {
                 output.skipped[0].reason,
                 "git checkout has dirty or unpushed state"
             );
+        });
+    }
+
+    #[test]
+    fn ignored_untracked_workspace_state_fails_closed_during_recovery() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let allocation =
+                allocate_attempt("ignored-run", "scheduler-plan", "task", 1).expect("allocate");
+            let workspace = allocation.path.join("workspace");
+            fs::create_dir(&workspace).expect("workspace");
+            run_git(&workspace, &["init", "-b", "main"]);
+            fs::write(workspace.join(".gitignore"), "local-source\n").expect("ignore rule");
+            fs::write(workspace.join("tracked.txt"), "base\n").expect("base file");
+            run_git(&workspace, &["add", "."]);
+            run_git(
+                &workspace,
+                &[
+                    "-c",
+                    "user.name=Homeboy",
+                    "-c",
+                    "user.email=homeboy@example.test",
+                    "commit",
+                    "-m",
+                    "base",
+                ],
+            );
+            fs::write(workspace.join("local-source"), "preserve\n").expect("local source");
+
+            let resource = read_index()
+                .expect("index")
+                .resources
+                .into_iter()
+                .find(|resource| resource.lease_id == allocation.lease_id)
+                .expect("resource");
+            let recovery = recover_authoritative_workspace_inner(&resource).expect("recover");
+
+            assert_eq!(recovery["state"], "untracked_changes_retained");
         });
     }
 


### PR DESCRIPTION
## Summary

- recover dirty, non-ephemeral authoritative workspaces when terminal cancellation finalization encounters stale `released` or `orphaned` labels without valid recovery evidence
- preserve the existing fail-closed behavior for unknown/untracked/submodule/recovery-failure cases and live owners
- add deterministic cancellation-replay coverage for a stale running provider row, dirty released/orphaned scratch, generated nested dirty fixtures, recovery-backed candidates, and bounded cleanup application

Fixes #10169.

## Retained-byte impact

This closes the post-merge gap that left the reproduced 178.65 GB terminal controller scratch protected by stale lifecycle labels. The replay now projects the tracked source state into authenticated bundle and patch evidence before bounded cleanup can reclaim eligible scratch.

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo test -p homeboy-agents controller_scratch::tests --no-fail-fast`
- `cargo test -p homeboy-agents replaying_cancel_repairs_stale_provider_execution --no-fail-fast`
- `cargo test -p homeboy-agents replaying_cancel_recovers_stale_released_and_orphaned_scratch_before_bounded_cleanup --no-fail-fast`
- `git diff --check origin/main...HEAD`

## AI assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Use: inspected the terminal scratch/resource lifecycle and post-merge reproduction, implemented the stale-label recovery guard and deterministic regression coverage, and ran focused verification. Chris Huber remains responsible for the final change.