### PR TITLE
fix(deploy): compare drift against canonical package

### DIFF
--- a/crates/homeboy-release/src/deploy/content_manifest.rs
+++ b/crates/homeboy-release/src/deploy/content_manifest.rs
@@ -64,6 +64,33 @@ pub(super) fn compare(local: &Path, remote: &str, client: &SshClient) -> Content
     comparison(&local, Some(&remote), status, differences, None)
 }
 
+/// Compare a deployed tree with the canonical archive selected for deployment.
+/// Archive entries are the package contract; source-only checkout files are not.
+pub(super) fn compare_archive(
+    archive: &Path,
+    remote: &str,
+    client: &SshClient,
+) -> ContentManifestComparison {
+    let local = match archive_manifest(archive) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            return unavailable(format!("canonical package manifest unavailable: {error}"))
+        }
+    };
+    let remote = match remote_manifest(remote, client) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => return comparison(&local, None, "missing", Vec::new(), None),
+        Err(error) => return unavailable(format!("remote manifest unavailable: {error}")),
+    };
+    let differences = differences(&local, &remote);
+    let status = if differences.is_empty() {
+        "match"
+    } else {
+        "different"
+    };
+    comparison(&local, Some(&remote), status, differences, None)
+}
+
 fn comparison(
     local: &Manifest,
     remote: Option<&Manifest>,
@@ -101,6 +128,59 @@ fn local_manifest(root: &Path) -> Result<Manifest, String> {
     let mut manifest = Manifest::default();
     visit(root, root, &mut manifest)?;
     Ok(manifest)
+}
+
+fn archive_manifest(path: &Path) -> Result<Manifest, String> {
+    let file = fs::File::open(path).map_err(|error| error.to_string())?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| error.to_string())?;
+    let mut names = Vec::new();
+    for index in 0..archive.len() {
+        let entry = archive.by_index(index).map_err(|error| error.to_string())?;
+        if !entry.is_dir() {
+            names.push(entry.name().trim_matches('/').to_string());
+        }
+    }
+    let root = archive_root(&names);
+    let mut manifest = Manifest::default();
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|error| error.to_string())?;
+        if entry.is_dir() {
+            continue;
+        }
+        let name = entry.name().trim_matches('/');
+        if name.is_empty() || ignored(name) {
+            continue;
+        }
+        let relative = root
+            .as_deref()
+            .and_then(|root| {
+                name.strip_prefix(root)
+                    .and_then(|path| path.strip_prefix('/'))
+            })
+            .unwrap_or(name)
+            .to_string();
+        let mut hash = Sha256::new();
+        std::io::copy(&mut entry, &mut hash).map_err(|error| error.to_string())?;
+        manifest.entries.insert(
+            relative,
+            Entry {
+                kind: 'f',
+                mode: executable_mode(entry.unix_mode().unwrap_or(0)),
+                value: format!("{:x}", hash.finalize()),
+            },
+        );
+    }
+    Ok(manifest)
+}
+
+fn archive_root(names: &[String]) -> Option<String> {
+    let first = names.first()?.split('/').next()?;
+    (!first.is_empty()
+        && names.iter().all(|name| {
+            name.strip_prefix(first)
+                .is_some_and(|suffix| suffix.starts_with('/'))
+        }))
+    .then(|| first.to_string())
 }
 
 fn visit(root: &Path, path: &Path, manifest: &mut Manifest) -> Result<(), String> {
@@ -255,7 +335,7 @@ mod tests {
     fn local_manifest_detects_content_add_delete_mode_symlink_and_ignores_runtime() {
         let temp = tempfile::tempdir().expect("temp");
         let local = temp.path().join("local");
-        let remote = temp.path().join("remote");
+        let remote = temp.path().join("plugin");
         fs::create_dir_all(&local).expect("local");
         fs::create_dir_all(&remote).expect("remote");
         fs::write(local.join("same"), "same").expect("same");
@@ -302,7 +382,7 @@ mod tests {
 
         let temp = tempfile::tempdir().expect("temp");
         let local = temp.path().join("local");
-        let remote = temp.path().join("remote");
+        let remote = temp.path().join("plugin");
         fs::create_dir_all(&local).expect("local");
         fs::create_dir_all(&remote).expect("remote");
         fs::write(local.join("script"), "same").expect("local script");
@@ -326,5 +406,95 @@ mod tests {
             ),
             vec!["script"]
         );
+    }
+
+    #[test]
+    fn canonical_package_manifest_ignores_source_only_files_and_detects_production_drift() {
+        let temp = tempfile::tempdir().expect("temp");
+        let package = temp.path().join("plugin.zip");
+        let remote = temp.path().join("remote");
+        fs::create_dir_all(&remote).expect("remote");
+        write_zip(
+            &package,
+            &[
+                ("plugin/plugin.php", "<?php // 1.0.0"),
+                ("plugin/assets/app.js", "production"),
+            ],
+        );
+        fs::write(remote.join("plugin.php"), "<?php // 1.0.0").expect("plugin");
+        fs::create_dir_all(remote.join("assets")).expect("assets");
+        fs::write(remote.join("assets/app.js"), "production").expect("asset");
+
+        // README, tests, build output, and git metadata are source-only and
+        // therefore absent from the authoritative package comparison.
+        let source = temp.path().join("source");
+        fs::create_dir_all(source.join("tests")).expect("tests");
+        fs::create_dir_all(source.join("build")).expect("build");
+        fs::write(source.join("README.md"), "source only").expect("readme");
+        fs::write(source.join("tests/test.php"), "source only").expect("test");
+        fs::write(source.join("build/plugin.zip"), "source only").expect("build");
+
+        let client = local_client();
+        assert_eq!(
+            compare_archive(&package, remote.to_str().expect("path"), &client).status,
+            "match"
+        );
+
+        fs::write(remote.join("assets/app.js"), "modified").expect("drift");
+        let drift = compare_archive(&package, remote.to_str().expect("path"), &client);
+        assert_eq!(drift.status, "different");
+        assert_eq!(drift.differences, vec!["assets/app.js"]);
+
+        fs::remove_file(remote.join("plugin.php")).expect("missing");
+        let missing = compare_archive(&package, remote.to_str().expect("path"), &client);
+        assert!(missing.differences.contains(&"plugin.php".to_string()));
+    }
+
+    #[test]
+    fn canonical_package_manifest_rejects_stale_or_missing_artifacts() {
+        let temp = tempfile::tempdir().expect("temp");
+        let stale = temp.path().join("stale.zip");
+        let remote = temp.path().join("remote");
+        fs::create_dir_all(&remote).expect("remote");
+        write_zip(&stale, &[("plugin/version", "1.0.0")]);
+        fs::write(remote.join("version"), "2.0.0").expect("remote version");
+        let client = local_client();
+
+        assert_eq!(
+            compare_archive(&stale, remote.to_str().expect("path"), &client).status,
+            "different"
+        );
+        assert_eq!(
+            compare_archive(
+                &temp.path().join("missing.zip"),
+                remote.to_str().expect("path"),
+                &client
+            )
+            .status,
+            "unavailable"
+        );
+    }
+
+    fn write_zip(path: &Path, entries: &[(&str, &str)]) {
+        let file = fs::File::create(path).expect("zip");
+        let mut zip = zip::ZipWriter::new(file);
+        for (name, contents) in entries {
+            zip.start_file(*name, zip::write::FileOptions::default())
+                .expect("zip entry");
+            std::io::Write::write_all(&mut zip, contents.as_bytes()).expect("zip contents");
+        }
+        zip.finish().expect("finish zip");
+    }
+
+    fn local_client() -> SshClient {
+        SshClient {
+            host: "local".to_string(),
+            user: "test".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: Default::default(),
+        }
     }
 }

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -224,6 +224,7 @@ pub(super) fn deploy_components(
             base_path,
             config,
             &ctx.client,
+            &resolved_release_artifacts,
         ));
     }
     if config.dry_run {
@@ -556,19 +557,16 @@ pub(super) fn deploy_components(
 /// bytes from GitHub (which can 404 or otherwise fail per component) so a real
 /// deploy can reuse the same run-scoped bytes across every target.
 ///
-/// Read-only modes (`--check`, `--dry-run`) return before the resolved map is
-/// ever consumed, so resolving here would only waste work and — worse — abort
-/// the entire project probe on the first unresolvable component (e.g. a release
-/// tag with no matching asset, or a component whose path resolution yields an
-/// empty path). Non-mutating modes therefore resolve nothing, matching the
-/// remote-path guard (#8190) and the exact-ref checkout guard. (#9169)
+/// Check mode consumes the same canonical release package selected for deploy
+/// when it is available. A failed optional lookup retains legacy source-tree
+/// checking rather than failing the complete read-only project probe.
 fn resolve_release_artifacts_for_deploy(
     components: &[Component],
     config: &DeployConfig,
     release_artifacts: &mut ReleaseArtifactStore,
 ) -> Result<HashMap<String, ReleaseArtifactLease>> {
     let mut resolved_release_artifacts: HashMap<String, ReleaseArtifactLease> = HashMap::new();
-    if config.check || config.dry_run {
+    if config.dry_run {
         return Ok(resolved_release_artifacts);
     }
 
@@ -576,10 +574,29 @@ fn resolve_release_artifacts_for_deploy(
         if let ReleaseArtifactPlan::Reuse { tag, .. } =
             release_artifact_plan(component, config, false, false)
         {
-            let artifact = resolve_planned_release_artifact(component, &tag, release_artifacts)
-                .map_err(|error| {
-                    Error::validation_invalid_argument("releaseArtifact", error, None, None)
-                })?;
+            let artifact = match resolve_planned_release_artifact(
+                component,
+                &tag,
+                release_artifacts,
+            ) {
+                Ok(artifact) => artifact,
+                Err(error) if config.check => {
+                    homeboy_core::log_status!(
+                        "deploy",
+                        "Canonical release package unavailable for '{}' ({error}); using legacy source-tree check",
+                        component.id
+                    );
+                    continue;
+                }
+                Err(error) => {
+                    return Err(Error::validation_invalid_argument(
+                        "releaseArtifact",
+                        error,
+                        None,
+                        None,
+                    ))
+                }
+            };
             homeboy_core::log_status!(
                 "deploy",
                 "Verified release asset: tag={} name={} size={} sha256={} source={}",
@@ -1042,12 +1059,11 @@ mod tests {
         assert_eq!(err.details["field"].as_str(), Some("build_command"));
     }
 
-    // A project `deploy --check` must not resolve/download release assets: that
-    // network step can fail per component (missing asset, empty path) and would
-    // abort the whole read-only probe. Check and dry-run resolve nothing; only a
-    // real deploy resolves (and would surface the failure). (#9169)
+    // A check resolves the canonical package when available, but an unavailable
+    // release asset must retain legacy source-tree checking rather than abort a
+    // project-wide read-only probe. Dry-run still resolves nothing. (#10253)
     #[test]
-    fn check_and_dry_run_skip_release_asset_resolution() {
+    fn check_tolerates_missing_canonical_package_and_dry_run_skips_resolution() {
         with_isolated_home(|_| {
             // A component whose release plan is `Reuse` (github remote_url +
             // build_artifact + expected_version) but whose asset cannot resolve.
@@ -1067,10 +1083,10 @@ mod tests {
                 &check_config,
                 &mut store,
             )
-            .expect("check mode must not abort on release-asset resolution");
+            .expect("check mode must retain legacy behavior when canonical package is missing");
             assert!(
                 resolved.is_empty(),
-                "check mode must resolve no release assets"
+                "missing canonical package must not produce a partial authority"
             );
 
             let mut dry_run_config = base_deploy_config();

--- a/crates/homeboy-release/src/deploy/orchestration/modes.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/modes.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
+use homeboy_core::git::release_download::ReleaseArtifactLease;
 use homeboy_core::project::Project;
 use homeboy_core::server::SshClient;
 
@@ -27,6 +28,7 @@ pub(super) fn run_check_mode(
     base_path: &str,
     config: &DeployConfig,
     client: &SshClient,
+    canonical_packages: &HashMap<String, ReleaseArtifactLease>,
 ) -> DeployOrchestrationResult {
     let mut git_probe_cache = GitProbeCache::default();
     let mut results: Vec<ComponentDeployResult> = components
@@ -35,12 +37,21 @@ pub(super) fn run_check_mode(
             let mut status =
                 calculate_component_status_with_git_cache(c, remote_versions, &mut git_probe_cache);
             let release_state = calculate_release_state(c);
-            let manifest = super::super::content_manifest::compare(
-                std::path::Path::new(&c.local_path),
-                &super::super::path_roots::resolve_effective_remote_path(project, c, base_path)
-                    .unwrap_or_default(),
-                client,
-            );
+            let manifest = if let Some(package) = canonical_packages.get(&c.id) {
+                super::super::content_manifest::compare_archive(
+                    &package.path,
+                    &super::super::path_roots::resolve_effective_remote_path(project, c, base_path)
+                        .unwrap_or_default(),
+                    client,
+                )
+            } else {
+                super::super::content_manifest::compare(
+                    std::path::Path::new(&c.local_path),
+                    &super::super::path_roots::resolve_effective_remote_path(project, c, base_path)
+                        .unwrap_or_default(),
+                    client,
+                )
+            };
             if manifest.status == "missing" {
                 status = ComponentStatus::Missing;
             } else if manifest.status == "different" && matches!(status, ComponentStatus::UpToDate)
@@ -626,6 +637,7 @@ mod tests {
             "/srv/site",
             &config,
             &local_client(),
+            &HashMap::new(),
         );
         assert_eq!(checked.results[0].status, "checked");
         assert_eq!(checked.results[0].local_version.as_deref(), Some("1.2.3"));
@@ -643,6 +655,90 @@ mod tests {
         assert_eq!(planned.results[0].status, "planned");
         assert_eq!(planned.results[0].local_version.as_deref(), Some("1.2.3"));
         assert_eq!(planned.results[0].remote_version.as_deref(), Some("1.3.0"));
+    }
+
+    #[test]
+    fn check_uses_canonical_package_for_clean_and_modified_production_trees() {
+        let temp = tempfile::tempdir().expect("temp");
+        let source = temp.path().join("source");
+        let remote = temp.path().join("plugin");
+        std::fs::create_dir_all(source.join("tests")).expect("source tests");
+        std::fs::create_dir_all(&remote).expect("remote");
+        std::fs::write(source.join("README.md"), "source only").expect("readme");
+        std::fs::write(source.join("tests/test.php"), "source only").expect("test");
+        std::fs::write(source.join("plugin.php"), "Version: 1.0.0\nrelease")
+            .expect("source plugin");
+        std::fs::write(remote.join("plugin.php"), "Version: 1.0.0\nrelease")
+            .expect("remote plugin");
+
+        let package = temp.path().join("plugin.zip");
+        let file = std::fs::File::create(&package).expect("package");
+        let mut zip = zip::ZipWriter::new(file);
+        zip.start_file("plugin/plugin.php", zip::write::FileOptions::default())
+            .expect("entry");
+        use std::io::Write as _;
+        zip.write_all(b"Version: 1.0.0\nrelease").expect("contents");
+        zip.finish().expect("finish");
+        let bytes = std::fs::read(&package).expect("package bytes");
+        let package =
+            ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
+                path: package,
+                tag: "v1.0.0".to_string(),
+                commit: Some("release".to_string()),
+                url: "https://example.test/plugin.zip".to_string(),
+                name: "plugin.zip".to_string(),
+                size: bytes.len() as u64,
+                sha256: crate::deploy::sha256_file(temp.path().join("plugin.zip").as_path())
+                    .expect("sha"),
+            })
+            .expect("lease");
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: source.to_string_lossy().to_string(),
+            remote_path: remote.to_string_lossy().to_string(),
+            version_targets: Some(vec![homeboy_core::component::VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                artifact_path: None,
+            }]),
+            ..Component::default()
+        };
+        let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let config = DeployConfig::check_all_no_pull_head();
+        let packages = HashMap::from([("plugin".to_string(), package)]);
+
+        let clean = run_check_mode(
+            std::slice::from_ref(&component),
+            &versions,
+            &versions,
+            &[],
+            &Project::default(),
+            ".",
+            &config,
+            &local_client(),
+            &packages,
+        );
+        assert_eq!(
+            clean.results[0].component_status,
+            Some(ComponentStatus::UpToDate)
+        );
+
+        std::fs::write(remote.join("plugin.php"), "modified").expect("drift");
+        let drift = run_check_mode(
+            &[component],
+            &versions,
+            &versions,
+            &[],
+            &Project::default(),
+            ".",
+            &config,
+            &local_client(),
+            &packages,
+        );
+        assert_eq!(
+            drift.results[0].component_status,
+            Some(ComponentStatus::RemoteModified)
+        );
     }
 
     fn git(path: &Path, args: &[&str]) {


### PR DESCRIPTION
## Summary
- compare `deploy --check` production content with the same canonical release ZIP selected for deployment
- keep source-tree comparison as the legacy fallback when no canonical package is available
- preserve missing, modified, extra, stale-artifact, and version-drift detection with archive-root handling tied to the generic target basename

Closes #10253

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-release`
- `cargo test -p homeboy-release deploy::content_manifest`
- `cargo test -p homeboy-release deploy::orchestration::modes::tests::check_uses_canonical_package_for_clean_and_modified_production_trees`
- `cargo test -p homeboy-release` (672 passed; 4 existing environment-sensitive failures in tagged-deploy guard fixtures, local group inheritance, and missing WordPress extension fixture)

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode drafted and tested the canonical package drift-check implementation. Chris Huber remains responsible for the change.