### PR TITLE
Fix nested extension JavaScript test routing

### DIFF
--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -758,7 +758,28 @@ pub fn compute_changed_test_files_for_files(
 ) -> homeboy_core::error::Result<Vec<String>> {
     let opts = resolve_drift_options(component, git_ref)?;
 
-    compute_changed_test_files_with_drift_options(component, changed_files, &opts)
+    let changed_files = component_relative_changed_files(component, changed_files);
+    compute_changed_test_files_with_drift_options(component, &changed_files, &opts)
+}
+
+/// Git reports paths relative to the repository root, while extension test
+/// contracts operate relative to the component root. Restrict a nested
+/// component's changed scope to its subtree and remove that shared prefix.
+fn component_relative_changed_files(component: &Component, files: &[String]) -> Vec<String> {
+    let Some(prefix) = git::get_component_path_prefix(&component.local_path) else {
+        return files.to_vec();
+    };
+    let prefix = Path::new(&prefix);
+
+    files
+        .iter()
+        .filter_map(|file| {
+            Path::new(file)
+                .strip_prefix(prefix)
+                .ok()
+                .map(|path| path.to_string_lossy().to_string())
+        })
+        .collect()
 }
 
 /// Return the subset of `changed_files` that are production or test source per
@@ -804,15 +825,16 @@ pub fn compute_changed_test_scope_for_files(
     changed_files: &[String],
 ) -> homeboy_core::error::Result<TestScopeOutput> {
     let opts = resolve_drift_options(component, git_ref)?;
+    let changed_files = component_relative_changed_files(component, changed_files);
     let selected_files =
-        compute_changed_test_files_with_drift_options(component, changed_files, &opts)?;
+        compute_changed_test_files_with_drift_options(component, &changed_files, &opts)?;
     let source_changes_without_tests = if selected_files.is_empty() {
         // A relocation refactor (symbol moved between files, unchanged name and
         // behavior) is coverage-neutral: it introduces no new untested surface,
         // so it must not force the changed-scope gate to fail closed. Exclude
         // files whose entire source change is a pure cross-file relocation
         // before flagging the rest as false-green. (#8927)
-        let relocation_only = drift::relocation_only_source_files(&opts, changed_files);
+        let relocation_only = drift::relocation_only_source_files(&opts, &changed_files);
 
         // Guard against silently-disabled source relevance. If the component's
         // drift config resolves no source/test glob patterns (e.g. a language
@@ -821,7 +843,7 @@ pub fn compute_changed_test_scope_for_files(
         // to a conservative docs/config heuristic so real source changes still
         // fail closed. (#8927)
         let relevant: Vec<String> = if opts.has_usable_patterns() {
-            source_relevant_changed_files(&opts, changed_files)
+            source_relevant_changed_files(&opts, &changed_files)
         } else {
             homeboy_core::log_status!(
                 "drift",

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -454,6 +454,92 @@ fn changed_wordpress_php_smoke_test_executes_with_generic_result_adapter() {
 }
 
 #[test]
+fn changed_nested_extension_js_smokes_use_component_relative_exclusive_route() {
+    with_isolated_home(|home| {
+        let repo = tempfile::tempdir().expect("temp repo");
+        let extension_root = repo.path().join("wordpress");
+        let tests_dir = extension_root.join("tests");
+        fs::create_dir_all(&tests_dir).expect("tests dir should be created");
+        for name in [
+            "wp-codebox-database-service-smoke.mjs",
+            "wp-codebox-phpunit-aggregate-smoke.mjs",
+            "wp-codebox-phpunit-multisite-smoke.mjs",
+        ] {
+            fs::write(tests_dir.join(name), "// JS smoke fixture\n").expect("test fixture");
+        }
+        fs::write(
+            extension_root.join("homeboy.json"),
+            r#"{
+  "id": "fixture",
+  "extensions": { "fixture-js": {} }
+}"#,
+        )
+        .expect("homeboy.json should be written");
+
+        let extension_dir = home.path().join(".config/homeboy/extensions/fixture-js");
+        fs::create_dir_all(&extension_dir).expect("extension dir should be created");
+        fs::write(
+            extension_dir.join("fixture-js.json"),
+            r#"{
+  "name": "Fixture JavaScript extension",
+  "version": "1.0.0",
+  "test": {
+    "extension_script": "test.sh",
+    "changed_file_routing": {
+      "strategy": "exclusive_env",
+      "exclusive_env": {
+        "name": "HOMEBOY_JS_SMOKE_FILES",
+        "globs": ["tests/**/*-smoke.mjs"]
+      }
+    }
+  }
+}"#,
+        )
+        .expect("extension manifest should be written");
+        let extension_script = extension_dir.join("test.sh");
+        fs::write(
+            &extension_script,
+            "#!/bin/sh\n[ \"$HOMEBOY_TEST_SCOPE_KIND\" = exclusive_env ]\n[ \"$HOMEBOY_TEST_SCOPE_ENV_NAME\" = HOMEBOY_JS_SMOKE_FILES ]\nprintf '%s' \"$HOMEBOY_TEST_SCOPE_ENV_VALUE\" | cmp -s - \"$HOMEBOY_COMPONENT_PATH/expected-js-smokes\"\nprintf 'js smoke passed=3 failed=0\\n'\n",
+        )
+        .expect("extension script should be written");
+        let mut perms = fs::metadata(&extension_script)
+            .expect("extension script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&extension_script, perms)
+            .expect("extension script should be executable");
+        fs::write(
+            extension_root.join("expected-js-smokes"),
+            "tests/wp-codebox-database-service-smoke.mjs\ntests/wp-codebox-phpunit-aggregate-smoke.mjs\ntests/wp-codebox-phpunit-multisite-smoke.mjs",
+        )
+        .expect("expected route should be written");
+        init_git_repo(repo.path());
+
+        let mut args = test_command_args(&extension_root);
+        args.changed_since = Some("HEAD".to_string());
+        args.precomputed_changed_files = Some(vec![
+            "wordpress/tests/wp-codebox-database-service-smoke.mjs".to_string(),
+            "wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs".to_string(),
+            "wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs".to_string(),
+        ]);
+        let (output, exit_code) =
+            run_test(args, &GlobalArgs {}).expect("JS smoke route should run");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.passed);
+        assert_eq!(output.test_counts.expect("test counts").passed, 3);
+        assert_eq!(
+            output.test_scope.expect("changed scope").selected_files,
+            vec![
+                "tests/wp-codebox-database-service-smoke.mjs",
+                "tests/wp-codebox-phpunit-aggregate-smoke.mjs",
+                "tests/wp-codebox-phpunit-multisite-smoke.mjs",
+            ]
+        );
+    });
+}
+
+#[test]
 fn successful_selected_test_without_result_evidence_fails_closed() {
     with_isolated_home(|home| {
         let dir = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
## Summary
- normalize changed files from repository-relative paths to the selected nested component root before test selection and extension routing
- preserve extension-owned changed-file routing contracts, allowing declared JS smoke globs to receive component-relative paths
- add an integration-level nested extension fixture that executes the JS smoke route for the three reported .mjs files

Fixes #10275

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli changed_nested_extension_js_smokes_use_component_relative_exclusive_route`
- `cargo test -p homeboy-extension test::tests::compute_changed_test_scope_detects_new_test_file`
- `cargo test -p homeboy-cli component_script_test`

`cargo test -p homeboy-extension` ran 610 tests: 600 passed and 10 existing unrelated failures in execution, lifecycle provider discovery, and trace canonicality tests.

## AI Assistance
Drafted with OpenAI GPT-5.6 Sol via OpenCode. Chris Huber owns and is responsible for every line.