### PR TITLE
fix(cli): stop batch fanout from silently running every cook locally

### DIFF
--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -92,6 +92,11 @@ fn lab_cli_arguments_are_visible_for_path(path: &[String]) -> bool {
             | ["agent-task", "fanout", "submit-batch"]
             | ["agent-task", "fanout", "status"]
             | ["agent-task", "fanout", "artifacts"]
+            // The fanout coordinator is controller-owned, but split placement
+            // hands each child attempt to the selected runner, so the placement
+            // arguments are load-bearing here and must stay discoverable.
+            | ["agent-task", "fanout", "cook-batch"]
+            | ["agent-task", "fanout", "run-plan"]
             | ["agent-task", "auth", "status"]
             | ["agent-task", "controller", "from-spec"]
             | ["agent-task", "controller", "run-from-spec"]

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -98,10 +98,20 @@ pub fn route_after_parse(
 
     let lab_command = lab_offload_command(&cli.command)?;
 
+    // Keep the readiness verdict, not just the selected id: when no runner is
+    // eligible the reasons and remediation commands are the only thing that can
+    // explain a local fallback to the operator.
+    let lab_readiness = if lab_command.is_some() && cli.runner.is_none() {
+        runners::lab_runner_readiness().ok()
+    } else {
+        None
+    };
     let inferred_runner_id = if lab_command.is_some() {
-        cli.runner
-            .clone()
-            .or_else(|| runners::resolve_default_lab_runner().ok().flatten())
+        cli.runner.clone().or_else(|| {
+            lab_readiness
+                .as_ref()
+                .and_then(|readiness| readiness.selected_runner_id.clone())
+        })
     } else {
         None
     };
@@ -254,7 +264,9 @@ pub fn route_after_parse(
             if destructive_fuzz_requires_lab(&cli.command) {
                 return Err(destructive_fuzz_local_execution_error());
             }
-            if let Some(warning) = agent_task_local_fanout_warning(&cli.command) {
+            if let Some(warning) =
+                agent_task_local_fanout_warning(&cli.command, lab_readiness.as_ref())
+            {
                 eprintln!("{warning}");
             }
             Ok(None)
@@ -1385,25 +1397,83 @@ fn validate_lab_env_name(source: &str, name: &str) -> homeboy::core::Result<Stri
     Ok(name.to_string())
 }
 
-fn agent_task_local_fanout_warning(command: &Commands) -> Option<String> {
+/// Warn before N provider attempts run on the controller instead of the Lab.
+///
+/// Batch fanout is the command most likely to overwhelm a controller, so it is
+/// covered here alongside `cook`. When a Lab runner was looked for and none was
+/// eligible, the readiness verdict carries the only explanation of why, and its
+/// remediation commands are the operator's shortest path back to the Lab.
+fn agent_task_local_fanout_warning(
+    command: &Commands,
+    readiness: Option<&runners::LabRunnerReadiness>,
+) -> Option<String> {
+    use crate::commands::agent_task::{
+        AgentTaskArgs, AgentTaskCommand, AgentTaskFanoutArgs, AgentTaskFanoutCommand,
+    };
+
     let (label, concurrency, task_count) = match command {
-        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-            command: crate::commands::agent_task::AgentTaskCommand::Cook(args),
-        }) => (
-            "agent-task cook local fanout",
-            args.dispatch.concurrency,
-            args.dispatch.tasks.len()
+        Commands::AgentTask(AgentTaskArgs {
+            command: AgentTaskCommand::Cook(args),
+        }) => {
+            let tasks = args.dispatch.tasks.len()
                 + usize::from(args.dispatch.prompt.is_some())
-                + usize::from(args.dispatch.core.tasks_json.is_some()),
+                + usize::from(args.dispatch.core.tasks_json.is_some());
+            if args.dispatch.concurrency <= 1 && tasks <= 1 {
+                return None;
+            }
+            (
+                "agent-task cook local fanout",
+                args.dispatch.concurrency.to_string(),
+                tasks.to_string(),
+            )
+        }
+        Commands::AgentTask(AgentTaskArgs {
+            command:
+                AgentTaskCommand::Fanout(AgentTaskFanoutArgs {
+                    command: AgentTaskFanoutCommand::CookBatch(args),
+                }),
+        }) if args.run_plan && !args.dry_run => {
+            if args.issues.len() <= 1 {
+                return None;
+            }
+            // cook-batch has no --concurrency flag: local workers are capped by
+            // available parallelism, so report what will actually run.
+            let workers = std::thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1)
+                .min(args.issues.len());
+            (
+                "agent-task fanout cook-batch local fanout",
+                workers.to_string(),
+                args.issues.len().to_string(),
+            )
+        }
+        Commands::AgentTask(AgentTaskArgs {
+            command:
+                AgentTaskCommand::Fanout(AgentTaskFanoutArgs {
+                    command: AgentTaskFanoutCommand::RunPlan(_),
+                }),
+        }) => (
+            // The plan is read downstream, so the child count is not known here.
+            "agent-task fanout run-plan local fanout",
+            "available-parallelism".to_string(),
+            "plan-defined".to_string(),
         ),
         _ => return None,
     };
 
-    (concurrency > 1 || task_count > 1).then(|| {
-        format!(
-            "HOMEBOY_LOCAL_FANOUT_WARNING: {label} will execute on this controller with concurrency={concurrency}, tasks={task_count}, execution_location=local. Use --runner <runner-id> or --placement lab to prevent local provider fanout."
-        )
-    })
+    let mut warning = format!(
+        "HOMEBOY_LOCAL_FANOUT_WARNING: {label} will execute on this controller with concurrency={concurrency}, tasks={task_count}, execution_location=local. Use --runner <runner-id> or --placement lab to prevent local provider fanout."
+    );
+    if let Some(readiness) = readiness {
+        for reason in &readiness.reasons {
+            warning.push_str(&format!(" lab_unavailable_reason={reason}"));
+        }
+        for remediation in &readiness.remediation_commands {
+            warning.push_str(&format!(" remediation=`{remediation}`"));
+        }
+    }
+    Some(warning)
 }
 
 fn inject_lab_changed_files(

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1796,3 +1796,123 @@ fn rig_install_source_sync_root_skips_git_url_and_missing_paths() {
     ];
     assert_eq!(rig_install_source_sync_root(&missing), None);
 }
+
+#[test]
+fn local_fanout_warning_covers_batch_fanout_not_just_cook() {
+    // Batch fanout is the command most able to overwhelm a controller, so a
+    // silent local fallback here is worse than for a single cook.
+    let cli = Cli::parse_from([
+        "homeboy",
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "https://github.com/o/r/issues/1",
+        "https://github.com/o/r/issues/2",
+        "--repo",
+        "r",
+        "--verify",
+        "cargo test",
+        "--run-plan",
+    ]);
+    let warning =
+        agent_task_local_fanout_warning(&cli.command, None).expect("batch fanout warns locally");
+    assert!(warning.contains("HOMEBOY_LOCAL_FANOUT_WARNING"));
+    assert!(warning.contains("fanout cook-batch"));
+    assert!(warning.contains("tasks=2"));
+    assert!(warning.contains("execution_location=local"));
+}
+
+#[test]
+fn local_fanout_warning_is_silent_for_a_single_child() {
+    let cli = Cli::parse_from([
+        "homeboy",
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "https://github.com/o/r/issues/1",
+        "--repo",
+        "r",
+        "--verify",
+        "cargo test",
+        "--run-plan",
+    ]);
+    assert_eq!(agent_task_local_fanout_warning(&cli.command, None), None);
+}
+
+#[test]
+fn local_fanout_warning_is_silent_for_a_dry_run_plan() {
+    // A dry run never dispatches providers, so it cannot heat the controller.
+    let cli = Cli::parse_from([
+        "homeboy",
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "https://github.com/o/r/issues/1",
+        "https://github.com/o/r/issues/2",
+        "--repo",
+        "r",
+        "--verify",
+        "cargo test",
+        "--dry-run",
+        "--run-plan",
+    ]);
+    assert_eq!(agent_task_local_fanout_warning(&cli.command, None), None);
+}
+
+#[test]
+fn local_fanout_warning_carries_lab_readiness_reasons_and_remediation() {
+    let cli = Cli::parse_from([
+        "homeboy",
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "https://github.com/o/r/issues/1",
+        "https://github.com/o/r/issues/2",
+        "--repo",
+        "r",
+        "--verify",
+        "cargo test",
+        "--run-plan",
+    ]);
+    let readiness = runners::LabRunnerReadiness {
+        state: runners::LabRunnerReadinessState::Stale,
+        selected_runner_id: None,
+        available_runner_ids: vec!["lab-a".to_string()],
+        reasons: vec!["lab-a daemon is stale".to_string()],
+        remediation_commands: vec!["homeboy runner refresh-homeboy lab-a".to_string()],
+    };
+    let warning = agent_task_local_fanout_warning(&cli.command, Some(&readiness))
+        .expect("batch fanout warns locally");
+    // Without these the operator has no way to learn why the Lab was skipped.
+    assert!(warning.contains("lab_unavailable_reason=lab-a daemon is stale"));
+    assert!(warning.contains("remediation=`homeboy runner refresh-homeboy lab-a`"));
+}
+
+#[test]
+fn batch_fanout_exposes_placement_arguments() {
+    // Split placement hands each child to the selected runner, so hiding these
+    // made a load-bearing flag undiscoverable.
+    for path in [
+        ["agent-task", "fanout", "cook-batch"],
+        ["agent-task", "fanout", "run-plan"],
+    ] {
+        let command = homeboy::cli_surface::Cli::command_with_scoped_lab_args();
+        let leaf = path.iter().fold(&command, |command, segment| {
+            command
+                .get_subcommands()
+                .find(|candidate| candidate.get_name() == *segment)
+                .unwrap_or_else(|| panic!("{segment} subcommand exists"))
+        });
+        for flag in ["placement", "runner"] {
+            let arg = leaf
+                .get_arguments()
+                .find(|arg| arg.get_id() == flag)
+                .unwrap_or_else(|| panic!("{} exposes --{flag}", path.join(" ")));
+            assert!(
+                !arg.is_hide_set(),
+                "{} must advertise --{flag}",
+                path.join(" ")
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #10283.

## Problem

Three compounding defects made `agent-task fanout cook-batch` — the command meant to keep the controller cool — the one most likely to heat it.

**1. Load-bearing flags hidden.** The fanout *coordinator* is deliberately controller-owned (`agent_task_fanout_local_only_contract`), but `run_split_placement_fanout` hands **each child attempt** to the selected runner. So `--placement`/`--runner` matter here — yet `cook-batch` and `run-plan` were absent from `lab_cli_arguments_are_visible_for_path` (`command_contract/lab.rs:71-125`), leaving `--runner` functional but undiscoverable while sibling `fanout submit-batch` advertised it.

**2. The local-fanout warning excluded fanout.** `agent_task_local_fanout_warning` matched only `Cook` and returned `None` for everything else (`route.rs:1399`). N provider attempts could start on the controller with **no warning at all** — and `cook-batch` has no `--concurrency` flag, so local workers are capped only by `available_parallelism()`.

**3. The reason for the Lab miss was discarded.** `route.rs:104` called `resolve_default_lab_runner()`, which is `Ok(lab_runner_readiness()?.selected_runner_id)` — collapsing the struct to an `Option<String>`. `LabRunnerReadiness`'s own doc comment (`lib.rs:597-599`) warns against exactly this: *"consumers use this rather than reducing runner state to an optional default ID, which loses the reason a connected runner was not selected."*

## Fix

- Add `["agent-task","fanout","cook-batch"]` and `["agent-task","fanout","run-plan"]` to the visible-argument allowlist.
- Widen the warning to both fanout variants. It stays silent for a single child and for `--dry-run` (which never dispatches a provider).
- Resolve `lab_runner_readiness()` once and thread it into the warning, so a local fallback names the blocking reason and the remediation command.

Reports the **effective local worker count** for `cook-batch` rather than a `--concurrency` value that does not exist.

## Tests

- `local_fanout_warning_covers_batch_fanout_not_just_cook` — the regression.
- `local_fanout_warning_is_silent_for_a_single_child` / `..._for_a_dry_run_plan` — no false positives.
- `local_fanout_warning_carries_lab_readiness_reasons_and_remediation` — the operator can learn *why*.
- `batch_fanout_exposes_placement_arguments` — asserts against the real clap surface, so re-hiding these fails the build.

## Scope note

This deliberately does **not** change the `local_only` contract for the coordinator — that is correct and intentional. It makes the split-placement path that already exists discoverable and honest. Whether `--placement lab` should route children rather than error is a separate behavioral question, tracked in #10283 for follow-up.

## Verification

`cargo check -p homeboy-cli --lib --tests` → 0 errors. Full build/test left to CI per repo policy.