### PR TITLE
cleanup(release): collapse deploy config copy, structure build exit code, drop blanket dead_code allow

### DIFF
--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -266,31 +266,15 @@ pub fn run_multi(
     for project_id in &valid_project_ids {
         homeboy_core::log_status!("deploy", "Deploying to project '{}'...", project_id);
 
+        // Per-target config is the caller's config with exactly two deltas:
+        // the explicitly requested component set, and a cleared resume id so
+        // each project target starts its own lifecycle run. Everything else is
+        // carried by `..config.clone()` so a new `DeployConfig` field can never
+        // be silently dropped here.
         let project_config = DeployConfig {
             component_ids: component_ids.to_vec(),
-            all: config.all,
-            outdated: config.outdated,
-            behind_upstream: config.behind_upstream,
-            dry_run: config.dry_run,
-            check: config.check,
-            force: config.force,
-            skip_build: config.skip_build,
-            keep_deps: config.keep_deps,
-            skip_deps_hydration: config.skip_deps_hydration,
-            expected_version: config.expected_version.clone(),
-            no_pull: config.no_pull,
-            allow_stale_source: config.allow_stale_source,
-            allow_downgrade: config.allow_downgrade,
-            head: config.head,
-            requested_ref: config.requested_ref.clone(),
-            requested_refs: config.requested_refs.clone(),
-            resolved_refs: config.resolved_refs.clone(),
-            preflighted_source_paths: config.preflighted_source_paths.clone(),
-            preflighted_component_identities: config.preflighted_component_identities.clone(),
-            prepared_projection: config.prepared_projection.clone(),
-            tagged: config.tagged,
-            prepared_artifact: config.prepared_artifact.clone(),
             resume_run_id: None,
+            ..config.clone()
         };
 
         if lifecycle_run

--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -11,7 +11,6 @@ mod path_roots;
 pub(crate) mod permissions;
 mod planning;
 mod policy;
-#[allow(dead_code)] // Internal contract consumed by the follow-up payload integration.
 pub(crate) mod preparation;
 pub(crate) mod provenance;
 mod safety_and_artifact;

--- a/crates/homeboy-release/src/deploy/orchestration/prepared_payloads.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/prepared_payloads.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use homeboy_core::component::Component;
+use homeboy_core::error::Error;
 use homeboy_core::project::Project;
 
 use super::super::binding::bind_project_payloads;
@@ -90,7 +91,7 @@ pub(super) fn prepare_component_deployments(
                             remote_versions.get(&component.id).cloned(),
                             error.to_string(),
                         );
-                        if let Some(exit_code) = preparation_build_exit_code(&error.to_string()) {
+                        if let Some(exit_code) = preparation_build_exit_code(&error) {
                             failure = failure.with_build_exit_code(Some(exit_code));
                         }
                         failures.push(failure);
@@ -150,11 +151,46 @@ pub(super) fn prepare_component_deployments(
     }
 }
 
-fn preparation_build_exit_code(message: &str) -> Option<i32> {
-    message
-        .strip_prefix("Invalid argument 'build': Build failed (exit code ")?
-        .split_once(')')?
-        .0
-        .parse()
-        .ok()
+/// Read the build exit code the preparation step recorded on the structured
+/// error details. The producer (`preparation::…` build failure) sets
+/// `details.exit_code`, so this never depends on the human-readable message.
+fn preparation_build_exit_code(error: &Error) -> Option<i32> {
+    error
+        .details
+        .get("exit_code")
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirrors what the preparation build-failure producer records, without
+    /// depending on the wording of the failure message.
+    fn build_failure(exit_code: Option<i32>) -> Error {
+        let mut error = Error::validation_invalid_argument(
+            "build",
+            "Build failed (exit code 3): extension build reported failure",
+            None,
+            None,
+        );
+        if let (Some(code), Some(details)) = (exit_code, error.details.as_object_mut()) {
+            details.insert("exit_code".to_string(), serde_json::Value::from(code));
+        }
+        error
+    }
+
+    #[test]
+    fn reads_structured_build_exit_code() {
+        assert_eq!(
+            preparation_build_exit_code(&build_failure(Some(3))),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_structured_exit_code_present() {
+        assert_eq!(preparation_build_exit_code(&build_failure(None)), None);
+    }
 }

--- a/crates/homeboy-release/src/deploy/preparation.rs
+++ b/crates/homeboy-release/src/deploy/preparation.rs
@@ -479,7 +479,7 @@ fn prepare_payload(
         let cleanup = GeneratedSourceArtifactCleanup::new(&component)?;
         let (build_exit_code, build_error) = homeboy_extension::build::build_component(&component);
         if let Some(message) = build_error {
-            return Err(Error::validation_invalid_argument(
+            let mut error = Error::validation_invalid_argument(
                 "build",
                 format!(
                     "Build failed (exit code {}): {message}",
@@ -487,7 +487,14 @@ fn prepare_payload(
                 ),
                 None,
                 None,
-            ));
+            );
+            // Carry the build exit code structurally. Consumers (deploy failure
+            // reporting) read `details.exit_code` instead of parsing the human
+            // message, so rewording the message above cannot lose the code.
+            if let (Some(code), Some(details)) = (build_exit_code, error.details.as_object_mut()) {
+                details.insert("exit_code".to_string(), serde_json::Value::from(code));
+            }
+            return Err(error);
         }
         generated_source_artifact = Some(cleanup);
     }

--- a/crates/homeboy-release/src/deploy/preparation.rs
+++ b/crates/homeboy-release/src/deploy/preparation.rs
@@ -11,7 +11,7 @@ use homeboy_core::error::{Error, Result};
 use super::execution::{
     release_artifact_plan, resolve_planned_release_artifact, ReleaseArtifactPlan,
 };
-use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
+use super::orchestration_ref_checkout::ExactRefCheckout;
 use super::{sha256_file, DeployConfig, PreparedDeployArtifact};
 use homeboy_core::git::release_download::{ReleaseArtifactLease, ReleaseArtifactStore};
 
@@ -108,11 +108,6 @@ impl ComponentPayloadPreparationRequest {
             release: self.component.release.clone(),
             ..Component::default()
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn evidence_digest(&self) -> String {
-        digest_json(&self.evidence())
     }
 }
 
@@ -235,7 +230,6 @@ impl From<&DeployConfig> for PreparationConfig {
 pub(crate) struct PreparedComponentPayload {
     pub artifact: PreparedDeployArtifact,
     pub source_commit: String,
-    pub exact_ref: Option<ExactRefIdentity>,
     _release_artifact: Option<ReleaseArtifactLease>,
     _exact_ref_checkout: Option<ExactRefCheckout>,
     payload_artifact: PreparedArtifactCleanup,
@@ -421,7 +415,6 @@ fn prepare_payload(
         return Ok(PreparedComponentPayload {
             source_commit: artifact.source_commit.clone(),
             artifact,
-            exact_ref: None,
             _release_artifact: None,
             _exact_ref_checkout: None,
             payload_artifact: PreparedArtifactCleanup(None),
@@ -581,7 +574,6 @@ fn prepare_payload(
     Ok(PreparedComponentPayload {
         artifact,
         source_commit,
-        exact_ref,
         _release_artifact: release_artifact,
         _exact_ref_checkout: checkout,
         payload_artifact,
@@ -1019,7 +1011,6 @@ mod tests {
 
         assert_eq!(first.identity(), second.identity());
         assert_eq!(first.evidence(), second.evidence());
-        assert_eq!(first.evidence_digest(), second.evidence_digest());
         assert_ne!(
             first.identity(),
             ComponentPayloadPreparationRequest::new(


### PR DESCRIPTION
Closes #10320

Three separable defects in `homeboy-release`'s deploy path, one commit each. No local build/test was run (VPS resource policy) — CI is the gate.

## A — 24-field hand-copy of a `Clone` type (`deploy/mod.rs`)

`run_multi` enumerated every `DeployConfig` field to build each per-project config. Adding a field and missing this site silently drops it for every multi-project deploy: no compile error, wrong behavior.

**Field-list verification.** `DeployConfig` (types.rs:75) has exactly 24 fields; the hand-copy listed all 24. Comparing each one against `config.*`:

- `component_ids` — **real delta**: comes from `run_multi`'s own `component_ids: &[String]` parameter (`component_ids.to_vec()`), not from `config.component_ids`.
- `resume_run_id` — **real delta**: forced to `None` so each project target starts its own lifecycle run.
- The other 22 (`all`, `outdated`, `behind_upstream`, `dry_run`, `check`, `force`, `skip_build`, `keep_deps`, `skip_deps_hydration`, `expected_version`, `no_pull`, `allow_stale_source`, `allow_downgrade`, `head`, `requested_ref`, `requested_refs`, `resolved_refs`, `preflighted_source_paths`, `preflighted_component_identities`, `prepared_projection`, `tagged`, `prepared_artifact`) were plain `config.x` / `config.x.clone()` copies with no transformation.

So the two deltas are the only ones, and the body collapses to `..config.clone()` — matching how `prepared_payloads.rs:51` already does it. Net -22 LOC.

## B — structured exit code recovered by string-parsing a human message

`prepared_payloads.rs` recovered the build exit code with
`strip_prefix("Invalid argument 'build': Build failed (exit code ")`. Any rewording — added context, extra fields, localization — silently dropped the exit code from every deploy failure report.

**The producer was reachable, so there is no fallback.** It is `deploy/preparation.rs:481` (`prepare_payload`), the single site that formats that message, from `homeboy_extension::build::build_component`'s `(Option<i32>, Option<String>)` return. It now records the code on the error's structured `details`:

```rust
if let (Some(code), Some(details)) = (build_exit_code, error.details.as_object_mut()) {
    details.insert("exit_code".to_string(), serde_json::Value::from(code));
}
```

and the consumer reads `error.details.get("exit_code")`. The string parser is deleted. The message text is unchanged, so nothing that greps logs regresses — but the code no longer depends on it. Two unit tests lock the reader's contract without asserting on message wording.

## C — blanket `#[allow(dead_code)]` over 1,545 lines

`deploy/mod.rs:14` suppressed dead-code analysis for the whole `preparation` module ("consumed by the follow-up payload integration"), plus a second allow on `evidence_digest`. The follow-up only half-landed, so the suppression became permanent and the compiler could no longer report what is actually dead. Both allows are removed.

Deadness was determined by grep across `crates/` and `tests/` (no local compiler runs), item by item.

**Deleted** — only references were the definition and its own `#[cfg(test)]`:

- `ComponentPayloadPreparationRequest::evidence_digest` — a one-line wrapper with exactly one caller: `assert_eq!(first.evidence_digest(), second.evidence_digest())`, which is strictly implied by the `assert_eq!(first.evidence(), second.evidence())` on the preceding line (`digest_json` is pure). That assertion is dropped with it.
- `PreparedComponentPayload::exact_ref` — written at both construction sites, read nowhere (including tests); the RAII checkout guard is the separate `_exact_ref_checkout`. Its now-unused `ExactRefIdentity` import goes with it.

**Deliberately kept:**

- `evidence()` and its redaction helpers (`redact_map`, `redact_remote_url`, `redact_extensions`, `redact_github`) — no production caller today (the deleted `evidence_digest` was the last one), but four tests assert real behavior, including that secrets and authenticated remote URLs are redacted out of preparation evidence. Deleting ~70 LOC of a tested secret-redaction feature is a product decision, not a cleanup.
- `PreparedComponentPayload::source_commit` — read only from tests (`payload.source_commit == requested_sha`), which is a genuine contract assertion. Redundant with `payload.artifact.source_commit`, but removing it deletes coverage.
- Every other `pub`/`pub(crate)` item in the module has a real non-test consumer: `ComponentPayloadPreparationRequest`/`::new`/`::identity`, `ComponentPayloadPreparationSource`, `PreparationConfig` (+ `From<&DeployConfig>`), `PreparedComponentPayload`, `PreparedPayloadCollection`/`::insert`/`::prepare` (`::len` is already `#[cfg(test)]`), and the private helpers. The module's only external consumer remains `orchestration/prepared_payloads.rs`, importing two symbols.

**Expected CI signal.** With the blanket allow gone, `evidence()`, the four redaction helpers, and `source_commit` are dead in a non-test build and will likely surface as `dead_code` warnings (they do not warn under `cargo test`/`--all-targets`, where the tests read them). That is the intended outcome of removing the suppression: the warning list should drive a follow-up that either wires the evidence/redaction contract into the payload integration it was written for, or removes that sub-feature with its tests on purpose.

## Verification

Only `cargo fmt` was run locally (VPS memory policy prohibits `cargo build`/`test`/`check`/`clippy` here). Full build, test, and warning inventory are left to CI.
