### PR TITLE
fix(release): preflight package asset ownership

### DIFF
--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -294,7 +294,10 @@ pub(crate) fn run_git_commit(
     let options = homeboy_core::git::CommitOptions {
         staged_only: false,
         files: None,
-        exclude: None,
+        // Package ownership is established before the release commit so target
+        // conflicts fail before commit/tag/push. Keep those generated outputs
+        // out of the version/changelog commit.
+        exclude: (!state.package_owned_paths.is_empty()).then(|| state.package_owned_paths.clone()),
         amend: should_amend,
     };
 

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -80,8 +80,10 @@ pub(crate) fn run_artifact_inventory(
 }
 
 /// Select one generic publication authority for every remote target filename.
-/// Final package output supersedes preflight output, while a disagreement
-/// between equally authoritative final producers fails before tag/push.
+/// Final package output supersedes preflight output. Within one phase, a
+/// previously declared canonical recovery artifact wins, followed by an
+/// explicit component `scripts.build` artifact; identical lower-precedence
+/// duplicates collapse, while differing bytes fail before commit/tag/push.
 pub(crate) fn establish_publication_authority(state: &mut ReleaseState) -> Result<Vec<String>> {
     let mut selected: BTreeMap<String, usize> = BTreeMap::new();
     let mut diagnostics = Vec::new();
@@ -92,7 +94,6 @@ pub(crate) fn establish_publication_authority(state: &mut ReleaseState) -> Resul
             .filter(|path| std::path::Path::new(path).is_file())
             .unwrap_or(&artifact.path);
         artifact.sha256 = Some(sha256_file(path)?);
-        artifact.publication_authority = false;
     }
     for index in 0..state.artifacts.len() {
         let target = artifact_target_name(&state.artifacts[index])?;
@@ -106,7 +107,7 @@ pub(crate) fn establish_publication_authority(state: &mut ReleaseState) -> Resul
         let existing_final = existing.phase == "final";
         let candidate_final = candidate.phase == "final";
         if same_bytes {
-            if !existing_final && candidate_final {
+            if artifact_precedence(candidate) > artifact_precedence(existing) {
                 selected.insert(target, index);
             }
             continue;
@@ -133,10 +134,23 @@ pub(crate) fn establish_publication_authority(state: &mut ReleaseState) -> Resul
             ));
         }
     }
+    for artifact in &mut state.artifacts {
+        artifact.publication_authority = false;
+    }
     for index in selected.into_values() {
         state.artifacts[index].publication_authority = true;
     }
     Ok(diagnostics)
+}
+
+fn artifact_precedence(artifact: &ReleaseArtifact) -> (u8, u8, u8) {
+    (
+        u8::from(artifact.phase == "final"),
+        u8::from(artifact.publication_authority),
+        // `scripts.build` is the generic component-owned build_artifact
+        // contract. Extensions remain free to produce additional targets.
+        u8::from(artifact.producer == "scripts.build"),
+    )
 }
 
 fn artifact_target_name(artifact: &ReleaseArtifact) -> Result<String> {
@@ -693,6 +707,63 @@ mod tests {
             1
         );
         assert!(state.artifacts[1].publication_authority);
+    }
+
+    #[test]
+    fn identical_component_build_artifact_is_the_canonical_package_owner() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let extension_dir = temp.path().join("extension");
+        let component_dir = temp.path().join("component");
+        std::fs::create_dir_all(&extension_dir).expect("extension dir");
+        std::fs::create_dir_all(&component_dir).expect("component dir");
+        let extension = extension_dir.join("plugin.zip");
+        let component = component_dir.join("plugin.zip");
+        std::fs::write(&extension, b"same").expect("extension bytes");
+        std::fs::write(&component, b"same").expect("component bytes");
+        let mut state = ReleaseState {
+            artifacts: vec![
+                artifact(&extension, "final", "extension:wordpress"),
+                artifact(&component, "final", "scripts.build"),
+            ],
+            ..ReleaseState::default()
+        };
+
+        establish_publication_authority(&mut state).expect("identical assets");
+        let publications = github_release_publications(&state).expect("publications");
+
+        assert!(state.artifacts[1].publication_authority);
+        assert_eq!(publications.len(), 1);
+        assert_eq!(
+            std::fs::read(&publications[0].source_path).expect("canonical bytes"),
+            b"same"
+        );
+    }
+
+    #[test]
+    fn recovery_preserves_the_declared_canonical_artifact_without_rebuild() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let canonical = temp.path().join("canonical/plugin.zip");
+        let duplicate = temp.path().join("duplicate/plugin.zip");
+        std::fs::create_dir_all(canonical.parent().unwrap()).expect("canonical dir");
+        std::fs::create_dir_all(duplicate.parent().unwrap()).expect("duplicate dir");
+        std::fs::write(&canonical, b"same").expect("canonical bytes");
+        std::fs::write(&duplicate, b"same").expect("duplicate bytes");
+        let mut selected = artifact(&canonical, "recovery", "from-artifacts");
+        selected.publication_authority = true;
+        let mut state = ReleaseState {
+            artifacts: vec![selected, artifact(&duplicate, "recovery", "from-artifacts")],
+            ..ReleaseState::default()
+        };
+
+        establish_publication_authority(&mut state).expect("recovery authority");
+        let publications = github_release_publications(&state).expect("publications");
+
+        assert!(state.artifacts[0].publication_authority);
+        assert_eq!(publications.len(), 1);
+        assert_eq!(
+            std::fs::read(&publications[0].source_path).expect("canonical bytes"),
+            b"same"
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -105,7 +105,7 @@ pub(in crate::release) fn build_release_steps(
         version_config,
     ));
 
-    let commit_needs = if has_prepare_capability(extensions) {
+    let package_needs = if has_prepare_capability(extensions) {
         steps.push(ready_step(
             "release.prepare",
             "release.prepare",
@@ -118,20 +118,12 @@ pub(in crate::release) fn build_release_steps(
         vec!["version".to_string()]
     };
 
-    steps.push(ready_step(
-        "git.commit",
-        "git.commit",
-        format!("Commit release: v{}", new_version),
-        commit_needs,
-        StepConfig::new(),
-    ));
-
-    let tag_needs = if package_step_needed {
+    let commit_needs = if package_step_needed {
         steps.push(ready_step(
             "package",
             "package",
-            "Package release artifacts",
-            vec!["git.commit".to_string()],
+            "Preflight release package ownership",
+            package_needs,
             StepConfig::new(),
         ));
         steps.push(ready_step(
@@ -143,14 +135,22 @@ pub(in crate::release) fn build_release_steps(
         ));
         vec!["artifacts.authority".to_string()]
     } else {
-        vec!["git.commit".to_string()]
+        package_needs
     };
+
+    steps.push(ready_step(
+        "git.commit",
+        "git.commit",
+        format!("Commit release: v{}", new_version),
+        commit_needs,
+        StepConfig::new(),
+    ));
 
     steps.push(ready_step(
         "git.tag",
         "git.tag",
         format!("Tag {}", tag_name),
-        tag_needs,
+        vec!["git.commit".to_string()],
         string_config("name", tag_name),
     ));
 

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -552,16 +552,20 @@ fn skip_publish_with_package_provider_still_packages_before_github_release() {
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
     let package_preflight_index = step_index(&ids, "preflight.package");
     let package_index = step_index(&ids, "package");
+    let authority_index = step_index(&ids, "artifacts.authority");
+    let commit_index = step_index(&ids, "git.commit");
+    let tag_index = step_index(&ids, "git.tag");
+    let push_index = step_index(&ids, "git.push");
     let github_release_index = step_index(&ids, "github.release");
 
     assert!(package_preflight_index < package_index);
+    assert!(package_index < authority_index);
+    assert!(authority_index < commit_index);
+    assert!(authority_index < tag_index);
+    assert!(authority_index < push_index);
     assert!(package_index < github_release_index);
-    assert_eq!(steps[package_index].needs, vec!["git.commit"]);
-    assert!(step_index(&ids, "package") < step_index(&ids, "artifacts.authority"));
-    assert_eq!(
-        steps[step_index(&ids, "git.tag")].needs,
-        vec!["artifacts.authority"]
-    );
+    assert_eq!(steps[commit_index].needs, vec!["artifacts.authority"]);
+    assert_eq!(steps[tag_index].needs, vec!["git.commit"]);
     assert_eq!(steps[github_release_index].needs, vec!["git.push"]);
     assert!(!ids.contains(&"publish.artifact-packager"));
     assert_eq!(
@@ -685,10 +689,7 @@ fn component_build_artifact_packages_before_github_release_without_extension() {
     let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
     assert!(step_index(&ids, "preflight.package") < step_index(&ids, "package"));
     assert!(step_index(&ids, "package") < step_index(&ids, "github.release"));
-    assert_eq!(
-        steps[step_index(&ids, "git.tag")].needs,
-        vec!["artifacts.authority"]
-    );
+    assert_eq!(steps[step_index(&ids, "git.tag")].needs, vec!["git.commit"]);
     assert_eq!(
         steps[step_index(&ids, "cleanup")].needs,
         vec!["github.release"]


### PR DESCRIPTION
Closes #10250

## Summary
- resolve package asset authority before release commit, tag, and push
- prefer matching explicit component build artifacts, preserve selected recovery artifacts, and reject conflicting target bytes
- keep generated package paths out of the release commit and cover ordering, deduplication, and recovery

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-release release::plan_steps::tests::skip_publish_with_package_provider_still_packages_before_github_release`
- `cargo test -p homeboy-release release::executor::artifacts::tests`
- `cargo test -p homeboy-release` (669 passed; 4 existing environment-sensitive failures in deploy ownership/tag fixtures and extension-store isolation)

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode drafted and tested the release ownership preflight implementation. Chris Huber remains responsible for the change.