### PR TITLE
Fix worktree cleanup apply gate

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -984,6 +984,19 @@ mod tests {
     }
 
     #[test]
+    fn worktree_cleanup_manifest_requires_explicit_apply() {
+        let manifest = current_command_safety_manifest();
+        let cleanup = manifest
+            .find_path(&["worktree", "cleanup"])
+            .expect("worktree cleanup must be present in the command safety manifest");
+
+        assert!(cleanup.operator);
+        assert!(cleanup.output.notes.contains("non-mutating"));
+        assert_eq!(cleanup.dry_run.flag.as_deref(), Some("--dry-run"));
+        assert!(cleanup.dangerous_flags.iter().any(|flag| flag == "--apply"));
+    }
+
+    #[test]
     fn documented_docs_surface_matches_manifest_and_parser() {
         let readme = std::fs::read_to_string(workspace_root().join("README.md"))
             .expect("failed to read README");

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -481,11 +481,11 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.dangerous_flags = vec!["--force"];
         }
         ["worktree", "cleanup"] => {
-            metadata.mutating(
-                "removes cleanup-eligible task worktrees; pass --cleanup-artifacts to also remove rebuildable Homeboy artifacts",
+            metadata.operator_mutating(
+                "default output is a non-mutating task-worktree cleanup plan; pass --apply to remove eligible worktrees, and --cleanup-artifacts to include rebuildable Homeboy artifacts",
             );
             metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--force", "--cleanup-artifacts"];
+            metadata.dangerous_flags = vec!["--apply", "--force", "--cleanup-artifacts"];
         }
         ["tunnel", "service", "expose"]
         | ["tunnel", "service", "set"]

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -612,8 +612,8 @@ const TASK_WORKTREES_METADATA: CleanupInventoryCategoryMetadata =
     CleanupInventoryCategoryMetadata {
         category: "task_worktrees",
         include_arg: "task-worktrees",
-        dry_run_command: "homeboy worktree cleanup --dry-run --cleanup-branches",
-        apply_command: "homeboy worktree cleanup --cleanup-branches",
+        dry_run_command: "homeboy worktree cleanup --cleanup-branches",
+        apply_command: "homeboy worktree cleanup --cleanup-branches --apply",
     };
 
 const WORKTREE_PROVIDERS_METADATA: CleanupInventoryCategoryMetadata =
@@ -1382,7 +1382,7 @@ fn cleanup_actionable(
             format!("{} cleanup", category.category.replace('_', " ")),
             if category.category == REPO_ARTIFACTS_METADATA.category {
                 apply_command(&category.canonical_cleanup_command)
-            } else if apply || category.category == TASK_WORKTREES_METADATA.category {
+            } else if apply {
                 category.specialist_command.clone()
             } else {
                 apply_command(&category.specialist_command)
@@ -2023,8 +2023,8 @@ mod tests {
                 TASK_WORKTREES_METADATA,
                 "task_worktrees",
                 "task-worktrees",
-                "homeboy worktree cleanup --dry-run --cleanup-branches",
                 "homeboy worktree cleanup --cleanup-branches",
+                "homeboy worktree cleanup --cleanup-branches --apply",
             ),
             (
                 TERMINAL_RUNS_METADATA,
@@ -2089,11 +2089,8 @@ mod tests {
     #[test]
     fn task_worktree_cleanup_next_actions_preserve_mode_specific_commands() {
         let cases = [
-            (
-                false,
-                "homeboy worktree cleanup --dry-run --cleanup-branches",
-            ),
-            (true, "homeboy worktree cleanup --cleanup-branches"),
+            (false, "homeboy worktree cleanup --cleanup-branches --apply"),
+            (true, "homeboy worktree cleanup --cleanup-branches --apply"),
         ];
 
         for (apply, command) in cases {

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -113,11 +113,14 @@ enum WorktreeCommand {
     },
     /// Remove cleanup-eligible task worktrees after safety checks
     Cleanup {
+        /// Remove planned worktrees and artifacts after safety checks. Without this flag, only reports the plan.
+        #[arg(long, conflicts_with = "dry_run")]
+        apply: bool,
         /// Allow dirty/unpushed worktree removal; hard gates still apply
         #[arg(long)]
         force: bool,
-        /// Report cleanup candidates without removing worktrees or artifacts.
-        #[arg(long)]
+        /// Deprecated plan-only alias retained for one release; bare cleanup also reports the plan.
+        #[arg(long, conflicts_with = "apply")]
         dry_run: bool,
         /// Also remove declared rebuildable artifacts from the Homeboy checkout that built this binary.
         #[arg(long)]
@@ -236,12 +239,14 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
             allow_unmerged_branch,
         })?),
         WorktreeCommand::Cleanup {
+            apply,
             force,
-            dry_run,
+            dry_run: _,
             cleanup_artifacts,
             cleanup_branches,
             allow_unmerged_branches,
         } => {
+            let dry_run = cleanup_is_dry_run(apply);
             let worktrees = worktree::cleanup(WorktreeCleanupOptions {
                 force,
                 dry_run,
@@ -252,7 +257,7 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
                 Some(artifact_cleanup::cleanup_artifacts(
                     ArtifactCleanupOptions {
                         path: None,
-                        apply: !dry_run,
+                        apply,
                         self_artifacts: true,
                         temp_roots: Vec::new(),
                         sort: ArtifactCleanupSort::Discovery,
@@ -274,45 +279,92 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
     Ok((output, 0))
 }
 
+fn cleanup_is_dry_run(apply: bool) -> bool {
+    !apply
+}
+
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
+    use clap::{error::ErrorKind, Parser};
 
     use crate::cli_surface::{Cli, Commands};
 
-    use super::WorktreeCommand;
+    use super::{cleanup_is_dry_run, WorktreeCommand};
 
     #[test]
-    fn worktree_cleanup_does_not_cleanup_artifacts_by_default() {
+    fn worktree_cleanup_bare_is_a_plan() {
         let cli = Cli::parse_from(["homeboy", "worktree", "cleanup"]);
 
         let Commands::Worktree(args) = cli.command else {
             panic!("expected worktree command");
         };
         let WorktreeCommand::Cleanup {
-            cleanup_artifacts, ..
+            apply,
+            dry_run,
+            cleanup_artifacts,
+            ..
         } = args.command
         else {
             panic!("expected worktree cleanup command");
         };
 
+        assert!(!apply);
+        assert!(!dry_run);
+        assert!(cleanup_is_dry_run(apply));
         assert!(!cleanup_artifacts);
     }
 
     #[test]
-    fn worktree_cleanup_artifact_cleanup_requires_explicit_flag() {
-        let cli = Cli::parse_from(["homeboy", "worktree", "cleanup", "--cleanup-artifacts"]);
+    fn worktree_cleanup_apply_enables_worktree_and_artifact_mutation() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "worktree",
+            "cleanup",
+            "--apply",
+            "--cleanup-artifacts",
+        ]);
 
         let Commands::Worktree(args) = cli.command else {
             panic!("expected worktree command");
         };
         let WorktreeCommand::Cleanup {
-            cleanup_artifacts, ..
+            apply,
+            cleanup_artifacts,
+            ..
         } = args.command
         else {
             panic!("expected worktree cleanup command");
         };
 
+        assert!(apply);
+        assert!(!cleanup_is_dry_run(apply));
         assert!(cleanup_artifacts);
+    }
+
+    #[test]
+    fn worktree_cleanup_dry_run_is_a_legacy_plan_only_alias() {
+        let cli = Cli::parse_from(["homeboy", "worktree", "cleanup", "--dry-run"]);
+
+        let Commands::Worktree(args) = cli.command else {
+            panic!("expected worktree command");
+        };
+        let WorktreeCommand::Cleanup { apply, dry_run, .. } = args.command else {
+            panic!("expected worktree cleanup command");
+        };
+
+        assert!(!apply);
+        assert!(dry_run);
+        assert!(cleanup_is_dry_run(apply));
+    }
+
+    #[test]
+    fn worktree_cleanup_rejects_conflicting_apply_and_dry_run() {
+        let error =
+            match Cli::try_parse_from(["homeboy", "worktree", "cleanup", "--apply", "--dry-run"]) {
+                Ok(_) => panic!("conflicting cleanup modes must be rejected"),
+                Err(error) => error,
+            };
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
     }
 }

--- a/docs/commands/worktree.md
+++ b/docs/commands/worktree.md
@@ -8,7 +8,7 @@ Manage component-backed task worktrees for generic Homeboy workflows.
 - `homeboy worktree list`
 - `homeboy worktree status <id>`
 - `homeboy worktree remove <id> [--force]`
-- `homeboy worktree cleanup [--force] [--cleanup-artifacts]`
+- `homeboy worktree cleanup [--apply] [--force] [--cleanup-artifacts]`
 
 For multi-PR orchestration, start with `homeboy --output homeboy-results/worktrees.json worktree list`, then pair each branch with `homeboy triage landing 'owner/repo#number' --drilldown` and any recorded `homeboy runs evidence <run-id>` output. See [Hold a PR fleet](../workflows/hold-a-pr-fleet.md) for the full local-plus-remote handoff loop.
 
@@ -16,4 +16,6 @@ For multi-PR orchestration, start with `homeboy --output homeboy-results/worktre
 
 Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. `--force` only bypasses dirty/unpushed checks; primary checkout and containment gates always apply.
 
-`worktree cleanup` is task-worktree cleanup by default. Use `homeboy cleanup artifacts` to plan rebuildable artifact cleanup, then pass `--apply` when the plan is acceptable. `worktree cleanup --cleanup-artifacts` is an explicit combined operator path for also removing declared rebuildable artifacts from the Homeboy checkout that built the active binary.
+`worktree cleanup` reports a task-worktree cleanup plan by default. Pass `--apply` to remove planned worktrees after the existing safety gates pass. `--dry-run` remains a deprecated plan-only alias for one release; it conflicts with `--apply`.
+
+Use `homeboy cleanup artifacts` to plan rebuildable artifact cleanup, then pass `--apply` when the plan is acceptable. `worktree cleanup --cleanup-artifacts` includes declared rebuildable artifacts from the Homeboy checkout that built the active binary; it remains plan-only unless `--apply` is also passed.

--- a/docs/workflows/hold-a-pr-fleet.md
+++ b/docs/workflows/hold-a-pr-fleet.md
@@ -127,7 +127,7 @@ Example handoff row:
 Preview cleanup first:
 
 ```bash
-homeboy worktree cleanup --dry-run
+homeboy worktree cleanup
 ```
 
 Remove one safe worktree when the branch is merged or no longer needed:
@@ -137,6 +137,11 @@ homeboy worktree remove <worktree-id> --cleanup-branch
 ```
 
 Use `--force` and unmerged branch cleanup flags only as explicit operator decisions after reading the safety report.
+Apply an approved plan explicitly:
+
+```bash
+homeboy worktree cleanup --apply
+```
 
 ## Reference
 

--- a/docs/workflows/manage-local-environments.md
+++ b/docs/workflows/manage-local-environments.md
@@ -88,9 +88,10 @@ Remove only when the worktree is safe to discard:
 ```bash
 homeboy worktree remove <worktree-id>
 homeboy worktree cleanup
+homeboy worktree cleanup --apply
 ```
 
-Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. Treat `--force` as an explicit operator decision, not routine cleanup.
+`worktree cleanup` plans by default; `--apply` removes only approved candidates. Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. Treat `--force` as an explicit operator decision, not routine cleanup.
 
 Use artifact cleanup separately so it stays plan-first:
 


### PR DESCRIPTION
## Summary
- make bare `homeboy worktree cleanup` plan-only and require `--apply` for worktree and optional artifact removal
- retain `--dry-run` as a deprecated plan-only alias for one release and reject `--apply --dry-run`
- update task-worktree actionable metadata, safety contracts, docs, and behavior tests

## Migration
- Existing bare cleanup invocations now produce a plan with `dry_run: true` in JSON.
- Use `homeboy worktree cleanup --apply` to mutate.
- `--dry-run` remains supported for one release as a compatibility alias.

## Verification
- `cargo test -p homeboy-cli worktree_cleanup`
- `cargo test -p homeboy-cli task_worktree_cleanup_next_actions_preserve_mode_specific_commands`
- `cargo test -p homeboy-cli worktree_cleanup_manifest_requires_explicit_apply`
- `cargo test -p homeboy-core worktree::tests::cleanup`
- Built CLI: bare and `--dry-run` both emitted `dry_run: true`; `--apply --dry-run` was rejected.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode drafted and implemented the CLI migration, tests, and documentation. Chris Huber remains responsible for every line.

Closes #10286