### PR TITLE
fix(agent-task): hydrate destination gate workspace

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -177,25 +177,11 @@ impl VerifyGateOptions {
         Duration::from_secs(self.gate_heartbeat_interval_seconds.max(1))
     }
 
-    /// Commands already declared as gates are toolchain requirements too. This
-    /// protects existing Cook invocations without duplicate CLI ceremony.
+    /// Toolchain preflight is opt-in. Gate commands are shell programs and may
+    /// be shell builtins, provider-owned aliases, or compound expressions, so
+    /// treating their first token as an executable changes their semantics.
     pub(crate) fn required_toolchains(&self) -> Vec<AgentTaskGateToolchainRequirement> {
-        let mut requirements = self.gate_toolchains.clone();
-        for gate in self.verify.iter().chain(&self.private_verify) {
-            let Some(command) = gate.split_whitespace().next() else {
-                continue;
-            };
-            if !requirements
-                .iter()
-                .any(|requirement| requirement.command == command)
-            {
-                requirements.push(AgentTaskGateToolchainRequirement {
-                    command: command.to_string(),
-                    probe_arguments: default_toolchain_probe_arguments(),
-                });
-            }
-        }
-        requirements
+        self.gate_toolchains.clone()
     }
 }
 
@@ -220,6 +206,8 @@ impl Default for VerifyGateOptions {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskGateSetupEvidence {
     pub schema: String,
+    /// The workspace whose dependency state this setup evidence describes.
+    pub workspace: String,
     pub package_root: String,
     pub lock_identity: String,
     pub setup_capability: String,
@@ -235,6 +223,7 @@ const MAX_GATE_DEPENDENCY_ROOTS: usize = 64;
 pub(crate) fn hydrate_gate_dependency_roots(
     checkout: &Path,
     enabled: bool,
+    workspace: &str,
 ) -> Result<Vec<AgentTaskGateSetupEvidence>> {
     if !enabled {
         return Ok(Vec::new());
@@ -300,6 +289,7 @@ pub(crate) fn hydrate_gate_dependency_roots(
             .to_string();
         evidence.push(AgentTaskGateSetupEvidence {
             schema: "homeboy/agent-task-gate-setup/v1".to_string(),
+            workspace: workspace.to_string(),
             package_root: if relative.is_empty() {
                 ".".to_string()
             } else {

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -193,7 +193,8 @@ pub fn resume_promoted_patch(
             "artifact_metadata": artifact.metadata,
             "worktree_path": target_path,
             "dependencies_materialized": gates.dependencies_materialized,
-            "gate_setup": gates.setup,
+            "candidate_checkout_setup": gates.candidate_setup,
+            "destination_gate_setup": gates.destination_gate_setup,
             "candidate_checkout": gates.candidate_checkout,
             "candidate": candidate,
             "resumed_post_apply_promotion": true,
@@ -622,7 +623,8 @@ pub(super) fn promote_with_provider_and_checkpoint(
                 "worktree_path": worktree_path,
                 "verified_revision": verified_revision,
                 "dependencies_materialized": gates.dependencies_materialized,
-                "gate_setup": gates.setup,
+                "candidate_checkout_setup": gates.candidate_setup,
+                "destination_gate_setup": gates.destination_gate_setup,
                 "candidate_checkout": gates.candidate_checkout,
                 "candidate": candidate,
             }),
@@ -779,7 +781,8 @@ pub(super) fn promote_with_provider_and_checkpoint(
             "artifact_metadata": artifact.metadata,
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
-            "gate_setup": gates.setup,
+            "candidate_checkout_setup": gates.candidate_setup,
+            "destination_gate_setup": gates.destination_gate_setup,
             "candidate_checkout": gates.candidate_checkout,
             "candidate": candidate,
             "destination_baseline": candidate,
@@ -1351,7 +1354,8 @@ fn promote_committed_changes(
             "artifact_metadata": artifact.map(|artifact| artifact.metadata.clone()).unwrap_or(Value::Null),
             "worktree_path": applied_worktree_path,
             "dependencies_materialized": gates.dependencies_materialized,
-            "gate_setup": gates.setup,
+            "candidate_checkout_setup": gates.candidate_setup,
+            "destination_gate_setup": gates.destination_gate_setup,
             "candidate_checkout": gates.candidate_checkout,
             "change_source": "local_commits",
             "base_ref": committed_patch.base_ref,
@@ -1386,39 +1390,29 @@ fn run_promotion_gates(
             .unwrap_or("unrecorded-promotion"),
         expected_candidate,
     )?;
-    let gate_path = candidate_checkout
-        .as_ref()
-        .map(ImmutableCandidateCheckout::path)
-        .unwrap_or(worktree_path);
-    // Materialize dependencies in the immutable checkout so repository-owned
-    // verification sees the candidate as committed content, never the dirty
-    // promotion target that finalization still owns.
-    let setup = crate::agent_task_gate::hydrate_gate_dependency_roots(
-        gate_path,
-        options.gates.hydrate_dependencies,
-    )
-    .map_err(|error| {
-        let mut cause = serde_json::json!({
-            "classification": "candidate_setup",
-            "code": error.code.as_str(),
-            "message": bounded_setup_error_text(&error.message),
-        });
-        if let Some(details) = cause.as_object_mut() {
-            details.insert(
-                "details".to_string(),
-                serde_json::Value::String(bounded_setup_error_text(&error.details.to_string())),
-            );
-        }
-        Error::dependency_step_failed(
-            "promotion.gate_setup",
-            "candidate_checkout".to_string(),
-            None,
-            Vec::new(),
-            Vec::new(),
-            None,
-            Some(cause),
+    // The immutable candidate establishes source identity only. Dependency
+    // setup is intentionally destination-only: gates must consume the exact
+    // executable projection this report describes.
+    let candidate_setup = Vec::new();
+    let destination_gate_setup = if worktree_path.is_dir() {
+        crate::agent_task_gate::hydrate_gate_dependency_roots(
+            worktree_path,
+            options.gates.hydrate_dependencies,
+            "destination_gate_workspace",
         )
-    })?;
+        .map_err(|error| {
+            gate_setup_failure(
+                "destination_gate_setup",
+                "destination_gate_workspace",
+                error,
+            )
+        })?
+    } else {
+        // An opaque provider destination cannot be hydrated locally. Its gate
+        // provider remains the authority, and the report makes no local
+        // materialization claim.
+        Vec::new()
+    };
     let declared_gates = options
         .gates
         .verify
@@ -1452,7 +1446,7 @@ fn run_promotion_gates(
             run_promotion_gate(
                 options,
                 provider,
-                gate_path,
+                worktree_path,
                 index + 1,
                 command,
                 visibility,
@@ -1486,8 +1480,9 @@ fn run_promotion_gates(
         status: status_for_report(options.dry_run, has_gate_failure),
         deterministic_gates,
         gate_results,
-        dependencies_materialized: !setup.is_empty(),
-        setup,
+        dependencies_materialized: !destination_gate_setup.is_empty(),
+        candidate_setup,
+        destination_gate_setup,
         candidate_checkout,
     })
 }
@@ -1502,6 +1497,24 @@ fn bounded_setup_error_text(value: &str) -> String {
         result.push(character);
     }
     result
+}
+
+fn gate_setup_failure(classification: &str, component: &str, error: Error) -> Error {
+    Error::dependency_step_failed(
+        "promotion.gate_setup",
+        component.to_string(),
+        None,
+        Vec::new(),
+        Vec::new(),
+        None,
+        Some(serde_json::json!({
+            "classification": classification,
+            "code": error.code.as_str(),
+            "message": bounded_setup_error_text(&error.message),
+            "details": bounded_setup_error_text(&error.details.to_string()),
+            "retry_action": "retry_dependency_hydration",
+        })),
+    )
 }
 
 /// A run-scoped detached worktree whose commit tree is exactly the promoted
@@ -1610,10 +1623,6 @@ impl ImmutableCandidateCheckout {
         Ok(Some(checkout))
     }
 
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
     fn identity(&self) -> AgentTaskGateCandidateCheckout {
         self.identity.clone()
     }
@@ -1706,7 +1715,13 @@ fn run_promotion_gate(
         &options.gates.required_toolchains(),
         Some(&runtime_tmpdir.context().tmp_dir),
     ) {
-        Err(error)
+        // This runs before provider verification. A missing destination tool is
+        // setup evidence, not candidate blame or provider-budget consumption.
+        Err(gate_setup_failure(
+            "destination_gate_toolchain",
+            "destination_gate_workspace",
+            error,
+        ))
     } else if let Some(supervision) = supervision.as_deref() {
         crate::agent_task_gate::run_gate_command_with_supervision(
             worktree_path,

--- a/crates/homeboy-agents/src/agent_task_promotion/promote/gate_run.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote/gate_run.rs
@@ -9,7 +9,8 @@ pub(super) struct PromotionGateRun {
     pub(super) deterministic_gates: Vec<AgentTaskGateReport>,
     pub(super) gate_results: Vec<HomeboyGateResult>,
     pub(super) dependencies_materialized: bool,
-    pub(super) setup: Vec<AgentTaskGateSetupEvidence>,
+    pub(super) candidate_setup: Vec<AgentTaskGateSetupEvidence>,
+    pub(super) destination_gate_setup: Vec<AgentTaskGateSetupEvidence>,
     pub(super) candidate_checkout: Option<AgentTaskGateCandidateCheckout>,
 }
 
@@ -24,7 +25,8 @@ impl PromotionGateRun {
             deterministic_gates: Vec::new(),
             gate_results: Vec::new(),
             dependencies_materialized: false,
-            setup: Vec::new(),
+            candidate_setup: Vec::new(),
+            destination_gate_setup: Vec::new(),
             candidate_checkout: None,
         }
     }

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -366,7 +366,7 @@ fn normalize_promotion_patch_leaves_unrelated_workspace_paths() {
 }
 
 #[test]
-fn empty_patch_failing_gate_is_reported_against_pinned_candidate() {
+fn empty_patch_failing_gate_is_reported_against_destination() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir(&repo).expect("create repo");
@@ -419,7 +419,7 @@ fn empty_patch_failing_gate_is_reported_against_pinned_candidate() {
         homeboy_core::gate::HomeboyGateStatus::Failed
     );
     assert_eq!(provider.apply_calls.len(), 0);
-    assert_ne!(provider.verify_calls[0].0, repo);
+    assert_eq!(provider.verify_calls[0].0, repo);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1304,7 +1304,7 @@ fn continue_all_gate_policy_runs_downstream_command_after_failure() {
 }
 
 #[test]
-fn promotion_runs_clean_checkout_gate_against_immutable_candidate() {
+fn promotion_runs_gates_in_the_destination_workspace() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path().join("workspace");
     std::fs::create_dir(&workspace).expect("workspace");
@@ -1337,10 +1337,7 @@ fn promotion_runs_clean_checkout_gate_against_immutable_candidate() {
             artifact_id: None,
             dry_run: false,
             gates: VerifyGateOptions {
-                verify: vec![
-                    "test -z \"$(git status --porcelain)\" && test \"$(cat src/lib.rs)\" = new"
-                        .to_string(),
-                ],
+                verify: vec!["test \"$(cat src/lib.rs)\" = new".to_string()],
                 ..Default::default()
             },
             provider_command: None,
@@ -1348,11 +1345,11 @@ fn promotion_runs_clean_checkout_gate_against_immutable_candidate() {
         },
         &mut provider,
     )
-    .expect("clean-checkout gate accepts the dirty promoted candidate");
+    .expect("destination gate accepts the promoted candidate");
 
     assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
-    assert_eq!(provider.verify_worktrees_clean, vec![true]);
-    assert_ne!(provider.verify_calls[0].0, workspace);
+    assert_eq!(provider.verify_worktrees_clean, vec![false]);
+    assert_eq!(provider.verify_calls[0].0, workspace);
     assert!(Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(&workspace)
@@ -1375,7 +1372,7 @@ fn promotion_runs_clean_checkout_gate_against_immutable_candidate() {
 }
 
 #[test]
-fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
+fn promotion_hydrates_destination_package_execution_projections_before_gates() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
@@ -1384,21 +1381,17 @@ fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
         git(&workspace, &["config", "user.email", "test@example.com"]);
         git(&workspace, &["config", "user.name", "Homeboy Test"]);
         std::fs::create_dir_all(workspace.join("src")).expect("source directory");
-        std::fs::create_dir_all(workspace.join("transformer")).expect("nested package");
         std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
         std::fs::write(
-            workspace.join("transformer/homeboy.json"),
-            r#"{"id":"nested-transformer"}"#,
+            workspace.join("homeboy.json"),
+            r#"{"id":"projection-fixture"}"#,
         )
         .expect("component manifest");
+        std::fs::write(workspace.join("dependency.lock"), "fixture-lock\n")
+            .expect("dependency lock fixture");
         std::fs::write(
-            workspace.join("transformer/dependency.lock"),
-            "fixture-lock\n",
-        )
-        .expect("dependency lock fixture");
-        std::fs::write(
-            workspace.join("transformer/homeboy-deps.json"),
-            r#"{"provider":"fixture-provider","commands":{"install":{"argv":["sh","-c","printf fixture > installed.marker"]}}}"#,
+            workspace.join("homeboy-deps.json"),
+            r##"{"provider":"fixture-provider","commands":{"install":{"argv":["sh","-c","mkdir -p node_modules/fixture node_modules/.bin && printf 'console.log(\"explicit module path\")\n' > node_modules/fixture/explicit.js && printf '#!/bin/sh\nexit 0\n' > node_modules/.bin/fixture-bin && chmod +x node_modules/.bin/fixture-bin"]}}}"##,
         )
         .expect("provider declaration");
         git(&workspace, &["add", "."]);
@@ -1425,7 +1418,12 @@ fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
                 artifact_id: None,
                 dry_run: false,
                 gates: VerifyGateOptions {
-                    verify: vec!["test -f transformer/installed.marker".to_string()],
+                    // The first gate addresses a module directly; the second
+                    // consumes the executable projection the provider created.
+                    verify: vec![
+                        "node ./node_modules/fixture/explicit.js".to_string(),
+                        "./node_modules/.bin/fixture-bin".to_string(),
+                    ],
                     ..Default::default()
                 },
                 provider_command: None,
@@ -1433,20 +1431,28 @@ fn promotion_hydrates_a_bounded_nested_dependency_root_before_its_gate() {
             },
             &mut provider,
         )
-        .expect("nested dependency setup makes the gate runnable");
+        .expect("destination dependency setup makes both gate forms runnable");
 
         assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
         assert_eq!(
-            report.provenance["gate_setup"][0]["package_root"],
-            "transformer"
+            report.provenance["candidate_checkout_setup"],
+            serde_json::json!([])
         );
         assert_eq!(
-            report.provenance["gate_setup"][0]["setup_capability"],
+            report.provenance["destination_gate_setup"][0]["workspace"],
+            "destination_gate_workspace"
+        );
+        assert_eq!(
+            report.provenance["destination_gate_setup"][0]["setup_capability"],
             "dependency.install"
         );
         assert!(
-            !workspace.join("transformer/installed.marker").exists(),
-            "setup writes only to the candidate checkout"
+            workspace.join("node_modules/fixture/explicit.js").exists(),
+            "destination hydration creates the explicit module path"
+        );
+        assert!(
+            workspace.join("node_modules/.bin/fixture-bin").exists(),
+            "destination hydration creates the executable projection"
         );
     });
 }
@@ -1493,7 +1499,14 @@ fn promotion_can_disable_candidate_dependency_hydration() {
         &mut provider,
     )
     .expect("disabled setup still runs gates");
-    assert_eq!(report.provenance["gate_setup"], serde_json::json!([]));
+    assert_eq!(
+        report.provenance["candidate_checkout_setup"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        report.provenance["destination_gate_setup"],
+        serde_json::json!([])
+    );
 }
 
 #[test]
@@ -1547,7 +1560,10 @@ fn promotion_setup_failure_is_bounded_and_never_dispatches_a_gate() {
         .expect_err("failed setup stops before a gate can spend repair capacity");
 
         assert_eq!(error.code.as_str(), "dependency_step_failed");
-        assert_eq!(error.details["cause"]["classification"], "candidate_setup");
+        assert_eq!(
+            error.details["cause"]["classification"],
+            "destination_gate_setup"
+        );
         assert!(
             error.details["cause"]["details"]
                 .as_str()
@@ -1560,6 +1576,69 @@ fn promotion_setup_failure_is_bounded_and_never_dispatches_a_gate() {
             "no gate/provider dispatch occurs"
         );
     });
+}
+
+#[test]
+fn missing_destination_tool_is_a_typed_setup_failure_before_provider_verification() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init", "-b", "main"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Homeboy Test"]);
+    std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+    std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+    git(&workspace, &["add", "."]);
+    git(&workspace, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(workspace),
+        apply_to_git: true,
+        ..Default::default()
+    };
+
+    let error = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("missing-destination-tool".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["homeboy-fixture-missing-tool".to_string()],
+                hydrate_dependencies: false,
+                gate_toolchains: vec![crate::agent_task_gate::AgentTaskGateToolchainRequirement {
+                    command: "homeboy-fixture-missing-tool".to_string(),
+                    probe_arguments: vec!["--version".to_string()],
+                }],
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect_err("missing tool is setup evidence, not a candidate gate failure");
+
+    assert_eq!(error.code.as_str(), "dependency_step_failed");
+    assert_eq!(
+        error.details["cause"]["classification"],
+        "destination_gate_toolchain"
+    );
+    assert_eq!(
+        error.details["cause"]["retry_action"],
+        "retry_dependency_hydration"
+    );
+    assert!(
+        provider.verify_calls.is_empty(),
+        "provider budget was not spent"
+    );
 }
 
 #[test]
@@ -1616,7 +1695,7 @@ fn promotion_rejects_mutation_after_checkpoint_before_gate_materialization() {
 }
 
 #[test]
-fn resumed_verification_runs_clean_checkout_gate_for_exact_dirty_candidate() {
+fn resumed_verification_runs_destination_gate_for_exact_dirty_candidate() {
     let temp = tempfile::tempdir().expect("tempdir");
     let target = temp.path().join("target");
     std::fs::create_dir(&target).expect("target");
@@ -1645,10 +1724,7 @@ fn resumed_verification_runs_clean_checkout_gate_for_exact_dirty_candidate() {
         artifact_id: None,
         dry_run: false,
         gates: VerifyGateOptions {
-            verify: vec![
-                "test -z \"$(git status --porcelain)\" && test \"$(cat src/lib.rs)\" = new"
-                    .to_string(),
-            ],
+            verify: vec!["test \"$(cat src/lib.rs)\" = new".to_string()],
             rerun_completed_gates: true,
             ..Default::default()
         },

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -247,7 +247,7 @@ fn normalize_promotion_patch_strips_lab_sandbox_workspace_prefix() {
 }
 
 #[test]
-fn empty_patch_runs_public_and_private_gates_against_pinned_candidate() {
+fn empty_patch_runs_public_and_private_gates_against_destination() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir(&repo).expect("create repo");
@@ -295,7 +295,7 @@ fn empty_patch_runs_public_and_private_gates_against_pinned_candidate() {
     assert_eq!(report.provenance["verified_revision"], revision);
     assert_eq!(provider.apply_calls.len(), 0);
     assert_eq!(provider.verify_calls.len(), 2);
-    assert_ne!(provider.verify_calls[0].0, repo);
+    assert_eq!(provider.verify_calls[0].0, repo);
     assert_eq!(provider.verify_calls[1].2, AgentTaskGateVisibility::Private);
     assert_eq!(
         provider.verify_calls[1].3,
@@ -369,7 +369,7 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
     );
     assert_eq!(provider.apply_calls.len(), 1);
     assert_eq!(provider.verify_calls.len(), 1);
-    assert_ne!(provider.verify_calls[0].0, repo);
+    assert_eq!(provider.verify_calls[0].0, repo);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- hydrate declared dependency roots in the exact promotion destination where deterministic gates execute, including provider-created executable projections
- report candidate-checkout setup separately from destination-gate setup; `dependencies_materialized` now describes the destination workspace
- classify declared missing destination tools as typed setup failures before provider verification, with a retry hydration action
- add a generic provider fixture covering an explicit module path followed by a bin shim

Fixes #10241

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-agents --tests`
- `cargo test -p homeboy-agents promotion_hydrates_destination_package_execution_projections_before_gates --lib`
- `cargo test -p homeboy-agents missing_destination_tool_is_a_typed_setup_failure_before_provider_verification --lib`
- `cargo test -p homeboy-agents resumed_verification_runs_destination_gate_for_exact_dirty_candidate --lib`

`cargo test -p homeboy-agents agent_task_promotion::tests:: --lib` remains non-green due existing remote-base fixture and shared reconciliation-state failures; the destination-execution assertions affected by this change were updated and covered by the focused tests above.

## AI assistance
OpenCode using OpenAI GPT-5.6 Sol implemented the destination-hydration flow, regression coverage, and verification. Chris Huber remains responsible for review and every line.