### PR TITLE
fix(stack): preserve cherry-pick conflict state for resolution

### DIFF
--- a/crates/homeboy-cli/src/commands/stack.rs
+++ b/crates/homeboy-cli/src/commands/stack.rs
@@ -7,8 +7,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy_stack::stack::{
-    self, ApplyOutput, DiffOutput, GitRef, InspectOptions, InspectOutput, PushOutput, RebaseOutput,
-    StackPrEntry, StackSpec, StatusOutput, SyncOutput,
+    self, ApplyOutput, ConflictPolicy, DiffOutput, GitRef, InspectOptions, InspectOutput,
+    PushOutput, RebaseOutput, StackPrEntry, StackSpec, StatusOutput, SyncOutput,
 };
 
 use super::{CmdResult, CommandReport};
@@ -76,11 +76,15 @@ enum StackCommand {
     },
     /// Materialize a stack: cherry-pick `base + prs` onto `target`.
     ///
-    /// Stops on the first cherry-pick conflict and prints a manual-resolve
-    /// message. (Phase 2 will add `--continue`.)
+    /// Stops on the first cherry-pick conflict, leaves the conflicted pick in
+    /// the checkout, and prints the git commands that resolve or abandon it.
     Apply {
         /// Stack ID.
         stack_id: String,
+        /// Run `git cherry-pick --abort` on conflict instead of leaving the
+        /// conflicted pick in place for manual resolution.
+        #[arg(long)]
+        abort_on_conflict: bool,
     },
     /// Rebuild the target branch from fresh base + current spec PRs.
     ///
@@ -89,6 +93,10 @@ enum StackCommand {
     Rebase {
         /// Stack ID.
         stack_id: String,
+        /// Run `git cherry-pick --abort` on conflict instead of leaving the
+        /// conflicted pick in place for manual resolution.
+        #[arg(long)]
+        abort_on_conflict: bool,
     },
     /// Read-only status report — upstream PR state + local target state.
     Status {
@@ -102,7 +110,8 @@ enum StackCommand {
     /// PRs that have been merged upstream (and whose content is in base)
     /// are removed from the spec; everything else is cherry-picked onto
     /// a freshly-rebuilt target. On the first cherry-pick conflict, the
-    /// in-progress pick is aborted and a manual-resolve message printed.
+    /// in-progress pick is left in the checkout and a resolve message
+    /// printed.
     Sync {
         /// Stack ID.
         stack_id: String,
@@ -110,6 +119,10 @@ enum StackCommand {
         /// target branch.
         #[arg(long)]
         dry_run: bool,
+        /// Run `git cherry-pick --abort` on conflict instead of leaving the
+        /// conflicted pick in place for manual resolution.
+        #[arg(long)]
+        abort_on_conflict: bool,
     },
     /// Push the materialized target branch to its configured remote.
     Push {
@@ -227,10 +240,30 @@ pub fn run(args: StackArgs, _global: &super::GlobalArgs) -> CmdResult<StackComma
             number,
             repo,
         } => remove_pr(&stack_id, number, repo.as_deref()),
-        StackCommand::Apply { stack_id } => apply(&stack_id),
-        StackCommand::Rebase { stack_id } => rebase(&stack_id),
+        StackCommand::Apply {
+            stack_id,
+            abort_on_conflict,
+        } => apply(
+            &stack_id,
+            ConflictPolicy::from_abort_flag(abort_on_conflict),
+        ),
+        StackCommand::Rebase {
+            stack_id,
+            abort_on_conflict,
+        } => rebase(
+            &stack_id,
+            ConflictPolicy::from_abort_flag(abort_on_conflict),
+        ),
         StackCommand::Status { stack_id } => status(&stack_id),
-        StackCommand::Sync { stack_id, dry_run } => sync(&stack_id, dry_run),
+        StackCommand::Sync {
+            stack_id,
+            dry_run,
+            abort_on_conflict,
+        } => sync(
+            &stack_id,
+            dry_run,
+            ConflictPolicy::from_abort_flag(abort_on_conflict),
+        ),
         StackCommand::Push { stack_id } => push(&stack_id),
         StackCommand::Diff { stack_id } => diff(&stack_id),
         StackCommand::Inspect {
@@ -412,9 +445,9 @@ fn remove_pr(stack_id: &str, number: u64, repo: Option<&str>) -> CmdResult<Stack
     ))
 }
 
-fn apply(stack_id: &str) -> CmdResult<StackCommandOutput> {
+fn apply(stack_id: &str, conflict_policy: ConflictPolicy) -> CmdResult<StackCommandOutput> {
     let spec = stack::load(stack_id)?;
-    let report = stack::apply(&spec)?;
+    let report = stack::apply(&spec, conflict_policy)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         StackCommandOutput::Apply(StackApplyOutput {
@@ -425,9 +458,9 @@ fn apply(stack_id: &str) -> CmdResult<StackCommandOutput> {
     ))
 }
 
-fn rebase(stack_id: &str) -> CmdResult<StackCommandOutput> {
+fn rebase(stack_id: &str, conflict_policy: ConflictPolicy) -> CmdResult<StackCommandOutput> {
     let spec = stack::load(stack_id)?;
-    let report = stack::rebase(&spec)?;
+    let report = stack::rebase(&spec, conflict_policy)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         StackCommandOutput::Rebase(StackRebaseOutput {
@@ -450,9 +483,13 @@ fn status(stack_id: &str) -> CmdResult<StackCommandOutput> {
     ))
 }
 
-fn sync(stack_id: &str, dry_run: bool) -> CmdResult<StackCommandOutput> {
+fn sync(
+    stack_id: &str,
+    dry_run: bool,
+    conflict_policy: ConflictPolicy,
+) -> CmdResult<StackCommandOutput> {
     let mut spec = stack::load(stack_id)?;
-    let report = stack::sync(&mut spec, dry_run)?;
+    let report = stack::sync(&mut spec, dry_run, conflict_policy)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         StackCommandOutput::Sync(StackSyncOutput {

--- a/crates/homeboy-rig/src/stack.rs
+++ b/crates/homeboy-rig/src/stack.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use super::spec::RigSpec;
 use homeboy_core::error::{ErrorCode, Result};
 use homeboy_core::plan::HomeboyPlan;
-use homeboy_stack::stack::{self, StackSpec, SyncOutput};
+use homeboy_stack::stack::{self, ConflictPolicy, StackSpec, SyncOutput};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RigStackPlanEntry {
@@ -202,7 +202,9 @@ fn sync_checked(
 ) -> Result<SyncOutput> {
     let mut spec = stack::load(stack_id)?;
     validate_component_stack_path(rig, component_id, &spec)?;
-    stack::sync(&mut spec, dry_run)
+    // Rig sync inherits the default conflict policy: pause with the
+    // conflicted pick intact so the operator can resolve it in the checkout.
+    stack::sync(&mut spec, dry_run, ConflictPolicy::default())
 }
 
 pub(crate) fn validate_component_stack_path(

--- a/crates/homeboy-stack/src/stack/apply.rs
+++ b/crates/homeboy-stack/src/stack/apply.rs
@@ -1,8 +1,10 @@
 //! `homeboy stack apply` — rebuild the target branch from base + cherry-picked PRs.
 //!
-//! Algorithm (Phase 1 MVP):
+//! Algorithm:
 //!
-//! 1. Resolve `component_path`, fetch `base.remote/base.branch`.
+//! 0. Resolve `component_path` and refuse to run while a cherry-pick from an
+//!    earlier (preserved) conflict is still paused in that checkout.
+//! 1. Fetch `base.remote/base.branch`.
 //! 2. Best-effort fetch `target.remote/target.branch` so existing local
 //!    history is up-to-date for diffing later. Failure here is non-fatal:
 //!    a fresh stack may not have pushed `target` yet.
@@ -14,13 +16,16 @@
 //!    - `git cherry-pick <sha>`.
 //!    - On `--allow-empty`-style "nothing to commit" outcome (the PR is
 //!      already in base), skip cleanly.
-//!    - On any other conflict, abort the in-progress cherry-pick and
-//!      return [`Error::stack_apply_conflict`] with a clear pause message.
+//!    - On any other conflict, return [`Error::stack_apply_conflict`] with a
+//!      pause message. The conflicted index and working tree are left in
+//!      place so the operator can actually resolve them; pass
+//!      [`ConflictPolicy::Abort`] (`--abort-on-conflict`) to have the
+//!      in-progress pick aborted instead.
 //!
-//! `apply` does NOT push to `target.remote`. That's `stack push` (Phase 2).
+//! `apply` does NOT push to `target.remote`. That's `stack push`.
 //!
-//! Conflict resume primitives (`--continue` / `--reset`) are deferred to
-//! Phase 2 — `apply` just prints what to run and exits non-zero.
+//! `apply` has no resume primitive of its own: it pauses on conflict and
+//! hands the operator raw `git cherry-pick --continue` / `--abort`.
 
 use serde::Serialize;
 use std::collections::HashSet;
@@ -52,10 +57,37 @@ pub enum PickOutcome {
     Picked,
     /// Cherry-pick was empty — the PR's head SHA is already in base.
     SkippedEmpty,
-    /// Cherry-pick conflicted. `apply` stops at this PR; the caller resolves
-    /// manually with standard git tools and reruns `apply` (Phase 2 will add
-    /// `--continue`).
+    /// Cherry-pick conflicted. `apply` stops at this PR; unless
+    /// [`ConflictPolicy::Abort`] was requested the conflicted state is left
+    /// in the checkout for the operator to resolve with standard git tools.
     Conflict,
+}
+
+/// What to do with the in-progress cherry-pick when a pick conflicts.
+///
+/// The default is [`ConflictPolicy::Preserve`]: aborting would delete the
+/// conflict markers, the index state, and `CHERRY_PICK_HEAD` that the error
+/// message tells the operator to resolve.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ConflictPolicy {
+    /// Leave the conflicted index and working tree exactly as git left them
+    /// so `git cherry-pick --continue` (or `--abort`) is available.
+    #[default]
+    Preserve,
+    /// Run `git cherry-pick --abort`, restoring a clean working tree and
+    /// discarding the conflicted state.
+    Abort,
+}
+
+impl ConflictPolicy {
+    /// Map the `--abort-on-conflict` CLI flag onto a policy.
+    pub fn from_abort_flag(abort_on_conflict: bool) -> Self {
+        if abort_on_conflict {
+            Self::Abort
+        } else {
+            Self::Preserve
+        }
+    }
 }
 
 /// Output envelope for `homeboy stack apply`.
@@ -82,18 +114,26 @@ pub struct ApplyOutput {
 pub type RebaseOutput = ApplyOutput;
 
 /// Apply a stack spec: build `target` from `base + prs`.
-pub fn apply(spec: &StackSpec) -> Result<ApplyOutput> {
-    rebuild(spec, "apply")
+pub fn apply(spec: &StackSpec, conflict_policy: ConflictPolicy) -> Result<ApplyOutput> {
+    rebuild(spec, "apply", conflict_policy)
 }
 
 /// Rebase a stack spec: rebuild `target` from `base + prs` without editing the
 /// stack spec, even when some listed PRs have merged upstream.
-pub fn rebase(spec: &StackSpec) -> Result<RebaseOutput> {
-    rebuild(spec, "rebase")
+pub fn rebase(spec: &StackSpec, conflict_policy: ConflictPolicy) -> Result<RebaseOutput> {
+    rebuild(spec, "rebase", conflict_policy)
 }
 
-fn rebuild(spec: &StackSpec, rerun_verb: &str) -> Result<ApplyOutput> {
+fn rebuild(
+    spec: &StackSpec,
+    rerun_verb: &str,
+    conflict_policy: ConflictPolicy,
+) -> Result<ApplyOutput> {
     let path = resolve_existing_component_path(spec)?;
+
+    // A preserved conflict from an earlier run is a reachable entry state —
+    // refuse to clobber it with the force-checkout below.
+    ensure_no_cherry_pick_in_progress(&path, &format!("homeboy stack {} {}", rerun_verb, spec.id))?;
 
     // 2. Fetch base — must succeed.
     fetch_remote_branch(&path, &spec.base.remote, &spec.base.branch)?;
@@ -145,10 +185,9 @@ fn rebuild(spec: &StackSpec, rerun_verb: &str) -> Result<ApplyOutput> {
                 });
             }
             CherryPickResult::Conflict(message) => {
-                // Abort the in-progress cherry-pick so the working tree is
-                // left clean. Phase 2 `--continue` will skip this abort.
-                let _ = run_git(&path, &["cherry-pick", "--abort"]);
-
+                // By default the conflicted state stays exactly where git
+                // left it — the error message below tells the operator to
+                // resolve it, so destroying it here would be a lie.
                 applied.push(AppliedPr {
                     repo: pr.repo.clone(),
                     number: pr.number,
@@ -157,15 +196,16 @@ fn rebuild(spec: &StackSpec, rerun_verb: &str) -> Result<ApplyOutput> {
                     note: Some(message.clone()),
                 });
 
-                return Err(Error::stack_apply_conflict(
-                    &spec.id,
-                    pr.number,
-                    &pr.repo,
-                    format!(
-                        "{}\n  Resolve manually with standard git tools, then re-run \
-                         `homeboy stack {} {}`. (Phase 3 will add `--continue`.)",
-                        message, rerun_verb, spec.id
-                    ),
+                return Err(conflict_error(
+                    ConflictContext {
+                        path: &path,
+                        stack_id: &spec.id,
+                        pr,
+                        sha: &head.sha,
+                        rerun_command: &format!("homeboy stack {} {}", rerun_verb, spec.id),
+                        policy: conflict_policy,
+                    },
+                    &message,
                 ));
             }
         }
@@ -195,6 +235,95 @@ pub(crate) enum CherryPickResult {
     Picked,
     Empty,
     Conflict(String),
+}
+
+/// Everything the conflict path needs to explain itself to the operator.
+pub(crate) struct ConflictContext<'a> {
+    /// Checkout the cherry-pick is paused in.
+    pub path: &'a str,
+    pub stack_id: &'a str,
+    pub pr: &'a StackPrEntry,
+    /// Head SHA that failed to apply.
+    pub sha: &'a str,
+    /// Full homeboy command to re-run once the tree is clean again.
+    pub rerun_command: &'a str,
+    pub policy: ConflictPolicy,
+}
+
+/// Finish a conflicted cherry-pick according to `ctx.policy` and build the
+/// operator-facing error.
+///
+/// Under [`ConflictPolicy::Preserve`] (the default) nothing is run: the
+/// conflicted index, the working-tree markers, and `CHERRY_PICK_HEAD` are the
+/// exact state the message asks the operator to resolve.
+pub(crate) fn conflict_error(ctx: ConflictContext<'_>, message: &str) -> Error {
+    if ctx.policy == ConflictPolicy::Abort {
+        let _ = run_git(ctx.path, &["cherry-pick", "--abort"]);
+    }
+    Error::stack_apply_conflict(
+        ctx.stack_id,
+        ctx.pr.number,
+        &ctx.pr.repo,
+        conflict_guidance(&ctx, message),
+    )
+}
+
+/// `true` while `path` has a cherry-pick paused mid-flight (`CHERRY_PICK_HEAD`
+/// still present).
+pub(crate) fn cherry_pick_in_progress(path: &str) -> bool {
+    run_git(
+        path,
+        &["rev-parse", "--verify", "--quiet", "CHERRY_PICK_HEAD"],
+    )
+    .map(|output| output.status.success())
+    .unwrap_or(false)
+}
+
+/// Refuse to rebuild `target` while a cherry-pick is still paused.
+///
+/// Preserving conflicts (the default) makes a half-resolved pick a reachable
+/// state at command entry; `git checkout -B` would either fail cryptically or
+/// throw away the operator's in-progress resolution.
+pub(crate) fn ensure_no_cherry_pick_in_progress(path: &str, rerun_command: &str) -> Result<()> {
+    if !cherry_pick_in_progress(path) {
+        return Ok(());
+    }
+    Err(Error::git_command_failed(format!(
+        "a cherry-pick is still in progress in {path}; refusing to rebuild the stack target over \
+         it.\n  Finish it: resolve the conflicts, `git add` the files, then run\n    \
+         git -C {path} cherry-pick --continue\n  \
+         Or discard it: git -C {path} cherry-pick --abort\n  \
+         Then re-run `{rerun_command}`."
+    )))
+}
+
+/// Render the resolution instructions for a conflicted pick. Pure — it names
+/// only commands that actually work from the state `ctx.policy` leaves behind.
+pub(crate) fn conflict_guidance(ctx: &ConflictContext<'_>, message: &str) -> String {
+    match ctx.policy {
+        ConflictPolicy::Abort => format!(
+            "{message}\n  \
+             --abort-on-conflict: ran `git cherry-pick --abort` in {path}, so the checkout is \
+             clean and the conflicted state for {sha} is gone.\n  \
+             Re-run `{rerun}` once the PR applies cleanly, or omit --abort-on-conflict to pause \
+             with the conflict intact and resolve it in place.",
+            path = ctx.path,
+            sha = ctx.sha,
+            rerun = ctx.rerun_command,
+        ),
+        ConflictPolicy::Preserve => format!(
+            "{message}\n  \
+             The cherry-pick of {sha} is still in progress in {path} — resolve it there.\n  \
+             Resolve: fix the conflicts, `git add` the files, then run\n    \
+             git -C {path} cherry-pick --continue\n  \
+             and re-run `{rerun}`.\n  \
+             Bail out: git -C {path} cherry-pick --abort\n  \
+             Pass --abort-on-conflict to have homeboy run that abort for you.",
+            path = ctx.path,
+            sha = ctx.sha,
+            rerun = ctx.rerun_command,
+        ),
+    }
 }
 
 pub(super) fn fetch_remote_branch(path: &str, remote: &str, branch: &str) -> Result<()> {

--- a/crates/homeboy-stack/src/stack/mod.rs
+++ b/crates/homeboy-stack/src/stack/mod.rs
@@ -17,8 +17,10 @@
 //! - State directory at `~/.config/homeboy/stacks/{id}.json` (mirror of rig layout)
 //! - CLI verbs: `list`, `show`, `create`, `add-pr`, `remove-pr`, `apply`,
 //!   `rebase`, `sync`, `status`, `inspect`
-//! - Pause-and-resume on cherry-pick conflicts (apply exits non-zero with a
-//!   clear message; user resolves manually with raw git tools)
+//! - Pause-and-resume on cherry-pick conflicts (apply exits non-zero, leaves
+//!   the conflicted pick in the checkout, and tells the user which raw git
+//!   commands resolve it; `--abort-on-conflict` opts into a clean tree
+//!   instead)
 //!
 //! Deferred to Phase 2+ (Extra-Chill/homeboy#1462):
 //! - `push`, `diff`, `continue` / `--reset` resume primitives
@@ -34,7 +36,7 @@ pub mod spec;
 pub mod status;
 pub mod sync;
 
-pub use apply::{apply, rebase, AppliedPr, ApplyOutput, PickOutcome, RebaseOutput};
+pub use apply::{apply, rebase, AppliedPr, ApplyOutput, ConflictPolicy, PickOutcome, RebaseOutput};
 pub use inspect::{
     inspect, inspect_at, InspectCommit, InspectCommitDetails, InspectOptions, InspectOutput,
     InspectPr,

--- a/crates/homeboy-stack/src/stack/sync.rs
+++ b/crates/homeboy-stack/src/stack/sync.rs
@@ -12,8 +12,10 @@
 //!      half-applied target branch but a correctly-pruned spec, so re-running
 //!      `sync` is a clean rebuild.
 //!   4. Force-recreate `target.branch` from `base.remote/base.branch`.
-//!   5. Cherry-pick the pick list in order. On conflict, abort the
-//!      in-progress pick and return [`Error::stack_apply_conflict`].
+//!   5. Cherry-pick the pick list in order. On conflict, return
+//!      [`Error::stack_apply_conflict`] and leave the conflicted pick in the
+//!      checkout for manual resolution — unless the caller asked for
+//!      [`ConflictPolicy::Abort`] (`--abort-on-conflict`).
 //!
 //! Drop semantics:
 //!   A PR is droppable iff `state == "MERGED"` AND its content is in base
@@ -39,10 +41,10 @@ const STACK_SYNC_REPLAY_KIND: &str = "stack.sync.replay";
 const STACK_SYNC_UNCERTAIN_KIND: &str = "stack.sync.uncertain";
 
 use super::apply::{
-    checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, AppliedPr,
-    CherryPickResult, PickOutcome,
+    checkout_force, cherry_pick, conflict_error, ensure_head_remote,
+    ensure_no_cherry_pick_in_progress, fetch_remote_branch, fetch_sha, AppliedPr, CherryPickResult,
+    ConflictContext, ConflictPolicy, PickOutcome,
 };
-use super::git::run_git;
 use super::pr_meta::fetch_pr_meta;
 pub(crate) use super::pr_meta::StackPrMeta as PrMeta;
 use super::spec::{resolve_existing_component_path, save, StackPrEntry, StackSpec};
@@ -568,7 +570,11 @@ pub fn diff(spec: &StackSpec) -> Result<DiffOutput> {
 
 /// Sync a stack: rebuild target from base, auto-drop merged PRs, replay
 /// the rest.
-pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
+pub fn sync(
+    spec: &mut StackSpec,
+    dry_run: bool,
+    conflict_policy: ConflictPolicy,
+) -> Result<SyncOutput> {
     let plan = plan_sync(spec)?;
 
     if dry_run {
@@ -589,6 +595,14 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
             spec.id, summary
         )));
     }
+
+    // A conflict preserved by an earlier run is a reachable entry state.
+    // Refuse before touching the spec or the target branch: the rebuild in
+    // step 5 would clobber a half-finished resolution.
+    ensure_no_cherry_pick_in_progress(
+        &plan.preview.component_path,
+        &format!("homeboy stack sync {}", spec.id),
+    )?;
 
     // 4. Persist the pruned spec BEFORE any cherry-picks. A partial pick
     //    failure leaves a half-applied target but a correct spec — re-run
@@ -634,8 +648,9 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
                 });
             }
             CherryPickResult::Conflict(message) => {
-                let _ = run_git(&plan.preview.component_path, &["cherry-pick", "--abort"]);
-
+                // Same contract as `apply`: the conflicted pick survives by
+                // default, because the error message points the operator
+                // straight at it.
                 applied.push(AppliedPr {
                     repo: pr.repo.clone(),
                     number: pr.number,
@@ -644,15 +659,16 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
                     note: Some(message.clone()),
                 });
 
-                return Err(Error::stack_apply_conflict(
-                    &spec.id,
-                    pr.number,
-                    &pr.repo,
-                    format!(
-                        "{}\n  Resolve manually with standard git tools, then re-run \
-                         `homeboy stack sync {}`. (Phase 3 will add `--continue`.)",
-                        message, spec.id
-                    ),
+                return Err(conflict_error(
+                    ConflictContext {
+                        path: &plan.preview.component_path,
+                        stack_id: &spec.id,
+                        pr,
+                        sha: &meta.head_sha,
+                        rerun_command: &format!("homeboy stack sync {}", spec.id),
+                        policy: conflict_policy,
+                    },
+                    &message,
                 ));
             }
         }

--- a/docs/commands/stack.md
+++ b/docs/commands/stack.md
@@ -81,9 +81,16 @@ Remove a PR entry. Use `--repo` when the same number appears for multiple repos 
 
 ```sh
 homeboy stack apply <stack-id>
+homeboy stack apply <stack-id> --abort-on-conflict
 ```
 
-Fetches the base, recreates the local target branch from the base, then cherry-picks every PR head in order. `apply` stops on the first conflict, aborts the in-progress pick, and prints a manual-resolution hint. It does not push.
+Fetches the base, recreates the local target branch from the base, then cherry-picks every PR head in order. It does not push.
+
+On the first conflict `apply` stops and **leaves the conflicted cherry-pick in the checkout** so it can actually be resolved. The error names the two commands that work from that state — `git -C <path> cherry-pick --continue` after staging the resolution, or `git -C <path> cherry-pick --abort` to bail out — plus the homeboy command to re-run afterwards.
+
+`--abort-on-conflict` opts into the old behaviour: homeboy runs `git cherry-pick --abort` for you and reports a clean tree. Use it for unattended runs where a dirty checkout is worse than a lost conflict.
+
+While a cherry-pick is still paused, `apply`, `rebase`, and `sync` refuse to rebuild the target branch rather than clobber an in-progress resolution.
 
 Safety manifest metadata marks `apply` and `rebase` as explicit branch-mutation
 actions. Use `status` for read-only inspection and `sync --dry-run` for the
@@ -102,9 +109,10 @@ Read-only report combining upstream PR state from GitHub with local target-branc
 ```sh
 homeboy stack sync <stack-id>
 homeboy stack sync <stack-id> --dry-run
+homeboy stack sync <stack-id> --abort-on-conflict
 ```
 
-Rebuilds the target branch from the fresh base and removes PRs whose content is already in the base. `--dry-run` reports what would be dropped and picked without mutating the spec or target branch.
+Rebuilds the target branch from the fresh base and removes PRs whose content is already in the base. `--dry-run` reports what would be dropped and picked without mutating the spec or target branch. Conflict handling — and `--abort-on-conflict` — match [`apply`](#apply).
 
 ### `inspect`
 

--- a/tests/core/stack/apply_test.rs
+++ b/tests/core/stack/apply_test.rs
@@ -9,8 +9,12 @@
 //! End-to-end correctness is verified out-of-band via the live-verify
 //! fixture spec described in the PR body.
 
-use crate::stack::apply::{checkout_force, cherry_pick, rebase, url_matches, CherryPickResult};
-use crate::stack::{save, GitRef, StackSpec};
+use crate::stack::apply::{
+    checkout_force, cherry_pick, cherry_pick_in_progress, conflict_error, conflict_guidance,
+    ensure_no_cherry_pick_in_progress, rebase, url_matches, CherryPickResult, ConflictContext,
+    ConflictPolicy,
+};
+use crate::stack::{save, GitRef, StackPrEntry, StackSpec};
 use homeboy_core::test_support::with_isolated_home;
 use std::fs;
 use std::process::Command;
@@ -103,6 +107,230 @@ fn cherry_pick_returns_conflict_with_message() {
 }
 
 // ---------------------------------------------------------------------------
+// conflict handling — policy + guidance
+// ---------------------------------------------------------------------------
+
+/// Drive a real cherry-pick conflict in a throwaway repo and hand back the
+/// checkout plus the SHA that failed to apply.
+fn repo_with_live_conflict() -> (tempfile::TempDir, String, String) {
+    let (dir, path) = init_repo();
+    commit_file(&dir, &path, "f.txt", "main version\n", "main edit");
+    git(&path, &["checkout", "-q", "-b", "feature", "HEAD~1"]);
+    let conflict_sha = commit_file(&dir, &path, "f.txt", "feature version\n", "feature edit");
+    git(&path, &["checkout", "-q", "main"]);
+
+    let result = cherry_pick(&path, &conflict_sha).expect("cherry_pick");
+    assert!(
+        matches!(result, CherryPickResult::Conflict(_)),
+        "fixture should produce a conflict, got {:?}",
+        result
+    );
+    assert!(
+        cherry_pick_in_progress(&path),
+        "fixture should leave a paused cherry-pick"
+    );
+    (dir, path, conflict_sha)
+}
+
+fn pr_entry() -> StackPrEntry {
+    StackPrEntry {
+        repo: "example-org/studio".to_string(),
+        number: 3120,
+        note: None,
+    }
+}
+
+#[test]
+fn conflict_error_preserves_state_by_default() {
+    let (dir, path, sha) = repo_with_live_conflict();
+    let pr = pr_entry();
+
+    let error = conflict_error(
+        ConflictContext {
+            path: &path,
+            stack_id: "demo",
+            pr: &pr,
+            sha: &sha,
+            rerun_command: "homeboy stack apply demo",
+            policy: ConflictPolicy::default(),
+        },
+        "CONFLICT (content): Merge conflict in f.txt",
+    );
+
+    // The conflict the message points at must still exist.
+    assert!(
+        cherry_pick_in_progress(&path),
+        "default policy must not abort the in-progress cherry-pick"
+    );
+    assert!(
+        dir.path().join(".git/CHERRY_PICK_HEAD").exists(),
+        "CHERRY_PICK_HEAD must survive so `cherry-pick --continue` works"
+    );
+    let conflicted = fs::read_to_string(dir.path().join("f.txt")).expect("read conflicted file");
+    assert!(
+        conflicted.contains("<<<<<<<"),
+        "conflict markers must survive; got: {conflicted}"
+    );
+
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("git -C") && rendered.contains("cherry-pick --continue"),
+        "message must name the resolve command; got: {rendered}"
+    );
+    assert!(
+        rendered.contains("cherry-pick --abort"),
+        "message must name the bail-out command; got: {rendered}"
+    );
+    assert!(
+        rendered.contains(&path),
+        "message must name the repo path; got: {rendered}"
+    );
+
+    let _ = Command::new("git")
+        .args(["cherry-pick", "--abort"])
+        .current_dir(&path)
+        .output();
+}
+
+#[test]
+fn conflict_error_aborts_when_opted_in() {
+    let (dir, path, sha) = repo_with_live_conflict();
+    let pr = pr_entry();
+
+    let error = conflict_error(
+        ConflictContext {
+            path: &path,
+            stack_id: "demo",
+            pr: &pr,
+            sha: &sha,
+            rerun_command: "homeboy stack apply demo",
+            policy: ConflictPolicy::Abort,
+        },
+        "CONFLICT (content): Merge conflict in f.txt",
+    );
+
+    assert!(
+        !cherry_pick_in_progress(&path),
+        "--abort-on-conflict must abort the in-progress cherry-pick"
+    );
+    assert!(!dir.path().join(".git/CHERRY_PICK_HEAD").exists());
+    let status = Command::new("git")
+        .args(["status", "--porcelain=v1"])
+        .current_dir(&path)
+        .output()
+        .unwrap();
+    assert!(
+        status.stdout.is_empty(),
+        "abort should restore a clean tree; got: {}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("--abort-on-conflict"),
+        "abort message must say the pick was aborted; got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("cherry-pick --continue"),
+        "abort message must not point at state it just destroyed; got: {rendered}"
+    );
+}
+
+#[test]
+fn conflict_error_carries_pr_coordinates() {
+    let (_dir, path) = init_repo();
+    let pr = pr_entry();
+
+    let error = conflict_error(
+        ConflictContext {
+            path: &path,
+            stack_id: "demo",
+            pr: &pr,
+            sha: "deadbeef",
+            rerun_command: "homeboy stack sync demo",
+            policy: ConflictPolicy::Preserve,
+        },
+        "CONFLICT (content): Merge conflict in f.txt",
+    );
+
+    assert_eq!(
+        error.code,
+        homeboy_core::error::ErrorCode::StackApplyConflict
+    );
+    let rendered = error.to_string();
+    assert!(rendered.contains("example-org/studio#3120"), "{rendered}");
+    assert!(rendered.contains("deadbeef"), "{rendered}");
+    assert!(rendered.contains("homeboy stack sync demo"), "{rendered}");
+}
+
+#[test]
+fn conflict_guidance_preserve_and_abort_differ() {
+    let pr = pr_entry();
+    fn ctx<'a>(pr: &'a StackPrEntry, policy: ConflictPolicy) -> ConflictContext<'a> {
+        ConflictContext {
+            path: "/tmp/checkout",
+            stack_id: "demo",
+            pr,
+            sha: "abc1234",
+            rerun_command: "homeboy stack apply demo",
+            policy,
+        }
+    }
+
+    let preserve = conflict_guidance(&ctx(&pr, ConflictPolicy::Preserve), "CONFLICT in f.txt");
+    assert!(preserve.contains("still in progress in /tmp/checkout"));
+    assert!(preserve.contains("git -C /tmp/checkout cherry-pick --continue"));
+    assert!(preserve.contains("git -C /tmp/checkout cherry-pick --abort"));
+
+    let abort = conflict_guidance(&ctx(&pr, ConflictPolicy::Abort), "CONFLICT in f.txt");
+    assert!(abort.contains("git cherry-pick --abort"));
+    assert!(abort.contains("/tmp/checkout"));
+    assert!(!abort.contains("cherry-pick --continue"));
+}
+
+#[test]
+fn conflict_policy_maps_the_cli_flag() {
+    assert_eq!(
+        ConflictPolicy::from_abort_flag(false),
+        ConflictPolicy::Preserve
+    );
+    assert_eq!(ConflictPolicy::from_abort_flag(true), ConflictPolicy::Abort);
+    assert_eq!(ConflictPolicy::default(), ConflictPolicy::Preserve);
+}
+
+// ---------------------------------------------------------------------------
+// ensure_no_cherry_pick_in_progress
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rebuild_preflight_allows_a_clean_checkout() {
+    let (_dir, path) = init_repo();
+    assert!(!cherry_pick_in_progress(&path));
+    ensure_no_cherry_pick_in_progress(&path, "homeboy stack apply demo")
+        .expect("clean checkout should pass the preflight");
+}
+
+#[test]
+fn rebuild_preflight_refuses_to_clobber_a_preserved_conflict() {
+    let (_dir, path, _sha) = repo_with_live_conflict();
+
+    let error = ensure_no_cherry_pick_in_progress(&path, "homeboy stack apply demo")
+        .expect_err("paused cherry-pick must block a rebuild");
+    let rendered = error.to_string();
+    assert!(rendered.contains(&path), "{rendered}");
+    assert!(rendered.contains("cherry-pick --continue"), "{rendered}");
+    assert!(rendered.contains("homeboy stack apply demo"), "{rendered}");
+
+    // The preflight is read-only — the conflict is still there afterwards.
+    assert!(cherry_pick_in_progress(&path));
+
+    let _ = Command::new("git")
+        .args(["cherry-pick", "--abort"])
+        .current_dir(&path)
+        .output();
+}
+
+// ---------------------------------------------------------------------------
 // checkout_force
 // ---------------------------------------------------------------------------
 
@@ -170,7 +398,7 @@ fn rebase_rebuilds_target_without_editing_spec() {
             .join(".config/homeboy/stacks/rebase-no-edit.json");
         let before = fs::read_to_string(&spec_path).expect("read spec before rebase");
 
-        let output = rebase(&spec).expect("rebase stack");
+        let output = rebase(&spec, ConflictPolicy::default()).expect("rebase stack");
         assert!(output.success);
         assert_eq!(output.picked_count, 0);
         assert_eq!(output.skipped_count, 0);


### PR DESCRIPTION
## The contradiction

`crates/homeboy-stack/src/stack/apply.rs` aborted the in-progress cherry-pick and *then* told the operator to resolve it:

```rust
let _ = run_git(&path, &["cherry-pick", "--abort"]);   // :150 destroys the state
...
"Resolve manually with standard git tools, then re-run ..."  // :165 points at nothing
```

The abort wiped the conflict markers, the index state, and `CHERRY_PICK_HEAD` that the message instructed the operator to fix. The only recourse was reconstructing the pick by hand from the reported SHA. `sync.rs:636-657` had the identical logic. The comments had drifted apart as well — `:149` said "Phase 2 `--continue`", `:166` said "Phase 3 will add `--continue`".

## What changed

- **New `ConflictPolicy` (`Preserve` default / `Abort`)** threaded through `stack::apply`, `stack::rebase`, and `stack::sync`, surfaced as `--abort-on-conflict` on all three CLI verbs. `homeboy rig stack sync` takes the default.
- **Default now leaves the conflict in place.** `conflict_error()` / `conflict_guidance()` in `apply.rs` are shared by both call sites; no abort runs unless the policy says so.
- **New operator message** (Preserve):

  ```
  <git conflict output>
    The cherry-pick of <sha> is still in progress in <path> — resolve it there.
    Resolve: fix the conflicts, `git add` the files, then run
      git -C <path> cherry-pick --continue
    and re-run `homeboy stack apply <id>`.
    Bail out: git -C <path> cherry-pick --abort
    Pass --abort-on-conflict to have homeboy run that abort for you.
  ```

  Under `--abort-on-conflict` the message instead reports that the pick was aborted and the tree is clean — it never names `--continue`, because that state is gone.
- **Preflight guard.** A paused pick is now a reachable entry state, so `apply`/`rebase`/`sync` refuse to force-recreate the target branch over an in-progress cherry-pick. Without it the next run dies inside `git checkout -B` with `error: you need to resolve your current index first` (verified against real git), or silently eats a half-finished resolution.
- **Roadmap comments replaced** with descriptions of current behaviour in `apply.rs`, `sync.rs`, `mod.rs`, the CLI help, and `docs/commands/stack.md`.

No new error types or contracts: `PickOutcome::Conflict` and `Error::stack_apply_conflict` are reused as-is, and the JSON output shapes are unchanged.

## Tests

Real conflict fixtures, not just plumbing. `repo_with_live_conflict()` drives an actual conflicting cherry-pick in a tempdir repo, then:

- `conflict_error_preserves_state_by_default` — asserts `CHERRY_PICK_HEAD` still exists, `<<<<<<<` markers still in the file, and the message names `cherry-pick --continue`, `cherry-pick --abort`, and the repo path.
- `conflict_error_aborts_when_opted_in` — asserts the pick is aborted, the tree is clean, and the message does **not** point at `--continue`.
- `rebuild_preflight_refuses_to_clobber_a_preserved_conflict` / `..._allows_a_clean_checkout` — the new guard, including that it is read-only.
- `conflict_error_carries_pr_coordinates`, `conflict_guidance_preserve_and_abort_differ`, `conflict_policy_maps_the_cli_flag` — error code/coordinates, message content, flag mapping.

The full `apply()`/`sync()` entry points still need `gh` for PR head SHAs, so they remain untested end-to-end (pre-existing limitation noted at the top of `apply_test.rs`); the conflict branch itself is now covered against real git state.

## Verification

`cargo fmt` only. Full build and test are left to CI per repo policy (heavy cargo runs are not permitted on the authoring host).

Closes #10289