### PR TITLE
fix(agent-task): support Windows operation claim liveness

### DIFF
--- a/crates/homeboy-agents/Cargo.toml
+++ b/crates/homeboy-agents/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "blo
 tempfile = "3.14"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading"] }
 
 [dev-dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -319,10 +319,45 @@ fn claim_owner_is_live(claim: &Value) -> bool {
     if pid == 0 || pid > i32::MAX as u64 {
         return false;
     }
+    process_is_live(pid as u32)
+}
+
+#[cfg(unix)]
+fn process_is_live(pid: u32) -> bool {
     // kill(pid, 0) checks process existence without signalling it. EPERM is
     // still proof of a live process that this controller may not inspect.
     let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
     result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+fn process_is_live(pid: u32) -> bool {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, GetLastError, ERROR_ACCESS_DENIED},
+        System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE,
+        },
+    };
+
+    // Access denied establishes that a process owns this PID, matching Unix's
+    // EPERM treatment. A queryable process is live only while STILL_ACTIVE.
+    unsafe {
+        let process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if process.is_null() {
+            return GetLastError() == ERROR_ACCESS_DENIED;
+        }
+        let mut exit_code = 0;
+        let queried = GetExitCodeProcess(process, &mut exit_code) != 0;
+        let _ = CloseHandle(process);
+        queried && exit_code == STILL_ACTIVE
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_is_live(_pid: u32) -> bool {
+    // Without a supported liveness primitive, preserve the lease until its
+    // deterministic deadline rather than risk re-entering an external effect.
+    true
 }
 
 /// RFC3339 timestamp `lease` after `base`. Falls back to `base` when the base is


### PR DESCRIPTION
## Summary
- isolate operation-claim owner PID liveness behind platform-specific implementations
- retain Unix `kill(pid, 0)` and `EPERM` semantics
- query Windows process exit state, treating access-denied processes as live

Closes #10276

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::operation_claims` (11 passed)
- `cargo check -p homeboy-agents --target x86_64-pc-windows-gnu` attempted; local host lacks `x86_64-w64-mingw32-gcc` required by transitive C dependencies before the crate compiles

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the issue and history, implemented the platform liveness boundary, ran the targeted lifecycle tests, and attempted the Windows target compile. Chris Huber owns the change and every line.