### PR TITLE
fix(agent-task): make gate toolchain preflight correct

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -26,6 +26,10 @@ const XDG_ENV_VARS: &[&str] = &[
     "XDG_RUNTIME_DIR",
 ];
 
+/// Temp-dir variables pinned to the invocation temp dir so every gate process
+/// — preflight probes included — shares one temporary root.
+const TMPDIR_ENV_VARS: &[&str] = &["TMPDIR", "TEMP", "TMP"];
+
 pub type AgentTaskGateVisibility = HomeboyGateVisibility;
 pub type AgentTaskGateRevealPolicy = HomeboyGateRevealPolicy;
 
@@ -800,12 +804,6 @@ pub(crate) fn run_gate_command_with_supervision(
         .stderr(Stdio::piped());
     let selected_environment = selected_gate_environment(gate_environment, runtime_tmpdir)?;
     selected_environment.apply(&mut process);
-    if let Some(runtime_tmpdir) = runtime_tmpdir {
-        process
-            .env("TMPDIR", runtime_tmpdir)
-            .env("TEMP", runtime_tmpdir)
-            .env("TMP", runtime_tmpdir);
-    }
     if supervision.is_some() {
         if !homeboy_core::engine::command::supports_process_tree_isolation() {
             return Err(Error::validation_invalid_argument(
@@ -919,10 +917,6 @@ pub(crate) fn run_gate_command_with_timeout(
         .stderr(Stdio::piped());
     let selected_environment = selected_gate_environment(gate_environment, Some(runtime_tmpdir))?;
     selected_environment.apply(&mut process);
-    process
-        .env("TMPDIR", runtime_tmpdir)
-        .env("TEMP", runtime_tmpdir)
-        .env("TMP", runtime_tmpdir);
     homeboy_core::engine::command::isolate_process_tree(&mut process);
     let mut child = process.spawn().map_err(|error| {
         Error::internal_io(
@@ -1009,6 +1003,18 @@ fn selected_gate_environment(
         let value = preserved_environment_value(source)?;
         values.insert(name.clone(), value);
         report.preserved.insert(name.clone(), source.clone());
+    }
+
+    // The invocation temp dir belongs to the shared environment definition, not
+    // to individual call sites. Preflight and execution must agree on it, or
+    // preflight validates a different directory than the gate will use — and,
+    // under the default inherit mode, silently falls back to the ambient TMPDIR
+    // or fails outright when the host has none. (#10245)
+    if let Some(runtime_tmpdir) = runtime_tmpdir {
+        let runtime_tmpdir = runtime_tmpdir.display().to_string();
+        for name in TMPDIR_ENV_VARS {
+            values.insert((*name).to_string(), runtime_tmpdir.clone());
+        }
     }
 
     let needs_scratch = policy.isolate_home || policy.isolate_xdg;
@@ -1903,5 +1909,64 @@ mod tests {
         }
         assert!(error.message.contains("gate toolchain preflight"));
         assert!(!error.message.contains("Fix the code"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn toolchain_preflight_runs_in_the_invocation_tmpdir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Deliberately hermetic: the probe is addressed by absolute path so the
+        // test never mutates PATH. Sibling tests spawn `sh` without holding
+        // ENV_MUTEX, so clobbering PATH here would break them under the test
+        // harness's parallelism.
+        let workspace = tempfile::tempdir().expect("workspace");
+        let runtime_tmpdir = tempfile::tempdir().expect("runtime tmpdir");
+        let bin = tempfile::tempdir().expect("bin");
+
+        // Fails unless every temp-dir variable points at the invocation temp
+        // dir. An unset variable compares as empty and exits non-zero too.
+        let tool = bin.path().join("record-tmpdir");
+        fs::write(
+            &tool,
+            format!(
+                "#!/bin/sh\n[ \"$TMPDIR\" = '{dir}' ] || exit 3\n[ \"$TEMP\" = '{dir}' ] || exit 4\n[ \"$TMP\" = '{dir}' ] || exit 5\nexit 0\n",
+                dir = runtime_tmpdir.path().display()
+            ),
+        )
+        .expect("tool");
+        let mut permissions = fs::metadata(&tool).expect("tool metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tool, permissions).expect("tool executable");
+
+        preflight_gate_toolchains(
+            workspace.path(),
+            &AgentTaskGateEnvironmentPolicy::default(),
+            &[AgentTaskGateToolchainRequirement {
+                command: tool.display().to_string(),
+                probe_arguments: vec!["initialize".to_string()],
+            }],
+            Some(runtime_tmpdir.path()),
+        )
+        .expect("preflight probes run in the invocation temp dir");
+    }
+
+    #[test]
+    fn gate_environment_pins_temp_dir_variables_to_the_invocation_tmpdir() {
+        let runtime_tmpdir = tempfile::tempdir().expect("runtime tmpdir");
+        let selected = selected_gate_environment(
+            &AgentTaskGateEnvironmentPolicy::default(),
+            Some(runtime_tmpdir.path()),
+        )
+        .expect("gate environment");
+
+        let expected = runtime_tmpdir.path().display().to_string();
+        for name in TMPDIR_ENV_VARS {
+            assert_eq!(
+                selected.values.get(*name),
+                Some(&expected),
+                "{name} must resolve to the invocation temp dir"
+            );
+        }
     }
 }

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -94,9 +94,14 @@ fn promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_i
 
     let helper_source = temp.path().join("bind_socket.rs");
     let helper = temp.path().join("bind_socket");
+    // Gate toolchain preflight probes this command with `--version` in the same
+    // environment the gate itself receives, so the helper must answer that probe
+    // without side effects — exactly like a real toolchain. Binding on every
+    // invocation would leave `gate.sock` behind and make the gate's own bind
+    // fail with EADDRINUSE.
     std::fs::write(
         &helper_source,
-        "use std::{env, os::unix::net::UnixListener, path::PathBuf};\nfn main() { let path = PathBuf::from(env::var_os(\"TMPDIR\").unwrap()).join(\"gate.sock\"); UnixListener::bind(&path).unwrap(); println!(\"{}\", path.display()); }\n",
+        "use std::{env, os::unix::net::UnixListener, path::PathBuf};\nfn main() { if env::args().any(|arg| arg == \"--version\") { println!(\"bind_socket 1.0\"); return; } let path = PathBuf::from(env::var_os(\"TMPDIR\").expect(\"TMPDIR\")).join(\"gate.sock\"); UnixListener::bind(&path).unwrap(); println!(\"{}\", path.display()); }\n",
     )
     .expect("socket helper source");
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());


### PR DESCRIPTION
Fixes #10245 and #10247. Two defects in the gate toolchain preflight, both of which take `main` red. One took it red earlier tonight ([run 30218445090](https://github.com/Extra-Chill/homeboy/actions/runs/30218445090)).

---

## 1. Preflight ran without the invocation temp dir (#10245)

`preflight_gate_toolchains` says it validates tools *"in the exact environment candidate gates will use"*. It didn't — both execution paths set the temp-dir variables **after** the shared builder returns:

```rust
let selected_environment = selected_gate_environment(gate_environment, runtime_tmpdir)?;
selected_environment.apply(&mut process);
process
    .env("TMPDIR", runtime_tmpdir)   // ← only here, not in the builder
    .env("TEMP", runtime_tmpdir)
    .env("TMP", runtime_tmpdir);
```

Preflight calls the same builder and stops, so probes ran without them:

```
gate toolchain preflight could not initialize `.../bind_socket` (exit 101)
  called `Option::unwrap()` on a `None` value      ← env::var_os("TMPDIR")
```

**Why it looked intermittent:** the policy defaults to `Inherit`, so `apply()` never calls `env_clear()` and the probe inherits the *ambient* `TMPDIR`. On a host that sets one, preflight "passes" while validating the wrong directory; on a GitHub runner, which doesn't, it fails. The passing case is worse — it proves nothing about the directory the gate uses.

**Fix:** move `TMPDIR`/`TEMP`/`TMP` into `selected_gate_environment()` so one definition covers preflight and both execution paths, and delete the duplicated blocks.

---

## 2. Preflight synthesized probes from gate command strings (#10247)

`required_toolchains()` derived a `--version` probe from the **first whitespace token** of every gate. Gates run through `sh -lc`, so that token is often not a probeable executable. Preflight then refused the promotion before any gate ran:

```
  4 preflight could not resolve or initialize `exit`
  4 preflight could not resolve or initialize `failing-gate`
  2 preflight could not resolve or initialize `true`
  1 preflight could not initialize `false`
```

`exit` is a shell builtin with no executable. `false` is an executable that exits non-zero by definition and can never answer a probe. The same applies to env-prefixed commands (`RUST_LOG=debug cargo test`), shell functions, and scripts without `--version`.

**Fix:** probe only explicitly declared `gate_toolchains`. Declaring one is the operator asserting the command exists and answers the probe; inferring it from arbitrary shell text fails closed on correct input. The value behind #9840 (catching `cargo` that can't initialize under an isolated `HOME`) is preserved for anyone who declares it — which the existing error hint already directs users to do.

---

## Why main looks green anyway

The push gate runs a **changed-scope** selection. The last green run executed one test:

```
Rust test scope: Scoped to changed integration tests: promotion_provider_stdin
[test-results] Total: 1, Passed: 1, Failed: 0
```

So these only surface when someone touches the affected files — which is exactly how `main` went red tonight. Green gate, unclean suite.

## Verification

Promotion suite failures drop from **15 → 7**; every remaining failure is environmental on my host (`SQLite ... disk I/O error`, git base capture), not preflight.

```
cargo test -p homeboy-agents --lib -- agent_task_gate::
  test result: ok. 26 passed; 0 failed

cargo test -p homeboy --test agent_task_promotion_provider
  test promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_id ... ok
  test result: ok. 2 passed; 0 failed
```

New tests, all confirmed load-bearing by reverting the production change:

- `toolchain_preflight_runs_in_the_invocation_tmpdir` — asserts all three variables equal the invocation temp dir. Hermetic by design: the probe is addressed by absolute path so the test never mutates `PATH`. Sibling tests spawn `sh` without holding `ENV_MUTEX`, so clobbering it breaks them under harness parallelism — I hit that while writing this and fixed the test, not the symptom.
- `gate_environment_pins_temp_dir_variables_to_the_invocation_tmpdir` — unit assertion on the builder.
- `only_declared_toolchains_are_probed_by_preflight` — replaces `existing_gate_commands_are_automatic_toolchain_requirements`, and pins the builtins (`exit 1`, `false`) that previously broke.

## Test fixture change, and why it isn't papering over the fix

The promotion fixture bound `$TMPDIR/gate.sock` on **every** invocation, including the derived `--version` probe. That was harmless only *because of* defect #1 — preflight ran in a different temp dir, so they never collided. With both correctly sharing one, the leftover socket makes the gate's own bind fail with `EADDRINUSE`. A real toolchain answers `--version` without side effects; the fixture now does too. The assertion under test — that the **gate** binds in the short invocation temp dir — is unchanged and still passes.

## Note for the author

Defect 2 reverses a deliberate design decision (`existing_gate_commands_are_automatic_toolchain_requirements` asserted the derivation). I believe the derivation is unsound for `sh -lc` gates, but flagging it explicitly since it's your call.