### PR TITLE
test(release): verify bounded escaped asset cleanup

### DIFF
--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -989,6 +989,43 @@ mod tests {
     }
 
     #[test]
+    fn bounded_force_termination_kills_session_escapee() {
+        use std::os::unix::process::CommandExt;
+
+        let pid_file = std::env::temp_dir().join(format!(
+            "homeboy-process-escaped-descendant-{}.pid",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&pid_file);
+        let script = format!(
+            "setsid sleep 30 & echo $! > {}; wait",
+            pid_file.display()
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]).process_group(0);
+        let mut child = command.spawn().expect("spawn owned process tree");
+        for _ in 0..100 {
+            if pid_file.exists() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let escaped_pid = std::fs::read_to_string(&pid_file)
+            .expect("escaped descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric escaped descendant pid");
+
+        let started = Instant::now();
+        force_terminate_process_tree_bounded(child.id(), Duration::from_millis(500))
+            .expect("force-terminate owned tree");
+        assert!(started.elapsed() < Duration::from_secs(1));
+        let _ = child.wait();
+        let _ = std::fs::remove_file(&pid_file);
+        assert!(!pid_is_running(escaped_pid));
+    }
+
+    #[test]
     fn force_stop_environment_ownership_requires_an_exact_assignment() {
         let environment = b"HOME=/tmp\0HOMEBOY_DAEMON_STARTUP_TOKEN=lease-token\0";
 

--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -997,10 +997,7 @@ mod tests {
             std::process::id()
         ));
         let _ = std::fs::remove_file(&pid_file);
-        let script = format!(
-            "setsid sleep 30 & echo $! > {}; wait",
-            pid_file.display()
-        );
+        let script = format!("setsid sleep 30 & echo $! > {}; wait", pid_file.display());
         let mut command = Command::new("sh");
         command.args(["-c", &script]).process_group(0);
         let mut child = command.spawn().expect("spawn owned process tree");

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -632,9 +632,9 @@ fn run_bounded_asset_download(
                 let remaining = expected_size.saturating_sub(size).min(bytes.len() as u64) as usize;
                 let accepted = bytes.len().min(remaining);
                 if accepted > 0 {
-                    output_file
-                        .write_all(&bytes[..accepted])
-                        .map_err(|error| format!("could not write temporary asset bytes: {error}"))?;
+                    output_file.write_all(&bytes[..accepted]).map_err(|error| {
+                        format!("could not write temporary asset bytes: {error}")
+                    })?;
                     hasher.update(&bytes[..accepted]);
                     size += accepted as u64;
                 }
@@ -646,25 +646,29 @@ fn run_bounded_asset_download(
                 Ok(())
             }) {
                 Ok(open) => open,
-                Err(error) => break Err(format!(
-                    "could not download GitHub Release asset '{}': {error}",
-                    asset_name
-                )),
+                Err(error) => {
+                    break Err(format!(
+                        "could not download GitHub Release asset '{}': {error}",
+                        asset_name
+                    ))
+                }
             };
         }
         if stderr_open {
             stderr_open = match drain_available_pipe(&mut stderr, |bytes| {
-                let remaining = GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES
-                    .saturating_sub(diagnostics.len());
+                let remaining =
+                    GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES.saturating_sub(diagnostics.len());
                 diagnostics.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
                 diagnostics_truncated |= bytes.len() > remaining;
                 Ok(())
             }) {
                 Ok(open) => open,
-                Err(error) => break Err(format!(
-                    "could not read GitHub Release asset '{}' diagnostics: {error}",
-                    asset_name
-                )),
+                Err(error) => {
+                    break Err(format!(
+                        "could not read GitHub Release asset '{}' diagnostics: {error}",
+                        asset_name
+                    ))
+                }
             };
         }
         if !stdout_open && !stderr_open {
@@ -692,9 +696,9 @@ fn run_bounded_asset_download(
                     ));
                 }
             }
-        } else if exited_at.is_some_and(|exit| {
-            exit.elapsed() >= GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT
-        }) {
+        } else if exited_at
+            .is_some_and(|exit| exit.elapsed() >= GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT)
+        {
             break Err(format!(
                 "GitHub Release asset '{}' pipes remained open after the download process exited",
                 asset_name
@@ -1186,13 +1190,8 @@ mod tests {
             let mut command = Command::new("sh");
             command.args(["-c", &script]);
             let started = Instant::now();
-            let result = run_bounded_asset_download(
-                &mut command,
-                "asset.zip",
-                4,
-                timeout,
-                Some(&downloads),
-            );
+            let result =
+                run_bounded_asset_download(&mut command, "asset.zip", 4, timeout, Some(&downloads));
             let _ = result_tx.send((result, started.elapsed()));
         });
 
@@ -1239,9 +1238,7 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(25));
         }
-        panic!(
-            "download process group {leader_pid} or descendant {descendant_pid} remained alive"
-        );
+        panic!("download process group {leader_pid} or descendant {descendant_pid} remained alive");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- apply the exact stable Rustfmt output omitted when #10342 was merged at `9c862f14c`
- directly test the bounded process-tree primitive against a Linux descendant that escapes the owner's process group with `setsid`
- retain the release-level timeout, oversize, tempfile, process liveness, and hard external-bound regressions merged in #10342

## Context
PR #10342 was merged externally while strict-review follow-up was still in progress. Its merged head contains the ownership redesign: nonblocking supervisor-owned pipes, bounded Linux descendant/process-group termination, bounded Windows `taskkill`, and direct-child reap. This follow-up contains only the post-merge stable formatting and process-layer escaped-descendant regression that could no longer be added to the merged PR.

## Cleanup ownership
The merged download supervisor owns stdout, stderr, tempfile writes, hashing, and diagnostics on one stack; no detached reader threads remain. Linux force cleanup snapshots descendants from `/proc` before killing both the dedicated process group and recorded descendants. The new process-layer test proves a `setsid sleep` escapee is stopped under a 500 ms termination budget and a one-second external assertion.

## Platform guarantees
- Linux: direct regression for procfs descendant discovery outside the owner process group.
- Other Unix: existing process-group/root cleanup remains compile-gated; Linux-only `setsid` ownership coverage does not claim procfs behavior elsewhere.
- Windows: merged bounded supervised `taskkill /T /F` behavior is unchanged by this follow-up.

## Verification
- `cargo test -p homeboy-release bounded_asset_download -- --nocapture` (6 passed)
- `cargo test -p homeboy-process --lib` (9 passed)
- `cargo check --workspace` (passed; existing warnings)
- `cargo build --workspace` (passed; existing warnings)
- `git diff --check origin/main...HEAD` (passed)
- stable Rustfmt passed on exact pre-replay content; this branch contains that output plus the exact stable formatting correction for the new regression

## Residual risk
Escaped-session descendant discovery remains Linux-specific. Non-Linux Unix hosts retain bounded process-group/root cleanup, and Windows tree completeness remains dependent on bounded `taskkill` behavior.

Follow-up to #10342 and #10336.