### PR TITLE
Fix dependency hydration CLI defaults

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -136,6 +136,7 @@ impl From<VerifyGateArgs> for VerifyGateOptions {
                 })
                 .collect(),
             gate_diagnostic_sidecars: Vec::new(),
+            hydrate_dependencies: true,
         }
     }
 }
@@ -171,6 +172,7 @@ mod tests {
         assert_eq!(defaults.gate_timeout_seconds, 30 * 60);
         assert_eq!(defaults.gate_heartbeat_interval_seconds, 5);
         assert!(!defaults.rerun_completed_gates);
+        assert!(defaults.hydrate_dependencies);
 
         let options: VerifyGateOptions = TestCli::try_parse_from([
             "homeboy",

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -826,6 +826,7 @@ impl BatchCookSpec {
                     gate_environment: self.gate_environment.clone(),
                     gate_toolchains: self.gate_toolchains.clone(),
                     gate_diagnostic_sidecars: Vec::new(),
+                    hydrate_dependencies: true,
                 },
                 max_attempts: self.max_attempts,
                 no_finalize: self.no_finalize,


### PR DESCRIPTION
## Summary
- initialize dependency hydration in Cook and fanout CLI gate options
- preserve the enabled-by-default hydration contract through typed option conversion
- add regression coverage for CLI defaults

Follow-up to #10223, which merged before this exact workspace compilation fix landed.

## Verification
- `cargo fmt --check`
- `cargo check --workspace --tests --locked`
- targeted Cook gate-policy CLI round-trip test

## AI assistance
Substantive debugging and code changes were produced with OpenAI GPT-5.6 Sol using OpenCode. The agent inspected the exact failing GitHub Actions job, reproduced the workspace compilation failure, implemented the fix, and ran the listed verification. Chris Huber remains responsible for the change.