### PR TITLE
refactor: replace ~35 hand-copied provider registries with a provider_registry! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "chrono",
  "homeboy-agents-contract",
  "homeboy-core",
+ "homeboy-engine-primitives",
  "homeboy-error",
  "homeboy-extension",
  "homeboy-lab-contract",
@@ -1295,6 +1296,7 @@ name = "homeboy-upgrade"
 version = "0.1.0"
 dependencies = [
  "homeboy-core",
+ "homeboy-engine-primitives",
  "homeboy-extension",
  "homeboy-product-identity",
  "libc",

--- a/crates/homeboy-agents/Cargo.toml
+++ b/crates/homeboy-agents/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-lab-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-contract" }
 homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-runner-contract" }
 homeboy-agents-contract = { version = "0.1.0", path = "../contracts/homeboy-agents-contract" }

--- a/crates/homeboy-agents/src/agent_task_controller_service/runner_availability.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/runner_availability.rs
@@ -10,8 +10,6 @@
 //! reports the runner unavailable — the controller loop only reaches this check
 //! for a runner-targeted action.
 
-use std::sync::Mutex;
-
 use crate::agent_task_loop_runner_policy::AgentTaskLoopRunnerAvailability;
 
 /// Computes whether a runner is available for controller action execution.
@@ -31,28 +29,19 @@ impl RunnerAvailabilityProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn RunnerAvailabilityProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn RunnerAvailabilityProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the runner-availability provider. Called once at startup by the
-/// runner layer.
-pub fn register_runner_availability_provider(provider: Box<dyn RunnerAvailabilityProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("runner availability provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RunnerAvailabilityProvider,
+    noop: NoopProvider,
+    /// Register the runner-availability provider. Called once at startup by the
+    /// runner layer.
+    register: pub fn register_runner_availability_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// The controller-action availability verdict for a runner, via the registered
 /// provider (or the no-op provider when the runner subsystem is absent).
 pub(crate) fn controller_runner_availability(runner_id: &str) -> AgentTaskLoopRunnerAvailability {
-    let slot = provider_slot()
-        .lock()
-        .expect("runner availability provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.controller_runner_availability(runner_id),
-        None => NoopProvider.controller_runner_availability(runner_id),
-    }
+    with_provider(|p| p.controller_runner_availability(runner_id))
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -12,8 +12,6 @@
 //! fail (so the caller annotates "runner disconnected"), and existence /
 //! connection checks report `false`.
 
-use std::sync::Mutex;
-
 use homeboy_core::api_jobs::{
     Job, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup, RunnerJobLogSnapshot,
 };
@@ -129,18 +127,15 @@ impl RunnerContinuationProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn RunnerContinuationProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn RunnerContinuationProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the runner-continuation provider. Called once at startup by the
-/// runner subsystem when it is present.
-pub fn register_runner_continuation_provider(provider: Box<dyn RunnerContinuationProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("runner continuation provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RunnerContinuationProvider,
+    noop: NoopProvider,
+    /// Register the runner-continuation provider. Called once at startup by the
+    /// runner subsystem when it is present.
+    register: pub fn register_runner_continuation_provider,
+    /// Run `f` against the registered provider, falling back to the no-op provider
+    /// when the runner subsystem is absent.
+    with: pub(crate) fn with_runner_continuation,
 }
 
 /// Clear any registered runner-continuation provider so a fresh test starts from
@@ -175,19 +170,5 @@ impl RunnerContinuationTestGuard {
 impl Drop for RunnerContinuationTestGuard {
     fn drop(&mut self) {
         clear_runner_continuation_provider_for_test();
-    }
-}
-
-/// Run `f` against the registered provider, falling back to the no-op provider
-/// when the runner subsystem is absent.
-pub(crate) fn with_runner_continuation<R>(
-    f: impl FnOnce(&dyn RunnerContinuationProvider) -> R,
-) -> R {
-    let slot = provider_slot()
-        .lock()
-        .expect("runner continuation provider lock");
-    match slot.as_deref() {
-        Some(provider) => f(provider),
-        None => f(&NoopProvider),
     }
 }

--- a/crates/homeboy-code-audit/src/compiler_warning_provider.rs
+++ b/crates/homeboy-code-audit/src/compiler_warning_provider.rs
@@ -19,7 +19,6 @@
 //! ships a compiler-warning script).
 
 use std::path::Path;
-use std::sync::Mutex;
 
 /// One compiler warning surfaced by an extension's compiler-warning script,
 /// reduced to the fields the audit detector maps into a finding.
@@ -56,30 +55,20 @@ impl CompilerWarningProvider for NoopProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn CompilerWarningProvider>>> = Mutex::new(None);
-
-/// Register the compiler-warning provider. Called once at binary startup by the
-/// extension layer (via the CLI). Replaces any previously registered provider.
-pub fn register_compiler_warning_provider(provider: Box<dyn CompilerWarningProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn CompilerWarningProvider,
+    noop: NoopProvider,
+    /// Register the compiler-warning provider. Called once at binary startup by the
+    /// extension layer (via the CLI). Replaces any previously registered provider.
+    register: pub fn register_compiler_warning_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Collect compiler warnings for `root` via the registered provider.
 pub(crate) fn compiler_warnings_for_root(root: &Path) -> Vec<AuditCompilerWarning> {
     with_provider(|p| p.compiler_warnings(root))
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn CompilerWarningProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopProvider),
-    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/component_provider.rs
+++ b/crates/homeboy-code-audit/src/component_provider.rs
@@ -17,7 +17,6 @@
 //! contribute no component-derived rules).
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use homeboy_audit_contract::AuditConfig;
 
@@ -78,15 +77,15 @@ impl AuditComponentProvider for NoopProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn AuditComponentProvider>>> = Mutex::new(None);
-
-/// Register the audit component provider. Called once at binary startup by the
-/// component layer (via the CLI). Replaces any previously registered provider.
-pub fn register_audit_component_provider(provider: Box<dyn AuditComponentProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn AuditComponentProvider,
+    noop: NoopProvider,
+    /// Register the audit component provider. Called once at binary startup by the
+    /// component layer (via the CLI). Replaces any previously registered provider.
+    register: pub fn register_audit_component_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Resolve a registered component by id via the registered provider.
@@ -102,16 +101,6 @@ pub(crate) fn resolve_effective(component_id: &str) -> Result<AuditComponentInfo
 /// Discover a component from a portable config at `root` via the provider.
 pub(crate) fn discover_from_portable(root: &Path) -> Option<AuditComponentInfo> {
     with_provider(|p| p.discover_from_portable(root))
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn AuditComponentProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopProvider),
-    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/extension_manifests.rs
+++ b/crates/homeboy-code-audit/src/extension_manifests.rs
@@ -14,8 +14,6 @@
 //! yields no manifests, which every call site already treats as "no extension
 //! contributed anything".
 
-use std::sync::Mutex;
-
 use homeboy_audit_contract::AuditConfig;
 
 use homeboy_audit_contract::TestMappingConfig;
@@ -68,17 +66,15 @@ impl AuditExtensionManifestProvider for NoopProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn AuditExtensionManifestProvider>>> = Mutex::new(None);
-
-/// Register the audit manifest provider. Called once at binary startup by the
-/// extension layer (via the CLI). Replaces any previously registered provider.
-pub fn register_audit_extension_manifest_provider(
-    provider: Box<dyn AuditExtensionManifestProvider>,
-) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn AuditExtensionManifestProvider,
+    noop: NoopProvider,
+    /// Register the audit manifest provider. Called once at binary startup by the
+    /// extension layer (via the CLI). Replaces any previously registered provider.
+    register: pub fn register_audit_extension_manifest_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Load every installed extension's audit view via the registered provider.
@@ -89,16 +85,6 @@ pub(crate) fn load_all_audit_manifests() -> Vec<AuditExtensionManifest> {
 /// Load a single extension's audit view via the registered provider.
 pub(crate) fn load_audit_manifest(id: &str) -> Option<AuditExtensionManifest> {
     with_provider(|p| p.load(id))
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn AuditExtensionManifestProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopProvider),
-    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/fingerprint_script_provider.rs
+++ b/crates/homeboy-code-audit/src/fingerprint_script_provider.rs
@@ -16,8 +16,6 @@
 //! simply produces no fingerprint for files only an extension script could
 //! handle (exactly as it does when no such extension is installed).
 
-use std::sync::Mutex;
-
 use homeboy_audit_contract::FingerprintOutput;
 
 /// The fingerprint-script contract the audit engine depends on. Implemented by
@@ -51,16 +49,16 @@ impl FingerprintScriptProvider for NoopProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn FingerprintScriptProvider>>> = Mutex::new(None);
-
-/// Register the fingerprint-script provider. Called once at binary startup by
-/// the extension layer (via the CLI). Replaces any previously registered
-/// provider.
-pub fn register_fingerprint_script_provider(provider: Box<dyn FingerprintScriptProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn FingerprintScriptProvider,
+    noop: NoopProvider,
+    /// Register the fingerprint-script provider. Called once at binary startup by
+    /// the extension layer (via the CLI). Replaces any previously registered
+    /// provider.
+    register: pub fn register_fingerprint_script_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Fingerprint a file via the registered extension-script provider.
@@ -70,16 +68,6 @@ pub(crate) fn fingerprint_via_script(
     content: &str,
 ) -> Option<FingerprintOutput> {
     with_provider(|p| p.fingerprint(file_extension, relative_path, content))
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn FingerprintScriptProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopProvider),
-    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/fixability_provider.rs
+++ b/crates/homeboy-code-audit/src/fixability_provider.rs
@@ -15,8 +15,6 @@
 //! e.g. audit running standalone — the no-op provider yields no fixes, which the
 //! caller already treats as "not fixable / fixability unavailable".
 
-use std::sync::Mutex;
-
 use super::fingerprint::FileFingerprint;
 use super::CodeAuditResult;
 use homeboy_audit_contract::AuditFinding;
@@ -67,15 +65,15 @@ impl AuditFixabilityProvider for NoopProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn AuditFixabilityProvider>>> = Mutex::new(None);
-
-/// Register the audit fixability provider. Called once at binary startup by the
-/// refactor layer (via the CLI). Replaces any previously registered provider.
-pub fn register_audit_fixability_provider(provider: Box<dyn AuditFixabilityProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn AuditFixabilityProvider,
+    noop: NoopProvider,
+    /// Register the audit fixability provider. Called once at binary startup by the
+    /// refactor layer (via the CLI). Replaces any previously registered provider.
+    register: pub fn register_audit_fixability_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Plan fixability verdicts for an audit result via the registered provider.
@@ -85,16 +83,6 @@ pub(crate) fn plan_fixability(
     fingerprints: &[FileFingerprint],
 ) -> Vec<FixabilityVerdict> {
     with_provider(|p| p.plan(result, source_path, fingerprints))
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn AuditFixabilityProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopProvider),
-    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/grammar_source_provider.rs
+++ b/crates/homeboy-code-audit/src/grammar_source_provider.rs
@@ -18,7 +18,6 @@
 //! and falls back to its built-in grammars / extension fingerprint scripts.
 
 use std::path::PathBuf;
-use std::sync::Mutex;
 
 /// The grammar-source contract the audit engine depends on. Implemented by the
 /// extension layer and registered at startup; audit calls it without depending
@@ -42,31 +41,21 @@ impl GrammarSourceProvider for NoopProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn GrammarSourceProvider>>> = Mutex::new(None);
-
-/// Register the grammar-source provider. Called once at binary startup by the
-/// extension layer (via the CLI). Replaces any previously registered provider.
-pub fn register_grammar_source_provider(provider: Box<dyn GrammarSourceProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn GrammarSourceProvider,
+    noop: NoopProvider,
+    /// Register the grammar-source provider. Called once at binary startup by the
+    /// extension layer (via the CLI). Replaces any previously registered provider.
+    register: pub fn register_grammar_source_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Resolve the grammar directory for `file_extension` via the registered
 /// provider.
 pub(crate) fn grammar_dir_for_ext(file_extension: &str) -> Option<PathBuf> {
     with_provider(|p| p.grammar_dir(file_extension))
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn GrammarSourceProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopProvider),
-    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/recorded_artifacts.rs
+++ b/crates/homeboy-code-audit/src/recorded_artifacts.rs
@@ -14,8 +14,6 @@
 //! standalone — the no-op provider yields no runs, which the detector already
 //! treats as "nothing recorded to check".
 
-use std::sync::Mutex;
-
 /// A recorded artifact, projected to what the portability detector needs.
 #[derive(Debug, Clone, Default)]
 pub struct AuditRecordedArtifact {
@@ -54,27 +52,21 @@ impl AuditRecordedArtifactProvider for NoopProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn AuditRecordedArtifactProvider>>> = Mutex::new(None);
-
-/// Register the recorded-artifact provider. Called once at binary startup by the
-/// observation layer (via the CLI). Replaces any previously registered provider.
-pub fn register_audit_recorded_artifact_provider(provider: Box<dyn AuditRecordedArtifactProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn AuditRecordedArtifactProvider,
+    noop: NoopProvider,
+    /// Register the recorded-artifact provider. Called once at binary startup by the
+    /// observation layer (via the CLI). Replaces any previously registered provider.
+    register: pub fn register_audit_recorded_artifact_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Recent recorded runs (with artifacts) for a component via the registered
 /// provider.
 pub(crate) fn recent_recorded_runs(component_id: &str, limit: usize) -> Vec<AuditRecordedRun> {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => provider.recent_runs(component_id, limit),
-        None => NoopProvider.recent_runs(component_id, limit),
-    }
+    with_provider(|p| p.recent_runs(component_id, limit))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/activity/agent_task_provider.rs
+++ b/crates/homeboy-core/src/activity/agent_task_provider.rs
@@ -10,8 +10,6 @@
 //! With no provider registered (no agent-task subsystem present) the no-op
 //! provider contributes no items and an empty health summary.
 
-use std::sync::Mutex;
-
 use serde_json::Value;
 
 use super::ActivityItem;
@@ -39,40 +37,25 @@ impl ActivityAgentTaskProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn ActivityAgentTaskProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn ActivityAgentTaskProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the agent-task activity provider. Called once at startup by the
-/// agent-task layer.
-pub fn register_activity_agent_task_provider(provider: Box<dyn ActivityAgentTaskProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("activity agent-task provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn ActivityAgentTaskProvider,
+    noop: NoopProvider,
+    /// Register the agent-task activity provider. Called once at startup by the
+    /// agent-task layer.
+    register: pub fn register_activity_agent_task_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// The agent-task activity items via the registered provider (or none when the
 /// agent-task subsystem is absent).
 pub(crate) fn agent_task_activity_items() -> Result<Vec<ActivityItem>> {
-    let slot = provider_slot()
-        .lock()
-        .expect("activity agent-task provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.agent_task_activity_items(),
-        None => NoopProvider.agent_task_activity_items(),
-    }
+    with_provider(|p| p.agent_task_activity_items())
 }
 
 /// The agent-task record-health summary (as JSON) via the registered provider
 /// (or an empty summary when the agent-task subsystem is absent).
 pub(crate) fn agent_task_record_health() -> Result<Value> {
-    let slot = provider_slot()
-        .lock()
-        .expect("activity agent-task provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.agent_task_record_health(),
-        None => NoopProvider.agent_task_record_health(),
-    }
+    with_provider(|p| p.agent_task_record_health())
 }

--- a/crates/homeboy-core/src/agent_task_secret_provider.rs
+++ b/crates/homeboy-core/src/agent_task_secret_provider.rs
@@ -8,8 +8,6 @@
 //! With no provider registered (no agent-task subsystem present) the no-op
 //! resolves nothing, so trace resolution falls through to its other sources.
 
-use std::sync::Mutex;
-
 /// Resolves secret-env values from the agent-task secret store.
 pub trait AgentTaskSecretProvider: Send + Sync {
     /// Resolve the named secret-env variables from the agent-task secret store,
@@ -25,28 +23,19 @@ impl AgentTaskSecretProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn AgentTaskSecretProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn AgentTaskSecretProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the agent-task secret provider. Called once at startup by the
-/// agent-task layer.
-pub fn register_agent_task_secret_provider(provider: Box<dyn AgentTaskSecretProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("agent-task secret provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn AgentTaskSecretProvider,
+    noop: NoopProvider,
+    /// Register the agent-task secret provider. Called once at startup by the
+    /// agent-task layer.
+    register: pub fn register_agent_task_secret_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Resolve agent-task secret-env values via the registered provider (or none
 /// when the agent-task subsystem is absent).
 pub(crate) fn resolve_agent_task_secret_env(names: &[String]) -> Vec<(String, String)> {
-    let slot = provider_slot()
-        .lock()
-        .expect("agent-task secret provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.resolve_agent_task_secret_env(names),
-        None => NoopProvider.resolve_agent_task_secret_env(names),
-    }
+    with_provider(|p| p.resolve_agent_task_secret_env(names))
 }

--- a/crates/homeboy-core/src/api_jobs/agent_task_terminal_recovery.rs
+++ b/crates/homeboy-core/src/api_jobs/agent_task_terminal_recovery.rs
@@ -10,8 +10,6 @@
 //! With no provider registered (no agent-task subsystem present) the no-op
 //! recovers nothing.
 
-use std::sync::Mutex;
-
 use serde_json::Value;
 
 use super::store::RecoveredTerminalJob;
@@ -31,32 +29,21 @@ impl AgentTaskTerminalRecoveryProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn AgentTaskTerminalRecoveryProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn AgentTaskTerminalRecoveryProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the agent-task terminal-recovery provider. Called once at startup by
-/// the agent-task layer.
-pub fn register_agent_task_terminal_recovery_provider(
-    provider: Box<dyn AgentTaskTerminalRecoveryProvider>,
-) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("agent-task terminal recovery provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn AgentTaskTerminalRecoveryProvider,
+    noop: NoopProvider,
+    /// Register the agent-task terminal-recovery provider. Called once at startup by
+    /// the agent-task layer.
+    register: pub fn register_agent_task_terminal_recovery_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Recover the terminal job for a durable agent-task run via the registered
 /// provider (or none when the agent-task subsystem is absent).
 pub(crate) fn recovered_terminal_agent_task_job(run_id: &str) -> Option<RecoveredTerminalJob> {
-    let slot = provider_slot()
-        .lock()
-        .expect("agent-task terminal recovery provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.recovered_terminal_agent_task_job(run_id),
-        None => NoopProvider.recovered_terminal_agent_task_job(run_id),
-    }
+    with_provider(|p| p.recovered_terminal_agent_task_job(run_id))
 }
 
 /// Build a [`RecoveredTerminalJob`] from its parts. Used by the agent-task

--- a/crates/homeboy-core/src/api_jobs/runner_job_preparation.rs
+++ b/crates/homeboy-core/src/api_jobs/runner_job_preparation.rs
@@ -12,7 +12,6 @@
 //! the correct behavior when there is no runner to dispatch to.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
 
 use crate::lab_contract::LabRunnerWorkload;
 use crate::secret_env_plan::SecretEnvPlan;
@@ -82,29 +81,15 @@ impl RunnerJobPreparationProvider for NoopRunnerJobPreparationProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn RunnerJobPreparationProvider>>> = Mutex::new(None);
-
-/// Register the runner job-preparation provider. Called once at binary startup
-/// by the runner layer (via the CLI).
-pub fn register_runner_job_preparation_provider(provider: Box<dyn RunnerJobPreparationProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
-}
-
-/// Run `f` against the registered provider, or the no-op provider if none is
-/// registered.
-pub(crate) fn with_runner_job_preparation<T>(
-    f: impl FnOnce(&dyn RunnerJobPreparationProvider) -> T,
-) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopRunnerJobPreparationProvider),
-    }
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RunnerJobPreparationProvider,
+    noop: NoopRunnerJobPreparationProvider,
+    /// Register the runner job-preparation provider. Called once at binary startup
+    /// by the runner layer (via the CLI).
+    register: pub fn register_runner_job_preparation_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none is
+    /// registered.
+    with: pub(crate) fn with_runner_job_preparation,
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/component_build_provider.rs
+++ b/crates/homeboy-core/src/component_build_provider.rs
@@ -13,8 +13,6 @@
 //! With no provider registered (no extension subsystem present) the no-op
 //! returns a not-supported error, so callers degrade gracefully.
 
-use std::sync::Mutex;
-
 use serde_json::Value;
 
 use crate::component::Component;
@@ -35,48 +33,44 @@ pub trait ComponentBuildRunner: Send + Sync {
     fn build_component(&self, component: &Component) -> (Option<i32>, Option<String>);
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentBuildRunner>>> {
-    static PROVIDER: Mutex<Option<Box<dyn ComponentBuildRunner>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the component-build runner. Called once at startup by the extension
-/// layer.
-pub fn register_component_build_runner(provider: Box<dyn ComponentBuildRunner>) {
-    let mut slot = provider_slot().lock().expect("component build runner lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn ComponentBuildRunner,
+    /// Register the component-build runner. Called once at startup by the extension
+    /// layer.
+    register: pub fn register_component_build_runner,
+    /// Run `f` against the registered runner, or `None` when none is registered.
+    /// This registry has no no-op implementation: each dispatch function below
+    /// reports its own "no runner registered" outcome.
+    with_optional: fn with_provider,
 }
 
 /// Build the component (exit_code, error) via the registered provider.
 pub fn build_component(component: &Component) -> (Option<i32>, Option<String>) {
-    let slot = provider_slot().lock().expect("component build runner lock");
-    match slot.as_deref() {
-        Some(provider) => provider.build_component(component),
+    with_provider(|runner| match runner {
+        Some(runner) => runner.build_component(component),
         None => (
             None,
             Some("no component-build runner registered".to_string()),
         ),
-    }
+    })
 }
 
 /// Whether the registered provider can build the component.
 pub fn can_build(component: &Component) -> bool {
-    let slot = provider_slot().lock().expect("component build runner lock");
-    match slot.as_deref() {
-        Some(provider) => provider.can_build(component),
+    with_provider(|runner| match runner {
+        Some(runner) => runner.can_build(component),
         None => false,
-    }
+    })
 }
 
 /// Build a component through the registered provider. Returns
 /// `(json_result, exit_code)`.
 pub fn run_component_build(component: &Component) -> Result<(Value, i32)> {
-    let slot = provider_slot().lock().expect("component build runner lock");
-    match slot.as_deref() {
-        Some(provider) => provider.run_component_build(component),
+    with_provider(|runner| match runner {
+        Some(runner) => runner.run_component_build(component),
         None => Err(Error::internal_io(
             "no component-build runner registered; the extension subsystem is not available",
             None,
         )),
-    }
+    })
 }

--- a/crates/homeboy-core/src/component_install_provider.rs
+++ b/crates/homeboy-core/src/component_install_provider.rs
@@ -10,7 +10,6 @@
 //! returns a not-supported error, so callers degrade gracefully.
 
 use std::path::PathBuf;
-use std::sync::Mutex;
 
 use crate::component::Component;
 use crate::{Error, Result};
@@ -44,18 +43,15 @@ pub trait ComponentInstallRunner: Send + Sync {
     ) -> Result<ComponentInstallResult>;
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentInstallRunner>>> {
-    static PROVIDER: Mutex<Option<Box<dyn ComponentInstallRunner>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the component-install runner. Called once at startup by the
-/// extension layer.
-pub fn register_component_install_runner(provider: Box<dyn ComponentInstallRunner>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("component install runner lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn ComponentInstallRunner,
+    /// Register the component-install runner. Called once at startup by the
+    /// extension layer.
+    register: pub fn register_component_install_runner,
+    /// Run `f` against the registered runner, or `None` when none is registered.
+    /// This registry has no no-op implementation: the dispatch function below
+    /// reports its own "extension subsystem not available" error.
+    with_optional: fn with_provider,
 }
 
 /// Install a component's extensions from a source through the registered
@@ -64,14 +60,11 @@ pub fn install_for_component(
     component: &Component,
     source: &str,
 ) -> Result<ComponentInstallResult> {
-    let slot = provider_slot()
-        .lock()
-        .expect("component install runner lock");
-    match slot.as_deref() {
-        Some(provider) => provider.install_for_component(component, source),
+    with_provider(|runner| match runner {
+        Some(runner) => runner.install_for_component(component, source),
         None => Err(Error::internal_io(
             "no component-install runner registered; the extension subsystem is not available",
             None,
         )),
-    }
+    })
 }

--- a/crates/homeboy-core/src/component_script_provider.rs
+++ b/crates/homeboy-core/src/component_script_provider.rs
@@ -10,7 +10,6 @@
 //! returns a not-supported error, so callers degrade gracefully.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use homeboy_extension_contract::{ExtensionCapability, ExtensionPhaseTiming};
 
@@ -57,18 +56,15 @@ pub trait ComponentScriptRunner: Send + Sync {
     ) -> Result<ComponentScriptOutput>;
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn ComponentScriptRunner>>> {
-    static PROVIDER: Mutex<Option<Box<dyn ComponentScriptRunner>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the component-script runner. Called once at startup by the
-/// extension layer.
-pub fn register_component_script_runner(provider: Box<dyn ComponentScriptRunner>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("component script runner lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn ComponentScriptRunner,
+    /// Register the component-script runner. Called once at startup by the
+    /// extension layer.
+    register: pub fn register_component_script_runner,
+    /// Run `f` against the registered runner, or `None` when none is registered.
+    /// This registry has no no-op implementation: each dispatch function below
+    /// reports its own "extension subsystem not available" error.
+    with_optional: fn with_provider,
 }
 
 /// Run a pre-resolved execution context through the registered provider.
@@ -78,16 +74,13 @@ pub fn run_with_context(
     path_override: Option<String>,
     script_args: &[String],
 ) -> Result<ComponentScriptOutput> {
-    let slot = provider_slot()
-        .lock()
-        .expect("component script runner lock");
-    match slot.as_deref() {
-        Some(provider) => provider.run_with_context(context, component, path_override, script_args),
+    with_provider(|runner| match runner {
+        Some(runner) => runner.run_with_context(context, component, path_override, script_args),
         None => Err(Error::internal_io(
             "no component-script runner registered; the extension subsystem is not available",
             None,
         )),
-    }
+    })
 }
 
 /// Run a component's scripts for a capability through the registered provider.
@@ -99,11 +92,8 @@ pub fn run_component_scripts_with_env(
     extra_env: &[(String, String)],
     script_args: &[String],
 ) -> Result<ComponentScriptOutput> {
-    let slot = provider_slot()
-        .lock()
-        .expect("component script runner lock");
-    match slot.as_deref() {
-        Some(provider) => provider.run_component_scripts_with_env(
+    with_provider(|runner| match runner {
+        Some(runner) => runner.run_component_scripts_with_env(
             component,
             capability,
             source_path,
@@ -115,5 +105,5 @@ pub fn run_component_scripts_with_env(
             "no component-script runner registered; the extension subsystem is not available",
             None,
         )),
-    }
+    })
 }

--- a/crates/homeboy-core/src/controller_pin_reference.rs
+++ b/crates/homeboy-core/src/controller_pin_reference.rs
@@ -16,7 +16,6 @@
 //! retention report, and pruning is always an explicit caller opt-in.
 
 use std::path::PathBuf;
-use std::sync::Mutex;
 
 use crate::Result;
 
@@ -38,31 +37,20 @@ impl ControllerPinReferenceProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn ControllerPinReferenceProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn ControllerPinReferenceProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the controller pin-reference provider. Called once at startup by the
-/// agent-task layer.
-pub fn register_controller_pin_reference_provider(
-    provider: Box<dyn ControllerPinReferenceProvider>,
-) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("controller pin reference provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn ControllerPinReferenceProvider,
+    noop: NoopProvider,
+    /// Register the controller pin-reference provider. Called once at startup by the
+    /// agent-task layer.
+    register: pub fn register_controller_pin_reference_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// The controller-runtime pins still referenced by nonterminal agent-task
 /// records, via the registered provider (or an empty set when the agent-task
 /// subsystem is absent).
 pub(crate) fn referenced_controller_pins() -> Result<Vec<PathBuf>> {
-    let slot = provider_slot()
-        .lock()
-        .expect("controller pin reference provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.referenced_controller_pins(),
-        None => NoopProvider.referenced_controller_pins(),
-    }
+    with_provider(|p| p.referenced_controller_pins())
 }

--- a/crates/homeboy-core/src/daemon/runner_exec_driver.rs
+++ b/crates/homeboy-core/src/daemon/runner_exec_driver.rs
@@ -16,7 +16,7 @@
 //! reached when a runner job was actually dispatched.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use serde_json::Value;
 
@@ -172,25 +172,14 @@ impl RunnerExecDriver for NoopRunnerExecDriver {
     }
 }
 
-fn driver_slot() -> &'static Mutex<Option<Arc<dyn RunnerExecDriver>>> {
-    static DRIVER: Mutex<Option<Arc<dyn RunnerExecDriver>>> = Mutex::new(None);
-    &DRIVER
-}
-
-/// Resolve the active driver, cloning the `Arc` so the registry lock is not
-/// held while a (potentially long-running) child process executes.
-fn active_driver() -> Arc<dyn RunnerExecDriver> {
-    let slot = driver_slot().lock().expect("runner exec driver lock");
-    match slot.as_ref() {
-        Some(driver) => Arc::clone(driver),
-        None => Arc::new(NoopRunnerExecDriver),
-    }
-}
-
-/// Register the runner exec driver. Called once at startup by the runner layer.
-pub fn register_runner_exec_driver(driver: Arc<dyn RunnerExecDriver>) {
-    let mut slot = driver_slot().lock().expect("runner exec driver lock");
-    *slot = Some(driver);
+homeboy_engine_primitives::provider_registry_arc! {
+    provider: dyn RunnerExecDriver,
+    noop: NoopRunnerExecDriver,
+    /// Register the runner exec driver. Called once at startup by the runner layer.
+    register: pub fn register_runner_exec_driver,
+    /// Resolve the active driver, cloning the `Arc` so the registry lock is not
+    /// held while a (potentially long-running) child process executes.
+    active: fn active_driver,
 }
 
 /// Prepare a runner process via the registered driver (or the no-op driver).

--- a/crates/homeboy-core/src/daemon/runner_workspace_root.rs
+++ b/crates/homeboy-core/src/daemon/runner_workspace_root.rs
@@ -10,8 +10,6 @@
 //! back on, so the caller reports the same "requires workspace_root" error it
 //! would for a runner without one.
 
-use std::sync::Mutex;
-
 /// Looks up configured fields from a runner's config by id, for the daemon's
 /// runner-broker endpoints (file API, job claim).
 pub trait RunnerWorkspaceRootProvider: Send + Sync {
@@ -34,38 +32,23 @@ impl RunnerWorkspaceRootProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn RunnerWorkspaceRootProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn RunnerWorkspaceRootProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the runner workspace-root provider. Called once at startup by the
-/// runner layer.
-pub fn register_runner_workspace_root_provider(provider: Box<dyn RunnerWorkspaceRootProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("runner workspace root provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RunnerWorkspaceRootProvider,
+    noop: NoopProvider,
+    /// Register the runner workspace-root provider. Called once at startup by the
+    /// runner layer.
+    register: pub fn register_runner_workspace_root_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Resolve a runner's configured workspace root via the registered provider.
 pub(crate) fn runner_workspace_root(runner_id: &str) -> Option<String> {
-    let slot = provider_slot()
-        .lock()
-        .expect("runner workspace root provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.runner_workspace_root(runner_id),
-        None => NoopProvider.runner_workspace_root(runner_id),
-    }
+    with_provider(|p| p.runner_workspace_root(runner_id))
 }
 
 /// Resolve a runner's configured concurrency limit via the registered provider.
 pub(crate) fn runner_concurrency_limit(runner_id: &str) -> Option<usize> {
-    let slot = provider_slot()
-        .lock()
-        .expect("runner workspace root provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.runner_concurrency_limit(runner_id),
-        None => NoopProvider.runner_concurrency_limit(runner_id),
-    }
+    with_provider(|p| p.runner_concurrency_limit(runner_id))
 }

--- a/crates/homeboy-core/src/extension_provider_discovery.rs
+++ b/crates/homeboy-core/src/extension_provider_discovery.rs
@@ -11,8 +11,6 @@
 //! validates nothing (an install without the agent-task subsystem has no
 //! agent-task providers to discover).
 
-use std::sync::Mutex;
-
 use crate::Result;
 
 /// Validates that an installed extension's declared agent-runtime providers are
@@ -32,30 +30,19 @@ impl ExtensionProviderDiscoveryValidator for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn ExtensionProviderDiscoveryValidator>>> {
-    static PROVIDER: Mutex<Option<Box<dyn ExtensionProviderDiscoveryValidator>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the extension provider-discovery validator. Called once at startup
-/// by the agent-task layer.
-pub fn register_extension_provider_discovery_validator(
-    provider: Box<dyn ExtensionProviderDiscoveryValidator>,
-) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("extension provider discovery validator lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn ExtensionProviderDiscoveryValidator,
+    noop: NoopProvider,
+    /// Register the extension provider-discovery validator. Called once at startup
+    /// by the agent-task layer.
+    register: pub fn register_extension_provider_discovery_validator,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Validate an installed extension's agent-runtime provider discovery via the
 /// registered validator (or the no-op when the agent-task subsystem is absent).
 pub fn validate_installed_extension_provider_discovery(extension_id: &str) -> Result<()> {
-    let slot = provider_slot()
-        .lock()
-        .expect("extension provider discovery validator lock");
-    match slot.as_deref() {
-        Some(provider) => provider.validate_installed_extension_provider_discovery(extension_id),
-        None => NoopProvider.validate_installed_extension_provider_discovery(extension_id),
-    }
+    with_provider(|p| p.validate_installed_extension_provider_discovery(extension_id))
 }

--- a/crates/homeboy-core/src/gate_feedback_baseline.rs
+++ b/crates/homeboy-core/src/gate_feedback_baseline.rs
@@ -13,7 +13,6 @@
 //! of a gate-feedback baseline — the safe default.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use serde_json::Value;
 
@@ -49,18 +48,15 @@ impl GateFeedbackBaselineProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn GateFeedbackBaselineProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn GateFeedbackBaselineProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the gate-feedback candidate-baseline provider. Called once at
-/// startup by the agent-task layer.
-pub fn register_gate_feedback_baseline_provider(provider: Box<dyn GateFeedbackBaselineProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("gate feedback baseline provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn GateFeedbackBaselineProvider,
+    noop: NoopProvider,
+    /// Register the gate-feedback candidate-baseline provider. Called once at
+    /// startup by the agent-task layer.
+    register: pub fn register_gate_feedback_baseline_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Verify a gate-feedback candidate baseline via the registered provider (or the
@@ -70,11 +66,5 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
     root: &Path,
     baseline: &Value,
 ) -> Result<String> {
-    let slot = provider_slot()
-        .lock()
-        .expect("gate feedback baseline provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.validate_gate_feedback_candidate_baseline(root, baseline),
-        None => NoopProvider.validate_gate_feedback_candidate_baseline(root, baseline),
-    }
+    with_provider(|p| p.validate_gate_feedback_candidate_baseline(root, baseline))
 }

--- a/crates/homeboy-core/src/lab_offload.rs
+++ b/crates/homeboy-core/src/lab_offload.rs
@@ -11,7 +11,6 @@
 //! only reached when a Lab command was actually dispatched.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 use crate::error::{Error, Result};
 use crate::lab_contract::{
@@ -99,29 +98,19 @@ impl LabOffloadProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Arc<dyn LabOffloadProvider>>> {
-    static PROVIDER: Mutex<Option<Arc<dyn LabOffloadProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the Lab-offload provider. Called once at startup by the runner layer.
-pub fn register_lab_offload_provider(provider: Arc<dyn LabOffloadProvider>) {
-    let mut slot = provider_slot().lock().expect("lab offload provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry_arc! {
+    provider: dyn LabOffloadProvider,
+    noop: NoopProvider,
+    /// Register the Lab-offload provider. Called once at startup by the runner layer.
+    register: pub fn register_lab_offload_provider,
+    /// The active provider (or the no-op provider). The `Arc` is cloned out so
+    /// the registry lock is not held during the (potentially long) offload.
+    active: fn active_provider,
 }
 
 /// Execute a Lab offload via the registered provider (or the no-op provider).
-/// The provider `Arc` is cloned out before executing so the registry lock is
-/// not held during the (potentially long) offload.
 pub(crate) fn execute_lab_offload(
     request: crate::lab_routing::LabRoutingRequest<'_>,
 ) -> Result<LabOffloadOutcome> {
-    let provider = {
-        let slot = provider_slot().lock().expect("lab offload provider lock");
-        slot.as_ref().map(Arc::clone)
-    };
-    match provider {
-        Some(provider) => provider.execute_lab_offload(request),
-        None => NoopProvider.execute_lab_offload(request),
-    }
+    active_provider().execute_lab_offload(request)
 }

--- a/crates/homeboy-core/src/lab_workspace_provenance.rs
+++ b/crates/homeboy-core/src/lab_workspace_provenance.rs
@@ -12,7 +12,6 @@
 //! only reached when a snapshot was actually signaled by a runner.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use crate::source_snapshot::SourceSnapshot;
 
@@ -101,31 +100,15 @@ impl LabWorkspaceProvenanceProvider for NoopLabWorkspaceProvenanceProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn LabWorkspaceProvenanceProvider>>> = Mutex::new(None);
-
-/// Register the lab-workspace provenance provider. Called once at startup by the
-/// runner layer (via the CLI).
-pub fn register_lab_workspace_provenance_provider(
-    provider: Box<dyn LabWorkspaceProvenanceProvider>,
-) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
-}
-
-/// Run `f` against the registered provider, or the no-op provider if none is
-/// registered.
-pub fn with_lab_workspace_provenance<T>(
-    f: impl FnOnce(&dyn LabWorkspaceProvenanceProvider) -> T,
-) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopLabWorkspaceProvenanceProvider),
-    }
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn LabWorkspaceProvenanceProvider,
+    noop: NoopLabWorkspaceProvenanceProvider,
+    /// Register the lab-workspace provenance provider. Called once at startup by the
+    /// runner layer (via the CLI).
+    register: pub fn register_lab_workspace_provenance_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none is
+    /// registered.
+    with: pub fn with_lab_workspace_provenance,
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -10,7 +10,6 @@
 //! how the callers already behave when no runner is connected.
 
 use std::path::PathBuf;
-use std::sync::Mutex;
 
 use homeboy_lab_runner_contract::RunnerArtifactRef;
 use serde_json::Value;
@@ -262,7 +261,7 @@ pub fn has_runner_evidence_provider() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, OnceLock};
+    use std::sync::{Arc, Mutex, OnceLock};
 
     use crate::observation::{ObservationStore, RunStatus};
     use crate::test_support::with_isolated_home;
@@ -361,7 +360,7 @@ mod tests {
 
         // Reset so the registered fake doesn't leak into other tests sharing the
         // process-global provider.
-        PROVIDER
+        provider_slot()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take();
@@ -534,7 +533,7 @@ mod tests {
             ]
         );
 
-        PROVIDER
+        provider_slot()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take();
@@ -634,7 +633,10 @@ mod tests {
             );
             assert!(calls.lock().expect("calls").is_empty());
         });
-        PROVIDER.lock().expect("provider").take();
+        provider_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
     }
 
     #[test]
@@ -672,7 +674,10 @@ mod tests {
                 404
             );
         });
-        PROVIDER.lock().expect("provider").take();
+        provider_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
     }
 
     #[test]
@@ -702,7 +707,10 @@ mod tests {
                 RunStatus::Running.as_str()
             );
         });
-        PROVIDER.lock().expect("provider").take();
+        provider_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
     }
 
     #[test]
@@ -745,6 +753,9 @@ mod tests {
                 RunStatus::Running.as_str()
             );
         });
-        PROVIDER.lock().expect("provider").take();
+        provider_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
     }
 }

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -222,15 +222,15 @@ impl RunnerEvidenceProvider for NoopRunnerEvidenceProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn RunnerEvidenceProvider>>> = Mutex::new(None);
-
-/// Register the runner-evidence provider. Called once at binary startup by the
-/// runner layer (via the CLI). Replaces any previously registered provider.
-pub fn register_runner_evidence_provider(provider: Box<dyn RunnerEvidenceProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RunnerEvidenceProvider,
+    noop: NoopRunnerEvidenceProvider,
+    /// Register the runner-evidence provider. Called once at binary startup by the
+    /// runner layer (via the CLI). Replaces any previously registered provider.
+    register: pub fn register_runner_evidence_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none is
+    /// registered. Keeps the lock held only for the duration of the call.
+    with: pub fn with_runner_evidence,
 }
 
 /// Refresh runner-owned evidence and return its authenticated runner/job
@@ -249,24 +249,14 @@ pub fn mirrored_runner_job_identities(run_id: &str) -> Result<Vec<(String, Strin
     Ok(identities)
 }
 
-/// Whether a runner-evidence provider is currently registered.
+/// Whether a runner-evidence provider is currently registered. Distinct from
+/// [`with_runner_evidence`], which cannot tell a registered provider from the
+/// no-op fallback, so it reads the registry slot directly.
 pub fn has_runner_evidence_provider() -> bool {
-    PROVIDER
+    provider_slot()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .is_some()
-}
-
-/// Run `f` against the registered provider, or the no-op provider if none is
-/// registered. Keeps the lock held only for the duration of the call.
-pub fn with_runner_evidence<T>(f: impl FnOnce(&dyn RunnerEvidenceProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopRunnerEvidenceProvider),
-    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/proof/loop_spec_validation.rs
+++ b/crates/homeboy-core/src/proof/loop_spec_validation.rs
@@ -12,8 +12,6 @@
 //! provider reports that the loop-spec schema cannot be validated, so a proof
 //! carrying that schema is flagged rather than silently accepted.
 
-use std::sync::Mutex;
-
 use serde_json::Value;
 
 use homeboy_gate_contract::proof::HomeboyProofValidationDiagnostic;
@@ -46,30 +44,21 @@ impl LoopSpecValidationProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn LoopSpecValidationProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn LoopSpecValidationProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the loop-spec validation provider. Called once at startup by the
-/// agent-task layer.
-pub fn register_loop_spec_validation_provider(provider: Box<dyn LoopSpecValidationProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("loop spec validation provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn LoopSpecValidationProvider,
+    noop: NoopProvider,
+    /// Register the loop-spec validation provider. Called once at startup by the
+    /// agent-task layer.
+    register: pub fn register_loop_spec_validation_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Validate a materialized loop-spec `spec` value via the registered provider
 /// (or the no-op provider when the agent-task subsystem is absent).
 pub(crate) fn validate_materialized_loop_spec(spec: &Value) -> Vec<LoopSpecValidationDiagnostic> {
-    let slot = provider_slot()
-        .lock()
-        .expect("loop spec validation provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.validate_materialized_loop_spec(spec),
-        None => NoopProvider.validate_materialized_loop_spec(spec),
-    }
+    with_provider(|p| p.validate_materialized_loop_spec(spec))
 }
 
 /// Validate a `homeboy/agent-task-loop-spec-materialization/v1` proof record:

--- a/crates/homeboy-core/src/refactor_transform_provider.rs
+++ b/crates/homeboy-core/src/refactor_transform_provider.rs
@@ -10,7 +10,6 @@
 //! nothing.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use homeboy_refactor_contract::TransformSet;
 
@@ -58,18 +57,15 @@ impl RefactorTransformProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn RefactorTransformProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn RefactorTransformProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the refactor transform provider. Called once at startup by the
-/// refactor layer.
-pub fn register_refactor_transform_provider(provider: Box<dyn RefactorTransformProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("refactor transform provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RefactorTransformProvider,
+    noop: NoopProvider,
+    /// Register the refactor transform provider. Called once at startup by the
+    /// refactor layer.
+    register: pub fn register_refactor_transform_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Apply a transform set via the registered provider (or the no-op when the
@@ -82,13 +78,5 @@ pub fn apply_transform_set(
     rerun_hint: Option<String>,
     extra_hints: Vec<String>,
 ) -> Result<AppliedTransformSummary> {
-    let slot = provider_slot()
-        .lock()
-        .expect("refactor transform provider lock");
-    match slot.as_deref() {
-        Some(provider) => {
-            provider.apply_transform_set(root, name, set, write, rerun_hint, extra_hints)
-        }
-        None => NoopProvider.apply_transform_set(root, name, set, write, rerun_hint, extra_hints),
-    }
+    with_provider(|p| p.apply_transform_set(root, name, set, write, rerun_hint, extra_hints))
 }

--- a/crates/homeboy-core/src/release_provider.rs
+++ b/crates/homeboy-core/src/release_provider.rs
@@ -11,8 +11,6 @@
 //! subsystem present) the no-op reports empty/None so status reporting degrades
 //! gracefully rather than failing.
 
-use std::sync::Mutex;
-
 use homeboy_release_contract::{
     ChangelogSnapshotData, ComponentDeployStatus, ComponentVersionSnapshot,
     FinalizedReleaseSnapshot, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
@@ -142,23 +140,14 @@ impl ReleaseProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn ReleaseProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn ReleaseProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the release provider. Called once at startup by the release layer.
-pub fn register_release_provider(provider: Box<dyn ReleaseProvider>) {
-    let mut slot = provider_slot().lock().expect("release provider lock");
-    *slot = Some(provider);
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn ReleaseProvider) -> T) -> T {
-    let slot = provider_slot().lock().expect("release provider lock");
-    match slot.as_deref() {
-        Some(provider) => f(provider),
-        None => f(&NoopProvider),
-    }
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn ReleaseProvider,
+    noop: NoopProvider,
+    /// Register the release provider. Called once at startup by the release layer.
+    register: pub fn register_release_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 pub(crate) fn deploy_component_statuses(project_id: &str) -> Result<Vec<ComponentDeployStatus>> {

--- a/crates/homeboy-core/src/rig_provider.rs
+++ b/crates/homeboy-core/src/rig_provider.rs
@@ -10,8 +10,6 @@
 //! rigs, so rig-scoped resolution is empty and the rig HTTP endpoints return
 //! empty results.
 
-use std::sync::Mutex;
-
 use serde_json::Value;
 
 use crate::component::Component;
@@ -62,23 +60,14 @@ impl RigProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn RigProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn RigProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the rig provider. Called once at startup by the rig layer.
-pub fn register_rig_provider(provider: Box<dyn RigProvider>) {
-    let mut slot = provider_slot().lock().expect("rig provider lock");
-    *slot = Some(provider);
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn RigProvider) -> T) -> T {
-    let slot = provider_slot().lock().expect("rig provider lock");
-    match slot.as_deref() {
-        Some(provider) => f(provider),
-        None => f(&NoopProvider),
-    }
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RigProvider,
+    noop: NoopProvider,
+    /// Register the rig provider. Called once at startup by the rig layer.
+    register: pub fn register_rig_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 pub(crate) fn rig_list_json() -> Result<Value> {

--- a/crates/homeboy-core/src/rig_toolchain_provider.rs
+++ b/crates/homeboy-core/src/rig_toolchain_provider.rs
@@ -15,7 +15,6 @@
 //! path, so the exec env's `PATH` is left unchanged.
 
 use std::ffi::OsString;
-use std::sync::Mutex;
 
 /// Supplies the rig toolchain command-step PATH.
 pub trait RigToolchainProvider: Send + Sync {
@@ -35,23 +34,18 @@ impl RigToolchainProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn RigToolchainProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn RigToolchainProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the rig toolchain provider. Called once at startup by the rig layer.
-pub fn register_rig_toolchain_provider(provider: Box<dyn RigToolchainProvider>) {
-    let mut slot = provider_slot().lock().expect("rig toolchain provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RigToolchainProvider,
+    noop: NoopProvider,
+    /// Register the rig toolchain provider. Called once at startup by the rig layer.
+    register: pub fn register_rig_toolchain_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// The rig toolchain command-step PATH via the registered provider (or none when
 /// the rig layer is absent).
 pub fn command_step_path(rig_id: Option<&str>) -> Option<OsString> {
-    let slot = provider_slot().lock().expect("rig toolchain provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.command_step_path(rig_id),
-        None => NoopProvider.command_step_path(rig_id),
-    }
+    with_provider(|p| p.command_step_path(rig_id))
 }

--- a/crates/homeboy-core/src/stack_provider.rs
+++ b/crates/homeboy-core/src/stack_provider.rs
@@ -7,8 +7,6 @@
 //! With no provider registered (no stack subsystem present) the no-op reports
 //! no stacks, so the stack HTTP endpoints return empty results.
 
-use std::sync::Mutex;
-
 use serde_json::Value;
 
 use crate::Result;
@@ -39,23 +37,14 @@ impl StackProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn StackProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn StackProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the stack provider. Called once at startup by the stack layer.
-pub fn register_stack_provider(provider: Box<dyn StackProvider>) {
-    let mut slot = provider_slot().lock().expect("stack provider lock");
-    *slot = Some(provider);
-}
-
-fn with_provider<T>(f: impl FnOnce(&dyn StackProvider) -> T) -> T {
-    let slot = provider_slot().lock().expect("stack provider lock");
-    match slot.as_deref() {
-        Some(provider) => f(provider),
-        None => f(&NoopProvider),
-    }
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn StackProvider,
+    noop: NoopProvider,
+    /// Register the stack provider. Called once at startup by the stack layer.
+    register: pub fn register_stack_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 pub(crate) fn stack_list_json() -> Result<Value> {

--- a/crates/homeboy-core/src/workspace_snapshot.rs
+++ b/crates/homeboy-core/src/workspace_snapshot.rs
@@ -11,7 +11,6 @@
 //! [`NoopProvider`] errors clearly.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use crate::error::{Error, Result};
 
@@ -43,18 +42,15 @@ impl WorkspaceSnapshotProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn WorkspaceSnapshotProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn WorkspaceSnapshotProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the workspace-snapshot provider. Called once at startup by the
-/// runner subsystem when it is present.
-pub fn register_workspace_snapshot_provider(provider: Box<dyn WorkspaceSnapshotProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("workspace snapshot provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn WorkspaceSnapshotProvider,
+    noop: NoopProvider,
+    /// Register the workspace-snapshot provider. Called once at startup by the
+    /// runner subsystem when it is present.
+    register: pub fn register_workspace_snapshot_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// Copy a local directory snapshot into `destination`, delegating to the
@@ -64,11 +60,5 @@ pub(crate) fn copy_snapshot_to_directory(
     destination: &Path,
     excludes: &[String],
 ) -> Result<()> {
-    let slot = provider_slot()
-        .lock()
-        .expect("workspace snapshot provider lock");
-    match slot.as_deref() {
-        Some(provider) => provider.copy_snapshot_to_directory(local_path, destination, excludes),
-        None => NoopProvider.copy_snapshot_to_directory(local_path, destination, excludes),
-    }
+    with_provider(|p| p.copy_snapshot_to_directory(local_path, destination, excludes))
 }

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -21,6 +21,7 @@ pub mod language;
 pub mod local_files;
 pub mod output_parse;
 pub mod phase_timing;
+pub mod provider_registry;
 pub mod shell;
 pub mod template;
 pub mod test_path;

--- a/crates/homeboy-engine-primitives/src/provider_registry.rs
+++ b/crates/homeboy-engine-primitives/src/provider_registry.rs
@@ -194,7 +194,7 @@ macro_rules! __provider_registry_slot {
 
 #[cfg(test)]
 mod tests {
-    trait Greeter: Send + Sync {
+    pub(crate) trait Greeter: Send + Sync {
         fn greet(&self) -> String;
     }
 
@@ -218,7 +218,7 @@ mod tests {
         provider: dyn Greeter,
         noop: NoopGreeter,
         /// Register the greeter used by this test module.
-        register: pub fn register_greeter,
+        register: pub(crate) fn register_greeter,
         with: fn with_greeter,
     }
 

--- a/crates/homeboy-engine-primitives/src/provider_registry.rs
+++ b/crates/homeboy-engine-primitives/src/provider_registry.rs
@@ -1,0 +1,244 @@
+//! Declarative process-global provider registries.
+//!
+//! Homeboy inverts a lot of subsystem behavior behind "provider" hooks: a leaf
+//! layer declares a trait plus a no-op implementation, an owning layer registers
+//! a real implementation at startup, and the leaf layer dispatches through a
+//! process-global slot. The registry half of that pattern — the `static`
+//! `Mutex<Option<_>>` slot, the `register_*` entry point, and the accessor that
+//! falls back to the no-op — is pure ceremony and was hand-copied across ~35
+//! modules in five crates.
+//!
+//! The copies drifted. Roughly two thirds reached for
+//! `.expect("... provider lock")`, which turns a poisoned registry lock into a
+//! process abort; the rest used
+//! `.unwrap_or_else(|poisoned| poisoned.into_inner())`, which recovers. The
+//! choice tracked whichever file happened to be copied, not any deliberate
+//! policy.
+//!
+//! These macros define that policy once: **a poisoned provider-registry lock
+//! always recovers via `into_inner()`.** The registry slot holds a `Box`/`Arc`
+//! trait object and nothing else; a panic elsewhere in the process cannot leave
+//! it in a torn state, so refusing to hand it out — and taking the process down
+//! with it — is strictly worse than handing back the provider that is still
+//! perfectly valid.
+//!
+//! What the macros deliberately do **not** own: the trait itself, the no-op
+//! implementation, and the per-method dispatch functions. Those carry the real
+//! per-site meaning (and their doc comments), so they stay hand-written and the
+//! macro stays a two-form, no-knob tool.
+//!
+//! # Forms
+//!
+//! `provider_registry!` — boxed provider with a no-op fallback. Generates a
+//! private slot accessor, the registration entry point, and a `with_*` accessor
+//! that runs a closure against the registered provider or the no-op:
+//!
+//! ```ignore
+//! homeboy_engine_primitives::provider_registry! {
+//!     provider: dyn StackProvider,
+//!     noop: NoopProvider,
+//!     /// Register the stack provider. Called once at startup by the stack layer.
+//!     register: pub fn register_stack_provider,
+//!     with: fn with_provider,
+//! }
+//!
+//! pub(crate) fn stack_list_json() -> Result<Value> {
+//!     with_provider(|p| p.stack_list_json())
+//! }
+//! ```
+//!
+//! `provider_registry!` with `with_optional:` — boxed provider with **no** no-op
+//! implementation, for registries whose dispatch functions each return their own
+//! "subsystem absent" error. The accessor yields `Option<&dyn Trait>`.
+//!
+//! `provider_registry_arc!` — `Arc` provider whose accessor clones the `Arc`
+//! out, so the registry lock is released before a (potentially long-running)
+//! call. Used where holding the lock across the call would serialize real work.
+
+/// Declare a process-global boxed provider registry.
+///
+/// See the [module docs](self) for the full rationale. Two forms:
+///
+/// - `noop: <expr>` + `with:` — accessor runs the closure against the
+///   registered provider or the no-op.
+/// - `with_optional:` (no `noop:`) — accessor runs the closure against
+///   `Option<&dyn Trait>` so each dispatch function supplies its own fallback.
+///
+/// A poisoned lock always recovers via `into_inner()`.
+#[macro_export]
+macro_rules! provider_registry {
+    (
+        provider: dyn $provider:path,
+        noop: $noop:expr,
+        $(#[$register_meta:meta])*
+        register: $register_vis:vis fn $register:ident,
+        $(#[$with_meta:meta])*
+        with: $with_vis:vis fn $with:ident $(,)?
+    ) => {
+        $crate::__provider_registry_slot!($provider);
+
+        $(#[$register_meta])*
+        $register_vis fn $register(provider: ::std::boxed::Box<dyn $provider>) {
+            let mut slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *slot = ::std::option::Option::Some(provider);
+        }
+
+        $(#[$with_meta])*
+        $with_vis fn $with<__ProviderRegistryOut>(
+            f: impl ::std::ops::FnOnce(&dyn $provider) -> __ProviderRegistryOut,
+        ) -> __ProviderRegistryOut {
+            let slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            match slot.as_deref() {
+                ::std::option::Option::Some(provider) => f(provider),
+                ::std::option::Option::None => f(&$noop),
+            }
+        }
+    };
+
+    (
+        provider: dyn $provider:path,
+        $(#[$register_meta:meta])*
+        register: $register_vis:vis fn $register:ident,
+        $(#[$with_meta:meta])*
+        with_optional: $with_vis:vis fn $with:ident $(,)?
+    ) => {
+        $crate::__provider_registry_slot!($provider);
+
+        $(#[$register_meta])*
+        $register_vis fn $register(provider: ::std::boxed::Box<dyn $provider>) {
+            let mut slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *slot = ::std::option::Option::Some(provider);
+        }
+
+        $(#[$with_meta])*
+        $with_vis fn $with<__ProviderRegistryOut>(
+            f: impl ::std::ops::FnOnce(
+                ::std::option::Option<&dyn $provider>,
+            ) -> __ProviderRegistryOut,
+        ) -> __ProviderRegistryOut {
+            let slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            f(slot.as_deref())
+        }
+    };
+}
+
+/// Declare a process-global `Arc` provider registry whose accessor clones the
+/// `Arc` out before returning, releasing the registry lock so it is not held
+/// across the provider call.
+///
+/// A poisoned lock always recovers via `into_inner()`.
+#[macro_export]
+macro_rules! provider_registry_arc {
+    (
+        provider: dyn $provider:path,
+        noop: $noop:expr,
+        $(#[$register_meta:meta])*
+        register: $register_vis:vis fn $register:ident,
+        $(#[$active_meta:meta])*
+        active: $active_vis:vis fn $active:ident $(,)?
+    ) => {
+        fn provider_slot() -> &'static ::std::sync::Mutex<
+            ::std::option::Option<::std::sync::Arc<dyn $provider>>,
+        > {
+            static PROVIDER: ::std::sync::Mutex<
+                ::std::option::Option<::std::sync::Arc<dyn $provider>>,
+            > = ::std::sync::Mutex::new(::std::option::Option::None);
+            &PROVIDER
+        }
+
+        $(#[$register_meta])*
+        $register_vis fn $register(provider: ::std::sync::Arc<dyn $provider>) {
+            let mut slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *slot = ::std::option::Option::Some(provider);
+        }
+
+        $(#[$active_meta])*
+        $active_vis fn $active() -> ::std::sync::Arc<dyn $provider> {
+            let slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            match slot.as_ref() {
+                ::std::option::Option::Some(provider) => ::std::sync::Arc::clone(provider),
+                ::std::option::Option::None => ::std::sync::Arc::new($noop),
+            }
+        }
+    };
+}
+
+/// Internal: the boxed slot accessor shared by both `provider_registry!` forms.
+/// The `static` lives inside the function body so it cannot collide with any
+/// module-level item at the expansion site.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __provider_registry_slot {
+    ($provider:path) => {
+        fn provider_slot(
+        ) -> &'static ::std::sync::Mutex<::std::option::Option<::std::boxed::Box<dyn $provider>>> {
+            static PROVIDER: ::std::sync::Mutex<
+                ::std::option::Option<::std::boxed::Box<dyn $provider>>,
+            > = ::std::sync::Mutex::new(::std::option::Option::None);
+            &PROVIDER
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    trait Greeter: Send + Sync {
+        fn greet(&self) -> String;
+    }
+
+    struct NoopGreeter;
+
+    impl Greeter for NoopGreeter {
+        fn greet(&self) -> String {
+            "noop".to_string()
+        }
+    }
+
+    struct RealGreeter;
+
+    impl Greeter for RealGreeter {
+        fn greet(&self) -> String {
+            "real".to_string()
+        }
+    }
+
+    crate::provider_registry! {
+        provider: dyn Greeter,
+        noop: NoopGreeter,
+        /// Register the greeter used by this test module.
+        register: pub fn register_greeter,
+        with: fn with_greeter,
+    }
+
+    // One test: the registry is a process global, so splitting these would make
+    // them order-dependent on each other.
+    #[test]
+    fn falls_back_to_noop_registers_and_survives_a_poisoned_lock() {
+        assert_eq!(with_greeter(|g| g.greet()), "noop");
+
+        register_greeter(Box::new(RealGreeter));
+        assert_eq!(with_greeter(|g| g.greet()), "real");
+
+        // Poison the slot from a panicking thread, then prove the accessor
+        // still hands the provider back instead of taking the process down.
+        let _ = std::thread::spawn(|| {
+            let _guard = provider_slot().lock().unwrap();
+            panic!("poison the registry lock");
+        })
+        .join();
+        assert!(provider_slot().is_poisoned());
+        assert_eq!(with_greeter(|g| g.greet()), "real");
+    }
+}

--- a/crates/homeboy-extension/src/bench/report/comparison/agent_task_matrix_provider.rs
+++ b/crates/homeboy-extension/src/bench/report/comparison/agent_task_matrix_provider.rs
@@ -10,7 +10,6 @@
 //! provider produces no matrix, and the comparison report simply omits it.
 
 use std::collections::BTreeMap;
-use std::sync::Mutex;
 
 use serde_json::Value;
 
@@ -44,18 +43,15 @@ impl BenchAgentTaskMatrixProvider for NoopProvider {
     }
 }
 
-fn provider_slot() -> &'static Mutex<Option<Box<dyn BenchAgentTaskMatrixProvider>>> {
-    static PROVIDER: Mutex<Option<Box<dyn BenchAgentTaskMatrixProvider>>> = Mutex::new(None);
-    &PROVIDER
-}
-
-/// Register the bench agent-task matrix provider. Called once at startup by the
-/// agent-task layer.
-pub fn register_bench_agent_task_matrix_provider(provider: Box<dyn BenchAgentTaskMatrixProvider>) {
-    let mut slot = provider_slot()
-        .lock()
-        .expect("bench agent-task matrix provider lock");
-    *slot = Some(provider);
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn BenchAgentTaskMatrixProvider,
+    noop: NoopProvider,
+    /// Register the bench agent-task matrix provider. Called once at startup by the
+    /// agent-task layer.
+    register: pub fn register_bench_agent_task_matrix_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none
+    /// is registered.
+    with: fn with_provider,
 }
 
 /// The agent-task matrix (plan + aggregate as JSON) for a bench comparison, via
@@ -66,13 +62,5 @@ pub(crate) fn bench_agent_task_matrix(
     entries: &[RigBenchEntry],
     axes_by_rig: &BTreeMap<String, BTreeMap<String, String>>,
 ) -> Option<(Value, Value)> {
-    let slot = provider_slot()
-        .lock()
-        .expect("bench agent-task matrix provider lock");
-    match slot.as_deref() {
-        Some(provider) => {
-            provider.bench_agent_task_matrix(component, iterations, entries, axes_by_rig)
-        }
-        None => NoopProvider.bench_agent_task_matrix(component, iterations, entries, axes_by_rig),
-    }
+    with_provider(|p| p.bench_agent_task_matrix(component, iterations, entries, axes_by_rig))
 }

--- a/crates/homeboy-upgrade/Cargo.toml
+++ b/crates/homeboy-upgrade/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
+++ b/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
@@ -9,7 +9,6 @@
 //! [`NoopRunnerUpgradeProvider`] reports no upgrades and no build identity.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use crate::upgrade::{ExtensionUpgradeEntry, InstallMethod, RunnerUpgradeEntry};
 use homeboy_core::error::Result;
@@ -59,25 +58,13 @@ impl RunnerUpgradeProvider for NoopRunnerUpgradeProvider {
     }
 }
 
-static PROVIDER: Mutex<Option<Box<dyn RunnerUpgradeProvider>>> = Mutex::new(None);
-
-/// Register the runner-upgrade provider. Called once at startup by the runner
-/// layer (via the CLI).
-pub fn register_runner_upgrade_provider(provider: Box<dyn RunnerUpgradeProvider>) {
-    let mut guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
-}
-
-/// Run `f` against the registered provider, or the no-op provider if none is
-/// registered.
-pub(crate) fn with_runner_upgrade<T>(f: impl FnOnce(&dyn RunnerUpgradeProvider) -> T) -> T {
-    let guard = PROVIDER
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match guard.as_ref() {
-        Some(provider) => f(provider.as_ref()),
-        None => f(&NoopRunnerUpgradeProvider),
-    }
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RunnerUpgradeProvider,
+    noop: NoopRunnerUpgradeProvider,
+    /// Register the runner-upgrade provider. Called once at startup by the runner
+    /// layer (via the CLI).
+    register: pub fn register_runner_upgrade_provider,
+    /// Run `f` against the registered provider, or the no-op provider if none is
+    /// registered.
+    with: pub(crate) fn with_runner_upgrade,
 }


### PR DESCRIPTION
Mechanical de-duplication of the process-global provider-registry pattern.

`Closes #10293`

## Why this is not cosmetic: the copies drifted on failure policy

The registry ceremony (`static Mutex<Option<Box<dyn _>>>` slot + `register_*()` +
a no-op-falling-back accessor) was hand-copied ~35 times. The copies split on
what happens when the registry lock is poisoned:

| Policy | Sites | Effect |
|---|---|---|
| `.expect("... provider lock")` | ~24 | **panics** — one provider that panicked while holding the lock takes the process down on the next access |
| `.unwrap_or_else(\|poisoned\| poisoned.into_inner())` | ~13 | **recovers** |

Compare `agent_task_secret_provider.rs` against `recorded_artifacts.rs`: same
abstraction, opposite failure policy, chosen by whichever file was copied.

## ⚠️ Behavior change: lock poisoning is now uniformly *recovering*

**This PR picks `into_inner()` recovery for every registry, converting a panic
into a recovery at ~24 sites.** The rationale: a registry slot holds nothing but
a trait object. There is no torn invariant for poisoning to protect. Refusing to
hand the provider back — and aborting the process — is strictly worse than
returning the provider, which is still perfectly valid. Reviewers who disagree
should say so here; it is the one intentional semantic change in the PR.

Every other change is signature- and symbol-preserving: no `register_*` caller
was touched.

## Host crate: `homeboy-engine-primitives`

The macro must be reachable from `homeboy-code-audit`, `homeboy-upgrade` and
`homeboy-extension` **without** a `homeboy-core` dependency (that would be a
cycle — core must not be depended on by the crates it inverts behavior out to).

`homeboy-engine-primitives` is a leaf (`homeboy-error` + `homeboy-paths` +
serde/regex only). `homeboy-core`, `homeboy-code-audit` and `homeboy-extension`
already depend on it; `homeboy-agents` and `homeboy-upgrade` gain a direct
dependency here. Since it is already compiled for core/extension in every build,
this adds no compile unit and no cycle risk. `macro_rules!` needs no runtime
support from its host, so nothing else came along with it.

## Variation catalogue

What the survey (`grep -rn 'static PROVIDER|provider_slot|adapter_slot|driver_slot'`)
actually found, and how each axis was handled:

| Axis | Variants observed | Handling |
|---|---|---|
| Container | `Box` (32) / `Arc` (3) | two macros; `Arc` form clones out before calling |
| Slot access | `fn provider_slot()` wrapper (23) / inlined `static PROVIDER` (12) | macro always generates the wrapper, `static` scoped inside its body |
| Dispatch | per-fn inline `lock()` + `match` (24) / `with_provider(\|p\| …)` closure (11) | closure form for all; per-method fns collapse to one-liners |
| Trait size | 1 method (most) … 12 methods (`release_provider`) | irrelevant — the macro owns no methods |
| No-op body | `Ok(None)` / `Ok(default)` / `Vec::new()` / `Err(...)` / a diagnostic | left hand-written, passed in as `noop:` |
| No-op **absent** | 3 sites (component build/install/script runners) — each dispatch fn returns its own "extension subsystem not available" error | second form `with_optional:` yields `Option<&dyn Trait>` |
| Return types | plain values, `Option`, `Result`, `Result<_, String>`, tuples | irrelevant — generic over the closure's return |
| Accessor visibility | private / `pub(crate)` / `pub` | `$vis` metavariable |
| No-op type name | `NoopProvider` / `NoopRunnerExecDriver` / `NoopLabWorkspaceProvenanceProvider` / … | caller-supplied |
| Extra per-site items | `has_runner_evidence_provider()`, test-support reset + RAII guard, `with_provider` closure helper | kept hand-written where meaningful (see below) |

Deliberate scope limit: the macros own **only** the registry. The trait, the
no-op implementation, and the per-method dispatch functions stay hand-written —
they carry the real per-site meaning and their doc comments. That keeps the
macro at two forms with no optional knobs rather than the six-knob monster that
covering the no-op bodies would have required.

## Converted: 35 of 35 candidates → 33 converted, 2 left alone

| Crate | Converted | Notes |
|---|---|---|
| `homeboy-core` | 22 | 17 boxed+no-op, 3 `with_optional`, 2 `Arc` |
| `homeboy-code-audit` | 7 | already recovering — behavior-preserving |
| `homeboy-agents` | 2 | |
| `homeboy-extension` | 1 | |
| `homeboy-upgrade` | 1 | already recovering |
| **Total** | **33** | |

### Left hand-written on purpose

- **`homeboy-lab-runner/src/lab_staging_controller.rs` `adapter_slot()`** — `Arc`
  with **no** no-op, and two bespoke accessors: `require_production_adapter() ->
  Result<Arc<_>>` and `routing_ready() -> bool`. Covering it would need a third
  macro form (optional-`Arc`) for exactly one site. Not worth it; this is the
  "don't force it" line. It is the only remaining `Mutex<Option<{Box,Arc}<dyn _>>>`
  in the tree.
- **`homeboy-core/src/daemon/controller_job_driver.rs`** — not the same
  abstraction. A keyed `HashMap<(job_type, version), Arc<dyn _>>` registry with
  duplicate-registration rejection, not a single slot.
- Near-misses excluded by the survey: `artifact_dom_boxes.rs` `PROVIDER_ENV_LOCK`
  (a `Mutex<()>` test env lock that only shares the name prefix),
  `cli_resolver.rs` (concrete struct behind `RwLock`, not a trait object),
  `agent_task_provider/catalog.rs` (`OnceLock<RwLock<Catalog>>`).

### Divergences dissolved rather than preserved

- `compiler_warning_provider.rs` had grown a bespoke `with_provider` closure
  helper the other copies lacked — that is now exactly what the macro generates.
- `compiler_warning_provider.rs` and `recorded_artifacts.rs` had skipped the slot
  accessor and inlined the `static`; both now use the shared shape.
- `runner_evidence.rs` keeps `has_runner_evidence_provider()` hand-written, since
  `with_runner_evidence()` cannot distinguish a registered provider from the no-op
  fallback. It reads the generated `provider_slot()` directly.
- `runner_continuation.rs` keeps its `#[cfg(test-support)]` reset helper and RAII
  guard; they call the generated `provider_slot()`.

## LOC delta

`37 files changed, 579 insertions(+), 718 deletions(-)` → **net −139 lines**,
and that is *after* adding ~200 lines of macro definition, module documentation
and a unit test. Excluding the new `provider_registry.rs`, the conversion
removes roughly **340 lines of duplicated ceremony**.

## Review order

One commit per crate batch, so a bad conversion is bisectable:

1. `refactor(engine-primitives)` — the macros + `homeboy-code-audit` (7 sites,
   behavior-preserving: these already recovered)
2. `refactor(core)` — 22 sites
3. `refactor(agents,extension,upgrade)` — 4 sites + 2 `Cargo.toml` deps

## Validation

`cargo fmt` clean. Full build/test is left to CI per repo policy — this VPS
cannot run a homeboy `cargo build` without OOM-killing co-resident services.
The correctness bar is that no public signature or symbol changed, so every
existing `register_*()` caller must still compile unchanged.
