### PR TITLE
fix(runs): scope watch evidence refresh

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -77,6 +77,15 @@ pub(crate) fn reconcile_owned_stale_running_runs(
     reconcile_orphaned_running_runs(store, limit, false, pid_is_running)
 }
 
+/// Reconcile only the run being read by a focused command. Fleet-wide
+/// reconciliation is intentionally reserved for `runs reconcile`.
+pub(crate) fn reconcile_owned_stale_running_run(
+    store: &ObservationStore,
+    run: &RunRecord,
+) -> homeboy::core::Result<Option<ReconciledRunSummary>> {
+    reconcile_orphaned_running_run(store, run, false, pid_is_running)
+}
+
 fn reconcile_orphaned_running_runs<F>(
     store: &ObservationStore,
     limit: i64,
@@ -91,41 +100,53 @@ where
         limit: Some(limit.clamp(1, 1000)),
         ..RunListFilter::default()
     })?;
-    let mut reconciled = Vec::new();
+    Ok(running
+        .iter()
+        .map(|run| reconcile_orphaned_running_run(store, run, dry_run, &pid_is_alive))
+        .collect::<homeboy::core::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
+}
 
-    for run in running {
-        let Some(reason) = stale_running_reason(&run, &pid_is_alive) else {
-            continue;
-        };
+fn reconcile_orphaned_running_run<F>(
+    store: &ObservationStore,
+    run: &RunRecord,
+    dry_run: bool,
+    pid_is_alive: F,
+) -> homeboy::core::Result<Option<ReconciledRunSummary>>
+where
+    F: Fn(u32) -> bool,
+{
+    let Some(reason) = stale_running_reason(run, &pid_is_alive) else {
+        return Ok(None);
+    };
 
-        let owner_pid = run_owner_pid(&run);
-        let artifact_count = if dry_run {
-            store.list_artifacts(&run.id)?.len()
-        } else {
-            reconcile_available_run_dir_artifacts(store, &run)?
-        };
-        let finished = if dry_run {
-            None
-        } else {
-            let metadata =
-                with_reconcile_metadata(&run, owner_pid, reason, &reconcile_run_dir_metadata(&run));
-            Some(store.finish_run(&run.id, RunStatus::Stale, Some(metadata))?)
-        };
+    let owner_pid = run_owner_pid(run);
+    let artifact_count = if dry_run {
+        store.list_artifacts(&run.id)?.len()
+    } else {
+        reconcile_available_run_dir_artifacts(store, run)?
+    };
+    let finished = if dry_run {
+        None
+    } else {
+        let metadata =
+            with_reconcile_metadata(run, owner_pid, reason, &reconcile_run_dir_metadata(run));
+        Some(store.finish_run(&run.id, RunStatus::Stale, Some(metadata))?)
+    };
 
-        reconciled.push(ReconciledRunSummary {
-            id: run.id,
-            kind: run.kind,
-            previous_status: run.status,
-            status: RunStatus::Stale.as_str().to_string(),
-            started_at: run.started_at,
-            finished_at: finished.and_then(|run| run.finished_at),
-            owner_pid,
-            reason: reason.to_string(),
-            artifact_count,
-        });
-    }
-
-    Ok(reconciled)
+    Ok(Some(ReconciledRunSummary {
+        id: run.id.clone(),
+        kind: run.kind.clone(),
+        previous_status: run.status.clone(),
+        status: RunStatus::Stale.as_str().to_string(),
+        started_at: run.started_at.clone(),
+        finished_at: finished.and_then(|run| run.finished_at),
+        owner_pid,
+        reason: reason.to_string(),
+        artifact_count,
+    }))
 }
 
 fn stale_running_reason<F>(run: &RunRecord, pid_is_alive: &F) -> Option<&'static str>

--- a/crates/homeboy-cli/src/commands/runs/watch.rs
+++ b/crates/homeboy-cli/src/commands/runs/watch.rs
@@ -9,8 +9,8 @@
 //! that reflects pass/fail.
 //!
 //! Two safety properties keep it from hanging forever:
-//! - Each poll runs the existing reconcile pass, so a run whose owner process
-//!   died transitions to `stale` and the watch surfaces it instead of waiting.
+//! - Each poll reconciles the requested run's owner, so a run whose owner
+//!   process died transitions to `stale` and the watch surfaces it instead of waiting.
 //! - `--timeout` bounds the total wait; on expiry the watch returns the
 //!   last-seen state with a distinct timeout exit code.
 
@@ -81,17 +81,20 @@ pub(super) trait RunPoller {
     fn poll(&self, run_id: &str) -> homeboy::core::Result<RunRecord>;
 }
 
-/// Production poller: reconcile dead-owner runs, refresh mirrored runner
-/// evidence, then read the freshest local record. Mirrors `runs show` side
-/// effects so a detached/offloaded run's status is up to date each poll.
+/// Production poller: refresh the requested mirrored runner evidence, reconcile
+/// its owner, then read the freshest local record. Fleet reconciliation remains
+/// an explicit `runs reconcile` operation rather than a side effect of a focused
+/// watch.
 struct StorePoller<'a> {
     store: &'a ObservationStore,
 }
 
 impl RunPoller for StorePoller<'_> {
     fn poll(&self, run_id: &str) -> homeboy::core::Result<RunRecord> {
-        runs_service::refresh_running_mirrored_daemon_evidence_best_effort(self.store);
-        reconcile::reconcile_owned_stale_running_runs(self.store, 1000)?;
+        let run = runs_service::require_run(self.store, run_id)?;
+        runs_service::refresh_selected_mirrored_daemon_evidence_best_effort(self.store, &run);
+        let run = runs_service::require_run(self.store, run_id)?;
+        reconcile::reconcile_owned_stale_running_run(self.store, &run)?;
         runs_service::require_run(self.store, run_id)
     }
 }

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -299,9 +299,12 @@ pub fn refresh_selected_mirrored_daemon_evidence_best_effort(
     run: &RunRecord,
 ) {
     if let Some(err) = refresh_selected_mirrored_daemon_evidence(store, run) {
+        let (runner_id, job_id) =
+            runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(run))
+                .expect("selected refresh errors only for mirrored runner jobs");
         eprintln!(
-            "Warning: could not refresh mirrored Lab runner evidence for `{}`: {}",
-            run.id, err.message
+            "Warning: could not refresh mirrored Lab runner evidence for `{}` (runner `{runner_id}`, job `{job_id}`): {}. Inspect it with `homeboy runner job logs {runner_id} {job_id}`.",
+            run.id, err.message,
         );
     }
 }

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -553,6 +553,7 @@ mod tests {
     struct SelectedRefreshProvider {
         calls: Arc<Mutex<Vec<String>>>,
         error: Option<Error>,
+        converge_target: bool,
     }
 
     impl RunnerEvidenceProvider for SelectedRefreshProvider {
@@ -582,6 +583,13 @@ mod tests {
 
         fn refresh_mirrored_daemon_evidence(&self, run_id: &str) -> Result<Option<Vec<RunRecord>>> {
             self.calls.lock().expect("calls").push(run_id.to_string());
+            if self.converge_target && run_id == "target" {
+                ObservationStore::open_initialized()?.finish_run(
+                    run_id,
+                    RunStatus::Pass,
+                    Some(serde_json::json!({ "refreshed": true })),
+                )?;
+            }
             self.error.clone().map_or(Ok(None), Err)
         }
 
@@ -627,6 +635,7 @@ mod tests {
             register_runner_evidence_provider(Box::new(SelectedRefreshProvider {
                 calls: calls.clone(),
                 error: Some(Error::internal_unexpected("unrelated refresh must not run")),
+                converge_target: false,
             }));
 
             assert!(
@@ -653,6 +662,7 @@ mod tests {
                     "daemon request failed: job not found",
                     serde_json::json!({ "http_status": 404, "path": "/jobs/job-1" }),
                 )),
+                converge_target: false,
             }));
 
             assert!(
@@ -686,6 +696,7 @@ mod tests {
             register_runner_evidence_provider(Box::new(SelectedRefreshProvider {
                 calls: calls.clone(),
                 error: Some(Error::internal_unexpected("runner transport unavailable")),
+                converge_target: false,
             }));
 
             let err = super::super::refresh_selected_mirrored_daemon_evidence(&store, &selected)
@@ -697,6 +708,49 @@ mod tests {
                     .get_run("selected")
                     .expect("read")
                     .expect("run")
+                    .status,
+                RunStatus::Running.as_str()
+            );
+        });
+        PROVIDER.lock().expect("provider").take();
+    }
+
+    #[test]
+    fn selected_refresh_converges_target_without_querying_hundreds_of_stale_mirrors() {
+        let _lock = provider_lock().lock().expect("provider lock");
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let target = mirrored_run("target");
+            store.import_run(&target).expect("target");
+            for index in 0..500 {
+                store
+                    .import_run(&mirrored_run(&format!("stale-mirror-{index}")))
+                    .expect("unrelated stale mirror");
+            }
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            register_runner_evidence_provider(Box::new(SelectedRefreshProvider {
+                calls: calls.clone(),
+                error: None,
+                converge_target: true,
+            }));
+
+            assert!(
+                super::super::refresh_selected_mirrored_daemon_evidence(&store, &target).is_none()
+            );
+            assert_eq!(*calls.lock().expect("calls"), vec!["target"]);
+            assert_eq!(
+                store
+                    .get_run("target")
+                    .expect("target read")
+                    .expect("target")
+                    .status,
+                RunStatus::Pass.as_str()
+            );
+            assert_eq!(
+                store
+                    .get_run("stale-mirror-499")
+                    .expect("unrelated read")
+                    .expect("unrelated")
                     .status,
                 RunStatus::Running.as_str()
             );


### PR DESCRIPTION
## Summary

Closes #10267.

- Make `runs watch <run-id>` refresh only the requested durable mirror and reconcile only that run owner.
- Keep fleet-wide mirror refresh and reconciliation in explicit `runs reconcile`.
- Include the target runner/job identity and `homeboy runner job logs` recovery command in a bounded refresh diagnostic.
- Cover 500 unrelated stale mirrors plus one target that converges; assert only the target is queried.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-core selected_refresh --no-fail-fast`
- `cargo test -p homeboy-cli runs::watch --no-fail-fast`

`cargo test -p homeboy-cli commands::runs --no-fail-fast` has one unrelated persistent failure: `commands::runs::remote::tests::remote_id_filter_matches_command_embedded_run_label` at `crates/homeboy-cli/src/commands/runs/remote.rs:614`. The focused watch and target-scoped evidence tests pass.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode drafted and verified the focused implementation and regression coverage. Chris Huber reviewed and owns every line.