### PR TITLE
Fix observable worktree cleanup dry-run deprecation

### DIFF
--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -166,6 +166,8 @@ pub struct WorktreeCleanupCommandOutput {
     pub worktrees: WorktreeCleanupOutput,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifact_cleanup: Option<ArtifactCleanupOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated_flag: Option<&'static str>,
 }
 
 pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<WorktreeOutput> {
@@ -241,7 +243,7 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
         WorktreeCommand::Cleanup {
             apply,
             force,
-            dry_run: _,
+            dry_run: deprecated_dry_run,
             cleanup_artifacts,
             cleanup_branches,
             allow_unmerged_branches,
@@ -273,6 +275,7 @@ pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<Worktre
             WorktreeOutput::Cleanup(WorktreeCleanupCommandOutput {
                 worktrees,
                 artifact_cleanup,
+                deprecated_flag: deprecated_dry_run.then_some("--dry-run"),
             })
         }
     };
@@ -355,6 +358,20 @@ mod tests {
         assert!(!apply);
         assert!(dry_run);
         assert!(cleanup_is_dry_run(apply));
+    }
+
+    #[test]
+    fn worktree_cleanup_dry_run_marks_the_deprecated_flag() {
+        let cli = Cli::parse_from(["homeboy", "worktree", "cleanup", "--dry-run"]);
+
+        let Commands::Worktree(args) = cli.command else {
+            panic!("expected worktree command");
+        };
+        let WorktreeCommand::Cleanup { dry_run, .. } = args.command else {
+            panic!("expected worktree cleanup command");
+        };
+
+        assert_eq!(dry_run.then_some("--dry-run"), Some("--dry-run"));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -632,9 +632,9 @@ fn run_bounded_asset_download(
                 let remaining = expected_size.saturating_sub(size).min(bytes.len() as u64) as usize;
                 let accepted = bytes.len().min(remaining);
                 if accepted > 0 {
-                    output_file
-                        .write_all(&bytes[..accepted])
-                        .map_err(|error| format!("could not write temporary asset bytes: {error}"))?;
+                    output_file.write_all(&bytes[..accepted]).map_err(|error| {
+                        format!("could not write temporary asset bytes: {error}")
+                    })?;
                     hasher.update(&bytes[..accepted]);
                     size += accepted as u64;
                 }
@@ -646,25 +646,29 @@ fn run_bounded_asset_download(
                 Ok(())
             }) {
                 Ok(open) => open,
-                Err(error) => break Err(format!(
-                    "could not download GitHub Release asset '{}': {error}",
-                    asset_name
-                )),
+                Err(error) => {
+                    break Err(format!(
+                        "could not download GitHub Release asset '{}': {error}",
+                        asset_name
+                    ))
+                }
             };
         }
         if stderr_open {
             stderr_open = match drain_available_pipe(&mut stderr, |bytes| {
-                let remaining = GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES
-                    .saturating_sub(diagnostics.len());
+                let remaining =
+                    GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES.saturating_sub(diagnostics.len());
                 diagnostics.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
                 diagnostics_truncated |= bytes.len() > remaining;
                 Ok(())
             }) {
                 Ok(open) => open,
-                Err(error) => break Err(format!(
-                    "could not read GitHub Release asset '{}' diagnostics: {error}",
-                    asset_name
-                )),
+                Err(error) => {
+                    break Err(format!(
+                        "could not read GitHub Release asset '{}' diagnostics: {error}",
+                        asset_name
+                    ))
+                }
             };
         }
         if !stdout_open && !stderr_open {
@@ -692,9 +696,9 @@ fn run_bounded_asset_download(
                     ));
                 }
             }
-        } else if exited_at.is_some_and(|exit| {
-            exit.elapsed() >= GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT
-        }) {
+        } else if exited_at
+            .is_some_and(|exit| exit.elapsed() >= GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT)
+        {
             break Err(format!(
                 "GitHub Release asset '{}' pipes remained open after the download process exited",
                 asset_name
@@ -1186,13 +1190,8 @@ mod tests {
             let mut command = Command::new("sh");
             command.args(["-c", &script]);
             let started = Instant::now();
-            let result = run_bounded_asset_download(
-                &mut command,
-                "asset.zip",
-                4,
-                timeout,
-                Some(&downloads),
-            );
+            let result =
+                run_bounded_asset_download(&mut command, "asset.zip", 4, timeout, Some(&downloads));
             let _ = result_tx.send((result, started.elapsed()));
         });
 
@@ -1239,9 +1238,7 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(25));
         }
-        panic!(
-            "download process group {leader_pid} or descendant {descendant_pid} remained alive"
-        );
+        panic!("download process group {leader_pid} or descendant {descendant_pid} remained alive");
     }
 
     #[test]

--- a/docs/commands/worktree.md
+++ b/docs/commands/worktree.md
@@ -16,6 +16,6 @@ For multi-PR orchestration, start with `homeboy --output homeboy-results/worktre
 
 Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. `--force` only bypasses dirty/unpushed checks; primary checkout and containment gates always apply.
 
-`worktree cleanup` reports a task-worktree cleanup plan by default. Pass `--apply` to remove planned worktrees after the existing safety gates pass. `--dry-run` remains a deprecated plan-only alias for one release; it conflicts with `--apply`.
+`worktree cleanup` reports a task-worktree cleanup plan by default. Pass `--apply` to remove planned worktrees after the existing safety gates pass. `--dry-run` remains a deprecated plan-only alias for one release; it conflicts with `--apply` and reports `deprecated_flag: "--dry-run"` in JSON output.
 
 Use `homeboy cleanup artifacts` to plan rebuildable artifact cleanup, then pass `--apply` when the plan is acceptable. `worktree cleanup --cleanup-artifacts` includes declared rebuildable artifacts from the Homeboy checkout that built the active binary; it remains plan-only unless `--apply` is also passed.


### PR DESCRIPTION
## Summary
- expose explicit legacy `--dry-run` use as additive `deprecated_flag: "--dry-run"` JSON output
- preserve bare cleanup as the unmarked default plan path
- document and cover the migration marker

## Verification
- `cargo test -p homeboy-cli worktree_cleanup`
- `cargo test -p homeboy-cli documented_docs_surface_matches_manifest_and_parser`
- `cargo build -p homeboy`
- Built CLI: verified bare cleanup and `--cleanup-artifacts` remain plan-only, `--dry-run` emits the marker, and `--apply --dry-run` exits 2.

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode independently reviewed merged PR #10360, identified the unobservable deprecation, and drafted this minimal follow-up and tests. Chris Huber remains responsible for every line.