### PR TITLE
fix(daemon): converge stale macOS lease stops

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -20,9 +20,7 @@ use crate::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::lab_contract::LabRunnerWorkload;
 use crate::paths;
-use crate::process::{
-    pid_has_ownership_token, pid_is_running, terminate_pid_with_sigterm_and_wait,
-};
+use crate::process::{pid_has_ownership_token, pid_is_running};
 use crate::runner_execution_envelope::PathMaterializationPlan;
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;

--- a/crates/homeboy-core/src/daemon/stop.rs
+++ b/crates/homeboy-core/src/daemon/stop.rs
@@ -6,6 +6,10 @@
 //! inherits the parent module's state types, lock, and persistence helpers.
 
 use super::*;
+use crate::process::{signal_pid, wait_for_pid_exit};
+
+const TERM_GRACE: Duration = Duration::from_secs(2);
+const KILL_GRACE: Duration = Duration::from_secs(2);
 
 pub fn stop() -> Result<DaemonStopResult> {
     stop_with_force(false)
@@ -100,8 +104,7 @@ fn force_stop_for_lease_unlocked(expected_lease_id: &str) -> Result<DaemonStopRe
         });
     }
 
-    let _ = read_lease_if_identity_matches(&path, &identity)?;
-    terminate_pid_with_sigterm_and_wait(state.pid, FORCE_STOP_WAIT)?;
+    let termination = terminate_exact_supervised_daemon(&path, &identity, &state)?;
     let evidence = DaemonTerminationEvidence {
         classification: DaemonTerminationClassification::CleanStop,
         observed_at: chrono::Utc::now().to_rfc3339(),
@@ -111,10 +114,7 @@ fn force_stop_for_lease_unlocked(expected_lease_id: &str) -> Result<DaemonStopRe
         active_jobs: 0,
         resource_evidence: "unavailable: forced stop does not collect OS resource snapshots"
             .to_string(),
-        os_evidence: format!(
-            "SIGTERM sent to recorded daemon PID and process death verified within {}ms",
-            FORCE_STOP_WAIT.as_millis()
-        ),
+        os_evidence: termination,
         exit_code: None,
         signal: Some(libc::SIGTERM),
         stdout: None,
@@ -130,6 +130,147 @@ fn force_stop_for_lease_unlocked(expected_lease_id: &str) -> Result<DaemonStopRe
         state_path: state_path_display,
         termination_evidence: Some(evidence),
     })
+}
+
+/// Stop the serving child first, allowing its supervisor to record the exit and
+/// leave normally. Every signal is preceded by fresh lease, zero-job, and token
+/// checks so a reused PID cannot be killed between the grace window and SIGKILL.
+fn terminate_exact_supervised_daemon(
+    path: &std::path::Path,
+    identity: &DaemonLeaseIdentity,
+    state: &DaemonState,
+) -> Result<String> {
+    let supervisor = supervised_parent_pid(state.pid, &state.startup_token)?;
+    revalidate_exact_termination_target(path, identity, state)?;
+    signal_pid(state.pid, libc::SIGTERM)?;
+    let child_signal = if wait_for_pid_exit(state.pid, TERM_GRACE) {
+        "SIGTERM"
+    } else {
+        revalidate_exact_termination_target(path, identity, state)?;
+        signal_pid(state.pid, libc::SIGKILL)?;
+        if !wait_for_pid_exit(state.pid, KILL_GRACE) {
+            return Err(Error::internal_unexpected(format!(
+                "daemon pid {} survived bounded SIGTERM-to-SIGKILL escalation",
+                state.pid
+            )));
+        }
+        "SIGKILL"
+    };
+
+    // The supervisor observes its child exit and normally leaves on its own.
+    // If it remains, prove its matching token before applying the same bounded
+    // escalation; an unrelated reparented process is never signaled.
+    let supervisor_signal = match supervisor {
+        Some(pid) if wait_for_pid_exit(pid, TERM_GRACE) => "exited after child",
+        Some(pid) => {
+            if !pid_has_ownership_token(pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)? {
+                return Err(Error::validation_invalid_argument(
+                    "daemon_lease",
+                    format!("supervisor pid {pid} no longer owns the daemon startup token"),
+                    Some(pid.to_string()),
+                    None,
+                ));
+            }
+            signal_pid(pid, libc::SIGTERM)?;
+            if wait_for_pid_exit(pid, TERM_GRACE) {
+                "SIGTERM"
+            } else {
+                if !pid_has_ownership_token(pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)? {
+                    return Err(Error::validation_invalid_argument(
+                        "daemon_lease",
+                        format!("supervisor pid {pid} changed identity before SIGKILL"),
+                        Some(pid.to_string()),
+                        None,
+                    ));
+                }
+                signal_pid(pid, libc::SIGKILL)?;
+                if !wait_for_pid_exit(pid, KILL_GRACE) {
+                    return Err(Error::internal_unexpected(format!(
+                        "daemon supervisor pid {pid} survived bounded SIGTERM-to-SIGKILL escalation"
+                    )));
+                }
+                "SIGKILL"
+            }
+        }
+        None => "not observed",
+    };
+    Ok(format!(
+        "exact startup-token ownership revalidated immediately before every signal; daemon pid {} stopped with {child_signal}; supervisor {supervisor_signal}",
+        state.pid
+    ))
+}
+
+fn revalidate_exact_termination_target(
+    path: &std::path::Path,
+    identity: &DaemonLeaseIdentity,
+    state: &DaemonState,
+) -> Result<()> {
+    let current = read_lease_if_identity_matches(path, identity)?;
+    if current.pid != state.pid || !active_daemon_job_ids()?.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "daemon_stop",
+            "daemon lease or active durable jobs changed before termination; refusing to signal",
+            Some(state.lease_id.clone()),
+            None,
+        ));
+    }
+    if !pid_has_ownership_token(state.pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)? {
+        return Err(Error::validation_invalid_argument(
+            "daemon_lease",
+            format!(
+                "daemon pid {} no longer owns the persisted startup token",
+                state.pid
+            ),
+            Some(state.pid.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// `ps` is the portable evidence adapter for the supervisor relationship. The
+/// token remains the exact identity proof on platforms without Linux `/proc`.
+fn supervised_parent_pid(child_pid: u32, startup_token: &str) -> Result<Option<u32>> {
+    let output = std::process::Command::new("ps")
+        .args(["-axo", "pid=,ppid=,command="])
+        .output()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("inspect daemon supervisor".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let rows = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            Some((
+                fields.next()?.parse::<u32>().ok()?,
+                fields.next()?.parse::<u32>().ok()?,
+                fields.collect::<Vec<_>>().join(" "),
+            ))
+        })
+        .collect::<Vec<_>>();
+    let Some((_, parent_pid, _)) = rows.iter().find(|(pid, _, _)| *pid == child_pid) else {
+        return Ok(None);
+    };
+    Ok(rows.iter().find_map(|(pid, _, command)| {
+        (*pid == *parent_pid
+            && command_has_startup_token(command, startup_token)
+            && command.contains("daemon supervise"))
+        .then_some(*pid)
+    }))
+}
+
+fn command_has_startup_token(command: &str, startup_token: &str) -> bool {
+    command
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .any(|pair| pair == ["--startup-token", startup_token])
 }
 
 pub(super) fn stop_with_force_for_lease(

--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -275,43 +275,65 @@ pub fn terminate_pid_with_sigterm_and_wait(pid: u32, timeout: Duration) -> Resul
         ));
     }
 
-    #[cfg(unix)]
-    {
-        unsafe {
-            if libc::kill(pid as libc::pid_t, libc::SIGTERM) != 0 {
-                let error = std::io::Error::last_os_error();
-                if error.raw_os_error() == Some(libc::ESRCH) {
-                    return Ok(());
-                }
-                return Err(Error::internal_io(
-                    error.to_string(),
-                    Some(format!("send SIGTERM to process {pid}")),
-                ));
-            }
-        }
-        let deadline = Instant::now() + timeout;
-        while process_is_running_after_sigterm(pid) {
-            if Instant::now() >= deadline {
-                return Err(Error::internal_unexpected(format!(
-                    "process {pid} remained alive for {}ms after SIGTERM",
-                    timeout.as_millis()
-                )));
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        return Ok(());
+    signal_pid(pid, libc::SIGTERM)?;
+    if wait_for_pid_exit(pid, timeout) {
+        Ok(())
+    } else {
+        Err(Error::internal_unexpected(format!(
+            "process {pid} remained alive for {}ms after SIGTERM",
+            timeout.as_millis()
+        )))
     }
+}
 
+/// Deliver one Unix signal to an exact PID. Ownership validation belongs to the
+/// caller because persisted protocol tokens are product-level evidence.
+pub fn signal_pid(pid: u32, signal: libc::c_int) -> Result<()> {
+    if pid == 0 || pid > i32::MAX as u32 {
+        return Err(Error::validation_invalid_argument(
+            "pid",
+            "recorded process PID is invalid",
+            Some(pid.to_string()),
+            None,
+        ));
+    }
+    #[cfg(unix)]
+    unsafe {
+        if libc::kill(pid as libc::pid_t, signal) != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(());
+            }
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(format!("send signal {signal} to process {pid}")),
+            ));
+        }
+        Ok(())
+    }
     #[cfg(not(unix))]
     {
-        let _ = timeout;
+        let _ = signal;
         Err(Error::validation_invalid_argument(
             "pid",
-            "SIGTERM process termination is unsupported on this platform",
+            "process signaling is unsupported on this platform",
             Some(pid.to_string()),
             None,
         ))
     }
+}
+
+/// Poll until a process has exited. This reaps direct children on Unix so a
+/// macOS zombie does not look like a surviving process.
+pub fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while process_is_running_after_sigterm(pid) {
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    true
 }
 
 #[cfg(unix)]
@@ -323,6 +345,11 @@ fn process_is_running_after_sigterm(pid: u32) -> bool {
     if reaped == pid as libc::pid_t {
         return false;
     }
+    pid_is_running(pid)
+}
+
+#[cfg(not(unix))]
+fn process_is_running_after_sigterm(pid: u32) -> bool {
     pid_is_running(pid)
 }
 

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1973,10 +1973,18 @@ fn stop_refuses_stale_lease_that_points_at_reused_pid() {
 
 #[cfg(unix)]
 fn spawn_force_stop_test_process(startup_token: Option<&str>) -> std::process::Child {
-    let mut command = Command::new("sleep");
-    command.arg("30").env_clear();
+    let mut command = Command::new("sh");
+    command.args([
+        "-c",
+        "while :; do sleep 1; done",
+        "homeboy",
+        "daemon",
+        "serve",
+    ]);
+    command.env_clear();
     if let Some(startup_token) = startup_token {
         command.env(DAEMON_STARTUP_TOKEN_ENV, startup_token);
+        command.args(["--startup-token", startup_token]);
     }
     command.spawn().expect("start force-stop test process")
 }
@@ -2031,7 +2039,7 @@ fn force_stop_active_jobs_block_signaling() {
     child.wait().expect("reap test process");
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[test]
 fn force_stop_matching_zero_job_stale_daemon_is_terminated_and_verified() {
     let _home = HomeGuard::new();
@@ -2051,9 +2059,43 @@ fn force_stop_matching_zero_job_stale_daemon_is_terminated_and_verified() {
     assert_eq!(evidence.lease_id.as_deref(), Some(state.lease_id.as_str()));
     assert_eq!(evidence.pid, Some(pid));
     assert_eq!(evidence.signal, Some(libc::SIGTERM));
-    assert!(evidence.os_evidence.contains("process death verified"));
+    assert!(evidence
+        .os_evidence
+        .contains("startup-token ownership revalidated"));
     assert!(!pid_is_running(pid));
     assert!(!state_path().expect("state path").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn force_stop_escalates_when_a_token_owned_daemon_ignores_sigterm() {
+    let _home = HomeGuard::new();
+    let startup_token = "force-stop-ignores-term";
+    let child = Command::new("sh")
+        .args([
+            "-c",
+            "trap '' TERM; while :; do sleep 1; done",
+            "homeboy",
+            "daemon",
+            "serve",
+            "--startup-token",
+            startup_token,
+        ])
+        .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
+        .spawn()
+        .expect("start TERM-resistant daemon fixture");
+    let pid = child.id();
+    let mut state = daemon_state_for_test(pid, "127.0.0.1:1");
+    state.binary_sha256 = Some("stale-binary-hash".to_string());
+    state.startup_token = startup_token.to_string();
+    write_daemon_state_for_test(&state);
+
+    let result = force_stop_for_lease(&state.lease_id).expect("bounded forced stop");
+
+    assert!(result.stopped);
+    let evidence = result.termination_evidence.expect("termination evidence");
+    assert!(evidence.os_evidence.contains("SIGKILL"));
+    assert!(!pid_is_running(pid));
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
- stop token-proven stale daemon children before their supervisors and wait for coordinated supervisor exit
- bound TERM-to-KILL escalation with immediate lease, zero-job, and startup-token revalidation before every signal
- use portable `ps` relationship evidence while retaining Linux environment evidence, and cover macOS-shaped graceful and TERM-resistant stop behavior

Closes #9738.

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-process`
- `cargo test -p homeboy-core force_stop --lib`
- `cargo test -p homeboy-core startup_ --lib`
- `cargo test -p homeboy-process --lib`

## Baseline Failures
Fresh `origin/main` at `970ba8fc4d7ba9bbda205e5a6d0d0420009643d4` reproduces these unchanged failures:
- `cargo test -p homeboy-core daemon_operation_lock_recovers_after_owner_exits_without_drop --lib`
- `cargo test -p homeboy-core remote_runner_broker_redacts_secret_env_from_public_surfaces --lib`

They are outside this PR's changed paths and were not modified.

## AI Assistance
- Model: OpenAI GPT-5.6 Sol (`openai/gpt-5.6-sol`)
- Tool: OpenCode
- Used for: issue-history review, implementation, deterministic regression coverage, and verification.
- Chris Huber remains responsible for every line.