### PR TITLE
fix(artifacts): reserve directory rollback targets

### DIFF
--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -165,7 +165,7 @@ impl ObservationStore {
         }
 
         let path = path.as_ref();
-        let metadata = fs::metadata(path).map_err(|e| {
+        let metadata = fs::symlink_metadata(path).map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 return Error::validation_invalid_argument(
                     "path",
@@ -386,7 +386,7 @@ impl ObservationStore {
         }
 
         let path = path.as_ref();
-        let metadata = fs::metadata(path).map_err(|e| {
+        let metadata = fs::symlink_metadata(path).map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 return Error::validation_invalid_argument(
                     "path",
@@ -439,19 +439,6 @@ impl ObservationStore {
         }
         let created_at = chrono::Utc::now().to_rfc3339();
         let stored_path = persisted_artifact_path(run_id, &id, path)?;
-        let stored_path_existed = match fs::symlink_metadata(&stored_path) {
-            Ok(_) => true,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-            Err(error) => {
-                return Err(Error::internal_io(
-                    error.to_string(),
-                    Some(format!(
-                        "inspect persisted artifact directory {}",
-                        stored_path.display()
-                    )),
-                ));
-            }
-        };
         copy_artifact_directory(path, &stored_path)?;
         let path_string = stored_path.to_string_lossy().to_string();
 
@@ -481,9 +468,7 @@ impl ObservationStore {
                 ],
             )
         }) {
-            if !stored_path_existed {
-                fs::remove_dir_all(&stored_path).ok();
-            }
+            fs::remove_dir_all(&stored_path).ok();
             return Err(error);
         }
 
@@ -1136,7 +1121,7 @@ fn collect_directory_tree_entries(
     children.sort_by_key(|entry| entry.file_name());
     for child in children {
         let child_relative = relative.join(child.file_name());
-        let metadata = child.metadata().map_err(|error| {
+        let metadata = child.file_type().map_err(|error| {
             Error::internal_io(
                 error.to_string(),
                 Some(format!("stat {}", child.path().display())),
@@ -1283,7 +1268,7 @@ mod tests {
                 ))
                 .expect("install insertion fault");
 
-            assert!(store
+            let error = store
                 .record_directory_artifact_with_id(
                     &run.id,
                     "evidence",
@@ -1291,7 +1276,10 @@ mod tests {
                     artifact_id,
                     serde_json::json!({}),
                 )
-                .is_err());
+                .expect_err("injected insert failure");
+            assert!(error
+                .to_string()
+                .contains("injected directory artifact insert failure"));
 
             assert!(
                 !stored_path.exists(),
@@ -1340,11 +1328,63 @@ mod tests {
                 fs::read(stored_path.join("stable.txt")).expect("read stable bytes"),
                 b"stable bytes"
             );
+            assert!(
+                !stored_path.join("copied.txt").exists(),
+                "an existing target must not be merged before a failed insert"
+            );
             assert!(store
                 .get_artifact(artifact_id)
                 .expect("lookup artifact")
                 .is_none());
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_copy_failure_removes_only_its_reserved_tree() {
+        use std::os::unix::fs::symlink;
+
+        with_isolated_home(|home| {
+            let source = home.path().join("directory-source");
+            fs::create_dir_all(&source).expect("create source");
+            fs::write(source.join("copied.txt"), b"copied bytes").expect("write source");
+            symlink("copied.txt", source.join("unsafe-link")).expect("create symlink");
+            let target = home.path().join("directory-target");
+
+            let error = copy_artifact_directory(&source, &target).expect_err("reject symlink");
+
+            assert!(error.to_string().contains("unsupported entry"));
+            assert!(!target.exists(), "partial copy must be rolled back");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_copy_rejects_a_symlinked_target_parent() {
+        use std::os::unix::fs::symlink;
+
+        with_isolated_home(|home| {
+            let source = home.path().join("directory-source");
+            fs::create_dir_all(&source).expect("create source");
+            fs::write(source.join("copied.txt"), b"copied bytes").expect("write source");
+            let outside = home.path().join("outside");
+            fs::create_dir(&outside).expect("create outside directory");
+            let linked_parent = home.path().join("linked-parent");
+            symlink(&outside, &linked_parent).expect("create parent symlink");
+
+            let error = copy_artifact_directory(&source, &linked_parent.join("target"))
+                .expect_err("reject symlinked target parent");
+
+            assert!(error.to_string().contains("parent is a symlink"));
+            assert!(!outside.join("target").exists());
+        });
+    }
+
+    #[test]
+    fn persisted_artifact_path_rejects_unsafe_identity_components() {
+        let source = Path::new("evidence");
+        assert!(persisted_artifact_path("../run", "artifact", source).is_err());
+        assert!(persisted_artifact_path("run", "../artifact", source).is_err());
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/store/helpers.rs
+++ b/crates/homeboy-core/src/observation/store/helpers.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use super::*;
 
@@ -232,6 +232,8 @@ pub(crate) fn persisted_artifact_path(
     artifact_id: &str,
     source: &Path,
 ) -> Result<PathBuf> {
+    validate_artifact_path_component("run_id", run_id)?;
+    validate_artifact_path_component("artifact_id", artifact_id)?;
     let file_name = source
         .file_name()
         .and_then(|name| name.to_str())
@@ -239,6 +241,22 @@ pub(crate) fn persisted_artifact_path(
         .map(|name| format!("{artifact_id}-{name}"))
         .unwrap_or_else(|| artifact_id.to_string());
     Ok(paths::artifact_root()?.join(run_id).join(file_name))
+}
+
+fn validate_artifact_path_component(field: &str, value: &str) -> Result<()> {
+    if !matches!(
+        Path::new(value).components().next(),
+        Some(Component::Normal(_))
+    ) || Path::new(value).components().count() != 1
+    {
+        return Err(Error::validation_invalid_argument(
+            field,
+            format!("{field} must be a single path component"),
+            Some(value.to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn copy_artifact_file(source: &Path, target: &Path) -> Result<()> {
@@ -249,6 +267,23 @@ pub(crate) fn copy_artifact_file(source: &Path, target: &Path) -> Result<()> {
                 Some(format!("create artifact directory {}", parent.display())),
             )
         })?;
+        let metadata = fs::symlink_metadata(parent).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("inspect artifact directory {}", parent.display())),
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                format!(
+                    "artifact directory parent is a symlink: {}",
+                    parent.display()
+                ),
+                Some(parent.display().to_string()),
+                None,
+            ));
+        }
     }
     fs::copy(source, target).map_err(|e| {
         Error::internal_io(
@@ -263,13 +298,48 @@ pub(crate) fn copy_artifact_file(source: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Reserve a new target directory before copying so a failed publication can
+/// remove only the tree created by this invocation.
 pub(crate) fn copy_artifact_directory(source: &Path, target: &Path) -> Result<()> {
-    fs::create_dir_all(target).map_err(|e| {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("create artifact directory {}", parent.display())),
+            )
+        })?;
+        let metadata = fs::symlink_metadata(parent).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("inspect artifact directory {}", parent.display())),
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                format!(
+                    "artifact directory parent is a symlink: {}",
+                    parent.display()
+                ),
+                Some(parent.display().to_string()),
+                None,
+            ));
+        }
+    }
+    fs::create_dir(target).map_err(|e| {
         Error::internal_io(
             e.to_string(),
-            Some(format!("create artifact directory {}", target.display())),
+            Some(format!("reserve artifact directory {}", target.display())),
         )
     })?;
+    if let Err(error) = copy_artifact_directory_contents(source, target) {
+        fs::remove_dir_all(target).ok();
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn copy_artifact_directory_contents(source: &Path, target: &Path) -> Result<()> {
     for entry in fs::read_dir(source).map_err(|e| {
         Error::internal_io(
             e.to_string(),
@@ -297,9 +367,28 @@ pub(crate) fn copy_artifact_directory(source: &Path, target: &Path) -> Result<()
             )
         })?;
         if entry_type.is_dir() {
-            copy_artifact_directory(&entry_source, &entry_target)?;
+            fs::create_dir(&entry_target).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!(
+                        "create artifact directory {}",
+                        entry_target.display()
+                    )),
+                )
+            })?;
+            copy_artifact_directory_contents(&entry_source, &entry_target)?;
         } else if entry_type.is_file() {
             copy_artifact_file(&entry_source, &entry_target)?;
+        } else {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                format!(
+                    "artifact directory contains unsupported entry: {}",
+                    entry_source.display()
+                ),
+                Some(entry_source.display().to_string()),
+                None,
+            ));
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

Follow-up to #10351 / phase 1 of #10284.

- Reserve directory artifact targets with exclusive creation before copying so cleanup owns only its own tree.
- Roll back partial copies, reject existing target trees rather than merging them, and preserve the original database insert error.
- Reject unsafe artifact identity path components plus source/target-parent symlinks and unsupported directory entries.
- Add focused fault-injection and filesystem-safety coverage.

## Validation

- cargo fmt --check
- cargo test -p homeboy-core observation::store::artifacts::tests --lib (12 passed)
- git diff --check

## Remaining Scope

#10284 phase-2 filesystem reconciliation remains intentionally out of scope: orphaned staging files, patch-capture scratch directories, and bytes left by process termination still need a dedicated reconciliation cleanup category.

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode independently reviewed #10351, identified the race and copy-failure gaps, and drafted the focused remediation and tests. Chris Huber owns and is responsible for every line.