### PR TITLE
fix(cli): gate worktree cleanup behind --apply

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -482,10 +482,9 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         }
         ["worktree", "cleanup"] => {
             metadata.mutating(
-                "removes cleanup-eligible task worktrees; pass --cleanup-artifacts to also remove rebuildable Homeboy artifacts",
+                "default output is a non-mutating cleanup plan; pass --apply to remove cleanup-eligible task worktrees and --cleanup-artifacts to also remove rebuildable Homeboy artifacts",
             );
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--force", "--cleanup-artifacts"];
+            metadata.dangerous_flags = vec!["--apply", "--force", "--cleanup-artifacts"];
         }
         ["tunnel", "service", "expose"]
         | ["tunnel", "service", "set"]

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -612,8 +612,8 @@ const TASK_WORKTREES_METADATA: CleanupInventoryCategoryMetadata =
     CleanupInventoryCategoryMetadata {
         category: "task_worktrees",
         include_arg: "task-worktrees",
-        dry_run_command: "homeboy worktree cleanup --dry-run --cleanup-branches",
-        apply_command: "homeboy worktree cleanup --cleanup-branches",
+        dry_run_command: "homeboy worktree cleanup --cleanup-branches",
+        apply_command: "homeboy worktree cleanup --cleanup-branches --apply",
     };
 
 const WORKTREE_PROVIDERS_METADATA: CleanupInventoryCategoryMetadata =
@@ -1382,7 +1382,7 @@ fn cleanup_actionable(
             format!("{} cleanup", category.category.replace('_', " ")),
             if category.category == REPO_ARTIFACTS_METADATA.category {
                 apply_command(&category.canonical_cleanup_command)
-            } else if apply || category.category == TASK_WORKTREES_METADATA.category {
+            } else if apply {
                 category.specialist_command.clone()
             } else {
                 apply_command(&category.specialist_command)
@@ -2023,8 +2023,8 @@ mod tests {
                 TASK_WORKTREES_METADATA,
                 "task_worktrees",
                 "task-worktrees",
-                "homeboy worktree cleanup --dry-run --cleanup-branches",
                 "homeboy worktree cleanup --cleanup-branches",
+                "homeboy worktree cleanup --cleanup-branches --apply",
             ),
             (
                 TERMINAL_RUNS_METADATA,
@@ -2086,14 +2086,17 @@ mod tests {
         }
     }
 
+    /// Task worktrees used to be the only category whose specialist command
+    /// deleted without `--apply`, which forced a special case in
+    /// `cleanup_actionable` so the plan mode would not append `--apply` to an
+    /// already-destructive command. Now that `homeboy worktree cleanup` is
+    /// plan-only by default, both modes surface the same `--apply`-gated
+    /// command like every other category (#10286).
     #[test]
-    fn task_worktree_cleanup_next_actions_preserve_mode_specific_commands() {
+    fn task_worktree_cleanup_next_actions_follow_the_apply_convention() {
         let cases = [
-            (
-                false,
-                "homeboy worktree cleanup --dry-run --cleanup-branches",
-            ),
-            (true, "homeboy worktree cleanup --cleanup-branches"),
+            (false, "homeboy worktree cleanup --cleanup-branches --apply"),
+            (true, "homeboy worktree cleanup --cleanup-branches --apply"),
         ];
 
         for (apply, command) in cases {

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -111,13 +111,18 @@ enum WorktreeCommand {
         #[arg(long, requires = "cleanup_branch")]
         allow_unmerged_branch: bool,
     },
-    /// Remove cleanup-eligible task worktrees after safety checks
+    /// Report cleanup-eligible task worktrees; pass --apply to remove them
     Cleanup {
+        /// Apply cleanup by removing cleanup-eligible task worktrees and any
+        /// selected artifacts. Without this flag, the command is a dry run.
+        #[arg(long)]
+        apply: bool,
         /// Allow dirty/unpushed worktree removal; hard gates still apply
         #[arg(long)]
         force: bool,
-        /// Report cleanup candidates without removing worktrees or artifacts.
-        #[arg(long)]
+        /// Deprecated no-op retained for one release: cleanup is already
+        /// plan-only unless --apply is passed.
+        #[arg(long, hide = true, conflicts_with = "apply")]
         dry_run: bool,
         /// Also remove declared rebuildable artifacts from the Homeboy checkout that built this binary.
         #[arg(long)]
@@ -163,6 +168,27 @@ pub struct WorktreeCleanupCommandOutput {
     pub worktrees: WorktreeCleanupOutput,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifact_cleanup: Option<ArtifactCleanupOutput>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// Soft deprecation note emitted when a caller still passes the legacy
+/// `--dry-run` flag. Cleanup is plan-only by default now, so the flag is a
+/// no-op kept for one release so existing scripts keep parsing.
+const DRY_RUN_DEPRECATION_NOTICE: &str = "`--dry-run` is deprecated and has no effect: `homeboy worktree cleanup` is plan-only by default. Pass --apply to remove worktrees.";
+
+/// Resolve the mutation gate for `worktree cleanup`.
+///
+/// Removal only happens when `--apply` is passed. `--dry-run` is a deprecated
+/// no-op alias; it can never turn the command into a mutation.
+fn cleanup_apply_mode(apply: bool, dry_run: bool) -> (bool, Vec<String>) {
+    let warnings = if dry_run {
+        vec![DRY_RUN_DEPRECATION_NOTICE.to_string()]
+    } else {
+        Vec::new()
+    };
+
+    (apply && !dry_run, warnings)
 }
 
 pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<WorktreeOutput> {
@@ -236,15 +262,17 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
             allow_unmerged_branch,
         })?),
         WorktreeCommand::Cleanup {
+            apply,
             force,
             dry_run,
             cleanup_artifacts,
             cleanup_branches,
             allow_unmerged_branches,
         } => {
+            let (apply, warnings) = cleanup_apply_mode(apply, dry_run);
             let worktrees = worktree::cleanup(WorktreeCleanupOptions {
                 force,
-                dry_run,
+                dry_run: !apply,
                 cleanup_branches,
                 allow_unmerged_branches,
             })?;
@@ -252,7 +280,7 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
                 Some(artifact_cleanup::cleanup_artifacts(
                     ArtifactCleanupOptions {
                         path: None,
-                        apply: !dry_run,
+                        apply,
                         self_artifacts: true,
                         temp_roots: Vec::new(),
                         sort: ArtifactCleanupSort::Discovery,
@@ -268,6 +296,7 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
             WorktreeOutput::Cleanup(WorktreeCleanupCommandOutput {
                 worktrees,
                 artifact_cleanup,
+                warnings,
             })
         }
     };
@@ -280,7 +309,75 @@ mod tests {
 
     use crate::cli_surface::{Cli, Commands};
 
-    use super::WorktreeCommand;
+    use super::{cleanup_apply_mode, WorktreeCommand, DRY_RUN_DEPRECATION_NOTICE};
+
+    /// Parse `worktree cleanup` and return its `(apply, dry_run)` gate flags.
+    fn parse_cleanup_gate(args: &[&str]) -> (bool, bool) {
+        let cli = Cli::parse_from(args);
+
+        let Commands::Worktree(args) = cli.command else {
+            panic!("expected worktree command");
+        };
+        let WorktreeCommand::Cleanup { apply, dry_run, .. } = args.command else {
+            panic!("expected worktree cleanup command");
+        };
+
+        (apply, dry_run)
+    }
+
+    /// The mutation gate for every other cleanup surface is `--apply`. The bare
+    /// command must stay plan-only so an operator or agent that generalizes
+    /// "append --apply to make it real" cannot delete worktrees on the preview
+    /// step.
+    #[test]
+    fn worktree_cleanup_is_plan_only_without_apply() {
+        let (apply, dry_run) = parse_cleanup_gate(&["homeboy", "worktree", "cleanup"]);
+
+        assert!(!apply);
+        assert!(!dry_run);
+        assert_eq!(cleanup_apply_mode(apply, dry_run), (false, Vec::new()));
+    }
+
+    #[test]
+    fn worktree_cleanup_mutates_only_with_apply() {
+        let (apply, dry_run) = parse_cleanup_gate(&["homeboy", "worktree", "cleanup", "--apply"]);
+
+        assert!(apply);
+        assert!(!dry_run);
+        assert_eq!(cleanup_apply_mode(apply, dry_run), (true, Vec::new()));
+    }
+
+    /// `--dry-run` is a deprecated no-op alias kept for one release so existing
+    /// scripts keep parsing. It must never mutate.
+    #[test]
+    fn worktree_cleanup_dry_run_still_parses_and_does_not_mutate() {
+        let (apply, dry_run) = parse_cleanup_gate(&["homeboy", "worktree", "cleanup", "--dry-run"]);
+
+        assert!(!apply);
+        assert!(dry_run);
+        assert_eq!(
+            cleanup_apply_mode(apply, dry_run),
+            (false, vec![DRY_RUN_DEPRECATION_NOTICE.to_string()])
+        );
+    }
+
+    #[test]
+    fn worktree_cleanup_rejects_dry_run_with_apply() {
+        assert!(
+            Cli::try_parse_from(["homeboy", "worktree", "cleanup", "--dry-run", "--apply"])
+                .is_err()
+        );
+    }
+
+    /// Defense in depth: even if the conflict gate were relaxed, the deprecated
+    /// alias can only ever downgrade to plan-only.
+    #[test]
+    fn worktree_cleanup_dry_run_cannot_upgrade_to_apply() {
+        assert_eq!(
+            cleanup_apply_mode(true, true),
+            (false, vec![DRY_RUN_DEPRECATION_NOTICE.to_string()])
+        );
+    }
 
     #[test]
     fn worktree_cleanup_does_not_cleanup_artifacts_by_default() {

--- a/docs/commands/worktree.md
+++ b/docs/commands/worktree.md
@@ -8,7 +8,7 @@ Manage component-backed task worktrees for generic Homeboy workflows.
 - `homeboy worktree list`
 - `homeboy worktree status <id>`
 - `homeboy worktree remove <id> [--force]`
-- `homeboy worktree cleanup [--force] [--cleanup-artifacts]`
+- `homeboy worktree cleanup [--apply] [--force] [--cleanup-artifacts]`
 
 For multi-PR orchestration, start with `homeboy --output homeboy-results/worktrees.json worktree list`, then pair each branch with `homeboy triage landing 'owner/repo#number' --drilldown` and any recorded `homeboy runs evidence <run-id>` output. See [Hold a PR fleet](../workflows/hold-a-pr-fleet.md) for the full local-plus-remote handoff loop.
 
@@ -16,4 +16,6 @@ For multi-PR orchestration, start with `homeboy --output homeboy-results/worktre
 
 Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. `--force` only bypasses dirty/unpushed checks; primary checkout and containment gates always apply.
 
-`worktree cleanup` is task-worktree cleanup by default. Use `homeboy cleanup artifacts` to plan rebuildable artifact cleanup, then pass `--apply` when the plan is acceptable. `worktree cleanup --cleanup-artifacts` is an explicit combined operator path for also removing declared rebuildable artifacts from the Homeboy checkout that built the active binary.
+`worktree cleanup` is task-worktree cleanup by default. Like every other Homeboy cleanup surface it is plan-only until `--apply` is passed: the bare command reports cleanup candidates and removes nothing. Use `homeboy cleanup artifacts` to plan rebuildable artifact cleanup, then pass `--apply` when the plan is acceptable. `worktree cleanup --cleanup-artifacts` is an explicit combined operator path for also removing declared rebuildable artifacts from the Homeboy checkout that built the active binary.
+
+`--dry-run` is accepted for one release as a deprecated no-op so existing scripts keep parsing; it emits a deprecation warning and cannot be combined with `--apply`.

--- a/docs/workflows/hold-a-pr-fleet.md
+++ b/docs/workflows/hold-a-pr-fleet.md
@@ -124,10 +124,11 @@ Example handoff row:
 
 ## 6. Clean Up Deliberately
 
-Preview cleanup first:
+Preview cleanup first. The bare command is plan-only; `--apply` is the mutation gate:
 
 ```bash
-homeboy worktree cleanup --dry-run
+homeboy worktree cleanup
+homeboy worktree cleanup --apply
 ```
 
 Remove one safe worktree when the branch is merged or no longer needed:

--- a/docs/workflows/manage-local-environments.md
+++ b/docs/workflows/manage-local-environments.md
@@ -88,7 +88,10 @@ Remove only when the worktree is safe to discard:
 ```bash
 homeboy worktree remove <worktree-id>
 homeboy worktree cleanup
+homeboy worktree cleanup --apply
 ```
+
+`homeboy worktree cleanup` reports cleanup candidates without removing anything. Pass `--apply` when the plan is acceptable.
 
 Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. Treat `--force` as an explicit operator decision, not routine cleanup.
 


### PR DESCRIPTION
Closes #10286

## The danger

`homeboy worktree cleanup` was **the one destructive-by-default command in a family of nine cleanup surfaces**. The bare command removed worktrees. Every sibling is the opposite — plan-only until `--apply`:

| Command | Gate |
|---|---|
| `homeboy cleanup` | `--apply` |
| `homeboy cleanup artifacts` | `--apply` |
| `homeboy cleanup worktrees` | `--apply` |
| `homeboy runs retention` | `--apply` |
| `homeboy runs artifact cleanup-persisted` | `--apply` |
| `homeboy runs artifact cleanup-downloads` | `--apply` |
| `homeboy runner workspace prune` | `--apply` |
| `homeboy runtime controller-prune` | `--apply` |
| `homeboy self cleanup-runtime-tmp` | `--apply` |
| **`homeboy worktree cleanup`** | **none — deleted by default** |

Worse: homeboy handed the destructive form to operators as a copyable next action. `TASK_WORKTREES_METADATA` declared:

```rust
dry_run_command: "homeboy worktree cleanup --dry-run --cleanup-branches",
apply_command:   "homeboy worktree cleanup --cleanup-branches",
```

which `cleanup_actionable` surfaced through `_homeboy_actionable.next_actions`. An operator or agent that generalized "append `--apply` to make it real" from the other eight categories would **delete worktrees on the preview step**.

## Changes

- **`--apply` is now the mutation gate** for `worktree cleanup`; the bare command is plan-only.
- **`--dry-run` back-compat:** kept as a hidden (`hide = true`) deprecated no-op for one release so existing scripts keep parsing. It emits a soft deprecation note in `warnings`, `conflicts_with = "apply"`, and the resolver (`cleanup_apply_mode`) can only ever downgrade to plan-only — it can never turn the command into a mutation.
- **`TASK_WORKTREES_METADATA`** repointed: `dry_run_command` is the bare command, `apply_command` appends `--apply`. Now identical in shape to the other eight categories.
- **Special case deleted.** The `else if apply || category.category == TASK_WORKTREES_METADATA.category` branch in `cleanup_actionable` existed *only* because task worktrees had inverted polarity. With polarity fixed it collapses to `else if apply`. Its test was rewritten to assert the converged behavior (both plan and apply mode now emit the same `--apply`-gated command) rather than deleted outright, so `cleanup_actionable` keeps coverage.
- **Safety manifest** (`["worktree", "cleanup"]`) now declares `--apply` in `dangerous_flags` and drops `dry_run_flag`, matching `cleanup artifacts` / `self cleanup-runtime-tmp` / `runner workspace prune`.

## Docs

- `docs/workflows/manage-local-environments.md` — showed the bare (destructive) command; now shows plan-then-`--apply`.
- `docs/workflows/hold-a-pr-fleet.md` — showed `--dry-run`; now shows the bare command as the preview.
- `docs/commands/worktree.md` — synopsis gains `[--apply]`; safety section documents plan-only default and the `--dry-run` deprecation.

Grepped the rest of `docs/` (excluding the generated changelog) and the repo's json/toml/sh/yml — no other stale `worktree cleanup` usages.

## Tests

`crates/homeboy-cli/src/commands/worktree.rs`:
- bare command parses plan-only and does not mutate
- `--apply` mutates
- `--dry-run` still parses, does not mutate, and emits the deprecation note
- `--dry-run --apply` is rejected at parse time
- defense-in-depth: `cleanup_apply_mode(true, true)` still resolves to plan-only

## Verification

`cargo fmt` run. Full build/test left to CI per repo policy (this host cannot run cargo builds).