### PR TITLE
fix(test): persist interrupted child evidence

### DIFF
--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -371,6 +371,8 @@ fn finish_test_observation(
         return;
     };
 
+    let child_supervision = child_supervision_metadata_from_observation(&observation);
+    let interrupted = child_supervision["child_supervision"]["status"] == "interrupted";
     let metadata = merge_metadata(
         merge_metadata(
             observation.active.initial_metadata().clone(),
@@ -386,15 +388,29 @@ fn finish_test_observation(
             "summary": workflow.summary,
             }),
         ),
-        validation_progress_metadata_from_observation(&observation),
+        merge_metadata(
+            validation_progress_metadata_from_observation(&observation),
+            child_supervision,
+        ),
     );
-    let status = if workflow.exit_code == 0 {
+    let metadata = if interrupted {
+        merge_metadata(
+            metadata,
+            serde_json::json!({ "observation_status": "interrupted" }),
+        )
+    } else {
+        metadata
+    };
+    let status = if interrupted {
+        RunStatus::Error
+    } else if workflow.exit_code == 0 {
         RunStatus::Pass
     } else {
         RunStatus::Fail
     };
     persist_test_findings(&observation, workflow);
     persist_validation_progress_artifacts(&observation);
+    persist_child_supervision_artifact(&observation);
     observation.active.finish(status, Some(metadata));
 }
 
@@ -488,8 +504,12 @@ fn finish_test_observation_error(
             "error": error.to_string(),
             }),
         ),
-        validation_progress_metadata_from_observation(&observation),
+        merge_metadata(
+            validation_progress_metadata_from_observation(&observation),
+            child_supervision_metadata_from_observation(&observation),
+        ),
     );
+    persist_child_supervision_artifact(&observation);
     observation.active.finish_error(Some(metadata));
 }
 
@@ -502,6 +522,36 @@ fn validation_progress_metadata_from_observation(
         .and_then(|path| RunDir::from_existing(path.clone()).ok())
         .map(|run_dir| validation_progress_metadata(&run_dir))
         .unwrap_or_else(|| serde_json::json!({}))
+}
+
+fn child_supervision_metadata_from_observation(observation: &TestObservation) -> serde_json::Value {
+    observation
+        .run_dir
+        .as_ref()
+        .and_then(|path| RunDir::from_existing(path.clone()).ok())
+        .and_then(|run_dir| {
+            std::fs::read_to_string(
+                run_dir.step_file(homeboy::core::engine::run_dir::files::CHILD_SUPERVISION),
+            )
+            .ok()
+        })
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+        .map(|supervision| serde_json::json!({ "child_supervision": supervision }))
+        .unwrap_or_else(|| serde_json::json!({}))
+}
+
+fn persist_child_supervision_artifact(observation: &TestObservation) {
+    let Some(run_dir) = observation
+        .run_dir
+        .as_ref()
+        .and_then(|path| RunDir::from_existing(path.clone()).ok())
+    else {
+        return;
+    };
+    observation.active.record_artifact_if_file(
+        "child_supervision",
+        &run_dir.step_file(homeboy::core::engine::run_dir::files::CHILD_SUPERVISION),
+    );
 }
 
 fn test_observation_command(component_id: &str, args: &TestArgs) -> String {
@@ -886,6 +936,73 @@ mod tests {
             assert!(artifacts
                 .iter()
                 .any(|artifact| artifact.kind == "validation_command_1_stderr"));
+            run_dir.cleanup();
+        });
+    }
+
+    #[test]
+    fn interrupted_test_observation_persists_parseable_partial_child_evidence() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let args = sample_args();
+            let run_dir = RunDir::create().expect("run dir");
+            std::fs::write(
+                run_dir.step_file(homeboy::core::engine::run_dir::files::CHILD_SUPERVISION),
+                r#"{
+                  "schema":"homeboy.child_supervision.v1",
+                  "status":"interrupted",
+                  "phase":"child",
+                  "command":"silent child",
+                  "child_pid":42,
+                  "started_at":"2026-01-01T00:00:00Z",
+                  "heartbeat_at":"2026-01-01T00:00:01Z",
+                  "finished_at":"2026-01-01T00:00:02Z",
+                  "timeout_ms":null,
+                  "cancellation_reason":"signal:15",
+                  "exit_code":143,
+                  "stdout_tail":"",
+                  "stderr_tail":""
+                }"#,
+            )
+            .expect("write child supervision");
+            let observation =
+                start_test_observation("homeboy", home.path(), &args, "test", Some(&run_dir))
+                    .expect("observation");
+            let run_id = observation.active.run_id().to_string();
+
+            finish_test_observation(
+                Some(observation),
+                &extension_test::TestRunWorkflowResult {
+                    status: "failed".to_string(),
+                    component: "homeboy".to_string(),
+                    exit_code: 143,
+                    test_counts: None,
+                    findings: None,
+                    failure_analysis_input: None,
+                    coverage: None,
+                    baseline_comparison: None,
+                    analysis: None,
+                    autofix: None,
+                    hints: None,
+                    test_scope: None,
+                    summary: None,
+                    raw_output: None,
+                    extension_phase_timings: Vec::new(),
+                },
+            );
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let record = store.get_run(&run_id).expect("read").expect("record");
+            assert_eq!(record.status, "error");
+            assert_eq!(record.metadata_json["observation_status"], "interrupted");
+            assert_eq!(
+                record.metadata_json["child_supervision"]["cancellation_reason"],
+                "signal:15"
+            );
+            let artifacts = store.list_artifacts(&run_id).expect("artifacts");
+            assert!(artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "child_supervision"));
             run_dir.cleanup();
         });
     }

--- a/crates/homeboy-core/src/engine/run_dir.rs
+++ b/crates/homeboy-core/src/engine/run_dir.rs
@@ -50,6 +50,7 @@ pub mod files {
     pub const RESOURCE_SUMMARY: &str = "resource-summary.json";
     pub const PHASE_TIMINGS: &str = "phase-timings.json";
     pub const VALIDATION_PROGRESS: &str = "validation-progress.json";
+    pub const CHILD_SUPERVISION: &str = "child-supervision.json";
     pub const EXTENSION_CHILDREN_DIR: &str = "extension-children";
     pub const ANNOTATIONS_DIR: &str = "annotations";
 }

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -1,4 +1,5 @@
 use std::io::{Cursor, Read, Write};
+use std::path::PathBuf;
 use std::process::{ChildStdin, Command, Stdio};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -6,6 +7,9 @@ use std::sync::{
 };
 use std::thread;
 use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::Serialize;
 
 use crate::engine::invocation;
 
@@ -158,6 +162,7 @@ fn run_local_command(
         }
     };
     let mut cleanup_guard = Some(ProcessGroupCleanupGuard::new(child.id()));
+    let mut supervision = ChildSupervision::start(env, command, child.id());
     let _invocation_child_guard = invocation_child_guard(
         env,
         child.id(),
@@ -190,8 +195,13 @@ fn run_local_command(
         })
     });
 
-    let (status, delegated_failure, timed_out) =
-        wait_for_child_or_delegated_failure(&mut child, env, &mut cleanup_guard, timeout);
+    let (status, delegated_failure, timed_out) = wait_for_child_or_delegated_failure(
+        &mut child,
+        env,
+        &mut cleanup_guard,
+        timeout,
+        supervision.as_mut(),
+    );
     let interrupted_signal = active_cleanup_signal();
 
     let stdin_failed = stdin_handle
@@ -255,6 +265,9 @@ fn run_local_command(
             child_resource: Some(monitor.finish()),
         },
     };
+    if let Some(supervision) = supervision.as_mut() {
+        supervision.finish(&output, interrupted_signal, timed_out, timeout);
+    }
     if let Some(cleanup_guard) = cleanup_guard.take() {
         cleanup_guard.cleanup();
     }
@@ -675,6 +688,7 @@ fn wait_for_child_or_delegated_failure(
     env: Option<&[(&str, &str)]>,
     cleanup_guard: &mut Option<ProcessGroupCleanupGuard>,
     timeout: Option<Duration>,
+    mut supervision: Option<&mut ChildSupervision>,
 ) -> (
     std::io::Result<std::process::ExitStatus>,
     Option<DelegatedRunTerminalFailure>,
@@ -684,6 +698,9 @@ fn wait_for_child_or_delegated_failure(
     let deadline = timeout.map(|timeout| Instant::now() + timeout);
 
     loop {
+        if let Some(supervision) = supervision.as_deref_mut() {
+            supervision.heartbeat();
+        }
         match child.try_wait() {
             Ok(Some(status)) => return (Ok(status), None, false),
             Ok(None) => {}
@@ -714,5 +731,203 @@ fn wait_for_child_or_delegated_failure(
             .map(|monitor| monitor.poll_interval)
             .unwrap_or_else(|| Duration::from_millis(50));
         std::thread::sleep(poll_interval);
+    }
+}
+
+const CHILD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+const CHILD_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
+
+#[derive(Serialize)]
+struct ChildSupervisionRecord {
+    schema: &'static str,
+    status: String,
+    phase: &'static str,
+    command: String,
+    child_pid: u32,
+    started_at: String,
+    heartbeat_at: String,
+    finished_at: Option<String>,
+    timeout_ms: Option<u128>,
+    cancellation_reason: Option<String>,
+    exit_code: Option<i32>,
+    stdout_tail: String,
+    stderr_tail: String,
+}
+
+struct ChildSupervision {
+    path: PathBuf,
+    record: ChildSupervisionRecord,
+    last_heartbeat: Instant,
+}
+
+impl ChildSupervision {
+    fn start(env: Option<&[(&str, &str)]>, command: &str, child_pid: u32) -> Option<Self> {
+        let run_dir = env?.iter().find_map(|(key, value)| {
+            (*key == crate::engine::run_dir::run_dir_env()).then_some(*value)
+        })?;
+        let now = Utc::now().to_rfc3339();
+        let supervision = Self {
+            path: PathBuf::from(run_dir).join(crate::engine::run_dir::files::CHILD_SUPERVISION),
+            record: ChildSupervisionRecord {
+                schema: "homeboy.child_supervision.v1",
+                status: "running".to_string(),
+                phase: "child",
+                command: crate::redaction::redact_string(command),
+                child_pid,
+                started_at: now.clone(),
+                heartbeat_at: now,
+                finished_at: None,
+                timeout_ms: None,
+                cancellation_reason: None,
+                exit_code: None,
+                stdout_tail: String::new(),
+                stderr_tail: String::new(),
+            },
+            last_heartbeat: Instant::now(),
+        };
+        supervision.persist();
+        Some(supervision)
+    }
+
+    fn heartbeat(&mut self) {
+        if self.last_heartbeat.elapsed() < CHILD_HEARTBEAT_INTERVAL {
+            return;
+        }
+        self.record.heartbeat_at = Utc::now().to_rfc3339();
+        self.last_heartbeat = Instant::now();
+        self.persist();
+    }
+
+    fn finish(
+        &mut self,
+        output: &CommandOutput,
+        signal: Option<i32>,
+        timed_out: bool,
+        timeout: Option<Duration>,
+    ) {
+        self.record.status = if timed_out || signal.is_some() {
+            "interrupted".to_string()
+        } else {
+            "completed".to_string()
+        };
+        self.record.heartbeat_at = Utc::now().to_rfc3339();
+        self.record.finished_at = Some(self.record.heartbeat_at.clone());
+        self.record.timeout_ms =
+            timed_out.then(|| timeout.map(|timeout| timeout.as_millis()).unwrap_or(0));
+        self.record.cancellation_reason = if timed_out {
+            Some("timeout".to_string())
+        } else {
+            signal.map(|signal| format!("signal:{signal}"))
+        };
+        self.record.exit_code = Some(output.exit_code);
+        self.record.stdout_tail = bounded_redacted_tail(&output.stdout);
+        self.record.stderr_tail = bounded_redacted_tail(&output.stderr);
+        self.persist();
+    }
+
+    fn persist(&self) {
+        let Some(parent) = self.path.parent() else {
+            return;
+        };
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+        let Ok(payload) = serde_json::to_vec_pretty(&self.record) else {
+            return;
+        };
+        let temporary = self
+            .path
+            .with_extension(format!("tmp-{}", std::process::id()));
+        if std::fs::write(&temporary, payload).is_ok() {
+            let _ = std::fs::rename(temporary, &self.path);
+        }
+    }
+}
+
+fn bounded_redacted_tail(output: &str) -> String {
+    let start = output.len().saturating_sub(CHILD_OUTPUT_TAIL_BYTES);
+    let start = output
+        .char_indices()
+        .find_map(|(index, _)| (index >= start).then_some(index))
+        .unwrap_or_default();
+    crate::redaction::redact_string(&output[start..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn supervision_output(run_dir: &tempfile::TempDir) -> serde_json::Value {
+        let payload = std::fs::read_to_string(
+            run_dir
+                .path()
+                .join(crate::engine::run_dir::files::CHILD_SUPERVISION),
+        )
+        .expect("child supervision artifact");
+        serde_json::from_str(&payload).expect("parseable child supervision artifact")
+    }
+
+    #[test]
+    fn timeout_persists_terminal_supervision_and_reaps_silent_child() {
+        let run_dir = tempfile::tempdir().expect("run dir");
+        let key = crate::engine::run_dir::run_dir_env();
+        let value = run_dir.path().to_string_lossy().to_string();
+        let env = [(key.as_str(), value.as_str())];
+
+        let output = execute_local_command_in_dir_with_timeout(
+            "sleep 30",
+            None,
+            Some(&env),
+            Duration::from_millis(25),
+        );
+
+        assert!(output.timed_out);
+        assert_eq!(output.exit_code, 124);
+        let supervision = supervision_output(&run_dir);
+        assert_eq!(supervision["schema"], "homeboy.child_supervision.v1");
+        assert_eq!(supervision["status"], "interrupted");
+        assert_eq!(supervision["cancellation_reason"], "timeout");
+        assert!(supervision["started_at"].is_string());
+        assert!(supervision["finished_at"].is_string());
+        assert!(supervision["heartbeat_at"].is_string());
+        assert!(supervision["command"].is_string());
+        assert!(supervision["child_pid"].as_u64().is_some());
+        #[cfg(unix)]
+        {
+            let pid = supervision["child_pid"].as_i64().expect("child pid") as libc::pid_t;
+            assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "child was reaped");
+            assert_eq!(
+                std::io::Error::last_os_error().raw_os_error(),
+                Some(libc::ESRCH)
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sigterm_persists_terminal_supervision_and_reaps_silent_child() {
+        let run_dir = tempfile::tempdir().expect("run dir");
+        let key = crate::engine::run_dir::run_dir_env();
+        let value = run_dir.path().to_string_lossy().to_string();
+        let env = [(key.as_str(), value.as_str())];
+        let foreground_pid = unsafe { libc::getpid() };
+        let interrupter = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(25));
+            unsafe { libc::kill(foreground_pid, libc::SIGTERM) };
+        });
+
+        let output = execute_local_command_in_dir("sleep 30", None, Some(&env));
+        interrupter.join().expect("interrupter");
+
+        assert_eq!(output.exit_code, 143);
+        let supervision = supervision_output(&run_dir);
+        assert_eq!(supervision["status"], "interrupted");
+        assert_eq!(supervision["cancellation_reason"], "signal:15");
+        let pid = supervision["child_pid"].as_i64().expect("child pid") as libc::pid_t;
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "child was reaped");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
     }
 }

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -1,3 +1,4 @@
+use std::fs::OpenOptions;
 use std::io::{Cursor, Read, Write};
 use std::path::PathBuf;
 use std::process::{ChildStdin, Command, Stdio};
@@ -195,14 +196,20 @@ fn run_local_command(
         })
     });
 
-    let (status, delegated_failure, timed_out) = wait_for_child_or_delegated_failure(
-        &mut child,
-        env,
-        &mut cleanup_guard,
-        timeout,
-        supervision.as_mut(),
-    );
-    let interrupted_signal = active_cleanup_signal();
+    let (status, delegated_failure, timed_out, interrupted_signal) =
+        wait_for_child_or_delegated_failure(
+            &mut child,
+            env,
+            &mut cleanup_guard,
+            timeout,
+            supervision.as_mut(),
+        );
+    // Descendants can inherit these pipes after the shell exits. Tear down the
+    // process group before joining readers so they cannot hold this command open.
+    if let Some(cleanup_guard) = cleanup_guard.take() {
+        cleanup_guard.cleanup();
+    }
+    let interrupted_signal = interrupted_signal.or_else(active_cleanup_signal);
 
     let stdin_failed = stdin_handle
         .and_then(StdinPump::finish_after_child)
@@ -267,9 +274,6 @@ fn run_local_command(
     };
     if let Some(supervision) = supervision.as_mut() {
         supervision.finish(&output, interrupted_signal, timed_out, timeout);
-    }
-    if let Some(cleanup_guard) = cleanup_guard.take() {
-        cleanup_guard.cleanup();
     }
     output
 }
@@ -693,6 +697,7 @@ fn wait_for_child_or_delegated_failure(
     std::io::Result<std::process::ExitStatus>,
     Option<DelegatedRunTerminalFailure>,
     bool,
+    Option<i32>,
 ) {
     let monitor = DelegatedRunFailureMonitor::from_env(env);
     let deadline = timeout.map(|timeout| Instant::now() + timeout);
@@ -701,10 +706,18 @@ fn wait_for_child_or_delegated_failure(
         if let Some(supervision) = supervision.as_deref_mut() {
             supervision.heartbeat();
         }
+        if let Some(signal) = active_cleanup_signal() {
+            if let Some(cleanup_guard) = cleanup_guard.take() {
+                cleanup_guard.cleanup();
+            } else {
+                let _ = child.kill();
+            }
+            return (child.wait(), None, false, Some(signal));
+        }
         match child.try_wait() {
-            Ok(Some(status)) => return (Ok(status), None, false),
+            Ok(Some(status)) => return (Ok(status), None, false, None),
             Ok(None) => {}
-            Err(error) => return (Err(error), None, false),
+            Err(error) => return (Err(error), None, false, None),
         }
 
         if let Some(failure) = monitor
@@ -714,7 +727,7 @@ fn wait_for_child_or_delegated_failure(
             if let Some(cleanup_guard) = cleanup_guard.take() {
                 cleanup_guard.cleanup();
             }
-            return (child.wait(), Some(failure), false);
+            return (child.wait(), Some(failure), false, None);
         }
 
         if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
@@ -723,7 +736,7 @@ fn wait_for_child_or_delegated_failure(
             } else {
                 let _ = child.kill();
             }
-            return (child.wait(), None, true);
+            return (child.wait(), None, true, None);
         }
 
         let poll_interval = monitor
@@ -736,6 +749,8 @@ fn wait_for_child_or_delegated_failure(
 
 const CHILD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 const CHILD_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
+static CHILD_SUPERVISION_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 #[derive(Serialize)]
 struct ChildSupervisionRecord {
@@ -835,11 +850,22 @@ impl ChildSupervision {
         let Ok(payload) = serde_json::to_vec_pretty(&self.record) else {
             return;
         };
-        let temporary = self
-            .path
-            .with_extension(format!("tmp-{}", std::process::id()));
-        if std::fs::write(&temporary, payload).is_ok() {
-            let _ = std::fs::rename(temporary, &self.path);
+        let temporary = self.path.with_extension(format!(
+            "tmp-{}-{}",
+            std::process::id(),
+            CHILD_SUPERVISION_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        ));
+        let Ok(mut file) = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+        else {
+            return;
+        };
+        if file.write_all(&payload).is_ok() && file.sync_all().is_ok() {
+            let _ = std::fs::rename(&temporary, &self.path);
+        } else {
+            let _ = std::fs::remove_file(temporary);
         }
     }
 }
@@ -905,26 +931,58 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn sigterm_persists_terminal_supervision_and_reaps_silent_child() {
+    fn sigterm_allows_child_process_group_to_exit_gracefully() {
         let run_dir = tempfile::tempdir().expect("run dir");
         let key = crate::engine::run_dir::run_dir_env();
         let value = run_dir.path().to_string_lossy().to_string();
-        let env = [(key.as_str(), value.as_str())];
+        let marker = run_dir.path().join("graceful-termination");
+        let marker_value = marker.to_string_lossy().to_string();
+        let env = [
+            (key.as_str(), value.as_str()),
+            ("MARKER", marker_value.as_str()),
+        ];
         let foreground_pid = unsafe { libc::getpid() };
         let interrupter = thread::spawn(move || {
             thread::sleep(Duration::from_millis(25));
             unsafe { libc::kill(foreground_pid, libc::SIGTERM) };
         });
 
-        let output = execute_local_command_in_dir("sleep 30", None, Some(&env));
+        let output = execute_local_command_in_dir(
+            "trap 'printf graceful > \"$MARKER\"; exit 0' TERM; while :; do sleep 1; done",
+            None,
+            Some(&env),
+        );
         interrupter.join().expect("interrupter");
 
         assert_eq!(output.exit_code, 143);
+        assert_eq!(
+            std::fs::read_to_string(marker).expect("graceful marker"),
+            "graceful"
+        );
         let supervision = supervision_output(&run_dir);
         assert_eq!(supervision["status"], "interrupted");
         assert_eq!(supervision["cancellation_reason"], "signal:15");
         let pid = supervision["child_pid"].as_i64().expect("child pid") as libc::pid_t;
         assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "child was reaped");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normal_completion_reaps_descendants_before_collecting_output() {
+        let started = Instant::now();
+        let output = execute_local_command("sleep 30 & printf '%s' \"$!\"");
+
+        assert!(output.success, "{}", output.stderr);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        let pid = output
+            .stdout
+            .parse::<libc::pid_t>()
+            .expect("descendant pid");
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "descendant was reaped");
         assert_eq!(
             std::io::Error::last_os_error().raw_os_error(),
             Some(libc::ESRCH)

--- a/crates/homeboy-core/src/server/process_cleanup.rs
+++ b/crates/homeboy-core/src/server/process_cleanup.rs
@@ -3,9 +3,6 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::Duration;
 
 #[cfg(unix)]
-static ACTIVE_CLEANUP_PGID: AtomicI32 = AtomicI32::new(0);
-
-#[cfg(unix)]
 static ACTIVE_CLEANUP_SIGNAL: AtomicI32 = AtomicI32::new(0);
 
 #[cfg(unix)]
@@ -39,9 +36,7 @@ impl ProcessGroupCleanupGuard {
         #[cfg(unix)]
         {
             let pgid = Some(root_pid as libc::pid_t);
-            if let Some(pgid) = pgid {
-                ACTIVE_CLEANUP_PGID.store(pgid, Ordering::SeqCst);
-            }
+            ACTIVE_CLEANUP_SIGNAL.store(0, Ordering::SeqCst);
             Self { pgid }
         }
 
@@ -56,9 +51,6 @@ impl ProcessGroupCleanupGuard {
         #[cfg(unix)]
         if let Some(pgid) = self.pgid {
             cleanup_process_group(pgid);
-            ACTIVE_CLEANUP_PGID
-                .compare_exchange(pgid, 0, Ordering::SeqCst, Ordering::SeqCst)
-                .ok();
             self.pgid = None;
         }
     }
@@ -79,9 +71,6 @@ impl Drop for ProcessGroupCleanupGuard {
         #[cfg(unix)]
         if let Some(pgid) = self.pgid.take() {
             cleanup_process_group(pgid);
-            ACTIVE_CLEANUP_PGID
-                .compare_exchange(pgid, 0, Ordering::SeqCst, Ordering::SeqCst)
-                .ok();
         }
     }
 }
@@ -102,14 +91,7 @@ fn install_process_cleanup_signal_handlers() {
 
 #[cfg(unix)]
 extern "C" fn cleanup_signal_handler(signal: libc::c_int) {
-    let pgid = ACTIVE_CLEANUP_PGID.load(Ordering::SeqCst);
     ACTIVE_CLEANUP_SIGNAL.store(signal, Ordering::SeqCst);
-    if pgid > 0 {
-        unsafe {
-            libc::kill(-pgid, libc::SIGTERM);
-            libc::kill(-pgid, libc::SIGKILL);
-        }
-    }
 }
 
 #[cfg(unix)]

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -25,6 +25,7 @@ use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::Path;
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub struct TestRunWorkflowArgs {
@@ -53,6 +54,16 @@ const NO_TESTS_APPLICABLE_FILE_ENV: &str = "HOMEBOY_NO_TESTS_APPLICABLE_FILE";
 const NO_TESTS_APPLICABLE_NONCE_ENV: &str = "HOMEBOY_NO_TESTS_APPLICABLE_NONCE";
 const NO_TESTS_APPLICABLE_EXTENSION_ENV: &str = "HOMEBOY_NO_TESTS_APPLICABLE_EXTENSION_ID";
 const NO_TESTS_APPLICABLE_STEP: &str = "test";
+const DEFAULT_TEST_TIMEOUT_SECONDS: u64 = 25 * 60;
+
+fn test_timeout() -> Duration {
+    std::env::var("HOMEBOY_TEST_TIMEOUT_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_TEST_TIMEOUT_SECONDS))
+}
 
 #[derive(Deserialize)]
 struct NoTestsApplicableEvidence {
@@ -318,6 +329,12 @@ fn run_main_test_workflow_inner(
         vec![("test runner".to_string(), args.component_label.clone())],
     )?;
     progress.start(0)?;
+    let timeout = test_timeout();
+    homeboy_core::log_status!(
+        "test",
+        "phase=child command=test runner timeout={}s; streaming bounded child supervision",
+        timeout.as_secs()
+    );
     let output = runner
         .env_if(args.changed_since.is_some(), "SCOPE_MODE", "changed")
         .env_if(
@@ -331,6 +348,7 @@ fn run_main_test_workflow_inner(
             "1",
         )
         .script_args(&passthrough_args)
+        .timeout(Some(timeout))
         .run()?;
     let stdout_artifact = write_command_artifact(run_dir, 0, "stdout", &output.stdout)?;
     let stderr_artifact = write_command_artifact(run_dir, 0, "stderr", &output.stderr)?;


### PR DESCRIPTION
## Summary
- persist an atomic, redacted child-supervision artifact with generic command/phase identity, heartbeat timestamps, bounded output tails, timeout/cancellation reason, and child PID
- apply a 25-minute configurable Test child timeout and retain supervision evidence in interrupted Test observations
- cover timeout, SIGTERM cancellation race, orphan reaping, and parseable partial Test evidence

Fixes #10217

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core server::client::local_exec::tests --lib -- --test-threads=1` (2 passed)
- `cargo test -p homeboy-extension test::run --lib` (22 passed)
- `cargo test -p homeboy-cli commands::test --lib` (40 passed)
- `cargo check -p homeboy-cli`

## AI Assistance
GPT-5.6-terra using OpenCode drafted the generic child-supervision, Test observation persistence, and deterministic tests. Chris Huber remains responsible for every line.