### PR TITLE
Fix scoped Cook continuation recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -411,7 +411,9 @@ pub(crate) fn moving_base_recovery_from_promotion(
         passed_gates: serde_json::to_value(&promotion.gate_results).unwrap_or(Value::Null),
         promotion,
         blocker: String::new(),
-        continuation: "homeboy agent-task run-next".to_string(),
+        // This recovery belongs to one immutable Cook attempt. `run-next` is a
+        // global scheduler operation and must never be offered as its recovery.
+        continuation: format!("homeboy agent-task cook-continue {run_id}"),
         base_movements: 0,
     }
 }
@@ -1762,7 +1764,7 @@ fn cook_failure_context(
                 },
                 super::AgentTaskCookRecoveryAction {
                     action: "resume".to_string(),
-                    command: format!("homeboy agent-task cook-continue {cook_id}"),
+                    command: format!("homeboy agent-task cook-continue {latest_run_id}"),
                 },
             ]
         })

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -364,7 +364,8 @@ pub struct MovingBaseCookRecovery {
 }
 
 pub(crate) fn moving_base_recovery_for_run(run_id: &str) -> Result<Option<MovingBaseCookRecovery>> {
-    agent_task_lifecycle::status(run_id)?
+    let record = agent_task_lifecycle::exact_record(run_id)?;
+    record
         .metadata
         .get("cook_moving_base_recovery")
         .cloned()
@@ -377,6 +378,40 @@ pub(crate) fn moving_base_recovery_for_run(run_id: &str) -> Result<Option<Moving
                 Some(run_id.to_string()),
                 None,
             )
+        })
+        .and_then(|recovery: Option<MovingBaseCookRecovery>| {
+            let Some(mut recovery) = recovery else {
+                return Ok(None);
+            };
+            if recovery.run_id != run_id
+                || record.metadata.get("cook_id").and_then(Value::as_str)
+                    != Some(recovery.cook_id.as_str())
+            {
+                return Err(Error::validation_invalid_argument(
+                    "cook_moving_base_recovery",
+                    "durable moving-base recovery does not match its immutable Cook attempt",
+                    Some(run_id.to_string()),
+                    None,
+                ));
+            }
+            let recipe = super::load_recipe(&recovery.cook_id)?;
+            if !recipe
+                .attempts
+                .iter()
+                .any(|attempt| attempt.run_id == run_id)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "cook_moving_base_recovery",
+                    "durable moving-base recovery run is not declared by its Cook recipe",
+                    Some(run_id.to_string()),
+                    None,
+                ));
+            }
+            // Recoveries written before scoped continuation used `run-next`.
+            // The run ID remains authoritative, so expose the safe command
+            // without requiring an unsafe migration of historical records.
+            recovery.continuation = format!("homeboy agent-task cook-continue {run_id}");
+            Ok(Some(recovery))
         })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -707,6 +707,14 @@ pub fn load_recipe(cook_id: &str) -> Result<AgentTaskCookRecipe> {
         )
     })?;
     validate_recipe(&recipe)?;
+    if recipe.cook_id != cook_id {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.cook_id",
+            "durable cook recipe identity does not match its storage location",
+            Some(recipe.cook_id.clone()),
+            None,
+        ));
+    }
     Ok(recipe)
 }
 
@@ -1348,6 +1356,14 @@ fn validate_continuation(continuation: &AgentTaskCookContinuation) -> Result<()>
             None,
         ));
     }
+    if continuation.key != format!("{}:{}", continuation.cook_id, continuation.run_id) {
+        return Err(Error::validation_invalid_argument(
+            "cook_continuation.key",
+            "durable continuation key does not match its Cook attempt",
+            Some(continuation.key.clone()),
+            None,
+        ));
+    }
     Ok(())
 }
 
@@ -1722,6 +1738,44 @@ mod tests {
                 serde_json::to_vec(&AgentTaskCookContinuation {
                     schema: CONTINUATION_SCHEMA.to_string(),
                     key: "other:other-run".to_string(),
+                    cook_id: "other".to_string(),
+                    run_id: "other-run".to_string(),
+                    retries: 0,
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+            let error = claim_continuation_for("cook", "run").unwrap_err();
+            assert!(error.message.contains("does not match"));
+            assert_eq!(
+                claim_continuation_for("other", "other-run")
+                    .unwrap()
+                    .expect("unrelated continuation remains pending")
+                    .continuation()
+                    .key,
+                "other:other-run"
+            );
+        });
+    }
+
+    #[test]
+    fn targeted_claim_rejects_a_key_with_unrelated_cook_fields() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut other = recipe();
+            other.cook_id = "other".to_string();
+            other.attempts[0].run_id = "other-run".to_string();
+            write_recipe(&recipe()).unwrap();
+            write_recipe(&other).unwrap();
+            enqueue_terminal_continuation("other", "other-run").unwrap();
+
+            let key = "cook:run";
+            let hash = format!("{:x}", sha2::Sha256::digest(key.as_bytes()));
+            fs::write(
+                queue_root().unwrap().join(format!("{hash}.pending")),
+                serde_json::to_vec(&AgentTaskCookContinuation {
+                    schema: CONTINUATION_SCHEMA.to_string(),
+                    key: key.to_string(),
                     cook_id: "other".to_string(),
                     run_id: "other-run".to_string(),
                     retries: 0,

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1705,6 +1705,45 @@ mod tests {
     }
 
     #[test]
+    fn mismatched_targeted_continuation_fails_closed_without_consuming_other_cook() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut other = recipe();
+            other.cook_id = "other".to_string();
+            other.attempts[0].run_id = "other-run".to_string();
+            write_recipe(&recipe()).unwrap();
+            write_recipe(&other).unwrap();
+            enqueue_terminal_continuation("cook", "run").unwrap();
+            enqueue_terminal_continuation("other", "other-run").unwrap();
+
+            let key = "cook:run";
+            let hash = format!("{:x}", sha2::Sha256::digest(key.as_bytes()));
+            fs::write(
+                queue_root().unwrap().join(format!("{hash}.pending")),
+                serde_json::to_vec(&AgentTaskCookContinuation {
+                    schema: CONTINUATION_SCHEMA.to_string(),
+                    key: "other:other-run".to_string(),
+                    cook_id: "other".to_string(),
+                    run_id: "other-run".to_string(),
+                    retries: 0,
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+            let error = claim_continuation_for("cook", "run").unwrap_err();
+            assert!(error.message.contains("does not match"));
+            assert_eq!(
+                claim_continuation_for("other", "other-run")
+                    .unwrap()
+                    .expect("unrelated continuation remains pending")
+                    .continuation()
+                    .key,
+                "other:other-run"
+            );
+        });
+    }
+
+    #[test]
     fn consumer_reconstructs_options_once_and_completed_work_never_replays() {
         homeboy_core::test_support::with_isolated_home(|_| {
             write_recipe(&recipe()).unwrap();

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -520,14 +520,20 @@ fn moving_base_recovery_report_retains_typed_evidence_and_exact_continuation() {
 fn moving_base_recovery_persists_across_restart_without_provider_replay() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let run_id = "moving-base-restart";
-        let plan = AgentTaskPlan::new("moving-base-restart", Vec::new());
-        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        let mut options =
+            batch_cook_options("cook-restart", Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        persist_initial_recipe(&options).unwrap();
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt("cook-restart", 1, run_id).unwrap();
         agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
             record.metadata["provider_executions_consumed"] = serde_json::json!(1);
         })
         .unwrap();
-        let recovery =
+        let mut recovery =
             moving_base_recovery_from_promotion("cook-restart", run_id, promotion(run_id));
+        // Historical recovery records emitted the global scheduler command.
+        recovery.continuation = "homeboy agent-task run-next".to_string();
 
         agent_task_lifecycle::record_cook_moving_base_recovery(
             run_id,
@@ -541,6 +547,10 @@ fn moving_base_recovery_persists_across_restart_without_provider_replay() {
         let record = agent_task_lifecycle::status(run_id).unwrap();
         assert_eq!(restarted.cook_id, "cook-restart");
         assert_eq!(restarted.run_id, run_id);
+        assert_eq!(
+            restarted.continuation,
+            format!("homeboy agent-task cook-continue {run_id}")
+        );
         assert_eq!(record.metadata["provider_executions_consumed"], 1);
     });
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -492,7 +492,7 @@ fn moving_base_recovery_report_retains_typed_evidence_and_exact_continuation() {
         prior_verified_base: "a".repeat(40),
         passed_gates: serde_json::json!([{"status": "passed"}]),
         blocker: "HEAD is behind or diverged from resolved base".to_string(),
-        continuation: "homeboy agent-task run-next".to_string(),
+        continuation: "homeboy agent-task cook-continue run-9267".to_string(),
         base_movements: 0,
     };
     let report =
@@ -504,7 +504,10 @@ fn moving_base_recovery_report_retains_typed_evidence_and_exact_continuation() {
         .moving_base_recovery
         .expect("typed recovery state");
     assert_eq!(recovery.run_id, "run-9267");
-    assert_eq!(recovery.continuation, "homeboy agent-task run-next");
+    assert_eq!(
+        recovery.continuation,
+        "homeboy agent-task cook-continue run-9267"
+    );
     assert_eq!(recovery.prior_verified_base, "a".repeat(40));
     assert!(report
         .value
@@ -5761,7 +5764,7 @@ fn post_materialization_failure_families_expose_only_durable_identity_and_legal_
                 serde_json::json!([
                     { "action": "status", "command": format!("homeboy agent-task status {} --full", options.initial_run_id) },
                     { "action": "diagnose", "command": format!("homeboy agent-task diagnose {}", options.initial_run_id) },
-                    { "action": "resume", "command": format!("homeboy agent-task cook-continue {cook_id}") },
+                    { "action": "resume", "command": format!("homeboy agent-task cook-continue {}", options.initial_run_id) },
                 ]),
                 "{status}"
             );

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -168,7 +168,7 @@ fn cook_continuation_pending(cook_id: &str, run_id: &str, provider_state: &str) 
         "status": "continuation_pending",
         "provider": { "state": provider_state, "run_id": run_id },
         "remaining_phases": ["harvest", "review", "gates", "promotion", "finalization"],
-        "continuation_command": format!("homeboy agent-task cook-continue {cook_id}"),
+        "continuation_command": format!("homeboy agent-task cook-continue {run_id}"),
     })
 }
 
@@ -180,7 +180,7 @@ fn cook_continuation_status(cook_id: &str, run_id: &str, provider_state: &str) -
         "status": "in_flight",
         "provider": { "state": provider_state, "run_id": run_id },
         "remaining_phases": ["harvest", "review", "gates", "promotion", "finalization"],
-        "continuation_command": format!("homeboy agent-task cook-continue {cook_id}"),
+        "continuation_command": format!("homeboy agent-task cook-continue {run_id}"),
     })
 }
 
@@ -188,11 +188,6 @@ fn cook_report_with_continuation(mut value: Value) -> Value {
     if value.get("status").and_then(Value::as_str) != Some("in_flight") {
         return value;
     }
-    let cook_id = value
-        .get("cook_id")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
     let run_id = value
         .get("latest_run_id")
         .and_then(Value::as_str)
@@ -216,7 +211,7 @@ fn cook_report_with_continuation(mut value: Value) -> Value {
         );
         report.insert(
             "continuation_command".to_string(),
-            serde_json::json!(format!("homeboy agent-task cook-continue {cook_id}")),
+            serde_json::json!(format!("homeboy agent-task cook-continue {run_id}")),
         );
     }
     value
@@ -903,7 +898,7 @@ mod tests {
         );
         assert_eq!(
             report["continuation_command"],
-            "homeboy agent-task cook-continue cook-1"
+            "homeboy agent-task cook-continue cook-1-attempt-1"
         );
     }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -68,9 +68,32 @@ pub(crate) fn continue_cook(args: CookContinueArgs) -> CmdResult<Value> {
         agent_task_lifecycle::cook_index(&recipe.cook_id)
             .ok()
             .map(|index| index.latest_run_id)
-            .unwrap_or_else(|| recipe.attempts[0].run_id.clone())
+            .filter(|run_id| {
+                recipe
+                    .attempts
+                    .iter()
+                    .any(|attempt| attempt.run_id == *run_id)
+            })
+            .unwrap_or_else(|| {
+                recipe
+                    .attempts
+                    .last()
+                    .expect("validated recipe has an attempt")
+                    .run_id
+                    .clone()
+            })
     };
     let record = agent_task_lifecycle::status(&run_id)?;
+    if record.run_id != run_id
+        || record.metadata.get("cook_id").and_then(Value::as_str) != Some(recipe.cook_id.as_str())
+    {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "cook_or_attempt_id",
+            "durable lifecycle record does not match its immutable Cook recipe",
+            Some(run_id),
+            None,
+        ));
+    }
     if !matches!(
         record.state,
         agent_task_lifecycle::AgentTaskRunState::Succeeded


### PR DESCRIPTION
## Summary
- emit run-bound `cook-continue <run-id>` recovery actions instead of global `run-next`
- make Cook JSON summaries and durable failure actions retain the exact attempt identity
- prove targeted continuation isolation, fail-closed tamper handling, and idempotent completed continuations

Fixes #10186.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents targeted_claim_does_not_consume_another_cooks_continuation --lib`
- `cargo test -p homeboy-agents mismatched_targeted_continuation_fails_closed_without_consuming_other_cook --lib`
- `cargo test -p homeboy-agents consumer_reconstructs_options_once_and_completed_work_never_replays --lib`
- `cargo test -p homeboy-agents moving_base_recovery_report_retains_typed_evidence_and_exact_continuation --lib`
- `cargo test -p homeboy-cli in_flight_cook_report_keeps_provider_state_and_managed_continuation_separate --lib`
- `cargo check -p homeboy-agents -p homeboy-cli`
- `git diff --check`

## AI Assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: root-cause analysis, implementation, deterministic regression coverage, and PR drafting.

Chris Huber remains responsible for every line.