### PR TITLE
Fix nested run artifact retrieval

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -567,6 +567,37 @@ fn pull_artifacts_to_local(
                     }
                 }
             }
+            runs_service::ArtifactStorage::PublicUrl => {
+                let output = pull_dir.map(|dir| dir.join(sanitize_artifact_filename(&artifact.id)));
+                match runs_service::download_public_artifact(artifact.clone(), output) {
+                    Ok(outcome) => {
+                        pulled_count += 1;
+                        RunsArtifactPullEntry {
+                            artifact_id: artifact.id.clone(),
+                            storage: "public_url",
+                            status: "pulled",
+                            output_path: Some(outcome.output_path.display().to_string()),
+                            size_bytes: outcome.size_bytes,
+                            content_type: outcome.content_type,
+                            sha256: outcome.sha256,
+                            error: None,
+                        }
+                    }
+                    Err(err) => {
+                        failed_count += 1;
+                        RunsArtifactPullEntry {
+                            artifact_id: artifact.id.clone(),
+                            storage: "public_url",
+                            status: "failed",
+                            output_path: None,
+                            size_bytes: None,
+                            content_type: None,
+                            sha256: None,
+                            error: Some(err.message),
+                        }
+                    }
+                }
+            }
             runs_service::ArtifactStorage::MetadataOnly => {
                 skipped_count += 1;
                 RunsArtifactPullEntry {
@@ -854,6 +885,28 @@ fn artifact_get_inner(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
             ))
         }
         runs_service::ArtifactStorage::Remote => remote_artifact::get(artifact, args.output),
+        runs_service::ArtifactStorage::PublicUrl => {
+            let source_content_url = artifact
+                .url
+                .clone()
+                .or_else(|| artifact.public_url.clone());
+            let outcome = runs_service::download_public_artifact(artifact, args.output)?;
+            Ok((
+                RunsOutput::ArtifactGet(RunsArtifactGetOutput {
+                    command: "runs.artifact.get",
+                    run_id: outcome.run_id,
+                    artifact_id: outcome.artifact_id,
+                    runner_id: None,
+                    source_content_url,
+                    output_path: outcome.output_path.display().to_string(),
+                    content_type: outcome.content_type,
+                    size_bytes: outcome.size_bytes,
+                    sha256: outcome.sha256,
+                    artifact_ref: None,
+                }),
+                0,
+            ))
+        }
         runs_service::ArtifactStorage::MetadataOnly => Err(Error::validation_invalid_argument(
             "artifact_id",
             format!(

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -1256,6 +1256,83 @@ fn artifact_get_fetches_nested_publication_artifact_store_ref() {
 }
 
 #[test]
+fn artifacts_index_and_fetch_nested_visual_summary_refs_from_public_urls() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run(
+                "fixture.matrix",
+                "static-site-importer",
+                "ssi",
+                Value::Null,
+            ))
+            .expect("run");
+        // The local runner directory has already been cleaned. The declared
+        // public URLs are the only valid evidence source for this run.
+        let public_url = serve_public_artifact_base_once(200);
+        let summary = home.path().join("fixture-result.json");
+        std::fs::write(
+            &summary,
+            serde_json::json!({
+                "fixtures": [{
+                    "fixture_id": "15-saas",
+                    "visual_compare": { "artifacts": [
+                        { "id": "visual_compare_15-saas_source", "kind": "visual_source", "path": "/gone/source.png", "public_url": format!("{public_url}/source.png") },
+                        { "id": "visual_compare_15-saas_candidate", "kind": "visual_candidate", "path": "/gone/candidate.png", "public_url": format!("{public_url}/candidate.png") },
+                        { "id": "visual_compare_15-saas_diff", "kind": "visual_diff", "path": "/gone/diff.png", "public_url": format!("{public_url}/diff.png") },
+                        { "artifact_id": "visual_compare_15-saas_dom", "kind": "dom_snapshot", "path": "/gone/dom.html", "public_url": format!("{public_url}/dom.html") }
+                    ]}
+                }]
+            })
+            .to_string(),
+        )
+        .expect("summary");
+        store
+            .record_artifact(&run.id, "fixture_result", &summary)
+            .expect("record summary");
+
+        let (listed, _) = artifacts(&run.id).expect("list artifacts");
+        let RunsOutput::Artifacts(listed) = listed else {
+            panic!("expected artifacts")
+        };
+        assert_eq!(listed.artifacts.len(), 5);
+        for id in [
+            "visual_compare_15-saas_source",
+            "visual_compare_15-saas_candidate",
+            "visual_compare_15-saas_diff",
+            "visual_compare_15-saas_dom",
+        ] {
+            assert!(
+                listed.artifacts.iter().any(|artifact| {
+                    artifact.metadata_json["original_manifest_id"] == id
+                        && artifact.artifact_type == "url"
+                }),
+                "missing indexed {id}"
+            );
+        }
+
+        let output_path = home.path().join("visual-source.png");
+        let (fetched, _) = artifact_get(RunsArtifactGetArgs {
+            run_id: run.id.clone(),
+            artifact_id: "visual_compare_15-saas_source".to_string(),
+            runner: None,
+            output: Some(output_path.clone()),
+            field: Vec::new(),
+        })
+        .expect("fetch public fallback");
+        let RunsOutput::ArtifactGet(fetched) = fetched else {
+            panic!("expected artifact get")
+        };
+        assert_eq!(
+            std::fs::read(&output_path).expect("downloaded bytes"),
+            b"{}"
+        );
+        assert_eq!(fetched.size_bytes, Some(2));
+    });
+}
+
+#[test]
 fn artifacts_command_derives_viewer_links_from_public_artifact_url_metadata() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();

--- a/crates/homeboy-core/src/observation/runs_service/artifact_resolve.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_resolve.rs
@@ -1,4 +1,8 @@
 use super::*;
+use std::io::Read;
+
+const PUBLIC_ARTIFACT_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const MAX_PUBLIC_ARTIFACT_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Resolve an artifact record by run/artifact token, validating that the
 /// recorded `run_id` matches the requested run.
@@ -190,11 +194,157 @@ pub fn download_remote_artifact(
     })
 }
 
+/// Fetch a declared public artifact without using runner credentials. Public
+/// locators survive ephemeral runner cleanup; the timeout and streaming cap
+/// keep an unreachable or oversized object from stalling `artifact get`.
+pub fn download_public_artifact(
+    artifact: ArtifactRecord,
+    output: Option<PathBuf>,
+) -> Result<ArtifactFetchOutcome> {
+    let url = artifact
+        .url
+        .as_deref()
+        .or(artifact.public_url.as_deref())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                format!("artifact {} has no public content URL", artifact.id),
+                Some(artifact.id.clone()),
+                None,
+            )
+        })?;
+    let parsed = reqwest::Url::parse(url).map_err(|err| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            err.to_string(),
+            Some(artifact.id.clone()),
+            None,
+        )
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "public artifact URL must use HTTP or HTTPS",
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    let client =
+        crate::http_probe::blocking_client(PUBLIC_ARTIFACT_FETCH_TIMEOUT).map_err(|err| {
+            Error::internal_unexpected(format!("build public artifact client: {err}"))
+        })?;
+    let mut response = client.get(parsed.clone()).send().map_err(|err| {
+        Error::internal_unexpected(format!("fetch public artifact {}: {err}", artifact.id))
+    })?;
+    if !response.status().is_success() {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "public artifact {} returned HTTP {}",
+                artifact.id,
+                response.status()
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    if response
+        .content_length()
+        .is_some_and(|size| size > MAX_PUBLIC_ARTIFACT_BYTES)
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "public artifact {} exceeds the {} byte download limit",
+                artifact.id, MAX_PUBLIC_ARTIFACT_BYTES
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    let filename = parsed
+        .path_segments()
+        .and_then(Iterator::last)
+        .filter(|name| !name.is_empty())
+        .unwrap_or(&artifact.id)
+        .to_string();
+    let output = output.unwrap_or_else(|| PathBuf::from(filename));
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    let mut writer = File::create(&output).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("create {}", output.display())),
+        )
+    })?;
+    let copied = io::copy(
+        &mut response.by_ref().take(MAX_PUBLIC_ARTIFACT_BYTES + 1),
+        &mut writer,
+    )
+    .map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("download public artifact {}", artifact.id)),
+        )
+    })?;
+    if copied > MAX_PUBLIC_ARTIFACT_BYTES {
+        drop(writer);
+        std::fs::remove_file(&output).ok();
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "public artifact {} exceeds the {} byte download limit",
+                artifact.id, MAX_PUBLIC_ARTIFACT_BYTES
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    writer.flush().map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("flush {}", output.display())))
+    })?;
+    writer.sync_all().map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("sync {}", output.display())))
+    })?;
+    Ok(ArtifactFetchOutcome {
+        run_id: artifact.run_id,
+        artifact_id: artifact.id,
+        output_path: output,
+        content_type: response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+            .or(artifact.mime),
+        size_bytes: i64::try_from(copied).ok(),
+        sha256: artifact.sha256,
+        artifact_ref: None,
+    })
+}
+
 /// Classify an artifact's storage so callers can decide between local
 /// copy, remote download, or a metadata-only error.
 pub fn classify_artifact_storage(artifact: &ArtifactRecord) -> ArtifactStorage {
     if artifact.artifact_type == "file" {
         return ArtifactStorage::LocalFile;
+    }
+    if artifact.artifact_type == "url"
+        && artifact
+            .url
+            .as_deref()
+            .or(artifact.public_url.as_deref())
+            .is_some()
+    {
+        return ArtifactStorage::PublicUrl;
     }
     if crate::execution_contract::is_remote_runner_artifact_path(&artifact.path)
         || artifact.artifact_type == "remote_file"

--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -166,6 +166,7 @@ struct RunnerDownloadCleanupPreview {
 pub enum ArtifactStorage {
     LocalFile,
     Remote,
+    PublicUrl,
     MetadataOnly,
     Other,
 }

--- a/crates/homeboy-core/src/publication_artifacts.rs
+++ b/crates/homeboy-core/src/publication_artifacts.rs
@@ -35,11 +35,20 @@ pub(crate) fn index_published_artifact_refs(
             }
         }
     }
-    index_manifest_refs(store, source, &manifest, |locator| {
-        let Some(path) = artifact_store_path(&artifact_root, locator) else {
+    index_manifest_refs(store, source, &manifest, |reference| {
+        if reference.locator_type == "public-url" {
+            let url = reference
+                .public_url
+                .as_deref()
+                .expect("public URL ref has URL");
+            return Ok(Some(IndexedArtifactPath::PublicUrl(url.to_string())));
+        }
+        let Some(path) = artifact_store_path(&artifact_root, &reference.locator) else {
             return Ok(None);
         };
-        if path.is_file() || materialize_artifact_store_path(&path, locator, &source_bases)? {
+        if path.is_file()
+            || materialize_artifact_store_path(&path, &reference.locator, &source_bases)?
+        {
             Ok(Some(IndexedArtifactPath::Local(path)))
         } else {
             Ok(Some(IndexedArtifactPath::Missing))
@@ -70,12 +79,19 @@ pub fn index_remote_published_artifact_refs_for_run(
         else {
             continue;
         };
-        index_manifest_refs(store, &artifact, &manifest, |locator| {
+        index_manifest_refs(store, &artifact, &manifest, |reference| {
+            if reference.locator_type == "public-url" {
+                let url = reference
+                    .public_url
+                    .as_deref()
+                    .expect("public URL ref has URL");
+                return Ok(Some(IndexedArtifactPath::PublicUrl(url.to_string())));
+            }
             Ok(Some(IndexedArtifactPath::Remote(
                 crate::execution_contract::runner_artifact_store_token(
                     &runner_id,
                     &remote_run_id,
-                    locator,
+                    &reference.locator,
                 ),
             )))
         })?;
@@ -87,6 +103,7 @@ pub fn index_remote_published_artifact_refs_for_run(
 enum IndexedArtifactPath {
     Local(PathBuf),
     Remote(String),
+    PublicUrl(String),
     Missing,
 }
 
@@ -101,7 +118,7 @@ fn index_manifest_refs(
     store: &ObservationStore,
     source: &ArtifactRecord,
     manifest: &Value,
-    mut resolve_path: impl FnMut(&str) -> Result<Option<IndexedArtifactPath>>,
+    mut resolve_path: impl FnMut(&ManifestArtifactRef<'_>) -> Result<Option<IndexedArtifactPath>>,
 ) -> Result<()> {
     let manifest_id = manifest
         .get("id")
@@ -113,7 +130,7 @@ fn index_manifest_refs(
 
     for reference in refs {
         let locator = reference.locator.as_str();
-        let Some(indexed_path) = resolve_path(locator)? else {
+        let Some(indexed_path) = resolve_path(&reference)? else {
             continue;
         };
         let (artifact_type, path) = match indexed_path {
@@ -121,11 +138,13 @@ fn index_manifest_refs(
                 ("file".to_string(), path.to_string_lossy().to_string())
             }
             IndexedArtifactPath::Remote(path) => ("remote_file".to_string(), path),
+            IndexedArtifactPath::PublicUrl(url) => ("url".to_string(), url),
             IndexedArtifactPath::Missing => continue,
         };
         let original_manifest_id = reference
             .reference
             .get("id")
+            .or_else(|| reference.reference.get("artifact_id"))
             .and_then(Value::as_str)
             .unwrap_or(locator);
         let id = published_artifact_id(&source.id, original_manifest_id, locator);
@@ -195,8 +214,8 @@ fn index_manifest_refs(
             kind,
             artifact_type,
             path,
-            url: None,
-            public_url: None,
+            url: reference.public_url.clone(),
+            public_url: reference.public_url.clone(),
             viewer_url: None,
             viewer_links: Vec::new(),
             sha256,
@@ -237,6 +256,13 @@ fn collect_publication_artifact_refs<'a>(
                         .and_then(Value::as_str)
                         .map(str::to_string),
                 });
+            } else if let Some(url) = explicit_public_artifact_url(value) {
+                refs.push(ManifestArtifactRef {
+                    reference: value,
+                    locator: url.to_string(),
+                    locator_type: "public-url",
+                    public_url: Some(url.to_string()),
+                });
             }
             for child in object.values() {
                 collect_publication_artifact_refs(child, url_bases, refs);
@@ -249,6 +275,28 @@ fn collect_publication_artifact_refs<'a>(
         }
         _ => {}
     }
+}
+
+/// A Homeboy-owned run summary can emit a nested artifact reference directly
+/// instead of wrapping it in a publication-manifest locator. Accept only an
+/// explicit artifact identity plus an HTTP(S) URL, preserving the declared
+/// public access boundary rather than reconstructing runner-local paths.
+fn explicit_public_artifact_url(reference: &Value) -> Option<&str> {
+    let has_identity = reference.get("id").and_then(Value::as_str).is_some()
+        || reference
+            .get("artifact_id")
+            .and_then(Value::as_str)
+            .is_some();
+    if !has_identity {
+        return None;
+    }
+    let url = reference
+        .get("public_url")
+        .or_else(|| reference.get("publicUrl"))
+        .or_else(|| reference.get("url"))
+        .and_then(Value::as_str)?;
+    let parsed = reqwest::Url::parse(url).ok()?;
+    matches!(parsed.scheme(), "http" | "https").then_some(url)
 }
 
 fn artifact_store_locator(reference: &Value) -> Option<&str> {

--- a/crates/homeboy-core/src/report_compare.rs
+++ b/crates/homeboy-core/src/report_compare.rs
@@ -239,6 +239,20 @@ fn read_artifact_record(artifact: ArtifactRecord) -> crate::Result<(String, Valu
             let value = read_json_file(&download.output_path)?;
             Ok((format!("{}:{}", artifact.run_id, artifact.id), value))
         }
+        runs_service::ArtifactStorage::PublicUrl => {
+            let tempdir = tempfile::Builder::new()
+                .prefix("homeboy-report-compare-")
+                .tempdir()
+                .map_err(|e| {
+                    Error::internal_io(e.to_string(), Some("create tempdir".to_string()))
+                })?;
+            let output = tempdir
+                .path()
+                .join(format!("{}.json", safe_file_component(&artifact.id)));
+            let download = runs_service::download_public_artifact(artifact.clone(), Some(output))?;
+            let value = read_json_file(&download.output_path)?;
+            Ok((format!("{}:{}", artifact.run_id, artifact.id), value))
+        }
         runs_service::ArtifactStorage::MetadataOnly => Err(Error::validation_invalid_argument(
             "old/new",
             format!(


### PR DESCRIPTION
## Summary
- Index explicit nested artifact IDs and public HTTP(S) locators emitted by Homeboy-owned run summaries.
- Retrieve public fallback artifacts through bounded 15-second, 64 MiB streaming downloads when runner-local evidence has expired.
- Cover source, candidate, diff, and DOM visual artifacts from a nested fixture summary while preserving existing artifact-store retrieval.

Closes #9468.

## Verification
- cargo fmt
- cargo test -p homeboy-cli artifacts_index_and_fetch_nested_visual_summary_refs_from_public_urls -- --nocapture
- cargo test -p homeboy-cli artifact_get_fetches_nested_publication_artifact_store_ref -- --nocapture
- cargo check -p homeboy-cli

## AI assistance
- **AI assistance:** Yes
- **Model/tool:** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Investigated the prior nested-artifact contracts, implemented indexing and bounded public fallback retrieval, added regression coverage, and ran verification. Chris remains responsible for review and merge.