### PR TITLE
fix(release): contain bounded asset downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "ctrlc",
  "homeboy-error",
  "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/homeboy-process/Cargo.toml
+++ b/crates/homeboy-process/Cargo.toml
@@ -16,3 +16,6 @@ path = "src/lib.rs"
 homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 libc = "0.2"
 ctrlc = "3.4"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -1375,68 +1375,9 @@ fn descendant_pids_from_rows(rows: &[(u32, u32)], owner_pid: u32) -> Vec<u32> {
     descendants
 }
 
-#[cfg(all(test, target_os = "linux"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_linux_stat_handles_command_names_with_spaces() {
-        let stat = "123 (name with spaces) Z 1 456 456 0 -1 0 0 0";
-        let process = parse_linux_stat(stat).expect("process stat");
-
-        assert_eq!(process.state, 'Z');
-        assert_eq!(process.parent_pid, 1);
-        assert_eq!(process.process_group_id, 456);
-    }
-
-    #[test]
-    fn descendant_rows_include_children_outside_the_owner_group() {
-        assert_eq!(
-            descendant_pids_from_rows(&[(10, 1), (11, 10), (12, 11), (13, 1)], 10),
-            vec![11, 12]
-        );
-    }
-
-    #[test]
-    fn force_stop_environment_ownership_requires_an_exact_assignment() {
-        let environment = b"HOME=/tmp\0HOMEBOY_DAEMON_STARTUP_TOKEN=lease-token\0";
-
-        assert!(environment_contains_assignment(
-            environment,
-            b"HOMEBOY_DAEMON_STARTUP_TOKEN=lease-token"
-        ));
-        assert!(!environment_contains_assignment(
-            environment,
-            b"HOMEBOY_DAEMON_STARTUP_TOKEN=lease"
-        ));
-    }
-}
-
-#[cfg(all(test, unix, not(target_os = "linux")))]
-mod ownership_token_tests {
-    use super::*;
-
-    #[test]
-    fn non_linux_ownership_checks_require_the_exact_startup_token_argument() {
-        let command = "homeboy daemon supervise --startup-token lease-token --addr 127.0.0.1:0";
-
-        assert!(command_has_option_value(
-            command,
-            "--startup-token",
-            "lease-token"
-        ));
-        assert!(!command_has_option_value(
-            command,
-            "--startup-token",
-            "lease"
-        ));
-        assert!(!command_has_option_value(
-            "homeboy daemon supervise --startup-token=lease-token",
-            "--startup-token",
-            "lease-token"
-        ));
-    }
-}
+#[cfg(test)]
+#[path = "unit_tests.rs"]
+mod tests;
 
 #[cfg(all(test, unix))]
 mod process_tree_tests {
@@ -1529,28 +1470,5 @@ mod process_tree_tests {
 
         let _ = reaper.join();
         assert!(!pid_is_running(pid));
-    }
-}
-
-#[cfg(all(test, target_os = "windows"))]
-mod windows_containment_tests {
-    use super::*;
-
-    #[test]
-    fn containment_assigns_a_suspended_child_to_a_job_before_execution() {
-        assert_eq!(
-            WINDOWS_CONTAINMENT_CREATION_FLAGS,
-            windows_sys::Win32::System::Threading::CREATE_SUSPENDED
-        );
-
-        let mut command = Command::new("cmd");
-        command.args(["/C", "exit", "0"]);
-        let mut containment = ProcessContainment::prepare(&mut command).expect("containment job");
-        let mut child = command.spawn().expect("suspended child");
-        containment.attach(&mut child).expect("job assignment");
-        assert!(child.wait().expect("child exit").success());
-        containment
-            .terminate_bounded(Duration::from_secs(1))
-            .expect("empty job");
     }
 }

--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -5,6 +5,19 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "linux")]
+static PROCESS_CONTAINMENT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[cfg(target_os = "linux")]
+static PROCESS_CONTAINMENT_SEQUENCE: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(target_os = "linux")]
+const PROCESS_CONTAINMENT_ENV: &str = "_HOMEBOY_PROCESS_CONTAINMENT";
+
+#[cfg(target_os = "windows")]
+const WINDOWS_CONTAINMENT_CREATION_FLAGS: u32 =
+    windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
+
 /// Generic process step shape shared by command/runner adapters.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessStep {
@@ -31,6 +44,402 @@ impl ProcessStep {
         self.working_dir = Some(working_dir.into());
         self
     }
+}
+
+/// Owns every process created by one command until the scope is explicitly
+/// drained. Linux combines subreaper adoption with an inherited scope marker;
+/// Windows assigns a suspended child to a kill-on-close Job Object before it
+/// can execute. Other Unix hosts use the strongest available process group.
+pub struct ProcessContainment {
+    owner_pid: Option<u32>,
+    #[cfg(target_os = "linux")]
+    marker: String,
+    #[cfg(target_os = "linux")]
+    previous_subreaper: libc::c_int,
+    #[cfg(target_os = "linux")]
+    subreaper_guard: Option<std::sync::MutexGuard<'static, ()>>,
+    #[cfg(target_os = "windows")]
+    job: windows_sys::Win32::Foundation::HANDLE,
+}
+
+impl ProcessContainment {
+    /// Establish containment and configure `command` before it is spawned.
+    pub fn prepare(command: &mut Command) -> Result<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::process::CommandExt;
+
+            let guard = PROCESS_CONTAINMENT_LOCK
+                .lock()
+                .map_err(|_| Error::internal_unexpected("process containment lock was poisoned"))?;
+            let mut previous_subreaper = 0;
+            if unsafe {
+                libc::prctl(
+                    libc::PR_GET_CHILD_SUBREAPER,
+                    &mut previous_subreaper as *mut libc::c_int,
+                )
+            } != 0
+            {
+                return Err(Error::internal_unexpected(format!(
+                    "inspect process subreaper state: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            if previous_subreaper == 0
+                && unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1) } != 0
+            {
+                return Err(Error::internal_unexpected(format!(
+                    "enable process subreaper containment: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            let sequence = PROCESS_CONTAINMENT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let started = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let marker = format!("{}-{}-{sequence}", std::process::id(), started);
+            command
+                .env(PROCESS_CONTAINMENT_ENV, &marker)
+                .process_group(0);
+            return Ok(Self {
+                owner_pid: None,
+                marker,
+                previous_subreaper,
+                subreaper_guard: Some(guard),
+            });
+        }
+
+        #[cfg(all(unix, not(target_os = "linux")))]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+            return Ok(Self { owner_pid: None });
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            use windows_sys::Win32::System::JobObjects::{
+                CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            };
+
+            let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+            if job.is_null() {
+                return Err(Error::internal_unexpected(format!(
+                    "create process containment job: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if unsafe {
+                SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    &limits as *const _ as *const std::ffi::c_void,
+                    std::mem::size_of_val(&limits) as u32,
+                )
+            } == 0
+            {
+                unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+                return Err(Error::internal_unexpected(format!(
+                    "configure process containment job: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            command.creation_flags(WINDOWS_CONTAINMENT_CREATION_FLAGS);
+            return Ok(Self {
+                owner_pid: None,
+                job,
+            });
+        }
+
+        #[cfg(all(not(unix), not(target_os = "windows")))]
+        {
+            let _ = command;
+            Err(Error::internal_unexpected(
+                "durable process containment is unsupported on this platform",
+            ))
+        }
+    }
+
+    /// Attach the newly spawned child and release it only after containment is
+    /// authoritative. On Windows the process is still suspended at this point.
+    pub fn attach(&mut self, child: &mut std::process::Child) -> Result<()> {
+        self.owner_pid = Some(child.id());
+
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+
+            if unsafe { AssignProcessToJobObject(self.job, child.as_raw_handle() as _) } == 0 {
+                return Err(Error::internal_unexpected(format!(
+                    "assign process {} to containment job: {}",
+                    child.id(),
+                    std::io::Error::last_os_error()
+                )));
+            }
+            resume_windows_process_threads(child.id())?;
+        }
+
+        Ok(())
+    }
+
+    /// Force every process in the scope to exit without exceeding `timeout`.
+    pub fn terminate_bounded(&mut self, timeout: Duration) -> Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            let deadline = Instant::now() + timeout;
+            loop {
+                let mut targets =
+                    linux_processes_with_environment_value(PROCESS_CONTAINMENT_ENV, &self.marker)?;
+                if let Some(owner_pid) = self.owner_pid {
+                    targets.extend(linux_descendant_pids(owner_pid)?);
+                    if pid_is_running(owner_pid) {
+                        targets.push(owner_pid);
+                    }
+                    unsafe {
+                        let _ = libc::kill(-(owner_pid as libc::pid_t), libc::SIGKILL);
+                    }
+                }
+                targets.retain(|pid| *pid != std::process::id());
+                targets.sort_unstable();
+                targets.dedup();
+                signal_pids(&targets, libc::SIGKILL)?;
+                reap_owned_children(&targets);
+
+                let group_running = self
+                    .owner_pid
+                    .is_some_and(|pid| process_group_is_running(pid as i32));
+                if targets.iter().all(|pid| !pid_is_running(*pid)) && !group_running {
+                    self.restore_linux_subreaper()?;
+                    return Ok(());
+                }
+                if Instant::now() >= deadline {
+                    return Err(Error::internal_unexpected(format!(
+                        "contained process scope did not exit within {} ms; surviving pids: {}",
+                        timeout.as_millis(),
+                        join_pids(
+                            &targets
+                                .into_iter()
+                                .filter(|pid| pid_is_running(*pid))
+                                .collect::<Vec<_>>()
+                        )
+                    )));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+
+        #[cfg(all(unix, not(target_os = "linux")))]
+        {
+            let owner_pid = self.owner_pid.ok_or_else(|| {
+                Error::internal_unexpected("process containment has no attached child")
+            })?;
+            return force_terminate_process_tree_bounded(owner_pid, timeout);
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+            if unsafe { TerminateJobObject(self.job, 1) } == 0 {
+                return Err(Error::internal_unexpected(format!(
+                    "terminate process containment job: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            let deadline = Instant::now() + timeout;
+            loop {
+                if windows_job_active_processes(self.job)? == 0 {
+                    return Ok(());
+                }
+                if Instant::now() >= deadline {
+                    return Err(Error::internal_unexpected(format!(
+                        "process containment job did not empty within {} ms",
+                        timeout.as_millis()
+                    )));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+
+        #[cfg(all(not(unix), not(target_os = "windows")))]
+        {
+            let _ = timeout;
+            Err(Error::internal_unexpected(
+                "durable process containment is unsupported on this platform",
+            ))
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn restore_linux_subreaper(&mut self) -> Result<()> {
+        if self.subreaper_guard.is_none() {
+            return Ok(());
+        }
+        if unsafe {
+            libc::prctl(
+                libc::PR_SET_CHILD_SUBREAPER,
+                self.previous_subreaper as libc::c_ulong,
+            )
+        } != 0
+        {
+            return Err(Error::internal_unexpected(format!(
+                "restore process subreaper state: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        self.subreaper_guard.take();
+        Ok(())
+    }
+}
+
+impl Drop for ProcessContainment {
+    fn drop(&mut self) {
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(targets) =
+                linux_processes_with_environment_value(PROCESS_CONTAINMENT_ENV, &self.marker)
+            {
+                let _ = signal_pids(&targets, libc::SIGKILL);
+                reap_owned_children(&targets);
+            }
+            if let Some(owner_pid) = self.owner_pid {
+                unsafe {
+                    let _ = libc::kill(-(owner_pid as libc::pid_t), libc::SIGKILL);
+                }
+            }
+            let _ = self.restore_linux_subreaper();
+        }
+
+        #[cfg(all(unix, not(target_os = "linux")))]
+        if let Some(owner_pid) = self.owner_pid {
+            unsafe {
+                let _ = libc::kill(-(owner_pid as libc::pid_t), libc::SIGKILL);
+            }
+        }
+
+        #[cfg(target_os = "windows")]
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.job);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_processes_with_environment_value(key: &str, value: &str) -> Result<Vec<u32>> {
+    let expected = format!("{key}={value}");
+    let entries = std::fs::read_dir("/proc").map_err(|error| {
+        Error::internal_unexpected(format!("inspect contained processes: {error}"))
+    })?;
+    let mut pids = Vec::new();
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<u32>() else {
+            continue;
+        };
+        let Ok(environment) = std::fs::read(entry.path().join("environ")) else {
+            continue;
+        };
+        if environment_contains_assignment(&environment, expected.as_bytes()) {
+            pids.push(pid);
+        }
+    }
+    Ok(pids)
+}
+
+#[cfg(target_os = "linux")]
+fn reap_owned_children(pids: &[u32]) {
+    for pid in pids {
+        let mut status = 0;
+        unsafe {
+            libc::waitpid(*pid as libc::pid_t, &mut status, libc::WNOHANG);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn resume_windows_process_threads(pid: u32) -> Result<()> {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows_sys::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(Error::internal_unexpected(format!(
+            "snapshot suspended process {pid} threads: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    let mut entry = THREADENTRY32 {
+        dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+        ..THREADENTRY32::default()
+    };
+    let mut found = false;
+    let mut current = unsafe { Thread32First(snapshot, &mut entry) };
+    while current != 0 {
+        if entry.th32OwnerProcessID == pid {
+            let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+            if thread.is_null() {
+                unsafe { CloseHandle(snapshot) };
+                return Err(Error::internal_unexpected(format!(
+                    "open suspended process {pid} thread: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            let resumed = unsafe { ResumeThread(thread) };
+            unsafe { CloseHandle(thread) };
+            if resumed == u32::MAX {
+                unsafe { CloseHandle(snapshot) };
+                return Err(Error::internal_unexpected(format!(
+                    "resume contained process {pid}: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            found = true;
+        }
+        current = unsafe { Thread32Next(snapshot, &mut entry) };
+    }
+    unsafe { CloseHandle(snapshot) };
+    if !found {
+        return Err(Error::internal_unexpected(format!(
+            "suspended process {pid} had no resumable thread"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn windows_job_active_processes(job: windows_sys::Win32::Foundation::HANDLE) -> Result<u32> {
+    use windows_sys::Win32::System::JobObjects::{
+        JobObjectBasicAccountingInformation, QueryInformationJobObject,
+        JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
+    };
+
+    let mut accounting = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+    if unsafe {
+        QueryInformationJobObject(
+            job,
+            JobObjectBasicAccountingInformation,
+            &mut accounting as *mut _ as *mut std::ffi::c_void,
+            std::mem::size_of_val(&accounting) as u32,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        return Err(Error::internal_unexpected(format!(
+            "inspect process containment job: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(accounting.ActiveProcesses)
 }
 
 pub fn pid_is_running(pid: u32) -> bool {
@@ -1120,5 +1529,28 @@ mod process_tree_tests {
 
         let _ = reaper.join();
         assert!(!pid_is_running(pid));
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_containment_tests {
+    use super::*;
+
+    #[test]
+    fn containment_assigns_a_suspended_child_to_a_job_before_execution() {
+        assert_eq!(
+            WINDOWS_CONTAINMENT_CREATION_FLAGS,
+            windows_sys::Win32::System::Threading::CREATE_SUSPENDED
+        );
+
+        let mut command = Command::new("cmd");
+        command.args(["/C", "exit", "0"]);
+        let mut containment = ProcessContainment::prepare(&mut command).expect("containment job");
+        let mut child = command.spawn().expect("suspended child");
+        containment.attach(&mut child).expect("job assignment");
+        assert!(child.wait().expect("child exit").success());
+        containment
+            .terminate_bounded(Duration::from_secs(1))
+            .expect("empty job");
     }
 }

--- a/crates/homeboy-process/src/unit_tests.rs
+++ b/crates/homeboy-process/src/unit_tests.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[cfg(target_os = "linux")]
+#[test]
+fn parse_linux_stat_handles_command_names_with_spaces() {
+    let stat = "123 (name with spaces) Z 1 456 456 0 -1 0 0 0";
+    let process = parse_linux_stat(stat).expect("process stat");
+
+    assert_eq!(process.state, 'Z');
+    assert_eq!(process.parent_pid, 1);
+    assert_eq!(process.process_group_id, 456);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn descendant_rows_include_children_outside_the_owner_group() {
+    assert_eq!(
+        descendant_pids_from_rows(&[(10, 1), (11, 10), (12, 11), (13, 1)], 10),
+        vec![11, 12]
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn force_stop_environment_ownership_requires_an_exact_assignment() {
+    let environment = b"HOME=/tmp\0HOMEBOY_DAEMON_STARTUP_TOKEN=lease-token\0";
+
+    assert!(environment_contains_assignment(
+        environment,
+        b"HOMEBOY_DAEMON_STARTUP_TOKEN=lease-token"
+    ));
+    assert!(!environment_contains_assignment(
+        environment,
+        b"HOMEBOY_DAEMON_STARTUP_TOKEN=lease"
+    ));
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+#[test]
+fn non_linux_ownership_checks_require_the_exact_startup_token_argument() {
+    let command = "homeboy daemon supervise --startup-token lease-token --addr 127.0.0.1:0";
+
+    assert!(command_has_option_value(
+        command,
+        "--startup-token",
+        "lease-token"
+    ));
+    assert!(!command_has_option_value(
+        command,
+        "--startup-token",
+        "lease"
+    ));
+    assert!(!command_has_option_value(
+        "homeboy daemon supervise --startup-token=lease-token",
+        "--startup-token",
+        "lease-token"
+    ));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn containment_assigns_a_suspended_child_to_a_job_before_execution() {
+    assert_eq!(
+        WINDOWS_CONTAINMENT_CREATION_FLAGS,
+        windows_sys::Win32::System::Threading::CREATE_SUSPENDED
+    );
+
+    let mut command = Command::new("cmd");
+    command.args(["/C", "exit", "0"]);
+    let mut containment = ProcessContainment::prepare(&mut command).expect("containment job");
+    let mut child = command.spawn().expect("suspended child");
+    containment.attach(&mut child).expect("job assignment");
+    assert!(child.wait().expect("child exit").success());
+    containment
+        .terminate_bounded(Duration::from_secs(1))
+        .expect("empty job");
+}

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -17,6 +17,7 @@ pub(crate) const GITHUB_RELEASE_UPLOAD_TIMEOUT_ENV: &str =
 const DEFAULT_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS: u64 = 30 * 60;
 const GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES: usize = 8 * 1024;
 const GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT: Duration = Duration::from_millis(500);
+const GITHUB_RELEASE_DOWNLOAD_PIPE_CHUNKS_PER_TURN: usize = 4;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GhCommandOutput {
@@ -594,17 +595,27 @@ fn run_bounded_asset_download(
         )
     })?;
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
+    let mut containment =
+        homeboy_core::process::ProcessContainment::prepare(command).map_err(|error| {
+            format!(
+                "could not contain GitHub Release asset '{}' download: {error}",
+                asset_name
+            )
+        })?;
     let mut child = command.spawn().map_err(|error| {
         format!(
             "could not download GitHub Release asset '{}': {error}",
             asset_name
         )
     })?;
+    if let Err(error) = containment.attach(&mut child) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!(
+            "could not contain GitHub Release asset '{}' download: {error}",
+            asset_name
+        ));
+    }
     let mut stdout = child.stdout.take().ok_or_else(|| {
         format!(
             "could not capture download stream for GitHub Release asset '{}'",
@@ -628,43 +639,56 @@ fn run_bounded_asset_download(
     let mut exited_at = None;
     let outcome = loop {
         if stdout_open {
-            stdout_open = match drain_available_pipe(&mut stdout, |bytes| {
-                let remaining = expected_size.saturating_sub(size).min(bytes.len() as u64) as usize;
-                let accepted = bytes.len().min(remaining);
-                if accepted > 0 {
-                    output_file
-                        .write_all(&bytes[..accepted])
-                        .map_err(|error| format!("could not write temporary asset bytes: {error}"))?;
-                    hasher.update(&bytes[..accepted]);
-                    size += accepted as u64;
-                }
-                if accepted != bytes.len() {
-                    return Err(format!(
-                        "download exceeded expected byte length {expected_size}"
-                    ));
-                }
-                Ok(())
-            }) {
+            stdout_open = match drain_available_pipe(
+                &mut stdout,
+                GITHUB_RELEASE_DOWNLOAD_PIPE_CHUNKS_PER_TURN,
+                |bytes| {
+                    let remaining =
+                        expected_size.saturating_sub(size).min(bytes.len() as u64) as usize;
+                    let accepted = bytes.len().min(remaining);
+                    if accepted > 0 {
+                        output_file.write_all(&bytes[..accepted]).map_err(|error| {
+                            format!("could not write temporary asset bytes: {error}")
+                        })?;
+                        hasher.update(&bytes[..accepted]);
+                        size += accepted as u64;
+                    }
+                    if accepted != bytes.len() {
+                        return Err(format!(
+                            "download exceeded expected byte length {expected_size}"
+                        ));
+                    }
+                    Ok(())
+                },
+            ) {
                 Ok(open) => open,
-                Err(error) => break Err(format!(
-                    "could not download GitHub Release asset '{}': {error}",
-                    asset_name
-                )),
+                Err(error) => {
+                    break Err(format!(
+                        "could not download GitHub Release asset '{}': {error}",
+                        asset_name
+                    ))
+                }
             };
         }
         if stderr_open {
-            stderr_open = match drain_available_pipe(&mut stderr, |bytes| {
-                let remaining = GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES
-                    .saturating_sub(diagnostics.len());
-                diagnostics.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
-                diagnostics_truncated |= bytes.len() > remaining;
-                Ok(())
-            }) {
+            stderr_open = match drain_available_pipe(
+                &mut stderr,
+                GITHUB_RELEASE_DOWNLOAD_PIPE_CHUNKS_PER_TURN,
+                |bytes| {
+                    let remaining =
+                        GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES.saturating_sub(diagnostics.len());
+                    diagnostics.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+                    diagnostics_truncated |= bytes.len() > remaining;
+                    Ok(())
+                },
+            ) {
                 Ok(open) => open,
-                Err(error) => break Err(format!(
-                    "could not read GitHub Release asset '{}' diagnostics: {error}",
-                    asset_name
-                )),
+                Err(error) => {
+                    break Err(format!(
+                        "could not read GitHub Release asset '{}' diagnostics: {error}",
+                        asset_name
+                    ))
+                }
             };
         }
         if !stdout_open && !stderr_open {
@@ -692,9 +716,9 @@ fn run_bounded_asset_download(
                     ));
                 }
             }
-        } else if exited_at.is_some_and(|exit| {
-            exit.elapsed() >= GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT
-        }) {
+        } else if exited_at
+            .is_some_and(|exit| exit.elapsed() >= GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT)
+        {
             break Err(format!(
                 "GitHub Release asset '{}' pipes remained open after the download process exited",
                 asset_name
@@ -705,13 +729,21 @@ fn run_bounded_asset_download(
     let status = match outcome {
         Ok(status) => status,
         Err(error) => {
-            let cleanup = terminate_asset_download_child(&mut child)
+            let cleanup = terminate_asset_download_child(&mut child, &mut containment)
                 .err()
                 .map(|cleanup| format!("; {cleanup}"))
                 .unwrap_or_default();
             return Err(format!("{error}{cleanup}"));
         }
     };
+    containment
+        .terminate_bounded(GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT)
+        .map_err(|error| {
+            format!(
+                "could not clean up GitHub Release asset '{}' download containment: {error}",
+                asset_name
+            )
+        })?;
     let mut diagnostics = String::from_utf8_lossy(&diagnostics).to_string();
     if diagnostics_truncated {
         diagnostics.push_str("\n[diagnostics truncated]");
@@ -726,13 +758,13 @@ fn run_bounded_asset_download(
     Ok((size, format!("{:x}", hasher.finalize())))
 }
 
-fn terminate_asset_download_child(child: &mut std::process::Child) -> Result<(), String> {
+fn terminate_asset_download_child(
+    child: &mut std::process::Child,
+    containment: &mut homeboy_core::process::ProcessContainment,
+) -> Result<(), String> {
     let pid = child.id();
     let started = Instant::now();
-    let tree_result = homeboy_core::process::force_terminate_process_tree_bounded(
-        pid,
-        GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT,
-    );
+    let tree_result = containment.terminate_bounded(GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT);
     let _ = child.kill();
     let deadline = started + GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT;
     loop {
@@ -754,10 +786,11 @@ fn terminate_asset_download_child(child: &mut std::process::Child) -> Result<(),
 #[cfg(unix)]
 fn drain_available_pipe<R: Read + std::os::fd::AsRawFd>(
     input: &mut R,
+    max_chunks: usize,
     mut consume: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<bool, String> {
     let mut buffer = [0_u8; 8192];
-    loop {
+    for _ in 0..max_chunks {
         let mut descriptor = libc::pollfd {
             fd: input.as_raw_fd(),
             events: libc::POLLIN,
@@ -781,11 +814,13 @@ fn drain_available_pipe<R: Read + std::os::fd::AsRawFd>(
             Err(error) => return Err(format!("could not read download pipe: {error}")),
         }
     }
+    Ok(true)
 }
 
 #[cfg(windows)]
 fn drain_available_pipe<R: Read + std::os::windows::io::AsRawHandle>(
     input: &mut R,
+    max_chunks: usize,
     mut consume: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<bool, String> {
     use std::os::windows::io::AsRawHandle;
@@ -797,7 +832,7 @@ fn drain_available_pipe<R: Read + std::os::windows::io::AsRawHandle>(
         return Err("download output handle is not a pipe".to_string());
     }
     let mut buffer = [0_u8; 8192];
-    loop {
+    for _ in 0..max_chunks {
         let mut available = 0;
         let peeked = unsafe {
             PeekNamedPipe(
@@ -826,11 +861,13 @@ fn drain_available_pipe<R: Read + std::os::windows::io::AsRawHandle>(
             Err(error) => return Err(format!("could not read download pipe: {error}")),
         }
     }
+    Ok(true)
 }
 
 #[cfg(all(not(unix), not(windows)))]
 fn drain_available_pipe<R: Read>(
     _input: &mut R,
+    _max_chunks: usize,
     _consume: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<bool, String> {
     Err("nonblocking download pipes are unsupported on this platform".to_string())
@@ -1129,6 +1166,42 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn bounded_asset_download_continuous_output_observes_timeout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let downloads = temp.path().join("downloads");
+        std::fs::create_dir(&downloads).expect("download tempdir");
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let mut command = Command::new("sh");
+            command.args([
+                "-c",
+                "(while :; do printf x; done) & (while :; do printf diagnostic >&2; done) & wait",
+            ]);
+            let started = Instant::now();
+            let result = run_bounded_asset_download(
+                &mut command,
+                "asset.zip",
+                u64::MAX,
+                Duration::from_millis(30),
+                Some(&downloads),
+            );
+            let _ = result_tx.send((result, started.elapsed()));
+        });
+
+        let (result, elapsed) = result_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("continuous output exceeded the external bound");
+        worker.join().expect("download worker");
+        let error = result.expect_err("continuous output must time out");
+        assert!(error.contains("timed out"), "unexpected error: {error}");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "continuous output cleanup took {elapsed:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn bounded_asset_download_timeout_closes_descendant_inherited_pipes() {
         assert_inherited_pipe_cleanup(
             "sleep 30",
@@ -1163,6 +1236,18 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bounded_asset_download_contains_escaped_descendant_after_leader_exit() {
+        assert_inherited_pipe_cleanup(
+            "setsid sleep 30",
+            "exit 0",
+            Duration::from_secs(5),
+            "pipes remained open",
+            "escaped descendant after leader exit",
+        );
+    }
+
     #[cfg(unix)]
     fn assert_inherited_pipe_cleanup(
         descendant_command: &str,
@@ -1186,13 +1271,8 @@ mod tests {
             let mut command = Command::new("sh");
             command.args(["-c", &script]);
             let started = Instant::now();
-            let result = run_bounded_asset_download(
-                &mut command,
-                "asset.zip",
-                4,
-                timeout,
-                Some(&downloads),
-            );
+            let result =
+                run_bounded_asset_download(&mut command, "asset.zip", 4, timeout, Some(&downloads));
             let _ = result_tx.send((result, started.elapsed()));
         });
 
@@ -1239,9 +1319,7 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(25));
         }
-        panic!(
-            "download process group {leader_pid} or descendant {descendant_pid} remained alive"
-        );
+        panic!("download process group {leader_pid} or descendant {descendant_pid} remained alive");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- cap each stdout/stderr drain turn at four 8 KiB chunks so continuous writers cannot starve timeout and cleanup checks
- add generic pre-spawn process containment: Linux subreaper adoption plus an inherited scope marker, Windows kill-on-close Job Objects with suspended-before-assignment startup, and process-group fallback on other Unix hosts
- terminate and verify the containment scope on every download exit path, including descendants that call `setsid` and survive an already-exited leader

## Containment design

Linux enables subreaper behavior and stamps the command before spawn. Descendants inherit the scope marker, and orphaned descendants are reparented to the supervising Homeboy process when the direct leader exits. Cleanup scans the durable marker and live ancestry, kills the original process group and every owned PID, reaps adopted children, and restores the prior subreaper state only after the scope is empty. This closes the old leader-exit race because ownership evidence exists before execution and does not depend on discovering ancestry from a leader that may already be gone.

Windows creates a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, starts the child with `CREATE_SUSPENDED`, assigns it to the job, then resumes its primary suspended thread. The child therefore cannot execute or create descendants before durable kernel ownership is established. Bounded cleanup terminates the job and polls its active-process count.

The release path remains responsible only for its byte cap, 8 KiB diagnostic retention, exact length and SHA-256 identity checks, authenticated asset-ID request, fail-closed errors, and tempfile cleanup. `homeboy-process` contains no release or GitHub concepts.

## Tests

- `cargo test -p homeboy-process --lib`
- `cargo test -p homeboy-release bounded_asset_download -- --nocapture`
- `cargo check --workspace`
- `cargo build -p homeboy-process -p homeboy-release`
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-process --target x86_64-pc-windows-gnu` with the Windows std target installed
- `homeboy review --changed-since origin/main --placement local --summary`: audit, lint, and test stages pass; the umbrella incorrectly exits 1 for the required `Cargo.lock` dependency metadata and mislabels it as formatting despite zero formatting findings. Tracked in #10389.

Regression coverage includes continuous stdout and stderr timing out under a hard external bound, plus an inherited-pipe descendant that calls `setsid`, outlives an already-exited leader, and is verified dead with its leader.

## Platform coverage

Linux behavior runs on this host. Windows code and its deterministic suspended-job contract test are platform-gated; `homeboy-process` cross-compiles for `x86_64-pc-windows-gnu`. A full `homeboy-release` Windows cross-check is not feasible on this Linux host because transitive C dependencies require the unavailable MinGW compiler, so Windows runtime behavior remains for Windows CI. Non-Linux Unix hosts retain the existing process-group fallback and cannot contain a descendant that deliberately changes its process group.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the existing process primitives, implemented the fix and regression coverage, and ran the verification gates. Chris Huber owns review and merge decisions.

Closes #10356