### PR TITLE
test(agent-task): prove pinned continuation identity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -882,8 +882,8 @@ pub fn record_provider_execution_terminal(
     })
 }
 
-#[cfg(test)]
-pub(crate) fn rewrite_record_for_test<F>(run_id: &str, mut rewrite: F) -> Result<AgentTaskRunRecord>
+#[cfg(any(test, feature = "test-support"))]
+pub fn rewrite_record_for_test<F>(run_id: &str, mut rewrite: F) -> Result<AgentTaskRunRecord>
 where
     F: FnMut(&mut AgentTaskRunRecord),
 {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1666,30 +1666,7 @@ where
                 // Resolve the former back to its active path: the baseline is
                 // execution evidence, not a task-worktree identity.
                 let continuation_plan = agent_task_lifecycle::load_plan(&attempt.run_id)?;
-                let baseline_bound_continuation =
-                    continuation_plan.tasks.first().is_some_and(|task| {
-                        task.inputs
-                            .pointer("/cook_loop/artifact_provenance/source_run_id")
-                            .is_some()
-                            || task
-                                .metadata
-                                .get("cook_initial_candidate_baseline")
-                                .is_some()
-                    });
-                if baseline_bound_continuation {
-                    if std::path::Path::new(&reconstructed.to_worktree).is_dir() {
-                        reconstructed.source_worktree_path =
-                            Some(reconstructed.to_worktree.clone().into());
-                    } else if let Some(worktree) =
-                        homeboy_core::worktree::resolve_workspace_ref_if_present(
-                            &reconstructed.to_worktree,
-                        )?
-                    {
-                        if worktree.state() == &homeboy_core::worktree::TaskWorktreeState::Active {
-                            reconstructed.source_worktree_path = Some(worktree.path().into());
-                        }
-                    }
-                }
+                rebind_baseline_continuation_workspace(&mut reconstructed, &continuation_plan)?;
                 reconstructed.initial_plan = continuation_plan;
             }
         }
@@ -2717,6 +2694,37 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
             Some(options.to_worktree.clone()),
             Some(vec!["Re-run Cook without a source CWD override so Homeboy binds the declared task worktree.".to_string()]),
         ));
+    }
+    Ok(())
+}
+
+/// A baseline is immutable provider evidence. Continue provider and controller
+/// work from the active task-worktree named by the recipe, never from that
+/// temporary baseline path.
+fn rebind_baseline_continuation_workspace(
+    options: &mut AgentTaskCookServiceOptions,
+    continuation_plan: &AgentTaskPlan,
+) -> Result<()> {
+    let baseline_bound_continuation = continuation_plan.tasks.first().is_some_and(|task| {
+        task.inputs
+            .pointer("/cook_loop/artifact_provenance/source_run_id")
+            .is_some()
+            || task
+                .metadata
+                .get("cook_initial_candidate_baseline")
+                .is_some()
+    });
+    if !baseline_bound_continuation {
+        return Ok(());
+    }
+    if std::path::Path::new(&options.to_worktree).is_dir() {
+        options.source_worktree_path = Some(options.to_worktree.clone().into());
+    } else if let Some(worktree) =
+        homeboy_core::worktree::resolve_workspace_ref_if_present(&options.to_worktree)?
+    {
+        if worktree.state() == &homeboy_core::worktree::TaskWorktreeState::Active {
+            options.source_worktree_path = Some(worktree.path().into());
+        }
     }
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1535,7 +1535,7 @@ fn batch_cook_options(
 struct CandidateAdoptionFixture {
     _temp: tempfile::TempDir,
     _source: std::path::PathBuf,
-    _target: std::path::PathBuf,
+    target: std::path::PathBuf,
     candidate: String,
     cook_id: String,
     run_id: String,
@@ -1669,7 +1669,7 @@ impl CandidateAdoptionFixture {
         let mut fixture = Self {
             _temp: temp,
             _source: source,
-            _target: target,
+            target,
             candidate,
             cook_id: cook_id.to_string(),
             run_id,
@@ -3651,6 +3651,28 @@ fn adoption_replays_provider_discovery_failure_in_the_same_recipe_attempt() {
         assert_eq!(failed_recipe.attempts.len(), 2);
         let failed_run_id = failed_recipe.attempts[1].run_id.clone();
         assert!(retryable_provider_discovery_failure(&failed_run_id));
+        let continuation_plan = agent_task_lifecycle::load_plan(&failed_run_id)
+            .expect("provider replay persists its baseline-bound continuation plan");
+        let baseline_root = continuation_plan.tasks[0]
+            .workspace
+            .root
+            .clone()
+            .expect("continuation plan has an authenticated baseline root");
+        let mut reconstructed = super::super::reconstruct_adoption_options(&failed_recipe)
+            .expect("reconstruct adoption policy");
+        super::rebind_baseline_continuation_workspace(&mut reconstructed, &continuation_plan)
+            .expect("restore the active task-worktree identity");
+        assert_eq!(reconstructed.to_worktree, fixture.options.to_worktree);
+        assert_eq!(
+            std::fs::canonicalize(reconstructed.source_worktree_path.unwrap()).unwrap(),
+            std::fs::canonicalize(&fixture.target).unwrap(),
+            "continuation reconstruction resolves the recipe handle to the active target worktree"
+        );
+        assert_ne!(
+            baseline_root,
+            fixture.target.display().to_string(),
+            "the persisted baseline is evidence, not the continuation workspace"
+        );
         agent_task_lifecycle::rewrite_record_for_test(&fixture.run_id, |record| {
             record
                 .candidate_adoption

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -252,6 +252,8 @@ pub mod gate {
 
 /// Durable run lifecycle: submit, run-record state, log/artifact loaders.
 pub mod lifecycle {
+    #[cfg(feature = "test-support")]
+    pub use super::super::agent_task_lifecycle::rewrite_record_for_test;
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, has_accepted_runner_handoff, list_records,

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1506,6 +1506,9 @@ fn extract_parent_command_from_error(e: &clap::Error) -> Option<String> {
 mod tests {
     use super::*;
     use clap::Parser;
+    use sha2::{Digest, Sha256};
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     #[test]
@@ -2230,6 +2233,112 @@ mod tests {
             ),
             "'/tmp/controller runtimes/homeboy'\\''s' agent-task cook-continue 'cook id'\\''s'"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cook_continue_reexecutes_the_verified_origin_runtime_for_the_exact_attempt() {
+        crate::test_support::with_isolated_home(|home| {
+            let target = home.path().join("active-task-worktree");
+            std::fs::create_dir(&target).expect("create active task worktree");
+            let mut plan: crate::agents::agent_tasks::scheduler::AgentTaskPlan =
+                serde_json::from_str(include_str!(
+                    "../../../tests/fixtures/agent_task_smoke_plan.json"
+                ))
+                .expect("deserialize durable test plan");
+            plan.tasks[0].workspace.root = Some(target.display().to_string());
+
+            let cook_id = "cook-runtime-a";
+            let run_id = "cook-runtime-a-attempt-1";
+            let options = crate::agents::agent_tasks::service::AgentTaskCookServiceOptions {
+                cook_id: cook_id.to_string(),
+                initial_run_id: run_id.to_string(),
+                initial_plan: plan.clone(),
+                to_worktree: target.display().to_string(),
+                source_worktree_path: Some(target.clone()),
+                provider_command: None,
+                provider_invocation: None,
+                gates: Default::default(),
+                max_attempts: 1,
+                no_finalize: true,
+                base: "main".to_string(),
+                task_base_sha: None,
+                head: None,
+                title: "runtime continuation fixture".to_string(),
+                commit_message: "runtime continuation fixture".to_string(),
+                source_refs: Vec::new(),
+                protected_branches: Vec::new(),
+                ai_tool: "test".to_string(),
+                ai_model: None,
+                ai_used_for: "test".to_string(),
+                attempt_dispatcher: None,
+                harvest_context: Default::default(),
+            };
+            crate::agents::agent_tasks::service::persist_initial_recipe(&options)
+                .expect("persist runtime-A cook recipe");
+            crate::agents::agent_tasks::lifecycle::submit_plan(&plan, Some(run_id))
+                .expect("persist runtime-A lifecycle run");
+
+            let invocation = home.path().join("runtime-a-invocation");
+            let runtime_a = home.path().join("runtime-a");
+            let identity = "homeboy test-runtime-a";
+            std::fs::write(
+                &runtime_a,
+                format!(
+                    "#!/bin/sh\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{{\"data\":{{\"display\":\"{identity}\"}}}}'\n  exit 0\nfi\nprintf '%s\\n' \"$@\" > \"$HOMEBOY_TEST_RUNTIME_A_INVOCATION\"\nexit 17\n"
+                ),
+            )
+            .expect("write runtime-A fixture");
+            std::fs::set_permissions(&runtime_a, std::fs::Permissions::from_mode(0o700))
+                .expect("make runtime-A fixture executable");
+            let digest = format!(
+                "{:x}",
+                Sha256::digest(std::fs::read(&runtime_a).expect("read runtime-A fixture"))
+            );
+            crate::agents::agent_tasks::lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.metadata["controller_runtime"] = serde_json::json!({
+                    "originating": {
+                        "build_identity": identity,
+                        "pinned_executable": runtime_a,
+                        "sha256": digest,
+                    }
+                });
+            })
+            .expect("record runtime-A pin");
+
+            let _env = EnvGuard::remove("HOMEBOY_TEST_RUNTIME_A_INVOCATION");
+            std::env::set_var("HOMEBOY_TEST_RUNTIME_A_INVOCATION", &invocation);
+            let exit_code = delegate_cook_continue_to_pinned_runtime(
+                cook_id,
+                &[
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "cook-continue".to_string(),
+                    cook_id.to_string(),
+                    "--full".to_string(),
+                ],
+            )
+            .expect("current runtime delegates to verified runtime A");
+
+            assert_eq!(exit_code, Some(17));
+            assert_eq!(
+                std::fs::read_to_string(invocation).expect("runtime-A invocation"),
+                format!("agent-task\ncook-continue\n{cook_id}\n--full\n")
+            );
+            assert_eq!(
+                crate::agents::agent_tasks::service::resolve_cook_continuation_run_id(cook_id)
+                    .expect("resolve exact continuation attempt"),
+                run_id
+            );
+            let pinned = crate::agents::agent_tasks::lifecycle::pinned_runtime_for_mutation(run_id)
+                .expect("validate runtime-A pin")
+                .expect("select runtime-A pin");
+            assert!(pinned.is_file());
+            assert_ne!(
+                pinned, runtime_a,
+                "runtime A must execute from its immutable pin"
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- prove continuation invoked under runtime B re-executes verified pinned runtime A for the exact durable attempt
- prove reconstructed workspace identity resolves the active continuation target rather than a persisted temporary baseline
- expose record mutation only to test-support consumers

Follow-up to #10334 after independent review identified missing compatibility and workspace-identity proof after the original PR had merged.

## Verification
- focused pinned runtime continuation test
- adoption replay workspace identity test
- operation-claim preservation test
- `cargo fmt --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode independently reviewed the persisted lifecycle change, identified missing behavioral proof, added the end-to-end regression coverage, and ran focused verification. Chris Huber reviewed and owns the change.