### PR TITLE
Fix fanout cook-batch workspace binding

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -194,6 +194,50 @@ pub fn persist_fanout_run_batch(
     Ok(record)
 }
 
+/// Record child failures that occurred before Cook could create a lifecycle
+/// record. These are terminal controller-admission failures, not unavailable
+/// runner observations, so status must retain them as failures.
+pub fn record_fanout_run_batch_failed_admissions<'a>(
+    batch_id: &str,
+    failed_run_ids: impl IntoIterator<Item = &'a str>,
+) -> Result<()> {
+    let mut batch = read_batch(batch_id)?;
+    let failed_run_ids = failed_run_ids.into_iter().collect::<HashSet<_>>();
+    if failed_run_ids.is_empty() {
+        return Ok(());
+    }
+    let mut changed = false;
+    for child in &mut batch.child_runs {
+        if failed_run_ids.contains(child.run_id.as_str())
+            && child.state != AgentTaskRunState::Failed
+        {
+            child.state = AgentTaskRunState::Failed;
+            changed = true;
+        }
+    }
+    if changed {
+        if !batch.metadata.is_object() {
+            batch.metadata = Value::Object(serde_json::Map::new());
+        }
+        let metadata = batch.metadata.as_object_mut().expect("metadata object");
+        let failures = metadata
+            .entry("terminal_admission_failures")
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+            .expect("admission failures are an array");
+        for run_id in &failed_run_ids {
+            if !failures.iter().any(|value| value.as_str() == Some(*run_id)) {
+                failures.push(Value::String((*run_id).to_string()));
+            }
+        }
+        let totals = totals_for_children(&batch.child_runs);
+        batch.state = aggregate_state(&totals);
+        batch.updated_at = Some(now_timestamp());
+        write_batch(&batch)?;
+    }
+    Ok(())
+}
+
 pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let mut batch = read_batch(batch_id)?;
     let mut changed = false;
@@ -202,6 +246,9 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let mut resumable_child_runs = Vec::new();
     let mut timed_out_child_runs = HashSet::new();
     for child in &mut batch.child_runs {
+        if terminal_admission_failure(&batch.metadata, &child.run_id) {
+            continue;
+        }
         match agent_task_lifecycle::status(&child.run_id) {
             Ok(record) => {
                 if child.state != record.state {
@@ -227,10 +274,12 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
                 }
             }
             Err(error) => {
-                unavailable_child_runs.push(child_issue(
-                    child,
-                    format!("unable to read child run status: {}", error.message),
-                ));
+                if !child.state.is_terminal() {
+                    unavailable_child_runs.push(child_issue(
+                        child,
+                        format!("unable to read child run status: {}", error.message),
+                    ));
+                }
             }
         }
     }
@@ -292,6 +341,12 @@ fn resumable_child_reason(record: &agent_task_lifecycle::AgentTaskRunRecord) -> 
         )),
         _ => None,
     }
+}
+
+fn terminal_admission_failure(metadata: &Value, run_id: &str) -> bool {
+    metadata["terminal_admission_failures"]
+        .as_array()
+        .is_some_and(|failures| failures.iter().any(|value| value.as_str() == Some(run_id)))
 }
 
 pub fn artifacts(batch_id: &str) -> Result<AgentTaskBatchArtifactsReport> {
@@ -731,6 +786,31 @@ mod tests {
             .next_actions
             .iter()
             .any(|action| action.contains("partial results only")));
+    }
+
+    #[test]
+    fn terminal_admission_failure_is_not_reclassified_as_unavailable() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let batch_id = format!("fanout-admission-failure-{}", uuid::Uuid::new_v4());
+        let child_run_id = format!("cook-workspace-bound-child-{}", uuid::Uuid::new_v4());
+        persist_fanout_run_batch(
+            &batch_id,
+            &batch_id,
+            &[FanoutRunBatchChild {
+                task_id: "workspace-bound-child".to_string(),
+                run_id: child_run_id.clone(),
+            }],
+            Value::Null,
+        )
+        .expect("persist fanout");
+        record_fanout_run_batch_failed_admissions(&batch_id, [child_run_id.as_str()])
+            .expect("record terminal admission failure");
+
+        let report = status(&batch_id).expect("terminal batch status");
+        assert_eq!(report.status, "failed");
+        assert_eq!(report.batch.state, AgentTaskBatchState::Failed);
+        assert_eq!(report.totals.failed, 1);
+        assert!(report.unavailable_child_runs.is_empty());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -185,7 +185,8 @@ pub mod cook_loop {
 /// Durable batch/fanout lifecycle records built from independent child runs.
 pub mod batch {
     pub use super::super::agent_task_batch::{
-        artifacts, persist_fanout_run_batch, read_batch_record, status, submit_plan_batch,
+        artifacts, persist_fanout_run_batch, read_batch_record,
+        record_fanout_run_batch_failed_admissions, status, submit_plan_batch,
         AgentTaskBatchArtifactsReport, AgentTaskBatchChildArtifacts, AgentTaskBatchChildRun,
         AgentTaskBatchCommands, AgentTaskBatchRecord, AgentTaskBatchState,
         AgentTaskBatchStatusReport, AgentTaskBatchTotals, FanoutRunBatchChild,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -233,6 +233,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
         },
         provider::ExtensionProviderAgentTaskExecutor::discover(),
     )?;
+    record_terminal_batch_admission_failures(&plan, &result.value)?;
     Ok(batch_cook_result(&plan, result))
 }
 
@@ -259,7 +260,23 @@ where
         },
         executor,
     )?;
+    record_terminal_batch_admission_failures(&plan, &result.value)?;
     Ok(batch_cook_result(&plan, result))
+}
+
+/// A failure before Cook creates its durable child record is nevertheless a
+/// terminal outcome for this controller-owned fanout. Persist it on the batch
+/// so later status reads do not leave the child running and unavailable.
+fn record_terminal_batch_admission_failures(
+    plan: &BatchCookFanoutPlan,
+    report: &agent_task_service::AgentTaskCookBatchReport,
+) -> Result<()> {
+    let failed = report
+        .cooks
+        .iter()
+        .filter(|cell| cell.result.is_none() && cell.exit_code != 0)
+        .map(|cell| cell.initial_run_id.as_str());
+    batch::record_fanout_run_batch_failed_admissions(&plan.fanout_id, failed)
 }
 
 fn batch_harvest_context() -> Result<homeboy::agents::agent_task_scheduler::HarvestExecutionContext>
@@ -368,8 +385,7 @@ fn cook_batch_inner(
     // effective backend explicit here also surfaces it in the preflight and
     // pins every child cook to the same resolved backend.
     resolve_and_validate_effective_backend(&mut args)?;
-    let plan = build_cook_batch_plan(&args)?;
-    preflight_batch_cook_recipes(&plan, attempt_dispatcher)?;
+    let mut plan = build_cook_batch_plan(&args)?;
     let branches = plan
         .cooks
         .iter()
@@ -396,6 +412,15 @@ fn cook_batch_inner(
             .rows
             .iter()
             .all(|row| matches!(row.status, worktree::WorktreeQueueCreateStatus::Created));
+    if can_run {
+        bind_materialized_worktrees(&mut plan, &worktrees)?;
+        // Compare the exact workspace-bound recipe that provider execution will
+        // persist, not the handle-only planning form created before worktree
+        // materialization.
+        preflight_batch_cook_recipes(&plan, attempt_dispatcher)?;
+    } else if args.dry_run {
+        preflight_batch_cook_recipes(&plan, attempt_dispatcher)?;
+    }
     let run_result = if args.run_plan && can_run {
         let (value, exit_code) = match attempt_dispatcher {
             Some(dispatcher) => {
@@ -451,6 +476,36 @@ fn cook_batch_inner(
         }),
         exit_code,
     ))
+}
+
+fn bind_materialized_worktrees(
+    plan: &mut BatchCookFanoutPlan,
+    worktrees: &worktree::WorktreeQueueCreateOutput,
+) -> Result<()> {
+    for cook in &mut plan.cooks {
+        let row = worktrees
+            .rows
+            .iter()
+            .find(|row| row.handle == cook.to_worktree)
+            .ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "worktree materialization omitted declared cook target '{}'",
+                    cook.to_worktree
+                ))
+            })?;
+        let path = row.path.as_deref().ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "materialized cook worktree '{}' has no filesystem path",
+                cook.to_worktree
+            ))
+        })?;
+        let path = std::fs::canonicalize(path)
+            .map_err(|error| Error::internal_io(error.to_string(), Some(path.to_string())))?;
+        let path = path.display().to_string();
+        cook.cwd = None;
+        cook.workspace = Some(path);
+    }
+    Ok(())
 }
 
 fn cook_batch_outer_exit_code(blocked: usize, run_result: &Option<Value>) -> i32 {
@@ -1700,6 +1755,55 @@ mod tests {
                 Some("homeboy@fix-issue-6453-homeboy")
             );
         });
+    }
+
+    #[test]
+    fn cook_batch_run_plan_binds_inferred_worktree_for_dispatch_and_promotion() {
+        // `cook-batch --run-plan` generates children without --cwd/--workspace.
+        // Once its declared worktree is materialized, the same canonical root
+        // must drive provider dispatch and promotion before execution starts.
+        let mut plan = build_cook_batch_plan(&cook_batch_args()).expect("generated cook plan");
+        let root = std::fs::canonicalize(env!("CARGO_MANIFEST_DIR")).expect("canonical root");
+        let rows = plan
+            .cooks
+            .iter()
+            .map(|cook| worktree::WorktreeQueueCreateRow {
+                branch: cook.head.clone().expect("generated head"),
+                handle: cook.to_worktree.clone(),
+                status: worktree::WorktreeQueueCreateStatus::Created,
+                command: Vec::new(),
+                retry_after_seconds: None,
+                active_lock_holder: None,
+                path: Some(root.display().to_string()),
+                error: None,
+            })
+            .collect();
+        bind_materialized_worktrees(
+            &mut plan,
+            &worktree::WorktreeQueueCreateOutput {
+                schema: "homeboy/worktree-queue-create/v1",
+                repo: "homeboy".to_string(),
+                base_ref: "origin/main".to_string(),
+                dry_run: false,
+                rows,
+            },
+        )
+        .expect("bind materialized worktrees");
+
+        let invocation = plan.cooks[0]
+            .to_cook_invocation(&plan)
+            .expect("workspace-bound cook invocation");
+        assert_eq!(invocation.dispatch.workspace.as_deref(), root.to_str());
+        assert_eq!(
+            invocation.options.source_worktree_path.as_deref(),
+            Some(root.as_path())
+        );
+
+        let compiled = compile_batch_cooks(&plan, |_| {}).expect("compile before provider");
+        assert_eq!(
+            compiled[0].initial_plan.tasks[0].workspace.root.as_deref(),
+            root.to_str()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Bind generated `cook-batch --run-plan` children to their materialized canonical task worktree before recipe and provider execution.
- Feed that same canonical path to dispatch and promotion source handling.
- Persist controller-local terminal child admission failures into fanout status so they remain failed rather than running/unavailable.

Closes #10349

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-cli cook_batch_run_plan_binds_inferred_worktree_for_dispatch_and_promotion`
- `cargo test -p homeboy-agents terminal_admission_failure_is_not_reclassified_as_unavailable`
- `cargo test -p homeboy-cli fanout` (42 passed; two pre-existing unrelated failures: `recipe_preflight_accepts_exact_replay_and_rejects_changed_inputs` and `agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_placement`)

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the implementation and tests. Chris Huber owns and is responsible for every line of this change.