### PR TITLE
fix(agent-task): honor explicit Cook model selection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -19,7 +19,9 @@ use crate::agent_task_scheduler::{AgentTaskExecutionBudget, AgentTaskPlan, Agent
 use crate::agent_task_secrets::validate_secret_env;
 use homeboy_core::{defaults, worktree, worktree_providers, Error, Result};
 
-use super::agent_task_dispatch_service::AgentTaskDispatchRequest;
+use super::agent_task_dispatch_service::{
+    AgentTaskDispatchRequest, AgentTaskModelSelection, AgentTaskModelSelectionReason,
+};
 
 mod prompt_spec;
 use prompt_spec::{
@@ -166,12 +168,12 @@ pub fn build_dispatch_plan_with_provider_requirements(
         .resolved_provider_policy
         .as_ref()
         .and_then(|policy| policy.rotation.clone());
-    if request
+    let rotation_selected_initial_model = request
         .core
         .resolved_provider_policy
         .as_ref()
-        .is_some_and(|policy| policy.rotation_starts_with_first_entry)
-    {
+        .is_some_and(|policy| policy.rotation_starts_with_first_entry);
+    if rotation_selected_initial_model {
         if let Some(rotation) = resolved_rotation.as_mut() {
             if !rotation.entries.is_empty() {
                 let first = rotation.entries.remove(0);
@@ -181,6 +183,17 @@ pub fn build_dispatch_plan_with_provider_requirements(
             }
         }
     }
+    let model_selection = AgentTaskModelSelection {
+        requested: request.model.clone(),
+        selected: policy_model.clone(),
+        reason: if request.model.is_some() {
+            AgentTaskModelSelectionReason::ExplicitRequest
+        } else if rotation_selected_initial_model {
+            AgentTaskModelSelectionReason::PolicyRotation
+        } else {
+            AgentTaskModelSelectionReason::Default
+        },
+    };
     let component_contracts = dispatch_component_contracts(&provider_config, &client_context)?;
     // Resolve + materialize the declared runtime dependency graph at known refs
     // and preflight-fail before dispatch when a required runtime dependency is
@@ -325,6 +338,12 @@ pub fn build_dispatch_plan_with_provider_requirements(
         format!("agent-task-dispatch-{}", uuid::Uuid::new_v4()),
         tasks,
     );
+    let model_selection = serde_json::to_value(&model_selection)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    plan.metadata["model_selection"] = model_selection.clone();
+    for task in &mut plan.tasks {
+        task.metadata["model_selection"] = model_selection.clone();
+    }
     plan.group_key = repo.clone();
     plan.options.max_concurrency = request.concurrency.max(1);
     plan.options.timeout_ms = request.core.timeout_ms;

--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -66,6 +66,25 @@ pub struct BackendSelection {
     pub overrides_default: bool,
 }
 
+/// The initial model decision persisted with a dispatch plan. This avoids
+/// deriving execution provenance from presentation-oriented disclosure text.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentTaskModelSelection {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected: Option<String>,
+    pub reason: AgentTaskModelSelectionReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentTaskModelSelectionReason {
+    ExplicitRequest,
+    PolicyRotation,
+    Default,
+}
+
 /// Dispatch inputs shared verbatim across the dispatch arg, command, and request
 /// carriers (and their test override fixtures). Factored into one struct so the
 /// `[attempts, client_context, provider_config, queue_only, tasks_json]` group
@@ -158,6 +177,7 @@ where
             catalog.provider_requires_cwd_git_checkout(backend, selector)
         })?;
     catalog.apply_provider_runner_secret_env_contracts(&mut plan);
+    catalog.validate_explicit_models(&plan)?;
     catalog.enforce_runtime_preflight_checks_for_plan(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
     preflight_plan_provider_config_with_providers(&plan, catalog.providers())?;
@@ -184,6 +204,7 @@ where
         provider_requires_cwd_git_checkout,
     )?;
     apply_provider_runner_secret_env_contracts(&mut plan);
+    AgentTaskProviderCatalog::discover().validate_explicit_models(&plan)?;
     enforce_runtime_preflight_checks_for_plan(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
     preflight_plan_provider_config_with_providers(
@@ -355,9 +376,9 @@ pub fn controller_resolved_execution_policy(
             .as_ref()
             .and_then(|policy| policy.liveness_timeout_ms),
         rotation,
-        // An explicit CLI backend/model is the first attempt. Default policy
-        // rotation retains its existing first-entry selection behavior.
-        rotation_starts_with_first_entry: !explicit_backend,
+        // An explicit model is immutable for the initial invocation. Rotation
+        // remains available for retries, but cannot silently replace it.
+        rotation_starts_with_first_entry: !explicit_backend && request.model.is_none(),
         runtime_identity,
     }
 }
@@ -693,5 +714,23 @@ mod tests {
             assert_eq!(identity.provider_id, "codex.agent-task-executor");
             assert_eq!(identity.provider["backend"], "codex");
         });
+    }
+
+    #[test]
+    fn explicit_model_prevents_default_rotation_from_replacing_the_initial_invocation() {
+        let request = resolve_dispatch_request_with_default_and_config(
+            AgentTaskDispatchCommand {
+                prompt: Some("Cook with Sol.".to_string()),
+                model: Some("openai/gpt-5.6-sol".to_string()),
+                ..AgentTaskDispatchCommand::default()
+            },
+            |_| Ok(Some("opencode".to_string())),
+            || Some("opencode".to_string()),
+        )
+        .expect("request");
+        let policy = controller_resolved_execution_policy(&request);
+
+        assert_eq!(policy.model.as_deref(), Some("openai/gpt-5.6-sol"));
+        assert!(!policy.rotation_starts_with_first_entry);
     }
 }

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -122,6 +122,44 @@ impl AgentTaskProviderCatalog {
         apply_provider_runner_secret_env_contracts_with_providers(plan, &self.providers);
     }
 
+    /// Validate explicit model requests before provider dispatch when a provider
+    /// declares its supported models. Providers with no declarations retain a
+    /// provider-generic model namespace.
+    pub fn validate_explicit_models(&self, plan: &AgentTaskPlan) -> homeboy_core::Result<()> {
+        for task in &plan.tasks {
+            let Some(requested) = task.metadata["model_selection"]["requested"].as_str() else {
+                continue;
+            };
+            let ProviderResolution::Resolved(provider) = resolve_provider_for_backend(
+                &self.providers,
+                &task.executor.backend,
+                task.executor.selector.as_deref(),
+            ) else {
+                continue;
+            };
+            let mut supported = provider
+                .cli
+                .profiles
+                .iter()
+                .filter_map(|profile| profile.model.clone())
+                .collect::<Vec<_>>();
+            supported.sort();
+            supported.dedup();
+            if !supported.is_empty() && !supported.iter().any(|model| model == requested) {
+                return Err(Error::validation_invalid_argument(
+                    "model",
+                    format!(
+                        "provider `{}` does not support requested model `{requested}`",
+                        provider.id
+                    ),
+                    Some(requested.to_string()),
+                    Some(vec![format!("supported models: {}", supported.join(", "))]),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Run declared runtime preflight checks for each task's resolved provider.
     pub fn enforce_runtime_preflight_checks_for_plan(
         &self,
@@ -255,6 +293,38 @@ mod tests {
         assert_eq!(
             catalog.ai_disclosure_for("no-such-backend", None, Some("m")),
             None
+        );
+    }
+
+    #[test]
+    fn declared_provider_rejects_unsupported_explicit_model_with_diagnostics() {
+        let catalog = disclosure_catalog();
+        let mut plan = AgentTaskPlan::new("model-preflight", Vec::new());
+        plan.tasks.push(
+            serde_json::from_value(serde_json::json!({
+                "schema": crate::agent_task::AGENT_TASK_REQUEST_SCHEMA,
+                "task_id": "task",
+                "executor": { "backend": "opencode" },
+                "instructions": "Cook",
+                "workspace": { "mode": "existing" },
+                "metadata": {
+                    "model_selection": {
+                        "requested": "openai/gpt-5.6-unknown",
+                        "selected": "openai/gpt-5.6-unknown",
+                        "reason": "explicit-request"
+                    }
+                }
+            }))
+            .expect("task"),
+        );
+
+        let error = catalog
+            .validate_explicit_models(&plan)
+            .expect_err("unsupported model");
+        assert!(error.message.contains("does not support requested model"));
+        assert_eq!(
+            error.details["tried"][0].as_str(),
+            Some("supported models: openai/gpt-5.6-sol, openai/gpt-5.6-terra")
         );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -766,6 +766,17 @@ pub fn compile_cook_attempt(
     )?;
     let request = agent_task_dispatch_service::resolve_dispatch_request(dispatch.into())?;
     options.initial_plan = build_dispatch_plan(&request)?;
+    crate::agent_task_provider::AgentTaskProviderCatalog::discover()
+        .validate_explicit_models(&options.initial_plan)?;
+    // Finalization disclosure is derived from the compiled provider invocation,
+    // not a pre-resolution CLI value. The plan is persisted in the recipe and
+    // remains authoritative across continuation.
+    options.ai_model = options
+        .initial_plan
+        .tasks
+        .first()
+        .and_then(|task| task.executor.model())
+        .map(str::to_string);
     Ok(options)
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -529,6 +529,11 @@ where
         .commit_message
         .clone()
         .unwrap_or_else(|| default_loop_commit_message(&args));
+    let selected_model = initial_plan
+        .tasks
+        .first()
+        .and_then(|task| task.executor.model())
+        .map(str::to_string);
     let durable_observer = |phase: &str, cook_id: &str, run_id: &str| {
         progress
             .map(|progress| progress(phase, Some(cook_id), Some(run_id)))
@@ -567,7 +572,7 @@ where
             // `OpenCode (GPT-5.5)` is presentation, not execution provenance, and
             // must not be reverse-parsed into a model — an omitted model stays
             // omitted so finalization records only real model identity (#9789).
-            ai_model: args.dispatch.model,
+            ai_model: selected_model,
             ai_used_for: args.ai_used_for,
             attempt_dispatcher,
             harvest_context:
@@ -648,6 +653,8 @@ pub(crate) fn compile_cook_plan(
         })?;
         task.metadata["cook_workspace_identity"] = workspace_identity_attestation(Path::new(root))?;
     }
+    homeboy::agents::agent_task_provider::AgentTaskProviderCatalog::discover()
+        .validate_explicit_models(&plan)?;
     record_cook_goal(&mut plan, args.goal.as_deref());
     Ok(plan)
 }


### PR DESCRIPTION
## Summary
- pin an explicit Cook `--model` ahead of default provider rotation and persist typed requested/selected/reason provenance on plans
- reject unsupported explicit models before dispatch when the selected provider declares supported profile models, while preserving generic providers with no declarations
- derive Cook finalization model disclosure from the compiled durable invocation so recipe, plan, provider metadata, status, continuation, and PR evidence agree

Fixes #10244

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents explicit_model_prevents_default_rotation_from_replacing_the_initial_invocation --lib`
- `cargo test -p homeboy-agents declared_provider_rejects_unsupported_explicit_model_with_diagnostics --lib`
- `cargo test -p homeboy-cli cook_invocation_preserves_explicit_model_selection --lib`

## AI Assistance
OpenCode, using OpenAI GPT-5.6 Sol, traced the Cook model flow, drafted the implementation and focused tests, and reviewed the resulting diff. Chris Huber reviewed and remains responsible for the change.