### PR TITLE
fix(agent-task): bound Cook recovery readers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -34,6 +34,12 @@ const PROMOTION_PROVIDER_COMMAND_ENV: &str = "HOMEBOY_AGENT_TASK_PROMOTION_COMMA
 /// retained evidence cannot grow without bound (#5077).
 const PROMOTION_CAPTURE_LIMIT_BYTES: usize = 65_536;
 const PROMOTION_PROVIDER_RESPONSE_LIMIT_BYTES: usize = 1_048_576;
+/// A provider is a control-plane dependency. Bound a silent command so a Cook
+/// can persist its failure and release its exactly-once claim for recovery.
+#[cfg(not(test))]
+const PROMOTION_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(test)]
+const PROMOTION_PROVIDER_TIMEOUT: Duration = Duration::from_millis(100);
 
 struct ProviderCapturedStream {
     response: Vec<u8>,
@@ -674,6 +680,8 @@ pub(crate) fn run_provider_command(
     let stderr_capture_thread =
         std::thread::spawn(move || capture_provider_stream(stderr, None, None));
     let mut response_overflow = false;
+    let started_at = std::time::Instant::now();
+    let mut timed_out = false;
     let status = loop {
         if overflow_receiver.try_recv().is_ok() {
             response_overflow = true;
@@ -705,6 +713,21 @@ pub(crate) fn run_provider_command(
             )
         })? {
             break status;
+        }
+        if started_at.elapsed() >= PROMOTION_PROVIDER_TIMEOUT {
+            timed_out = true;
+            process.kill().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("terminate timed out agent-task promotion provider command".to_string()),
+                )
+            })?;
+            break process.wait().map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("wait for timed out agent-task promotion provider command".to_string()),
+                )
+            })?;
         }
         std::thread::sleep(Duration::from_millis(10));
     };
@@ -762,6 +785,27 @@ pub(crate) fn run_provider_command(
                 stdout: report.stdout.clone(),
                 stderr: report.stderr.clone(),
                 truncated: true,
+            }),
+        ));
+    }
+    if timed_out {
+        return Err(Error::validation_invalid_argument_with_evidence(
+            "promotion_provider.command",
+            format!(
+                "promotion provider command timed out after {} seconds: {}",
+                PROMOTION_PROVIDER_TIMEOUT.as_secs(),
+                display
+            ),
+            None,
+            None,
+            Some(homeboy_core::error::CommandEvidence {
+                command: display,
+                cwd: invocation.cwd.clone(),
+                location: Some("local".to_string()),
+                exit_code,
+                stdout: report.stdout.clone(),
+                stderr: report.stderr.clone(),
+                truncated: report.capture.stdout.truncated || report.capture.stderr.truncated,
             }),
         ));
     }

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1876,6 +1876,36 @@ fn provider_failure_surfaces_bounded_stdout_and_stderr_evidence() {
 }
 
 #[test]
+fn configured_provider_timeout_is_bounded_and_retains_command_evidence() {
+    let request = AgentTaskPromotionApplyRequest {
+        schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+        to_workspace: "target-workspace".to_string(),
+        patch: None,
+        patch_path: "changes.patch".to_string(),
+        changed_files: vec!["src/lib.rs".to_string()],
+        gate_feedback_baseline: None,
+        dry_run: false,
+        trusted_unpushed_candidate_destination: None,
+    };
+    let started = std::time::Instant::now();
+    let error = run_provider_command(
+        &CommandInvocation {
+            argv: vec!["sh".to_string(), "-c".to_string(), "sleep 2".to_string()],
+            ..Default::default()
+        },
+        &request,
+    )
+    .expect_err("silent provider must be terminated");
+
+    assert!(started.elapsed() < std::time::Duration::from_secs(1));
+    assert!(error.message.contains("timed out"));
+    assert_eq!(
+        error.details["command_evidence"]["command"],
+        "sh -c sleep 2"
+    );
+}
+
+#[test]
 fn provider_response_validation_distinguishes_json_schema_and_required_field_errors() {
     let request = AgentTaskPromotionApplyRequest {
         schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -7,6 +7,7 @@
 
 use serde::Serialize;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 
 use homeboy::agents::agent_task_service as agent_task_service_direct;
@@ -36,6 +37,7 @@ use crate::commands::utils::response::{
 const COMPACT_REF_LIMIT: usize = 12;
 const COMPACT_TASK_LIMIT: usize = 12;
 const COMPACT_TEXT_LIMIT: usize = 512;
+const FULL_TEXT_LIMIT: usize = 4 * 1024;
 
 pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     if args.bridge {
@@ -71,6 +73,7 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
     attach_transport_proxy_recovery_guidance(&mut value, &args.run_id);
     if args.full {
+        bound_full_reader_payload(&mut value);
         attach_agent_task_status_actionable(&mut value, &args.run_id);
         return Ok((value, 0));
     }
@@ -78,6 +81,28 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     let mut summary = summary;
     attach_agent_task_status_actionable(&mut summary, &args.run_id);
     Ok((summary, 0))
+}
+
+/// Full recovery output remains a local reader: retain a stable digest for a
+/// large value instead of repeating multi-attempt patches in every projection.
+fn bound_full_reader_payload(value: &mut Value) {
+    match value {
+        Value::String(text) if text.len() > FULL_TEXT_LIMIT => {
+            let digest = Sha256::digest(text.as_bytes());
+            *text = format!("[omitted {} bytes; sha256={:x}]", text.len(), digest);
+        }
+        Value::Array(items) => {
+            for item in items {
+                bound_full_reader_payload(item);
+            }
+        }
+        Value::Object(fields) => {
+            for item in fields.values_mut() {
+                bound_full_reader_payload(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn is_missing_agent_task_run_metadata_error(error: &homeboy::core::Error) -> bool {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1431,6 +1431,49 @@ fn evidence_command_truncates_large_file_evidence() {
     });
 }
 
+#[test]
+fn promotion_heavy_30kb_fixture_keeps_status_and_diagnose_bounded() {
+    with_isolated_home(|_| {
+        let run_id = "run-cli-promotion-heavy-reader";
+        agent_task_lifecycle::submit_plan(&test_plan(), Some(run_id)).expect("seed run");
+        let patch = "x".repeat(30 * 1024);
+        for attempt in 1..=3 {
+            agent_task_lifecycle::record_promotion(
+                run_id,
+                json!({
+                    "attempt": attempt,
+                    "provenance": { "gate_feedback_baseline": { "current_diff": patch } },
+                }),
+            )
+            .expect("persist multi-attempt promotion fixture");
+        }
+
+        let started = std::time::Instant::now();
+        let (status_value, _) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            full: true,
+            bridge: false,
+            since_cursor: None,
+        })
+        .expect("read status without a runner");
+        let (diagnose_value, _) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: true,
+        })
+        .expect("diagnose without a runner");
+
+        assert!(started.elapsed() < std::time::Duration::from_secs(1));
+        let rendered = status_value.to_string();
+        assert!(
+            rendered.len() < 20 * 1024,
+            "full status must deduplicate large diff payloads"
+        );
+        assert!(!rendered.contains(&patch));
+        assert!(rendered.contains("sha256="));
+        assert_eq!(diagnose_value["schema"], "homeboy/agent-task-diagnose/v1");
+    });
+}
+
 struct EvidenceFixtureExecutor {
     run_id: String,
     file_uri: String,

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -688,6 +688,10 @@ mod tests {
             ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "evidence", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "diagnose", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "reconcile", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "list"].as_slice(),
             ["homeboy", "agent-task", "active"].as_slice(),
             ["homeboy", "agent-task", "latest"].as_slice(),
@@ -724,12 +728,10 @@ mod tests {
     }
 
     #[test]
-    fn agent_task_hydration_and_review_remain_resource_managed() {
-        // Hydration and review can load full evidence or run promotion work, so
-        // unlike metadata inspection they retain their portability admission.
+    fn agent_task_mutating_recovery_commands_remain_resource_managed() {
+        // Bounded readers are exempt above; replay and promotion still execute
+        // provider or worktree operations and retain resource admission.
         for args in [
-            ["homeboy", "agent-task", "evidence", "agent-task-123"].as_slice(),
-            ["homeboy", "agent-task", "diagnose", "agent-task-123"].as_slice(),
             [
                 "homeboy",
                 "agent-task",


### PR DESCRIPTION
## Summary

Completes the remaining bounded-recovery slice on top of merged #10256:

- terminates silent configured promotion-provider commands after a bounded timeout and persists typed command evidence
- keeps `status --full` bounded by replacing repeated large durable values with stable SHA-256 references
- classifies evidence, diagnose, review, and per-run reconcile preview as bounded local reads under warm/hot controller policy
- adds a 30 KB, three-attempt promotion fixture proving status and diagnose return without runner availability and do not repeat the diff payload

Related: #10233, #10235, #10236, #10237, #10240, #10242.

## Issue Closure

Closes none. The following acceptance gaps remain and are explicitly not claimed by this PR:

- #10233: no end-to-end configured DMC provider Cook that reaches gates with the declared managed worktree; success/rejection coverage remains at the provider boundary.
- #10235: reader output has bounded payload coverage, but no comprehensive row/byte/wall-clock matrix across every reader, caller mode, and Lab state.
- #10236: dead/live owner claim behavior is covered, but crash-before/after-side-effect reconciliation and dry-run identity preservation are not end-to-end proven.
- #10237: failure context and canonical next actions are present from #10256, but no complete contract matrix for provider, gate, stale claim, and finalization states.
- #10240: nested provider diagnostics are durable and bounded, but no full Cook continuation test of the standard failed command-result envelope.
- #10242: the 30 KB multi-attempt unavailable-runner fixture proves bounded status/diagnose latency, but broader pagination and external-reconciliation timing coverage remains.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents configured_provider_timeout_is_bounded_and_retains_command_evidence --lib`
- `cargo test -p homeboy-agents provider_failure_surfaces_bounded_stdout_and_stderr_evidence --lib`
- `cargo test -p homeboy-agents provider_response_validation_distinguishes_json_schema_and_required_field_errors --lib`
- `cargo test -p homeboy-agents dead_owner_claim_is_reclaimed_without_waiting_for_lease_expiry --lib`
- `cargo test -p homeboy-agents live_owner_claim_remains_held_without_side_effect_reentry --lib`
- `cargo test -p homeboy-cli promotion_heavy_30kb_fixture_keeps_status_and_diagnose_bounded --lib`
- `cargo test -p homeboy-cli bounded_agent_task_metadata_reads_bypass_hot_admission_for_all_runner_states --lib`

## AI Assistance

Substantive implementation and regression tests were drafted with OpenCode using OpenAI GPT-5.6 Sol. Chris Huber remains responsible for every line.