### PR TITLE
fix(release): bound digestless asset reader cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "homeboy-extension",
  "homeboy-product-identity",
  "homeboy-release-contract",
+ "libc",
  "regex",
  "semver",
  "serde",
@@ -1183,6 +1184,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "uuid",
+ "windows-sys 0.61.2",
  "zip",
 ]
 

--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -562,6 +562,101 @@ pub fn terminate_process_tree_best_effort(pid: u32) -> Result<()> {
     }
 }
 
+/// Force-terminate an owned process tree without allowing cleanup itself to
+/// exceed `timeout`. Linux snapshots descendants from procfs so children that
+/// changed sessions or process groups remain under the owner's cleanup scope.
+pub fn force_terminate_process_tree_bounded(pid: u32, timeout: Duration) -> Result<()> {
+    if pid == 0 || pid > i32::MAX as u32 {
+        return Err(Error::validation_invalid_argument(
+            "pid",
+            "owned process-tree leader PID is invalid",
+            Some(pid.to_string()),
+            None,
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        #[cfg(target_os = "linux")]
+        let mut targets = linux_descendant_pids(pid)?;
+        #[cfg(not(target_os = "linux"))]
+        let mut targets = Vec::new();
+        targets.push(pid);
+        targets.retain(|target| *target != std::process::id());
+        targets.sort_unstable();
+        targets.dedup();
+
+        unsafe {
+            if libc::kill(-(pid as libc::pid_t), libc::SIGKILL) != 0
+                && std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+            {
+                return Err(Error::internal_unexpected(format!(
+                    "force-terminate owned process group {pid}: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+        }
+        signal_pids(&targets, libc::SIGKILL)?;
+        let survivors = wait_for_exit(&targets, timeout);
+        if survivors.is_empty() && !process_group_is_running(pid as i32) {
+            return Ok(());
+        }
+        return Err(Error::internal_unexpected(format!(
+            "owned process tree {pid} did not exit within {} ms; surviving pids: {}",
+            timeout.as_millis(),
+            join_pids(&survivors)
+        )));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let step = windows_taskkill_process_tree_step(pid);
+        let mut taskkill = Command::new(&step.program)
+            .args(&step.args)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|error| {
+                Error::internal_unexpected(format!(
+                    "terminate process tree {pid} with taskkill: {error}"
+                ))
+            })?;
+        let deadline = Instant::now() + timeout;
+        loop {
+            match taskkill.try_wait() {
+                Ok(Some(status)) if status.success() => return Ok(()),
+                Ok(Some(status)) => {
+                    return Err(Error::internal_unexpected(format!(
+                        "terminate process tree {pid} with taskkill exited {status}"
+                    )))
+                }
+                Ok(None) if Instant::now() >= deadline => {
+                    let _ = taskkill.kill();
+                    return Err(Error::internal_unexpected(format!(
+                        "terminate process tree {pid} with taskkill exceeded {} ms",
+                        timeout.as_millis()
+                    )));
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Err(error) => {
+                    let _ = taskkill.kill();
+                    return Err(Error::internal_unexpected(format!(
+                        "monitor process tree {pid} taskkill: {error}"
+                    )));
+                }
+            }
+        }
+    }
+
+    #[cfg(all(not(unix), not(target_os = "windows")))]
+    {
+        let _ = timeout;
+        Err(Error::internal_unexpected(
+            "bounded process-tree termination is unsupported on this platform",
+        ))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessTreeTermination {
     pub owner_pid: u32,
@@ -720,10 +815,11 @@ fn wait_for_exit(pids: &[u32], grace: std::time::Duration) -> Vec<u32> {
             .copied()
             .filter(|pid| pid_is_running(*pid))
             .collect();
-        if survivors.is_empty() || std::time::Instant::now() >= deadline {
+        let now = std::time::Instant::now();
+        if survivors.is_empty() || now >= deadline {
             return survivors;
         }
-        std::thread::sleep(SIGTERM_POLL_INTERVAL);
+        std::thread::sleep(SIGTERM_POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
     }
 }
 
@@ -813,6 +909,7 @@ fn linux_process_group_has_running_member(pgid: i32) -> Option<bool> {
 #[cfg(target_os = "linux")]
 struct LinuxProcessStat {
     state: char,
+    parent_pid: u32,
     process_group_id: i32,
 }
 
@@ -821,12 +918,52 @@ fn parse_linux_stat(stat: &str) -> Option<LinuxProcessStat> {
     let after_command = stat.rsplit_once(") ")?.1;
     let mut fields = after_command.split_whitespace();
     let state = fields.next()?.chars().next()?;
-    let _parent_pid = fields.next()?;
+    let parent_pid = fields.next()?.parse().ok()?;
     let process_group_id = fields.next()?.parse().ok()?;
     Some(LinuxProcessStat {
         state,
+        parent_pid,
         process_group_id,
     })
+}
+
+#[cfg(target_os = "linux")]
+fn linux_descendant_pids(owner_pid: u32) -> Result<Vec<u32>> {
+    let entries = std::fs::read_dir("/proc").map_err(|error| {
+        Error::internal_unexpected(format!("inspect owned process tree {owner_pid}: {error}"))
+    })?;
+    let mut rows = Vec::new();
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<u32>() else {
+            continue;
+        };
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        if let Some(process) = parse_linux_stat(&stat) {
+            rows.push((pid, process.parent_pid));
+        }
+    }
+    Ok(descendant_pids_from_rows(&rows, owner_pid))
+}
+
+#[cfg(target_os = "linux")]
+fn descendant_pids_from_rows(rows: &[(u32, u32)], owner_pid: u32) -> Vec<u32> {
+    let mut descendants = Vec::new();
+    let mut frontier = vec![owner_pid];
+    while let Some(parent) = frontier.pop() {
+        for (pid, parent_pid) in rows {
+            if *parent_pid == parent && !descendants.contains(pid) {
+                descendants.push(*pid);
+                frontier.push(*pid);
+            }
+        }
+    }
+    descendants
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -839,7 +976,16 @@ mod tests {
         let process = parse_linux_stat(stat).expect("process stat");
 
         assert_eq!(process.state, 'Z');
+        assert_eq!(process.parent_pid, 1);
         assert_eq!(process.process_group_id, 456);
+    }
+
+    #[test]
+    fn descendant_rows_include_children_outside_the_owner_group() {
+        assert_eq!(
+            descendant_pids_from_rows(&[(10, 1), (11, 10), (12, 11), (13, 1)], 10),
+            vec![11, 12]
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/Cargo.toml
+++ b/crates/homeboy-release/Cargo.toml
@@ -27,5 +27,11 @@ glob-match = "0.2"
 uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Pipes"] }
+
 [dev-dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -10,7 +10,6 @@ use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 pub(crate) const GITHUB_RELEASE_UPLOAD_TIMEOUT_ENV: &str =
@@ -588,7 +587,7 @@ fn run_bounded_asset_download(
             asset_name
         )
     })?;
-    let output_file = download.reopen().map_err(|error| {
+    let mut output_file = download.reopen().map_err(|error| {
         format!(
             "could not open temporary file for GitHub Release asset '{}': {error}",
             asset_name
@@ -606,79 +605,117 @@ fn run_bounded_asset_download(
             asset_name
         )
     })?;
-    let stdout = child.stdout.take().ok_or_else(|| {
+    let mut stdout = child.stdout.take().ok_or_else(|| {
         format!(
             "could not capture download stream for GitHub Release asset '{}'",
             asset_name
         )
     })?;
-    let stderr = child.stderr.take().ok_or_else(|| {
+    let mut stderr = child.stderr.take().ok_or_else(|| {
         format!(
             "could not capture download diagnostics for GitHub Release asset '{}'",
             asset_name
         )
     })?;
-    let (stream_tx, stream_rx) = mpsc::channel();
-    let output_handle = std::thread::spawn(move || {
-        let _ = stream_tx.send(stream_bounded_asset(stdout, output_file, expected_size));
-    });
-    let stderr_handle = std::thread::spawn(move || drain_bounded_diagnostics(stderr));
     let started = Instant::now();
-    let mut stream_result = None;
-    let status = loop {
-        match stream_rx.try_recv() {
-            Ok(Ok(identity)) => stream_result = Some(identity),
-            Ok(Err(error)) => break Err(format!(
-                "could not download GitHub Release asset '{}': {error}",
-                asset_name
-            )),
-            Err(mpsc::TryRecvError::Empty) => {}
-            Err(mpsc::TryRecvError::Disconnected) => break Err(format!(
-                "could not download GitHub Release asset '{}': download stream ended unexpectedly",
-                asset_name
-            )),
+    let mut hasher = Sha256::new();
+    let mut size = 0_u64;
+    let mut diagnostics = Vec::new();
+    let mut diagnostics_truncated = false;
+    let mut stdout_open = true;
+    let mut stderr_open = true;
+    let mut status = None;
+    let mut exited_at = None;
+    let outcome = loop {
+        if stdout_open {
+            stdout_open = match drain_available_pipe(&mut stdout, |bytes| {
+                let remaining = expected_size.saturating_sub(size).min(bytes.len() as u64) as usize;
+                let accepted = bytes.len().min(remaining);
+                if accepted > 0 {
+                    output_file
+                        .write_all(&bytes[..accepted])
+                        .map_err(|error| format!("could not write temporary asset bytes: {error}"))?;
+                    hasher.update(&bytes[..accepted]);
+                    size += accepted as u64;
+                }
+                if accepted != bytes.len() {
+                    return Err(format!(
+                        "download exceeded expected byte length {expected_size}"
+                    ));
+                }
+                Ok(())
+            }) {
+                Ok(open) => open,
+                Err(error) => break Err(format!(
+                    "could not download GitHub Release asset '{}': {error}",
+                    asset_name
+                )),
+            };
         }
-        match child.try_wait() {
-            Ok(Some(status)) => break Ok(status),
-            Ok(None) if started.elapsed() >= timeout => break Err(format!(
-                "download of GitHub Release asset '{}' timed out",
-                asset_name
-            )),
-            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
-            Err(error) => break Err(format!(
-                "could not monitor download of GitHub Release asset '{}': {error}",
-                asset_name
-            )),
+        if stderr_open {
+            stderr_open = match drain_available_pipe(&mut stderr, |bytes| {
+                let remaining = GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES
+                    .saturating_sub(diagnostics.len());
+                diagnostics.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+                diagnostics_truncated |= bytes.len() > remaining;
+                Ok(())
+            }) {
+                Ok(open) => open,
+                Err(error) => break Err(format!(
+                    "could not read GitHub Release asset '{}' diagnostics: {error}",
+                    asset_name
+                )),
+            };
         }
+        if !stdout_open && !stderr_open {
+            if let Some(status) = status {
+                break Ok(status);
+            }
+        }
+        if status.is_none() {
+            match child.try_wait() {
+                Ok(Some(exit_status)) => {
+                    status = Some(exit_status);
+                    exited_at = Some(Instant::now());
+                }
+                Ok(None) if started.elapsed() >= timeout => {
+                    break Err(format!(
+                        "download of GitHub Release asset '{}' timed out",
+                        asset_name
+                    ));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    break Err(format!(
+                        "could not monitor download of GitHub Release asset '{}': {error}",
+                        asset_name
+                    ));
+                }
+            }
+        } else if exited_at.is_some_and(|exit| {
+            exit.elapsed() >= GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT
+        }) {
+            break Err(format!(
+                "GitHub Release asset '{}' pipes remained open after the download process exited",
+                asset_name
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(10));
     };
-    let status = match status {
+    let status = match outcome {
         Ok(status) => status,
         Err(error) => {
-            terminate_asset_download_child(&mut child);
-            let cleanup = finish_asset_download_readers(
-                &mut child,
-                output_handle,
-                stderr_handle,
-            )
-            .err()
-            .map(|cleanup| format!("; {cleanup}"))
-            .unwrap_or_default();
+            let cleanup = terminate_asset_download_child(&mut child)
+                .err()
+                .map(|cleanup| format!("; {cleanup}"))
+                .unwrap_or_default();
             return Err(format!("{error}{cleanup}"));
         }
     };
-    let diagnostics = finish_asset_download_readers(&mut child, output_handle, stderr_handle)
-        .map_err(|error| {
-            format!(
-                "could not clean up GitHub Release asset '{}' download: {error}",
-                asset_name
-            )
-        })?;
-    let stream_result = match stream_result {
-        Some(identity) => Ok(identity),
-        None => stream_rx
-            .try_recv()
-            .map_err(|_| "download stream ended without reporting an asset identity".to_string())?,
-    };
+    let mut diagnostics = String::from_utf8_lossy(&diagnostics).to_string();
+    if diagnostics_truncated {
+        diagnostics.push_str("\n[diagnostics truncated]");
+    }
     if !status.success() {
         return Err(format!(
             "could not download GitHub Release asset '{}': {}",
@@ -686,113 +723,117 @@ fn run_bounded_asset_download(
             diagnostics.trim()
         ));
     }
-    stream_result.map_err(|error| {
-        format!(
-            "could not download GitHub Release asset '{}': {error}",
-            asset_name
-        )
-    })
-}
-
-fn terminate_asset_download_child(child: &mut std::process::Child) {
-    let pid = child.id();
-    #[cfg(unix)]
-    let _ = homeboy_core::process::terminate_isolated_process_group(pid);
-    #[cfg(not(unix))]
-    let _ = homeboy_core::process::terminate_process_tree_best_effort(pid);
-    let _ = child.kill();
-    let _ = child.wait();
-}
-
-fn finish_asset_download_readers(
-    child: &mut std::process::Child,
-    output_handle: std::thread::JoinHandle<()>,
-    stderr_handle: std::thread::JoinHandle<String>,
-) -> Result<String, String> {
-    if !wait_for_asset_download_readers(&output_handle, &stderr_handle) {
-        terminate_asset_download_child(child);
-        if !wait_for_asset_download_readers(&output_handle, &stderr_handle) {
-            return Err(format!(
-                "stdout/stderr readers did not finish within {} ms after process-tree termination",
-                GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT.as_millis()
-            ));
-        }
-    }
-    output_handle
-        .join()
-        .map_err(|_| "download stream reader panicked".to_string())?;
-    stderr_handle
-        .join()
-        .map_err(|_| "download diagnostics reader panicked".to_string())
-}
-
-fn wait_for_asset_download_readers(
-    output_handle: &std::thread::JoinHandle<()>,
-    stderr_handle: &std::thread::JoinHandle<String>,
-) -> bool {
-    let deadline = Instant::now() + GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT;
-    while !output_handle.is_finished() || !stderr_handle.is_finished() {
-        if Instant::now() >= deadline {
-            return false;
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    true
-}
-
-fn stream_bounded_asset(
-    mut input: impl Read,
-    mut output: impl Write,
-    expected_size: u64,
-) -> Result<(u64, String), String> {
-    let mut hasher = Sha256::new();
-    let mut size = 0_u64;
-    let mut buffer = [0_u8; 8192];
-    loop {
-        let read = input
-            .read(&mut buffer)
-            .map_err(|error| format!("could not read asset bytes: {error}"))?;
-        if read == 0 {
-            break;
-        }
-        let remaining = expected_size.saturating_sub(size).min(buffer.len() as u64) as usize;
-        let accepted = read.min(remaining);
-        if accepted > 0 {
-            output
-                .write_all(&buffer[..accepted])
-                .map_err(|error| format!("could not write temporary asset bytes: {error}"))?;
-            hasher.update(&buffer[..accepted]);
-            size += accepted as u64;
-        }
-        if accepted != read {
-            return Err(format!(
-                "download exceeded expected byte length {expected_size}"
-            ));
-        }
-    }
     Ok((size, format!("{:x}", hasher.finalize())))
 }
 
-fn drain_bounded_diagnostics(mut input: impl Read) -> String {
-    let mut diagnostics = Vec::new();
-    let mut truncated = false;
+fn terminate_asset_download_child(child: &mut std::process::Child) -> Result<(), String> {
+    let pid = child.id();
+    let started = Instant::now();
+    let tree_result = homeboy_core::process::force_terminate_process_tree_bounded(
+        pid,
+        GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT,
+    );
+    let _ = child.kill();
+    let deadline = started + GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if Instant::now() >= deadline => {
+                return Err(format!(
+                    "download process {pid} did not exit within {} ms",
+                    GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT.as_millis()
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(error) => return Err(format!("could not reap download process {pid}: {error}")),
+        }
+    }
+    tree_result.map_err(|error| error.to_string())
+}
+
+#[cfg(unix)]
+fn drain_available_pipe<R: Read + std::os::fd::AsRawFd>(
+    input: &mut R,
+    mut consume: impl FnMut(&[u8]) -> Result<(), String>,
+) -> Result<bool, String> {
     let mut buffer = [0_u8; 8192];
     loop {
-        let Ok(read) = input.read(&mut buffer) else {
-            break;
+        let mut descriptor = libc::pollfd {
+            fd: input.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
         };
-        if read == 0 {
-            break;
+        let ready = unsafe { libc::poll(&mut descriptor, 1, 0) };
+        if ready < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(format!("could not poll download pipe: {error}"));
         }
-        let remaining = GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES.saturating_sub(diagnostics.len());
-        diagnostics.extend_from_slice(&buffer[..read.min(remaining)]);
-        truncated |= read > remaining;
+        if ready == 0 {
+            return Ok(true);
+        }
+        match input.read(&mut buffer) {
+            Ok(0) => return Ok(false),
+            Ok(read) => consume(&buffer[..read])?,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(format!("could not read download pipe: {error}")),
+        }
     }
-    let mut diagnostics = String::from_utf8_lossy(&diagnostics).to_string();
-    if truncated {
-        diagnostics.push_str("\n[diagnostics truncated]");
+}
+
+#[cfg(windows)]
+fn drain_available_pipe<R: Read + std::os::windows::io::AsRawHandle>(
+    input: &mut R,
+    mut consume: impl FnMut(&[u8]) -> Result<(), String>,
+) -> Result<bool, String> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{GetFileType, FILE_TYPE_PIPE};
+    use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+
+    let handle = input.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
+    if unsafe { GetFileType(handle) } != FILE_TYPE_PIPE {
+        return Err("download output handle is not a pipe".to_string());
     }
-    diagnostics
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let mut available = 0;
+        let peeked = unsafe {
+            PeekNamedPipe(
+                handle,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                &mut available,
+                std::ptr::null_mut(),
+            )
+        };
+        if peeked == 0 {
+            let error = std::io::Error::last_os_error();
+            if available == 0 && matches!(error.raw_os_error(), Some(109 | 233)) {
+                return Ok(false);
+            }
+            return Err(format!("could not inspect download pipe: {error}"));
+        }
+        if available == 0 {
+            return Ok(true);
+        }
+        let read_size = buffer.len().min(available as usize);
+        match input.read(&mut buffer[..read_size]) {
+            Ok(0) => return Ok(false),
+            Ok(read) => consume(&buffer[..read])?,
+            Err(error) => return Err(format!("could not read download pipe: {error}")),
+        }
+    }
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn drain_available_pipe<R: Read>(
+    _input: &mut R,
+    _consume: impl FnMut(&[u8]) -> Result<(), String>,
+) -> Result<bool, String> {
+    Err("nonblocking download pipes are unsupported on this platform".to_string())
 }
 
 /// GitHub REST represents release asset checksums as `sha256:<hex>`. Preserve
@@ -973,6 +1014,7 @@ pub(crate) fn github_cli_env(github: &GitHubRepo, config: &GithubConfig) -> Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
 
     fn remote_asset(name: &str, size: u64, digest: Option<String>) -> GitHubReleaseAsset {
         GitHubReleaseAsset {
@@ -1089,6 +1131,7 @@ mod tests {
     #[test]
     fn bounded_asset_download_timeout_closes_descendant_inherited_pipes() {
         assert_inherited_pipe_cleanup(
+            "sleep 30",
             "wait",
             Duration::from_millis(50),
             "timed out",
@@ -1100,6 +1143,7 @@ mod tests {
     #[test]
     fn bounded_asset_download_oversize_closes_descendant_inherited_pipes() {
         assert_inherited_pipe_cleanup(
+            "sleep 30",
             "printf 'oversized'; wait",
             Duration::from_secs(5),
             "exceeded expected byte length 4",
@@ -1107,8 +1151,21 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bounded_asset_download_timeout_kills_escaped_inherited_pipes() {
+        assert_inherited_pipe_cleanup(
+            "setsid sleep 30",
+            "wait",
+            Duration::from_millis(50),
+            "timed out",
+            "escaped timeout",
+        );
+    }
+
     #[cfg(unix)]
     fn assert_inherited_pipe_cleanup(
+        descendant_command: &str,
         command_tail: &str,
         timeout: Duration,
         expected_error: &str,
@@ -1120,7 +1177,7 @@ mod tests {
         let leader_pid = temp.path().join("leader.pid");
         let descendant_pid = temp.path().join("descendant.pid");
         let script = format!(
-            "echo $$ > {}; sleep 30 & echo $! > {}; {command_tail}",
+            "echo $$ > {}; {descendant_command} & echo $! > {}; {command_tail}",
             quote_arg(&leader_pid.display().to_string()),
             quote_arg(&descendant_pid.display().to_string())
         );

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -17,6 +17,7 @@ pub(crate) const GITHUB_RELEASE_UPLOAD_TIMEOUT_ENV: &str =
     "HOMEBOY_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS";
 const DEFAULT_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS: u64 = 30 * 60;
 const GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES: usize = 8 * 1024;
+const GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GhCommandOutput {
@@ -594,6 +595,11 @@ fn run_bounded_asset_download(
         )
     })?;
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
     let mut child = command.spawn().map_err(|error| {
         format!(
             "could not download GitHub Release asset '{}': {error}",
@@ -622,61 +628,57 @@ fn run_bounded_asset_download(
     let status = loop {
         match stream_rx.try_recv() {
             Ok(Ok(identity)) => stream_result = Some(identity),
-            Ok(Err(error)) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = output_handle.join();
-                let _ = stderr_handle.join();
-                return Err(format!(
-                    "could not download GitHub Release asset '{}': {error}",
-                    asset_name
-                ));
-            }
+            Ok(Err(error)) => break Err(format!(
+                "could not download GitHub Release asset '{}': {error}",
+                asset_name
+            )),
             Err(mpsc::TryRecvError::Empty) => {}
-            Err(mpsc::TryRecvError::Disconnected) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = output_handle.join();
-                let _ = stderr_handle.join();
-                return Err(format!(
-                    "could not download GitHub Release asset '{}': download stream ended unexpectedly",
-                    asset_name
-                ));
-            }
+            Err(mpsc::TryRecvError::Disconnected) => break Err(format!(
+                "could not download GitHub Release asset '{}': download stream ended unexpectedly",
+                asset_name
+            )),
         }
         match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) if started.elapsed() >= timeout => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = output_handle.join();
-                let _ = stderr_handle.join();
-                return Err(format!(
-                    "download of GitHub Release asset '{}' timed out",
-                    asset_name
-                ));
-            }
+            Ok(Some(status)) => break Ok(status),
+            Ok(None) if started.elapsed() >= timeout => break Err(format!(
+                "download of GitHub Release asset '{}' timed out",
+                asset_name
+            )),
             Ok(None) => std::thread::sleep(Duration::from_millis(25)),
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = output_handle.join();
-                let _ = stderr_handle.join();
-                return Err(format!(
-                    "could not monitor download of GitHub Release asset '{}': {error}",
-                    asset_name
-                ));
-            }
+            Err(error) => break Err(format!(
+                "could not monitor download of GitHub Release asset '{}': {error}",
+                asset_name
+            )),
         }
     };
+    let status = match status {
+        Ok(status) => status,
+        Err(error) => {
+            terminate_asset_download_child(&mut child);
+            let cleanup = finish_asset_download_readers(
+                &mut child,
+                output_handle,
+                stderr_handle,
+            )
+            .err()
+            .map(|cleanup| format!("; {cleanup}"))
+            .unwrap_or_default();
+            return Err(format!("{error}{cleanup}"));
+        }
+    };
+    let diagnostics = finish_asset_download_readers(&mut child, output_handle, stderr_handle)
+        .map_err(|error| {
+            format!(
+                "could not clean up GitHub Release asset '{}' download: {error}",
+                asset_name
+            )
+        })?;
     let stream_result = match stream_result {
         Some(identity) => Ok(identity),
         None => stream_rx
-            .recv()
+            .try_recv()
             .map_err(|_| "download stream ended without reporting an asset identity".to_string())?,
     };
-    let _ = output_handle.join();
-    let diagnostics = stderr_handle.join().unwrap_or_default();
     if !status.success() {
         return Err(format!(
             "could not download GitHub Release asset '{}': {}",
@@ -690,6 +692,52 @@ fn run_bounded_asset_download(
             asset_name
         )
     })
+}
+
+fn terminate_asset_download_child(child: &mut std::process::Child) {
+    let pid = child.id();
+    #[cfg(unix)]
+    let _ = homeboy_core::process::terminate_isolated_process_group(pid);
+    #[cfg(not(unix))]
+    let _ = homeboy_core::process::terminate_process_tree_best_effort(pid);
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn finish_asset_download_readers(
+    child: &mut std::process::Child,
+    output_handle: std::thread::JoinHandle<()>,
+    stderr_handle: std::thread::JoinHandle<String>,
+) -> Result<String, String> {
+    if !wait_for_asset_download_readers(&output_handle, &stderr_handle) {
+        terminate_asset_download_child(child);
+        if !wait_for_asset_download_readers(&output_handle, &stderr_handle) {
+            return Err(format!(
+                "stdout/stderr readers did not finish within {} ms after process-tree termination",
+                GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT.as_millis()
+            ));
+        }
+    }
+    output_handle
+        .join()
+        .map_err(|_| "download stream reader panicked".to_string())?;
+    stderr_handle
+        .join()
+        .map_err(|_| "download diagnostics reader panicked".to_string())
+}
+
+fn wait_for_asset_download_readers(
+    output_handle: &std::thread::JoinHandle<()>,
+    stderr_handle: &std::thread::JoinHandle<String>,
+) -> bool {
+    let deadline = Instant::now() + GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT;
+    while !output_handle.is_finished() || !stderr_handle.is_finished() {
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    true
 }
 
 fn stream_bounded_asset(
@@ -1034,6 +1082,108 @@ mod tests {
                 .count(),
             0,
             "timed-out download must clean up its tempfile"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_asset_download_timeout_closes_descendant_inherited_pipes() {
+        assert_inherited_pipe_cleanup(
+            "wait",
+            Duration::from_millis(50),
+            "timed out",
+            "timeout",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_asset_download_oversize_closes_descendant_inherited_pipes() {
+        assert_inherited_pipe_cleanup(
+            "printf 'oversized'; wait",
+            Duration::from_secs(5),
+            "exceeded expected byte length 4",
+            "oversize",
+        );
+    }
+
+    #[cfg(unix)]
+    fn assert_inherited_pipe_cleanup(
+        command_tail: &str,
+        timeout: Duration,
+        expected_error: &str,
+        case: &str,
+    ) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let downloads = temp.path().join("downloads");
+        std::fs::create_dir(&downloads).expect("download tempdir");
+        let leader_pid = temp.path().join("leader.pid");
+        let descendant_pid = temp.path().join("descendant.pid");
+        let script = format!(
+            "echo $$ > {}; sleep 30 & echo $! > {}; {command_tail}",
+            quote_arg(&leader_pid.display().to_string()),
+            quote_arg(&descendant_pid.display().to_string())
+        );
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let mut command = Command::new("sh");
+            command.args(["-c", &script]);
+            let started = Instant::now();
+            let result = run_bounded_asset_download(
+                &mut command,
+                "asset.zip",
+                4,
+                timeout,
+                Some(&downloads),
+            );
+            let _ = result_tx.send((result, started.elapsed()));
+        });
+
+        let (result, elapsed) = result_rx
+            .recv_timeout(Duration::from_secs(3))
+            .unwrap_or_else(|_| panic!("{case} cleanup exceeded the external bound"));
+        worker.join().expect("download worker");
+        let error = result.unwrap_err();
+        assert!(error.contains(expected_error), "unexpected error: {error}");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "{case} cleanup took {elapsed:?}"
+        );
+        assert_fixture_processes_stopped(&leader_pid, &descendant_pid);
+        assert_eq!(
+            std::fs::read_dir(temp.path().join("downloads"))
+                .expect("read download tempdir")
+                .count(),
+            0,
+            "{case} inherited pipes must not retain the tempfile"
+        );
+    }
+
+    #[cfg(unix)]
+    fn assert_fixture_processes_stopped(
+        leader_pid_path: &std::path::Path,
+        descendant_pid_path: &std::path::Path,
+    ) {
+        let leader_pid = std::fs::read_to_string(leader_pid_path)
+            .expect("leader pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric leader pid");
+        let descendant_pid = std::fs::read_to_string(descendant_pid_path)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant pid");
+        for _ in 0..40 {
+            if !homeboy_core::process::process_group_is_running(leader_pid as i32)
+                && !homeboy_core::process::pid_is_running(descendant_pid)
+            {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!(
+            "download process group {leader_pid} or descendant {descendant_pid} remained alive"
         );
     }
 


### PR DESCRIPTION
## Summary
- replace blocking stdout/stderr reader threads with supervisor-owned nonblocking pipe draining, so returning always drops pipe and tempfile handles
- force-terminate owned timeout/oversize trees under a bounded cleanup budget, including Linux descendants that escaped the process group with `setsid`
- preserve authenticated immutable asset-ID download, exact expected-length cap, canonical SHA-256 calculation, 8 KiB diagnostics retention, and fail-closed verification

## Cleanup ownership model
The download supervisor owns the child, both pipe handles, the tempfile writer, hash state, and diagnostics state on one stack. Unix uses `poll(2)` and Windows uses `PeekNamedPipe`; there are no reader threads or detached join handles. Timeout, oversize, stream, and monitor failures therefore return only after dropping all local pipe/tempfile handles.

The child still starts in a dedicated Unix process group. Bounded force cleanup snapshots Linux descendants from `/proc` before signaling, then sends `SIGKILL` to the owned group and every recorded descendant, covering children that called `setsid`. The direct child is killed and reaped with deadline polling. Windows runs `taskkill /T /F` as a supervised child with null stdio, polls it against the same bounded timeout, and kills the helper if it exceeds that timeout.

## Platform behavior
- Linux: nonblocking pipes, process-group isolation, procfs descendant ownership, escaped-session termination, and direct-child reap.
- Other Unix: nonblocking pipes and bounded process-group/root termination; procfs escaped-session discovery is Linux-specific.
- Windows: nonblocking `PeekNamedPipe`, bounded supervised `taskkill /T /F`, direct-child fallback, and stack-owned pipe/tempfile handles.
- Other targets: fail closed because cancellation-aware pipe draining is unsupported.

## Hard bounds
- download timeout remains operator-configured and byte overflow still fails immediately
- post-exit inherited pipes get a 500 ms settlement limit
- force tree termination and direct-child reap share a 500 ms cleanup deadline
- timeout, oversize, and escaped-session fixtures enforce a 3 second external receive bound and a measured return under 2 seconds

## Tests
- `cargo test -p homeboy-release bounded_asset_download -- --nocapture` (6 passed)
- `cargo test -p homeboy-process --lib` (9 passed)
- `cargo check --workspace` (passed; existing warnings)
- `cargo build --workspace` (passed; existing warnings)
- `git diff --check` (passed)
- stable Rustfmt output from CI was applied exactly in `4a5ea2171`

## Residual risks
Non-Linux Unix hosts do not have procfs descendant discovery, so descendants that deliberately create a new session rely on root/process-group cleanup limits. Windows tree completeness depends on `taskkill`; if it times out, Homeboy still returns within the bound with local pipe/tempfile ownership released and an explicit cleanup error.

Fixes #10336