### PR TITLE
cleanup: delete dead pub API surface (#10292)

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -208,18 +208,6 @@ pub enum RoleOwners {
     Many(Vec<String>),
 }
 
-impl CompositionConfig {
-    /// The single extension id that owns `role`, if the role designates exactly
-    /// one owner. Multi-owner roles return `None` (they do not designate a
-    /// unique capability owner).
-    pub fn role_owner(&self, role: &str) -> Option<&str> {
-        match self.roles.get(role) {
-            Some(RoleOwners::One(owner)) => Some(owner.as_str()),
-            _ => None,
-        }
-    }
-}
-
 impl ExtensionManifest {
     pub fn validate_notification_transports(&self) -> homeboy_error::Result<()> {
         let mut ids = std::collections::HashSet::new();
@@ -533,14 +521,6 @@ impl ExtensionManifest {
             .unwrap_or(&[])
     }
 
-    /// Get capabilities this extension provides (empty if not specified).
-    pub fn provided_capabilities(&self) -> &[String] {
-        self.provides
-            .as_ref()
-            .map(|p| p.capabilities.as_slice())
-            .unwrap_or(&[])
-    }
-
     /// Get component discovery marker rules (empty if not specified).
     pub fn discovery_markers(&self) -> &[DiscoveryMarkerConfig] {
         self.provides
@@ -569,11 +549,6 @@ impl ExtensionManifest {
         self.scripts.as_ref().and_then(|s| s.topology.as_deref())
     }
 
-    /// Get the validate script path (relative to extension dir), if configured.
-    pub fn validate_script(&self) -> Option<&str> {
-        self.scripts.as_ref().and_then(|s| s.validate.as_deref())
-    }
-
     /// Get the format script path (relative to extension dir), if configured.
     pub fn format_script(&self) -> Option<&str> {
         self.scripts.as_ref().and_then(|s| s.format.as_deref())
@@ -591,11 +566,6 @@ impl ExtensionManifest {
         self.scripts
             .as_ref()
             .and_then(|s| s.compiler_warning_fixes.as_deref())
-    }
-
-    /// Get the contract script path (relative to extension dir), if configured.
-    pub fn contract_script(&self) -> Option<&str> {
-        self.scripts.as_ref().and_then(|s| s.contract.as_deref())
     }
 }
 
@@ -622,12 +592,21 @@ mod composition_tests {
 
         let composition = manifest.composition.expect("composition present");
         assert_eq!(composition.includes, vec!["nodejs".to_string()]);
-        // Single-owner role resolves to the owning extension.
-        assert_eq!(composition.role_owner("javascript"), Some("nodejs"));
-        // Multi-owner role does not designate a unique owner.
-        assert_eq!(composition.role_owner("project"), None);
+        // A bare string owner deserializes into the single-owner shape.
+        assert_eq!(
+            composition.roles.get("javascript"),
+            Some(&RoleOwners::One("nodejs".to_string()))
+        );
+        // A list owner deserializes into the multi-owner shape.
+        assert_eq!(
+            composition.roles.get("project"),
+            Some(&RoleOwners::Many(vec![
+                "wordpress-plugin".to_string(),
+                "wordpress-theme".to_string(),
+            ]))
+        );
         // Absent role.
-        assert_eq!(composition.role_owner("missing"), None);
+        assert_eq!(composition.roles.get("missing"), None);
     }
 
     #[test]

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -184,8 +184,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
     let mut metadata = CommandSafetyMetadata::default();
 
     if let Some(top_level) = path.first().and_then(|name| registered_command(name)) {
-        metadata.structured_output =
-            top_level.json_family != crate::command_contract::CommandJsonFamily::RawOnly;
         metadata.output_notes = top_level.output_notes;
         metadata.lab_supported = top_level.lab_supported;
         metadata.lab_notes = top_level.lab_notes;

--- a/crates/homeboy-cli/src/command_contract/output.rs
+++ b/crates/homeboy-cli/src/command_contract/output.rs
@@ -66,7 +66,6 @@ pub enum CommandJsonFamily {
     Quality,
     Workspace,
     Ops,
-    RawOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,7 +73,6 @@ pub enum CommandDispatchFamily {
     Quality,
     Workspace,
     Ops,
-    RawOnly,
 }
 
 impl From<CommandJsonFamily> for CommandDispatchFamily {
@@ -83,7 +81,6 @@ impl From<CommandJsonFamily> for CommandDispatchFamily {
             CommandJsonFamily::Quality => CommandDispatchFamily::Quality,
             CommandJsonFamily::Workspace => CommandDispatchFamily::Workspace,
             CommandJsonFamily::Ops => CommandDispatchFamily::Ops,
-            CommandJsonFamily::RawOnly => CommandDispatchFamily::RawOnly,
         }
     }
 }
@@ -91,7 +88,6 @@ impl From<CommandJsonFamily> for CommandDispatchFamily {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandOutputContractKind {
     JsonEnvelope,
-    RawOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -1177,7 +1177,6 @@ fn json_family(value: CommandJsonFamily) -> &'static str {
         CommandJsonFamily::Quality => "quality",
         CommandJsonFamily::Workspace => "workspace",
         CommandJsonFamily::Ops => "ops",
-        CommandJsonFamily::RawOnly => "raw_only",
     }
 }
 
@@ -1186,7 +1185,6 @@ fn dispatch_family(value: CommandDispatchFamily) -> &'static str {
         CommandDispatchFamily::Quality => "quality",
         CommandDispatchFamily::Workspace => "workspace",
         CommandDispatchFamily::Ops => "ops",
-        CommandDispatchFamily::RawOnly => "raw_only",
     }
 }
 
@@ -1224,7 +1222,6 @@ fn output_file_mode(value: CommandOutputFileMode) -> &'static str {
 fn output_contract(value: CommandOutputContractKind) -> &'static str {
     match value {
         CommandOutputContractKind::JsonEnvelope => "json_envelope",
-        CommandOutputContractKind::RawOnly => "raw_only",
     }
 }
 

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -315,19 +315,11 @@ fn dispatch(
         CommandDispatchFamily::Quality => quality::dispatch(command, global),
         CommandDispatchFamily::Workspace => workspace::dispatch(command, global),
         CommandDispatchFamily::Ops => ops::dispatch(command, global),
-        CommandDispatchFamily::RawOnly => {
-            unsupported_raw_command("List command uses raw output mode")
-        }
     }
 }
 
 fn map<T: serde::Serialize>(result: super::CmdResult<T>) -> JsonRun {
     crate::commands::utils::response::map_cmd_result_to_json(result)
-}
-
-fn unsupported_raw_command(message: &'static str) -> JsonRun {
-    let err = homeboy::core::Error::validation_invalid_argument("output_mode", message, None, None);
-    crate::commands::utils::response::map_cmd_result_to_json::<Value>(Err(err))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/command_execution_plan.rs
+++ b/crates/homeboy-core/src/command_execution_plan.rs
@@ -5,59 +5,6 @@ use serde::Serialize;
 use crate::lab_contract::{LabRoutingPolicy, LabRunnerWorkloadCapability};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct CommandExecutionPlan {
-    pub label: String,
-    pub portability: CommandPortability,
-    pub remote_argv: Vec<String>,
-    pub source_policy: CommandSourcePolicy,
-    pub workspace_policy: CommandWorkspacePolicy,
-    pub output_contract: CommandOutputContract,
-}
-
-impl CommandExecutionPlan {
-    pub fn remote(
-        label: impl Into<String>,
-        remote_argv: Vec<String>,
-        source_policy: CommandSourcePolicy,
-        workspace_policy: CommandWorkspacePolicy,
-        output_contract: CommandOutputContract,
-    ) -> Self {
-        Self {
-            label: label.into(),
-            portability: CommandPortability::Portable,
-            remote_argv,
-            source_policy,
-            workspace_policy,
-            output_contract,
-        }
-    }
-
-    pub fn local_only(label: impl Into<String>, reason: impl Into<String>) -> Self {
-        Self {
-            label: label.into(),
-            portability: CommandPortability::LocalOnly {
-                reason: reason.into(),
-            },
-            remote_argv: Vec::new(),
-            source_policy: CommandSourcePolicy::ControllerCwdOrExplicitPath,
-            workspace_policy: CommandWorkspacePolicy::Snapshot,
-            output_contract: CommandOutputContract::inherit(),
-        }
-    }
-
-    pub fn safe_remote_argv(&self) -> Option<&[String]> {
-        matches!(self.portability, CommandPortability::Portable).then_some(&self.remote_argv)
-    }
-
-    pub fn local_only_reason(&self) -> Option<&str> {
-        match &self.portability {
-            CommandPortability::Portable => None,
-            CommandPortability::LocalOnly { reason } => Some(reason),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "state")]
 pub enum CommandPortability {
     Portable,

--- a/crates/homeboy-extension/src/test/drift.rs
+++ b/crates/homeboy-extension/src/test/drift.rs
@@ -42,30 +42,6 @@ pub struct DriftOptions {
 }
 
 impl DriftOptions {
-    /// Create options with common defaults for a PHP project.
-    pub fn php(root: &Path, since: &str) -> Self {
-        Self {
-            root: root.to_path_buf(),
-            since: since.to_string(),
-            source_patterns: vec![
-                "src/**/*.php".into(),
-                "inc/**/*.php".into(),
-                "lib/**/*.php".into(),
-            ],
-            test_patterns: vec!["tests/**/*.php".into()],
-        }
-    }
-
-    /// Create options with common defaults for a Rust project.
-    pub fn rust(root: &Path, since: &str) -> Self {
-        Self {
-            root: root.to_path_buf(),
-            since: since.to_string(),
-            source_patterns: vec!["src/**/*.rs".into()],
-            test_patterns: vec!["tests/**/*.rs".into()],
-        }
-    }
-
     /// Create options from an extension-declared drift selection contract.
     pub fn from_config(
         root: &Path,
@@ -1215,7 +1191,13 @@ mod tests {
 
     #[test]
     fn has_usable_patterns_reflects_config() {
-        let configured = DriftOptions::rust(Path::new("/tmp"), "HEAD");
+        let config = TestDriftConfig {
+            source_dirs: vec!["src".to_string()],
+            test_dirs: vec!["tests".to_string()],
+            file_extensions: vec!["rs".to_string()],
+            inline_tests: true,
+        };
+        let configured = DriftOptions::from_config(Path::new("/tmp"), "HEAD", &config, &[]);
         assert!(configured.has_usable_patterns());
 
         let empty = DriftOptions {

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -296,32 +296,6 @@ where
     cleanup_result
 }
 
-/// Connect using an explicit dead-lease or missing-lease selector. A
-/// lease-less store is handled by its dedicated operator-confirmed path.
-pub fn connect_with_recovery(
-    runner_id: &str,
-    orphan_lease_id: Option<&str>,
-    missing_lease_state_identity: Option<&str>,
-) -> Result<(RunnerConnectReport, i32)> {
-    if missing_lease_state_identity.is_some() {
-        return Err(Error::validation_invalid_argument(
-            "recover_missing_lease_state",
-            "missing-lease recovery requires the explicit remote recovery command",
-            missing_lease_state_identity.map(str::to_string),
-            None,
-        ));
-    }
-    connect_with_orphan_adoption(runner_id, orphan_lease_id, &[], false, None, None, None)
-}
-
-/// Reconnect after the explicit lease-less recovery transaction has terminalized
-/// the unowned store and started its replacement daemon.
-pub fn connect_with_leaseless_orphan_reconciliation(
-    runner_id: &str,
-) -> Result<(RunnerConnectReport, i32)> {
-    connect_with_orphan_adoption(runner_id, None, &[], true, None, None, None)
-}
-
 /// Connect while explicitly adopting one recorded dead remote lease. This is an
 /// operator recovery path; ordinary reconnects never infer orphan ownership.
 pub fn connect_with_orphan_adoption(

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -119,11 +119,10 @@ pub use command_path::preflight_remote_argv_path_translation;
 pub(crate) use connection::daemon_endpoint_identity;
 pub(crate) use connection::disconnect_with_force;
 pub use connection::{
-    close_reconnected_job_log_owner, connect, connect_reverse,
-    connect_with_leaseless_orphan_reconciliation, connect_with_live_lease_adoption,
-    connect_with_orphan_adoption, connect_with_recovery, disconnect, reconnect_job_log_owner,
-    reverse_broker_artifact, reverse_broker_artifact_content, reverse_broker_reconcile,
-    runner_artifact_content, status, statuses, submit_reverse_broker_job,
+    close_reconnected_job_log_owner, connect, connect_reverse, connect_with_live_lease_adoption,
+    connect_with_orphan_adoption, disconnect, reconnect_job_log_owner, reverse_broker_artifact,
+    reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
+    statuses, submit_reverse_broker_job,
 };
 pub(crate) use connection::{
     configured_runner_homeboy_build_identity, local_live_session, status_for_admission,

--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -27,11 +27,10 @@
 pub use crate::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, close_reconnected_job_log_owner,
-    connect, connect_with_leaseless_orphan_reconciliation, connect_with_live_lease_adoption,
-    connect_with_orphan_adoption, connect_with_recovery, reconnect_job_log_owner,
-    reverse_broker_artifact, reverse_broker_artifact_content, reverse_broker_reconcile,
-    runner_artifact_content, BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope,
-    MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    connect, connect_with_live_lease_adoption, connect_with_orphan_adoption,
+    reconnect_job_log_owner, reverse_broker_artifact, reverse_broker_artifact_content,
+    reverse_broker_reconcile, runner_artifact_content, BrokerAuthGrant, BrokerAuthStore,
+    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use crate::{
     connect_reverse, disconnect, download_remote_artifact,
@@ -110,11 +109,11 @@ pub mod registry {
 pub mod connection {
     pub use crate::{
         connect, connect_reverse, connect_with_live_lease_adoption, connect_with_orphan_adoption,
-        connect_with_recovery, disconnect, run_reverse_worker, status, statuses,
-        ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput,
-        RunnerAvailability, RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport,
-        RunnerFailureKind, RunnerSession, RunnerSessionRole, RunnerSessionState,
-        RunnerStaleDaemonWarning, RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
+        disconnect, run_reverse_worker, status, statuses, ReverseRunnerConnectOptions,
+        ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, RunnerAvailability,
+        RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+        RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+        RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
     };
 }
 


### PR DESCRIPTION
Deletes `pub` items whose only references were their own definition, their own re-exports, and their own tests. Every row was re-verified against fresh `origin/main` before deletion (`grep` across `crates/`, plus a non-`.rs` sweep for serialized contract strings) rather than trusted from the audit.

Closes #10292

## Deleted

| Item | Location | Re-verified evidence |
|---|---|---|
| `CommandExecutionPlan` + `remote`, `local_only`, `safe_remote_argv`, `local_only_reason` | `homeboy-core/src/command_execution_plan.rs` | Only 2 hits workspace-wide: the struct declaration and its own `impl` block. Zero constructors, zero consumers. |
| `connect_with_recovery` | `homeboy-lab-runner/src/connection.rs` | Zero call sites; all 3 non-definition hits were re-exports (`lib.rs`, 2× `runners.rs`). Also unusable by construction — errored whenever its distinguishing `missing_lease_state_identity` arg was `Some`, and the other branch just forwarded to `connect_with_orphan_adoption` with `connect`'s defaults. |
| `connect_with_leaseless_orphan_reconciliation` | `homeboy-lab-runner/src/connection.rs` | Zero call sites; both non-definition hits were re-exports. |
| `RawOnly` on `CommandJsonFamily`, `CommandDispatchFamily`, `CommandOutputContractKind` | `homeboy-cli/src/command_contract/output.rs` | Never constructed. All 9 refs were the 3 declarations + unreachable match arms (`contract/mod.rs` ×3, `json_output/mod.rs`, the `From` conversion arm) + one constant-true comparison in `safety_manifest.rs`. No `raw_only` string survives in `.rs`, `.md`, or `.json`. |
| `unsupported_raw_command` | `homeboy-cli/src/commands/json_output/mod.rs` | Cascade — reachable only from the removed `CommandDispatchFamily::RawOnly` dispatch arm. |
| `CompositionConfig::role_owner` | `homeboy-extension-contract/src/manifest.rs` | Only callers were its own unit test. Removing it emptied `impl CompositionConfig`, so the block goes too. |
| `ExtensionManifest::provided_capabilities` | `homeboy-extension-contract/src/manifest.rs` | Zero references. |
| `ExtensionManifest::validate_script` / `contract_script` | `homeboy-extension-contract/src/manifest.rs` | One ref each — its own definition. (`contract_script`'s other apparent hits are the unrelated `run_compiler_warning_contract_script`, which is live and untouched.) |
| `DriftOptions::php` | `homeboy-extension/src/test/drift.rs` | Zero callers. Hardcoded `src/**/*.php` etc. in a workload-agnostic crate. |
| `DriftOptions::rust` | `homeboy-extension/src/test/drift.rs` | Exactly one caller, a test in its own file. Superseded by manifest-driven `from_config`. |

Net: **171 deletions / 34 insertions** across 10 files.

## Tests adjusted, not dropped

Two tests referenced deleted items. Both keep their real coverage:

- `deserializes_mixed_single_and_list_role_owners` — its actual value is proving the untagged `RoleOwners` enum accepts both the bare-string and list shapes. Now asserts on the `roles` map directly (`RoleOwners::One` / `RoleOwners::Many`) instead of going through the removed accessor.
- `has_usable_patterns_reflects_config` — now builds its configured fixture via `DriftOptions::from_config` with an explicit `TestDriftConfig`, so it exercises the manifest-driven constructor that supersedes `DriftOptions::rust`.

## Kept — verified live, deliberately not deleted

| Look-alike | Why it stays |
|---|---|
| `VersionConstraint` (`homeboy-extension-contract/src/version.rs`) | Live via `core_compat.rs:47` and `homeboy-extension/src/validation.rs:91`. |
| `provided_capabilities` (`homeboy-rig/src/pipeline/ordering.rs:239`) | Different function, same name as the deleted manifest accessor. `pub(super)`, called at `ordering.rs:110` and `pipeline/mod.rs:255`. |
| `ExtensionManifest::provided_file_extensions` | Sibling of the deleted `provided_capabilities`, but has ~15 live consumers across `homeboy-refactor` and `homeboy-code-audit`. |
| `LabRoutePlan` (`command_execution_plan.rs`) | Live via `lab_routing.rs`. Only `CommandExecutionPlan` died in that module. |
| Serde fields `ScriptsConfig::validate` / `contract`, `ProvidesConfig::capabilities`, `CompositionConfig::roles` | Only the *accessors* were dead. These fields are the `extension.json` wire schema — removing them would change the manifest contract. |

## Deferred

- **`validate_extension_requirements`** (`homeboy-extension/src/validation.rs:74`) is mentioned in #10292 but is **not** touched here. It is a strict superset of the live `validate_required_extensions`, so "wire it in" may well be the correct answer rather than "delete it". That judgment call deserves its own PR and its own review.
- `runners.rs` **nested re-export group structure** is left alone for #10297. This PR only removes the dead names from those groups (required for compilation); `cargo fmt` reflowed the surrounding lines but no group was restructured.

## Notes for the reviewer

- One commit per item group, so a wrong deletion can be bisected and reverted independently.
- `safety_manifest.rs` set `structured_output` by comparing `json_family != RawOnly`. With `RawOnly` gone that is constant-true, and the field already defaults to `true` — so the assignment is dropped rather than hardcoded to `true`.
- `CommandOutputContractKind` is now a single-variant enum (`JsonEnvelope`). Collapsing it away entirely would touch every command descriptor and is out of scope here.
- Only `cargo fmt` was run locally (clean). Full build/test/clippy is left to CI.
