### PR TITLE
fix(agent-task): resolve Cook targets before provisioning

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -283,20 +283,28 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
         );
     }
 
-    if let Ok(resolution) =
-        homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-            &args.to_worktree,
-            &defaults::load_config(),
-            None,
-        )
-    {
-        homeboy::core::worktree_providers::validate_task_worktree_root(
-            Path::new(&resolution.worktree.path),
-            &args.to_worktree,
-        )?;
-        return Ok(
-            serde_json::json!({ "action": "existing", "kind": "provider", "provider": resolution.provider_id, "handle": resolution.worktree.handle, "path": resolution.worktree.path, "branch": resolution.worktree.branch }),
-        );
+    let config = defaults::load_config();
+    match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+        &args.to_worktree,
+        &config,
+        None,
+    ) {
+        Ok(resolution) => {
+            homeboy::core::worktree_providers::validate_task_worktree_root(
+                Path::new(&resolution.worktree.path),
+                &args.to_worktree,
+            )?;
+            return Ok(
+                serde_json::json!({ "action": "existing", "kind": "provider", "provider": resolution.provider_id, "handle": resolution.worktree.handle, "path": resolution.worktree.path, "branch": resolution.worktree.branch }),
+            );
+        }
+        Err(error)
+            if error
+                .details
+                .get("worktree_provider_lookup")
+                .and_then(Value::as_str)
+                == Some("not_found") => {}
+        Err(error) => return Err(error),
     }
 
     let repo = args.dispatch.repo.clone().ok_or_else(|| {
@@ -323,7 +331,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             head,
             task_url,
         },
-        &defaults::load_config(),
+        &config,
     )
     .map(|provision| {
         serde_json::json!({

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -29,6 +29,17 @@ impl AgentTaskCookAttemptDispatcher for RecipeOnlyDispatcher {
     }
 }
 
+fn cook_args_from_cli(args: Vec<String>) -> AgentTaskCookArgs {
+    let cli = Cli::parse_from(args);
+    let Commands::AgentTask(agent_task) = cli.command else {
+        panic!("agent-task command");
+    };
+    let AgentTaskCommand::Cook(cook) = agent_task.command else {
+        panic!("cook command");
+    };
+    cook
+}
+
 #[test]
 fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
     with_isolated_home(|_| {
@@ -291,6 +302,160 @@ fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
             !ensured.exists(),
             "invalid Cook inputs must cause zero ensure mutations"
         );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn cook_resolves_existing_provider_destination_without_creation_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        let destination_root = tempfile::tempdir().expect("destination root");
+        let destination = destination_root.path().join("task");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/existing",
+                destination.to_str().expect("destination path"),
+                "HEAD",
+            ])
+            .current_dir(workspace.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
+        let provider_dir = tempfile::tempdir().expect("provider dir");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@existing\",\"path\":\"{}\",\"branch\":\"fix/existing\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+                destination.display()
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                    },
+                ),
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "reuse destination".to_string(),
+            "--to-worktree".to_string(),
+            "fixture@existing".to_string(),
+            "--no-finalize".to_string(),
+        ]);
+        let provision = super::super::run::provision_cook_destination(&args)
+            .expect("existing provider destination resolves without creation fields");
+
+        assert_eq!(provision["action"], "existing");
+        assert_eq!(provision["provider"], "fixture");
+        assert_eq!(provision["path"], destination.display().to_string());
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("provider tempdir");
+        let ensured = temp.path().join("ensured");
+        let provider = temp.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then exit 77; fi\ntouch '{}'\n",
+                ensured.display()
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string(), "resolve".to_string()]),
+                    ensure: Some(vec![provider.display().to_string(), "ensure".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                    },
+                ),
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "resolve destination".to_string(),
+            "--to-worktree".to_string(),
+            "fixture@missing".to_string(),
+            "--no-finalize".to_string(),
+        ]);
+        let error = super::super::run::provision_cook_destination(&args)
+            .expect_err("provider lookup failure is not a missing destination");
+
+        assert!(error
+            .message
+            .contains("provider `fixture` resolve command failed"));
+        assert!(!ensured.exists(), "failed lookup must not run ensure");
     });
 }
 


### PR DESCRIPTION
## Summary
- resolve provider-managed `--to-worktree` destinations before requiring creation-only arguments
- preserve provider lookup and safety failures; only confirmed absence proceeds to generic ensure provisioning
- cover existing managed targets without creation metadata and non-absence provider errors

Closes #9476
Closes #10239

## Tests
- `cargo test -p homeboy-cli cook_resolves_existing_provider_destination_without_creation_metadata --no-fail-fast`
- `cargo test -p homeboy-cli cook_does_not_collapse_provider_lookup_failures_into_missing_destination_metadata --no-fail-fast`
- `cargo test -p homeboy-core provision_creates_missing_destination_from_explicit_generic_intent --no-fail-fast`
- `cargo test -p homeboy-core concurrent_identical_provisioning_reuses_one_destination_and_idempotency_key --no-fail-fast`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to inspect the provider and Cook lifecycle contracts, implement the resolution-ordering repair, and add targeted regression coverage. Chris remains responsible for every line.