### PR TITLE
cleanup(lab-runner): delete duplicate nested re-export groups

### DIFF
--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -1,24 +1,15 @@
 //! Stable facade for runner configuration, connection, execution, and lab
 //! offload APIs.
 //!
-//! New command and integration code MUST import runner APIs from this module
-//! instead of depending directly on `core::runner::*`. The runner module tree
-//! itself only exposes a hand-picked surface (most submodules are private),
-//! but routing every consumer through this facade keeps the contract explicit
-//! and lets the underlying module layout evolve without touching external
-//! callers.
+//! The runner module tree only exposes a hand-picked surface (most submodules
+//! are private). Routing consumers through this facade keeps that contract
+//! explicit and lets the underlying module layout evolve without touching
+//! external callers. Some in-tree callers still import from the crate root
+//! directly for names this facade does not re-export.
 //!
-//! The exports are organised into nested API groups by operation:
-//!
-//! - top-level: stable identity, registry, capability, and session contracts
-//!   that callers reach for most often.
-//! - [`registry`]: CRUD helpers over the runner config registry.
-//! - [`connection`]: connect/disconnect/status helpers for runner sessions.
-//! - [`execution`]: exec entry points and option/output contracts.
-//! - [`workspace`]: workspace sync and patch application contracts.
-//! - [`evidence`]: artifact evidence/mirroring helpers.
-//! - [`capabilities`]: lab runner capability evaluation contracts.
-//! - [`lab_offload`]: lab offload entry points and contracts.
+//! Exports are a single flat list covering stable identity, registry,
+//! connection, execution, workspace, evidence, capability, and lab offload
+//! contracts.
 
 // ----------------------------------------------------------------------------
 // Stable top-level contracts
@@ -79,8 +70,7 @@ pub use crate::{
     RunnerWorkspaceUpdateOutput, RuntimeMaterializationStatus,
 };
 
-// Registry CRUD entry points (re-exported at the root for ergonomics; also
-// available via the explicit `registry` group below).
+// Registry CRUD entry points.
 pub use crate::{
     apply_secret_env_migration, create, delete_safe, effective_env, enable_server_runner, exists,
     list, load, merge, secret_env_migration_plan,
@@ -91,87 +81,3 @@ pub use crate::{
 // (currently `commands::runs::remote`) compile, but do not expose them as
 // public API.
 pub use crate::daemon_api_get;
-
-// ----------------------------------------------------------------------------
-// Explicit API groups
-// ----------------------------------------------------------------------------
-
-/// CRUD helpers over the runner config registry.
-pub mod registry {
-    pub use crate::{
-        apply_secret_env_migration, create, delete_safe, effective_env, enable_server_runner,
-        exists, list, load, merge, resolve_default_lab_runner, secret_env_migration_plan, Runner,
-        RunnerKind, RunnerSpec,
-    };
-}
-
-/// Connect/disconnect/status helpers for runner sessions.
-pub mod connection {
-    pub use crate::{
-        connect, connect_reverse, connect_with_live_lease_adoption, connect_with_orphan_adoption,
-        disconnect, run_reverse_worker, status, statuses, ReverseRunnerConnectOptions,
-        ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, RunnerAvailability,
-        RunnerChangedRuntimePath, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-        RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-        RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode,
-    };
-}
-
-/// Exec entry points and option/output contracts.
-pub mod execution {
-    pub use crate::{
-        exec, promote_runner_exec_artifact_dirs, promote_runner_exec_artifacts,
-        promote_runner_exec_summaries, promoted_output, runner_exec_failure_error,
-        runner_exec_structured_summary, RunnerExecDiagnostics, RunnerExecMode, RunnerExecOptions,
-        RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecStructuredSummary,
-        RunnerResourceMetrics,
-    };
-}
-
-/// Workspace sync and patch application contracts.
-pub mod workspace {
-    pub use crate::{
-        apply_change_artifact, apply_workspace_patch, list_workspaces,
-        plan_managed_runner_source_sync, plan_managed_runner_source_syncs, plan_workspace_pull,
-        prune_workspaces, pull_workspace, sync_workspace, workspace_snapshots,
-        ManagedRunnerSourceSyncPlan, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
-        RunnerWorkspaceApplyStatus, RunnerWorkspaceListEntry, RunnerWorkspaceListOutput,
-        RunnerWorkspaceMaterializationPlan, RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions,
-        RunnerWorkspacePruneOutput, RunnerWorkspacePruneSkippedEntry, RunnerWorkspacePullOptions,
-        RunnerWorkspacePullOutput, RunnerWorkspacePullPlan, RunnerWorkspaceSnapshotAppliedFilters,
-        RunnerWorkspaceSnapshotEntry, RunnerWorkspaceSnapshotFilters,
-        RunnerWorkspaceSnapshotsOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-        RunnerWorkspaceSyncOutput,
-    };
-}
-
-/// Artifact evidence and mirroring helpers.
-pub mod evidence {
-    pub use crate::{
-        download_remote_artifact, is_remote_runner_artifact_path,
-        is_reportable_artifact_evidence_path, is_retrievable_runner_artifact,
-        mirror_connected_runner_run, mirrored_runner_job_identity,
-        refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path,
-        runner_artifact_store_token, runner_job_log_snapshot, RemoteArtifactDownload,
-    };
-}
-
-/// Lab runner capability evaluation contracts.
-pub mod capabilities {
-    pub use crate::{
-        evaluate_lab_runner_capabilities_for_runner, prepare_lab_runner_capability,
-        LabRunnerCapabilityContract, LabRunnerGateDecision, LabRunnerGateMode,
-        PreparedLabRunnerCapability, RunnerCapabilityPreflight, RunnerRequiredTool,
-    };
-}
-
-/// Lab offload entry points and contracts.
-pub mod lab_offload {
-    pub use crate::{
-        execute_lab_offload, lab_offload_changed_since_ref, lab_offload_metadata,
-        lab_offload_metadata_with_workspace_mapping, preflight_lab_offload_changed_since,
-        prepare_git_lab_offload_changed_since, LabJobOverrides, LabOffloadCommand,
-        LabOffloadOutcome, LabOffloadRequest, LabOffloadSourcePathMode,
-        LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,
-    };
-}


### PR DESCRIPTION
Closes #10297

## What

`crates/homeboy-lab-runner/src/runners.rs` exported every symbol twice — once as a flat `pub use` list, then again inside seven nested API-group modules: `registry`, `connection`, `execution`, `workspace`, `evidence`, `capabilities`, `lab_offload`. This deletes the nested duplicates.

**LOC: 103 deleted, 9 inserted (net −94).** 84 of the deleted lines are the nested group modules themselves; the rest is the doc comment describing them.

## Verification method

`rg` is unavailable in this environment, so all greps used `grep -rn` with a **control grep run first to prove the tooling actually matches** (a prior sweep produced a silent false negative from a missing `rg`). Control: `grep -rn "runners::"` → 100 hits.

- Qualified paths: `grep -rn "runners::(registry|connection|execution|workspace|evidence|capabilities|lab_offload)"` across **all file types** repo-wide (excluding `.git`/`target`) → **exit 1, zero matches**. Docs and markdown included.
- Brace imports: a qualified-path grep cannot see `use ...runners::{self, registry}`, so every one of the 28 `use ...runners::{` sites was expanded and inspected. No bare group name is imported anywhere; all imported items are `self`/`self as runner` or flat-list types and functions.
- Intra-doc links: `[`registry`]`-style links to the deleted groups → zero, so rustdoc won't break.
- **No identifier lost:** every identifier token in the deleted region was checked against the retained file. The only tokens not still present are prose words from the deleted group doc comments (`Artifact`, `mirroring`, `Workspace`, `sync`, `patch`, `Exec`, `option`, `output`, …). Every real code identifier is still exported by the flat list — this is a pure duplicate removal with **no change to the public surface**.

Verified against fresh `origin/main` (`87663b5e4`) with #10406 (`df8ce8f8e`, the dead pub API sweep) already an ancestor, so this reflects the post-sweep file.

## The flat re-exports were kept

Deliberately. They are load-bearing: ~30 consumers in `homeboy-cli`, plus two intra-crate (`dev_run.rs:163,164,642,1028` and `execution/artifact_promotion.rs:14`). Only the nested duplicates die.

## Correction to the issue: `daemon_api_get` is NOT dead — kept

#10297 also flagged `pub use crate::daemon_api_get;`, stating its documented consumer (`commands::runs::remote`) does not reference it. **That finding is incorrect.** `crates/homeboy-cli/src/commands/runs/remote.rs:8` does `use homeboy::runner::runners as runner;` and then calls `runner::daemon_api_get(...)` at **:50 and :230**. Since `homeboy::runner` is `homeboy_lab_runner` (`homeboy-cli/src/lib.rs:26`), that resolves straight through this re-export. Deleting it would break the build. The comment above it is accurate, so it stays as-is.

## Doc-comment rule

The module doc asserted *"New command and integration code MUST import runner APIs from this module."* Three files already break it: `commands/runner/status.rs:1251` and `runner/tests/status.rs:13` import `homeboy::runner::{…}` directly, and `runner/exec.rs:264` calls `homeboy_lab_runner::reconcile_runner_generation_after_evidence`.

**Chose to delete the claim** rather than repoint the call sites. Repointing is not trivial: `RunnerActiveJobError` and `reconcile_runner_generation_after_evidence` are *not* in the facade, so honoring the rule would mean **adding** public API inside a dead-code deletion PR. The doc now describes what the module actually is and acknowledges that some in-tree callers import from the crate root. No lint added, per scope.

## Testing

`cargo fmt` only (clean, no reflow beyond the edit). Full build/test intentionally left to CI — the authoring host cannot run `cargo build`/`check`/`test` without OOM. CI is the merge gate.
