### PR TITLE
Fix bounded runner workspace prune continuation

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1307,6 +1307,7 @@ fn remote_lab_workspace_categories(
                 min_age_hours: 24,
                 limit: 25,
                 passes: if apply { 10 } else { 1 },
+                cursor: None,
             },
         ) {
             Ok((output, _)) => output,

--- a/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
@@ -138,6 +138,10 @@ pub(super) enum RunnerWorkspaceCommand {
         /// Maximum apply passes to run. Each pass re-scans and removes at most --limit candidates.
         #[arg(long, default_value_t = 1)]
         passes: usize,
+
+        /// Opaque continuation cursor returned by an incomplete workspace-prune scan.
+        #[arg(long)]
+        cursor: Option<String>,
     },
 }
 
@@ -212,6 +216,7 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
             min_age_hours,
             limit,
             passes,
+            cursor,
         } => runner::prune_workspaces(
             &runner_id,
             runner::RunnerWorkspacePruneOptions {
@@ -219,6 +224,7 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
                 min_age_hours,
                 limit,
                 passes,
+                cursor,
             },
         )
         .map(|(output, exit_code)| (RunnerWorkspaceOutput::Prune(output), exit_code)),

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::fs::OpenOptions;
 use std::hash::{Hash, Hasher};
@@ -1170,11 +1171,19 @@ pub fn prune_workspaces(
     let mut total_candidate_bytes = 0;
     let mut scanned_workspace_count = 0;
     let mut scan_complete = true;
+    let mut continuation_cursor = options.cursor.clone();
     let remaining_candidates: Vec<RunnerWorkspacePruneEntry> = Vec::new();
     for pass in 0..passes {
-        let scan = prune_candidates_for_runner(&runner, &lab_workspaces_root, &options, limit)?;
+        let scan = prune_candidates_for_runner(
+            &runner,
+            &lab_workspaces_root,
+            &options,
+            limit,
+            continuation_cursor.as_deref(),
+        )?;
         scanned_workspace_count += scan.scanned_workspace_count;
         scan_complete = scan.scan_complete;
+        continuation_cursor = scan.continuation_cursor;
         let candidates = scan.candidates;
         for withheld in scan.withheld {
             match withheld.liveness.state.as_str() {
@@ -1209,6 +1218,9 @@ pub fn prune_workspaces(
             total_candidate_bytes = candidates.iter().map(|entry| entry.bytes).sum();
         }
         if candidates.is_empty() {
+            if options.apply && !scan_complete {
+                continue;
+            }
             break;
         }
         for candidate in candidates {
@@ -1258,21 +1270,26 @@ pub fn prune_workspaces(
     let remaining_candidate_bytes = remaining_candidates.iter().map(|entry| entry.bytes).sum();
     let has_more = !scan_complete || remaining_candidate_count > 0 || !skipped.is_empty();
     let runner_arg = shell_arg(&runner.id);
+    let cursor_arg = (!scan_complete)
+        .then(|| continuation_cursor.as_deref())
+        .flatten()
+        .map(|cursor| format!(" --cursor {}", shell_arg(cursor)))
+        .unwrap_or_default();
     let next_command = has_more.then(|| {
         if options.apply {
             format!(
-                "homeboy runner workspace prune {runner_arg} --apply --min-age-hours {} --limit {limit} --passes {passes}",
+                "homeboy runner workspace prune {runner_arg} --apply --min-age-hours {} --limit {limit} --passes {passes}{cursor_arg}",
                 options.min_age_hours
             )
         } else {
             format!(
-                "homeboy runner workspace prune {runner_arg} --min-age-hours {} --limit {limit}",
+                "homeboy runner workspace prune {runner_arg} --min-age-hours {} --limit {limit}{cursor_arg}",
                 options.min_age_hours
             )
         }
     });
     let drain_command = format!(
-        "homeboy runner workspace prune {runner_arg} --apply --min-age-hours {} --limit {limit} --passes 10",
+        "homeboy runner workspace prune {runner_arg} --apply --min-age-hours {} --limit {limit} --passes 10{cursor_arg}",
         options.min_age_hours
     );
     let total_removed_bytes = removed.iter().map(|entry| entry.bytes).sum();
@@ -1299,6 +1316,7 @@ pub fn prune_workspaces(
             reconcile_command: format!("homeboy runner job reconcile {runner_arg}"),
             scanned_workspace_count,
             scan_complete,
+            continuation_cursor: (!scan_complete).then_some(continuation_cursor).flatten(),
             total_candidate_count,
             total_candidate_bytes,
             total_removed_bytes,
@@ -1317,12 +1335,19 @@ fn prune_candidates_for_runner(
     lab_workspaces_root: &str,
     options: &RunnerWorkspacePruneOptions,
     scan_limit: usize,
+    cursor: Option<&str>,
 ) -> Result<PruneCandidateScan> {
     match runner.kind {
-        RunnerKind::Local => {
-            prune_candidates_local(runner, Path::new(lab_workspaces_root), options, scan_limit)
+        RunnerKind::Local => prune_candidates_local(
+            runner,
+            Path::new(lab_workspaces_root),
+            options,
+            scan_limit,
+            cursor,
+        ),
+        RunnerKind::Ssh => {
+            prune_candidates_ssh(runner, lab_workspaces_root, options, scan_limit, cursor)
         }
-        RunnerKind::Ssh => prune_candidates_ssh(runner, lab_workspaces_root, options, scan_limit),
     }
 }
 
@@ -1331,6 +1356,7 @@ struct PruneCandidateScan {
     withheld: Vec<RunnerWorkspacePruneEntry>,
     scanned_workspace_count: usize,
     scan_complete: bool,
+    continuation_cursor: Option<String>,
 }
 
 /// Reap a single run-scoped materialized workspace (and its sibling Homeboy
@@ -2447,6 +2473,7 @@ fn prune_candidates_local(
     root: &Path,
     options: &RunnerWorkspacePruneOptions,
     scan_limit: usize,
+    cursor: Option<&str>,
 ) -> Result<PruneCandidateScan> {
     if !root.is_dir() {
         return Ok(PruneCandidateScan {
@@ -2454,34 +2481,51 @@ fn prune_candidates_local(
             withheld: Vec::new(),
             scanned_workspace_count: 0,
             scan_complete: true,
+            continuation_cursor: None,
         });
     }
+    let after = cursor
+        .map(|cursor| decode_prune_cursor(root, cursor))
+        .transpose()?;
     let mut candidates = Vec::new();
     let mut withheld = Vec::new();
-    let mut entries = fs::read_dir(root).map_err(|err| {
+    let entries = fs::read_dir(root).map_err(|err| {
         Error::internal_io(
             err.to_string(),
             Some("read runner workspace root".to_string()),
         )
     })?;
-    let mut scanned_workspace_count = 0;
-    let mut scan_complete = true;
-    while let Some(entry) = entries.next() {
+    let mut paths = BTreeSet::new();
+    for entry in entries {
         let entry = entry.map_err(|err| {
             Error::internal_io(
                 err.to_string(),
                 Some("read runner workspace entry".to_string()),
             )
         })?;
-        let path = entry.path();
         if !entry.file_type().map(|kind| kind.is_dir()).unwrap_or(false) {
             continue;
         }
-        if scanned_workspace_count == scan_limit {
-            scan_complete = false;
-            break;
+        let path = entry.path();
+        if after.as_ref().is_some_and(|after| path <= *after) {
+            continue;
         }
-        scanned_workspace_count += 1;
+        paths.insert(path);
+        if paths.len() > scan_limit.saturating_add(1) {
+            paths.pop_last();
+        }
+    }
+    let scan_complete = paths.len() <= scan_limit;
+    if !scan_complete {
+        paths.pop_last();
+    }
+    let inspected = paths.into_iter().collect::<Vec<_>>();
+    let scanned_workspace_count = inspected.len();
+    let continuation_cursor = (!scan_complete)
+        .then(|| inspected.last())
+        .flatten()
+        .map(|path| encode_prune_cursor(path));
+    for path in inspected {
         if let Some(candidate) = classify_local_candidate(runner, root, &path, options)? {
             if candidate.liveness.state == "inactive" {
                 candidates.push(candidate);
@@ -2501,6 +2545,7 @@ fn prune_candidates_local(
         withheld,
         scanned_workspace_count,
         scan_complete,
+        continuation_cursor,
     })
 }
 
@@ -2525,9 +2570,9 @@ fn classify_local_candidate(
         Ok(content) => content,
         Err(_) => return Ok(None),
     };
-    let metadata: serde_json::Value = serde_json::from_str(&metadata).map_err(|err| {
-        Error::internal_json(err.to_string(), Some(metadata_path.display().to_string()))
-    })?;
+    let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&metadata) else {
+        return Ok(None);
+    };
     if metadata.get("schema").and_then(|value| value.as_str())
         != Some("homeboy/runner-workspace/v1")
     {
@@ -2824,11 +2869,15 @@ fn prune_candidates_ssh(
     root: &str,
     options: &RunnerWorkspacePruneOptions,
     scan_limit: usize,
+    cursor: Option<&str>,
 ) -> Result<PruneCandidateScan> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
     let min_age = options.min_age_hours.saturating_mul(3600);
-    let command = prune_scan_command(root, min_age, scan_limit);
+    let after = cursor
+        .map(|cursor| decode_prune_cursor(Path::new(root), cursor))
+        .transpose()?;
+    let command = prune_scan_command(root, min_age, scan_limit, after.as_deref());
     let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
@@ -2842,7 +2891,7 @@ fn prune_candidates_ssh(
     for line in output.stdout.lines() {
         if let Some(status) = line.strip_prefix("__homeboy_prune_scan__\t") {
             let parts = status.split('\t').collect::<Vec<_>>();
-            let [scanned_workspace_count, completion] = parts.as_slice() else {
+            let [scanned_workspace_count, completion, last_inspected] = parts.as_slice() else {
                 return Err(Error::internal_unexpected(
                     "runner workspace prune scan returned an invalid completion status".to_string(),
                 ));
@@ -2862,7 +2911,17 @@ fn prune_candidates_ssh(
                     ));
                 }
             };
-            scan_status = Some((scanned_workspace_count, scan_complete));
+            let continuation_cursor = match (*completion, *last_inspected) {
+                ("complete", "") => None,
+                ("partial", path) if !path.is_empty() => Some(encode_prune_cursor(Path::new(path))),
+                _ => {
+                    return Err(Error::internal_unexpected(
+                        "runner workspace prune scan returned an invalid continuation cursor"
+                            .to_string(),
+                    ))
+                }
+            };
+            scan_status = Some((scanned_workspace_count, scan_complete, continuation_cursor));
             continue;
         }
         let parts = line.splitn(4, '\t').collect::<Vec<_>>();
@@ -2872,11 +2931,12 @@ fn prune_candidates_ssh(
         let age_seconds = parts[0].parse::<u64>().unwrap_or(0);
         let bytes = parts[1].parse::<u64>().unwrap_or(0);
         let remote_path = parts[2].to_string();
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(parts[3])
-            .map_err(|err| Error::internal_json(err.to_string(), None))?;
-        let metadata: serde_json::Value = serde_json::from_slice(&decoded)
-            .map_err(|err| Error::internal_json(err.to_string(), Some(remote_path.clone())))?;
+        let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(parts[3]) else {
+            continue;
+        };
+        let Ok(metadata) = serde_json::from_slice::<serde_json::Value>(&decoded) else {
+            continue;
+        };
         if metadata.get("schema").and_then(|value| value.as_str())
             != Some("homeboy/runner-workspace/v1")
         {
@@ -2925,16 +2985,18 @@ fn prune_candidates_ssh(
             .then_with(|| b.age_seconds.cmp(&a.age_seconds))
             .then_with(|| a.remote_path.cmp(&b.remote_path))
     });
-    let (scanned_workspace_count, scan_complete) = scan_status.ok_or_else(|| {
-        Error::internal_unexpected(
-            "runner workspace prune scan did not return a completion status".to_string(),
-        )
-    })?;
+    let (scanned_workspace_count, scan_complete, continuation_cursor) =
+        scan_status.ok_or_else(|| {
+            Error::internal_unexpected(
+                "runner workspace prune scan did not return a completion status".to_string(),
+            )
+        })?;
     Ok(PruneCandidateScan {
         candidates,
         withheld,
         scanned_workspace_count,
         scan_complete,
+        continuation_cursor,
     })
 }
 
@@ -2964,13 +3026,51 @@ fn prune_candidate_reason_from_decoded_metadata(
     (!Path::new(source_path).exists()).then(|| "source_path_missing".to_string())
 }
 
-pub(crate) fn prune_scan_command(root: &str, min_age: u64, scan_limit: usize) -> String {
+pub(crate) fn prune_scan_command(
+    root: &str,
+    min_age: u64,
+    scan_limit: usize,
+    after: Option<&Path>,
+) -> String {
     format!(
-        "root={root}; meta_rel={meta}; min_age={min_age}; now=$(date +%s); if [ -d \"$root\" ]; then find \"$root\" -mindepth 1 -maxdepth 1 -type d -print | {{ scanned=0; complete=complete; while IFS= read -r dir; do if [ \"$scanned\" -ge {scan_limit} ]; then complete=partial; break; fi; scanned=$((scanned + 1)); meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; mtime=$(stat -c %Y \"$dir\" 2>/dev/null || stat -f %m \"$dir\" 2>/dev/null || echo 0); age=$((now-mtime)); [ \"$age\" -ge \"$min_age\" ] || continue; if find \"$dir/.homeboy\" -type f \\( -name \"*.patch\" -o -name \"*.diff\" -o -name \"*patch*\" \\) 2>/dev/null | grep -q .; then continue; fi; blocks=$(du -sk \"$dir\" 2>/dev/null); blocks=${{blocks%%[!0-9]*}}; bytes=$((blocks * 1024)); printf \"%s\\t%s\\t%s\\t\" \"$age\" \"${{bytes:-0}}\" \"$dir\"; base64 < \"$meta\" | tr -d \"\\n\"; printf \"\\n\"; done; printf \"__homeboy_prune_scan__\\t%s\\t%s\\n\" \"$scanned\" \"$complete\"; }}; else printf \"__homeboy_prune_scan__\\t0\\tcomplete\\n\"; fi",
+        "root={root}; after={after}; meta_rel={meta}; min_age={min_age}; now=$(date +%s); if [ -d \"$root\" ]; then LC_ALL=C find \"$root\" -mindepth 1 -maxdepth 1 -type d -print | LC_ALL=C sort | {{ scanned=0; complete=complete; last=; while IFS= read -r dir; do [ -z \"$after\" ] || [ \"$dir\" \\> \"$after\" ] || continue; if [ \"$scanned\" -ge {scan_limit} ]; then complete=partial; break; fi; scanned=$((scanned + 1)); last=$dir; meta=\"$dir/$meta_rel\"; [ -f \"$meta\" ] || continue; mtime=$(stat -c %Y \"$dir\" 2>/dev/null || stat -f %m \"$dir\" 2>/dev/null || echo 0); age=$((now-mtime)); [ \"$age\" -ge \"$min_age\" ] || continue; if find \"$dir/.homeboy\" -type f \\( -name \"*.patch\" -o -name \"*.diff\" -o -name \"*patch*\" \\) 2>/dev/null | grep -q .; then continue; fi; blocks=$(du -sk \"$dir\" 2>/dev/null); blocks=${{blocks%%[!0-9]*}}; bytes=$((blocks * 1024)); printf \"%s\\t%s\\t%s\\t\" \"$age\" \"${{bytes:-0}}\" \"$dir\"; base64 < \"$meta\" | tr -d \"\\n\"; printf \"\\n\"; done; printf \"__homeboy_prune_scan__\\t%s\\t%s\\t%s\\n\" \"$scanned\" \"$complete\" \"$last\"; }}; else printf \"__homeboy_prune_scan__\\t0\\tcomplete\\t\\n\"; fi",
         root = shell::quote_arg(root),
+        after = shell::quote_arg(after.and_then(Path::to_str).unwrap_or("")),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
         min_age = shell::quote_arg(&min_age.to_string()),
         scan_limit = scan_limit,
+    )
+}
+
+const PRUNE_CURSOR_PREFIX: &str = "homeboy-workspace-prune/v1\0";
+
+fn encode_prune_cursor(path: &Path) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(format!("{PRUNE_CURSOR_PREFIX}{}", path.display()))
+}
+
+fn decode_prune_cursor(root: &Path, cursor: &str) -> Result<std::path::PathBuf> {
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| invalid_prune_cursor())?;
+    let decoded = String::from_utf8(decoded).map_err(|_| invalid_prune_cursor())?;
+    let path = decoded
+        .strip_prefix(PRUNE_CURSOR_PREFIX)
+        .filter(|path| !path.is_empty())
+        .map(Path::new)
+        .ok_or_else(invalid_prune_cursor)?;
+    if path.parent() != Some(root) || path.file_name().is_none() {
+        return Err(invalid_prune_cursor());
+    }
+    Ok(path.to_path_buf())
+}
+
+fn invalid_prune_cursor() -> Error {
+    Error::validation_invalid_argument(
+        "cursor",
+        "workspace prune cursor is invalid for this workspace root",
+        None,
+        None,
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -41,6 +41,7 @@ fn prune_workspaces_previews_orphans_without_deleting_by_default() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune preview");
@@ -105,6 +106,7 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune apply");
@@ -153,6 +155,7 @@ fn prune_preserves_process_owned_workspace_in_preview_and_apply() {
                     min_age_hours: 0,
                     limit: 10,
                     passes: 1,
+                    cursor: None,
                 },
             )
             .expect("prune process-owned workspace");
@@ -208,6 +211,7 @@ fn prune_preserves_active_job_lifecycle_lease() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune active lease workspace");
@@ -255,6 +259,7 @@ fn prune_workspaces_reaps_ttl_expired_lifecycle_workspace_with_live_source() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune preview");
@@ -329,6 +334,7 @@ fn preserved_failure_lifecycle_is_registered_for_ttl_pruning() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune preview");
@@ -344,6 +350,7 @@ fn preserved_failure_lifecycle_is_registered_for_ttl_pruning() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("apply ttl prune");
@@ -407,6 +414,7 @@ fn uncertain_handoff_disarms_ttl_pruning() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune preview");
@@ -456,6 +464,7 @@ fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
                 min_age_hours: 0,
                 limit: 10,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune preview");
@@ -515,6 +524,7 @@ fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
                 min_age_hours: 0,
                 limit: 1,
                 passes: 1,
+                cursor: None,
             },
         )
         .expect("prune preview");
@@ -528,14 +538,15 @@ fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
         assert_eq!(output.remaining_candidate_count, 0);
         assert_eq!(output.remaining_candidate_bytes, 0);
         assert!(output.has_more);
-        assert_eq!(
-            output.next_command.as_deref(),
-            Some("homeboy runner workspace prune lab-local-prune-limited --min-age-hours 0 --limit 1")
-        );
-        assert_eq!(
-            output.drain_command,
-            "homeboy runner workspace prune lab-local-prune-limited --apply --min-age-hours 0 --limit 1 --passes 10"
-        );
+        let cursor = output
+            .continuation_cursor
+            .as_deref()
+            .expect("continuation cursor");
+        assert!(output
+            .next_command
+            .as_deref()
+            .is_some_and(|command| command.contains(&format!("--cursor {cursor}"))));
+        assert!(output.drain_command.contains(&format!("--cursor {cursor}")));
     });
 }
 
@@ -578,6 +589,7 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
                 min_age_hours: 0,
                 limit: 1,
                 passes: 10,
+                cursor: None,
             },
         )
         .expect("prune drain");
@@ -597,14 +609,24 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
 }
 
 #[test]
-fn prune_workspaces_bounds_thousands_of_entries_per_pass_and_drains_stably() {
+fn prune_workspaces_advances_through_thousands_of_mixed_entries() {
     homeboy_core::test_support::with_isolated_home(|_| {
         const WORKSPACE_COUNT: usize = 5_214;
+        const ORPHAN_INDICES: [usize; 3] = [1_333, 2_607, 5_213];
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let workspaces_root = runner_root.path().join("_lab_workspaces");
         fs::create_dir_all(&workspaces_root).expect("workspaces root");
         for index in 0..WORKSPACE_COUNT {
-            write_orphan_workspace(&workspaces_root.join(format!("workspace-{index:05}")));
+            let workspace = workspaces_root.join(format!("workspace-{index:05}"));
+            if ORPHAN_INDICES.contains(&index) {
+                write_orphan_workspace(&workspace);
+            } else if index % 11 == 0 {
+                fs::create_dir_all(workspace.join(".homeboy")).expect("malformed workspace");
+                fs::write(workspace.join(WORKSPACE_METADATA_FILE), "{malformed")
+                    .expect("malformed metadata");
+            } else {
+                fs::create_dir_all(workspace).expect("metadata-free workspace");
+            }
         }
         crate::create(
             &format!(
@@ -615,33 +637,47 @@ fn prune_workspaces_bounds_thousands_of_entries_per_pass_and_drains_stably() {
         )
         .expect("create runner");
 
-        let options = RunnerWorkspacePruneOptions {
-            apply: true,
-            min_age_hours: 0,
-            limit: 5,
-            passes: 3,
-        };
-        let (first, _) = prune_workspaces("lab-local-prune-thousands", options.clone())
-            .expect("first bounded drain");
-        let (second, _) =
-            prune_workspaces("lab-local-prune-thousands", options).expect("second bounded drain");
+        let mut cursor = None;
+        let mut scanned = 0;
+        let mut removed = Vec::new();
+        for _ in 0..20 {
+            let (output, _) = prune_workspaces(
+                "lab-local-prune-thousands",
+                RunnerWorkspacePruneOptions {
+                    apply: true,
+                    min_age_hours: 0,
+                    limit: 127,
+                    passes: 3,
+                    cursor,
+                },
+            )
+            .expect("bounded mixed-entry drain");
+            assert!(output.scanned_workspace_count <= 127 * 3);
+            scanned += output.scanned_workspace_count;
+            removed.extend(output.removed);
+            if output.scan_complete {
+                assert!(output.continuation_cursor.is_none());
+                break;
+            }
+            cursor = Some(
+                output
+                    .continuation_cursor
+                    .expect("partial scan continuation cursor"),
+            );
+        }
 
-        assert_eq!(first.scanned_workspace_count, 15);
-        assert_eq!(first.removed.len(), 15);
-        assert_eq!(first.total_candidate_count, 5);
-        assert!(!first.scan_complete);
-        assert!(first.has_more);
-        assert_eq!(second.scanned_workspace_count, 15);
-        assert_eq!(second.removed.len(), 15);
-        assert!(first.removed.iter().all(|entry| !second
-            .removed
-            .iter()
-            .any(|next| next.remote_path == entry.remote_path)));
+        assert_eq!(scanned, WORKSPACE_COUNT);
+        assert_eq!(removed.len(), ORPHAN_INDICES.len());
+        for index in ORPHAN_INDICES {
+            assert!(!workspaces_root
+                .join(format!("workspace-{index:05}"))
+                .exists());
+        }
         assert_eq!(
             fs::read_dir(&workspaces_root)
                 .expect("remaining workspaces")
                 .count(),
-            WORKSPACE_COUNT - 30
+            WORKSPACE_COUNT - ORPHAN_INDICES.len()
         );
     });
 }
@@ -655,7 +691,12 @@ fn ssh_prune_scan_command_bounds_thousands_of_entries() {
 
     let output = Command::new("sh")
         .arg("-c")
-        .arg(prune_scan_command(&temp.path().display().to_string(), 0, 5))
+        .arg(prune_scan_command(
+            &temp.path().display().to_string(),
+            0,
+            5,
+            None,
+        ))
         .output()
         .expect("run generated prune scan command");
 
@@ -672,6 +713,27 @@ fn ssh_prune_scan_command_bounds_thousands_of_entries() {
     assert!(
         stdout.contains("__homeboy_prune_scan__\t5\tpartial"),
         "{stdout}"
+    );
+
+    let after = temp.path().join("workspace-00004");
+    let resumed = Command::new("sh")
+        .arg("-c")
+        .arg(prune_scan_command(
+            &temp.path().display().to_string(),
+            0,
+            5,
+            Some(&after),
+        ))
+        .output()
+        .expect("resume generated prune scan command");
+    assert!(resumed.status.success(), "{resumed:?}");
+    let resumed_stdout = String::from_utf8_lossy(&resumed.stdout);
+    assert!(!resumed_stdout.contains("workspace-00004\t"));
+    assert!(resumed_stdout.contains("workspace-00005\t"));
+    assert!(resumed_stdout.contains("workspace-00009\t"));
+    assert!(
+        resumed_stdout.contains("__homeboy_prune_scan__\t5\tpartial"),
+        "{resumed_stdout}"
     );
 }
 
@@ -699,7 +761,7 @@ fn ssh_prune_scan_command_handles_paths_that_need_shell_quoting() {
 
     let output = Command::new("sh")
         .arg("-c")
-        .arg(prune_scan_command(&root.display().to_string(), 0, 10))
+        .arg(prune_scan_command(&root.display().to_string(), 0, 10, None))
         .output()
         .expect("run generated prune scan command");
 

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -327,6 +327,8 @@ pub struct RunnerWorkspacePruneOptions {
     pub min_age_hours: u64,
     pub limit: usize,
     pub passes: usize,
+    /// Opaque cursor returned by a prior incomplete workspace-prune scan.
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -352,6 +354,9 @@ pub struct RunnerWorkspacePruneOutput {
     pub scanned_workspace_count: usize,
     /// Whether the inspected window reached the end of the workspace root.
     pub scan_complete: bool,
+    /// Opaque cursor for resuming strictly after the last inspected workspace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation_cursor: Option<String>,
     /// Candidate totals are limited to the first bounded scan window.
     pub total_candidate_count: usize,
     pub total_candidate_bytes: u64,

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -828,11 +828,12 @@ Safety rules:
 ```sh
 homeboy runner workspace prune <runner-id> --min-age-hours 24 --limit 5
 homeboy runner workspace prune <runner-id> --apply --min-age-hours 24 --limit 5 --passes 10
+homeboy runner workspace prune <runner-id> --cursor <opaque-cursor>
 ```
 
 `workspace prune` only removes metadata-backed, inactive Lab workspaces that are old enough, have no pending patch or diff artifact, and are orphaned or have an expired lifecycle TTL. It never removes outside `_lab_workspaces`.
 
-`--limit` bounds the workspace directories inspected, sized, retained in memory, and removed in each pass. `--passes` bounds apply passes. Output now includes `scanned_workspace_count` and `scan_complete`: when `scan_complete` is false, `has_more` is true and `total_candidate_*` plus `remaining_candidate_*` describe only the inspected window, not every runner workspace. Use the emitted `next_command` or `drain_command` to continue safely.
+`--limit` bounds the workspace directories inspected, sized, retained in memory, and removed in each pass. `--passes` bounds apply passes. Output now includes `scanned_workspace_count` and `scan_complete`: when `scan_complete` is false, `has_more` is true, `continuation_cursor` is an opaque token that resumes strictly after the last inspected workspace, and `total_candidate_*` plus `remaining_candidate_*` describe only the inspected window. Use the emitted `next_command` or `drain_command` unchanged; both carry the cursor when needed.
 
 ### `workspace apply`
 


### PR DESCRIPTION
## Summary
Make bounded runner workspace pruning advance monotonically through mixed eligible and retained entries.

## What changed
- Adds validated opaque cursors for local and SSH scans, propagates them through CLI output and continuation commands, and keeps local ordering memory bounded to limit plus one.

## How to test
1. Run `cargo check -p homeboy-cli`; expect CLI and runner contract compile successfully.
2. Run `cargo test -p homeboy-lab-runner prune_workspaces_advances_through_thousands_of_mixed_entries`; expect The 5,214-entry mixed namespace is traversed once and three separated orphans are removed.
3. Run `cargo test -p homeboy-lab-runner ssh_prune_scan_command_bounds_thousands_of_entries`; expect SSH scan resumes at workspace-00005 after a cursor ending at workspace-00004.

## Compatibility
The new input and output are additive; cursors are root-bound and invalid or cross-root tokens are rejected.

## Evidence
**Declared public contracts**
- `runner.workspace.prune`: Adds optional --cursor input and optional continuation\_cursor output; emitted continuation commands resume after the last inspected workspace

**Compatibility impact:** Additive CLI option and additive omitted-when-empty JSON field; existing invocations and existing output fields retain their semantics

**External-consumer impact:** Existing consumers can ignore continuation\_cursor; consumers following emitted commands gain deterministic progress through retained prefixes

**External usage:** unavailable_manual_review; source: GitHub public code search for the exact runner workspace prune command; limitations: Public code search returned no indexed external usages and cannot cover private or unindexed consumers; evidence: https://github.com/Extra-Chill/homeboy/issues/10157#issuecomment-5086988671

- Base advanced after verification: verified main at 5d51c38acfc549058ad4218665b8d131b2cae2a4; publication observed 8ad02b3a26c631c2eed7527faabb71973bf21afe. Candidate ancestry was validated against the verified snapshot.
- CI expected: Homeboy CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/10157
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/homeboy/issues/10350
- Verified finalization base: main at 5d51c38acfc549058ad4218665b8d131b2cae2a4
- cli-check: passed (cargo check -p homeboy-cli) (Passed)
- mixed-cursor-drain: passed (5,214 mixed entries traversed exactly once and all eligible orphans removed) (Passed)
- ssh-cursor-order: passed (resumed SSH scan starts strictly after the prior page) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode with Homeboy)
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode GPT-5.6 Terra drafted the initial patch; GPT-5.6 Sol reviewed it, corrected retained-prefix starvation, bounded local memory, strengthened tests, and verified the candidate

## Source relationships
- Closes #10157
- Relates to #10350
