### PR TITLE
Fix adopted candidate provenance base

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -11,6 +11,7 @@ use super::types::AgentTaskPromotionOptions;
 pub(crate) struct CommittedChangesPatch {
     pub(crate) base_ref: String,
     pub(crate) candidate: String,
+    pub(crate) historical_task_base: Option<String>,
     pub(crate) patch_path: PathBuf,
     pub(crate) sha256: String,
     pub(crate) commit_range: String,
@@ -26,14 +27,6 @@ pub(crate) fn committed_changes_patch(
     if !worktree_path.is_dir() {
         return Ok(None);
     }
-    let Some(mut base_ref) = resolve_committed_changes_base(
-        worktree_path,
-        options.task_base_sha.as_deref(),
-        options.base_ref.as_deref(),
-    )?
-    else {
-        return Ok(None);
-    };
     if options.candidate_ref.is_some() {
         ensure_clean_source(worktree_path)?;
     }
@@ -50,30 +43,23 @@ pub(crate) fn committed_changes_patch(
         }
     }
 
-    // Explicit adoption of a pre-existing immutable candidate: the cook can
-    // record the candidate commit itself as the task base, so a provider that
-    // reviews it and returns no-op leaves an empty base..candidate diff and
-    // promotion has nothing to adopt (#8895). When the caller supplied an
-    // explicit candidate_ref and the recorded base IS the candidate, resolve the
-    // effective base to the candidate's first parent so the immutable commit
-    // becomes the promotable change. Fail closed: a root commit (no parent)
-    // cannot be adopted this way. This only triggers for explicit adoption, so
-    // ordinary no-op cooks still reject a base-equal promotion.
-    if options.candidate_ref.is_some() && base_ref == candidate {
-        let parent = git_stdout(
+    let (base_ref, historical_task_base) = if options.candidate_ref.is_some() {
+        resolve_adoption_candidate_base(
             worktree_path,
-            &["rev-parse", "--verify", &format!("{candidate}^{{commit}}~1")],
-        )
-        .map_err(|_| {
-            Error::validation_invalid_argument(
-                "candidate_ref",
-                "adopted candidate equals the recorded task base but has no parent commit to adopt against; supply a candidate with at least one committed change",
-                Some(candidate.clone()),
-                None,
-            )
-        })?;
-        base_ref = parent.trim().to_string();
-    }
+            &candidate,
+            options.task_base_sha.as_deref(),
+        )?
+    } else {
+        let Some(base_ref) = resolve_committed_changes_base(
+            worktree_path,
+            options.task_base_sha.as_deref(),
+            options.base_ref.as_deref(),
+        )?
+        else {
+            return Ok(None);
+        };
+        (base_ref, None)
+    };
     let is_ancestor = Command::new("git")
         .args(["merge-base", "--is-ancestor", &base_ref, &candidate])
         .current_dir(worktree_path)
@@ -130,11 +116,78 @@ pub(crate) fn committed_changes_patch(
     Ok(Some(CommittedChangesPatch {
         base_ref,
         candidate,
+        historical_task_base,
         patch_path,
         sha256,
         commit_range,
         commits,
     }))
+}
+
+/// Explicit adoption is scoped to the immutable candidate's sole parent, not
+/// the task's historical workspace base. A rebased candidate may have many
+/// unrelated upstream commits between those two points.
+fn resolve_adoption_candidate_base(
+    cwd: &Path,
+    candidate: &str,
+    task_base_sha: Option<&str>,
+) -> Result<(String, Option<String>)> {
+    let parents = git_stdout(cwd, &["rev-list", "--parents", "-n", "1", candidate])?;
+    let mut identities = parents.split_whitespace();
+    let _commit = identities.next();
+    let parent = identities.next();
+    if parent.is_none() || identities.next().is_some() {
+        return Err(Error::validation_invalid_argument(
+            "candidate_ref",
+            "adopted candidate must have exactly one parent so its immutable base is unambiguous",
+            Some(candidate.to_string()),
+            None,
+        ));
+    }
+    let parent = parent.expect("validated candidate parent").to_string();
+    let is_ancestor = Command::new("git")
+        .args(["merge-base", "--is-ancestor", &parent, candidate])
+        .current_dir(cwd)
+        .status()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?
+        .success();
+    if !is_ancestor {
+        return Err(Error::validation_invalid_argument(
+            "candidate_ref",
+            "adopted candidate is not descended from its immutable parent base",
+            Some(candidate.to_string()),
+            None,
+        ));
+    }
+    let historical_task_base = task_base_sha
+        .filter(|base| !base.trim().is_empty())
+        .map(|base| {
+            git_stdout(
+                cwd,
+                &["rev-parse", "--verify", &format!("{base}^{{commit}}")],
+            )
+            .map(|base| base.trim().to_string())
+        })
+        .transpose()?;
+    if let Some(historical) = historical_task_base.as_deref() {
+        if historical != candidate {
+            let related = Command::new("git")
+                .args(["merge-base", "--is-ancestor", historical, &parent])
+                .current_dir(cwd)
+                .status()
+                .map_err(|error| Error::git_command_failed(error.to_string()))?
+                .success();
+            if !related {
+                return Err(Error::validation_invalid_argument(
+                    "task_base_sha",
+                    "recorded task base is unrelated to the adopted candidate parent; refusing ambiguous adoption provenance",
+                    Some(historical.to_string()),
+                    None,
+                ));
+            }
+        }
+    }
+    Ok((parent, historical_task_base))
 }
 
 fn ensure_clean_source(cwd: &Path) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1353,6 +1353,7 @@ fn promote_committed_changes(
             "base_ref": committed_patch.base_ref,
             "commit_range": committed_patch.commit_range,
             "commits": committed_patch.commits,
+            "historical_task_base": committed_patch.historical_task_base,
             "candidate": candidate,
             "destination_baseline": candidate,
             "gate_feedback_baseline": gate_feedback_baseline,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -728,12 +728,138 @@ fn adopt_no_op_pre_existing_candidate_when_base_equals_candidate() {
     assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
     assert_eq!(report.patch_artifact.id, "committed-changes");
     assert_eq!(report.changed_files, vec!["lib.rs"]);
+    assert_eq!(report.provenance["base_ref"], git_head(&repo, "HEAD~1"));
+    assert_eq!(report.provenance["historical_task_base"], candidate);
     assert_eq!(
         report.provenance["candidate"]["fingerprint"]["head"],
         candidate
     );
     assert_eq!(provider.apply_calls.len(), 1);
     assert_eq!(provider.verify_calls.len(), 1);
+}
+
+#[test]
+fn adoption_scopes_a_rebased_two_file_candidate_to_its_parent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "agent@example.test"]);
+    git(&repo, &["config", "user.name", "Agent"]);
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::write(repo.join("base.txt"), "base\n").expect("write base");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "historical base"]);
+    let historical_base = git_head(&repo, "HEAD");
+    for (path, contents) in [("upstream-a.txt", "a\n"), ("upstream-b.txt", "b\n")] {
+        std::fs::write(repo.join(path), contents).expect("write upstream");
+        git(&repo, &["add", path]);
+        git(&repo, &["commit", "-m", "intervening upstream"]);
+    }
+    let candidate_base = git_head(&repo, "HEAD");
+    git(&repo, &["checkout", "-b", "candidate"]);
+    std::fs::write(repo.join("candidate-a.txt"), "a\n").expect("write candidate a");
+    std::fs::write(repo.join("candidate-b.txt"), "b\n").expect("write candidate b");
+    git(&repo, &["add", "candidate-a.txt", "candidate-b.txt"]);
+    git(&repo, &["commit", "-m", "candidate"]);
+    let candidate = git_head(&repo, "HEAD");
+    let (source_path, source) = write_empty_patch_source(&temp);
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("adopted-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            task_base_sha: Some(historical_base.clone()),
+            candidate_ref: Some(candidate.clone()),
+            to_worktree: "repo@adopted".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut FakePromotionWorkspaceProvider {
+            workspace_path: Some(repo.clone()),
+            ..Default::default()
+        },
+    )
+    .expect("rebased candidate promotes from its immutable parent");
+
+    assert_eq!(
+        report.changed_files,
+        vec!["candidate-a.txt", "candidate-b.txt"]
+    );
+    assert_eq!(report.provenance["base_ref"], candidate_base);
+    assert_eq!(
+        report.provenance["commit_range"],
+        format!("{candidate_base}..{candidate}")
+    );
+    assert_eq!(
+        report.provenance["commits"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(report.provenance["historical_task_base"], historical_base);
+}
+
+#[test]
+fn adoption_rejects_an_unrelated_historical_task_base() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "agent@example.test"]);
+    git(&repo, &["config", "user.name", "Agent"]);
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::write(repo.join("base.txt"), "base\n").expect("write base");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "base"]);
+    std::fs::write(repo.join("candidate.txt"), "candidate\n").expect("write candidate");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "candidate"]);
+    let candidate = git_head(&repo, "HEAD");
+    git(&repo, &["checkout", "--orphan", "unrelated"]);
+    git(&repo, &["rm", "-rf", "."]);
+    std::fs::write(repo.join("unrelated.txt"), "unrelated\n").expect("write unrelated");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "unrelated"]);
+    let unrelated = git_head(&repo, "HEAD");
+    git(&repo, &["checkout", "--detach", &candidate]);
+    let (source_path, source) = write_empty_patch_source(&temp);
+
+    let error = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("adopted-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            task_base_sha: Some(unrelated),
+            candidate_ref: Some(candidate),
+            to_worktree: "repo@adopted".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut FakePromotionWorkspaceProvider {
+            workspace_path: Some(repo),
+            ..Default::default()
+        },
+    )
+    .expect_err("unrelated historical base must fail closed");
+
+    assert!(error
+        .message
+        .contains("unrelated to the adopted candidate parent"));
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -474,18 +474,21 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             None,
         ));
     }
-    let task_base_sha = options.task_base_sha.as_deref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "task_base_sha",
-            "candidate adoption requires the recorded immutable task base for baseline-aware verification",
-            None,
-            None,
-        )
-    })?;
+    let candidate_base_sha = promotion.provenance["base_ref"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion.provenance.base_ref",
+                "candidate adoption requires the resolved immutable candidate base for baseline-aware verification",
+                None,
+                None,
+            )
+        })?;
     compare_adoption_gate_failures_to_base(
         &mut promotion,
         &source_worktree,
-        task_base_sha,
+        &candidate_base_sha,
         &record.run_id,
     )?;
     if agent_task_lifecycle::candidate_adoption_cancel_requested(&record.run_id)? {
@@ -505,6 +508,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         "candidate_ref": candidate_sha,
         "source_worktree_path": options.source_worktree_path,
         "recorded_task_base": options.task_base_sha,
+        "candidate_base": candidate_base_sha,
         "recovery": recovery,
         "ai_model": adoption_ai_model,
         "ai_model_source": ai_model_source,


### PR DESCRIPTION
## Summary

- scope immutable candidate adoption commits and changed files to the candidate's sole parent rather than the historical task base
- retain the historical task base as separate provenance and compare inherited gate failures against the candidate base
- fail closed for dirty sources, ambiguous parentage, and unrelated historical task bases

Fixes #9706.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_promotion::tests::part_b::adoption_ -- --nocapture`
- `cargo test -p homeboy-agents agent_task_service::cook_promotion::moving_base_tests -- --nocapture`
- `cargo test -p homeboy-agents agent_task_finalization::tests::durable_finalization_uses_promoted_files_for_clean_committed_candidate -- --nocapture`
- `cargo check -p homeboy-cli`
- `git diff --check`

## AI Assistance

- Model: OpenAI GPT-5.6 Terra
- Tool: OpenCode
- Used for: issue and merged-fix analysis, implementation, deterministic reproduction coverage, and verification.

Chris Huber remains responsible for every line.