### PR TITLE
fix(release): parse versions with semver instead of splitting on dots

### DIFF
--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -5,6 +5,7 @@ use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_core::plan::{PlanStep, PlanValues};
+use semver::Version;
 
 use super::context::{load_component, resolve_extensions};
 use super::execution_dispatch::{
@@ -182,9 +183,9 @@ fn resolve_head_release(
     if let Some((tag, version)) = tags
         .iter()
         .filter_map(|tag| release_tag_version(tag, tag_prefix).map(|version| (tag, version)))
-        .max_by(|(_, a), (_, b)| compare_versions(a, b))
+        .max_by(|(_, a), (_, b)| a.cmp(b))
     {
-        return Ok((tag.to_string(), version));
+        return Ok((tag.to_string(), version.to_string()));
     }
 
     let latest_local = latest_release_tag(local_path, tag_prefix).unwrap_or(None);
@@ -226,24 +227,24 @@ fn resolve_head_release(
     ))
 }
 
-fn release_tag_version(tag: &str, tag_prefix: Option<&str>) -> Option<String> {
+/// Parse the semver version carried by a release tag.
+///
+/// Strips the optional component tag prefix (`<prefix>-v1.2.3`) and the
+/// conventional `v`, then defers to `semver::Version::parse`. Prerelease and
+/// build metadata are preserved (`v1.2.3-beta.1`, `v1.2.3+build.5`) instead of
+/// being rejected — the previous hand-rolled `split('.')` demanded exactly
+/// three all-ASCII-digit parts, so no prerelease tag was ever recognised as a
+/// release tag.
+///
+/// Returns `None` when the tag does not carry a valid semver version. A tag
+/// that fails to parse is never silently coerced into a version.
+fn release_tag_version(tag: &str, tag_prefix: Option<&str>) -> Option<Version> {
     let tag = match tag_prefix {
         Some(prefix) => tag.strip_prefix(&format!("{}-", prefix))?,
         None => tag,
     };
     let version = tag.strip_prefix('v').unwrap_or(tag);
-    let mut parts = version.split('.');
-    let major = parts.next()?;
-    let minor = parts.next()?;
-    let patch = parts.next()?;
-    if parts.next().is_some()
-        || [major, minor, patch]
-            .iter()
-            .any(|part| part.is_empty() || !part.chars().all(|c| c.is_ascii_digit()))
-    {
-        return None;
-    }
-    Some(version.to_string())
+    Version::parse(version).ok()
 }
 
 fn latest_release_tag(local_path: &str, tag_prefix: Option<&str>) -> Result<Option<String>> {
@@ -271,21 +272,8 @@ fn latest_remote_release_tag(local_path: &str, tag_prefix: Option<&str>) -> Resu
         .filter_map(|tag| {
             release_tag_version(tag, tag_prefix).map(|version| (tag.to_string(), version))
         })
-        .max_by(|(_, a), (_, b)| compare_versions(a, b))
+        .max_by(|(_, a), (_, b)| a.cmp(b))
         .map(|(tag, _)| tag))
-}
-
-fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
-    version_parts(a).cmp(&version_parts(b))
-}
-
-fn version_parts(version: &str) -> (u64, u64, u64) {
-    let mut parts = version.split('.').map(|part| part.parse().unwrap_or(0));
-    (
-        parts.next().unwrap_or(0),
-        parts.next().unwrap_or(0),
-        parts.next().unwrap_or(0),
-    )
 }
 
 fn read_current_release_notes(component: &Component) -> Result<Option<String>> {
@@ -312,13 +300,97 @@ fn read_current_release_notes(component: &Component) -> Result<Option<String>> {
 mod tests {
     use super::{
         build_dry_run_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
-        resolve_head_release,
+        release_tag_version, resolve_head_release,
     };
     use crate::release::types::{ReleaseOptions, ReleaseStepStatus};
     use homeboy_core::plan::PlanStepStatus;
+    use semver::Version;
     use std::collections::HashSet;
     use std::path::Path;
     use std::process::Command;
+
+    // ========================================================================
+    // release_tag_version — semver parsing (see #10321)
+    // ========================================================================
+
+    #[test]
+    fn release_tag_version_parses_plain_and_prefixed_tags() {
+        assert_eq!(
+            release_tag_version("v1.2.3", None),
+            Some(Version::new(1, 2, 3))
+        );
+        assert_eq!(
+            release_tag_version("1.2.3", None),
+            Some(Version::new(1, 2, 3))
+        );
+        assert_eq!(
+            release_tag_version("wordpress-v1.2.3", Some("wordpress")),
+            Some(Version::new(1, 2, 3))
+        );
+        // A prefixed component tag must not match when the prefix is absent.
+        assert_eq!(release_tag_version("v1.2.3", Some("wordpress")), None);
+    }
+
+    /// The hand-rolled parser required exactly three all-ASCII-digit parts, so
+    /// every prerelease tag was invisible to release-tag resolution.
+    #[test]
+    fn release_tag_version_accepts_prerelease_and_build_metadata() {
+        let pre = release_tag_version("v1.2.3-beta.1", None).expect("prerelease tag parses");
+        assert_eq!(pre.to_string(), "1.2.3-beta.1");
+        assert_eq!(pre.pre.as_str(), "beta.1");
+
+        let build = release_tag_version("v1.2.3+build.5", None).expect("build metadata tag parses");
+        assert_eq!(build.to_string(), "1.2.3+build.5");
+        assert_eq!(build.build.as_str(), "build.5");
+
+        let both = release_tag_version("v1.2.3-rc.1+build.5", None).expect("combined tag parses");
+        assert_eq!(both.to_string(), "1.2.3-rc.1+build.5");
+    }
+
+    /// Malformed tags must be rejected outright. The old `version_parts` helper
+    /// used `.unwrap_or(0)`, so `v1.x.3` silently compared as `1.0.3`.
+    #[test]
+    fn release_tag_version_rejects_malformed_tags() {
+        for tag in ["v1.x.3", "v1.2", "v1.2.3.4", "release", "v", "v1..3", ""] {
+            assert_eq!(
+                release_tag_version(tag, None),
+                None,
+                "tag '{}' must not parse as a release version",
+                tag
+            );
+        }
+    }
+
+    /// Ordering now comes from `semver`'s `Ord`, which implements the full
+    /// precedence rules: a prerelease sorts below its release, and build
+    /// metadata is ignored for precedence (semver §10-11).
+    #[test]
+    fn release_tag_versions_sort_by_semver_precedence() {
+        let v = |tag: &str| release_tag_version(tag, None).expect(tag);
+
+        assert!(v("v1.2.3-beta.1") < v("v1.2.3"));
+        assert!(v("v1.2.3-alpha") < v("v1.2.3-beta.1"));
+        assert!(v("v1.2.3-beta.2") < v("v1.2.3-beta.10"));
+        assert!(v("v1.2.3") < v("v1.10.0"));
+        assert!(v("v1.9.0") < v("v1.10.0"));
+        assert_eq!(
+            v("v1.2.3+build.5").cmp(&v("v1.2.3")),
+            std::cmp::Ordering::Equal
+        );
+
+        // The regression the hand-rolled compare produced: `v1.x.3` used to
+        // parse as `(1, 0, 3)` and could win a `max_by` against a real tag.
+        // It is now rejected, so it can never participate in the comparison.
+        let mut tags = ["v1.2.3-beta.1", "v1.x.3", "v1.2.3", "v0.9.9"]
+            .into_iter()
+            .filter_map(|tag| release_tag_version(tag, None))
+            .collect::<Vec<_>>();
+        tags.sort();
+        assert_eq!(
+            tags.iter().map(|v| v.to_string()).collect::<Vec<_>>(),
+            vec!["0.9.9", "1.2.3-beta.1", "1.2.3"]
+        );
+    }
 
     #[test]
     fn test_initial_executable_preflight_ids() {

--- a/crates/homeboy-release/src/release/version.rs
+++ b/crates/homeboy-release/src/release/version.rs
@@ -45,33 +45,50 @@ pub fn parse_version(content: &str, pattern: &str) -> Option<String> {
 ///
 /// bump_type can be:
 /// - "patch", "minor", or "major" — increments the corresponding semver component
-/// - An explicit version string like "2.0.0" — returned as-is after validation
+/// - An explicit version string like "2.0.0" — returned after semver validation
+///
+/// Both the current version and an explicit target are parsed with
+/// `semver::Version`, so prerelease and build metadata are understood rather
+/// than rejected. A version that does not parse yields `None`; it is never
+/// silently coerced to `0.0.0`.
+///
+/// # Prerelease semantics
+///
+/// A named bump **drops prerelease and build metadata and then increments the
+/// named field**:
+///
+/// - `1.2.3-beta.1` + `patch` → `1.2.4`
+/// - `1.2.3-beta.1` + `minor` → `1.3.0`
+/// - `1.2.3-beta.1` + `major` → `2.0.0`
+/// - `1.2.3+build.5` + `patch` → `1.2.4`
+///
+/// This single rule keeps the result **strictly greater** than the input for
+/// every bump type, which is exactly the invariant the release floor checks
+/// (`validate_release_version_floor`, `release_version_floor_base`) rely on —
+/// no special cases, no chance of planning a non-advancing release. Build
+/// metadata is dropped because semver §10 excludes it from precedence, so
+/// carrying it onto a new release would be meaningless.
+///
+/// npm's alternative reading — "`patch` on `1.2.3-beta.1` *releases* it as
+/// `1.2.3`" — is intentionally not implemented here. Homeboy already has a
+/// first-class way to express that: pass the explicit target,
+/// `homeboy release <component> --bump 1.2.3`.
 pub fn increment_version(version: &str, bump_type: &str) -> Option<String> {
+    // Explicit target version, e.g. `--bump 2.0.0` or `--bump 2.0.0-rc.1`.
     if bump_type.contains('.') {
-        let parts: Vec<&str> = bump_type.split('.').collect();
-        if parts.len() != 3 || parts.iter().any(|p| p.parse::<u32>().is_err()) {
-            return None;
-        }
-        return Some(bump_type.to_string());
+        return Some(semver::Version::parse(bump_type).ok()?.to_string());
     }
 
-    let parts: Vec<&str> = version.split('.').collect();
-    if parts.len() != 3 {
-        return None;
-    }
+    let current = semver::Version::parse(version).ok()?;
 
-    let major: u32 = parts[0].parse().ok()?;
-    let minor: u32 = parts[1].parse().ok()?;
-    let patch: u32 = parts[2].parse().ok()?;
-
-    let (new_major, new_minor, new_patch) = match bump_type {
-        "patch" => (major, minor, patch + 1),
-        "minor" => (major, minor + 1, 0),
-        "major" => (major + 1, 0, 0),
+    let next = match bump_type {
+        "patch" => semver::Version::new(current.major, current.minor, current.patch + 1),
+        "minor" => semver::Version::new(current.major, current.minor + 1, 0),
+        "major" => semver::Version::new(current.major + 1, 0, 0),
         _ => return None,
     };
 
-    Some(format!("{}.{}.{}", new_major, new_minor, new_patch))
+    Some(next.to_string())
 }
 
 /// Get version string from a component's first version target.
@@ -662,6 +679,95 @@ mod tests {
     #[test]
     fn increment_version_unknown_bump_type() {
         assert_eq!(increment_version("1.0.0", "huge"), None);
+    }
+
+    // ========================================================================
+    // Prerelease / build metadata handling (see #10321)
+    // ========================================================================
+
+    /// `--bump patch` on a prerelease used to return `None` because the
+    /// hand-rolled parser split on `.` and demanded exactly three numeric
+    /// parts, so `1.2.3-beta.1` yielded `["1", "2", "3-beta", "1"]`.
+    #[test]
+    fn increment_version_bumps_prerelease_by_dropping_it() {
+        assert_eq!(
+            increment_version("1.2.3-beta.1", "patch"),
+            Some("1.2.4".to_string())
+        );
+        assert_eq!(
+            increment_version("1.2.3-beta.1", "minor"),
+            Some("1.3.0".to_string())
+        );
+        assert_eq!(
+            increment_version("1.2.3-beta.1", "major"),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    /// Every named bump must land strictly above the prerelease it came from,
+    /// so the release floor checks can never plan a non-advancing release.
+    #[test]
+    fn increment_version_prerelease_result_is_strictly_greater() {
+        let current = semver::Version::parse("1.2.3-beta.1").unwrap();
+        for bump in ["patch", "minor", "major"] {
+            let next = increment_version("1.2.3-beta.1", bump).expect(bump);
+            let next = semver::Version::parse(&next).expect("bumped version is valid semver");
+            assert!(
+                next > current,
+                "{} bump produced {} which does not advance past {}",
+                bump,
+                next,
+                current
+            );
+        }
+    }
+
+    /// Build metadata is excluded from precedence by semver §10, so it is not
+    /// carried onto the next release.
+    #[test]
+    fn increment_version_drops_build_metadata() {
+        assert_eq!(
+            increment_version("1.2.3+build.5", "patch"),
+            Some("1.2.4".to_string())
+        );
+        assert_eq!(
+            increment_version("1.2.3-rc.1+build.5", "minor"),
+            Some("1.3.0".to_string())
+        );
+    }
+
+    /// An explicit target version is validated through semver, which means a
+    /// prerelease or build-metadata target is now accepted. This is the
+    /// supported way to "release" a prerelease as its final version.
+    #[test]
+    fn increment_version_explicit_prerelease_target() {
+        assert_eq!(
+            increment_version("1.2.3-beta.1", "1.2.3"),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(
+            increment_version("1.2.3", "2.0.0-rc.1"),
+            Some("2.0.0-rc.1".to_string())
+        );
+        assert_eq!(
+            increment_version("1.2.3", "2.0.0+build.5"),
+            Some("2.0.0+build.5".to_string())
+        );
+    }
+
+    /// A malformed current version must be an explicit `None`, never silently
+    /// coerced (the old `version_parts` sibling used `.unwrap_or(0)`, so
+    /// `1.x.3` degraded to `1.0.3`).
+    #[test]
+    fn increment_version_rejects_malformed_current_version() {
+        for version in ["1.x.3", "1.2", "1.2.3.4", "v1.2.3", "", "not-a-version"] {
+            assert_eq!(
+                increment_version(version, "patch"),
+                None,
+                "'{}' must not be coerced into a bumpable version",
+                version
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The two user-visible bugs

**1. `homeboy release <component> --bump patch` returns `None` on a prerelease.**
`increment_version()` split on `.` and required exactly three parts, so `1.2.3-beta.1` became `["1", "2", "3-beta", "1"]` and bailed. A component sitting on a prerelease could not be released at all.

**2. `v1.x.3` silently sorts as `1.0.3`.**
`version_parts()` mapped every segment through `.parse().unwrap_or(0)`, so a malformed tag turned into a plausible-looking version that could win the `max_by` picking the latest release tag.

## Root cause

`homeboy-release` hand-rolled semver parsing in three places while the `semver` crate was *already* a direct dependency of the crate (`crates/homeboy-release/Cargo.toml`, `semver = "1.0"`) and already in use next door — `planning_semver.rs`, `planner.rs`, `deploy/types.rs`, and `version.rs:336` all call `semver::Version::parse`. These three sites just never adopted it. `crates/contracts/homeboy-extension-contract/src/version.rs` is the reference implementation of how this repo consumes `semver`.

**No dependency change was needed** — no `Cargo.toml` edit, no re-export from `homeboy-extension-contract`. The workspace has no `[workspace.dependencies]` table; crates declare deps directly, and this one already had it.

## Changes

`crates/homeboy-release/src/release/execution_plan.rs`
- `release_tag_version()` returns `Option<semver::Version>` via `Version::parse` after stripping the component tag prefix and the conventional `v`. Prerelease and build metadata are preserved (`v1.2.3-beta.1`, `v1.2.3+build.5`) instead of rejected. Malformed tags still yield `None` — never a coerced value.
- `compare_versions()` and `version_parts()` **deleted**. Ordering is `semver`'s `Ord`, which implements full precedence: a prerelease sorts below its release, build metadata is excluded from precedence. The `.unwrap_or(0)` silent-corruption path is gone.

`crates/homeboy-release/src/release/version.rs`
- `increment_version()` parses both the current version and an explicit `--bump 2.0.0` target with `Version::parse`.

## Prerelease + bump semantics (decision)

A named bump **drops prerelease/build metadata and increments the named field**:

| current | bump | next |
|---|---|---|
| `1.2.3-beta.1` | patch | `1.2.4` |
| `1.2.3-beta.1` | minor | `1.3.0` |
| `1.2.3-beta.1` | major | `2.0.0` |
| `1.2.3+build.5` | patch | `1.2.4` |

Why this and not npm's rule (`patch` on `1.2.3-beta.1` *releases* it as `1.2.3`):

- **One rule, no special cases, and the result is always strictly greater than the input** for every bump type. That is precisely the invariant `validate_release_version_floor` ("Next release version X is not greater than latest release tag Y") and `release_version_floor_base` depend on, so there is no path to planning a non-advancing release.
- npm's reading needs per-field special-casing (strip the prerelease only when the lower fields are already zero), which is more surface for exactly the class of bug this PR is fixing.
- Homeboy already has a first-class way to express "ship this prerelease as its final version": the explicit target `homeboy release <component> --bump 1.2.3`, which now validates through semver and accepts prerelease/build targets too.
- Build metadata is dropped because semver §10 excludes it from precedence; carrying it onto a new release would be meaningless.

This is documented on `increment_version` itself.

## Callers

Checked all of them; **none needed adjusting**, and no signature changed.

- `release_tag_version` — private, 2 call sites, both in `execution_plan.rs` (`resolve_head_release` and `latest_remote_release_tag`). Both now `.to_string()` at the boundary; `resolve_head_release` still returns `Result<(String, String)>`.
- `compare_versions` — both call sites were `max_by`, replaced with `a.cmp(b)`.
- `increment_version` — still `Option<String>`. Call sites: `version.rs:499` (`bump_component_version_with_changelog`), `planner.rs:133`, `execution_dispatch.rs:306`. All consume the string and re-parse with `semver` downstream, so a prerelease flowing through is already handled.

The only intentional behavior change for callers is the good one: a prerelease tag at HEAD is now recognised as a release tag rather than being invisible, and a malformed tag is excluded from tag ranking rather than participating as a fake version.

## Tests

`execution_plan.rs`
- `release_tag_version_parses_plain_and_prefixed_tags` — `v1.2.3`, bare `1.2.3`, `wordpress-v1.2.3` with prefix, and prefix-required negative.
- `release_tag_version_accepts_prerelease_and_build_metadata` — `-beta.1`, `+build.5`, and combined; asserts `pre`/`build` survive.
- `release_tag_version_rejects_malformed_tags` — `v1.x.3`, `v1.2`, `v1.2.3.4`, `release`, `v`, `v1..3`, `""` all `None`.
- `release_tag_versions_sort_by_semver_precedence` — `1.2.3-beta.1 < 1.2.3`, `alpha < beta.1`, `beta.2 < beta.10`, `1.9.0 < 1.10.0`, build metadata compares `Equal`; plus a direct regression assert that `v1.x.3` can no longer enter the ranking.

`version.rs`
- `increment_version_bumps_prerelease_by_dropping_it` — bug #1 regression, all three bump types.
- `increment_version_prerelease_result_is_strictly_greater` — asserts the monotonicity invariant the floor checks rely on.
- `increment_version_drops_build_metadata`.
- `increment_version_explicit_prerelease_target` — `--bump 1.2.3` from a beta, `--bump 2.0.0-rc.1`, `--bump 2.0.0+build.5`.
- `increment_version_rejects_malformed_current_version` — bug #2 regression; explicit `None`, never `0.0.0`.

Existing tests are unchanged and still hold, including `increment_version_explicit_invalid` (`"2.0"` and `"abc.def.ghi"` are still rejected, now by `Version::parse`) and the `resolve_head_release` git-fixture tests.

## Verification

`cargo fmt` run. Full build/test is **left to CI** — this host cannot run `cargo build`/`cargo test` without OOM-killing co-resident services.

## Follow-up (deliberately out of scope)

The same hand-rolled pattern still lives in five other places. This PR is `homeboy-release` only:

- `core/git/commits.rs:455`
- `lab-runner/lab/offload/metadata.rs:288-293`
- `lab-runner/lab_staging_controller.rs:383,436`
- `upgrade/helpers.rs:122`
- `code-audit/requirements.rs:152-153`

Closes #10321
