### PR TITLE
fix(core): make multi-extension artifact resolution deterministic

### DIFF
--- a/crates/homeboy-core/src/component/resolution.rs
+++ b/crates/homeboy-core/src/component/resolution.rs
@@ -4,7 +4,7 @@ use crate::component::{
 use crate::error::{Error, Result};
 use crate::git::run_git;
 use homeboy_extension_contract::ExtensionCapability;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Shared target-resolution input for component/path-oriented commands.
@@ -111,27 +111,86 @@ pub fn resolve_target_from_component(
     resolved_target_from_component(component, false)
 }
 
-pub fn resolve_artifact(component: &Component) -> Option<String> {
+/// Resolve the effective build artifact pattern for a component.
+///
+/// An explicit `build_artifact` always wins. Otherwise the pattern comes from
+/// the component's linked extensions.
+///
+/// `Component.extensions` is a `HashMap` with `RandomState`, so its iteration
+/// order differs on every process. A first-match-wins scan therefore resolved a
+/// *different* artifact path on different runs of the same binary whenever two
+/// linked extensions (e.g. `wordpress` + `nodejs`) both declared
+/// `build.artifact_pattern` — a silent wrong-artifact deploy (#10281). Every
+/// provider is collected instead, and the distinct rendered patterns decide:
+///
+/// - no provider → `Ok(None)`; the component is simply not artifact-producing
+/// - one distinct pattern → `Ok(Some(pattern))`, however many extensions
+///   declare it (agreeing extensions are not ambiguous)
+/// - conflicting patterns → [`crate::extension_execution::disambiguate_capability_owner`],
+///   the same ownership rule every other capability uses: explicit
+///   `capability_extensions.build`, then `composition.includes` primacy, then a
+///   hard ambiguity error the component author must resolve
+///
+/// Extensions that fail to load are skipped rather than failing resolution:
+/// a component may reference an extension that is not installed locally, and
+/// callers that require one (deploy planning) validate that separately.
+pub fn resolve_artifact(component: &Component) -> Result<Option<String>> {
     if let Some(ref artifact) = component.build_artifact {
-        return Some(artifact.clone());
+        return Ok(Some(artifact.clone()));
     }
 
-    if let Some(ref extensions) = component.extensions {
-        for extension_id in extensions.keys() {
-            if let Ok(manifest) = crate::extension_store::load_extension(extension_id) {
-                if let Some(ref build) = manifest.build {
-                    if let Some(ref pattern) = build.artifact_pattern {
-                        let resolved = pattern
-                            .replace("{component_id}", &component.id)
-                            .replace("{local_path}", &component.local_path);
-                        return Some(resolved);
-                    }
-                }
-            }
+    let providers = artifact_pattern_providers(component);
+    let distinct: BTreeSet<&str> = providers.values().map(String::as_str).collect();
+
+    match distinct.len() {
+        0 => Ok(None),
+        1 => Ok(distinct.into_iter().next().map(ToOwned::to_owned)),
+        _ => {
+            let candidates: Vec<String> = providers.keys().cloned().collect();
+            let owner = crate::extension_execution::disambiguate_capability_owner(
+                component,
+                ExtensionCapability::Build,
+                &candidates,
+            )?;
+            Ok(providers.get(&owner).cloned())
         }
     }
+}
 
-    None
+/// Linked extensions that declare a `build.artifact_pattern`, mapped to the
+/// pattern rendered for this component.
+///
+/// Keyed by extension ID in a `BTreeMap` so the candidate list handed to
+/// ambiguity resolution — and the error message listing it — is stable across
+/// runs, unlike the component's own `HashMap` iteration order.
+fn artifact_pattern_providers(component: &Component) -> BTreeMap<String, String> {
+    let mut providers = BTreeMap::new();
+
+    let Some(extensions) = component.extensions.as_ref() else {
+        return providers;
+    };
+
+    for extension_id in extensions.keys() {
+        let Ok(manifest) = crate::extension_store::load_extension(extension_id) else {
+            continue;
+        };
+        let Some(pattern) = manifest
+            .build
+            .as_ref()
+            .and_then(|build| build.artifact_pattern.as_ref())
+        else {
+            continue;
+        };
+
+        providers.insert(
+            extension_id.clone(),
+            pattern
+                .replace("{component_id}", &component.id)
+                .replace("{local_path}", &component.local_path),
+        );
+    }
+
+    providers
 }
 
 /// Validates component local_path is usable (absolute and exists).
@@ -989,7 +1048,7 @@ mod tests {
         };
 
         assert_eq!(
-            resolve_artifact(&explicit),
+            resolve_artifact(&explicit).expect("explicit artifact resolves"),
             Some("dist/plugin.zip".to_string())
         );
 
@@ -1005,7 +1064,155 @@ mod tests {
             ..Component::default()
         };
 
-        assert_eq!(resolve_artifact(&missing_extension), None);
+        assert_eq!(
+            resolve_artifact(&missing_extension).expect("unloadable extensions are skipped"),
+            None
+        );
+    }
+
+    /// Write an extension manifest that declares `build.artifact_pattern`, and
+    /// optionally composes the given extensions via `composition.includes`.
+    fn write_build_extension(home: &Path, id: &str, artifact_pattern: &str, includes: &[&str]) {
+        let dir = home.join(".config/homeboy/extensions").join(id);
+        std::fs::create_dir_all(&dir).expect("extension dir");
+
+        let mut manifest = serde_json::json!({
+            "name": id,
+            "version": "1.0.0",
+            "build": { "artifact_pattern": artifact_pattern },
+        });
+        if !includes.is_empty() {
+            manifest["composition"] = serde_json::json!({ "includes": includes });
+        }
+
+        std::fs::write(dir.join(format!("{id}.json")), manifest.to_string())
+            .expect("extension manifest");
+    }
+
+    fn component_with_extensions(id: &str, extension_ids: &[&str]) -> Component {
+        Component {
+            id: id.to_string(),
+            local_path: format!("/tmp/{id}"),
+            extensions: Some(
+                extension_ids
+                    .iter()
+                    .map(|extension_id| {
+                        (
+                            (*extension_id).to_string(),
+                            ScopedExtensionConfig::default(),
+                        )
+                    })
+                    .collect(),
+            ),
+            ..Component::default()
+        }
+    }
+
+    /// Resolution repeated enough times that `HashMap` iteration order over the
+    /// component's linked extensions would have varied within the run. Every
+    /// call must agree — that is the whole point of #10281.
+    fn resolve_artifact_repeatedly(component: &Component) -> Vec<Result<Option<String>>> {
+        (0..32).map(|_| resolve_artifact(component)).collect()
+    }
+
+    #[test]
+    fn resolve_artifact_uses_single_extension_artifact_pattern() {
+        crate::test_support::with_isolated_home(|home| {
+            write_build_extension(home.path(), "wordpress", "build/{component_id}.zip", &[]);
+
+            let component = component_with_extensions("plugin", &["wordpress"]);
+
+            assert_eq!(
+                resolve_artifact(&component).expect("single provider resolves"),
+                Some("build/plugin.zip".to_string())
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_artifact_accepts_two_extensions_declaring_the_same_pattern() {
+        crate::test_support::with_isolated_home(|home| {
+            // Two providers that agree are not ambiguous: whichever one the
+            // HashMap yields first, the resolved artifact is identical.
+            write_build_extension(home.path(), "wordpress", "build/{component_id}.zip", &[]);
+            write_build_extension(home.path(), "nodejs", "build/{component_id}.zip", &[]);
+
+            let component = component_with_extensions("plugin", &["wordpress", "nodejs"]);
+
+            for resolved in resolve_artifact_repeatedly(&component) {
+                assert_eq!(
+                    resolved.expect("agreeing providers are unambiguous"),
+                    Some("build/plugin.zip".to_string())
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn resolve_artifact_conflicting_patterns_fail_deterministically() {
+        crate::test_support::with_isolated_home(|home| {
+            // Two providers that disagree used to be a coin flip decided by
+            // HashMap iteration order — the same binary could deploy
+            // `build/plugin.zip` on one run and `dist/plugin.tgz` on the next.
+            write_build_extension(home.path(), "wordpress", "build/{component_id}.zip", &[]);
+            write_build_extension(home.path(), "nodejs", "dist/{component_id}.tgz", &[]);
+
+            let component = component_with_extensions("plugin", &["wordpress", "nodejs"]);
+
+            for resolved in resolve_artifact_repeatedly(&component) {
+                let err = resolved.expect_err("conflicting artifact patterns must not be guessed");
+                assert_eq!(err.code.as_str(), "validation.invalid_argument");
+                // The exact message is stable too, including the provider list.
+                assert_eq!(
+                    err.message,
+                    "Component 'plugin' has multiple linked extensions with build support: nodejs, wordpress"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn resolve_artifact_conflict_is_resolved_by_capability_extensions() {
+        crate::test_support::with_isolated_home(|home| {
+            write_build_extension(home.path(), "wordpress", "build/{component_id}.zip", &[]);
+            write_build_extension(home.path(), "nodejs", "dist/{component_id}.tgz", &[]);
+
+            let mut component = component_with_extensions("plugin", &["wordpress", "nodejs"]);
+            component
+                .capability_extensions
+                .insert("build".to_string(), "nodejs".to_string());
+
+            for resolved in resolve_artifact_repeatedly(&component) {
+                assert_eq!(
+                    resolved.expect("explicit ownership resolves the conflict"),
+                    Some("dist/plugin.tgz".to_string())
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn resolve_artifact_conflict_is_resolved_by_composition_primary() {
+        crate::test_support::with_isolated_home(|home| {
+            // WordPress composes Node.js, so it owns the shared build
+            // capability — the same rule every other capability follows.
+            write_build_extension(
+                home.path(),
+                "wordpress",
+                "build/{component_id}.zip",
+                &["nodejs"],
+            );
+            write_build_extension(home.path(), "nodejs", "dist/{component_id}.tgz", &[]);
+
+            let component = component_with_extensions("plugin", &["wordpress", "nodejs"]);
+
+            for resolved in resolve_artifact_repeatedly(&component) {
+                assert_eq!(
+                    resolved.expect("composition primary resolves the conflict"),
+                    Some("build/plugin.zip".to_string())
+                );
+            }
+        });
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension_execution.rs
+++ b/crates/homeboy-core/src/extension_execution.rs
@@ -265,20 +265,49 @@ fn resolve_extension_for_capability_if_available(
     match matching.len() {
         0 => Ok(None),
         1 => Ok(Some(matching.remove(0))),
-        _ => {
-            // The manifests can encode which linked extension is primary via
-            // `composition.includes`: a component that links WordPress + Node.js
-            // has WordPress declare `includes: ["nodejs"]`, so WordPress owns the
-            // shared capabilities and Node.js is the composed subordinate. When
-            // exactly one of the ambiguous extensions includes all the others,
-            // resolve to it instead of forcing a manual `capability_extensions`
-            // selection. Explicit selection (handled above) still wins.
-            if let Some(primary) = composition_primary_extension(&matching)? {
-                return Ok(Some(primary));
-            }
-            Err(capability_ambiguous_error(component, capability, &matching))
+        _ => disambiguate_capability_owner(component, capability, &matching).map(Some),
+    }
+}
+
+/// Pick the owning extension when several linked extensions provide the same
+/// capability.
+///
+/// This is the single ownership rule for multi-extension components, shared by
+/// capability execution resolution and by artifact-pattern resolution
+/// ([`crate::component::resolve_artifact`]) so both stay deterministic and
+/// agree on who owns a contested capability:
+///
+/// 1. explicit `capability_extensions.<capability>` selection, when it names
+///    one of the candidates;
+/// 2. `composition.includes` primacy — the manifests can encode which linked
+///    extension is primary: a component that links WordPress + Node.js has
+///    WordPress declare `includes: ["nodejs"]`, so WordPress owns the shared
+///    capabilities and Node.js is the composed subordinate. When exactly one
+///    of the candidates includes all the others, resolve to it instead of
+///    forcing a manual `capability_extensions` selection;
+/// 3. otherwise the ambiguity is genuine and the component author must resolve
+///    it, so this returns [`capability_ambiguous_error`].
+///
+/// `candidates` must be in a deterministic order (the error message lists
+/// them), and must never be empty.
+pub(crate) fn disambiguate_capability_owner(
+    component: &Component,
+    capability: ExtensionCapability,
+    candidates: &[String],
+) -> Result<String> {
+    if let Some(explicit) = explicit_capability_extension(component, capability) {
+        if let Some(selected) = candidates.iter().find(|id| id.as_str() == explicit) {
+            return Ok(selected.clone());
         }
     }
+
+    if let Some(primary) = composition_primary_extension(candidates)? {
+        return Ok(primary);
+    }
+
+    Err(capability_ambiguous_error(
+        component, capability, candidates,
+    ))
 }
 
 /// If exactly one of the ambiguous extensions composes all of the others via its

--- a/crates/homeboy-core/src/project/readiness.rs
+++ b/crates/homeboy-core/src/project/readiness.rs
@@ -53,7 +53,11 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
                 Some(&standalone_snapshot),
             ) {
                 let is_git = comp.deploy_strategy.as_deref() == Some("git");
-                let has_artifact = component::resolve_artifact(&comp).is_some();
+                // An ambiguous artifact owner is an authoring error, not a
+                // readiness signal, and this closure has no error channel. Treat
+                // it as "not deployable" here; `build`/`deploy` surface the
+                // actionable ambiguity error when the component is used.
+                let has_artifact = component::resolve_artifact(&comp).ok().flatten().is_some();
                 is_git || has_artifact
             } else {
                 false

--- a/crates/homeboy-extension/src/build/mod.rs
+++ b/crates/homeboy-extension/src/build/mod.rs
@@ -757,7 +757,7 @@ fn apply_artifact_inputs(comp: &Component) -> Result<Vec<ResolvedArtifactInput>>
         return Ok(Vec::new());
     }
 
-    let artifact_pattern = component::resolve_artifact(comp).ok_or_else(|| {
+    let artifact_pattern = component::resolve_artifact(comp)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "build_artifact",
             format!(

--- a/crates/homeboy-release/src/deploy/planning.rs
+++ b/crates/homeboy-release/src/deploy/planning.rs
@@ -810,12 +810,44 @@ pub(super) fn load_project_components_with_projection(
             continue;
         }
 
-        // Resolve effective artifact (component value OR extension pattern)
-        let effective_artifact = component::resolve_artifact(&loaded);
-
         // Git-deploy and file-deploy components don't need a build artifact
         let is_git_deploy = loaded.deploy_strategy.as_deref() == Some("git");
         let is_file_deploy = loaded.deploy_strategy.as_deref() == Some("file");
+
+        // Resolve effective artifact (component value OR extension pattern).
+        //
+        // Skipped for git/file deploys, which ignore the artifact entirely — they
+        // must not be blocked by an artifact-ownership conflict they never
+        // consult. For everyone else, two linked extensions declaring different
+        // `artifact_pattern`s is now a hard error instead of a HashMap-order coin
+        // flip that deployed a different artifact on different runs (#10281).
+        // It is reported like a missing extension: fatal for a component the
+        // operator actually asked to deploy, skip-and-warn otherwise, so one
+        // misconfigured component cannot poison a whole project-wide pass (#4587).
+        let effective_artifact = if is_git_deploy || is_file_deploy {
+            None
+        } else {
+            match component::resolve_artifact(&loaded) {
+                Ok(artifact) => artifact,
+                Err(err) => {
+                    if is_requested && !check {
+                        return Err(err);
+                    }
+
+                    let reason = err.message.clone();
+                    homeboy_core::log_status!("deploy", "Skipping '{}': {}", loaded.id, reason);
+                    if check {
+                        extension_skipped.push(ExtensionSkippedComponent {
+                            id: loaded.id.clone(),
+                            reason,
+                        });
+                    } else {
+                        skipped.push(loaded.id.clone());
+                    }
+                    continue;
+                }
+            }
+        };
 
         match effective_artifact {
             Some(artifact) if !is_git_deploy && !is_file_deploy => {

--- a/crates/homeboy-release/src/deploy/preparation.rs
+++ b/crates/homeboy-release/src/deploy/preparation.rs
@@ -629,7 +629,7 @@ fn configured_artifact_path(component: &Component) -> Result<PathBuf> {
 }
 
 fn artifact_pattern(component: &Component) -> Result<String> {
-    homeboy_core::component::resolve_artifact(component).ok_or_else(|| {
+    homeboy_core::component::resolve_artifact(component)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "build_artifact",
             "Component has no build artifact configured by itself or a linked extension",


### PR DESCRIPTION
Closes #10281

## The bug

`component::resolve_artifact` scanned `Component.extensions` and returned the **first** linked extension declaring `build.artifact_pattern`. `Component.extensions` is a `HashMap<String, ScopedExtensionConfig>` with `RandomState`, so iteration order differs on every process.

**User-visible consequence:** a component linking two extensions that both declare an artifact pattern (e.g. `wordpress` + `nodejs`) resolved a *different deploy artifact on different runs of the same binary*, with no warning. `homeboy deploy` could ship `build/plugin.zip` on one run and `dist/plugin.tgz` on the next — a silent wrong-artifact deploy, and irreproducible build/release output.

## `resolve_artifact` was the outlier

Every sibling multi-extension resolver in the same module already handled this:

| Call site | Accumulator | Ambiguity handling |
|---|---|---|
| `component/remote_path.rs:38-59` | `HashSet` | requires `matches.len() == 1`, else `None` |
| `component/drift.rs:69-81` | `BTreeSet` | order-independent union (all values kept) |
| `extension_execution.rs:256-281` | `Vec` | `composition.includes` primacy, else `capability_ambiguous_error` |
| **`component/resolution.rs:119-132`** | **none** | **first match wins — non-deterministic** |

## The fix

`resolve_artifact` now collects **every** provider (keyed by extension ID in a `BTreeMap`, so the candidate list and the error message that lists it are stable), deduplicates the rendered patterns, and:

- **no provider** → `Ok(None)` — unchanged; the component is simply not artifact-producing
- **one distinct pattern** → `Ok(Some(pattern))`, however many extensions declare it — agreeing extensions are not a conflict
- **conflicting patterns** → the existing capability-ownership rule

## Disambiguation strategy: error, not `None`

Per the issue's guidance I checked whether `capability_ambiguous_error` was reachable, and it is — same crate (`homeboy-core`), no layering violation. **The callers forced this choice.** Mirroring `remote_path.rs` and returning `None` would have collapsed "two extensions disagree" into "no artifact configured", which in `deploy/planning.rs` prints `Skipping '<id>': no artifact configured (non-deployable component)` — actively misleading for a component that declares two artifacts. The other three callers would have been equally silent.

So the ambiguous case reuses the established ownership rule instead of inventing one. The tail of `resolve_extension_for_capability_if_available` is extracted into `disambiguate_capability_owner`, now shared by both call sites:

1. explicit `capability_extensions.build` — the existing escape hatch (`model.rs:82`), no new contract
2. `composition.includes` primacy — a component linking `wordpress` + `nodejs` where WordPress declares `includes: ["nodejs"]` resolves to WordPress, exactly as `deps`/`test`/`lint` already do for the same pair. Without this, the very pair named in the issue would have started erroring where every other capability resolves cleanly.
3. otherwise `capability_ambiguous_error` — genuine ambiguity the component author must resolve

No new config field and no new error variant.

## Signature change and callers

`resolve_artifact` returns `Result<Option<String>>` so the ambiguity can surface. Four callers:

- `homeboy-extension/src/build/mod.rs:760` and `homeboy-release/src/deploy/preparation.rs:632` already errored on `None` — they just propagate with `?`.
- `homeboy-release/src/deploy/planning.rs` resolves the artifact only for non-git/non-file deploys (those strategies ignore it entirely and must not be blocked by a conflict they never consult). A conflict is reported like a missing extension: fatal for a component the operator actually requested, skip-and-warn otherwise, so one misconfigured component cannot poison a project-wide `--check` pass (per #4587).
- `homeboy-core/src/project/readiness.rs:56` has no error channel (returns `(bool, Vec<String>)` from inside an `.any()` closure), so a conflict counts as not-deployable there; `build`/`deploy` surface the actionable message.

Extensions that fail to load are still skipped rather than failing resolution — a component may reference an extension that is not installed locally, and deploy planning validates that separately.

## Tests

All in `crates/homeboy-core/src/component/resolution.rs`, using the existing `with_isolated_home` + extension-manifest fixture style. The three conflict/agreement tests resolve 32 times per run, so `HashMap` order would have varied within a single test:

- `resolve_artifact_uses_single_extension_artifact_pattern` — one provider resolves as before, including `{component_id}` substitution
- `resolve_artifact_accepts_two_extensions_declaring_the_same_pattern` — two extensions, identical pattern → not ambiguous
- `resolve_artifact_conflicting_patterns_fail_deterministically` — two extensions, different patterns → same `Err` every time, asserting the **exact** message (including the alphabetized provider list `nodejs, wordpress`), so neither the outcome nor the wording can drift with map order
- `resolve_artifact_conflict_is_resolved_by_capability_extensions` — `capability_extensions.build` makes it deterministic
- `resolve_artifact_conflict_is_resolved_by_composition_primary` — `composition.includes` makes it deterministic
- `test_resolve_artifact` updated for the new signature; the "unloadable extension → `None`" tolerance is still asserted

## Verification

`cargo fmt` only. Full build/test is left to CI per repo policy (this host cannot absorb a homeboy cargo build).
