### PR TITLE
feat(rig): repair shared paths and services, not just symlinks

### DIFF
--- a/crates/homeboy-cli/src/commands/rig/output.rs
+++ b/crates/homeboy-cli/src/commands/rig/output.rs
@@ -87,7 +87,7 @@ pub struct RigSourceSummary {
 pub struct RigShowOutput {
     pub command: &'static str,
     pub rig: RigSpec,
-    #[serde(skip_serializing_if = "RigResourcesSpec::is_empty")]
+    #[serde(skip_serializing_if = "RigResourcesSpec::is_unset")]
     pub resources: RigResourcesSpec,
 }
 
@@ -215,6 +215,7 @@ mod tests {
                 paths: vec!["/Users/user/Developer/studio".to_string()],
                 ports: vec![9724],
                 process_patterns: vec!["wordpress-server-child.mjs".to_string()],
+                ..Default::default()
             },
         };
 

--- a/crates/homeboy-cli/src/commands/runs/resources.rs
+++ b/crates/homeboy-cli/src/commands/runs/resources.rs
@@ -904,6 +904,7 @@ mod tests {
             paths: vec!["/tmp/homeboy-studio".to_string()],
             ports: vec![9724],
             process_patterns: vec!["app-server-child.mjs".to_string()],
+            ..Default::default()
         }
     }
 

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -97,12 +97,13 @@ pub use spec::{
     DependencyMaterializationStepSpec, DiscoverSpec, ExecutableRequirementSpec,
     FilesystemAssertionKind, FilesystemAssertionSpec, NewerThanSpec,
     NormalizedDependencyMaterializationStep, PatchOp, PipelineStep, RigRequirementsSpec,
-    RigResourcesSpec, RigSpec, RunnerToolRequirementSpec, ServiceKind, ServiceSpec, SharedPathOp,
-    SharedPathSpec, StackOp, SymlinkSpec, TimeSource, TraceConfig, TraceDependencySpec,
-    TraceExperimentArtifactSpec, TraceExperimentCommandSpec, TraceExperimentSpec,
-    TraceGuardrailSpec, TraceNativePublicPreviewSpec, TracePhaseTemplateSpec,
+    RigResourceRetentionSpec, RigResourcesSpec, RigSpec, RunnerToolRequirementSpec, ServiceKind,
+    ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource, TraceConfig,
+    TraceDependencySpec, TraceExperimentArtifactSpec, TraceExperimentCommandSpec,
+    TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec, TracePhaseTemplateSpec,
     TracePreviewAssetFanoutSpec, TraceProfileSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
-    TraceVariantSpec, WorkloadSpec,
+    TraceVariantSpec, WorkloadSpec, RIG_RESOURCE_CLASSES, RIG_RESOURCE_CLASS_EXCLUSIVE,
+    RIG_RESOURCE_CLASS_PATHS, RIG_RESOURCE_CLASS_PORTS, RIG_RESOURCE_CLASS_PROCESS_PATTERNS,
 };
 pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,

--- a/crates/homeboy-rig/src/lint.rs
+++ b/crates/homeboy-rig/src/lint.rs
@@ -521,6 +521,7 @@ fn portability_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
             continue;
         };
         failures.extend(shared_path_failures(root, file, &value));
+        failures.extend(resource_retention_failures(root, file, &value));
     }
 
     Ok(failures)
@@ -581,6 +582,66 @@ fn shared_path_failures(root: &Path, file: &Path, rig: &serde_json::Value) -> Ve
         }
     }
     failures
+}
+
+/// `delete_after_ttl` without a `ttl` is contract-invalid: the lifecycle record
+/// would fail validation and the run's whole lifecycle index would be dropped.
+/// Catch it at lint time instead of losing the artifact at runtime.
+fn resource_retention_failures(root: &Path, file: &Path, rig: &serde_json::Value) -> Vec<String> {
+    let rel = display_relative(root, file);
+    let Some(resources) = rig.get("resources").and_then(|value| value.as_object()) else {
+        return Vec::new();
+    };
+
+    let mut failures = Vec::new();
+
+    if let Some(lifecycle) = resources.get("lifecycle") {
+        failures.extend(retention_failure(&rel, "resources.lifecycle", lifecycle));
+    }
+    if let Some(by_class) = resources.get("lifecycle_by_class") {
+        match by_class.as_object() {
+            Some(classes) => {
+                for (class, retention) in classes {
+                    if !crate::spec::RIG_RESOURCE_CLASSES.contains(&class.as_str()) {
+                        failures.push(format!(
+                            "{rel}: resources.lifecycle_by_class has unknown resource class '{class}'"
+                        ));
+                        continue;
+                    }
+                    failures.extend(retention_failure(
+                        &rel,
+                        &format!("resources.lifecycle_by_class.{class}"),
+                        retention,
+                    ));
+                }
+            }
+            None => failures.push(format!(
+                "{rel}: resources.lifecycle_by_class must be an object"
+            )),
+        }
+    }
+
+    failures
+}
+
+fn retention_failure(rel: &str, label: &str, retention: &serde_json::Value) -> Option<String> {
+    let Some(object) = retention.as_object() else {
+        return Some(format!("{rel}: {label} must be an object"));
+    };
+    let policy = object
+        .get("cleanup_policy")
+        .and_then(|value| value.as_str());
+    let ttl = object
+        .get("ttl")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|ttl| !ttl.is_empty());
+    if policy == Some("delete_after_ttl") && ttl.is_none() {
+        return Some(format!(
+            "{rel}: {label} declares delete_after_ttl without a ttl"
+        ));
+    }
+    None
 }
 
 fn workload_reference_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
@@ -1228,6 +1289,69 @@ mod tests {
         let error = portability_step.error.as_ref().expect("error");
         assert!(error.contains("~/Developer"));
         assert!(error.contains("shared_paths[0]"));
+    }
+
+    #[test]
+    fn package_lint_reports_delete_after_ttl_without_ttl() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("retention");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "retention",
+                "resources": {
+                    "ports": [9724],
+                    "lifecycle_by_class": {
+                        "ports": {"cleanup_policy": "delete_after_ttl"},
+                        "sockets": {"ttl": "PT1H"}
+                    }
+                }
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let step = portability_step(&outcome);
+
+        assert_eq!(step.status, "fail");
+        let error = step.error.as_ref().expect("error");
+        assert!(error.contains("delete_after_ttl without a ttl"));
+        assert!(error.contains("unknown resource class 'sockets'"));
+    }
+
+    #[test]
+    fn package_lint_accepts_declared_resource_retention() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("retention");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "retention",
+                "resources": {
+                    "ports": [9724],
+                    "lifecycle": {"cleanup_policy": "delete_on_terminal"},
+                    "lifecycle_by_class": {
+                        "ports": {"ttl": "PT1H", "cleanup_policy": "delete_after_ttl"}
+                    }
+                }
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let step = portability_step(&outcome);
+
+        assert!(
+            !step
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("delete_after_ttl"),
+            "a ttl-backed delete_after_ttl declaration is valid: {:?}",
+            step.error
+        );
     }
 
     #[test]

--- a/crates/homeboy-rig/src/pipeline/fs_step.rs
+++ b/crates/homeboy-rig/src/pipeline/fs_step.rs
@@ -335,6 +335,223 @@ fn cleanup_shared_path(
     Ok(())
 }
 
+/// What a single ownership-checked shared-path repair did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SharedPathRepairStatus {
+    /// Drift corrected using the declared `ensure` / `cleanup` ops.
+    Repaired,
+    /// Already healthy — nothing to do.
+    Unchanged,
+    /// Drift this rig must not fix on its own; needs manual attention.
+    Blocked,
+}
+
+/// One shared path's repair outcome, shaped for `RepairResourceReport`.
+#[derive(Debug, Clone)]
+pub(crate) struct SharedPathRepair {
+    pub link: String,
+    pub target: String,
+    pub previous_target: Option<String>,
+    pub status: SharedPathRepairStatus,
+    pub detail: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Repair declared shared paths without running the `up` pipeline.
+///
+/// This is the same ownership contract as `SharedPathOp::Ensure` /
+/// `SharedPathOp::Cleanup`: only links this rig created and still owns are
+/// removed, real files and directories are never touched, and a symlink owned
+/// by something else is reported rather than replaced.
+pub(crate) fn repair_shared_paths(rig: &RigSpec) -> Result<Vec<SharedPathRepair>> {
+    if rig.shared_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut state = RigState::load(&rig.id)?;
+    let mut state_changed = false;
+    let mut repairs = Vec::with_capacity(rig.shared_paths.len());
+
+    for shared in &rig.shared_paths {
+        repairs.push(repair_shared_path(
+            rig,
+            shared,
+            &mut state,
+            &mut state_changed,
+        )?);
+    }
+
+    if state_changed {
+        state.save(&rig.id)?;
+    }
+    Ok(repairs)
+}
+
+fn repair_shared_path(
+    rig: &RigSpec,
+    shared: &SharedPathSpec,
+    state: &mut RigState,
+    state_changed: &mut bool,
+) -> Result<SharedPathRepair> {
+    let (link_path, target_path) = resolve_shared_paths(rig, shared);
+    let key = shared_path_key(&link_path);
+    let link = link_path.to_string_lossy().into_owned();
+    let target = target_path.to_string_lossy().into_owned();
+    let owned_target = state
+        .shared_paths
+        .get(&key)
+        .map(|owned| PathBuf::from(&owned.target));
+
+    let outcome = |status, previous_target, detail: &str, error: Option<String>| SharedPathRepair {
+        link: link.clone(),
+        target: target.clone(),
+        previous_target,
+        status,
+        detail: Some(detail.to_string()),
+        error,
+    };
+
+    match std::fs::symlink_metadata(&link_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let current = std::fs::read_link(&link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!("read {}: {}", link_path.display(), e),
+                )
+            })?;
+            let rig_owns_link = owned_target.as_ref().is_some_and(|owned| owned == &current);
+            let previous = current.to_string_lossy().into_owned();
+
+            if current == target_path {
+                if target_path.exists() {
+                    return Ok(outcome(
+                        SharedPathRepairStatus::Unchanged,
+                        Some(previous),
+                        "shared path links to its declared target",
+                        None,
+                    ));
+                }
+                if !rig_owns_link {
+                    return Ok(outcome(
+                        SharedPathRepairStatus::Blocked,
+                        Some(previous),
+                        "shared target is missing behind a link this rig does not own",
+                        Some(format!(
+                            "shared target {} does not exist; repair only removes links it created",
+                            target_path.display()
+                        )),
+                    ));
+                }
+                // Rig-owned link to a target that vanished: `cleanup` removes
+                // only what we created, leaving an honest missing dependency
+                // instead of a dangling link.
+                cleanup_shared_path(rig, shared, state, state_changed)?;
+                return Ok(outcome(
+                    SharedPathRepairStatus::Repaired,
+                    Some(previous),
+                    "removed rig-owned link to a target that no longer exists",
+                    None,
+                ));
+            }
+
+            if !rig_owns_link {
+                return Ok(outcome(
+                    SharedPathRepairStatus::Blocked,
+                    Some(previous),
+                    "shared path points somewhere this rig did not link it",
+                    Some(format!(
+                        "{} points at {}, expected {}; repair will not replace a symlink it does not own",
+                        link_path.display(),
+                        current.display(),
+                        target_path.display()
+                    )),
+                ));
+            }
+
+            // Declared target moved. Drop the link we own, then re-ensure.
+            cleanup_shared_path(rig, shared, state, state_changed)?;
+            match ensure_after_cleanup(rig, shared, &target_path, state, state_changed) {
+                Ok(()) => Ok(outcome(
+                    SharedPathRepairStatus::Repaired,
+                    Some(previous),
+                    "relinked rig-owned shared path to its declared target",
+                    None,
+                )),
+                Err(error) => Ok(outcome(
+                    SharedPathRepairStatus::Blocked,
+                    Some(previous),
+                    "removed the drifted rig-owned link but could not relink it",
+                    Some(error),
+                )),
+            }
+        }
+        Ok(_) => {
+            // A real file or directory satisfies the dependency. Never remove
+            // it — just drop a stale ownership record if we still hold one.
+            if state.shared_paths.remove(&key).is_some() {
+                *state_changed = true;
+                return Ok(outcome(
+                    SharedPathRepairStatus::Repaired,
+                    None,
+                    "cleared a stale ownership record for a real path at the link location",
+                    None,
+                ));
+            }
+            Ok(outcome(
+                SharedPathRepairStatus::Unchanged,
+                None,
+                "a real path already satisfies the shared dependency",
+                None,
+            ))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let stale_record = state.shared_paths.remove(&key).is_some();
+            if stale_record {
+                *state_changed = true;
+            }
+            match ensure_after_cleanup(rig, shared, &target_path, state, state_changed) {
+                Ok(()) => Ok(outcome(
+                    SharedPathRepairStatus::Repaired,
+                    None,
+                    "recreated the missing shared path link",
+                    None,
+                )),
+                Err(error) => Ok(outcome(
+                    SharedPathRepairStatus::Blocked,
+                    None,
+                    "shared path is missing and cannot be recreated safely",
+                    Some(error),
+                )),
+            }
+        }
+        Err(e) => Ok(outcome(
+            SharedPathRepairStatus::Blocked,
+            None,
+            "shared path could not be inspected",
+            Some(format!("stat {}: {}", link_path.display(), e)),
+        )),
+    }
+}
+
+/// Run the declared `ensure` op for one shared path, reporting why it could not
+/// run instead of failing the whole repair.
+fn ensure_after_cleanup(
+    rig: &RigSpec,
+    shared: &SharedPathSpec,
+    target_path: &Path,
+    state: &mut RigState,
+    state_changed: &mut bool,
+) -> std::result::Result<(), String> {
+    if !target_path.exists() {
+        return Err(format!(
+            "shared target {} does not exist",
+            target_path.display()
+        ));
+    }
+    ensure_shared_path(rig, shared, state, state_changed).map_err(|error| error.to_string())
+}
+
 fn resolve_shared_paths(rig: &RigSpec, shared: &SharedPathSpec) -> (PathBuf, PathBuf) {
     (
         PathBuf::from(expand_vars(rig, &shared.link)),

--- a/crates/homeboy-rig/src/pipeline/mod.rs
+++ b/crates/homeboy-rig/src/pipeline/mod.rs
@@ -140,6 +140,8 @@ pub fn cleanup_shared_paths(rig: &RigSpec) -> Result<()> {
     fs_step::cleanup_shared_paths(rig)
 }
 
+pub(super) use fs_step::{repair_shared_paths, SharedPathRepair, SharedPathRepairStatus};
+
 fn run_ordered_steps(
     rig: &RigSpec,
     name: &str,

--- a/crates/homeboy-rig/src/resource_lifecycle.rs
+++ b/crates/homeboy-rig/src/resource_lifecycle.rs
@@ -4,7 +4,10 @@ use homeboy_core::resource_lifecycle_index::{
     ResourceLifecycleRecord, ResourceLifecycleResourceStatus, RESOURCE_LIFECYCLE_INDEX_SCHEMA,
 };
 
-use super::spec::RigResourcesSpec;
+use super::spec::{
+    RigResourceRetentionSpec, RigResourcesSpec, RIG_RESOURCE_CLASS_EXCLUSIVE,
+    RIG_RESOURCE_CLASS_PATHS, RIG_RESOURCE_CLASS_PORTS, RIG_RESOURCE_CLASS_PROCESS_PATTERNS,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RigResourceLifecycleOptions {
@@ -45,21 +48,29 @@ pub fn rig_resource_lifecycle_records(
 ) -> Vec<ResourceLifecycleRecord> {
     let mut records = Vec::new();
 
+    let exclusive_retention = resources.retention_for_class(RIG_RESOURCE_CLASS_EXCLUSIVE);
+    let path_retention = resources.retention_for_class(RIG_RESOURCE_CLASS_PATHS);
+    let port_retention = resources.retention_for_class(RIG_RESOURCE_CLASS_PORTS);
+    let process_pattern_retention =
+        resources.retention_for_class(RIG_RESOURCE_CLASS_PROCESS_PATTERNS);
+
     for token in &resources.exclusive {
         records.push(record(
             &options,
             "rig_exclusive",
             format!("rig://{rig_id}/exclusive/{token}"),
+            &exclusive_retention,
         ));
     }
     for path in &resources.paths {
-        records.push(record(&options, "rig_path", path.clone()));
+        records.push(record(&options, "rig_path", path.clone(), &path_retention));
     }
     for port in &resources.ports {
         records.push(record(
             &options,
             "rig_port",
             format!("tcp://localhost:{port}"),
+            &port_retention,
         ));
     }
     for pattern in &resources.process_patterns {
@@ -67,6 +78,7 @@ pub fn rig_resource_lifecycle_records(
             &options,
             "rig_process_pattern",
             format!("process-pattern:{pattern}"),
+            &process_pattern_retention,
         ));
     }
 
@@ -107,7 +119,9 @@ fn record(
     options: &RigResourceLifecycleOptions,
     kind: &str,
     path: String,
+    retention: &RigResourceRetentionSpec,
 ) -> ResourceLifecycleRecord {
+    let (cleanup_policy, ttl) = resolved_retention(retention);
     ResourceLifecycleRecord {
         owner: options.owner.clone(),
         run_id: options.run_id.clone(),
@@ -115,8 +129,8 @@ fn record(
         path,
         root_bound: None,
         kind: kind.to_string(),
-        ttl: None,
-        cleanup_policy: ResourceCleanupPolicy::Manual,
+        ttl,
+        cleanup_policy,
         evidence_retention: ResourceEvidenceRetention::Metadata,
         cleanup_intent: options.cleanup_intent,
         cleanup_command: Some(format!(
@@ -127,18 +141,46 @@ fn record(
     }
 }
 
+/// Resolve a declared retention into the concrete lifecycle record fields.
+///
+/// Absent declarations keep the historical posture (`manual`, no ttl). A
+/// `delete_after_ttl` policy without a ttl is contract-invalid, and emitting it
+/// would make the whole lifecycle index fail validation and disappear, so it
+/// degrades to `manual` here. `homeboy rig lint` reports the misdeclaration.
+fn resolved_retention(
+    retention: &RigResourceRetentionSpec,
+) -> (ResourceCleanupPolicy, Option<String>) {
+    let ttl = retention
+        .ttl
+        .as_ref()
+        .map(|ttl| ttl.trim().to_string())
+        .filter(|ttl| !ttl.is_empty());
+    let policy = retention
+        .cleanup_policy
+        .unwrap_or(ResourceCleanupPolicy::Manual);
+    if matches!(policy, ResourceCleanupPolicy::DeleteAfterTtl) && ttl.is_none() {
+        return (ResourceCleanupPolicy::Manual, None);
+    }
+    (policy, ttl)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn converts_rig_resource_declarations_to_lifecycle_records() {
-        let resources = RigResourcesSpec {
+    fn fixture_resources() -> RigResourcesSpec {
+        RigResourcesSpec {
             exclusive: vec!["runtime".to_string()],
             paths: vec!["/tmp/homeboy-rig".to_string()],
             ports: vec![9981],
             process_patterns: vec!["homeboy fixture".to_string()],
-        };
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn converts_rig_resource_declarations_to_lifecycle_records() {
+        let resources = fixture_resources();
 
         let index = rig_resource_lifecycle_index(
             "fixture-rig",
@@ -166,12 +208,7 @@ mod tests {
 
     #[test]
     fn propagates_runner_id_to_resource_records() {
-        let resources = RigResourcesSpec {
-            exclusive: vec!["runtime".to_string()],
-            paths: vec!["/tmp/homeboy-rig".to_string()],
-            ports: vec![9981],
-            process_patterns: vec!["homeboy fixture".to_string()],
-        };
+        let resources = fixture_resources();
 
         let mut options =
             RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active);
@@ -200,6 +237,165 @@ mod tests {
             index.resources[0].cleanup_intent,
             ResourceCleanupIntent::Apply
         );
+    }
+
+    /// Non-breaking guarantee: a spec that declares no `ttl`/`cleanup_policy`
+    /// produces byte-identical lifecycle records to the pre-retention behavior
+    /// (`manual`, no ttl) for every resource class.
+    #[test]
+    fn specs_without_retention_declarations_keep_manual_records() {
+        let resources = fixture_resources();
+        assert!(resources.lifecycle.is_empty());
+        assert!(resources.lifecycle_by_class.is_empty());
+
+        let records = rig_resource_lifecycle_records(
+            "fixture-rig",
+            &resources,
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active),
+        );
+
+        assert_eq!(records.len(), 4);
+        for record in &records {
+            assert_eq!(
+                record.cleanup_policy,
+                ResourceCleanupPolicy::Manual,
+                "{} must keep the historical manual policy",
+                record.kind
+            );
+            assert_eq!(record.ttl, None, "{} must keep no ttl", record.kind);
+        }
+    }
+
+    #[test]
+    fn applies_declared_retention_defaults_to_every_class() {
+        let resources = RigResourcesSpec {
+            lifecycle: RigResourceRetentionSpec {
+                ttl: Some("PT1H".to_string()),
+                cleanup_policy: Some(ResourceCleanupPolicy::DeleteAfterTtl),
+            },
+            ..fixture_resources()
+        };
+
+        let index = rig_resource_lifecycle_index(
+            "fixture-rig",
+            &resources,
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active),
+        );
+
+        index.validate().expect("contract-valid lifecycle index");
+        for record in &index.resources {
+            assert_eq!(record.cleanup_policy, ResourceCleanupPolicy::DeleteAfterTtl);
+            assert_eq!(record.ttl.as_deref(), Some("PT1H"));
+        }
+    }
+
+    #[test]
+    fn per_class_retention_overrides_only_its_own_class() {
+        let mut resources = fixture_resources();
+        resources.lifecycle_by_class.insert(
+            RIG_RESOURCE_CLASS_PORTS.to_string(),
+            RigResourceRetentionSpec {
+                ttl: Some("PT1H".to_string()),
+                cleanup_policy: Some(ResourceCleanupPolicy::DeleteAfterTtl),
+            },
+        );
+
+        let index = rig_resource_lifecycle_index(
+            "fixture-rig",
+            &resources,
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active),
+        );
+
+        index.validate().expect("contract-valid lifecycle index");
+        for record in &index.resources {
+            if record.kind == "rig_port" {
+                assert_eq!(record.cleanup_policy, ResourceCleanupPolicy::DeleteAfterTtl);
+                assert_eq!(record.ttl.as_deref(), Some("PT1H"));
+            } else {
+                assert_eq!(record.cleanup_policy, ResourceCleanupPolicy::Manual);
+                assert_eq!(record.ttl, None);
+            }
+        }
+    }
+
+    #[test]
+    fn per_class_retention_inherits_unset_fields_from_the_default() {
+        let mut resources = fixture_resources();
+        resources.lifecycle.ttl = Some("P1D".to_string());
+        resources.lifecycle_by_class.insert(
+            RIG_RESOURCE_CLASS_PORTS.to_string(),
+            RigResourceRetentionSpec {
+                ttl: None,
+                cleanup_policy: Some(ResourceCleanupPolicy::DeleteAfterTtl),
+            },
+        );
+
+        let index = rig_resource_lifecycle_index(
+            "fixture-rig",
+            &resources,
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active),
+        );
+
+        index.validate().expect("contract-valid lifecycle index");
+        let port = index
+            .resources
+            .iter()
+            .find(|record| record.kind == "rig_port")
+            .expect("port record");
+        assert_eq!(port.cleanup_policy, ResourceCleanupPolicy::DeleteAfterTtl);
+        assert_eq!(port.ttl.as_deref(), Some("P1D"));
+    }
+
+    /// `delete_after_ttl` without a ttl is contract-invalid. Degrading to
+    /// `manual` keeps the whole index emittable instead of silently dropping
+    /// every lifecycle record for the run.
+    #[test]
+    fn delete_after_ttl_without_ttl_degrades_to_manual() {
+        let resources = RigResourcesSpec {
+            lifecycle: RigResourceRetentionSpec {
+                ttl: None,
+                cleanup_policy: Some(ResourceCleanupPolicy::DeleteAfterTtl),
+            },
+            ..fixture_resources()
+        };
+
+        let index = rig_resource_lifecycle_index(
+            "fixture-rig",
+            &resources,
+            RigResourceLifecycleOptions::new("run-1", ResourceLifecycleResourceStatus::Active),
+        );
+
+        index.validate().expect("contract-valid lifecycle index");
+        for record in &index.resources {
+            assert_eq!(record.cleanup_policy, ResourceCleanupPolicy::Manual);
+            assert_eq!(record.ttl, None);
+        }
+    }
+
+    #[test]
+    fn retention_declarations_survive_spec_round_trip() {
+        let mut resources = RigResourcesSpec {
+            lifecycle: RigResourceRetentionSpec {
+                ttl: None,
+                cleanup_policy: Some(ResourceCleanupPolicy::DeleteOnTerminal),
+            },
+            ..Default::default()
+        };
+        resources.lifecycle_by_class.insert(
+            RIG_RESOURCE_CLASS_PORTS.to_string(),
+            RigResourceRetentionSpec {
+                ttl: Some("PT1H".to_string()),
+                cleanup_policy: Some(ResourceCleanupPolicy::DeleteAfterTtl),
+            },
+        );
+
+        // No resources declared, but the block still carries information.
+        assert!(resources.is_empty());
+        assert!(!resources.is_unset());
+
+        let json = serde_json::to_string(&resources).expect("serialize");
+        let parsed: RigResourcesSpec = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, resources);
     }
 
     #[test]

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -18,9 +18,9 @@ use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
 use super::lint::run_package_lint;
 use super::pipeline::{
-    cleanup_shared_paths, run_command_step, run_pipeline, run_pipeline_check_groups,
-    run_pipeline_with_settings, run_prepare_requirement_steps, PipelineOutcome,
-    PipelineStepOutcome,
+    cleanup_shared_paths, repair_shared_paths, run_command_step, run_pipeline,
+    run_pipeline_check_groups, run_pipeline_with_settings, run_prepare_requirement_steps,
+    PipelineOutcome, PipelineStepOutcome, SharedPathRepair, SharedPathRepairStatus,
 };
 use super::resource_lifecycle::{
     dependency_materialization_cache_lifecycle_record, rig_resource_lifecycle_index,
@@ -92,6 +92,13 @@ pub struct DownReport {
 }
 
 /// Report from `rig repair`.
+///
+/// Counters partition `resources` by status:
+///
+/// - `repaired` — drift this rig owned and corrected
+/// - `unchanged` — already healthy
+/// - `blocked` — drift that needs manual attention; fails the command
+/// - `skipped` — declared resources `repair` deliberately does not manage
 #[derive(Debug, Clone, Serialize)]
 pub struct RepairReport {
     pub rig_id: String,
@@ -99,6 +106,7 @@ pub struct RepairReport {
     pub repaired: usize,
     pub unchanged: usize,
     pub blocked: usize,
+    pub skipped: usize,
     pub success: bool,
 }
 
@@ -111,9 +119,21 @@ pub struct RepairResourceReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous_target: Option<String>,
     pub status: String,
+    /// Human-readable explanation of what repair did, or why it did not act.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
+
+/// `repaired` — drift this rig owned and corrected.
+pub const REPAIR_STATUS_REPAIRED: &str = "repaired";
+/// `unchanged` — the resource is already healthy.
+pub const REPAIR_STATUS_UNCHANGED: &str = "unchanged";
+/// `blocked` — drift repair refuses to touch; needs manual attention.
+pub const REPAIR_STATUS_BLOCKED: &str = "blocked";
+/// `skipped` — declared, but outside what `repair` manages.
+pub const REPAIR_STATUS_SKIPPED: &str = "skipped";
 
 /// Report from `rig status`.
 #[derive(Debug, Clone, Serialize)]
@@ -690,25 +710,45 @@ pub fn run_down_with_settings(rig: &RigSpec, settings: &[(String, String)]) -> R
 
 /// Repair safe declared drift without running the heavy `up` pipeline.
 ///
-/// v1 intentionally repairs only declared symlinks. It will create missing
-/// symlinks and replace drifted symlinks, but refuses to remove real
-/// files/directories at the link path.
+/// Covered classes, all ownership-checked — repair never removes something
+/// this rig did not create:
+///
+/// - `symlinks` — creates missing links, replaces drifted ones, refuses to
+///   remove a real file or directory at the link path
+/// - `shared_paths` — reuses the declared `ensure` / `cleanup` ops, so only
+///   links this rig created and still owns are removed or relinked
+/// - `services` — clears rig state for a recorded PID that is no longer alive
+///   (`service::stop` is a no-op on a dead PID beyond dropping the record).
+///   Repair never starts services and never signals adopted `external`
+///   processes.
+///
+/// The remaining declared classes — `resources.exclusive`, `resources.paths`,
+/// `resources.ports`, `resources.process_patterns` — are inspected read-only
+/// and reported as `skipped` with the reason, so the coverage gap is visible in
+/// the report rather than silently absent.
 pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
     let _lease = acquire_active_run_lease(rig, "repair")?;
     let mut resources = Vec::new();
+
+    for link in &rig.symlinks {
+        resources.push(repair_symlink(rig, link)?);
+    }
+    resources.extend(repair_rig_shared_paths(rig)?);
+    resources.extend(repair_services(rig)?);
+    resources.extend(report_declared_resources(rig));
+
     let mut repaired = 0;
     let mut unchanged = 0;
     let mut blocked = 0;
-
-    for link in &rig.symlinks {
-        let resource = repair_symlink(rig, link)?;
+    let mut skipped = 0;
+    for resource in &resources {
         match resource.status.as_str() {
-            "repaired" => repaired += 1,
-            "unchanged" => unchanged += 1,
-            "blocked" => blocked += 1,
+            REPAIR_STATUS_REPAIRED => repaired += 1,
+            REPAIR_STATUS_UNCHANGED => unchanged += 1,
+            REPAIR_STATUS_BLOCKED => blocked += 1,
+            REPAIR_STATUS_SKIPPED => skipped += 1,
             _ => {}
         }
-        resources.push(resource);
     }
 
     Ok(RepairReport {
@@ -718,7 +758,173 @@ pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
         repaired,
         unchanged,
         blocked,
+        skipped,
     })
+}
+
+/// Repair declared shared paths through the shared-path ops.
+fn repair_rig_shared_paths(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
+    Ok(repair_shared_paths(rig)?
+        .into_iter()
+        .map(|repair: SharedPathRepair| RepairResourceReport {
+            kind: "shared_path".to_string(),
+            path: repair.link,
+            expected_target: Some(repair.target),
+            previous_target: repair.previous_target,
+            status: match repair.status {
+                SharedPathRepairStatus::Repaired => REPAIR_STATUS_REPAIRED,
+                SharedPathRepairStatus::Unchanged => REPAIR_STATUS_UNCHANGED,
+                SharedPathRepairStatus::Blocked => REPAIR_STATUS_BLOCKED,
+            }
+            .to_string(),
+            detail: repair.detail,
+            error: repair.error,
+        })
+        .collect())
+}
+
+/// Reconcile declared services with live process state.
+///
+/// Only stale rig-recorded PIDs are repaired: the rig wrote that PID, the
+/// process is gone, and the record is drift. Running services are left alone,
+/// stopped services are reported (starting them is `up`'s job), and adopted
+/// `external` services are never signalled — this rig does not own them.
+fn repair_services(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
+    let mut service_ids = rig.services.keys().cloned().collect::<Vec<_>>();
+    service_ids.sort();
+
+    let mut reports = Vec::with_capacity(service_ids.len());
+    for service_id in service_ids {
+        let spec = &rig.services[&service_id];
+        if spec.kind == ServiceKind::External {
+            reports.push(service_resource(
+                &service_id,
+                REPAIR_STATUS_SKIPPED,
+                None,
+                "external services are adopted, not rig-managed; repair does not signal a process this rig did not start",
+                None,
+            ));
+            continue;
+        }
+
+        match service::status(&rig.id, &service_id)? {
+            ServiceStatus::Running(pid) => reports.push(service_resource(
+                &service_id,
+                REPAIR_STATUS_UNCHANGED,
+                Some(pid.to_string()),
+                "service is running",
+                None,
+            )),
+            ServiceStatus::Stale(pid) => {
+                // `stop` on a dead PID only drops the stale state record.
+                service::stop(rig, &service_id)?;
+                reports.push(service_resource(
+                    &service_id,
+                    REPAIR_STATUS_REPAIRED,
+                    Some(pid.to_string()),
+                    "cleared stale rig state for a process that is no longer running",
+                    None,
+                ));
+            }
+            ServiceStatus::Stopped => reports.push(service_resource(
+                &service_id,
+                REPAIR_STATUS_SKIPPED,
+                None,
+                "service is not running; repair does not start services — run `homeboy rig up`",
+                None,
+            )),
+        }
+    }
+    Ok(reports)
+}
+
+fn service_resource(
+    service_id: &str,
+    status: &str,
+    previous_target: Option<String>,
+    detail: &str,
+    error: Option<String>,
+) -> RepairResourceReport {
+    RepairResourceReport {
+        kind: "service".to_string(),
+        path: service_id.to_string(),
+        expected_target: None,
+        previous_target,
+        status: status.to_string(),
+        detail: Some(detail.to_string()),
+        error,
+    }
+}
+
+/// Read-only coverage report for the declarative `resources` block.
+///
+/// These classes have no ownership-safe repair without new infrastructure
+/// (binding ports, signalling matched processes, or creating paths whose shape
+/// the rig never declared). Reporting them keeps the gap tracked instead of
+/// hidden behind a silent skip.
+fn report_declared_resources(rig: &RigSpec) -> Vec<RepairResourceReport> {
+    let mut reports = Vec::new();
+
+    for token in &rig.resources.exclusive {
+        reports.push(declared_resource(
+            "rig_exclusive",
+            expand_vars(rig, token),
+            REPAIR_STATUS_SKIPPED,
+            "exclusive resource tokens are lease-scoped; repair does not adjust rig leases",
+        ));
+    }
+
+    for path in &rig.resources.paths {
+        let expanded = expand_vars(rig, path);
+        let candidate = Path::new(&expanded);
+        let present = candidate.exists() || candidate.is_symlink();
+        reports.push(declared_resource(
+            "rig_path",
+            expanded,
+            if present {
+                REPAIR_STATUS_UNCHANGED
+            } else {
+                REPAIR_STATUS_SKIPPED
+            },
+            if present {
+                "declared resource path is present"
+            } else {
+                "declared resource path is missing; repair does not create paths the rig never described — run `homeboy rig up`"
+            },
+        ));
+    }
+
+    for port in &rig.resources.ports {
+        reports.push(declared_resource(
+            "rig_port",
+            format!("tcp://localhost:{port}"),
+            REPAIR_STATUS_SKIPPED,
+            "port ownership is declarative; repair does not bind, probe, or reclaim ports",
+        ));
+    }
+
+    for pattern in &rig.resources.process_patterns {
+        reports.push(declared_resource(
+            "rig_process_pattern",
+            format!("process-pattern:{}", expand_vars(rig, pattern)),
+            REPAIR_STATUS_SKIPPED,
+            "process-pattern ownership is declarative; repair does not signal matched processes",
+        ));
+    }
+
+    reports
+}
+
+fn declared_resource(kind: &str, path: String, status: &str, detail: &str) -> RepairResourceReport {
+    RepairResourceReport {
+        kind: kind.to_string(),
+        path,
+        expected_target: None,
+        previous_target: None,
+        status: status.to_string(),
+        detail: Some(detail.to_string()),
+        error: None,
+    }
 }
 
 fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceReport> {
@@ -749,7 +955,8 @@ fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceRep
             let previous_target = current.to_string_lossy().into_owned();
             if current == target_path {
                 return Ok(RepairResourceReport {
-                    status: "unchanged".to_string(),
+                    status: REPAIR_STATUS_UNCHANGED.to_string(),
+                    detail: Some("symlink already points at its declared target".to_string()),
                     ..symlink_resource(path, expected_target, Some(previous_target), None)
                 });
             }
@@ -763,12 +970,14 @@ fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceRep
             })?;
             create_repair_symlink(rig, &target_path, &link_path)?;
             Ok(RepairResourceReport {
-                status: "repaired".to_string(),
+                status: REPAIR_STATUS_REPAIRED.to_string(),
+                detail: Some("relinked drifted symlink to its declared target".to_string()),
                 ..symlink_resource(path, expected_target, Some(previous_target), None)
             })
         }
         Ok(_) => Ok(RepairResourceReport {
-            status: "blocked".to_string(),
+            status: REPAIR_STATUS_BLOCKED.to_string(),
+            detail: Some("link path holds a real file or directory".to_string()),
             ..symlink_resource(
                 path,
                 expected_target,
@@ -779,7 +988,8 @@ fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceRep
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             create_repair_symlink(rig, &target_path, &link_path)?;
             Ok(RepairResourceReport {
-                status: "repaired".to_string(),
+                status: REPAIR_STATUS_REPAIRED.to_string(),
+                detail: Some("created missing declared symlink".to_string()),
                 ..symlink_resource(path, expected_target, None, None)
             })
         }
@@ -803,6 +1013,7 @@ fn symlink_resource(
         expected_target: Some(expected_target),
         previous_target,
         status: String::new(),
+        detail: None,
         error,
     }
 }

--- a/crates/homeboy-rig/src/spec.rs
+++ b/crates/homeboy-rig/src/spec.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use homeboy_core::resource_cleanup_intent::ResourceCleanupIntent;
+use homeboy_core::resource_lifecycle_index::ResourceCleanupPolicy;
 use homeboy_extension::trace::TraceProbeConfig;
 use homeboy_extension::trace::TraceSpanMetadata;
 use std::collections::{BTreeMap, HashMap};
@@ -77,7 +78,7 @@ pub struct RigSpec {
     ///
     /// Phase 1 is declarative only: these are parsed, validated by serde, and
     /// displayed for operators. Runtime lock/conflict enforcement is deferred.
-    #[serde(default, skip_serializing_if = "RigResourcesSpec::is_empty")]
+    #[serde(default, skip_serializing_if = "RigResourcesSpec::is_unset")]
     pub resources: RigResourcesSpec,
 
     /// Rig-owned resource lifecycle defaults consumed when Homeboy emits
@@ -298,14 +299,95 @@ pub struct RigResourcesSpec {
     /// Process command-line substrings the rig may stop or inspect.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub process_patterns: Vec<String>,
+
+    /// Lifecycle retention defaults applied to every declared resource class
+    /// when Homeboy emits resource lifecycle index records.
+    ///
+    /// Absent fields keep the historical posture: no `ttl`, `manual` cleanup
+    /// policy, which means an operator reclaims the resource by hand.
+    #[serde(default, skip_serializing_if = "RigResourceRetentionSpec::is_empty")]
+    pub lifecycle: RigResourceRetentionSpec,
+
+    /// Per-class lifecycle overrides keyed by resource class: `exclusive`,
+    /// `paths`, `ports`, `process_patterns`.
+    ///
+    /// Resolution order is override → `lifecycle` default → historical
+    /// `manual`/no-ttl behavior, so a rig can declare "this port lease expires
+    /// after an hour" without changing how its paths are retained.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub lifecycle_by_class: BTreeMap<String, RigResourceRetentionSpec>,
 }
 
+/// Resource class key for [`RigResourcesSpec::exclusive`].
+pub const RIG_RESOURCE_CLASS_EXCLUSIVE: &str = "exclusive";
+/// Resource class key for [`RigResourcesSpec::paths`].
+pub const RIG_RESOURCE_CLASS_PATHS: &str = "paths";
+/// Resource class key for [`RigResourcesSpec::ports`].
+pub const RIG_RESOURCE_CLASS_PORTS: &str = "ports";
+/// Resource class key for [`RigResourcesSpec::process_patterns`].
+pub const RIG_RESOURCE_CLASS_PROCESS_PATTERNS: &str = "process_patterns";
+
+/// Every resource class a rig can declare lifecycle retention for.
+pub const RIG_RESOURCE_CLASSES: [&str; 4] = [
+    RIG_RESOURCE_CLASS_EXCLUSIVE,
+    RIG_RESOURCE_CLASS_PATHS,
+    RIG_RESOURCE_CLASS_PORTS,
+    RIG_RESOURCE_CLASS_PROCESS_PATTERNS,
+];
+
 impl RigResourcesSpec {
+    /// True when no resource is declared. Lease acquisition and lifecycle
+    /// emission both gate on this, so retention-only declarations must not
+    /// change the answer.
     pub fn is_empty(&self) -> bool {
         self.exclusive.is_empty()
             && self.paths.is_empty()
             && self.ports.is_empty()
             && self.process_patterns.is_empty()
+    }
+
+    /// True when the whole block carries no information — used as the serde
+    /// skip predicate so a retention-only block still round-trips to disk.
+    pub fn is_unset(&self) -> bool {
+        self.is_empty() && self.lifecycle.is_empty() && self.lifecycle_by_class.is_empty()
+    }
+
+    /// Effective retention for one resource class.
+    pub fn retention_for_class(&self, class: &str) -> RigResourceRetentionSpec {
+        match self.lifecycle_by_class.get(class) {
+            Some(override_spec) => override_spec.or(&self.lifecycle),
+            None => self.lifecycle.clone(),
+        }
+    }
+}
+
+/// Lifecycle retention a rig declares for a resource class.
+///
+/// Both fields are optional and both default to the historical behavior, so
+/// existing rig specs deserialize and behave exactly as before.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RigResourceRetentionSpec {
+    /// ISO-8601 duration after which the resource is reclaimable, e.g. `PT1H`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<String>,
+
+    /// Cleanup policy recorded in the resource lifecycle index. Defaults to
+    /// `manual` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_policy: Option<ResourceCleanupPolicy>,
+}
+
+impl RigResourceRetentionSpec {
+    pub fn is_empty(&self) -> bool {
+        self.ttl.is_none() && self.cleanup_policy.is_none()
+    }
+
+    /// Fill unset fields from `fallback`.
+    pub fn or(&self, fallback: &Self) -> Self {
+        Self {
+            ttl: self.ttl.clone().or_else(|| fallback.ttl.clone()),
+            cleanup_policy: self.cleanup_policy.or(fallback.cleanup_policy),
+        }
     }
 }
 

--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -271,6 +271,8 @@ Managed services are detached, tracked by PID in rig state, and logged under `~/
 | `paths` | array | Filesystem paths the rig mutates or requires exclusively. |
 | `ports` | array | TCP ports the rig binds or assumes ownership of. |
 | `process_patterns` | array | Process command-line substrings the rig may stop or inspect. |
+| `lifecycle` | object | Lifecycle retention defaults applied to every class above. Optional. |
+| `lifecycle_by_class` | object | Per-class retention overrides keyed by `exclusive`, `paths`, `ports`, `process_patterns`. Optional. |
 
 ```jsonc
 {
@@ -286,6 +288,43 @@ Managed services are detached, tracked by PID in rig state, and logged under `~/
 Use `${env.NAME}` in `exclusive` tokens when a rig needs a namespace-scoped logical lock for parallel-safe runs. Unset environment variables expand to an empty string, matching other rig string expansion fields, and unknown token families remain literal.
 
 Leases guard concurrent active commands; they are not long-lived ownership records after the command exits.
+
+### Resource Retention (`lifecycle` / `lifecycle_by_class`)
+
+Every rig resource Homeboy records in a run's resource lifecycle index carries a
+cleanup policy. Without a declaration that policy is `manual` with no TTL — the
+operator reclaims the resource by hand. Declare retention to say otherwise.
+
+| Field | Type | Description |
+|---|---|---|
+| `ttl` | string | ISO-8601 duration after which the resource is reclaimable, e.g. `PT1H`, `P30D`. |
+| `cleanup_policy` | string | One of `preserve`, `manual`, `delete_after_ttl`, `delete_on_success`, `delete_on_terminal`. |
+
+```jsonc
+{
+  "resources": {
+    "paths": ["~/Sites/example/wp-content/plugins"],
+    "ports": [9724],
+    // Default for every class declared above.
+    "lifecycle": { "cleanup_policy": "delete_on_terminal" },
+    // This port lease expires after an hour; paths keep the default.
+    "lifecycle_by_class": {
+      "ports": { "ttl": "PT1H", "cleanup_policy": "delete_after_ttl" }
+    }
+  }
+}
+```
+
+Resolution order per class is `lifecycle_by_class.<class>` → `lifecycle` →
+`manual` with no TTL. Unset fields in an override inherit from `lifecycle`, so
+a class can override the policy while keeping the default TTL.
+
+Both fields are optional. A spec that omits them produces exactly the lifecycle
+records it produced before retention was declarable.
+
+`delete_after_ttl` requires a `ttl`. A policy declared without one is reported by
+`homeboy rig lint` and recorded as `manual`, so a misdeclaration never silently
+deletes anything or drops the run's lifecycle index.
 
 ## `SymlinkSpec`
 

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -179,6 +179,32 @@ as safe and declared by the rig spec, and it refuses broader environment
 materialization. `check` remains read-only; `repair` is the middle path for safe
 state correction; `up` is the full mutating setup pipeline.
 
+Every repair is ownership-checked. Repair never removes a file, directory, or
+symlink this rig did not create, and never signals a process it did not start.
+
+| Declared class | Coverage |
+|---|---|
+| `symlinks` | **Repaired.** Creates missing links and relinks drifted ones. A real file or directory at the link path is reported `blocked`, never removed. |
+| `shared_paths` | **Repaired** through the declared `ensure` / `cleanup` ops. Recreates a missing link, relinks or removes a link this rig owns, drops stale ownership records. A symlink this rig does not own, or a missing shared target, is reported `blocked`. |
+| `services` | **Repaired** for stale state only — a PID this rig recorded that is no longer alive. Running services are left alone. Repair does not start services (that is `up`), and adopted `external` services are reported, never signalled. |
+| `resources.paths` | Reported. Present paths are `unchanged`; missing ones are `skipped` — repair does not create paths whose shape the rig never described. |
+| `resources.ports` | Reported `skipped`. Port ownership is declarative; repair does not bind, probe, or reclaim ports. |
+| `resources.process_patterns` | Reported `skipped`. Repair does not signal matched processes. |
+| `resources.exclusive` | Reported `skipped`. Exclusive tokens are lease-scoped; repair does not adjust rig leases. |
+
+Each entry in the report carries a status and a `detail` explaining what
+happened:
+
+| Status | Meaning | Exit code |
+|---|---|---|
+| `repaired` | Drift this rig owned and corrected. | 0 |
+| `unchanged` | Already healthy. | 0 |
+| `skipped` | Declared, but outside what repair manages. The `detail` says what to run instead. | 0 |
+| `blocked` | Drift that needs manual attention — repair refuses to act. | 1 |
+
+The report totals each status (`repaired`, `unchanged`, `skipped`, `blocked`).
+`success` is false, and the command exits 1, only when something is `blocked`.
+
 ### `status`
 
 ```sh

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -68,15 +68,14 @@ fn resources() -> RigResourcesSpec {
         paths: vec!["~/Developer/studio".to_string()],
         ports: vec![9724],
         process_patterns: vec!["app-server-child.mjs".to_string()],
+        ..Default::default()
     }
 }
 
 fn namespaced_resources(namespace_env: &str) -> RigResourcesSpec {
     RigResourcesSpec {
         exclusive: vec![format!("studio-runtime:${{env.{}}}", namespace_env)],
-        paths: Vec::new(),
-        ports: Vec::new(),
-        process_patterns: Vec::new(),
+        ..Default::default()
     }
 }
 
@@ -169,8 +168,7 @@ fn test_acquire_active_run_lease_expands_settings_in_resources() {
         let resources = RigResourcesSpec {
             exclusive: vec!["fixture:${env.HOMEBOY_SETTINGS_FIXTURE_NAMESPACE}".to_string()],
             paths: vec!["/tmp/fixture-${env.HOMEBOY_SETTINGS_FIXTURE_NAMESPACE}".to_string()],
-            ports: Vec::new(),
-            process_patterns: Vec::new(),
+            ..Default::default()
         };
         let studio = rig("studio", resources.clone());
         let studio_bfb = rig("studio-bfb", resources);

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -295,6 +295,7 @@ fn test_run_up_persists_step_order_source_and_component_snapshot() {
             paths: vec![repo.to_string_lossy().to_string()],
             ports: vec![9981],
             process_patterns: Vec::new(),
+            ..Default::default()
         };
         rig.components.insert(
             "component".to_string(),

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -21,16 +21,18 @@ use crate::dependency_materialization_cache::{
 use crate::pipeline::PipelineOutcome;
 use crate::runner::{
     head_sha_and_branch, run_check, run_check_groups, run_down, run_down_with_settings,
-    run_fuzz_prepare, run_repair, run_status, run_up, snapshot_state, CheckReport,
-    RigComponentStatusReport, RigStatusReport, ServiceStatusReport, SymlinkStatusState, UpReport,
+    run_fuzz_prepare, run_repair, run_status, run_up, snapshot_state, CheckReport, RepairReport,
+    RepairResourceReport, RigComponentStatusReport, RigStatusReport, ServiceStatusReport,
+    SymlinkStatusState, UpReport,
 };
 use crate::spec::{
     ComponentSpec, DependencyMaterializationOutputKind, DependencyMaterializationOutputSpec,
-    DependencyMaterializationSafety, DependencyMaterializationStepSpec, ExecutableRequirementSpec,
-    FilesystemAssertionKind, FilesystemAssertionSpec, PipelineStep, RigRequirementsSpec,
-    RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, SymlinkSpec,
+    DependencyMaterializationSafety, DependencyMaterializationStepSpec, DiscoverSpec,
+    ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec, PipelineStep,
+    RigRequirementsSpec, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp,
+    SharedPathSpec, SymlinkSpec,
 };
-use crate::state::RigState;
+use crate::state::{RigState, ServiceState};
 use homeboy_core::test_support::with_isolated_home;
 
 fn empty_pipeline(name: &str) -> PipelineOutcome {
@@ -183,6 +185,7 @@ fn test_run_up() {
             paths: vec!["/tmp/run-up-path".to_string()],
             ports: vec![9981],
             process_patterns: vec!["run-up-process".to_string()],
+            ..Default::default()
         };
         let report = run_up(&rig).expect("run_up succeeds with empty pipeline");
         assert_eq!(report.rig_id, "run-up-fixture");
@@ -658,6 +661,345 @@ fn test_run_repair_does_not_run_pipeline_commands() {
             !command_marker.exists(),
             "repair must not run heavy or arbitrary pipeline commands"
         );
+    });
+}
+
+// ------------------------------------------------------------------
+// repair: shared paths
+// ------------------------------------------------------------------
+
+fn shared_path_spec(id: &str, link: &std::path::Path, target: &std::path::Path) -> RigSpec {
+    RigSpec {
+        shared_paths: vec![SharedPathSpec {
+            link: link.to_string_lossy().into_owned(),
+            target: target.to_string_lossy().into_owned(),
+        }],
+        ..minimal_spec(id)
+    }
+}
+
+fn resource(report: &RepairReport, kind: &str) -> RepairResourceReport {
+    report
+        .resources
+        .iter()
+        .find(|resource| resource.kind == kind)
+        .unwrap_or_else(|| panic!("{kind} resource in report"))
+        .clone()
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_creates_missing_shared_path() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let target = tmp.path().join("primary-node_modules");
+        let link = tmp.path().join("worktree-node_modules");
+        std::fs::create_dir(&target).expect("target dir");
+
+        let rig = shared_path_spec("repair-missing-shared-path-fixture", &link, &target);
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        let shared = resource(&report, "shared_path");
+        assert_eq!(shared.status, "repaired");
+        assert_eq!(std::fs::read_link(&link).expect("read link"), target);
+
+        // Ownership is recorded, so `down` / a later repair can clean it up.
+        let state = RigState::load("repair-missing-shared-path-fixture").expect("state");
+        assert!(state
+            .shared_paths
+            .contains_key(link.to_string_lossy().as_ref()));
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_leaves_healthy_shared_path_alone() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let target = tmp.path().join("primary-node_modules");
+        let link = tmp.path().join("worktree-node_modules");
+        std::fs::create_dir(&target).expect("target dir");
+        unix_symlink(&target, &link);
+
+        let rig = shared_path_spec("repair-healthy-shared-path-fixture", &link, &target);
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        assert_eq!(report.unchanged, 1);
+        assert_eq!(resource(&report, "shared_path").status, "unchanged");
+        assert_eq!(std::fs::read_link(&link).expect("read link"), target);
+    });
+}
+
+/// Ownership contract: a symlink this rig never created is reported, never
+/// replaced — even when it points somewhere the spec disagrees with.
+#[cfg(unix)]
+#[test]
+fn test_run_repair_blocks_unowned_shared_path_symlink() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let target = tmp.path().join("primary-node_modules");
+        let foreign = tmp.path().join("someone-elses-node_modules");
+        let link = tmp.path().join("worktree-node_modules");
+        std::fs::create_dir(&target).expect("target dir");
+        std::fs::create_dir(&foreign).expect("foreign dir");
+        unix_symlink(&foreign, &link);
+
+        let rig = shared_path_spec("repair-unowned-shared-path-fixture", &link, &target);
+        let report = run_repair(&rig).expect("repair reports blocked resource");
+
+        assert!(!report.success);
+        assert_eq!(report.blocked, 1);
+        let shared = resource(&report, "shared_path");
+        assert_eq!(shared.status, "blocked");
+        assert!(shared
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("does not own"));
+        assert_eq!(
+            std::fs::read_link(&link).expect("read link"),
+            foreign,
+            "an unowned symlink must survive repair untouched"
+        );
+    });
+}
+
+/// A rig-owned link whose target vanished is dangling drift. `cleanup` removes
+/// exactly what this rig created and nothing else.
+#[cfg(unix)]
+#[test]
+fn test_run_repair_removes_rig_owned_dangling_shared_path() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let target = tmp.path().join("primary-node_modules");
+        let link = tmp.path().join("worktree-node_modules");
+        std::fs::create_dir(&target).expect("target dir");
+
+        let rig = shared_path_spec("repair-dangling-shared-path-fixture", &link, &target);
+        run_repair(&rig).expect("repair creates the link");
+        std::fs::remove_dir_all(&target).expect("remove target");
+
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        assert_eq!(report.repaired, 1);
+        assert_eq!(resource(&report, "shared_path").status, "repaired");
+        assert!(!link.is_symlink(), "dangling rig-owned link is removed");
+
+        let state = RigState::load("repair-dangling-shared-path-fixture").expect("state");
+        assert!(state.shared_paths.is_empty(), "ownership record is dropped");
+    });
+}
+
+/// A real directory at the link path satisfies the dependency. Repair must
+/// never delete it to "fix" the declaration.
+#[cfg(unix)]
+#[test]
+fn test_run_repair_never_removes_a_real_directory_at_a_shared_path() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let target = tmp.path().join("primary-node_modules");
+        let link = tmp.path().join("worktree-node_modules");
+        std::fs::create_dir(&target).expect("target dir");
+        std::fs::create_dir(&link).expect("real dir at link path");
+        std::fs::write(link.join("marker"), "real").expect("marker");
+
+        let rig = shared_path_spec("repair-real-dir-shared-path-fixture", &link, &target);
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        assert_eq!(resource(&report, "shared_path").status, "unchanged");
+        assert_eq!(
+            std::fs::read_to_string(link.join("marker")).expect("marker"),
+            "real"
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_blocks_shared_path_with_missing_target() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let target = tmp.path().join("never-materialized");
+        let link = tmp.path().join("worktree-node_modules");
+
+        let rig = shared_path_spec("repair-missing-target-fixture", &link, &target);
+        let report = run_repair(&rig).expect("repair reports blocked resource");
+
+        assert!(!report.success);
+        assert_eq!(report.blocked, 1);
+        let shared = resource(&report, "shared_path");
+        assert_eq!(shared.status, "blocked");
+        assert!(shared
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("does not exist"));
+        assert!(!link.exists() && !link.is_symlink());
+    });
+}
+
+// ------------------------------------------------------------------
+// repair: services
+// ------------------------------------------------------------------
+
+fn service_rig(id: &str, kind: ServiceKind) -> RigSpec {
+    let discover = (kind == ServiceKind::External).then(|| DiscoverSpec {
+        pattern: "homeboy-repair-fixture-never-matches".to_string(),
+        argv_contains: Vec::new(),
+    });
+    let mut services = HashMap::new();
+    services.insert(
+        "web".to_string(),
+        ServiceSpec {
+            kind,
+            cwd: Some("/tmp".to_string()),
+            port: Some(9724),
+            command: None,
+            env: HashMap::new(),
+            health: None,
+            discover,
+        },
+    );
+    RigSpec {
+        services,
+        ..minimal_spec(id)
+    }
+}
+
+/// Dead PID in rig state is drift the rig owns: it wrote that record. Repair
+/// clears it without signalling anything (the process is already gone).
+#[test]
+fn test_run_repair_clears_stale_service_state() {
+    with_isolated_home(|_dir| {
+        let rig = service_rig("repair-stale-service-fixture", ServiceKind::HttpStatic);
+        let mut state = RigState::default();
+        state.services.insert(
+            "web".to_string(),
+            ServiceState {
+                // Above i32::MAX, so it can never be a live PID.
+                pid: Some(u32::MAX),
+                started_at: Some("2026-01-01T00:00:00Z".to_string()),
+                status: "running".to_string(),
+            },
+        );
+        state.save("repair-stale-service-fixture").expect("state");
+
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        assert_eq!(report.repaired, 1);
+        let service = resource(&report, "service");
+        assert_eq!(service.status, "repaired");
+        assert_eq!(service.path, "web");
+        assert_eq!(service.previous_target.as_deref(), Some("4294967295"));
+
+        let state = RigState::load("repair-stale-service-fixture").expect("state");
+        assert!(
+            !state.services.contains_key("web"),
+            "stale service record is cleared"
+        );
+    });
+}
+
+/// `repair` is not `up`: it reports a stopped service instead of starting one.
+#[test]
+fn test_run_repair_does_not_start_stopped_services() {
+    with_isolated_home(|_dir| {
+        let rig = service_rig("repair-stopped-service-fixture", ServiceKind::HttpStatic);
+
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        assert_eq!(report.skipped, 1);
+        let service = resource(&report, "service");
+        assert_eq!(service.status, "skipped");
+        assert!(service
+            .detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("does not start services"));
+
+        let state = RigState::load("repair-stopped-service-fixture").expect("state");
+        assert!(state.services.is_empty(), "repair started nothing");
+    });
+}
+
+/// Adopted `external` processes belong to something else. Repair reports them
+/// and never signals them.
+#[test]
+fn test_run_repair_skips_external_services() {
+    with_isolated_home(|_dir| {
+        let rig = service_rig("repair-external-service-fixture", ServiceKind::External);
+
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        assert_eq!(report.skipped, 1);
+        let service = resource(&report, "service");
+        assert_eq!(service.status, "skipped");
+        assert!(service
+            .detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("adopted"));
+    });
+}
+
+// ------------------------------------------------------------------
+// repair: declarative resource coverage
+// ------------------------------------------------------------------
+
+/// Classes repair cannot fix safely are reported, not silently dropped.
+#[test]
+fn test_run_repair_reports_uncovered_declared_resources() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let present = tmp.path().join("present");
+        std::fs::create_dir(&present).expect("present dir");
+
+        let mut rig = minimal_spec("repair-declared-resources-fixture");
+        rig.resources = RigResourcesSpec {
+            exclusive: vec!["repair-runtime".to_string()],
+            paths: vec![
+                present.to_string_lossy().into_owned(),
+                tmp.path().join("absent").to_string_lossy().into_owned(),
+            ],
+            ports: vec![9981],
+            process_patterns: vec!["repair-fixture".to_string()],
+            ..Default::default()
+        };
+
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        // Nothing here is repairable, but nothing is silently missing either.
+        assert!(report.success);
+        assert_eq!(report.repaired, 0);
+        assert_eq!(report.blocked, 0);
+        assert_eq!(report.resources.len(), 5);
+        assert_eq!(report.unchanged, 1, "the present declared path is healthy");
+        assert_eq!(report.skipped, 4);
+
+        let kinds = report
+            .resources
+            .iter()
+            .map(|resource| resource.kind.as_str())
+            .collect::<Vec<_>>();
+        assert!(kinds.contains(&"rig_exclusive"));
+        assert!(kinds.contains(&"rig_path"));
+        assert!(kinds.contains(&"rig_port"));
+        assert!(kinds.contains(&"rig_process_pattern"));
+
+        for resource in &report.resources {
+            assert!(
+                resource.detail.is_some(),
+                "{} must explain itself",
+                resource.kind
+            );
+        }
     });
 }
 

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -83,6 +83,7 @@ fn test_state_round_trips_with_materialized_ownership() {
                 paths: vec!["/tmp/studio".to_string()],
                 ports: vec![9724],
                 process_patterns: vec!["app-server-child".to_string()],
+                ..Default::default()
             },
             components: Default::default(),
         }),


### PR DESCRIPTION
`homeboy rig repair` advertises *"Repair safe declared drift without running the full `up` pipeline."* Its entire body was `for link in &rig.symlinks` — 1 of 7 declared resource classes. Meanwhile `SharedPathOp::Cleanup` (*"Remove only symlinks this rig created and still owns"*) was a fully implemented, ownership-safe cleanup op that `run_repair` never called.

## Coverage after this PR

| Class | Status |
|---|---|
| `symlinks` | **Repaired** (unchanged behavior) |
| `shared_paths` | **Repaired** — new |
| `services` | **Repaired** (stale PID state) — new |
| `resources.paths` | Reported, not repaired |
| `resources.ports` | Reported, not repaired |
| `resources.process_patterns` | Reported, not repaired |
| `resources.exclusive` (leases) | Reported, not repaired |

Plus the dependency-materialization cache, which already had automatic TTL reclamation and is untouched here.

### Why the last four are deliberately not repaired

They cannot be repaired safely without new infrastructure, and inventing it inside a command whose contract is *"safe declared drift"* is the wrong trade:

- **ports** — reclaiming a port means binding it (racy) or killing whatever holds it. This rig may not own that process.
- **process_patterns** — repairing means signalling processes matched by a substring. A pattern match is not ownership evidence.
- **paths** — the spec declares a path the rig *touches*, not its shape. Repair cannot know whether to create a file, a directory, or nothing.
- **exclusive** — lease-scoped tokens with no on-disk state between commands; `rig release-lock` already owns that surface.

They are not silently skipped. Each declared entry is inspected read-only and emitted as a `skipped` resource with a `detail` saying why and what to run instead, so the gap shows up in the report rather than disappearing.

## Ownership contract

Every repair is ownership-checked. Repair never removes a file, directory, or symlink this rig did not create, and never signals a process it did not start:

- shared paths reuse the existing `ensure` / `cleanup` ops — a link whose recorded owner target does not match what is on disk is reported `blocked`, not replaced; a real directory at the link path satisfies the dependency and is left alone
- services only clear rig state for a PID this rig wrote that is no longer alive; `external` services are adopted, so they are reported and never signalled
- repair still does not start services or run pipeline commands

## Report shape

`RepairReport` gains `skipped`; `RepairResourceReport` gains `detail`.

| Status | Meaning | Exit |
|---|---|---|
| `repaired` | drift this rig owned and corrected | 0 |
| `unchanged` | already healthy | 0 |
| `skipped` | declared, outside what repair manages | 0 |
| `blocked` | needs manual attention | 1 |

`success` is false only when something is `blocked` — the existing exit-code contract is preserved.

## Declarable resource retention

`resource_lifecycle::record()` hardcoded `cleanup_policy: Manual` for all four rig resource kinds, so the lifecycle index told every operator that everything was `Manual` and a rig author had no way to say "this port lease expires after an hour".

`resources` now accepts:

```jsonc
"resources": {
  "ports": [9724],
  "paths": ["~/Sites/example/wp-content/plugins"],
  "lifecycle": { "cleanup_policy": "delete_on_terminal" },
  "lifecycle_by_class": {
    "ports": { "ttl": "PT1H", "cleanup_policy": "delete_after_ttl" }
  }
}
```

Resolution is `lifecycle_by_class.<class>` → `lifecycle` → historical `manual`/no-ttl, with unset override fields inheriting from the default.

**Non-breaking, and proved by test.** Both fields are `Option`, both `#[serde(default, skip_serializing_if = "Option::is_none")]` like the other optional `RigSpec` fields, and `specs_without_retention_declarations_keep_manual_records` asserts that a spec declaring neither produces `Manual` + no ttl for every one of the four classes — the exact records emitted before. `RigResourcesSpec::is_empty()` is deliberately unchanged (lease acquisition and lifecycle emission gate on it, so a retention-only block must not start acquiring leases); a new `is_unset()` is used only as the serde skip predicate so a retention-only block still round-trips to disk.

`delete_after_ttl` without a `ttl` is contract-invalid and would make the whole index fail validation and silently disappear. `rig lint` now reports it (and unknown class keys), and the emitter degrades that combination to `manual` so a misdeclaration can never cost a run its lifecycle index.

## Tests

- shared paths: creates missing, leaves healthy alone, blocks unowned symlink (asserts the foreign link survives), removes rig-owned dangling link, never removes a real directory, blocks a missing shared target
- services: clears stale PID state, does not start a stopped service, skips `external`
- declarative classes: all four reported with details, counters partition correctly
- lifecycle: non-breaking baseline, defaults applied to every class, per-class override isolation, per-class inheritance from the default, `delete_after_ttl`-without-ttl degradation, retention round-trip
- lint: rejects `delete_after_ttl` without ttl and unknown class keys; accepts a valid declaration

Docs updated: `docs/commands/rig.md` now documents the per-class coverage table and status semantics (the help text was a promise the code did not keep — the code changed to keep it), and `docs/commands/rig-spec.md` documents `lifecycle` / `lifecycle_by_class`.

Local verification was `cargo fmt` only; full build and test are left to CI per this host's resource limits.

Refs #10319 — closes the shared-path/service/lifecycle gap; ports, process patterns, paths, and exclusive tokens remain uncovered by design and are now visible in the report.
