### PR TITLE
fix(agent-task): accept full Windows PID range

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -316,10 +316,22 @@ fn claim_owner_is_live(claim: &Value) -> bool {
         // conservative compatibility boundary until it expires.
         return true;
     };
-    if pid == 0 || pid > i32::MAX as u64 {
+    if !owner_pid_is_valid(pid) {
         return false;
     }
     process_is_live(pid as u32)
+}
+
+fn owner_pid_is_valid(pid: u64) -> bool {
+    if pid == 0 || pid > u32::MAX as u64 {
+        return false;
+    }
+    // Unix `pid_t` is signed on the supported targets. Windows process IDs
+    // occupy the full unsigned DWORD range.
+    #[cfg(unix)]
+    return pid <= i32::MAX as u64;
+    #[cfg(not(unix))]
+    true
 }
 
 #[cfg(unix)]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/operation_claims.rs
@@ -173,6 +173,13 @@ fn dead_owner_claim_is_reclaimed_without_waiting_for_lease_expiry() {
     });
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_accepts_the_full_process_id_range() {
+    assert!(owner_pid_is_valid(u32::MAX as u64));
+    assert!(!owner_pid_is_valid(u32::MAX as u64 + 1));
+}
+
 #[test]
 fn live_owner_claim_remains_held_without_side_effect_reentry() {
     with_isolated_home(|_| {


### PR DESCRIPTION
## Summary
- preserve active Windows operation claims whose process IDs exceed `i32::MAX`
- validate the full unsigned Windows PID range
- add Windows-gated bounds coverage

Follow-up to #10327 after independent review found the remediation after the original PR had merged.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::operation_claims`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode independently reviewed the original implementation, identified the Windows PID-range defect, implemented the correction, and ran focused verification. Chris Huber reviewed and owns the change.