### PR TITLE
fix(agent-task): recover Cook promotion failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -52,21 +52,26 @@ pub enum ClaimOutcome {
 }
 
 /// State of a single durable operation claim.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum ClaimState {
     /// Leased and in flight (no result recorded yet).
     Running,
     /// Completed with an immutable recorded result.
     Completed,
+    /// The owner reached a terminal error before it could publish a successful
+    /// side effect. The diagnostic is durable and a later explicit continuation
+    /// may acquire a new lease for the same idempotent operation.
+    Failed,
 }
 
 /// A durable operation claim projected for reconciliation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct OperationClaim {
     pub operation_key: String,
     pub state: ClaimState,
     pub leased_at: String,
     pub lease_deadline: Option<String>,
+    pub owner_pid: Option<u32>,
     pub result: Option<Value>,
 }
 
@@ -109,12 +114,17 @@ pub fn claim_cook_operation(
                 );
                 return false;
             }
-            // A still-fresh lease is owned by another pass.
-            if !lease_is_expired(existing, &now) {
+            // A fresh lease with a live local owner is never adopted. A dead
+            // controller cannot complete the effect, so its claim is safe to
+            // reconcile immediately instead of waiting for its wall-clock TTL.
+            if existing["state"] != json!("failed")
+                && !lease_is_expired(existing, &now)
+                && claim_owner_is_live(existing)
+            {
                 outcome = ClaimOutcome::LeaseHeld;
                 return false;
             }
-            // Expired lease: reclaim it for this pass.
+            // Expired or dead-owner lease: reclaim it for this pass.
         }
 
         let claim = json!({
@@ -122,6 +132,7 @@ pub fn claim_cook_operation(
             "state": "running",
             "leased_at": now,
             "lease_deadline": lease_deadline,
+            "owner_pid": std::process::id(),
         });
         // Replace an expired lease in place, or append a new one.
         if let Some(slot) = claims
@@ -183,6 +194,53 @@ pub fn complete_cook_operation(run_id: &str, operation_key: &str, result: Value)
     Ok(())
 }
 
+/// Terminalize a claimed operation that did not produce its external result.
+/// Failed claims retain their exact bounded diagnostic but are intentionally
+/// reclaimable by a later explicit continuation.
+pub fn fail_cook_operation(run_id: &str, operation_key: &str, result: Value) -> Result<()> {
+    transition_cook_operation(run_id, operation_key, "failed", result)
+}
+
+fn transition_cook_operation(
+    run_id: &str,
+    operation_key: &str,
+    state: &str,
+    result: Value,
+) -> Result<()> {
+    let run_id = sanitize_run_id(run_id);
+    let now = now_timestamp();
+    let mut found = false;
+    store::mutate_record(&run_id, |record| {
+        let Some(claim) = record
+            .ensure_metadata_object()
+            .get_mut(OPERATION_CLAIMS_KEY)
+            .and_then(Value::as_array_mut)
+            .and_then(|claims| {
+                claims
+                    .iter_mut()
+                    .find(|claim| claim["operation_key"] == json!(operation_key))
+            })
+        else {
+            return false;
+        };
+        found = true;
+        if claim["state"] == json!("completed") {
+            return false;
+        }
+        claim["state"] = json!(state);
+        claim["completed_at"] = json!(now);
+        claim["result"] = result.clone();
+        record.updated_at = Some(now.clone());
+        true
+    })?;
+    if !found {
+        return Err(Error::internal_unexpected(
+            "cook operation terminalized without its durable claim; reserve the operation before performing its side effect",
+        ));
+    }
+    Ok(())
+}
+
 /// Read a single operation claim for reconciliation, if present.
 pub fn operation_claim(run_id: &str, operation_key: &str) -> Result<Option<OperationClaim>> {
     let run_id = sanitize_run_id(run_id);
@@ -219,6 +277,7 @@ fn project_claim(claim: &Value) -> Option<OperationClaim> {
     let operation_key = claim.get("operation_key")?.as_str()?.to_string();
     let state = match claim.get("state").and_then(Value::as_str)? {
         "completed" => ClaimState::Completed,
+        "failed" => ClaimState::Failed,
         _ => ClaimState::Running,
     };
     Some(OperationClaim {
@@ -233,6 +292,10 @@ fn project_claim(claim: &Value) -> Option<OperationClaim> {
             .get("lease_deadline")
             .and_then(Value::as_str)
             .map(str::to_string),
+        owner_pid: claim
+            .get("owner_pid")
+            .and_then(Value::as_u64)
+            .and_then(|pid| pid.try_into().ok()),
         result: claim.get("result").cloned(),
     })
 }
@@ -245,6 +308,21 @@ fn lease_is_expired(claim: &Value, now: &str) -> bool {
         .get("lease_deadline")
         .and_then(Value::as_str)
         .is_some_and(|deadline| deadline <= now)
+}
+
+fn claim_owner_is_live(claim: &Value) -> bool {
+    let Some(pid) = claim.get("owner_pid").and_then(Value::as_u64) else {
+        // Historical claims have no owner identity. Their lease remains the
+        // conservative compatibility boundary until it expires.
+        return true;
+    };
+    if pid == 0 || pid > i32::MAX as u64 {
+        return false;
+    }
+    // kill(pid, 0) checks process existence without signalling it. EPERM is
+    // still proof of a live process that this controller may not inspect.
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 /// RFC3339 timestamp `lease` after `base`. Falls back to `base` when the base is

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/operation_claims.rs
@@ -11,8 +11,8 @@ use serde_json::json;
 
 use super::*;
 use crate::agent_task_lifecycle::{
-    claim_cook_operation, complete_cook_operation, operation_claim, operation_lease_is_active,
-    ClaimOutcome, ClaimState,
+    claim_cook_operation, complete_cook_operation, fail_cook_operation, operation_claim,
+    operation_lease_is_active, ClaimOutcome, ClaimState,
 };
 use homeboy_core::test_support::with_isolated_home;
 
@@ -129,6 +129,64 @@ fn active_lease_is_reported_until_completion() {
             !operation_lease_is_active("op-claim-7", "promote:live").expect("inactive"),
             "a completed operation no longer holds an active lease"
         );
+    });
+}
+
+#[test]
+fn failed_claim_preserves_diagnostic_and_is_reclaimable_by_explicit_continuation() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-failed");
+        let key = "promote:failed";
+        claim_cook_operation("op-claim-failed", key, LEASE).expect("claim");
+        fail_cook_operation(
+            "op-claim-failed",
+            key,
+            json!({"status":"failed","code":"ValidationInvalidArgument","message":"malformed response"}),
+        )
+        .expect("terminalize failure");
+        let failed = operation_claim("op-claim-failed", key)
+            .expect("read")
+            .expect("claim");
+        assert_eq!(failed.state, ClaimState::Failed);
+        assert_eq!(failed.result.unwrap()["message"], "malformed response");
+        assert_eq!(
+            claim_cook_operation("op-claim-failed", key, LEASE).expect("explicit retry"),
+            ClaimOutcome::Acquired
+        );
+    });
+}
+
+#[test]
+fn dead_owner_claim_is_reclaimed_without_waiting_for_lease_expiry() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-dead-owner");
+        let key = "promote:dead";
+        claim_cook_operation("op-claim-dead-owner", key, LEASE).expect("claim");
+        rewrite_record_for_test("op-claim-dead-owner", |record| {
+            record.metadata["cook_operation_claims"][0]["owner_pid"] = json!(u32::MAX);
+        })
+        .expect("write dead owner");
+        assert_eq!(
+            claim_cook_operation("op-claim-dead-owner", key, LEASE).expect("reclaim dead owner"),
+            ClaimOutcome::Acquired
+        );
+    });
+}
+
+#[test]
+fn live_owner_claim_remains_held_without_side_effect_reentry() {
+    with_isolated_home(|_| {
+        seed_run("op-claim-live-owner");
+        let key = "promote:live-owner";
+        claim_cook_operation("op-claim-live-owner", key, LEASE).expect("claim");
+        assert_eq!(
+            claim_cook_operation("op-claim-live-owner", key, LEASE).expect("observe live owner"),
+            ClaimOutcome::LeaseHeld
+        );
+        let claim = operation_claim("op-claim-live-owner", key)
+            .expect("read")
+            .expect("claim");
+        assert_eq!(claim.owner_pid, Some(std::process::id()));
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -785,12 +785,23 @@ pub(crate) fn run_provider_command(
             }),
         ));
     }
+    let provider_evidence = || homeboy_core::error::CommandEvidence {
+        command: display.clone(),
+        cwd: invocation.cwd.clone(),
+        location: Some("local".to_string()),
+        exit_code,
+        stdout: report.stdout.clone(),
+        stderr: report.stderr.clone(),
+        truncated: report.capture.stdout.truncated || report.capture.stderr.truncated,
+    };
     let response_value: serde_json::Value =
         serde_json::from_str(&full_stdout).map_err(|error| {
-            Error::validation_invalid_json(
-                error,
-                Some("agent-task promotion provider response".to_string()),
-                Some(report.stdout.clone()),
+            Error::validation_invalid_argument_with_evidence(
+                "promotion_provider.response",
+                format!("Invalid JSON: {error}"),
+                None,
+                None,
+                Some(provider_evidence()),
             )
         })?;
     // Homeboy commands emit the standard result envelope. Accept its data
@@ -805,7 +816,7 @@ pub(crate) fn run_provider_command(
     let schema = match response_value.get("schema") {
         Some(serde_json::Value::String(schema)) => schema,
         Some(actual) => {
-            return Err(Error::validation_invalid_argument(
+            return Err(Error::validation_invalid_argument_with_evidence(
                 "promotion_provider.response.schema",
                 format!(
                     "expected {}, got {}",
@@ -813,10 +824,11 @@ pub(crate) fn run_provider_command(
                 ),
                 None,
                 None,
+                Some(provider_evidence()),
             ));
         }
         None => {
-            return Err(Error::validation_invalid_argument(
+            return Err(Error::validation_invalid_argument_with_evidence(
                 "promotion_provider.response.schema",
                 format!(
                     "expected {}, got missing schema",
@@ -824,11 +836,12 @@ pub(crate) fn run_provider_command(
                 ),
                 None,
                 None,
+                Some(provider_evidence()),
             ));
         }
     };
     if schema != AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA {
-        return Err(Error::validation_invalid_argument(
+        return Err(Error::validation_invalid_argument_with_evidence(
             "promotion_provider.response.schema",
             format!(
                 "expected {}, got {}",
@@ -836,27 +849,39 @@ pub(crate) fn run_provider_command(
             ),
             None,
             None,
+            Some(provider_evidence()),
         ));
     }
     let response: AgentTaskPromotionApplyResponse = serde_json::from_value(response_value)
         .map_err(|error| {
-            Error::validation_invalid_json(
-                error,
-                Some("agent-task promotion provider response".to_string()),
-                Some(report.stdout.clone()),
+            Error::validation_invalid_argument_with_evidence(
+                "promotion_provider.response",
+                format!("invalid response: {error}"),
+                None,
+                None,
+                Some(provider_evidence()),
             )
         })?;
     if response.workspace_path.trim().is_empty() {
-        return Err(Error::validation_invalid_argument(
+        return Err(Error::validation_invalid_argument_with_evidence(
             "promotion_provider.response.workspace_path",
             "promotion provider response must include a workspace_path",
             None,
             None,
+            Some(provider_evidence()),
         ));
     }
 
     let workspace_path = PathBuf::from(response.workspace_path);
-    validate_provider_workspace_path(&workspace_path)?;
+    validate_provider_workspace_path(&workspace_path).map_err(|error| {
+        Error::validation_invalid_argument_with_evidence(
+            "promotion_provider.response.workspace_path",
+            error.message,
+            None,
+            None,
+            Some(provider_evidence()),
+        )
+    })?;
 
     let mut command_evidence = response.command_evidence;
     if command_evidence.is_empty() {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1846,5 +1846,7 @@ fn provider_response_validation_distinguishes_json_schema_and_required_field_err
         .expect_err("invalid provider response");
 
         assert!(error.message.contains(expected), "{}", error.message);
+        assert_eq!(error.details["command_evidence"]["exit_code"], 0);
+        assert_eq!(error.details["command_evidence"]["stdout"], response);
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -335,11 +335,31 @@ fn promote_with_operation_claim(
         // `promote_or_load_attempt` still resolves an already-produced promotion;
         // if none exists yet, promotion proceeds (content-addressed and idempotent
         // on disk). Do not mark the claim completed from here — its owner does.
-        agent_task_lifecycle::ClaimOutcome::LeaseHeld => promote_or_load_attempt(options, run_id),
+        agent_task_lifecycle::ClaimOutcome::LeaseHeld => {
+            let claim = agent_task_lifecycle::operation_claim(run_id, &operation_key)?;
+            let mut error = Error::validation_invalid_argument(
+                "promotion_operation",
+                "operation_in_progress",
+                Some(operation_key),
+                Some(vec![format!("homeboy agent-task cook-continue {run_id}")]),
+            );
+            error.details["claim"] = serde_json::to_value(claim).unwrap_or(Value::Null);
+            Err(error)
+        }
         // This pass owns the operation. Promote, then record the result as the
         // claim's immutable completion.
         agent_task_lifecycle::ClaimOutcome::Acquired => {
-            let promotion = promote_or_load_attempt(options, run_id)?;
+            let promotion = match promote_or_load_attempt(options, run_id) {
+                Ok(promotion) => promotion,
+                Err(error) => {
+                    agent_task_lifecycle::fail_cook_operation(
+                        run_id,
+                        &operation_key,
+                        bounded_error_diagnostic(&error),
+                    )?;
+                    return Err(error);
+                }
+            };
             agent_task_lifecycle::complete_cook_operation(
                 run_id,
                 &operation_key,
@@ -348,6 +368,49 @@ fn promote_with_operation_claim(
             )?;
             Ok(promotion)
         }
+    }
+}
+
+fn bounded_error_diagnostic(error: &Error) -> Value {
+    let mut details = homeboy_core::redaction::redact_json(&error.details);
+    bound_diagnostic_value(&mut details, 0);
+    serde_json::json!({
+        "status": "failed",
+        "code": format!("{:?}", error.code),
+        "message": truncate_diagnostic_text(&homeboy_core::redaction::redact_string(&error.message)),
+        "details": details,
+    })
+}
+
+fn bound_diagnostic_value(value: &mut Value, depth: usize) {
+    if depth >= 4 {
+        *value = Value::String("[omitted: diagnostic depth limit]".to_string());
+        return;
+    }
+    match value {
+        Value::String(text) => *text = truncate_diagnostic_text(text),
+        Value::Array(items) => {
+            items.truncate(8);
+            for item in items {
+                bound_diagnostic_value(item, depth + 1);
+            }
+        }
+        Value::Object(entries) => {
+            for item in entries.values_mut() {
+                bound_diagnostic_value(item, depth + 1);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn truncate_diagnostic_text(text: &str) -> String {
+    const LIMIT: usize = 2048;
+    if text.len() <= LIMIT {
+        text.to_string()
+    } else {
+        let prefix: String = text.chars().take(LIMIT).collect();
+        format!("{prefix}...[truncated]")
     }
 }
 
@@ -630,12 +693,20 @@ pub struct AgentTaskCookFailureContext {
     pub latest_run_id: String,
     pub durable_recipe_ref: String,
     pub lifecycle_state: String,
+    pub phase: String,
+    pub reason_code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocking_claim: Option<Value>,
     pub provider_budget_consumed: bool,
     pub provider_executions_consumed: u64,
     pub recovery_legal: bool,
     pub recovery_reason: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub legal_actions: Vec<AgentTaskCookRecoveryAction>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<AgentTaskCookRecoveryAction>,
 }
 
 /// An exact command that is legal for the durable Cook state.

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1786,7 +1786,32 @@ fn cook_failure_context(
         .map(|record| format!("{:?}", record.state))
         .unwrap_or_else(|| "recipe_persisted_without_lifecycle_record".to_string());
     let recovery_legal = record.is_some();
-    let legal_actions = recovery_legal
+    let promotion_claim =
+        agent_task_lifecycle::operation_claim(&latest_run_id, &format!("promote:{latest_run_id}"))
+            .ok()
+            .flatten();
+    let blocking_claim = promotion_claim.as_ref().and_then(|claim| {
+        (claim.state == agent_task_lifecycle::ClaimState::Running)
+            .then(|| serde_json::to_value(claim).unwrap_or(Value::Null))
+    });
+    let diagnostic = promotion_claim
+        .as_ref()
+        .filter(|claim| claim.state == agent_task_lifecycle::ClaimState::Failed)
+        .and_then(|claim| claim.result.clone());
+    let (phase, reason_code) = if blocking_claim.is_some() {
+        ("promotion".to_string(), "operation_in_progress".to_string())
+    } else if let Some(diagnostic) = diagnostic.as_ref() {
+        (
+            "promotion".to_string(),
+            diagnostic["code"]
+                .as_str()
+                .unwrap_or("promotion_rejected")
+                .to_string(),
+        )
+    } else {
+        ("provider".to_string(), lifecycle_state.to_ascii_lowercase())
+    };
+    let mut legal_actions = recovery_legal
         .then(|| {
             vec![
                 super::AgentTaskCookRecoveryAction {
@@ -1804,11 +1829,24 @@ fn cook_failure_context(
             ]
         })
         .unwrap_or_default();
+    if blocking_claim.is_some() {
+        legal_actions.insert(
+            2,
+            super::AgentTaskCookRecoveryAction {
+                action: "reconcile".to_string(),
+                command: format!("homeboy agent-task reconcile {latest_run_id} --dry-run"),
+            },
+        );
+    }
     Some(super::AgentTaskCookFailureContext {
         cook_id: cook_id.to_string(),
         latest_run_id,
         durable_recipe_ref: format!("homeboy://agent-task/cooks/{cook_id}/recipe"),
         lifecycle_state,
+        phase,
+        reason_code,
+        diagnostic,
+        blocking_claim,
         provider_budget_consumed: provider_executions_consumed > 0,
         provider_executions_consumed,
         recovery_legal,
@@ -1817,6 +1855,7 @@ fn cook_failure_context(
         } else {
             "No recovery command is legal because the durable recipe has no lifecycle record. Start a fresh Cook after preserving the recipe reference for investigation.".to_string()
         },
+        next_actions: legal_actions.clone(),
         legal_actions,
     })
 }

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -47,11 +47,8 @@ pub(super) fn agent_task_resource_behavior(
         | agent_task::AgentTaskCommand::RunPlan(_)
         | agent_task::AgentTaskCommand::Run(_)
         | agent_task::AgentTaskCommand::RunNext
-        | agent_task::AgentTaskCommand::Evidence(_)
-        | agent_task::AgentTaskCommand::Diagnose(_)
         | agent_task::AgentTaskCommand::ReplayProviderBoundary(_)
         | agent_task::AgentTaskCommand::Resume(_)
-        | agent_task::AgentTaskCommand::Review(_)
         | agent_task::AgentTaskCommand::Promote(_)
         | agent_task::AgentTaskCommand::Adopt(_)
         | agent_task::AgentTaskCommand::PromotionProvider(_)
@@ -67,10 +64,14 @@ pub(super) fn agent_task_resource_behavior(
         | agent_task::AgentTaskCommand::List(_)
         | agent_task::AgentTaskCommand::Latest(_)
         | agent_task::AgentTaskCommand::Logs(_)
-        | agent_task::AgentTaskCommand::Artifacts(_) => {
+        | agent_task::AgentTaskCommand::Artifacts(_)
+        | agent_task::AgentTaskCommand::Evidence(_)
+        | agent_task::AgentTaskCommand::Diagnose(_)
+        | agent_task::AgentTaskCommand::Review(_) => AgentTaskResourceBehavior::BoundedMetadataRead,
+        agent_task::AgentTaskCommand::Active(active) if !active.reconcile => {
             AgentTaskResourceBehavior::BoundedMetadataRead
         }
-        agent_task::AgentTaskCommand::Active(active) if !active.reconcile => {
+        agent_task::AgentTaskCommand::Reconcile(reconcile) if !reconcile.apply => {
             AgentTaskResourceBehavior::BoundedMetadataRead
         }
         agent_task::AgentTaskCommand::Active(_)


### PR DESCRIPTION
## Summary

Implements the owning-layer recovery slice for the Cook promotion failure chain:

- retains configured-provider response validation evidence, including bounded stdout/stderr, exit code, and argv-backed command evidence
- terminalizes rejected promotion claims with redacted, bounded typed diagnostics; failed claims are explicitly retryable
- records a local owner PID, reclaims provably dead owners before lease expiry, and returns typed `operation_in_progress` for live owners without re-entering the side effect
- emits Cook `failure_context` phase/reason/diagnostic/blocking-claim data and canonical executable `next_actions`
- classifies agent-task evidence, diagnose, review, and reconciliation previews as bounded read-only operations

Related: #10233, #10235, #10236, #10237, #10240, #10242.

No issues are closed by this PR: their full acceptance contracts include additional end-to-end scenarios beyond this recovery slice.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents failed_claim_preserves_diagnostic_and_is_reclaimable_by_explicit_continuation --lib`
- `cargo test -p homeboy-agents provider_response_validation_distinguishes_json_schema_and_required_field_errors --lib`
- `cargo check -p homeboy-cli`

## AI Assistance

Substantive implementation and regression tests were drafted with OpenCode using OpenAI GPT-5.6 Sol. Chris Huber remains responsible for every line.