### PR TITLE
fix(rig): preflight managed checkout safety

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/matrix.rs
+++ b/crates/homeboy-cli/src/commands/bench/matrix.rs
@@ -47,6 +47,7 @@ fn prepare_rig_bench_context(
     let declared_spec = spec.clone();
     apply_bench_path_override(&mut spec, args);
     source.spec = spec.clone();
+    rig::preflight_effective_component_checkouts(&spec)?;
     let prepare_settings = bench_prepare_settings(args);
     let lease =
         rig::lease::acquire_active_run_lease_with_settings(&spec, "bench", &prepare_settings)?;

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -770,6 +770,15 @@ fn check(
         apply_check_path_override(&mut rig, path)?;
     }
     let report = rig::run_check(&rig)?;
+    if let Some(path) = path_override {
+        if let Some((component_id, _)) = rig
+            .components
+            .iter()
+            .find(|(_, component)| component.path == path)
+        {
+            rig::record_effective_component_path(&rig.id, component_id, path)?;
+        }
+    }
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         RigCommandOutput::Check(RigCheckOutput {

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -20,6 +20,11 @@ const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_millis(100);
 const PROVIDER_CLEANUP_OUTPUT_LIMIT: usize = 64 * 1024;
+#[cfg(not(test))]
+const PROVIDER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(test)]
+const PROVIDER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(1);
+const PROVIDER_LOOKUP_OUTPUT_LIMIT: usize = 64 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct WorktreeProviderCleanupOptions {
@@ -161,6 +166,54 @@ pub fn resolve_worktree_provider_handle_from_config(
 /// Resolve a provider-managed workspace and retain the selected provider id.
 pub fn resolve_worktree_provider(handle: &str) -> Result<WorktreeProviderResolution> {
     resolve_worktree_provider_from_config(handle, &defaults::load_config())
+}
+
+/// Resolve an effective checkout path through configured providers.
+///
+/// Unlike handle resolution this is intentionally optional: a rig may declare
+/// an ordinary local checkout. When a provider owns the exact path, its safety
+/// contract is validated before callers start expensive work.
+pub fn resolve_worktree_provider_path(
+    path: &std::path::Path,
+) -> Result<Option<WorktreeProviderResolution>> {
+    resolve_worktree_provider_path_from_config(path, &defaults::load_config())
+}
+
+pub fn resolve_worktree_provider_path_from_config(
+    path: &std::path::Path,
+    config: &HomeboyConfig,
+) -> Result<Option<WorktreeProviderResolution>> {
+    let requested = match std::fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return Ok(None),
+    };
+    let mut provider_ids = config
+        .worktree_providers
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    provider_ids.sort();
+    for provider_id in provider_ids {
+        let provider = &config.worktree_providers[&provider_id];
+        if !provider.enabled {
+            continue;
+        }
+        let Some(command) = provider.commands.list.as_ref() else {
+            continue;
+        };
+        let worktrees = run_provider_list_command(&provider_id, provider, command)?;
+        let Some(worktree) = worktrees.into_iter().find(|worktree| {
+            std::fs::canonicalize(&worktree.path).ok().as_deref() == Some(requested.as_path())
+        }) else {
+            continue;
+        };
+        validate_provider_handle(&provider_id, &worktree, None, None)?;
+        return Ok(Some(WorktreeProviderResolution {
+            provider_id,
+            worktree,
+        }));
+    }
+    Ok(None)
 }
 
 pub fn resolve_worktree_provider_from_config(
@@ -348,7 +401,13 @@ fn run_provider_ensure_command(provider_id: &str, command: &[String]) -> Result<
             None,
         ));
     };
-    let output = Command::new(program).args(args).output().map_err(|error| {
+    let mut process = Command::new(program);
+    process
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::engine::command::isolate_process_tree(&mut process);
+    let mut child = process.spawn().map_err(|error| {
         Error::validation_invalid_argument(
             "to_worktree",
             format!("worktree provider `{provider_id}` ensure command could not start: {error}"),
@@ -356,6 +415,39 @@ fn run_provider_ensure_command(provider_id: &str, command: &[String]) -> Result<
             None,
         )
     })?;
+    let output = crate::engine::command::wait_with_bounded_output_supervised(
+        &mut child,
+        PROVIDER_LOOKUP_OUTPUT_LIMIT,
+        PROVIDER_LOOKUP_TIMEOUT,
+        Duration::from_millis(100),
+        || false,
+        |_, _| Ok(()),
+    )
+    .map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` ensure command could not be supervised: {error}"
+            ),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` ensure command timed out after {} ms",
+                PROVIDER_LOOKUP_TIMEOUT.as_millis()
+            ),
+            Some(provider_id.to_string()),
+            Some(vec![
+                "Refresh or repair the configured workspace provider, then retry the operation."
+                    .to_string(),
+            ]),
+        ));
+    }
+    let output = output.output.into_output();
     if output.status.success() {
         return Ok(());
     }
@@ -516,7 +608,13 @@ fn run_provider_lookup_command(
                 None,
             )
         })?;
-    let output = Command::new(program).args(args).output().map_err(|error| {
+    let mut process = Command::new(program);
+    process
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::engine::command::isolate_process_tree(&mut process);
+    let mut child = process.spawn().map_err(|error| {
         Error::validation_invalid_argument(
             "to_worktree",
             format!(
@@ -526,6 +624,37 @@ fn run_provider_lookup_command(
             None,
         )
     })?;
+    let output = crate::engine::command::wait_with_bounded_output_supervised(
+        &mut child,
+        PROVIDER_LOOKUP_OUTPUT_LIMIT,
+        PROVIDER_LOOKUP_TIMEOUT,
+        Duration::from_millis(100),
+        || false,
+        |_, _| Ok(()),
+    )
+    .map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree provider `{provider_id}` {operation} command could not be supervised: {error}"),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` {operation} command timed out after {} ms",
+                PROVIDER_LOOKUP_TIMEOUT.as_millis()
+            ),
+            Some(provider_id.to_string()),
+            Some(vec![
+                "Refresh or repair the configured workspace provider, then retry the operation."
+                    .to_string(),
+            ]),
+        ));
+    }
+    let output = output.output.into_output();
     if !output.status.success() {
         return Err(Error::validation_invalid_argument_with_evidence(
             "to_worktree",
@@ -2045,6 +2174,98 @@ mod tests {
 
         assert_eq!(handle.path, workspace.path().display().to_string());
         assert_eq!(handle.branch, "cook-target");
+    }
+
+    #[test]
+    fn path_resolution_rejects_a_provider_declared_primary_before_work_starts() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "main");
+        let script = fake_list_provider_script(json!({ "worktrees": [{
+            "handle": "fixture",
+            "path": workspace.path(),
+            "branch": "main",
+            "safety": { "dirty": false, "unpushed": false, "primary": true }
+        }]}));
+
+        let error = resolve_worktree_provider_path_from_config(
+            workspace.path(),
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                commands: WorktreeProviderCommands {
+                    list: Some(vec![script]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            }),
+        )
+        .expect_err("provider primary must fail before rig work starts");
+
+        assert!(error.message.contains("primary"));
+        assert_eq!(error.details["worktree_provider_lookup"], Value::Null);
+    }
+
+    #[test]
+    fn path_resolution_accepts_an_explicit_provider_worktree_identity() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "fix/10251");
+        let script = fake_list_provider_script(json!({ "worktrees": [{
+            "handle": "fixture@fix-10251",
+            "path": workspace.path(),
+            "branch": "fix/10251",
+            "safety": { "dirty": false, "unpushed": false, "primary": false }
+        }]}));
+
+        let resolution = resolve_worktree_provider_path_from_config(
+            workspace.path(),
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                commands: WorktreeProviderCommands {
+                    list: Some(vec![script]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            }),
+        )
+        .expect("provider lookup")
+        .expect("exact path is provider managed");
+
+        assert_eq!(resolution.provider_id, "fixture");
+        assert_eq!(resolution.worktree.handle, "fixture@fix-10251");
+        assert_eq!(
+            resolution.worktree.path,
+            workspace.path().display().to_string()
+        );
+    }
+
+    #[test]
+    fn path_resolution_reports_provider_timeout() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let dir = unique_fixture_script_dir();
+        let script = dir.join("provider");
+        fs::write(&script, "#!/bin/sh\nsleep 2\nprintf '{\"worktrees\":[]}'\n")
+            .expect("write provider");
+        make_executable(&script);
+
+        let error = resolve_worktree_provider_path_from_config(
+            workspace.path(),
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                commands: WorktreeProviderCommands {
+                    list: Some(vec![script.to_string_lossy().to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            }),
+        )
+        .expect_err("a hung provider must be bounded");
+
+        assert!(error.message.contains("timed out"));
     }
 
     #[test]

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -73,10 +73,11 @@ pub use resource_lifecycle::{
     rig_resource_lifecycle_index, rig_resource_lifecycle_records, RigResourceLifecycleOptions,
 };
 pub use runner::{
-    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups,
-    run_check_groups_with_settings, run_check_with_settings, run_down, run_down_with_settings,
-    run_fuzz_prepare, run_lint, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport,
-    CheckReport, DownReport, FuzzPrepareReport, RepairReport, RepairResourceReport,
+    head_sha_and_branch, preflight_effective_component_checkouts, record_effective_component_path,
+    run_bench_prepare, run_check, run_check_groups, run_check_groups_with_settings,
+    run_check_with_settings, run_down, run_down_with_settings, run_fuzz_prepare, run_lint,
+    run_repair, run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport, DownReport,
+    FuzzPrepareReport, RepairReport, RepairResourceReport, RigComponentStatusReport,
     RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -120,12 +120,27 @@ pub struct RepairResourceReport {
 pub struct RigStatusReport {
     pub rig_id: String,
     pub description: String,
+    /// Current component checkout resolution, independent of historical
+    /// materialization resources.
+    pub components: Vec<RigComponentStatusReport>,
     pub services: Vec<ServiceStatusReport>,
     pub symlinks: Vec<SymlinkStatusReport>,
     pub last_up: Option<String>,
     pub last_check: Option<String>,
     pub last_check_result: Option<String>,
     pub materialized: Option<MaterializedRigState>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RigComponentStatusReport {
+    pub id: String,
+    pub path: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#ref: Option<String>,
+    pub freshness: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -162,6 +177,7 @@ pub enum SymlinkStatusState {
 
 /// Materialize a rig: run the `up` pipeline, stash timestamp in state.
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
+    preflight_effective_component_checkouts(rig)?;
     let _lease = acquire_active_run_lease(rig, "up")?;
     let observer = RigRunObserver::start(rig, "up");
 
@@ -220,6 +236,7 @@ pub fn run_check_with_settings(
     rig: &RigSpec,
     settings: &[(String, String)],
 ) -> Result<CheckReport> {
+    preflight_effective_component_checkouts(rig)?;
     let observer = RigRunObserver::start(rig, "check");
 
     let execute = || {
@@ -320,6 +337,7 @@ pub fn run_check_groups_with_settings(
     groups: &[String],
     settings: &[(String, String)],
 ) -> Result<CheckReport> {
+    preflight_effective_component_checkouts(rig)?;
     let outcome = run_pipeline_check_groups(rig, groups, false, settings)?;
 
     Ok(CheckReport {
@@ -852,9 +870,24 @@ pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
         .collect::<Vec<_>>();
     symlinks.sort_by(|a, b| a.link.cmp(&b.link));
 
+    let mut components = rig
+        .components
+        .iter()
+        .map(|(id, component)| {
+            component_status(
+                rig,
+                id,
+                &component.path,
+                state.last_effective_components.get(id),
+            )
+        })
+        .collect::<Vec<_>>();
+    components.sort_by(|a, b| a.id.cmp(&b.id));
+
     Ok(RigStatusReport {
         rig_id: rig.id.clone(),
         description: rig.description.clone(),
+        components,
         services,
         symlinks,
         last_up: state.last_up,
@@ -862,6 +895,80 @@ pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
         last_check_result: state.last_check_result,
         materialized: state.materialized,
     })
+}
+
+/// Validate every provider-owned component checkout before acquiring a rig
+/// lease, opening an observation, or running a pipeline step.
+pub fn preflight_effective_component_checkouts(rig: &RigSpec) -> Result<()> {
+    for component in rig.components.values() {
+        let path = expand_vars(rig, &component.path);
+        let path = shellexpand::tilde(&path).into_owned();
+        homeboy_core::worktree_providers::resolve_worktree_provider_path(Path::new(&path))?;
+    }
+    Ok(())
+}
+
+/// Persist a caller-selected effective checkout for later status reporting.
+pub fn record_effective_component_path(rig_id: &str, component_id: &str, path: &str) -> Result<()> {
+    let (sha, branch) = head_sha_and_branch(path);
+    let mut state = RigState::load(rig_id)?;
+    state.last_effective_components.insert(
+        component_id.to_string(),
+        ComponentSnapshot {
+            path: path.to_string(),
+            declared_path: None,
+            sha,
+            branch,
+        },
+    );
+    state.save(rig_id)
+}
+
+fn component_status(
+    rig: &RigSpec,
+    id: &str,
+    declared_path: &str,
+    last_effective: Option<&ComponentSnapshot>,
+) -> RigComponentStatusReport {
+    let declared = shellexpand::tilde(&expand_vars(rig, declared_path)).into_owned();
+    let (path, source) = match last_effective {
+        Some(snapshot) if snapshot.path != declared => {
+            (snapshot.path.clone(), "last_override".to_string())
+        }
+        _ => (declared, "installed_default".to_string()),
+    };
+    match homeboy_core::worktree_providers::resolve_worktree_provider_path(Path::new(&path)) {
+        Ok(Some(resolution)) => RigComponentStatusReport {
+            id: id.to_string(),
+            path: resolution.worktree.path,
+            source: format!("provider:{}", resolution.provider_id),
+            r#ref: Some(resolution.worktree.branch),
+            freshness: "current".to_string(),
+            error: None,
+        },
+        Ok(None) => {
+            let (_, branch) = head_sha_and_branch(&path);
+            RigComponentStatusReport {
+                id: id.to_string(),
+                path,
+                source,
+                r#ref: branch,
+                freshness: "unmanaged".to_string(),
+                error: None,
+            }
+        }
+        Err(error) => {
+            let (_, branch) = head_sha_and_branch(&path);
+            RigComponentStatusReport {
+                id: id.to_string(),
+                path,
+                source: "provider".to_string(),
+                r#ref: branch,
+                freshness: "stale".to_string(),
+                error: Some(error.message),
+            }
+        }
+    }
 }
 
 fn symlink_status(rig: &RigSpec, link: &super::spec::SymlinkSpec) -> SymlinkStatusReport {

--- a/crates/homeboy-rig/src/state.rs
+++ b/crates/homeboy-rig/src/state.rs
@@ -41,6 +41,10 @@ pub struct RigState {
     /// Long-lived ownership materialized by the last successful `rig up`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub materialized: Option<MaterializedRigState>,
+
+    /// Effective component identities selected by the most recent invocation.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub last_effective_components: BTreeMap<String, ComponentSnapshot>,
 }
 
 /// Persistent record of what a successful `rig up` materialized.

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -21,8 +21,8 @@ use crate::dependency_materialization_cache::{
 use crate::pipeline::PipelineOutcome;
 use crate::runner::{
     head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings,
-    run_fuzz_prepare, run_repair, run_status, run_up, snapshot_state, CheckReport, RigStatusReport,
-    ServiceStatusReport, SymlinkStatusState, UpReport,
+    run_fuzz_prepare, run_repair, run_status, run_up, snapshot_state, CheckReport,
+    RigComponentStatusReport, RigStatusReport, ServiceStatusReport, SymlinkStatusState, UpReport,
 };
 use crate::spec::{
     ComponentSpec, DependencyMaterializationOutputKind, DependencyMaterializationOutputSpec,
@@ -120,6 +120,7 @@ fn test_status_report_empty_services_serializes() {
     let report = RigStatusReport {
         rig_id: "test".to_string(),
         description: "empty rig".to_string(),
+        components: Vec::<RigComponentStatusReport>::new(),
         services: Vec::new(),
         symlinks: Vec::new(),
         last_up: None,
@@ -246,6 +247,68 @@ fn test_run_check() {
         let status = run_status(&rig).expect("run_status reads back state");
         assert_eq!(status.last_check_result.as_deref(), Some("pass"));
         assert!(status.last_check.is_some(), "last_check timestamp recorded");
+    });
+}
+
+#[test]
+fn status_projects_current_component_identity_without_materialized_resources() {
+    with_isolated_home(|_dir| {
+        let checkout = tempfile::tempdir().expect("checkout");
+        let init = std::process::Command::new("git")
+            .args(["init", "-b", "status-projection"])
+            .current_dir(checkout.path())
+            .status()
+            .expect("initialize checkout");
+        assert!(init.success());
+        std::fs::write(checkout.path().join("fixture.txt"), "fixture").expect("write fixture");
+        let commit = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test",
+                "add",
+                "fixture.txt",
+            ])
+            .current_dir(checkout.path())
+            .status()
+            .expect("stage fixture");
+        assert!(commit.success());
+        let commit = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test",
+                "commit",
+                "-m",
+                "fixture",
+            ])
+            .current_dir(checkout.path())
+            .status()
+            .expect("commit fixture");
+        assert!(commit.success());
+        let rig: RigSpec = serde_json::from_str(&format!(
+            r#"{{"id":"status-projection","components":{{"fixture":{{"path":"{}"}}}}}}"#,
+            checkout.path().display()
+        ))
+        .expect("parse rig");
+
+        let report = run_status(&rig).expect("status");
+
+        assert_eq!(report.components.len(), 1);
+        assert_eq!(report.components[0].id, "fixture");
+        assert_eq!(
+            report.components[0].path,
+            checkout.path().display().to_string()
+        );
+        assert_eq!(report.components[0].source, "installed_default");
+        assert_eq!(
+            report.components[0].r#ref.as_deref(),
+            Some("status-projection")
+        );
+        assert_eq!(report.components[0].freshness, "unmanaged");
+        assert!(report.materialized.is_none());
     });
 }
 

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -31,6 +31,7 @@ fn test_state_round_trips_with_service() {
         services: Default::default(),
         shared_paths: Default::default(),
         materialized: None,
+        last_effective_components: Default::default(),
     };
     state.services.insert(
         "tarball".to_string(),


### PR DESCRIPTION
## Summary
- resolve effective rig component paths through configured generic worktree providers before rig leases, observers, and pipelines
- bound provider lookup/ensure commands and preserve provider-owned safety remediation
- project effective component path, source, ref, and freshness in rig status; persist explicit check overrides

## Validation
- `cargo fmt --check`
- `cargo check -p homeboy-rig -p homeboy-cli`
- `cargo test -p homeboy-core worktree_providers::tests::path_resolution -- --nocapture`
- `cargo test -p homeboy-rig runner_test::status_projects_current_component_identity_without_materialized_resources -- --nocapture`

Closes #10251

## AI Assistance
Drafted with OpenCode using `openai/gpt-5.6-terra` to inspect the existing provider and rig flows, implement the generic preflight/status changes, and add focused regression coverage. Chris Huber remains responsible for every line.