### PR TITLE
fix(agents): propagate notification routes onto fanout worker threads

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/notification_route.rs
+++ b/crates/contracts/homeboy-lab-contract/src/notification_route.rs
@@ -135,6 +135,31 @@ pub fn current() -> Option<NotificationRoute> {
     CURRENT_NOTIFICATION_ROUTE.with(|current| current.borrow().clone())
 }
 
+/// A route captured from one thread so it can be re-bound on another.
+///
+/// The current route is thread-local, so work moved onto a worker thread
+/// (`thread::spawn`, `thread::scope`) starts with no route and silently stops
+/// attributing its runs to the caller's destination. Capture on the parent
+/// thread and re-bind inside the child body.
+#[derive(Debug, Clone, Default)]
+pub struct PropagatedNotificationRoute(Option<NotificationRoute>);
+
+impl PropagatedNotificationRoute {
+    /// Re-bind the captured route for the duration of `operation`.
+    pub fn bind<T>(&self, operation: impl FnOnce() -> T) -> T {
+        with_current(self.0.clone(), operation)
+    }
+
+    pub fn route(&self) -> Option<&NotificationRoute> {
+        self.0.as_ref()
+    }
+}
+
+/// Capture the calling thread's route for propagation onto worker threads.
+pub fn capture() -> PropagatedNotificationRoute {
+    PropagatedNotificationRoute(current())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,6 +203,30 @@ mod tests {
         assert_eq!(first.join().unwrap(), "first");
         assert_eq!(second.join().unwrap(), "second");
         assert!(current().is_none());
+    }
+
+    #[test]
+    fn captured_route_is_rebound_on_a_worker_thread() {
+        let observed = with_current(
+            Some(NotificationRoute::new("extension", "parent-route").unwrap()),
+            || {
+                let propagated = capture();
+                std::thread::spawn(move || propagated.bind(current))
+                    .join()
+                    .unwrap()
+            },
+        );
+        assert_eq!(observed.unwrap().route, "parent-route");
+    }
+
+    #[test]
+    fn capture_without_a_bound_route_leaves_workers_unrouted() {
+        let propagated = capture();
+        assert!(propagated.route().is_none());
+        let observed = std::thread::spawn(move || propagated.bind(current))
+            .join()
+            .unwrap();
+        assert!(observed.is_none());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -629,15 +629,20 @@ where
                     join_handle: None,
                 });
 
+                // Re-bind the caller's notification route: it is thread-local,
+                // so provider work dispatched here would otherwise run unrouted.
+                let notification_route = homeboy_core::notification_route::capture();
                 let join_handle = thread::spawn(move || {
-                    let _attempt_workspace = attempt_workspace;
-                    let outcome = executor.execute(request, context);
-                    let _ = tx.send(SchedulerEvent::TaskResult(TaskResult {
-                        task_id,
-                        attempt,
-                        outcome,
-                        scratch,
-                    }));
+                    notification_route.bind(|| {
+                        let _attempt_workspace = attempt_workspace;
+                        let outcome = executor.execute(request, context);
+                        let _ = tx.send(SchedulerEvent::TaskResult(TaskResult {
+                            task_id,
+                            attempt,
+                            outcome,
+                            scratch,
+                        }));
+                    })
                 });
                 running
                     .last_mut()

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -722,46 +722,55 @@ impl AgentTaskScheduleSupport {
                 workspace_key: task.workspace_key.clone(),
             });
             if let (Some(join_handle), Some(action_path)) = (task.join_handle.take(), action_path) {
+                // Deferred cleanup outlives the scheduler thread, so it must
+                // carry the caller's route to keep recovery attributable.
+                let notification_route = homeboy_core::notification_route::capture();
                 std::thread::spawn(move || {
-                    let joined = join_handle
-                        .join()
-                        .map_err(|_| "provider worker panicked".to_string());
-                    let mut recovered = deferred_timeout_outcome(
-                        &task.task_id,
-                        task.timeout_ms.unwrap_or_default(),
-                        "deferred_cleanup",
-                    );
-                    // A completed join proves the provider no longer owns the
-                    // checkout, so its committed candidate is safe to harvest.
-                    recovered.status = AgentTaskOutcomeStatus::Succeeded;
-                    recovered.failure_classification = None;
-                    let harvest = joined.and_then(|_| {
-                        super::harvest_uncommitted_patch(&mut recovered, &task)
-                            .and_then(|_| super::harvest_committed_patch(&mut recovered, &task))
-                            .map_err(|error| format!("{error:?}"))
-                    });
-                    if harvest.is_ok() {
-                        // The provider has exited, so runtime artifact discovery can no
-                        // longer race its writes to the isolated attempt workspace.
-                        Self::reconcile_timeout_artifacts(
-                            &mut recovered,
-                            &task.request,
+                    notification_route.bind(|| {
+                        let joined = join_handle
+                            .join()
+                            .map_err(|_| "provider worker panicked".to_string());
+                        let mut recovered = deferred_timeout_outcome(
+                            &task.task_id,
+                            task.timeout_ms.unwrap_or_default(),
                             "deferred_cleanup",
                         );
-                        super::finalize_candidate_artifacts(&mut recovered, &task);
-                    }
-                    super::engine::release_scratch(
-                        &task.scratch,
-                        "scheduler_timeout_completion",
-                        &recovered,
-                    );
-                    let cleanup = harvest.and_then(|_| {
-                        task._attempt_workspace
-                            .as_ref()
-                            .map(|workspace| workspace.cleanup())
-                            .unwrap_or(Ok(()))
-                    });
-                    super::complete_deferred_cleanup_recovery(&action_path, &recovered, cleanup);
+                        // A completed join proves the provider no longer owns the
+                        // checkout, so its committed candidate is safe to harvest.
+                        recovered.status = AgentTaskOutcomeStatus::Succeeded;
+                        recovered.failure_classification = None;
+                        let harvest = joined.and_then(|_| {
+                            super::harvest_uncommitted_patch(&mut recovered, &task)
+                                .and_then(|_| super::harvest_committed_patch(&mut recovered, &task))
+                                .map_err(|error| format!("{error:?}"))
+                        });
+                        if harvest.is_ok() {
+                            // The provider has exited, so runtime artifact discovery can no
+                            // longer race its writes to the isolated attempt workspace.
+                            Self::reconcile_timeout_artifacts(
+                                &mut recovered,
+                                &task.request,
+                                "deferred_cleanup",
+                            );
+                            super::finalize_candidate_artifacts(&mut recovered, &task);
+                        }
+                        super::engine::release_scratch(
+                            &task.scratch,
+                            "scheduler_timeout_completion",
+                            &recovered,
+                        );
+                        let cleanup = harvest.and_then(|_| {
+                            task._attempt_workspace
+                                .as_ref()
+                                .map(|workspace| workspace.cleanup())
+                                .unwrap_or(Ok(()))
+                        });
+                        super::complete_deferred_cleanup_recovery(
+                            &action_path,
+                            &recovered,
+                            cleanup,
+                        );
+                    })
                 });
             }
         }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -805,42 +805,48 @@ where
     let cooks = Arc::new(options.cooks);
     let next = Arc::new(Mutex::new(0usize));
     let (tx, rx) = mpsc::channel();
+    // The caller's route is thread-local, so each worker must re-bind it or its
+    // children submit unrouted and never notify the originating destination.
+    let notification_route = homeboy_core::notification_route::capture();
     std::thread::scope(|scope| {
         for _ in 0..workers {
             let cooks = Arc::clone(&cooks);
             let next = Arc::clone(&next);
             let tx = tx.clone();
             let executor = executor.clone();
-            scope.spawn(move || loop {
-                let index = {
-                    let mut next = next.lock().expect("cook batch work queue");
-                    if *next == cooks.len() {
-                        return;
-                    }
-                    let index = *next;
-                    *next += 1;
-                    index
-                };
-                let cook = cooks[index].clone();
-                let cell = match run_cook(cook.clone(), executor.clone()) {
-                    Ok(result) => AgentTaskCookBatchCellReport {
-                        cook_id: cook.cook_id,
-                        initial_run_id: cook.initial_run_id,
-                        status: result.value.status.clone(),
-                        exit_code: result.exit_code,
-                        result: Some(result.value),
-                        error: None,
-                    },
-                    Err(error) => AgentTaskCookBatchCellReport {
-                        cook_id: cook.cook_id,
-                        initial_run_id: cook.initial_run_id,
-                        status: "failed".to_string(),
-                        exit_code: 1,
-                        result: None,
-                        error: Some(error.to_string()),
-                    },
-                };
-                let _ = tx.send((index, cell));
+            let notification_route = notification_route.clone();
+            scope.spawn(move || {
+                notification_route.bind(|| loop {
+                    let index = {
+                        let mut next = next.lock().expect("cook batch work queue");
+                        if *next == cooks.len() {
+                            return;
+                        }
+                        let index = *next;
+                        *next += 1;
+                        index
+                    };
+                    let cook = cooks[index].clone();
+                    let cell = match run_cook(cook.clone(), executor.clone()) {
+                        Ok(result) => AgentTaskCookBatchCellReport {
+                            cook_id: cook.cook_id,
+                            initial_run_id: cook.initial_run_id,
+                            status: result.value.status.clone(),
+                            exit_code: result.exit_code,
+                            result: Some(result.value),
+                            error: None,
+                        },
+                        Err(error) => AgentTaskCookBatchCellReport {
+                            cook_id: cook.cook_id,
+                            initial_run_id: cook.initial_run_id,
+                            status: "failed".to_string(),
+                            exit_code: 1,
+                            result: None,
+                            error: Some(error.to_string()),
+                        },
+                    };
+                    let _ = tx.send((index, cell));
+                })
             });
         }
     });

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1256,6 +1256,42 @@ struct BatchAttemptDispatcher {
     fail: bool,
 }
 
+/// Records the notification route observed from inside the batch worker
+/// thread, so a lost thread-local binding is caught at the fanout boundary
+/// rather than only at the primitive.
+#[derive(Debug)]
+struct RouteObservingAttemptDispatcher {
+    observed: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+impl AgentTaskCookAttemptDispatcher for RouteObservingAttemptDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(serde_json::json!({ "kind": "test-route-observer" }))
+    }
+
+    fn dispatch_attempt(
+        &self,
+        _plan: AgentTaskPlan,
+        run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        self.observed
+            .lock()
+            .expect("observed routes")
+            .push(homeboy_core::notification_route::current().map(|route| route.route));
+        agent_task_lifecycle::record_detached_lab_run(
+            agent_task_lifecycle::DetachedLabRunRecord {
+                run_id,
+                runner_id: "fixture-lab",
+                runner_job_id: "fixture-job",
+                remote_workspace: "/runner/workspace",
+                remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+            },
+        )?;
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 struct AdmissionFailingAttemptDispatcher {
     message: &'static str,
@@ -2552,6 +2588,67 @@ fn cook_batch_preserves_order_concurrency_and_failure_isolation() {
             .status()
             .expect("run process-isolated cook batch");
     assert!(status.success());
+}
+
+#[test]
+fn cook_batch_children_inherit_the_callers_notification_route() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let status = context
+            .controller_runtime_command(homeboy_core::test_support::TestBinary::CurrentTest)
+            .args([
+                "--ignored",
+                "--exact",
+                "agent_task_service::cook::tests::cook_batch_children_inherit_the_callers_notification_route_process",
+            ])
+            .status()
+            .expect("run process-isolated cook batch route propagation");
+    assert!(status.success());
+}
+
+#[test]
+#[ignore = "invoked by cook_batch_children_inherit_the_callers_notification_route"]
+fn cook_batch_children_inherit_the_callers_notification_route_process() {
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let cooks = ["first", "second"]
+        .into_iter()
+        .map(|cook_id| {
+            batch_cook_options(
+                cook_id,
+                Arc::new(RouteObservingAttemptDispatcher {
+                    observed: Arc::clone(&observed),
+                }),
+            )
+        })
+        .collect::<Vec<_>>();
+    for cook in &cooks {
+        agent_task_lifecycle::submit_plan(&cook.initial_plan, Some(&cook.initial_run_id))
+            .expect("submit attempt");
+    }
+
+    let route = homeboy_core::notification_route::NotificationRoute::new(
+        "extension",
+        "opaque-fanout-route",
+    )
+    .expect("route");
+    homeboy_core::notification_route::with_current(Some(route), || {
+        run_cook_batch(
+            AgentTaskCookBatchOptions {
+                batch_id: "fixture-route-batch".to_string(),
+                cooks,
+                max_concurrency: 2,
+            },
+            UnusedExecutor,
+        )
+        .expect("batch completes")
+    });
+
+    // Every worker runs on its own thread; without propagation each would
+    // observe None and the originating destination would never be notified.
+    let observed = observed.lock().expect("observed routes").clone();
+    assert_eq!(observed.len(), 2);
+    for route in observed {
+        assert_eq!(route.as_deref(), Some("opaque-fanout-route"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #10282.

## Problem

Run-scoped notification routing shipped in #7787/#7804. It does not survive fan-out.

`NotificationRoute` is bound **thread-locally** (`notification_route.rs:13-15`, bound at `cli_runtime.rs:527`). Fan-out spawns new OS threads and never propagated it, so each child's durable record hit `if let Some(route) = notification_route::current()` (`lifecycle_ops.rs:385-387`) with `None`. The daemon's completion notifier then read the route back off the record (`daemon/mod.rs:1078-1080`), found none, and delivered nothing.

Net effect: `--notification-route` on `agent-task fanout cook-batch` was accepted, validated, and advertised in `--help`, then **silently discarded for every child**. No warning, no error, no diagnostic — "fan out N tasks and report to my chat thread" was structurally impossible.

## Fix

Extends the existing primitive rather than adding a contract:

```rust
pub fn capture() -> PropagatedNotificationRoute
impl PropagatedNotificationRoute { pub fn bind<T>(&self, operation: impl FnOnce() -> T) -> T }
```

Capture on the parent thread, re-bind inside the child body. Applied at the three production spawn sites:

| Site | Why it matters |
|---|---|
| `agent_task_service/cook.rs:814` | cook-batch workers — each creates child run records |
| `agent_task_scheduler/engine.rs:632` | the provider executor thread |
| `agent_task_scheduler/scheduling.rs:725` | deferred timeout cleanup, which outlives the scheduler thread |

Left alone deliberately: the cook heartbeat thread (`cook.rs:1966`) reports progress only — the plan body runs on the parent thread inside the scope and keeps its route.

## Tests

Two levels, because a primitive-only test would not have caught this:

- `captured_route_is_rebound_on_a_worker_thread` / `capture_without_a_bound_route_leaves_workers_unrouted` — the primitive.
- `cook_batch_children_inherit_the_callers_notification_route` — process-isolated, runs a real 2-worker `run_cook_batch` under a bound route and asserts **each worker thread** observes it. Without propagation both observe `None`.

## Verification

`cargo check -p homeboy-agents -p homeboy-lab-contract --lib --tests` → 0 errors. Full build/test left to CI per repo policy.