### PR TITLE
fix(core): honor configured retention in controller-runtime prune

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -624,10 +624,14 @@ pub fn pin_current_controller_runtime(
 
 /// Prune immutable controller pins through the durable lifecycle ownership
 /// boundary so nonterminal records remain authoritative retention roots.
+///
+/// Retention policy is resolved by core from the operator's configuration; this
+/// boundary only forwards the overrides an operator typed.
 pub fn prune_controller_runtime_pins(
     apply: bool,
+    overrides: homeboy_core::controller_runtime::ControllerRuntimeRetentionOverrides,
 ) -> Result<homeboy_core::controller_runtime::ControllerRuntimePruneResult> {
-    homeboy_core::controller_runtime::prune_pins(apply)
+    homeboy_core::controller_runtime::prune_pins(apply, overrides)
 }
 
 fn migrate_record_controller_runtime(record: &mut AgentTaskRunRecord) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -277,11 +277,17 @@ fn controller_runtime_retention_keeps_mutable_and_retained_terminal_runs() {
             homeboy_core::controller_runtime::retention_report().expect("retention report");
         assert!(report.retained.contains(&active_pin));
         assert!(report.retained.contains(&terminal_pin));
-        let dry_run = prune_controller_runtime_pins(false).expect("plan pin pruning");
+        // Opt out of the configured age/size window so this asserts reference
+        // retention specifically, not "nothing was old enough to delete".
+        let purge = homeboy_core::controller_runtime::ControllerRuntimeRetentionOverrides {
+            limit: None,
+            ignore_retention: true,
+        };
+        let dry_run = prune_controller_runtime_pins(false, purge).expect("plan pin pruning");
         assert!(dry_run.retained.contains(&active_pin));
         assert!(dry_run.retained.contains(&terminal_pin));
         assert!(dry_run.removed.is_empty());
-        let applied = prune_controller_runtime_pins(true).expect("prune unreferenced pins");
+        let applied = prune_controller_runtime_pins(true, purge).expect("prune unreferenced pins");
         assert!(!applied.removed.contains(&terminal_pin));
         assert!(active_pin.exists());
         assert!(terminal_pin.exists());

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -6,7 +6,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use homeboy::core::cleanup::{
     self, ArtifactCleanupOptions, ArtifactCleanupSort, ResourceCleanupOptions,
 };
-use homeboy::core::controller_runtime::{self, ControllerRuntimeCleanupOptions};
+use homeboy::core::controller_runtime::{self, ControllerRuntimeRetentionOverrides};
 use homeboy::core::defaults;
 use homeboy::core::engine;
 use homeboy::core::engine::shell::quote_arg;
@@ -682,8 +682,8 @@ const CONTROLLER_RUNTIMES_METADATA: CleanupInventoryCategoryMetadata =
     CleanupInventoryCategoryMetadata {
         category: "controller_runtimes",
         include_arg: "controller-runtimes",
-        dry_run_command: "homeboy cleanup --include controller-runtimes",
-        apply_command: "homeboy cleanup --include controller-runtimes --apply",
+        dry_run_command: "homeboy runtime controller-prune",
+        apply_command: "homeboy runtime controller-prune --apply",
     };
 
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
@@ -869,14 +869,15 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
         )?);
     }
     if selected.includes(CleanupCategoryArg::ControllerRuntimes) {
-        let output = controller_runtime::cleanup(ControllerRuntimeCleanupOptions {
+        // Policy is resolved by core so this path and `homeboy runtime
+        // controller-prune` cannot drift apart again (#10288).
+        let output = controller_runtime::cleanup(controller_runtime::resolve_cleanup_options(
             apply,
-            min_age: std::time::Duration::from_secs(
-                configured.controller_runtime_days.saturating_mul(86_400),
-            ),
-            max_total_bytes: configured.controller_runtime_max_bytes,
-            limit: usize::try_from(limit).unwrap_or(usize::MAX),
-        })?;
+            ControllerRuntimeRetentionOverrides {
+                limit: Some(limit),
+                ignore_retention: false,
+            },
+        ))?;
         let estimated_bytes = output
             .snapshots
             .iter()
@@ -2064,8 +2065,8 @@ mod tests {
                 CONTROLLER_RUNTIMES_METADATA,
                 "controller_runtimes",
                 "controller-runtimes",
-                "homeboy cleanup --include controller-runtimes",
-                "homeboy cleanup --include controller-runtimes --apply",
+                "homeboy runtime controller-prune",
+                "homeboy runtime controller-prune --apply",
             ),
         ];
 

--- a/crates/homeboy-cli/src/commands/infra/runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/runtime.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use homeboy::core::controller_runtime::ControllerRuntimeRetentionOverrides;
 use serde::Serialize;
 
 use crate::commands::CmdResult;
@@ -36,6 +37,11 @@ enum RuntimeCommand {
         /// Delete pins not retained by nonterminal durable runs or the active generation.
         #[arg(long)]
         apply: bool,
+
+        /// Purge every unreferenced pin, ignoring the configured controller
+        /// runtime retention window. Destructive: prefer the configured window.
+        #[arg(long)]
+        ignore_retention: bool,
     },
 }
 
@@ -92,6 +98,12 @@ pub struct RuntimePromotionTakeoverOutput {
 pub struct ControllerRuntimePruneOutput {
     command: String,
     apply: bool,
+    /// Retention policy actually applied, so an operator can see the configured
+    /// window is honored instead of inferring it from what disappeared.
+    ignore_retention: bool,
+    min_age_seconds: u64,
+    max_total_bytes: u64,
+    limit: usize,
     retained: Vec<String>,
     eligible: Vec<String>,
     removed: Vec<String>,
@@ -108,7 +120,10 @@ pub fn run(args: RuntimeArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
             revision,
         } => refresh_runtime_package(&runtime_id, &source, revision.as_deref()),
         RuntimeCommand::PromotionTakeover => promotion_takeover(),
-        RuntimeCommand::ControllerPrune { apply } => controller_prune(apply),
+        RuntimeCommand::ControllerPrune {
+            apply,
+            ignore_retention,
+        } => controller_prune(apply, ignore_retention),
     }
 }
 
@@ -145,8 +160,16 @@ pub fn run_plain_text(args: RuntimeArgs) -> homeboy::core::Result<(String, i32)>
     }
 }
 
-fn controller_prune(apply: bool) -> CmdResult<RuntimeOutput> {
-    let result = homeboy::agents::agent_tasks::lifecycle::prune_controller_runtime_pins(apply)?;
+fn controller_prune(apply: bool, ignore_retention: bool) -> CmdResult<RuntimeOutput> {
+    let overrides = ControllerRuntimeRetentionOverrides {
+        limit: None,
+        ignore_retention,
+    };
+    // Resolved by the same core helper the prune itself uses, so the reported
+    // policy cannot describe a window the deletion did not apply.
+    let policy = homeboy::core::controller_runtime::resolve_cleanup_options(apply, overrides);
+    let result =
+        homeboy::agents::agent_tasks::lifecycle::prune_controller_runtime_pins(apply, overrides)?;
     let stringify = |paths: Vec<std::path::PathBuf>| {
         paths
             .into_iter()
@@ -157,6 +180,10 @@ fn controller_prune(apply: bool) -> CmdResult<RuntimeOutput> {
         RuntimeOutput::ControllerPrune(ControllerRuntimePruneOutput {
             command: "runtime.controller_prune".to_string(),
             apply,
+            ignore_retention,
+            min_age_seconds: policy.min_age.as_secs(),
+            max_total_bytes: policy.max_total_bytes,
+            limit: policy.limit,
             retained: stringify(result.retained),
             eligible: stringify(result.eligible),
             removed: stringify(result.removed),

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -127,6 +127,60 @@ pub struct ControllerRuntimeCleanupOptions {
     pub limit: usize,
 }
 
+/// Operator overrides layered on top of the configured controller runtime
+/// retention window.
+///
+/// Controller runtime cleanup has two supported entry points — `homeboy
+/// cleanup --include controller-runtimes` and `homeboy runtime
+/// controller-prune`. Both resolve their effective policy through
+/// [`resolve_cleanup_options`] so one command cannot honor the operator's
+/// configured window while the other silently deletes outside it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ControllerRuntimeRetentionOverrides {
+    /// Operator `--limit`. `None` uses the configured retention limit.
+    pub limit: Option<i64>,
+    /// Explicit opt-in to a policy-free purge. Deleting pins the configured
+    /// window still protects is destructive, so it is never the default.
+    pub ignore_retention: bool,
+}
+
+/// Resolve the effective cleanup policy from persisted configuration.
+///
+/// This is the single place controller runtime retention becomes concrete
+/// numbers. Call sites pass only what an operator typed; they never invent a
+/// window of their own.
+pub fn resolve_cleanup_options(
+    apply: bool,
+    overrides: ControllerRuntimeRetentionOverrides,
+) -> ControllerRuntimeCleanupOptions {
+    cleanup_options_from_retention(apply, overrides, &crate::defaults::load_config().retention)
+}
+
+fn cleanup_options_from_retention(
+    apply: bool,
+    overrides: ControllerRuntimeRetentionOverrides,
+    retention: &crate::defaults::RetentionConfig,
+) -> ControllerRuntimeCleanupOptions {
+    if overrides.ignore_retention {
+        // The historical unbounded purge, now reachable only by explicit
+        // operator opt-in: every eligible identity is expired and over budget.
+        return ControllerRuntimeCleanupOptions {
+            apply,
+            min_age: Duration::ZERO,
+            max_total_bytes: 0,
+            limit: usize::MAX,
+        };
+    }
+    ControllerRuntimeCleanupOptions {
+        apply,
+        min_age: Duration::from_secs(retention.controller_runtime_days.saturating_mul(86_400)),
+        max_total_bytes: retention.controller_runtime_max_bytes,
+        // A nonsensical negative limit fails closed at zero removals rather
+        // than widening into an unbounded delete.
+        limit: usize::try_from(overrides.limit.unwrap_or(retention.limit)).unwrap_or(0),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct ControllerRuntimePruneResult {
     pub retained: Vec<PathBuf>,
@@ -246,22 +300,14 @@ fn retention_report_with_references_at(
 }
 
 /// Remove only content-addressed pins not referenced by a nonterminal durable
-/// record or the active generation. The caller chooses mutation explicitly.
-pub fn prune_pins(apply: bool) -> Result<ControllerRuntimePruneResult> {
-    let result = cleanup(ControllerRuntimeCleanupOptions {
-        apply,
-        min_age: Duration::ZERO,
-        max_total_bytes: 0,
-        limit: usize::MAX,
-    })?;
-    Ok(ControllerRuntimePruneResult {
-        retained: result.retained,
-        eligible: result.eligible,
-        removed: result.removed,
-        removed_identities: result.removed_identities,
-        reclaimed_bytes: result.reclaimed_bytes,
-        snapshots: result.snapshots,
-    })
+/// record or the active generation, and only those the configured retention
+/// window no longer protects. The caller chooses mutation explicitly, and may
+/// opt out of the window explicitly through the overrides.
+pub fn prune_pins(
+    apply: bool,
+    overrides: ControllerRuntimeRetentionOverrides,
+) -> Result<ControllerRuntimePruneResult> {
+    cleanup(resolve_cleanup_options(apply, overrides))
 }
 
 /// Inventory and reclaim immutable runtime identities. The admission lock makes
@@ -3239,6 +3285,137 @@ mod tests {
             assert!(applied.removed.contains(&stale_pin));
             assert!(current_pin.exists());
             assert!(!stale_pin.exists());
+        });
+    }
+
+    #[cfg(unix)]
+    fn save_retention_config(retention: crate::defaults::RetentionConfig) {
+        crate::defaults::save_config(&crate::defaults::HomeboyConfig {
+            retention,
+            ..crate::defaults::HomeboyConfig::default()
+        })
+        .expect("save retention config");
+    }
+
+    #[test]
+    fn resolved_prune_policy_reads_configuration_and_purges_only_on_opt_in() {
+        let retention = crate::defaults::RetentionConfig {
+            controller_runtime_days: 14,
+            controller_runtime_max_bytes: 4096,
+            limit: 7,
+            ..crate::defaults::RetentionConfig::default()
+        };
+
+        let configured = cleanup_options_from_retention(
+            true,
+            ControllerRuntimeRetentionOverrides::default(),
+            &retention,
+        );
+        assert_eq!(configured.min_age, Duration::from_secs(14 * 86_400));
+        assert_eq!(configured.max_total_bytes, 4096);
+        assert_eq!(configured.limit, 7);
+
+        let overridden = cleanup_options_from_retention(
+            true,
+            ControllerRuntimeRetentionOverrides {
+                limit: Some(2),
+                ignore_retention: false,
+            },
+            &retention,
+        );
+        assert_eq!(overridden.limit, 2);
+        assert_eq!(overridden.min_age, configured.min_age);
+        assert_eq!(overridden.max_total_bytes, configured.max_total_bytes);
+
+        let purge = cleanup_options_from_retention(
+            true,
+            ControllerRuntimeRetentionOverrides {
+                limit: Some(2),
+                ignore_retention: true,
+            },
+            &retention,
+        );
+        assert_eq!(purge.min_age, Duration::ZERO);
+        assert_eq!(purge.max_total_bytes, 0);
+        assert_eq!(purge.limit, usize::MAX);
+
+        let negative = cleanup_options_from_retention(
+            true,
+            ControllerRuntimeRetentionOverrides {
+                limit: Some(-1),
+                ignore_retention: false,
+            },
+            &retention,
+        );
+        assert_eq!(negative.limit, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_pins_honors_the_configured_window_until_a_purge_is_requested() {
+        crate::test_support::with_isolated_home(|_| {
+            save_retention_config(crate::defaults::RetentionConfig {
+                controller_runtime_days: 3_650,
+                controller_runtime_max_bytes: u64::MAX,
+                limit: 10,
+                ..crate::defaults::RetentionConfig::default()
+            });
+            let temporary = tempfile::tempdir().expect("temporary controller directory");
+            let stale = temporary.path().join("stale");
+            let digest = fake_controller(&stale, "homeboy test+stale", "stale");
+            let pin = pinned_path("homeboy test+stale", &digest).expect("stale path");
+            publish_pin(&stale, &pin, &digest).expect("publish stale");
+
+            // Unreferenced, so eligible — but still inside the operator's
+            // configured age and size budget, so it must survive.
+            let planned = prune_pins(false, ControllerRuntimeRetentionOverrides::default())
+                .expect("plan inside configured window");
+            assert!(planned.eligible.contains(&pin));
+            let applied = prune_pins(true, ControllerRuntimeRetentionOverrides::default())
+                .expect("apply inside configured window");
+            assert!(applied.removed.is_empty());
+            assert!(pin.exists());
+
+            let purged = prune_pins(
+                true,
+                ControllerRuntimeRetentionOverrides {
+                    limit: None,
+                    ignore_retention: true,
+                },
+            )
+            .expect("explicit policy-free purge");
+            assert!(purged.removed.contains(&pin));
+            assert!(!pin.exists());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_pins_bounds_removals_by_the_configured_limit() {
+        crate::test_support::with_isolated_home(|_| {
+            save_retention_config(crate::defaults::RetentionConfig {
+                controller_runtime_days: 0,
+                controller_runtime_max_bytes: u64::MAX,
+                limit: 1,
+                ..crate::defaults::RetentionConfig::default()
+            });
+            let temporary = tempfile::tempdir().expect("temporary controller directory");
+            let pins = (0..3)
+                .map(|index| {
+                    let artifact = temporary.path().join(format!("stale-{index}"));
+                    let identity = format!("homeboy test+stale-{index}");
+                    let digest = fake_controller(&artifact, &identity, &format!("stale {index}"));
+                    let pin = pinned_path(&identity, &digest).expect("stale path");
+                    publish_pin(&artifact, &pin, &digest).expect("publish stale");
+                    pin
+                })
+                .collect::<Vec<_>>();
+
+            let applied = prune_pins(true, ControllerRuntimeRetentionOverrides::default())
+                .expect("apply configured limit");
+
+            assert_eq!(applied.removed_identities.len(), 1);
+            assert_eq!(pins.iter().filter(|pin| pin.exists()).count(), 2);
         });
     }
 

--- a/docs/commands/runtime.md
+++ b/docs/commands/runtime.md
@@ -38,3 +38,25 @@ Use `--plain` when a shell wrapper needs a sourceable path without parsing JSON:
 ```bash
 source "$(homeboy runtime helper path --plain runner-prelude.sh)"
 ```
+
+## Controller Runtime Pruning
+
+`homeboy runtime controller-prune` is the specialist command behind the
+`controller_runtimes` cleanup category. It removes only content-addressed
+controller pins that no nonterminal durable run and no active admission
+generation still reference.
+
+```bash
+homeboy runtime controller-prune
+homeboy runtime controller-prune --apply
+```
+
+Pruning honors the configured retention policy — `retention.controller_runtime_days`,
+`retention.controller_runtime_max_bytes`, and `retention.limit` — resolved from
+the same helper `homeboy cleanup --include controller-runtimes` uses, so the two
+entry points always apply the identical window. The resolved policy is echoed in
+the command output as `min_age_seconds`, `max_total_bytes`, and `limit`.
+
+`--ignore-retention` discards that window and purges every unreferenced pin. It
+is destructive and never the default; reference-based retention still applies,
+but the operator's age and size budget does not.


### PR DESCRIPTION
## Data loss

`homeboy runtime controller-prune` is a supported, documented-enough-to-find command that **purged immutable controller runtime pins while ignoring the operator's configured retention window**. It called `controller_runtime::cleanup` with `min_age: Duration::ZERO`, `max_total_bytes: 0`, `limit: usize::MAX` — with `min_age` zero every eligible identity is "expired" and with `max_total_bytes` zero every inventory is "pressured", so it was doubly unbounded.

The other entry point onto the exact same cleanup engine — `homeboy cleanup --include controller-runtimes` — passed the configured `retention.controller_runtime_days`, `retention.controller_runtime_max_bytes`, and `retention.limit`. One supported command deleted the data the other deliberately protected.

Closes #10288

## Shared policy resolver (not an in-place patch)

The issue is that one policy was implemented twice, so the fix is to make it implementable once. Added to `homeboy-core`:

- `ControllerRuntimeRetentionOverrides { limit: Option<i64>, ignore_retention: bool }` — only what an operator actually typed.
- `controller_runtime::resolve_cleanup_options(apply, overrides)` — the single place retention becomes concrete numbers, reading `defaults::load_config().retention`.

Both call sites now go through it:

| path | before | after |
|---|---|---|
| `homeboy cleanup --include controller-runtimes` | built `ControllerRuntimeCleanupOptions` inline from config | `resolve_cleanup_options(apply, { limit: Some(limit), ignore_retention: false })` |
| `homeboy runtime controller-prune` | hardcoded `ZERO` / `0` / `usize::MAX` | `resolve_cleanup_options(apply, { limit: None, ignore_retention })` |

The two paths now differ in exactly one legitimate way: `cleanup` forwards its existing `--limit` operator override, `controller-prune` has no such flag and takes the configured limit. Everything else is byte-identical because it comes from one function.

`prune_pins(apply)` became `prune_pins(apply, overrides)` and is now a one-liner over the resolver; the lifecycle boundary `prune_controller_runtime_pins` forwards overrides unchanged.

Hardening while in there: a negative configured `retention.limit` now fails closed at zero removals rather than saturating to `usize::MAX` (the old `unwrap_or(usize::MAX)` shape was only safe on the cleanup path because it validates `limit >= 1` first; the prune path had no such guard).

## Opt-in purge

Yes — the unbounded behavior is preserved, but only behind an explicit flag:

```bash
homeboy runtime controller-prune --apply --ignore-retention
```

Follows the existing `--apply` convention on that subcommand. Reference-based retention (nonterminal durable runs, active admission generation) still applies under the flag; only the operator's age/size budget is discarded.

The command output now also echoes the resolved policy (`ignore_retention`, `min_age_seconds`, `max_total_bytes`, `limit`) so an operator can see which window was honored instead of inferring it from what disappeared.

## Discoverability

`CONTROLLER_RUNTIMES_METADATA` named itself as its own specialist (`homeboy cleanup --include controller-runtimes`), so the specialist command was never surfaced in cleanup inventory next-actions. Repointed at `homeboy runtime controller-prune` / `--apply`, matching the shape of the other 8 categories that name a real specialist. Added a `## Controller Runtime Pruning` section to `docs/commands/runtime.md`.

## Tests

- `resolved_prune_policy_reads_configuration_and_purges_only_on_opt_in` — pure resolver: configured days/bytes/limit map through, `--limit` override wins, `ignore_retention` restores `ZERO`/`0`/`usize::MAX`, negative limit clamps to 0.
- `prune_pins_honors_the_configured_window_until_a_purge_is_requested` — a fresh unreferenced pin under a 3650-day configured window is reported eligible but survives `--apply`, then is removed under `ignore_retention`.
- `prune_pins_bounds_removals_by_the_configured_limit` — 3 expired identities, configured `limit: 1`, exactly one removed.
- Updated `controller_runtime_retention_keeps_mutable_and_retained_terminal_runs` to pass `ignore_retention: true`, so it keeps asserting *reference* retention rather than passing incidentally because nothing was old enough to delete.
- Updated the `cleanup_inventory_static_metadata_preserves_specialist_commands` case for the new metadata.

Fixtures follow the existing `with_isolated_home` + `fake_controller`/`pinned_path`/`publish_pin` style in that module.

## Verification

`cargo fmt` only. Full build and test are left to CI per repo policy — this host cannot run cargo builds without OOM.