### PR TITLE
fix(lab-runner): gate dispatch on workload-declared capabilities

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lab/types.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/types.rs
@@ -3,6 +3,10 @@
 use super::workload::LabRunnerWorkloadCapability;
 
 pub const LAB_CAPABILITY_PLAYWRIGHT: &str = "playwright";
+/// Capability naming the extension-parity guarantee. Unlike tool capabilities,
+/// this one is satisfied by the execution pipeline's own parity gate rather than
+/// by probing a runner binary.
+pub const LAB_CAPABILITY_EXTENSION_PARITY: &str = "extension_parity";
 pub const LAB_TRACE_EXTRA_CAPABILITIES: &[&str] = &[LAB_CAPABILITY_PLAYWRIGHT];
 pub const LAB_NO_SECRET_ENV_SOURCES: &[LabSecretEnvSource] = &[];
 /// Runner identity retained by a child already executing on Lab. Unlike the
@@ -15,6 +19,18 @@ pub const LAB_TRACE_SECRET_ENV_SOURCES: &[LabSecretEnvSource] = &[LabSecretEnvSo
 pub const LAB_TUNNEL_SECRET_ENV_SOURCES: &[LabSecretEnvSource] = &[LabSecretEnvSource::Tunnel];
 pub const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror. For Lab/offloaded dependency preparation and verification, run `homeboy rig check <rig-id> --runner <runner-id>` or the rig's benchmark profile through `homeboy rig run <rig-id> --runner <runner-id>`.";
 pub const RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON: &str = "rig source-management commands (`rig install`, `rig update`, `rig sync`, and `rig sources`) manage the controller's local rig registry and may read arbitrary local package paths. They are not Lab-portable yet. Install or refresh the rig locally first, then run Lab-compatible verification with `homeboy rig check <rig-id> --runner <runner-id>` or `homeboy rig run <rig-id> --runner <runner-id>`.";
+
+/// Whether a workload-declared capability is satisfied by a dedicated
+/// execution-pipeline gate instead of a runner tool probe.
+///
+/// Capability names default to runner tools (fail closed): an unrecognised name
+/// becomes a required tool the runner must actually provide. Only the names
+/// listed here are exempt, because a separate gate already enforces them —
+/// `extension_parity` is enforced by `plan_extension_parity` /
+/// `ensure_extension_materialized` in the lab-runner execution pipeline.
+pub fn lab_capability_is_pipeline_enforced(name: &str) -> bool {
+    name.trim() == LAB_CAPABILITY_EXTENSION_PARITY
+}
 
 /// Routing-policy flags owned by the Lab command contract and retained through
 /// route planning, offload, and runner dispatch.

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -947,6 +947,76 @@ mod tests {
             .is_some_and(|hint| hint.contains("Remote execution was not started"))));
     }
 
+    /// End-to-end gate for Extra-Chill/homeboy#10287: a capability the controller
+    /// declared on the workload must reach the dispatch preflight and refuse a
+    /// runner that cannot satisfy it. Before the fix the workload's declared
+    /// capabilities were discarded and every runner passed.
+    #[test]
+    fn workload_declared_capability_refuses_a_runner_missing_the_tool() {
+        let plan = homeboy_core::plan::HomeboyPlan::builder_for_description(
+            homeboy_core::plan::PlanKind::LabOffload,
+            "capability gate",
+        )
+        .build();
+        let command = crate::LabOffloadCommand {
+            command: homeboy_core::lab_contract::LabCommandContract::portable(
+                "trace",
+                None,
+                false,
+                &[],
+            ),
+            required_extensions: Vec::new(),
+            required_capabilities: vec![homeboy_core::lab_contract::LabRunnerWorkloadCapability {
+                name: "playwright".to_string(),
+                required: true,
+            }],
+            workload: None,
+        };
+        let workload = crate::workload::build_lab_runner_workload(
+            crate::workload::LabRunnerWorkloadBuildInput {
+                plan: &plan,
+                command: &command,
+                capture_patch: false,
+                mutation_flag: None,
+                allow_dirty_lab_workspace: false,
+                runner_id: "lab",
+                runner_mode: "direct_ssh",
+                assignment_source: "explicit",
+                status: "offloaded",
+                remote_workspace: Some("/srv/homeboy/work"),
+                fallback_reason: None,
+                workspace_mapping_ref: None,
+                proof_id: None,
+            },
+        );
+
+        let preflight =
+            crate::workload::merge_lab_runner_workload_capability_preflight(None, Some(&workload))
+                .expect("workload capability reaches the dispatch preflight");
+
+        let capable = RunnerCapabilitySnapshot {
+            tools: [RunnerRequiredTool::new("playwright")]
+                .into_iter()
+                .collect(),
+            commands: BTreeSet::new(),
+            tool_capabilities: BTreeSet::new(),
+            components: BTreeSet::new(),
+        };
+        validate_runner_capability_preflight("lab", &preflight, &capable, &HashMap::new())
+            .expect("a runner providing the declared capability passes");
+
+        let err = validate_runner_capability_preflight(
+            "lab",
+            &preflight,
+            &RunnerCapabilitySnapshot::default(),
+            &HashMap::new(),
+        )
+        .expect_err("a runner missing the declared capability is refused");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("tools: playwright"));
+    }
+
     #[test]
     fn runner_capability_preflight_accepts_matching_requirements() {
         let preflight = RunnerCapabilityPreflight {

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -915,7 +915,7 @@ pub(crate) fn exec_with_status_snapshot(
     let capability_preflight = super::workload::merge_lab_runner_workload_capability_preflight(
         remote_execution_preflight(&options.command, options.capability_preflight.as_ref()),
         options.lab_runner_workload.as_ref(),
-    )?;
+    );
     let run_capability_preflight = |runner: &Runner| -> Result<()> {
         preflight_runner_capability_plan(runner, capability_preflight.as_ref(), &request_env)
     };

--- a/crates/homeboy-lab-runner/src/execution/worker.rs
+++ b/crates/homeboy-lab-runner/src/execution/worker.rs
@@ -144,7 +144,7 @@ pub(super) fn exec_worker_local_with_process_output(
         super::super::workload::merge_lab_runner_workload_capability_preflight(
             options.capability_preflight.clone(),
             options.lab_runner_workload.as_ref(),
-        )?;
+        );
     preflight_worker_local_capability_plan(&plan.runner, capability_preflight.as_ref(), &plan.env)?;
     let output = execute(&plan)?;
     let (mut output, exit_code) = exec_output(

--- a/crates/homeboy-lab-runner/src/workload.rs
+++ b/crates/homeboy-lab-runner/src/workload.rs
@@ -2,19 +2,20 @@ use clap::Parser;
 use homeboy_agents::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::{
-    LabRunnerWorkload, LabRunnerWorkloadAgentTask, LabRunnerWorkloadAgentTaskDispatchKind,
-    LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy, LabRunnerWorkloadAssignment,
-    LabRunnerWorkloadCapability, LabRunnerWorkloadCommandFamily,
+    lab_capability_is_pipeline_enforced, LabRunnerWorkload, LabRunnerWorkloadAgentTask,
+    LabRunnerWorkloadAgentTaskDispatchKind, LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy,
+    LabRunnerWorkloadAssignment, LabRunnerWorkloadCapability, LabRunnerWorkloadCommandFamily,
     LabRunnerWorkloadExtensionRevision, LabRunnerWorkloadKind, LabRunnerWorkloadMutationPolicy,
     LabRunnerWorkloadResultRefs, LabRunnerWorkloadSecrets, LabRunnerWorkloadState,
-    LabRunnerWorkloadWorkspaceMappings, LAB_RUNNER_WORKLOAD_SCHEMA,
+    LabRunnerWorkloadWorkspaceMappings, LAB_CAPABILITY_EXTENSION_PARITY,
+    LAB_RUNNER_WORKLOAD_SCHEMA,
 };
 use homeboy_core::plan::HomeboyPlan;
 use homeboy_core::secret_env_plan::SecretEnvPlan;
 
 use super::{
     LabOffloadCommand, LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy,
-    RunnerCapabilityPreflight,
+    RunnerCapabilityPreflight, RunnerRequiredTool,
 };
 
 pub(crate) struct LabRunnerWorkloadBuildInput<'a> {
@@ -573,15 +574,40 @@ fn dispatched_positional_command_parts(command_args: &[String]) -> Vec<&str> {
     parts
 }
 
+/// Union the workload's declared capabilities into the dispatch capability
+/// preflight so a runner that cannot satisfy them is refused before execution.
+///
+/// The workload is the controller's declaration of what the runner must be able
+/// to do; without this merge those declarations are shipped to the runner and
+/// never gated (Extra-Chill/homeboy#10287). Capability names map to runner tool
+/// requirements — the declarative tool registry probes any tool id — except for
+/// pipeline-enforced capabilities like `extension_parity`, which are gated by
+/// their own execution-pipeline step and name no runner binary.
 pub(crate) fn merge_lab_runner_workload_capability_preflight(
-    preflight: Option<RunnerCapabilityPreflight>,
+    mut preflight: Option<RunnerCapabilityPreflight>,
     workload: Option<&LabRunnerWorkload>,
-) -> Result<Option<RunnerCapabilityPreflight>> {
+) -> Option<RunnerCapabilityPreflight> {
     let Some(workload) = workload else {
-        return Ok(preflight);
+        return preflight;
     };
-    let _ = workload;
-    Ok(preflight)
+    for capability in &workload.required_capabilities {
+        if !capability.required {
+            continue;
+        }
+        let name = capability.name.trim();
+        if name.is_empty() || lab_capability_is_pipeline_enforced(name) {
+            continue;
+        }
+        let tool = RunnerRequiredTool::new(name);
+        let preflight = preflight.get_or_insert_with(|| RunnerCapabilityPreflight {
+            command: workload.kind.command_label.clone(),
+            ..Default::default()
+        });
+        if !preflight.required_tools.contains(&tool) {
+            preflight.required_tools.push(tool);
+        }
+    }
+    preflight
 }
 
 pub(crate) fn merge_lab_runner_workload_required_extensions(
@@ -628,7 +654,7 @@ fn required_capabilities(command: &LabOffloadCommand) -> Vec<LabRunnerWorkloadCa
     let mut capabilities = Vec::new();
     if command.routing_policy.requires_extension_parity || !command.required_extensions.is_empty() {
         capabilities.push(LabRunnerWorkloadCapability {
-            name: "extension_parity".to_string(),
+            name: LAB_CAPABILITY_EXTENSION_PARITY.to_string(),
             required: true,
         });
     }
@@ -923,6 +949,73 @@ mod tests {
         );
         assert_eq!(workload.result_refs.plan_id, "lab_offload.test");
         assert_eq!(workload.result_refs.proof_id.as_deref(), Some("proof-1"));
+    }
+
+    /// A workload-declared tool capability must reach the dispatch preflight, or
+    /// the runner is never gated on it (Extra-Chill/homeboy#10287).
+    #[test]
+    fn lab_runner_workload_capabilities_merge_into_preflight() {
+        let workload = workload();
+
+        let preflight = merge_lab_runner_workload_capability_preflight(None, Some(&workload))
+            .expect("workload capabilities create a preflight");
+
+        assert_eq!(preflight.command, "trace");
+        assert!(preflight
+            .required_tools
+            .contains(&RunnerRequiredTool::new("playwright")));
+    }
+
+    /// `extension_parity` names an execution-pipeline gate, not a runner binary.
+    /// Merging it as a required tool would probe a `extension_parity` executable
+    /// that no runner has and refuse every parity-bearing dispatch.
+    #[test]
+    fn pipeline_enforced_capabilities_are_not_merged_as_runner_tools() {
+        let workload = workload();
+
+        let preflight = merge_lab_runner_workload_capability_preflight(None, Some(&workload))
+            .expect("workload capabilities create a preflight");
+
+        assert!(workload
+            .required_capabilities
+            .iter()
+            .any(|capability| capability.name == LAB_CAPABILITY_EXTENSION_PARITY));
+        assert!(!preflight
+            .required_tools
+            .contains(&RunnerRequiredTool::new(LAB_CAPABILITY_EXTENSION_PARITY)));
+    }
+
+    /// Merging must extend an explicit preflight rather than replace it, and must
+    /// leave the caller's preflight untouched when there is no workload.
+    #[test]
+    fn capability_merge_preserves_the_explicit_preflight_and_no_workload_case() {
+        let workload = workload();
+        let explicit = RunnerCapabilityPreflight {
+            command: "runner.exec".to_string(),
+            required_tools: vec![RunnerRequiredTool::homeboy()],
+            ..Default::default()
+        };
+
+        let merged =
+            merge_lab_runner_workload_capability_preflight(Some(explicit.clone()), Some(&workload))
+                .expect("explicit preflight is retained");
+
+        assert_eq!(merged.command, "runner.exec");
+        assert!(merged
+            .required_tools
+            .contains(&RunnerRequiredTool::homeboy()));
+        assert!(merged
+            .required_tools
+            .contains(&RunnerRequiredTool::new("playwright")));
+
+        assert_eq!(
+            merge_lab_runner_workload_capability_preflight(Some(explicit.clone()), None),
+            Some(explicit)
+        );
+        assert_eq!(
+            merge_lab_runner_workload_capability_preflight(None, None),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #10287

## Enforcement trace (the question this PR had to answer first)

**Are `LabRunnerWorkload.required_capabilities` enforced anywhere else? No.** Every read site is inert.

Full set of reads of `workload.required_capabilities` in `crates/`:

| Site | What it does |
|---|---|
| `crates/homeboy-lab-runner/src/workload.rs:365-374` (`validate_lab_runner_workload_required_capabilities`) | Only rejects **empty** capability names. Never compares a name against anything the runner has. |
| `crates/homeboy-lab-runner/src/workload.rs:586-611` (this function) | Discarded the workload (`let _ = workload;`) and returned the input preflight unchanged. |
| `workload.rs:909-911` | Test assertions on the built workload. |

That is the complete list. Nothing else in the tree reads the field.

### The preflight that gates dispatch never learned about them

`RunnerCapabilityPreflight` (`crates/contracts/homeboy-lab-runner-contract/src/lib.rs:207-215`) has no `required_capabilities` field at all — it gates on `required_tools`, `required_commands`, `required_tool_capabilities`, `required_components`, `required_env`. The only consumer that refuses a dispatch is `validate_runner_capability_preflight` (`crates/homeboy-lab-runner/src/capabilities.rs:83-129`), reached via:

- `preflight_runner_capability_plan` — remote dispatch, from `execution/mod.rs:915`
- `preflight_worker_local_capability_plan` (`execution/worker.rs:164-178`) — runner-side worker, from `execution/worker.rs:144`

Both of those preflights are exactly what this function was supposed to populate.

### The controller-side Lab gate drops them too

`lab_capabilities.rs:22-29` copies the capability names into `LabRunnerCapabilityContract.required_capabilities`, but `prepare_lab_runner_capability` (`capabilities.rs:48-60`) builds `PreparedLabRunnerCapability` from `contract.required_tools` **only** — the `required_capabilities` field is never read. `evaluate_lab_runner_capabilities` (`capabilities.rs:432-445`) then gates solely on `plan.required_tools`. So `LabRunnerCapabilityContract.required_capabilities` is a second dead carrier of the same data.

### Runner-side receipt validation: none

`validate_lab_runner_workload_dispatch` (`workload.rs:250-271`) is the runner-side receipt check. It validates schema, assignment identity, remote workspace, mutation policy, secrets, and command — and for capabilities calls only the empty-name check above. The runner does **not** independently verify capabilities.

### `extension_parity` specifically

Injected at `workload.rs:654-661`. The name string `"extension_parity"` appears nowhere as a check — the only other occurrences are the plan-step id `lab.extension_parity` and the module name. Actual parity enforcement is a completely separate pipeline driven by `required_extensions`, not by the capability entry:

- `crates/homeboy-lab-runner/src/execution/mod.rs:883-899` — `plan_extension_parity` → `ensure_extension_materialized` → `validate_extension_ready`
- `crates/homeboy-lab-runner/src/execution/worker.rs:114-131` — same sequence on the worker path

**This matters for the fix**: `extension_parity` names a pipeline gate, not a runner binary. Merging it as a required tool would probe for an `extension_parity` executable that no runner has and refuse every parity-bearing dispatch.

### `playwright` specifically

The only command declaring an extra capability is `trace` (`LAB_TRACE_EXTRA_CAPABILITIES = [LAB_CAPABILITY_PLAYWRIGHT]`, `contracts/homeboy-lab-contract/src/lab/types.rs:6`, applied at `homeboy-cli/src/commands/trace.rs:270-275`). Nothing required `playwright` of a runner. The `"…missing required capability parity for \`trace\`: tools: playwright"` string in `lab/offload/tests/exec_errors.rs:350` is a **hand-written test input** passed straight into `automatic_capability_fallback_or_error` — it is not evidence that the gate produced it.

The `preflight_trace_runner_capabilities` check in `crates/homeboy-extension/src/trace/preflight.rs:131-162` is a different mechanism entirely: rig-spec-declared capabilities checked against `HOMEBOY_TRACE_RUNNER_CAPABILITIES*` env, fed from `rig::runner_capabilities_for_extension`. It never sees the Lab workload.

### When the enforcement was lost

`git log -S` traces it exactly. Introduced live in `89f32c96e` ("Add runner workload dispatch contract"), where the body merged `playwright` into `preflight.required_tools` as `RunnerRequiredTool::Playwright` and was covered by `runner_workload_capabilities_merge_into_preflight`. Commit **`19d393bb6` ("refactor: make dependency tools declarative (#7465)")** replaced the `RunnerRequiredTool` enum with declarative string tool ids, deleted the enum-variant merge and its test, and left `let _ = workload;` behind. The declarative registry replaced *how tools are described*, not *that workload capabilities are required* — nothing took over the gate.

**Conclusion: live gating gap, not dead code.** Direction: implement the merge.

## Change

- `merge_lab_runner_workload_capability_preflight` now unions the workload's `required` capabilities into the preflight's `required_tools`, creating a preflight (command = workload command label) when the caller supplied none, and extending an explicit preflight in place otherwise. The declarative tool registry probes any tool id (`tool_registry.rs:46-50` falls back to the id as the command), so a capability name maps cleanly onto a tool requirement.
- Pipeline-enforced capabilities are skipped via the new `lab_capability_is_pipeline_enforced` in the lab contract, alongside the new `LAB_CAPABILITY_EXTENSION_PARITY` constant (which also replaces the bare `"extension_parity"` literal at the injection site). The predicate is a **deny-list**, so it fails closed: an unrecognised capability name becomes a required tool the runner must actually provide.
- Dropped the vestigial `Result` — the function is infallible — and updated both call sites.

Blast radius is narrow and intentional: `trace` is the only command that declares an extra capability, so the behavioral change is that Lab `trace` dispatch again requires `playwright` on the runner — the pre-#7465 contract.

## Tests

- `lab_runner_workload_capabilities_merge_into_preflight` — a workload-declared capability reaches the preflight (restores the test deleted by #7465).
- `pipeline_enforced_capabilities_are_not_merged_as_runner_tools` — `extension_parity` is present on the workload but is not turned into a tool requirement.
- `capability_merge_preserves_the_explicit_preflight_and_no_workload_case` — merging extends rather than replaces an explicit preflight; no workload leaves the input untouched.
- `workload_declared_capability_refuses_a_runner_missing_the_tool` (`capabilities.rs`) — end-to-end: build a real workload, merge, then assert `validate_runner_capability_preflight` **passes** for a runner providing the capability and **refuses** one that does not.

Build/test left to CI per repo policy.
