### PR TITLE
fix(release): establish authoritative publication assets

### DIFF
--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -671,6 +671,10 @@ mod tests {
             durable_path: Some(artifact_path.display().to_string()),
             artifact_type: None,
             platform: None,
+            phase: "final".to_string(),
+            producer: "test".to_string(),
+            sha256: None,
+            publication_authority: false,
         }];
 
         let component = Component {
@@ -709,6 +713,10 @@ mod tests {
             durable_path: Some(artifact_path.display().to_string()),
             artifact_type: None,
             platform: None,
+            phase: "final".to_string(),
+            producer: "test".to_string(),
+            sha256: None,
+            publication_authority: false,
         }];
 
         let component = Component {
@@ -756,6 +764,10 @@ mod tests {
             durable_path: None,
             artifact_type: None,
             platform: None,
+            phase: "final".to_string(),
+            producer: "test".to_string(),
+            sha256: None,
+            publication_authority: false,
         }];
 
         let result = super::run_deployment_step(
@@ -882,6 +894,10 @@ mod tests {
                 durable_path: Some(artifact_path.display().to_string()),
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             };
             std::fs::create_dir_all(source.join("build")).expect("package build directory");
             std::fs::write(source.join("build/intermediate"), "build").expect("build output");

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -170,6 +170,23 @@ pub(super) fn execute_release_plan_step(
                 }),
             ))
         }
+        "artifacts.authority" => Ok(Some(
+            executor::artifacts::establish_publication_authority(&mut context.state)
+                .map(|diagnostics| {
+                    executor::step_success(
+                        "artifacts.authority",
+                        "artifacts.authority",
+                        Some(serde_json::json!({ "artifacts": context.state.artifacts })),
+                        diagnostics
+                            .into_iter()
+                            .map(|message| homeboy_core::error::Hint { message })
+                            .collect(),
+                    )
+                })
+                .unwrap_or_else(|err| {
+                    failed_result("artifacts.authority", "artifacts.authority", err)
+                }),
+        )),
         "git.tag" => {
             let tag_name = step
                 .inputs
@@ -649,6 +666,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
             | "release.prepare"
             | "git.commit"
             | "package"
+            | "artifacts.authority"
             | "git.tag"
             | "git.push"
             // A failed github.release means the GitHub Release object was not

--- a/crates/homeboy-release/src/release/execution_projection.rs
+++ b/crates/homeboy-release/src/release/execution_projection.rs
@@ -94,6 +94,7 @@ fn release_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<Ch
                 durable_path: _,
                 artifact_type,
                 platform,
+                ..
             } = artifact;
             let id = format!("{}.artifact.{}", step.id, index + 1);
             let artifact_type = artifact_type.unwrap_or_else(|| "release_artifact".to_string());

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -615,12 +615,20 @@ mod tests {
                     durable_path: Some(durable.display().to_string()),
                     artifact_type: None,
                     platform: None,
+                    phase: "final".to_string(),
+                    producer: "test".to_string(),
+                    sha256: None,
+                    publication_authority: false,
                 },
                 ReleaseArtifact {
                     path: temp.path().join("missing.zip").display().to_string(),
                     durable_path: None,
                     artifact_type: None,
                     platform: None,
+                    phase: "final".to_string(),
+                    producer: "test".to_string(),
+                    sha256: None,
+                    publication_authority: false,
                 },
             ],
             ..ReleaseState::default()
@@ -670,6 +678,10 @@ mod tests {
                 durable_path: None,
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
             package_owned_paths: vec!["build".to_string(), "fixture-1.2.3.tgz".to_string()],
             ..ReleaseState::default()
@@ -1042,6 +1054,10 @@ mod tests {
                 durable_path: Some(".homeboy/artifacts/missing-plugin.zip".to_string()),
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
             ..ReleaseState::default()
         };
@@ -1103,6 +1119,10 @@ mod tests {
                 durable_path: None,
                 artifact_type: Some("npm".to_string()),
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
             ..ReleaseState::default()
         };

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -64,13 +64,11 @@ pub(crate) fn run_artifact_inventory(
 
     let artifact_count = artifacts.len();
     state.artifacts.extend(artifacts);
-    let diagnostics = establish_publication_authority(state)?;
     let artifacts = state.artifacts.clone();
     let data = serde_json::json!({
         "dir": artifact_dir,
         "artifact_count": artifact_count,
         "artifacts": artifacts,
-        "diagnostics": diagnostics,
     });
 
     Ok(step_success(
@@ -695,6 +693,31 @@ mod tests {
             1
         );
         assert!(state.artifacts[1].publication_authority);
+    }
+
+    #[test]
+    fn authority_preserves_distinct_platform_assets() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let macos = temp.path().join("component-macos.zip");
+        let linux = temp.path().join("component-linux.zip");
+        std::fs::write(&macos, b"macos").expect("macos bytes");
+        std::fs::write(&linux, b"linux").expect("linux bytes");
+        let mut state = ReleaseState {
+            artifacts: vec![
+                artifact(&macos, "final", "package"),
+                artifact(&linux, "final", "package"),
+            ],
+            ..ReleaseState::default()
+        };
+
+        establish_publication_authority(&mut state).expect("authority");
+        let publications = github_release_publications(&state).expect("publications");
+
+        assert_eq!(publications.len(), 2);
+        assert!(state
+            .artifacts
+            .iter()
+            .all(|artifact| artifact.publication_authority));
     }
 
     fn artifact(path: &std::path::Path, phase: &str, producer: &str) -> ReleaseArtifact {

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -1,5 +1,7 @@
 use homeboy_core::error::{Error, Result};
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 
 use super::{step_success, ReleaseArtifact, ReleaseState, ReleaseStepResult};
 
@@ -61,11 +63,14 @@ pub(crate) fn run_artifact_inventory(
     }
 
     let artifact_count = artifacts.len();
-    state.artifacts.extend(artifacts.clone());
+    state.artifacts.extend(artifacts);
+    let diagnostics = establish_publication_authority(state)?;
+    let artifacts = state.artifacts.clone();
     let data = serde_json::json!({
         "dir": artifact_dir,
         "artifact_count": artifact_count,
         "artifacts": artifacts,
+        "diagnostics": diagnostics,
     });
 
     Ok(step_success(
@@ -74,6 +79,99 @@ pub(crate) fn run_artifact_inventory(
         Some(data),
         Vec::new(),
     ))
+}
+
+/// Select one generic publication authority for every remote target filename.
+/// Final package output supersedes preflight output, while a disagreement
+/// between equally authoritative final producers fails before tag/push.
+pub(crate) fn establish_publication_authority(state: &mut ReleaseState) -> Result<Vec<String>> {
+    let mut selected: BTreeMap<String, usize> = BTreeMap::new();
+    let mut diagnostics = Vec::new();
+    for artifact in &mut state.artifacts {
+        let path = artifact
+            .durable_path
+            .as_deref()
+            .filter(|path| std::path::Path::new(path).is_file())
+            .unwrap_or(&artifact.path);
+        artifact.sha256 = Some(sha256_file(path)?);
+        artifact.publication_authority = false;
+    }
+    for index in 0..state.artifacts.len() {
+        let target = artifact_target_name(&state.artifacts[index])?;
+        let Some(existing_index) = selected.get(&target).copied() else {
+            selected.insert(target, index);
+            continue;
+        };
+        let existing = &state.artifacts[existing_index];
+        let candidate = &state.artifacts[index];
+        let same_bytes = existing.sha256 == candidate.sha256;
+        let existing_final = existing.phase == "final";
+        let candidate_final = candidate.phase == "final";
+        if same_bytes {
+            if !existing_final && candidate_final {
+                selected.insert(target, index);
+            }
+            continue;
+        }
+        if !existing_final && candidate_final {
+            diagnostics.push(format!(
+                "Release asset '{}' from {} ({}) is non-authoritative; final package output from {} ({}) supersedes its sha256 {} with {}",
+                target, existing.producer, existing.phase, candidate.producer, candidate.phase,
+                existing.sha256.as_deref().unwrap_or_default(), candidate.sha256.as_deref().unwrap_or_default()
+            ));
+            selected.insert(target, index);
+        } else if existing_final && !candidate_final {
+            diagnostics.push(format!(
+                "Release asset '{}' from {} ({}) is non-authoritative; final package output from {} ({}) supersedes its sha256 {} with {}",
+                target, candidate.producer, candidate.phase, existing.producer, existing.phase,
+                candidate.sha256.as_deref().unwrap_or_default(), existing.sha256.as_deref().unwrap_or_default()
+            ));
+        } else {
+            return Err(Error::validation_invalid_argument(
+                "release assets",
+                format!("release assets targeting '{}' have conflicting authoritative bytes from {} and {}", target, existing.producer, candidate.producer),
+                None,
+                None,
+            ));
+        }
+    }
+    for index in selected.into_values() {
+        state.artifacts[index].publication_authority = true;
+    }
+    Ok(diagnostics)
+}
+
+fn artifact_target_name(artifact: &ReleaseArtifact) -> Result<String> {
+    std::path::Path::new(&artifact.path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "release assets",
+                format!("release artifact '{}' has no valid filename", artifact.path),
+                None,
+                None,
+            )
+        })
+}
+
+fn sha256_file(path: &str) -> Result<String> {
+    let mut file = std::fs::File::open(path).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to hash release artifact '{}': {}", path, error),
+            Some(path.to_string()),
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to hash release artifact '{}': {}", path, error),
+            Some(path.to_string()),
+        )
+    })?;
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn is_package_recovery_manifest(manifest_path: &std::path::Path) -> bool {
@@ -126,6 +224,10 @@ fn inventory_directory_files(
             durable_path: None,
             artifact_type: None,
             platform: None,
+            phase: "recovery".to_string(),
+            producer: "from-artifacts".to_string(),
+            sha256: None,
+            publication_authority: false,
         });
     }
     Ok(artifacts)
@@ -303,9 +405,12 @@ fn validate_recovery_artifact(
 #[cfg(test)]
 mod tests {
     use super::{
-        run_artifact_inventory, PackageRecoveryContext, PACKAGE_RECOVERY_MANIFEST,
-        PACKAGE_RECOVERY_MANIFEST_SCHEMA, PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
+        establish_publication_authority, run_artifact_inventory, PackageRecoveryContext,
+        PACKAGE_RECOVERY_MANIFEST, PACKAGE_RECOVERY_MANIFEST_SCHEMA,
+        PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
     };
+    use crate::release::executor::github_release::github_release_publications;
+    use crate::release::types::ReleaseArtifact;
     use crate::release::types::ReleaseState;
     use crate::release::ReleaseStepStatus;
 
@@ -498,5 +603,110 @@ mod tests {
             "commit": "abc123",
             "artifacts": [{ "path": artifact }]
         })
+    }
+
+    #[test]
+    fn final_package_authority_supersedes_different_preflight_bytes_and_publishes_once() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let preflight_dir = temp.path().join("preflight");
+        let final_dir = temp.path().join("final");
+        std::fs::create_dir_all(&preflight_dir).expect("preflight dir");
+        std::fs::create_dir_all(&final_dir).expect("final dir");
+        let preflight = preflight_dir.join("component.asset");
+        let final_package = final_dir.join("component.asset");
+        std::fs::write(&preflight, b"validation bytes").expect("preflight bytes");
+        std::fs::write(&final_package, b"production bytes").expect("final bytes");
+        let mut state = ReleaseState {
+            artifacts: vec![
+                artifact(&preflight, "preflight", "validation"),
+                artifact(&final_package, "final", "package"),
+            ],
+            ..ReleaseState::default()
+        };
+
+        let diagnostics = establish_publication_authority(&mut state).expect("authority");
+        let publications = github_release_publications(&state).expect("publications");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            state
+                .artifacts
+                .iter()
+                .filter(|artifact| artifact.publication_authority)
+                .count(),
+            1
+        );
+        assert!(state.artifacts[1].publication_authority);
+        assert_eq!(publications.len(), 1);
+        assert_eq!(
+            std::fs::read(&publications[0].source_path).expect("published bytes"),
+            b"production bytes"
+        );
+    }
+
+    #[test]
+    fn authority_rejects_conflicting_final_bytes_before_tagging() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first_dir = temp.path().join("first");
+        let second_dir = temp.path().join("second");
+        std::fs::create_dir_all(&first_dir).expect("first dir");
+        std::fs::create_dir_all(&second_dir).expect("second dir");
+        let first = first_dir.join("asset.bin");
+        let second = second_dir.join("asset.bin");
+        std::fs::write(&first, b"first").expect("first bytes");
+        std::fs::write(&second, b"second").expect("second bytes");
+        let mut state = ReleaseState {
+            artifacts: vec![
+                artifact(&first, "final", "one"),
+                artifact(&second, "final", "two"),
+            ],
+            ..ReleaseState::default()
+        };
+
+        let error =
+            establish_publication_authority(&mut state).expect_err("conflicting final assets");
+        assert!(error.message.contains("conflicting authoritative bytes"));
+    }
+
+    #[test]
+    fn authority_collapses_identical_duplicate_bytes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first_dir = temp.path().join("first");
+        let second_dir = temp.path().join("second");
+        std::fs::create_dir_all(&first_dir).expect("first dir");
+        std::fs::create_dir_all(&second_dir).expect("second dir");
+        let first = first_dir.join("asset.bin");
+        let second = second_dir.join("asset.bin");
+        std::fs::write(&first, b"same").expect("first bytes");
+        std::fs::write(&second, b"same").expect("second bytes");
+        let mut state = ReleaseState {
+            artifacts: vec![
+                artifact(&first, "preflight", "one"),
+                artifact(&second, "final", "two"),
+            ],
+            ..ReleaseState::default()
+        };
+
+        establish_publication_authority(&mut state).expect("identical assets");
+        assert_eq!(
+            github_release_publications(&state)
+                .expect("publications")
+                .len(),
+            1
+        );
+        assert!(state.artifacts[1].publication_authority);
+    }
+
+    fn artifact(path: &std::path::Path, phase: &str, producer: &str) -> ReleaseArtifact {
+        ReleaseArtifact {
+            path: path.display().to_string(),
+            durable_path: Some(path.display().to_string()),
+            artifact_type: None,
+            platform: None,
+            phase: phase.to_string(),
+            producer: producer.to_string(),
+            sha256: None,
+            publication_authority: false,
+        }
     }
 }

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -79,9 +79,14 @@ pub(crate) fn gh_release_exists(
 }
 
 pub(crate) fn github_release_artifact_paths(state: &ReleaseState) -> Vec<String> {
+    let authority_established = state
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.publication_authority);
     state
         .artifacts
         .iter()
+        .filter(|artifact| !authority_established || artifact.publication_authority)
         .filter_map(|artifact| {
             artifact
                 .durable_path
@@ -102,7 +107,15 @@ pub(crate) fn github_release_publications(
 ) -> Result<Vec<ReleaseAssetPublication>, String> {
     let mut publications: BTreeMap<String, ReleaseAssetPublication> = BTreeMap::new();
     let mut direct_sources = HashSet::new();
-    for artifact in &state.artifacts {
+    let authority_established = state
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.publication_authority);
+    for artifact in state
+        .artifacts
+        .iter()
+        .filter(|artifact| !authority_established || artifact.publication_authority)
+    {
         let source_path = artifact
             .durable_path
             .as_deref()
@@ -687,6 +700,10 @@ mod tests {
                 durable_path: Some(durable.display().to_string()),
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
             ..ReleaseState::default()
         };
@@ -712,6 +729,10 @@ mod tests {
                 durable_path: None,
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
             ..ReleaseState::default()
         };
@@ -738,6 +759,10 @@ mod tests {
                 durable_path: None,
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
             ..ReleaseState::default()
         };
@@ -762,6 +787,10 @@ mod tests {
                 durable_path: None,
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
             ..ReleaseState::default()
         };
@@ -805,6 +834,10 @@ mod tests {
             durable_path: durable_path.map(|path| path.display().to_string()),
             artifact_type: None,
             platform: None,
+            phase: "final".to_string(),
+            producer: "test".to_string(),
+            sha256: None,
+            publication_authority: false,
         }
     }
 

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -94,6 +94,10 @@ pub(crate) fn run_package(
         let artifact_start = state.artifacts.len();
         store_artifacts_from_output(state, &response)
             .map_err(|err| package_provider_error(&extension.id, err))?;
+        for artifact in &mut state.artifacts[artifact_start..] {
+            artifact.phase = "final".to_string();
+            artifact.producer = format!("extension:{}", extension.id);
+        }
         persist_package_artifacts(state, artifact_start, component_id, component_local_path)
             .map_err(|err| package_provider_error(&extension.id, err))?;
         responses.push(serde_json::json!({
@@ -263,6 +267,10 @@ fn collect_declared_build_artifact(
         durable_path: None,
         artifact_type: None,
         platform: None,
+        phase: "final".to_string(),
+        producer: "scripts.build".to_string(),
+        sha256: None,
+        publication_authority: false,
     });
     persist_package_artifacts(state, artifact_start, component_id, component_local_path)
 }

--- a/crates/homeboy-release/src/release/executor/package_preflight.rs
+++ b/crates/homeboy-release/src/release/executor/package_preflight.rs
@@ -408,6 +408,10 @@ mod tests {
             durable_path: None,
             artifact_type: Some("archive".to_string()),
             platform: None,
+            phase: "final".to_string(),
+            producer: "test".to_string(),
+            sha256: None,
+            publication_authority: false,
         }];
         let error = validate_package_completeness(&component, repo.path(), &artifacts)
             .expect_err("missing tracked runtime file should fail");
@@ -442,6 +446,10 @@ mod tests {
             durable_path: None,
             artifact_type: Some("archive".to_string()),
             platform: None,
+            phase: "final".to_string(),
+            producer: "test".to_string(),
+            sha256: None,
+            publication_authority: false,
         }];
         validate_package_completeness(&component, repo.path(), &artifacts)
             .expect("excluded runtime file should not fail");
@@ -702,6 +710,10 @@ mod tests {
             durable_path: None,
             artifact_type: Some("archive".to_string()),
             platform: None,
+            phase: "final".to_string(),
+            producer: "test".to_string(),
+            sha256: None,
+            publication_authority: false,
         }]
     }
 

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -66,6 +66,7 @@ pub fn package_existing_tag(
             "release.package completed without producing any artifacts",
         ));
     }
+    super::executor::artifacts::establish_publication_authority(&mut state)?;
 
     let artifact_dir = release_package_dir(component_id, tag)?;
     fs::create_dir_all(&artifact_dir).map_err(|error| {
@@ -123,6 +124,25 @@ pub fn package_existing_tag(
         "release",
         "Release package manifest written to {}",
         manifest_path.display()
+    );
+    for artifact in result
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.publication_authority)
+    {
+        homeboy_core::log_status!(
+            "release",
+            "Authoritative release asset: {} sha256 {} ({})",
+            artifact.path,
+            artifact.sha256.as_deref().unwrap_or("unavailable"),
+            artifact.producer
+        );
+    }
+    homeboy_core::log_status!(
+        "release",
+        "Resume publication: homeboy release {} --head --from-artifacts {}",
+        component_id,
+        artifact_dir.display()
     );
 
     Ok(result)
@@ -210,6 +230,10 @@ fn copy_release_artifacts(
             durable_path: Some(destination.display().to_string()),
             artifact_type: artifact.artifact_type.clone(),
             platform: artifact.platform.clone(),
+            phase: artifact.phase.clone(),
+            producer: artifact.producer.clone(),
+            sha256: artifact.sha256.clone(),
+            publication_authority: artifact.publication_authority,
         });
     }
     Ok(copied)
@@ -250,6 +274,10 @@ mod tests {
                 durable_path: None,
                 artifact_type: Some("archive".to_string()),
                 platform: None,
+                phase: "final".to_string(),
+                producer: "test".to_string(),
+                sha256: None,
+                publication_authority: false,
             }],
         )
         .expect("copy artifacts");

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -203,7 +203,13 @@ fn copy_release_artifacts(
     artifacts: &[ReleaseArtifact],
 ) -> Result<Vec<ReleaseArtifact>> {
     let mut copied = Vec::new();
-    for artifact in artifacts {
+    // The recovery manifest is a publication contract, so retain only the
+    // selected asset for each target name. Copying superseded duplicates would
+    // overwrite the same destination and make the manifest unverifiable.
+    for artifact in artifacts
+        .iter()
+        .filter(|artifact| artifact.publication_authority)
+    {
         let source = resolve_artifact_path(component_local_path, &artifact.path);
         let file_name = source.file_name().ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -277,7 +283,7 @@ mod tests {
                 phase: "final".to_string(),
                 producer: "test".to_string(),
                 sha256: None,
-                publication_authority: false,
+                publication_authority: true,
             }],
         )
         .expect("copy artifacts");
@@ -286,5 +292,52 @@ mod tests {
         assert_eq!(fs::read_to_string(&copied_path).expect("copied"), "zip");
         assert_eq!(copied[0].path, copied_path.display().to_string());
         assert_eq!(copied[0].artifact_type.as_deref(), Some("archive"));
+    }
+
+    #[test]
+    fn copy_release_artifacts_omits_superseded_duplicate_targets() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let component = temp.path().join("component");
+        let build = component.join("build");
+        let artifact_dir = temp.path().join("artifact-root");
+        fs::create_dir_all(&build).expect("build dir");
+        fs::create_dir_all(&artifact_dir).expect("artifact dir");
+        fs::write(build.join("plugin.zip"), "final").expect("artifact");
+
+        let copied = copy_release_artifacts(
+            &component.display().to_string(),
+            &artifact_dir,
+            &[
+                ReleaseArtifact {
+                    path: "build/plugin.zip".to_string(),
+                    durable_path: None,
+                    artifact_type: None,
+                    platform: Some("preflight".to_string()),
+                    phase: "preflight".to_string(),
+                    producer: "preflight".to_string(),
+                    sha256: Some("superseded".to_string()),
+                    publication_authority: false,
+                },
+                ReleaseArtifact {
+                    path: "build/plugin.zip".to_string(),
+                    durable_path: None,
+                    artifact_type: None,
+                    platform: Some("universal".to_string()),
+                    phase: "final".to_string(),
+                    producer: "package".to_string(),
+                    sha256: Some("authoritative".to_string()),
+                    publication_authority: true,
+                },
+            ],
+        )
+        .expect("copy authoritative artifact");
+
+        assert_eq!(copied.len(), 1);
+        assert_eq!(
+            fs::read_to_string(artifact_dir.join("plugin.zip")).unwrap(),
+            "final"
+        );
+        assert_eq!(copied[0].platform.as_deref(), Some("universal"));
+        assert!(copied[0].publication_authority);
     }
 }

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -293,7 +293,14 @@ fn build_head_release_steps(
             vec![artifact_need.clone()],
             string_config("dir", dir),
         ));
-        artifact_need = "artifacts.inventory".to_string();
+        steps.push(ready_step(
+            "artifacts.authority",
+            "artifacts.authority",
+            "Establish authoritative release assets",
+            vec!["artifacts.inventory".to_string()],
+            StepConfig::new(),
+        ));
+        artifact_need = "artifacts.authority".to_string();
     } else if package_step_needed {
         steps.push(ready_step(
             "package",

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -134,7 +134,14 @@ pub(in crate::release) fn build_release_steps(
             vec!["git.commit".to_string()],
             StepConfig::new(),
         ));
-        vec!["package".to_string()]
+        steps.push(ready_step(
+            "artifacts.authority",
+            "artifacts.authority",
+            "Establish authoritative release assets",
+            vec!["package".to_string()],
+            StepConfig::new(),
+        ));
+        vec!["artifacts.authority".to_string()]
     } else {
         vec!["git.commit".to_string()]
     };
@@ -295,7 +302,14 @@ fn build_head_release_steps(
             vec![artifact_need.clone()],
             StepConfig::new(),
         ));
-        artifact_need = "package".to_string();
+        steps.push(ready_step(
+            "artifacts.authority",
+            "artifacts.authority",
+            "Establish authoritative release assets",
+            vec!["package".to_string()],
+            StepConfig::new(),
+        ));
+        artifact_need = "artifacts.authority".to_string();
     }
 
     if options.pipeline.skip_publish && !publish_targets.is_empty() {

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -906,14 +906,20 @@ fn head_release_plan_skips_mutation_steps_and_uses_existing_artifacts() {
     assert!(!ids.contains(&"git.push"));
     assert_eq!(
         ids,
-        vec!["artifacts.inventory", "github.release", "publish.wordpress"]
+        vec![
+            "artifacts.inventory",
+            "artifacts.authority",
+            "github.release",
+            "publish.wordpress"
+        ]
     );
     assert_eq!(
         steps[0].inputs.get("dir").and_then(|value| value.as_str()),
         Some("artifacts")
     );
     assert_eq!(steps[1].needs, vec!["artifacts.inventory"]);
-    assert_eq!(steps[2].needs, vec!["artifacts.inventory"]);
+    assert_eq!(steps[2].needs, vec!["artifacts.authority"]);
+    assert_eq!(steps[3].needs, vec!["artifacts.authority"]);
 }
 
 #[test]
@@ -962,8 +968,16 @@ fn head_release_skip_publish_still_uploads_existing_artifacts() {
     .expect("steps");
 
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
-    assert_eq!(ids, vec!["artifacts.inventory", "github.release"]);
+    assert_eq!(
+        ids,
+        vec![
+            "artifacts.inventory",
+            "artifacts.authority",
+            "github.release"
+        ]
+    );
     assert_eq!(steps[1].needs, vec!["artifacts.inventory"]);
+    assert_eq!(steps[2].needs, vec!["artifacts.authority"]);
 }
 
 #[test]

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -557,7 +557,11 @@ fn skip_publish_with_package_provider_still_packages_before_github_release() {
     assert!(package_preflight_index < package_index);
     assert!(package_index < github_release_index);
     assert_eq!(steps[package_index].needs, vec!["git.commit"]);
-    assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["package"]);
+    assert!(step_index(&ids, "package") < step_index(&ids, "artifacts.authority"));
+    assert_eq!(
+        steps[step_index(&ids, "git.tag")].needs,
+        vec!["artifacts.authority"]
+    );
     assert_eq!(steps[github_release_index].needs, vec!["git.push"]);
     assert!(!ids.contains(&"publish.artifact-packager"));
     assert_eq!(
@@ -635,9 +639,18 @@ fn head_skip_publish_with_package_provider_still_packages_before_github_release(
     .expect("steps");
 
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
-    assert_eq!(ids, vec!["package", "github.release", "cleanup"]);
+    assert_eq!(
+        ids,
+        vec![
+            "package",
+            "artifacts.authority",
+            "github.release",
+            "cleanup"
+        ]
+    );
     assert_eq!(steps[1].needs, vec!["package"]);
-    assert_eq!(steps[2].needs, vec!["github.release"]);
+    assert_eq!(steps[2].needs, vec!["artifacts.authority"]);
+    assert_eq!(steps[3].needs, vec!["github.release"]);
 }
 
 #[test]
@@ -672,7 +685,10 @@ fn component_build_artifact_packages_before_github_release_without_extension() {
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
     assert!(step_index(&ids, "preflight.package") < step_index(&ids, "package"));
     assert!(step_index(&ids, "package") < step_index(&ids, "github.release"));
-    assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["package"]);
+    assert_eq!(
+        steps[step_index(&ids, "git.tag")].needs,
+        vec!["artifacts.authority"]
+    );
     assert_eq!(
         steps[step_index(&ids, "cleanup")].needs,
         vec!["github.release"]
@@ -713,9 +729,18 @@ fn head_component_build_artifact_packages_before_github_release_without_extensio
     .expect("steps");
 
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
-    assert_eq!(ids, vec!["package", "github.release", "cleanup"]);
+    assert_eq!(
+        ids,
+        vec![
+            "package",
+            "artifacts.authority",
+            "github.release",
+            "cleanup"
+        ]
+    );
     assert_eq!(steps[1].needs, vec!["package"]);
-    assert_eq!(steps[2].needs, vec!["github.release"]);
+    assert_eq!(steps[2].needs, vec!["artifacts.authority"]);
+    assert_eq!(steps[3].needs, vec!["github.release"]);
 }
 
 #[test]

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -283,6 +283,28 @@ pub struct ReleaseArtifact {
     pub artifact_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<String>,
+    /// Lifecycle phase that produced these bytes. Final package output has
+    /// precedence over validation/preflight output with the same target name.
+    #[serde(default = "default_artifact_phase")]
+    pub phase: String,
+    /// Producer responsible for the artifact (component build, extension, or
+    /// externally supplied recovery inventory).
+    #[serde(default = "default_artifact_producer")]
+    pub producer: String,
+    /// Content identity persisted with the durable inventory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    /// Exactly one artifact per target name is allowed to publish.
+    #[serde(default)]
+    pub publication_authority: bool,
+}
+
+fn default_artifact_phase() -> String {
+    "final".to_string()
+}
+
+fn default_artifact_producer() -> String {
+    "unknown".to_string()
 }
 
 /// Mutable state threaded through sequential release execution.

--- a/crates/homeboy-release/src/release/utils.rs
+++ b/crates/homeboy-release/src/release/utils.rs
@@ -56,6 +56,10 @@ pub fn parse_release_artifacts(value: &serde_json::Value) -> Result<Vec<ReleaseA
                 durable_path: None,
                 artifact_type: None,
                 platform: None,
+                phase: "final".to_string(),
+                producer: "unknown".to_string(),
+                sha256: None,
+                publication_authority: false,
             },
             serde_json::Value::Object(map) => {
                 let path = validation::require(
@@ -77,6 +81,10 @@ pub fn parse_release_artifacts(value: &serde_json::Value) -> Result<Vec<ReleaseA
                     durable_path: None,
                     artifact_type,
                     platform,
+                    phase: "final".to_string(),
+                    producer: "unknown".to_string(),
+                    sha256: None,
+                    publication_authority: false,
                 }
             }
             _ => {


### PR DESCRIPTION
## Summary
- record phase, producer, SHA-256, and publication authority on release artifacts
- select final package output as the single authority before tag/push and pass only authorities to GitHub publication
- preserve authority in recovery manifests and print the exact `--head --from-artifacts` continuation

## Tests
- `cargo fmt --check`
- `cargo check -p homeboy-release`
- `cargo test -p homeboy-release release::plan_steps::tests`
- `cargo test -p homeboy-release artifacts::tests`

## AI Assistance
- Model: OpenAI gpt-5.6-terra
- Tool: OpenCode
- Use: implemented the release artifact authority model, regression coverage, and validation updates. Chris Huber remains responsible for every line.

Fixes #10149