### PR TITLE
fix(release): preserve bounded download supervision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "ctrlc",
  "homeboy-error",
  "libc",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/homeboy-process/Cargo.toml
+++ b/crates/homeboy-process/Cargo.toml
@@ -16,3 +16,4 @@ path = "src/lib.rs"
 homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 libc = "0.2"
 ctrlc = "3.4"
+uuid = { version = "1.11", features = ["v4"] }

--- a/crates/homeboy-process/src/lib.rs
+++ b/crates/homeboy-process/src/lib.rs
@@ -4,6 +4,86 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+#[cfg(target_os = "linux")]
+use uuid::Uuid;
+
+#[cfg(target_os = "linux")]
+const PROCESS_SCOPE_ENV: &str = "HOMEBOY_PROCESS_SCOPE";
+
+/// Owns a process group and, on Linux, an inherited scope marker that survives
+/// descendants changing sessions or outliving their direct parent.
+pub struct ProcessContainment {
+    leader_pid: Option<u32>,
+    #[cfg(target_os = "linux")]
+    scope: String,
+}
+
+impl ProcessContainment {
+    /// Establish containment before spawning so every descendant inherits its
+    /// ownership marker from the first instruction it executes.
+    pub fn prepare(command: &mut Command) -> Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let scope = Uuid::new_v4().to_string();
+            command.env(PROCESS_SCOPE_ENV, &scope);
+            return Ok(Self {
+                leader_pid: None,
+                scope,
+            });
+        }
+        #[cfg(not(target_os = "linux"))]
+        Ok(Self { leader_pid: None })
+    }
+
+    pub fn attach(&mut self, child: &std::process::Child) -> Result<()> {
+        self.leader_pid = Some(child.id());
+        Ok(())
+    }
+
+    /// Terminate a failed child and its owned scope within `timeout`. The
+    /// direct child remains the caller's reaping responsibility.
+    pub fn terminate_on_failure_bounded(
+        &self,
+        timeout: Duration,
+        leader_has_exited: bool,
+    ) -> Result<()> {
+        let pid = self.leader_pid.ok_or_else(|| {
+            Error::internal_unexpected("process containment was not attached to a child")
+        })?;
+        #[cfg(target_os = "linux")]
+        {
+            if leader_has_exited {
+                return terminate_linux_scope_members(&self.scope, timeout, None);
+            }
+            return terminate_linux_process_scope(pid, &self.scope, timeout);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = leader_has_exited;
+            force_terminate_process_tree_bounded(pid, timeout)
+        }
+    }
+
+    /// Clean up descendants after the direct child has exited. Linux uses only
+    /// the inherited marker here, never the former leader's process-group ID.
+    /// Other platforms intentionally preserve their existing normal-exit path.
+    pub fn cleanup_after_leader_exit_bounded(&self, timeout: Duration) -> Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            return terminate_linux_scope_members(&self.scope, timeout, None);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = timeout;
+            Ok(())
+        }
+    }
+}
 
 /// Generic process step shape shared by command/runner adapters.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -659,6 +739,50 @@ pub fn force_terminate_process_tree_bounded(pid: u32, timeout: Duration) -> Resu
     }
 }
 
+#[cfg(target_os = "linux")]
+fn terminate_linux_process_scope(owner_pid: u32, scope: &str, timeout: Duration) -> Result<()> {
+    unsafe {
+        if libc::kill(-(owner_pid as libc::pid_t), libc::SIGKILL) != 0
+            && std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+        {
+            return Err(Error::internal_unexpected(format!(
+                "force-terminate owned process group {owner_pid}: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+    }
+
+    terminate_linux_scope_members(scope, timeout, Some(owner_pid))
+}
+
+#[cfg(target_os = "linux")]
+fn terminate_linux_scope_members(
+    scope: &str,
+    timeout: Duration,
+    owner_pid: Option<u32>,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let targets = linux_scope_pids(scope)?;
+        signal_pids(&targets, libc::SIGKILL)?;
+        let survivors = linux_scope_pids(scope)?;
+        if survivors.is_empty() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            let owner = owner_pid
+                .map(|pid| format!(" {pid}"))
+                .unwrap_or_else(|| " after leader exit".to_string());
+            return Err(Error::internal_unexpected(format!(
+                "owned process scope{owner} did not exit within {} ms; surviving pids: {}",
+                timeout.as_millis(),
+                join_pids(&survivors)
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessTreeTermination {
     pub owner_pid: u32,
@@ -951,6 +1075,33 @@ fn linux_descendant_pids(owner_pid: u32) -> Result<Vec<u32>> {
         }
     }
     Ok(descendant_pids_from_rows(&rows, owner_pid))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_scope_pids(scope: &str) -> Result<Vec<u32>> {
+    let entries = std::fs::read_dir("/proc").map_err(|error| {
+        Error::internal_unexpected(format!("inspect owned process scope: {error}"))
+    })?;
+    let expected = format!("{PROCESS_SCOPE_ENV}={scope}");
+    let mut pids = Vec::new();
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<u32>() else {
+            continue;
+        };
+        let Ok(environment) = std::fs::read(entry.path().join("environ")) else {
+            continue;
+        };
+        if environment_contains_assignment(&environment, expected.as_bytes()) && pid_is_running(pid)
+        {
+            pids.push(pid);
+        }
+    }
+    pids.sort_unstable();
+    Ok(pids)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -17,6 +17,7 @@ pub(crate) const GITHUB_RELEASE_UPLOAD_TIMEOUT_ENV: &str =
 const DEFAULT_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS: u64 = 30 * 60;
 const GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES: usize = 8 * 1024;
 const GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT: Duration = Duration::from_millis(500);
+const GITHUB_RELEASE_DOWNLOAD_PIPE_CHUNKS_PER_TURN: usize = 4;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GhCommandOutput {
@@ -594,17 +595,27 @@ fn run_bounded_asset_download(
         )
     })?;
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
+    let mut containment =
+        homeboy_core::process::ProcessContainment::prepare(command).map_err(|error| {
+            format!(
+                "could not contain GitHub Release asset '{}' download: {error}",
+                asset_name
+            )
+        })?;
     let mut child = command.spawn().map_err(|error| {
         format!(
             "could not download GitHub Release asset '{}': {error}",
             asset_name
         )
     })?;
+    if let Err(error) = containment.attach(&child) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!(
+            "could not contain GitHub Release asset '{}' download: {error}",
+            asset_name
+        ));
+    }
     let mut stdout = child.stdout.take().ok_or_else(|| {
         format!(
             "could not capture download stream for GitHub Release asset '{}'",
@@ -628,23 +639,28 @@ fn run_bounded_asset_download(
     let mut exited_at = None;
     let outcome = loop {
         if stdout_open {
-            stdout_open = match drain_available_pipe(&mut stdout, |bytes| {
-                let remaining = expected_size.saturating_sub(size).min(bytes.len() as u64) as usize;
-                let accepted = bytes.len().min(remaining);
-                if accepted > 0 {
-                    output_file.write_all(&bytes[..accepted]).map_err(|error| {
-                        format!("could not write temporary asset bytes: {error}")
-                    })?;
-                    hasher.update(&bytes[..accepted]);
-                    size += accepted as u64;
-                }
-                if accepted != bytes.len() {
-                    return Err(format!(
-                        "download exceeded expected byte length {expected_size}"
-                    ));
-                }
-                Ok(())
-            }) {
+            stdout_open = match drain_available_pipe(
+                &mut stdout,
+                GITHUB_RELEASE_DOWNLOAD_PIPE_CHUNKS_PER_TURN,
+                |bytes| {
+                    let remaining =
+                        expected_size.saturating_sub(size).min(bytes.len() as u64) as usize;
+                    let accepted = bytes.len().min(remaining);
+                    if accepted > 0 {
+                        output_file.write_all(&bytes[..accepted]).map_err(|error| {
+                            format!("could not write temporary asset bytes: {error}")
+                        })?;
+                        hasher.update(&bytes[..accepted]);
+                        size += accepted as u64;
+                    }
+                    if accepted != bytes.len() {
+                        return Err(format!(
+                            "download exceeded expected byte length {expected_size}"
+                        ));
+                    }
+                    Ok(())
+                },
+            ) {
                 Ok(open) => open,
                 Err(error) => {
                     break Err(format!(
@@ -655,13 +671,17 @@ fn run_bounded_asset_download(
             };
         }
         if stderr_open {
-            stderr_open = match drain_available_pipe(&mut stderr, |bytes| {
-                let remaining =
-                    GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES.saturating_sub(diagnostics.len());
-                diagnostics.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
-                diagnostics_truncated |= bytes.len() > remaining;
-                Ok(())
-            }) {
+            stderr_open = match drain_available_pipe(
+                &mut stderr,
+                GITHUB_RELEASE_DOWNLOAD_PIPE_CHUNKS_PER_TURN,
+                |bytes| {
+                    let remaining =
+                        GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES.saturating_sub(diagnostics.len());
+                    diagnostics.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+                    diagnostics_truncated |= bytes.len() > remaining;
+                    Ok(())
+                },
+            ) {
                 Ok(open) => open,
                 Err(error) => {
                     break Err(format!(
@@ -709,13 +729,22 @@ fn run_bounded_asset_download(
     let status = match outcome {
         Ok(status) => status,
         Err(error) => {
-            let cleanup = terminate_asset_download_child(&mut child)
-                .err()
-                .map(|cleanup| format!("; {cleanup}"))
-                .unwrap_or_default();
+            let cleanup =
+                terminate_asset_download_child(&mut child, &mut containment, status.is_some())
+                    .err()
+                    .map(|cleanup| format!("; {cleanup}"))
+                    .unwrap_or_default();
             return Err(format!("{error}{cleanup}"));
         }
     };
+    containment
+        .cleanup_after_leader_exit_bounded(GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT)
+        .map_err(|error| {
+            format!(
+                "could not clean up GitHub Release asset '{}' download containment: {error}",
+                asset_name
+            )
+        })?;
     let mut diagnostics = String::from_utf8_lossy(&diagnostics).to_string();
     if diagnostics_truncated {
         diagnostics.push_str("\n[diagnostics truncated]");
@@ -730,12 +759,16 @@ fn run_bounded_asset_download(
     Ok((size, format!("{:x}", hasher.finalize())))
 }
 
-fn terminate_asset_download_child(child: &mut std::process::Child) -> Result<(), String> {
+fn terminate_asset_download_child(
+    child: &mut std::process::Child,
+    containment: &mut homeboy_core::process::ProcessContainment,
+    leader_has_exited: bool,
+) -> Result<(), String> {
     let pid = child.id();
     let started = Instant::now();
-    let tree_result = homeboy_core::process::force_terminate_process_tree_bounded(
-        pid,
+    let tree_result = containment.terminate_on_failure_bounded(
         GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT,
+        leader_has_exited,
     );
     let _ = child.kill();
     let deadline = started + GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT;
@@ -758,10 +791,11 @@ fn terminate_asset_download_child(child: &mut std::process::Child) -> Result<(),
 #[cfg(unix)]
 fn drain_available_pipe<R: Read + std::os::fd::AsRawFd>(
     input: &mut R,
+    max_chunks: usize,
     mut consume: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<bool, String> {
     let mut buffer = [0_u8; 8192];
-    loop {
+    for _ in 0..max_chunks {
         let mut descriptor = libc::pollfd {
             fd: input.as_raw_fd(),
             events: libc::POLLIN,
@@ -785,11 +819,13 @@ fn drain_available_pipe<R: Read + std::os::fd::AsRawFd>(
             Err(error) => return Err(format!("could not read download pipe: {error}")),
         }
     }
+    Ok(true)
 }
 
 #[cfg(windows)]
 fn drain_available_pipe<R: Read + std::os::windows::io::AsRawHandle>(
     input: &mut R,
+    max_chunks: usize,
     mut consume: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<bool, String> {
     use std::os::windows::io::AsRawHandle;
@@ -801,7 +837,7 @@ fn drain_available_pipe<R: Read + std::os::windows::io::AsRawHandle>(
         return Err("download output handle is not a pipe".to_string());
     }
     let mut buffer = [0_u8; 8192];
-    loop {
+    for _ in 0..max_chunks {
         let mut available = 0;
         let peeked = unsafe {
             PeekNamedPipe(
@@ -830,11 +866,13 @@ fn drain_available_pipe<R: Read + std::os::windows::io::AsRawHandle>(
             Err(error) => return Err(format!("could not read download pipe: {error}")),
         }
     }
+    Ok(true)
 }
 
 #[cfg(all(not(unix), not(windows)))]
 fn drain_available_pipe<R: Read>(
     _input: &mut R,
+    _max_chunks: usize,
     _consume: impl FnMut(&[u8]) -> Result<(), String>,
 ) -> Result<bool, String> {
     Err("nonblocking download pipes are unsupported on this platform".to_string())
@@ -1132,6 +1170,87 @@ mod tests {
                 .count(),
             0,
             "timed-out download must clean up its tempfile"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_asset_download_continuous_output_observes_timeout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let downloads = temp.path().join("downloads");
+        std::fs::create_dir(&downloads).expect("download tempdir");
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let mut command = Command::new("sh");
+            command.args([
+                "-c",
+                "(while :; do printf x; done) & (while :; do printf diagnostic >&2; done) & wait",
+            ]);
+            let started = Instant::now();
+            let result = run_bounded_asset_download(
+                &mut command,
+                "asset.zip",
+                u64::MAX,
+                Duration::from_millis(30),
+                Some(&downloads),
+            );
+            let _ = result_tx.send((result, started.elapsed()));
+        });
+
+        let (result, elapsed) = result_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("continuous output exceeded the external bound");
+        worker.join().expect("download worker");
+        let error = result.expect_err("continuous output must time out");
+        assert!(error.contains("timed out"), "unexpected error: {error}");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "continuous output cleanup took {elapsed:?}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bounded_asset_download_kills_setsid_descendant_after_leader_exit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let downloads = temp.path().join("downloads");
+        std::fs::create_dir(&downloads).expect("download tempdir");
+        let descendant_pid = temp.path().join("descendant.pid");
+        let script = format!(
+            "setsid sleep 30 & echo $! > {}; exit 0",
+            quote_arg(&descendant_pid.display().to_string())
+        );
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let mut command = Command::new("sh");
+            command.args(["-c", &script]);
+            let result = run_bounded_asset_download(
+                &mut command,
+                "asset.zip",
+                4,
+                Duration::from_secs(5),
+                Some(&downloads),
+            );
+            let _ = result_tx.send(result);
+        });
+
+        let error = result_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("leader-exit cleanup exceeded the external bound")
+            .expect_err("inherited descendant pipes must fail cleanup");
+        worker.join().expect("download worker");
+        assert!(
+            error.contains("pipes remained open"),
+            "unexpected error: {error}"
+        );
+        let pid = std::fs::read_to_string(&descendant_pid)
+            .expect("descendant pid")
+            .trim()
+            .parse::<u32>()
+            .expect("numeric descendant pid");
+        assert!(
+            !homeboy_core::process::pid_is_running(pid),
+            "setsid descendant {pid} survived cleanup"
         );
     }
 


### PR DESCRIPTION
## Summary
- bound stdout and stderr draining per supervision turn so continuous writers cannot starve timeout checks
- establish inherited Linux process-scope ownership before spawn and clean marker-owned descendants after leader exit or session escape
- preserve existing non-Linux behavior and avoid process-wide subreaper state

## Verification
- `cargo test -p homeboy-release bounded_asset_download -- --nocapture` (6 passed)
- `cargo test -p homeboy-process --lib` (6 passed)
- `cargo check -p homeboy-release -p homeboy-process`
- `cargo fmt --all --check`
- `git diff --check`

Linux CI provides the platform-gated leader-exit `setsid` regression. The remaining Windows durable-ownership acceptance criterion in #10356 stays open for a separately proven implementation.

Supersedes the safe bounded subset of #10390 without its process-wide Linux subreaper or unproven Windows Job Object changes.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode investigated #10390 against current main, implemented the bounded subset, and reviewed/remediated cleanup semantics and regressions. Chris Huber reviewed and owns every line.