### PR TITLE
fix(cli): collapse the imperative command-safety registry into spec tables

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -966,6 +966,71 @@ mod tests {
         }
     }
 
+    /// Every declared safety path must resolve to a real node in the
+    /// clap-derived command surface.
+    ///
+    /// This is the structural guard for the class of bug in #10313: safety was
+    /// declared for `review audit baseline refresh`, a spelling that only
+    /// exists in pre-parse argv rewriting, while clap exposes
+    /// `review audit-baseline refresh`. The declaration could never match, so
+    /// the manifest reported a command that mutates persisted baseline data as
+    /// non-mutating. A declared path that clap does not expose is always a bug.
+    #[test]
+    fn command_path_safety_specs_resolve_to_clap_surface_nodes() {
+        fn resolves(entries: &[CommandSurfaceEntry], path: &[&str]) -> bool {
+            let Some((first, rest)) = path.split_first() else {
+                return true;
+            };
+
+            entries
+                .iter()
+                .find(|entry| entry.name == *first)
+                .is_some_and(|entry| resolves(&entry.subcommands, rest))
+        }
+
+        let surface = current_command_surface();
+
+        for spec in crate::command_contract::COMMAND_SPECS {
+            for path_safety in spec.subcommand_safety {
+                for declared in path_safety.paths {
+                    let path = std::iter::once(spec.name)
+                        .chain(declared.split_whitespace())
+                        .collect::<Vec<_>>();
+
+                    assert!(
+                        resolves(&surface.commands, &path),
+                        "command `{}` declares safety metadata for `{}`, which is not a path in the clap command surface",
+                        spec.name,
+                        path.join(" ")
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn review_audit_baseline_manifest_declares_baseline_mutation() {
+        let manifest = current_command_safety_manifest();
+
+        for subcommand in ["refresh", "merge", "prune"] {
+            let entry = manifest
+                .find_path(&["review", "audit-baseline", subcommand])
+                .unwrap_or_else(|| panic!("review audit-baseline {subcommand} must be present in the command safety manifest"));
+
+            assert!(
+                entry.mutates,
+                "review audit-baseline {subcommand} mutates persisted audit baseline data"
+            );
+        }
+
+        assert!(
+            manifest
+                .find_path(&["review", "audit", "baseline", "refresh"])
+                .is_none(),
+            "`review audit baseline` is a pre-parse argv spelling, not a clap path"
+        );
+    }
+
     #[test]
     fn rig_lint_manifest_declares_static_read_only_behavior() {
         let manifest = current_command_safety_manifest();

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -215,21 +215,10 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["contract", "manifest"] => {}
-        ["self", "docs", "map"] => {
-            metadata.mutating(
-                "default JSON output is non-mutating; pass --write to write markdown docs to disk",
-            );
-            metadata.dangerous_flags = vec!["--write"];
-        }
         ["cleanup", "artifacts"] => {
             metadata.mutating(
                 "default output is a non-mutating cleanup plan; pass --apply to remove artifacts",
             );
-            metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["self", "cleanup-runtime-tmp"] => {
-            metadata.operator_mutating("default output is a non-mutating cleanup plan; pass --apply to delete runtime temp entries");
             metadata.dangerous_flags = vec!["--apply"];
         }
         ["extension", "setup"]

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -10,13 +10,20 @@
 //! The clap argument shapes themselves stay in [`crate::cli_surface`]; only the
 //! *derivation* of safety metadata from those shapes lives here. The public
 //! entry points are re-exported from `cli_surface` so call sites are unchanged.
+//!
+//! Safety metadata itself is declared once, in
+//! [`crate::command_contract::COMMAND_SPECS`]: top-level `CommandSafetySpec`
+//! plus a `CommandPathSafetySpec` table per command family. This module only
+//! resolves those declarations against the live clap surface, so a declared
+//! path that does not exist in clap is a bug the registry guard test catches
+//! rather than a silently ignored entry.
 
 use crate::cli_surface::{
     current_command_surface, CommandDocsMetadata, CommandDryRunMetadata, CommandLabMetadata,
     CommandOutputMetadata, CommandSafetyAuditFinding, CommandSafetyAuditReport, CommandSafetyEntry,
     CommandSafetyManifest, CommandSurface, CommandSurfaceEntry, DynamicCommandDescriptor,
 };
-use crate::command_contract::registered_command;
+use crate::command_contract::{registered_command, CommandSafetySpec};
 
 pub fn current_command_safety_manifest() -> CommandSafetyManifest {
     command_safety_manifest_from(current_command_surface())
@@ -64,15 +71,15 @@ fn command_safety_entry(
 ) -> CommandSafetyEntry {
     let mut path = parent_path.to_vec();
     path.push(entry.name.clone());
-    let mut safety = command_safety_metadata(&path);
+    let mut resolved = resolved_command_safety(&path);
     let dynamic_command = dynamic_command_for_path(&path, dynamic_commands);
 
     if let Some(dynamic_safety) = dynamic_command.and_then(|command| command.safety.as_ref()) {
-        safety.mutates = dynamic_safety.mutates;
-        safety.operator = dynamic_safety.operator;
-        safety.output_notes = dynamic_safety.output_notes;
-        safety.lab_notes = dynamic_safety.lab_notes;
-        safety.dangerous_flags = dynamic_safety.dangerous_flags.clone();
+        resolved.safety.mutates = dynamic_safety.mutates;
+        resolved.safety.operator = dynamic_safety.operator;
+        resolved.output_notes = dynamic_safety.output_notes;
+        resolved.lab_notes = dynamic_safety.lab_notes;
+        resolved.dangerous_flags = dynamic_safety.dangerous_flags.clone();
     }
 
     CommandSafetyEntry {
@@ -80,26 +87,26 @@ fn command_safety_entry(
         aliases: entry.visible_aliases.clone(),
         hidden: entry.hidden,
         path: path.clone(),
-        mutates: safety.mutates,
-        operator: safety.operator,
+        mutates: resolved.safety.mutates,
+        operator: resolved.safety.operator,
         dry_run: CommandDryRunMetadata {
-            supported: safety.dry_run_flag.is_some(),
-            flag: safety.dry_run_flag.map(str::to_string),
+            supported: resolved.safety.dry_run_flag.is_some(),
+            flag: resolved.safety.dry_run_flag.map(str::to_string),
         },
         output: CommandOutputMetadata {
-            structured: safety.structured_output,
-            notes: safety.output_notes.to_string(),
+            structured: true,
+            notes: resolved.output_notes.to_string(),
         },
         lab: CommandLabMetadata {
-            supported: safety.lab_supported,
-            notes: safety.lab_notes.to_string(),
+            supported: resolved.lab_supported,
+            notes: resolved.lab_notes.to_string(),
         },
         docs: CommandDocsMetadata {
             path: docs_path(&path, dynamic_commands),
         },
-        risk_exemption: safety.risk_exemption.map(str::to_string),
+        risk_exemption: resolved.safety.risk_exemption.map(str::to_string),
         extension: dynamic_command.and_then(|command| command.extension.clone()),
-        dangerous_flags: safety
+        dangerous_flags: resolved
             .dangerous_flags
             .into_iter()
             .map(str::to_string)
@@ -112,44 +119,61 @@ fn command_safety_entry(
     }
 }
 
-struct CommandSafetyMetadata {
-    mutates: bool,
-    operator: bool,
-    dry_run_flag: Option<&'static str>,
-    structured_output: bool,
+/// Output/Lab notes for command paths with no `COMMAND_SPECS` entry, i.e.
+/// dynamic extension commands.
+const DEFAULT_OUTPUT_NOTES: &str = "standard CLI output contract";
+const DEFAULT_LAB_NOTES: &str = "not declared as Lab-routable in the safety manifest";
+
+/// Command safety resolved from the declarative registry for one clap path.
+struct ResolvedCommandSafety {
+    safety: CommandSafetySpec,
     output_notes: &'static str,
     lab_supported: bool,
     lab_notes: &'static str,
-    risk_exemption: Option<&'static str>,
+    /// Owned so dynamic (extension) commands can replace the declared flags.
     dangerous_flags: Vec<&'static str>,
 }
 
-impl Default for CommandSafetyMetadata {
-    fn default() -> Self {
-        Self {
-            mutates: false,
-            operator: false,
-            dry_run_flag: None,
-            structured_output: true,
-            output_notes: "standard CLI output contract",
-            lab_supported: false,
-            lab_notes: "not declared as Lab-routable in the safety manifest",
-            risk_exemption: None,
-            dangerous_flags: Vec::new(),
+/// Resolves one clap path against the declarative command registry: top-level
+/// command metadata first, then the owning command's `CommandPathSafetySpec`
+/// table. There is no second, imperative registry — a command path that wants
+/// safety metadata declares it in `COMMAND_SPECS`.
+fn resolved_command_safety(path: &[String]) -> ResolvedCommandSafety {
+    let mut resolved = ResolvedCommandSafety {
+        safety: CommandSafetySpec::read_only(),
+        output_notes: DEFAULT_OUTPUT_NOTES,
+        lab_supported: false,
+        lab_notes: DEFAULT_LAB_NOTES,
+        dangerous_flags: Vec::new(),
+    };
+
+    let Some(top_level) = path.first().and_then(|name| registered_command(name)) else {
+        return resolved;
+    };
+
+    resolved.output_notes = top_level.output_notes;
+    resolved.lab_supported = top_level.lab_supported;
+    resolved.lab_notes = top_level.lab_notes;
+
+    if path.len() == 1 {
+        resolved.safety = top_level.safety;
+    }
+
+    let subcommand_path = path.iter().skip(1).map(String::as_str).collect::<Vec<_>>();
+    if let Some(path_safety) = top_level.path_safety(&subcommand_path) {
+        resolved.safety = path_safety.safety;
+
+        if let Some(output_notes) = path_safety.output_notes {
+            resolved.output_notes = output_notes;
+        }
+        if let Some(lab_notes) = path_safety.lab_notes {
+            resolved.lab_notes = lab_notes;
         }
     }
-}
 
-impl CommandSafetyMetadata {
-    fn mutating(&mut self, output_notes: &'static str) {
-        self.mutates = true;
-        self.output_notes = output_notes;
-    }
+    resolved.dangerous_flags = resolved.safety.dangerous_flags.to_vec();
 
-    fn operator_mutating(&mut self, output_notes: &'static str) {
-        self.mutating(output_notes);
-        self.operator = true;
-    }
+    resolved
 }
 
 fn flatten_manifest_entries(entries: &[CommandSafetyEntry]) -> Vec<&CommandSafetyEntry> {
@@ -169,105 +193,6 @@ fn entry_has_action_metadata(entry: &CommandSafetyEntry) -> bool {
         || entry.risk_exemption.is_some()
         || entry.output.notes.contains("--apply")
         || entry.output.notes.contains("--dry-run")
-}
-
-fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
-    let mut metadata = CommandSafetyMetadata::default();
-
-    if let Some(top_level) = path.first().and_then(|name| registered_command(name)) {
-        metadata.output_notes = top_level.output_notes;
-        metadata.lab_supported = top_level.lab_supported;
-        metadata.lab_notes = top_level.lab_notes;
-
-        if path.len() == 1 {
-            metadata.mutates = top_level.safety.mutates;
-            metadata.operator = top_level.safety.operator;
-            metadata.dry_run_flag = top_level.safety.dry_run_flag;
-            metadata.risk_exemption = top_level.safety.risk_exemption;
-            metadata.dangerous_flags = top_level.safety.dangerous_flags.to_vec();
-        }
-
-        let subcommand_path = path.iter().skip(1).map(String::as_str).collect::<Vec<_>>();
-        if let Some(path_safety) = top_level.path_safety(&subcommand_path) {
-            metadata.mutates = path_safety.safety.mutates;
-            metadata.operator = path_safety.safety.operator;
-            metadata.dry_run_flag = path_safety.safety.dry_run_flag;
-            metadata.risk_exemption = path_safety.safety.risk_exemption;
-            metadata.dangerous_flags = path_safety.safety.dangerous_flags.to_vec();
-            if let Some(output_notes) = path_safety.output_notes {
-                metadata.output_notes = output_notes;
-            }
-            if let Some(lab_notes) = path_safety.lab_notes {
-                metadata.lab_notes = lab_notes;
-            }
-            return metadata;
-        }
-    }
-
-    let path = path.iter().map(String::as_str).collect::<Vec<_>>();
-    match path.as_slice() {
-        ["worktree", "queue-create"] => {
-            metadata.mutating("default output creates task worktrees one-at-a-time; pass --dry-run to plan without creating");
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["worktree", "create"] => {
-            metadata.mutating("creates a task worktree from a registered component checkout");
-        }
-        ["worktree", "remove"] => {
-            metadata.mutating("removes a task worktree after safety checks");
-            metadata.dangerous_flags = vec!["--force"];
-        }
-        ["worktree", "cleanup"] => {
-            metadata.operator_mutating(
-                "default output is a non-mutating task-worktree cleanup plan; pass --apply to remove eligible worktrees, and --cleanup-artifacts to include rebuildable Homeboy artifacts",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--apply", "--force", "--cleanup-artifacts"];
-        }
-        ["tunnel", "service", "expose"]
-        | ["tunnel", "service", "set"]
-        | ["tunnel", "service", "remove"] => {
-            metadata.operator_mutating("mutates private service tunnel declarations");
-        }
-        ["tunnel", "service", "start"] | ["tunnel", "service", "stop"] => {
-            metadata.operator_mutating("mutates private service tunnel runtime state");
-        }
-        ["tunnel", "preview-client", "start"]
-        | ["tunnel", "preview-consumer", "run"]
-        | ["tunnel", "preview-ingress", "serve"]
-        | ["tunnel", "artifact-origin", "serve"] => {
-            metadata.operator_mutating("starts or supervises tunnel preview runtime state");
-        }
-        ["tunnel", "preview-ingress", "route"] | ["tunnel", "preview-ingress", "unroute"] => {
-            metadata.operator_mutating("mutates preview ingress route state");
-        }
-        ["tunnel", "preview-ingress", "install"] => {
-            metadata.operator = true;
-            metadata.output_notes = "renders a non-destructive operator install plan";
-        }
-        ["stack", "create"] | ["stack", "add-pr"] | ["stack", "remove-pr"] => {
-            metadata.mutating("mutates persisted stack specification metadata");
-        }
-        ["stack", "apply"] | ["stack", "rebase"] => {
-            metadata.operator_mutating("mutates the configured stack target branch");
-            metadata.risk_exemption = Some(
-                "stack command name is the explicit branch mutation action; status/sync --dry-run are the planning paths",
-            );
-        }
-        ["stack", "sync"] => {
-            metadata.operator_mutating("mutates the configured stack target branch and may update the stack spec unless --dry-run is passed");
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["stack", "push"] => {
-            metadata.operator_mutating("pushes the configured stack target branch to its remote");
-            metadata.risk_exemption = Some(
-                "push is the explicit remote publication action; no dry-run contract exists yet",
-            );
-        }
-        _ => {}
-    }
-
-    metadata
 }
 
 fn docs_path(path: &[String], dynamic_commands: &[DynamicCommandDescriptor]) -> Option<String> {

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -206,42 +206,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["git", "issue", "create"]
-        | ["git", "issue", "comment"]
-        | ["git", "issue", "close"]
-        | ["git", "issue", "edit"] => {
-            metadata
-                .operator_mutating("mutates GitHub issue state through the configured repository");
-            metadata.risk_exemption = Some(
-                "the issue subcommand is the explicit GitHub write action; no dry-run contract exists yet",
-            );
-        }
-        ["git", "pr", "create"]
-        | ["git", "pr", "edit"]
-        | ["git", "pr", "comment"]
-        | ["git", "pr", "refresh"]
-        | ["git", "pr", "policy", "open"] => {
-            metadata.operator_mutating("mutates GitHub pull request state or branch state");
-            metadata.risk_exemption = Some(
-                "the PR subcommand is the explicit GitHub write action; no dry-run contract exists yet",
-            );
-        }
-        ["git", "pr", "fleet"] | ["git", "pr", "land"] => {
-            metadata.operator_mutating(
-                "reports by default or with --dry-run; apply/merge flags mutate PR state",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--apply", "--delete-branch"];
-        }
-        ["refactor", "rename"]
-        | ["refactor", "add"]
-        | ["refactor", "move"]
-        | ["refactor", "propagate"]
-        | ["refactor", "transform"]
-        | ["refactor", "decompose"] => {
-            metadata.mutating("reports a plan by default; pass --write to rewrite source files");
-            metadata.dangerous_flags = vec!["--write"];
-        }
         ["runner", "add"]
         | ["runner", "enable"]
         | ["runner", "set"]
@@ -353,9 +317,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.risk_exemption = Some(
                 "push is the explicit remote publication action; no dry-run contract exists yet",
             );
-        }
-        ["refactor", "undo", "delete"] => {
-            metadata.mutating("deletes an undo snapshot without restoring it");
         }
         _ => {}
     }

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -150,15 +150,6 @@ impl CommandSafetyMetadata {
         self.mutating(output_notes);
         self.operator = true;
     }
-
-    fn guarded_operator_mutating(
-        &mut self,
-        output_notes: &'static str,
-        dangerous_flags: Vec<&'static str>,
-    ) {
-        self.operator_mutating(output_notes);
-        self.dangerous_flags = dangerous_flags;
-    }
 }
 
 fn flatten_manifest_entries(entries: &[CommandSafetyEntry]) -> Vec<&CommandSafetyEntry> {
@@ -215,35 +206,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["cleanup", "artifacts"] => {
-            metadata.mutating(
-                "default output is a non-mutating cleanup plan; pass --apply to remove artifacts",
-            );
-            metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["extension", "setup"]
-        | ["extension", "refresh"]
-        | ["extension", "relink"]
-        | ["extension", "dev-run"]
-        | ["extension", "install-for-component"]
-        | ["extension", "set"] => {
-            metadata.mutating("mutates installed extension files or extension manifest metadata");
-        }
-        ["extension", "install"] => {
-            metadata.mutating("mutates installed extension files or extension manifest metadata");
-            metadata.dangerous_flags = vec!["--replace"];
-        }
-        ["extension", "update"] => {
-            metadata.mutating("mutates installed extension files or extension manifest metadata");
-            metadata.dangerous_flags = vec!["--force"];
-        }
-        ["runtime", "refresh"] => {
-            metadata.mutating("mutates installed runtime package files");
-        }
-        ["extension", "uninstall"] => {
-            metadata.mutating("mutates installed extension files or extension manifest metadata");
-            metadata.dangerous_flags = vec!["uninstall"];
-        }
         ["runs", "reconcile"] => {
             metadata.mutating("marks orphaned running records stale unless --dry-run is passed");
             metadata.dry_run_flag = Some("--dry-run");
@@ -506,18 +468,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.operator_mutating("pushes the configured stack target branch to its remote");
             metadata.risk_exemption = Some(
                 "push is the explicit remote publication action; no dry-run contract exists yet",
-            );
-        }
-        ["extension", "run"] | ["extension", "exec"] => {
-            metadata.guarded_operator_mutating(
-                "executes extension-owned runtime commands with forwarded arguments that may mutate the target system",
-                vec!["extension runtime command", "passthrough args"],
-            );
-        }
-        ["extension", "action"] => {
-            metadata.guarded_operator_mutating(
-                "executes extension-owned actions that may mutate the target system",
-                vec!["extension action"],
             );
         }
         ["refactor", "undo", "delete"] => {

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -206,60 +206,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["runner", "add"]
-        | ["runner", "enable"]
-        | ["runner", "set"]
-        | ["runner", "trust"]
-        | ["runner", "pair"]
-        | ["runner", "remove"]
-        | ["runner", "disconnect"]
-        | ["runner", "refresh-homeboy"] => {
-            metadata.operator_mutating(
-                "mutates runner configuration, trust policy, or runner lifecycle state",
-            );
-        }
-        ["runner", "connect"] | ["runner", "work"] => {
-            metadata.operator_mutating("mutates runner lifecycle state");
-            metadata.risk_exemption = Some(
-                "runner lifecycle command name is the explicit operator action; no dry-run contract exists yet",
-            );
-        }
-        ["runner", "doctor"] => {
-            metadata.operator_mutating(
-                "diagnoses runners by default; --repair mutates runner lifecycle state",
-            );
-            metadata.dangerous_flags = vec!["--repair"];
-        }
-        ["runner", "exec"] => {
-            metadata.operator_mutating("executes commands on a runner unless --dry-run is passed");
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["runner", "lifecycle"] => {
-            metadata.output_notes = "non-mutating runner workspace lifecycle/finalization readiness report suitable for RunOutcomeEnvelope embedding";
-        }
-        ["runner", "workspace", "sync"] => {
-            metadata.operator_mutating("materializes a local worktree into runner workspace state");
-            metadata.dangerous_flags = vec!["--allow-dirty-lab-workspace"];
-        }
-        ["runner", "workspace", "update"] => {
-            metadata
-                .operator_mutating("advances a prepared runner workspace from its snapshot lease");
-        }
-        ["runner", "workspace", "pull"] => {
-            metadata.operator_mutating(
-                "copies selected files from runner workspace state to a local destination",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["runner", "workspace", "apply"] => {
-            metadata
-                .operator_mutating("applies a Lab-generated workspace patch to a local worktree");
-            metadata.dangerous_flags = vec!["--force"];
-        }
-        ["runner", "workspace", "prune"] => {
-            metadata.operator_mutating("default output is a non-mutating orphan cleanup plan with candidate/remaining bytes; pass --apply to delete exact runner workspace paths and --passes to drain bounded pages");
-            metadata.dangerous_flags = vec!["--apply"];
-        }
         ["worktree", "queue-create"] => {
             metadata.mutating("default output creates task worktrees one-at-a-time; pass --dry-run to plan without creating");
             metadata.dry_run_flag = Some("--dry-run");

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -206,51 +206,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["agent-task", "promote"] => {
-            metadata.mutating(
-                "applies a selected patch artifact into a managed worktree unless --dry-run is passed",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["agent-task", "active"] => {
-            metadata.mutating(
-                "reads active runs by default; --reconcile previews the full fleet mutation set and --apply authorizes its cancellation",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["agent-task", "reconcile"] => {
-            metadata.mutating(
-                "previews reconciliation for one durable run; --apply authorizes a scoped lifecycle mutation after provider-state inspection",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["agent-task", "controller", "init"]
-        | ["agent-task", "controller", "from-spec"]
-        | ["agent-task", "controller", "run-from-spec"]
-        | ["agent-task", "controller", "materialize"]
-        | ["agent-task", "controller", "events"]
-        | ["agent-task", "controller", "apply-event"]
-        | ["agent-task", "controller", "run-next"]
-        | ["agent-task", "controller", "run"]
-        | ["agent-task", "controller", "resume"]
-        | ["agent-task", "controller", "mark-human-ready"] => {
-            metadata.mutating("mutates durable agent-task loop controller state");
-        }
-        ["agent-task", "auth", "remove"] => {
-            metadata.operator_mutating("removes one agent-task provider secret source mapping");
-        }
-        ["agent-task", "prompts", "remove"] => {
-            metadata.mutating("removes one stored agent-task prompt");
-        }
-        ["agent-task", "fanout", "cook-batch"] => {
-            metadata.operator_mutating(
-                "creates/reuses task worktrees and can run the generated fanout unless --dry-run is passed",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--run-plan"];
-        }
         ["fuzz", "replay"] | ["fuzz", "minimize"] => {
             metadata.mutating(
                 "replays or minimizes a persisted fuzz case against local code and may write run artifacts",

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -206,36 +206,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["runs", "reconcile"] => {
-            metadata.mutating("marks orphaned running records stale unless --dry-run is passed");
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["runs", "import"] => {
-            metadata.mutating(
-                "imports observation bundle or GitHub Actions artifacts into the local run store",
-            );
-        }
-        ["runs", "loop-sync"] => {
-            metadata.mutating(
-                "syncs copied loop archives into observation runs/artifacts unless --dry-run is passed",
-            );
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["runs", "artifact", "cleanup-downloads"] | ["runs", "artifact", "cleanup-persisted"] => {
-            metadata.mutating(
-                "default output is a non-mutating cleanup plan; pass --apply to delete artifacts",
-            );
-            metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["runs", "resources"] => {
-            metadata.mutating("default output is non-mutating; pass --cleanup-plan to plan lifecycle resource cleanup or --apply with --cleanup-root to delete bounded apply-intended candidates");
-            metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["runs", "artifact", "attach"] => {
-            metadata.mutating(
-                "copies an existing runner-side file into the persisted local artifact store and records it against a run",
-            );
-        }
         ["agent-task", "promote"] => {
             metadata.mutating(
                 "applies a selected patch artifact into a managed worktree unless --dry-run is passed",
@@ -326,11 +296,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             );
             metadata.dry_run_flag = Some("--dry-run");
             metadata.dangerous_flags = vec!["--apply", "--delete-branch"];
-        }
-        ["runs", "findings", "reconcile"] | ["runs", "findings", "reconcile-run"] => {
-            metadata.operator_mutating("default output is a non-mutating issue reconciliation plan; pass --apply to mutate tracker state");
-            metadata.dry_run_flag = Some("--dry-run");
-            metadata.dangerous_flags = vec!["--apply"];
         }
         ["refactor", "rename"]
         | ["refactor", "add"]

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -222,9 +222,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             );
             metadata.dangerous_flags = vec!["--write"];
         }
-        ["review", "ci", "autofix"] => {
-            metadata.operator_mutating("commits and pushes prepared CI autofix changes");
-        }
         ["cleanup", "artifacts"] => {
             metadata.mutating(
                 "default output is a non-mutating cleanup plan; pass --apply to remove artifacts",
@@ -383,9 +380,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.operator_mutating("default output is a non-mutating issue reconciliation plan; pass --apply to mutate tracker state");
             metadata.dry_run_flag = Some("--dry-run");
             metadata.dangerous_flags = vec!["--apply"];
-        }
-        ["review", "audit", "baseline", "refresh"] | ["review", "audit", "baseline", "merge"] => {
-            metadata.mutating("mutates persisted audit baseline data in component configuration");
         }
         ["refactor", "rename"]
         | ["refactor", "add"]

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -206,25 +206,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
 
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
     match path.as_slice() {
-        ["fuzz", "replay"] | ["fuzz", "minimize"] => {
-            metadata.mutating(
-                "replays or minimizes a persisted fuzz case against local code and may write run artifacts",
-            );
-        }
-        ["fuzz"] | ["fuzz", "run"] | ["fuzz", "plan"] | ["fuzz", "run-campaign"] => {
-            metadata.output_notes = "read-only fuzz planning/execution contract by default; --allow-destructive infers isolated mode and attaches an auditable homeboy/isolation-proof/v1 unless one is supplied";
-            metadata.dangerous_flags = vec!["--allow-destructive"];
-        }
-        ["rig", "release-lock"] => {
-            metadata.operator_mutating(
-                "releases a local rig active-run lease; --force can reclaim a live holder's guardrail",
-            );
-            metadata.dangerous_flags = vec!["--force"];
-        }
-        ["db", "delete-row"] | ["db", "drop-table"] => {
-            metadata
-                .operator_mutating("default output is a non-mutating plan; pass --apply to mutate");
-        }
         ["git", "issue", "create"]
         | ["git", "issue", "comment"]
         | ["git", "issue", "close"]
@@ -260,23 +241,6 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         | ["refactor", "decompose"] => {
             metadata.mutating("reports a plan by default; pass --write to rewrite source files");
             metadata.dangerous_flags = vec!["--write"];
-        }
-        ["rig", "up"] => {
-            metadata.operator_mutating("mutates local rig runtime state unless --dry-run is passed with --runner to emit a runner exec plan");
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["rig", "down"] | ["rig", "repair"] | ["rig", "install"] | ["rig", "update"] => {
-            metadata.operator_mutating("mutates local rig runtime state or installed rig packages");
-        }
-        ["rig", "sync"]
-        | ["rig", "app", "install"]
-        | ["rig", "app", "update"]
-        | ["rig", "app", "uninstall"] => {
-            metadata.operator_mutating("mutates rig-managed files unless --dry-run is passed");
-            metadata.dry_run_flag = Some("--dry-run");
-        }
-        ["rig", "sources", "remove"] | ["rig", "sources", "refresh"] => {
-            metadata.mutating("mutates installed rig source metadata");
         }
         ["runner", "add"]
         | ["runner", "enable"]

--- a/crates/homeboy-cli/src/command_contract/descriptors.rs
+++ b/crates/homeboy-cli/src/command_contract/descriptors.rs
@@ -20,7 +20,7 @@ macro_rules! ops_command_descriptors {
             (daemon, Daemon, crate::commands::daemon::DaemonArgs, command_spec("daemon", CommandJsonFamily::Ops), crate::commands::daemon::run),
             (schedule, Schedule, crate::commands::schedule::ScheduleArgs, command_spec("schedule", CommandJsonFamily::Ops), crate::commands::schedule::run),
             (status, Status, crate::commands::status::StatusArgs, command_spec("status", CommandJsonFamily::Ops), crate::commands::status::run),
-            (git, Git, crate::commands::git::GitArgs, command_spec("git", CommandJsonFamily::Ops), crate::commands::git::run),
+            (git, Git, crate::commands::git::GitArgs, CommandSpec { subcommand_safety: GIT_SUBCOMMAND_SAFETY, ..command_spec("git", CommandJsonFamily::Ops) }, crate::commands::git::run),
             (self_cmd, SelfCmd, crate::commands::self_cmd::SelfArgs, CommandSpec { subcommand_safety: SELF_SUBCOMMAND_SAFETY, ..command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") }, crate::commands::self_cmd::run),
             (api, Api, crate::commands::api::ApiArgs, CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) }, crate::commands::api::run),
             (upgrade, Upgrade, crate::commands::upgrade::UpgradeArgs, command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)), crate::commands::upgrade::run),
@@ -48,7 +48,7 @@ macro_rules! ops_command_spec {
     (daemon) => { command_spec("daemon", CommandJsonFamily::Ops) };
     (schedule) => { command_spec("schedule", CommandJsonFamily::Ops) };
     (status) => { command_spec("status", CommandJsonFamily::Ops) };
-    (git) => { command_spec("git", CommandJsonFamily::Ops) };
+    (git) => { CommandSpec { subcommand_safety: GIT_SUBCOMMAND_SAFETY, ..command_spec("git", CommandJsonFamily::Ops) } };
     (self_cmd) => { CommandSpec { subcommand_safety: SELF_SUBCOMMAND_SAFETY, ..command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") } };
     (api) => { CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) } };
     (upgrade) => { command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)) };

--- a/crates/homeboy-cli/src/command_contract/descriptors.rs
+++ b/crates/homeboy-cli/src/command_contract/descriptors.rs
@@ -11,7 +11,7 @@ macro_rules! ops_command_descriptors {
         $consumer! {
             (ssh, Ssh, crate::commands::ssh::SshArgs, command_spec("ssh", CommandJsonFamily::Ops), crate::commands::ssh::run),
             (server, Server, crate::commands::server::ServerArgs, CommandSpec { subcommand_safety: SERVER_SUBCOMMAND_SAFETY, ..command_spec("server", CommandJsonFamily::Ops) }, crate::commands::server::run),
-            (db, Db, crate::commands::db::DbArgs, command_spec("db", CommandJsonFamily::Ops), crate::commands::db::run),
+            (db, Db, crate::commands::db::DbArgs, CommandSpec { subcommand_safety: DB_SUBCOMMAND_SAFETY, ..command_spec("db", CommandJsonFamily::Ops) }, crate::commands::db::run),
             (file, File, crate::commands::file::FileArgs, CommandSpec { subcommand_safety: FILE_SUBCOMMAND_SAFETY, ..command_spec("file", CommandJsonFamily::Ops) }, crate::commands::file::run),
             (logs, Logs, crate::commands::logs::LogsArgs, command_spec("logs", CommandJsonFamily::Ops), crate::commands::logs::run),
             (triage, Triage, crate::commands::triage::TriageArgs, command_spec_with_safety("triage", CommandJsonFamily::Ops, operator_safety(None, TRIAGE_DANGEROUS_FLAGS)), crate::commands::triage::run),
@@ -39,7 +39,7 @@ macro_rules! ops_command_descriptors {
 macro_rules! ops_command_spec {
     (ssh) => { command_spec("ssh", CommandJsonFamily::Ops) };
     (server) => { CommandSpec { subcommand_safety: SERVER_SUBCOMMAND_SAFETY, ..command_spec("server", CommandJsonFamily::Ops) } };
-    (db) => { command_spec("db", CommandJsonFamily::Ops) };
+    (db) => { CommandSpec { subcommand_safety: DB_SUBCOMMAND_SAFETY, ..command_spec("db", CommandJsonFamily::Ops) } };
     (file) => { CommandSpec { subcommand_safety: FILE_SUBCOMMAND_SAFETY, ..command_spec("file", CommandJsonFamily::Ops) } };
     (logs) => { command_spec("logs", CommandJsonFamily::Ops) };
     (triage) => { command_spec_with_safety("triage", CommandJsonFamily::Ops, operator_safety(None, TRIAGE_DANGEROUS_FLAGS)) };

--- a/crates/homeboy-cli/src/command_contract/descriptors.rs
+++ b/crates/homeboy-cli/src/command_contract/descriptors.rs
@@ -21,7 +21,7 @@ macro_rules! ops_command_descriptors {
             (schedule, Schedule, crate::commands::schedule::ScheduleArgs, command_spec("schedule", CommandJsonFamily::Ops), crate::commands::schedule::run),
             (status, Status, crate::commands::status::StatusArgs, command_spec("status", CommandJsonFamily::Ops), crate::commands::status::run),
             (git, Git, crate::commands::git::GitArgs, command_spec("git", CommandJsonFamily::Ops), crate::commands::git::run),
-            (self_cmd, SelfCmd, crate::commands::self_cmd::SelfArgs, command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation"), crate::commands::self_cmd::run),
+            (self_cmd, SelfCmd, crate::commands::self_cmd::SelfArgs, CommandSpec { subcommand_safety: SELF_SUBCOMMAND_SAFETY, ..command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") }, crate::commands::self_cmd::run),
             (api, Api, crate::commands::api::ApiArgs, CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) }, crate::commands::api::run),
             (upgrade, Upgrade, crate::commands::upgrade::UpgradeArgs, command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)), crate::commands::upgrade::run),
         }
@@ -49,7 +49,7 @@ macro_rules! ops_command_spec {
     (schedule) => { command_spec("schedule", CommandJsonFamily::Ops) };
     (status) => { command_spec("status", CommandJsonFamily::Ops) };
     (git) => { command_spec("git", CommandJsonFamily::Ops) };
-    (self_cmd) => { command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") };
+    (self_cmd) => { CommandSpec { subcommand_safety: SELF_SUBCOMMAND_SAFETY, ..command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") } };
     (api) => { CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) } };
     (upgrade) => { command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)) };
 }

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -603,6 +603,64 @@ const REVIEW_AUDIT_BASELINE_PATHS: &[&str] = &[
     "audit-baseline prune",
 ];
 
+const EXTENSION_MUTATING_PATHS: &[&str] = &[
+    "setup",
+    "refresh",
+    "relink",
+    "dev-run",
+    "install-for-component",
+    "set",
+];
+const EXTENSION_MUTATION_NOTES: &str =
+    "mutates installed extension files or extension manifest metadata";
+const EXTENSION_PASSTHROUGH_DANGEROUS_FLAGS: &[&str] =
+    &["extension runtime command", "passthrough args"];
+
+const EXTENSION_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        EXTENSION_MUTATING_PATHS,
+        mutating_safety(),
+        EXTENSION_MUTATION_NOTES,
+    ),
+    paths_safety(
+        &["install"],
+        guarded_mutating_safety(&["--replace"]),
+        EXTENSION_MUTATION_NOTES,
+    ),
+    paths_safety(
+        &["update"],
+        guarded_mutating_safety(&["--force"]),
+        EXTENSION_MUTATION_NOTES,
+    ),
+    paths_safety(
+        &["uninstall"],
+        guarded_mutating_safety(&["uninstall"]),
+        EXTENSION_MUTATION_NOTES,
+    ),
+    paths_safety(
+        &["run", "exec"],
+        operator_safety(None, EXTENSION_PASSTHROUGH_DANGEROUS_FLAGS),
+        "executes extension-owned runtime commands with forwarded arguments that may mutate the target system",
+    ),
+    paths_safety(
+        &["action"],
+        operator_safety(None, &["extension action"]),
+        "executes extension-owned actions that may mutate the target system",
+    ),
+];
+
+const RUNTIME_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
+    &["refresh"],
+    mutating_safety(),
+    "mutates installed runtime package files",
+)];
+
+const CLEANUP_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
+    &["artifacts"],
+    guarded_mutating_safety(CLEANUP_DANGEROUS_FLAGS),
+    "default output is a non-mutating cleanup plan; pass --apply to remove artifacts",
+)];
+
 const SELF_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
     paths_safety(
         &["docs map"],
@@ -715,28 +773,34 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     ),
     crate::ops_command_spec!(daemon),
     crate::ops_command_spec!(schedule),
-    command_spec_with_representative_argv(
-        &["homeboy", "extension", "refresh", "."],
-        lab_command_spec_with_summary(
-            "extension",
-            CommandJsonFamily::Workspace,
-            "Lab runner routing covers runner extension refresh/update/dev-run workflows",
-            EXTENSION_LAB_SUPPORT,
-        ),
-    ),
+    CommandSpec {
+        subcommand_safety: EXTENSION_SUBCOMMAND_SAFETY,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "extension", "refresh", "."],
+            lab_command_spec_with_summary(
+                "extension",
+                CommandJsonFamily::Workspace,
+                "Lab runner routing covers runner extension refresh/update/dev-run workflows",
+                EXTENSION_LAB_SUPPORT,
+            ),
+        )
+    },
     crate::ops_command_spec!(status),
-    command_spec_with_output_notes_and_safety(
-        "cleanup",
-        CommandJsonFamily::Workspace,
-        "cleanup subcommands report plans by default and require --apply for removals",
-        CommandSafetySpec {
-            mutates: true,
-            operator: false,
-            dry_run_flag: None,
-            risk_exemption: None,
-            dangerous_flags: CLEANUP_DANGEROUS_FLAGS,
-        },
-    ),
+    CommandSpec {
+        subcommand_safety: CLEANUP_SUBCOMMAND_SAFETY,
+        ..command_spec_with_output_notes_and_safety(
+            "cleanup",
+            CommandJsonFamily::Workspace,
+            "cleanup subcommands report plans by default and require --apply for removals",
+            CommandSafetySpec {
+                mutates: true,
+                operator: false,
+                dry_run_flag: None,
+                risk_exemption: None,
+                dangerous_flags: CLEANUP_DANGEROUS_FLAGS,
+            },
+        )
+    },
     crate::ops_command_spec!(git),
     command_spec_with_output_notes_and_safety(
         "release",
@@ -789,22 +853,25 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         )
     },
     command_spec("runner", CommandJsonFamily::Workspace),
-    command_spec_with_representative_argv(
-        &[
-            "homeboy",
-            "runtime",
-            "refresh",
-            "example-runtime",
-            "--source",
-            ".",
-        ],
-        lab_command_spec_with_summary(
-            "runtime",
-            CommandJsonFamily::Workspace,
-            "Lab runner routing covers runtime package refresh workflows",
-            RUNTIME_LAB_SUPPORT,
-        ),
-    ),
+    CommandSpec {
+        subcommand_safety: RUNTIME_SUBCOMMAND_SAFETY,
+        ..command_spec_with_representative_argv(
+            &[
+                "homeboy",
+                "runtime",
+                "refresh",
+                "example-runtime",
+                "--source",
+                ".",
+            ],
+            lab_command_spec_with_summary(
+                "runtime",
+                CommandJsonFamily::Workspace,
+                "Lab runner routing covers runtime package refresh workflows",
+                RUNTIME_LAB_SUPPORT,
+            ),
+        )
+    },
     command_spec_with_representative_argv(
         &["homeboy", "worktree", "cleanup"],
         lab_command_spec_with_summary(

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -455,6 +455,16 @@ const fn with_dry_run(safety: CommandSafetySpec, dry_run_flag: &'static str) -> 
     }
 }
 
+const fn with_risk_exemption(
+    safety: CommandSafetySpec,
+    risk_exemption: &'static str,
+) -> CommandSafetySpec {
+    CommandSafetySpec {
+        risk_exemption: Some(risk_exemption),
+        ..safety
+    }
+}
+
 const fn paths_safety(
     paths: &'static [&'static str],
     safety: CommandSafetySpec,
@@ -648,6 +658,62 @@ const FUZZ_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
         FUZZ_MEASUREMENT_PATHS,
         guarded_safety(FUZZ_DANGEROUS_FLAGS),
         "read-only fuzz planning/execution contract by default; --allow-destructive infers isolated mode and attaches an auditable homeboy/isolation-proof/v1 unless one is supplied",
+    ),
+];
+
+const GIT_ISSUE_WRITE_PATHS: &[&str] =
+    &["issue create", "issue comment", "issue close", "issue edit"];
+const GIT_PR_WRITE_PATHS: &[&str] = &[
+    "pr create",
+    "pr edit",
+    "pr comment",
+    "pr refresh",
+    "pr policy open",
+];
+
+const GIT_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        GIT_ISSUE_WRITE_PATHS,
+        with_risk_exemption(
+            operator_safety(None, &[]),
+            "the issue subcommand is the explicit GitHub write action; no dry-run contract exists yet",
+        ),
+        "mutates GitHub issue state through the configured repository",
+    ),
+    paths_safety(
+        GIT_PR_WRITE_PATHS,
+        with_risk_exemption(
+            operator_safety(None, &[]),
+            "the PR subcommand is the explicit GitHub write action; no dry-run contract exists yet",
+        ),
+        "mutates GitHub pull request state or branch state",
+    ),
+    paths_safety(
+        &["pr fleet", "pr land"],
+        operator_safety(Some("--dry-run"), &["--apply", "--delete-branch"]),
+        "reports by default or with --dry-run; apply/merge flags mutate PR state",
+    ),
+];
+
+const REFACTOR_SOURCE_REWRITE_PATHS: &[&str] = &[
+    "rename",
+    "add",
+    "move",
+    "propagate",
+    "transform",
+    "decompose",
+];
+
+const REFACTOR_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        REFACTOR_SOURCE_REWRITE_PATHS,
+        guarded_mutating_safety(&["--write"]),
+        "reports a plan by default; pass --write to rewrite source files",
+    ),
+    paths_safety(
+        &["undo delete"],
+        mutating_safety(),
+        "deletes an undo snapshot without restoring it",
     ),
 ];
 
@@ -985,6 +1051,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             risk_exemption: None,
             dangerous_flags: REFACTOR_DANGEROUS_FLAGS,
         },
+        subcommand_safety: REFACTOR_SUBCOMMAND_SAFETY,
         ..command_spec_with_representative_argv(
             &["homeboy", "refactor", "--all"],
             lab_command_spec_with_output_notes_and_summary(

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -52,6 +52,9 @@ pub struct CommandSafetySpec {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandPathSafetySpec {
+    /// Space-separated subcommand paths *below* the owning command, matched
+    /// against the clap-derived command surface. The empty string addresses the
+    /// owning command itself.
     pub paths: &'static [&'static str],
     pub safety: CommandSafetySpec,
     pub output_notes: Option<&'static str>,
@@ -522,6 +525,8 @@ const PROJECT_MUTATING_PATHS: &[&str] = &[
 const COMPONENT_MUTATING_PATHS: &[&str] = &["create", "set", "delete", "rename", "setup"];
 const COMPONENT_GUARDED_PATHS: &[&str] = &["reconcile", "artifacts"];
 const RIG_STATIC_LINT_PATHS: &[&str] = &["lint", "package lint", "materialize"];
+const RIG_RUNTIME_MUTATING_PATHS: &[&str] = &["down", "repair", "install", "update"];
+const RIG_MANAGED_FILE_PATHS: &[&str] = &["sync", "app install", "app update", "app uninstall"];
 
 const DEPS_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
     DEPS_MUTATING_PATHS,
@@ -595,10 +600,61 @@ const COMPONENT_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
         "default output is non-mutating; pass --apply to repair or remove artifacts",
     ),
 ];
-const RIG_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
-    RIG_STATIC_LINT_PATHS,
-    CommandSafetySpec::read_only(),
-    "reads rig package files and emits the standard JSON lint report without evaluating the live environment",
+const RIG_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        RIG_STATIC_LINT_PATHS,
+        CommandSafetySpec::read_only(),
+        "reads rig package files and emits the standard JSON lint report without evaluating the live environment",
+    ),
+    paths_safety(
+        &["release-lock"],
+        operator_safety(None, &["--force"]),
+        "releases a local rig active-run lease; --force can reclaim a live holder's guardrail",
+    ),
+    paths_safety(
+        &["up"],
+        operator_safety(Some("--dry-run"), &[]),
+        "mutates local rig runtime state unless --dry-run is passed with --runner to emit a runner exec plan",
+    ),
+    paths_safety(
+        RIG_RUNTIME_MUTATING_PATHS,
+        operator_safety(None, &[]),
+        "mutates local rig runtime state or installed rig packages",
+    ),
+    paths_safety(
+        RIG_MANAGED_FILE_PATHS,
+        operator_safety(Some("--dry-run"), &[]),
+        "mutates rig-managed files unless --dry-run is passed",
+    ),
+    paths_safety(
+        &["sources remove", "sources refresh"],
+        mutating_safety(),
+        "mutates installed rig source metadata",
+    ),
+];
+
+const FUZZ_CASE_REPLAY_PATHS: &[&str] = &["replay", "minimize"];
+/// The empty path addresses bare `homeboy fuzz`, which shares the default
+/// planning/execution contract with its measurement subcommands.
+const FUZZ_MEASUREMENT_PATHS: &[&str] = &["", "run", "plan", "run-campaign"];
+
+const FUZZ_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        FUZZ_CASE_REPLAY_PATHS,
+        mutating_safety(),
+        "replays or minimizes a persisted fuzz case against local code and may write run artifacts",
+    ),
+    paths_safety(
+        FUZZ_MEASUREMENT_PATHS,
+        guarded_safety(FUZZ_DANGEROUS_FLAGS),
+        "read-only fuzz planning/execution contract by default; --allow-destructive infers isolated mode and attaches an auditable homeboy/isolation-proof/v1 unless one is supplied",
+    ),
+];
+
+const DB_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
+    &["delete-row", "drop-table"],
+    operator_safety(None, &[]),
+    "default output is a non-mutating plan; pass --apply to mutate",
 )];
 
 /// `review audit-baseline` is the real clap path; `review audit baseline` only
@@ -819,6 +875,7 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
     ),
     CommandSpec {
         safety: guarded_safety(FUZZ_DANGEROUS_FLAGS),
+        subcommand_safety: FUZZ_SUBCOMMAND_SAFETY,
         ..command_spec_with_representative_argv(
             &["homeboy", "fuzz"],
             lab_command_spec_with_summary(

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -603,6 +603,19 @@ const REVIEW_AUDIT_BASELINE_PATHS: &[&str] = &[
     "audit-baseline prune",
 ];
 
+const SELF_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        &["docs map"],
+        guarded_mutating_safety(&["--write"]),
+        "default JSON output is non-mutating; pass --write to write markdown docs to disk",
+    ),
+    paths_safety(
+        &["cleanup-runtime-tmp"],
+        operator_safety(None, &["--apply"]),
+        "default output is a non-mutating cleanup plan; pass --apply to delete runtime temp entries",
+    ),
+];
+
 const REVIEW_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
     paths_safety(
         &["ci autofix"],

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -465,6 +465,15 @@ const fn with_risk_exemption(
     }
 }
 
+/// Operator-gated but non-mutating: an explicit operator entry point that only
+/// renders a plan.
+const fn operator_read_only() -> CommandSafetySpec {
+    CommandSafetySpec {
+        operator: true,
+        ..CommandSafetySpec::read_only()
+    }
+}
+
 const fn paths_safety(
     paths: &'static [&'static str],
     safety: CommandSafetySpec,
@@ -658,6 +667,98 @@ const FUZZ_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
         FUZZ_MEASUREMENT_PATHS,
         guarded_safety(FUZZ_DANGEROUS_FLAGS),
         "read-only fuzz planning/execution contract by default; --allow-destructive infers isolated mode and attaches an auditable homeboy/isolation-proof/v1 unless one is supplied",
+    ),
+];
+
+const WORKTREE_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        &["queue-create"],
+        with_dry_run(mutating_safety(), "--dry-run"),
+        "default output creates task worktrees one-at-a-time; pass --dry-run to plan without creating",
+    ),
+    paths_safety(
+        &["create"],
+        mutating_safety(),
+        "creates a task worktree from a registered component checkout",
+    ),
+    paths_safety(
+        &["remove"],
+        guarded_mutating_safety(&["--force"]),
+        "removes a task worktree after safety checks",
+    ),
+    paths_safety(
+        &["cleanup"],
+        operator_safety(
+            Some("--dry-run"),
+            &["--apply", "--force", "--cleanup-artifacts"],
+        ),
+        "default output is a non-mutating task-worktree cleanup plan; pass --apply to remove eligible worktrees, and --cleanup-artifacts to include rebuildable Homeboy artifacts",
+    ),
+];
+
+const TUNNEL_SERVICE_DECLARATION_PATHS: &[&str] =
+    &["service expose", "service set", "service remove"];
+const TUNNEL_PREVIEW_RUNTIME_PATHS: &[&str] = &[
+    "preview-client start",
+    "preview-consumer run",
+    "preview-ingress serve",
+    "artifact-origin serve",
+];
+
+const TUNNEL_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        TUNNEL_SERVICE_DECLARATION_PATHS,
+        operator_safety(None, &[]),
+        "mutates private service tunnel declarations",
+    ),
+    paths_safety(
+        &["service start", "service stop"],
+        operator_safety(None, &[]),
+        "mutates private service tunnel runtime state",
+    ),
+    paths_safety(
+        TUNNEL_PREVIEW_RUNTIME_PATHS,
+        operator_safety(None, &[]),
+        "starts or supervises tunnel preview runtime state",
+    ),
+    paths_safety(
+        &["preview-ingress route", "preview-ingress unroute"],
+        operator_safety(None, &[]),
+        "mutates preview ingress route state",
+    ),
+    paths_safety(
+        &["preview-ingress install"],
+        operator_read_only(),
+        "renders a non-destructive operator install plan",
+    ),
+];
+
+const STACK_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        &["create", "add-pr", "remove-pr"],
+        mutating_safety(),
+        "mutates persisted stack specification metadata",
+    ),
+    paths_safety(
+        &["apply", "rebase"],
+        with_risk_exemption(
+            operator_safety(None, &[]),
+            "stack command name is the explicit branch mutation action; status/sync --dry-run are the planning paths",
+        ),
+        "mutates the configured stack target branch",
+    ),
+    paths_safety(
+        &["sync"],
+        operator_safety(Some("--dry-run"), &[]),
+        "mutates the configured stack target branch and may update the stack spec unless --dry-run is passed",
+    ),
+    paths_safety(
+        &["push"],
+        with_risk_exemption(
+            operator_safety(None, &[]),
+            "push is the explicit remote publication action; no dry-run contract exists yet",
+        ),
+        "pushes the configured stack target branch to its remote",
     ),
 ];
 
@@ -1165,32 +1266,38 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             ),
         )
     },
-    command_spec_with_representative_argv(
-        &["homeboy", "worktree", "cleanup"],
-        lab_command_spec_with_summary(
-            "worktree",
-            CommandJsonFamily::Workspace,
-            "Lab runner routing covers runner-resident task worktree cleanup",
-            WORKTREE_LAB_SUPPORT,
-        ),
-    ),
-    command_spec_with_representative_argv(
-        &[
-            "homeboy",
-            "tunnel",
-            "service",
-            "start",
-            "example-service",
-            "--command",
-            "npm start",
-        ],
-        lab_command_spec_with_summary(
-            "tunnel",
-            CommandJsonFamily::Workspace,
-            "Lab runner routing covers tunnel preview and service workflows",
-            TUNNEL_LAB_SUPPORT,
-        ),
-    ),
+    CommandSpec {
+        subcommand_safety: WORKTREE_SUBCOMMAND_SAFETY,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "worktree", "cleanup"],
+            lab_command_spec_with_summary(
+                "worktree",
+                CommandJsonFamily::Workspace,
+                "Lab runner routing covers runner-resident task worktree cleanup",
+                WORKTREE_LAB_SUPPORT,
+            ),
+        )
+    },
+    CommandSpec {
+        subcommand_safety: TUNNEL_SUBCOMMAND_SAFETY,
+        ..command_spec_with_representative_argv(
+            &[
+                "homeboy",
+                "tunnel",
+                "service",
+                "start",
+                "example-service",
+                "--command",
+                "npm start",
+            ],
+            lab_command_spec_with_summary(
+                "tunnel",
+                CommandJsonFamily::Workspace,
+                "Lab runner routing covers tunnel preview and service workflows",
+                TUNNEL_LAB_SUPPORT,
+            ),
+        )
+    },
     CommandSpec {
         subcommand_safety: RUNS_SUBCOMMAND_SAFETY,
         ..command_spec_with_output_notes(
@@ -1200,7 +1307,10 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         )
     },
     crate::ops_command_spec!(self_cmd),
-    command_spec("stack", CommandJsonFamily::Workspace),
+    CommandSpec {
+        subcommand_safety: STACK_SUBCOMMAND_SAFETY,
+        ..command_spec("stack", CommandJsonFamily::Workspace)
+    },
     crate::ops_command_spec!(api),
     crate::ops_command_spec!(upgrade),
 ];

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -661,6 +661,73 @@ const FUZZ_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
     ),
 ];
 
+const RUNNER_CONFIG_PATHS: &[&str] = &[
+    "add",
+    "enable",
+    "set",
+    "trust",
+    "pair",
+    "remove",
+    "disconnect",
+    "refresh-homeboy",
+];
+
+const RUNNER_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        RUNNER_CONFIG_PATHS,
+        operator_safety(None, &[]),
+        "mutates runner configuration, trust policy, or runner lifecycle state",
+    ),
+    paths_safety(
+        &["connect", "work"],
+        with_risk_exemption(
+            operator_safety(None, &[]),
+            "runner lifecycle command name is the explicit operator action; no dry-run contract exists yet",
+        ),
+        "mutates runner lifecycle state",
+    ),
+    paths_safety(
+        &["doctor"],
+        operator_safety(None, &["--repair"]),
+        "diagnoses runners by default; --repair mutates runner lifecycle state",
+    ),
+    paths_safety(
+        &["exec"],
+        operator_safety(Some("--dry-run"), &[]),
+        "executes commands on a runner unless --dry-run is passed",
+    ),
+    paths_safety(
+        &["lifecycle"],
+        CommandSafetySpec::read_only(),
+        "non-mutating runner workspace lifecycle/finalization readiness report suitable for RunOutcomeEnvelope embedding",
+    ),
+    paths_safety(
+        &["workspace sync"],
+        operator_safety(None, &["--allow-dirty-lab-workspace"]),
+        "materializes a local worktree into runner workspace state",
+    ),
+    paths_safety(
+        &["workspace update"],
+        operator_safety(None, &[]),
+        "advances a prepared runner workspace from its snapshot lease",
+    ),
+    paths_safety(
+        &["workspace pull"],
+        operator_safety(Some("--dry-run"), &[]),
+        "copies selected files from runner workspace state to a local destination",
+    ),
+    paths_safety(
+        &["workspace apply"],
+        operator_safety(None, &["--force"]),
+        "applies a Lab-generated workspace patch to a local worktree",
+    ),
+    paths_safety(
+        &["workspace prune"],
+        operator_safety(None, &["--apply"]),
+        "default output is a non-mutating orphan cleanup plan with candidate/remaining bytes; pass --apply to delete exact runner workspace paths and --passes to drain bounded pages",
+    ),
+];
+
 const GIT_ISSUE_WRITE_PATHS: &[&str] =
     &["issue create", "issue comment", "issue close", "issue edit"];
 const GIT_PR_WRITE_PATHS: &[&str] = &[
@@ -1075,7 +1142,10 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             ),
         )
     },
-    command_spec("runner", CommandJsonFamily::Workspace),
+    CommandSpec {
+        subcommand_safety: RUNNER_SUBCOMMAND_SAFETY,
+        ..command_spec("runner", CommandJsonFamily::Workspace)
+    },
     CommandSpec {
         subcommand_safety: RUNTIME_SUBCOMMAND_SAFETY,
         ..command_spec_with_representative_argv(

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -610,6 +610,57 @@ const REVIEW_AUDIT_BASELINE_PATHS: &[&str] = &[
     "audit-baseline prune",
 ];
 
+const AGENT_TASK_CONTROLLER_PATHS: &[&str] = &[
+    "controller init",
+    "controller from-spec",
+    "controller run-from-spec",
+    "controller materialize",
+    "controller events",
+    "controller apply-event",
+    "controller run-next",
+    "controller run",
+    "controller resume",
+    "controller mark-human-ready",
+];
+
+const AGENT_TASK_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        &["promote"],
+        with_dry_run(mutating_safety(), "--dry-run"),
+        "applies a selected patch artifact into a managed worktree unless --dry-run is passed",
+    ),
+    paths_safety(
+        &["active"],
+        with_dry_run(guarded_mutating_safety(&["--apply"]), "--dry-run"),
+        "reads active runs by default; --reconcile previews the full fleet mutation set and --apply authorizes its cancellation",
+    ),
+    paths_safety(
+        &["reconcile"],
+        with_dry_run(guarded_mutating_safety(&["--apply"]), "--dry-run"),
+        "previews reconciliation for one durable run; --apply authorizes a scoped lifecycle mutation after provider-state inspection",
+    ),
+    paths_safety(
+        AGENT_TASK_CONTROLLER_PATHS,
+        mutating_safety(),
+        "mutates durable agent-task loop controller state",
+    ),
+    paths_safety(
+        &["auth remove"],
+        operator_safety(None, &[]),
+        "removes one agent-task provider secret source mapping",
+    ),
+    paths_safety(
+        &["prompts remove"],
+        mutating_safety(),
+        "removes one stored agent-task prompt",
+    ),
+    paths_safety(
+        &["fanout cook-batch"],
+        operator_safety(Some("--dry-run"), &["--run-plan"]),
+        "creates/reuses task worktrees and can run the generated fanout unless --dry-run is passed",
+    ),
+];
+
 const RUNS_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
     paths_safety(
         &["reconcile"],
@@ -739,15 +790,18 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         lab_notes: "read-only local activity query; never offloaded because it inspects operator-local stores",
         ..command_spec("activity", CommandJsonFamily::Workspace)
     },
-    command_spec_with_representative_argv(
-        &["homeboy", "agent-task", "providers"],
-        lab_command_spec_with_summary(
-            "agent-task",
-            CommandJsonFamily::Workspace,
-            "Lab runner routing covers portable, explicit-runner, and runner-resident agent-task workflows",
-            AGENT_TASK_LAB_SUPPORT,
-        ),
-    ),
+    CommandSpec {
+        subcommand_safety: AGENT_TASK_SUBCOMMAND_SAFETY,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "agent-task", "providers"],
+            lab_command_spec_with_summary(
+                "agent-task",
+                CommandJsonFamily::Workspace,
+                "Lab runner routing covers portable, explicit-runner, and runner-resident agent-task workflows",
+                AGENT_TASK_LAB_SUPPORT,
+            ),
+        )
+    },
     CommandSpec {
         subcommand_safety: PROJECT_SUBCOMMAND_SAFETY,
         ..command_spec("project", CommandJsonFamily::Workspace)

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -445,6 +445,13 @@ const fn guarded_mutating_safety(dangerous_flags: &'static [&'static str]) -> Co
     }
 }
 
+const fn with_dry_run(safety: CommandSafetySpec, dry_run_flag: &'static str) -> CommandSafetySpec {
+    CommandSafetySpec {
+        dry_run_flag: Some(dry_run_flag),
+        ..safety
+    }
+}
+
 const fn paths_safety(
     paths: &'static [&'static str],
     safety: CommandSafetySpec,
@@ -601,6 +608,44 @@ const REVIEW_AUDIT_BASELINE_PATHS: &[&str] = &[
     "audit-baseline refresh",
     "audit-baseline merge",
     "audit-baseline prune",
+];
+
+const RUNS_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        &["reconcile"],
+        with_dry_run(mutating_safety(), "--dry-run"),
+        "marks orphaned running records stale unless --dry-run is passed",
+    ),
+    paths_safety(
+        &["import"],
+        mutating_safety(),
+        "imports observation bundle or GitHub Actions artifacts into the local run store",
+    ),
+    paths_safety(
+        &["loop-sync"],
+        with_dry_run(mutating_safety(), "--dry-run"),
+        "syncs copied loop archives into observation runs/artifacts unless --dry-run is passed",
+    ),
+    paths_safety(
+        &["artifact cleanup-downloads", "artifact cleanup-persisted"],
+        guarded_mutating_safety(&["--apply"]),
+        "default output is a non-mutating cleanup plan; pass --apply to delete artifacts",
+    ),
+    paths_safety(
+        &["resources"],
+        guarded_mutating_safety(&["--apply"]),
+        "default output is non-mutating; pass --cleanup-plan to plan lifecycle resource cleanup or --apply with --cleanup-root to delete bounded apply-intended candidates",
+    ),
+    paths_safety(
+        &["artifact attach"],
+        mutating_safety(),
+        "copies an existing runner-side file into the persisted local artifact store and records it against a run",
+    ),
+    paths_safety(
+        &["findings reconcile", "findings reconcile-run"],
+        operator_safety(Some("--dry-run"), &["--apply"]),
+        "default output is a non-mutating issue reconciliation plan; pass --apply to mutate tracker state",
+    ),
 ];
 
 const EXTENSION_MUTATING_PATHS: &[&str] = &[
@@ -898,11 +943,14 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
             TUNNEL_LAB_SUPPORT,
         ),
     ),
-    command_spec_with_output_notes(
-        "runs",
-        CommandJsonFamily::Workspace,
-        "inspects persisted evidence, artifacts, artifact postprocessing, and finding reconciliation workflows",
-    ),
+    CommandSpec {
+        subcommand_safety: RUNS_SUBCOMMAND_SAFETY,
+        ..command_spec_with_output_notes(
+            "runs",
+            CommandJsonFamily::Workspace,
+            "inspects persisted evidence, artifacts, artifact postprocessing, and finding reconciliation workflows",
+        )
+    },
     crate::ops_command_spec!(self_cmd),
     command_spec("stack", CommandJsonFamily::Workspace),
     crate::ops_command_spec!(api),

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -594,6 +594,28 @@ const RIG_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
     "reads rig package files and emits the standard JSON lint report without evaluating the live environment",
 )];
 
+/// `review audit-baseline` is the real clap path; `review audit baseline` only
+/// exists as a pre-parse argv rewrite in `commands::utils::args`, so declaring
+/// safety against that spelling silently classifies the command as read-only.
+const REVIEW_AUDIT_BASELINE_PATHS: &[&str] = &[
+    "audit-baseline refresh",
+    "audit-baseline merge",
+    "audit-baseline prune",
+];
+
+const REVIEW_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
+    paths_safety(
+        &["ci autofix"],
+        operator_safety(None, &[]),
+        "commits and pushes prepared CI autofix changes",
+    ),
+    paths_safety(
+        REVIEW_AUDIT_BASELINE_PATHS,
+        mutating_safety(),
+        "mutates persisted audit baseline data in component configuration",
+    ),
+];
+
 pub const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
         output_notes: "unified active/recent activity read model in the standard JSON envelope",
@@ -710,15 +732,18 @@ pub const COMMAND_SPECS: &[CommandSpec] = &[
         operator_safety(Some("--dry-run"), RELEASE_DANGEROUS_FLAGS),
     ),
     command_spec("report", CommandJsonFamily::Workspace),
-    command_spec_with_representative_argv(
-        &["homeboy", "review"],
-        lab_command_spec_with_summary(
-            "review",
-            CommandJsonFamily::Quality,
-            "portable Lab offload is available for release-gate review runs",
-            REVIEW_LAB_SUPPORT,
-        ),
-    ),
+    CommandSpec {
+        subcommand_safety: REVIEW_SUBCOMMAND_SAFETY,
+        ..command_spec_with_representative_argv(
+            &["homeboy", "review"],
+            lab_command_spec_with_summary(
+                "review",
+                CommandJsonFamily::Quality,
+                "portable Lab offload is available for release-gate review runs",
+                REVIEW_LAB_SUPPORT,
+            ),
+        )
+    },
     CommandSpec {
         safety: CommandSafetySpec {
             mutates: true,


### PR DESCRIPTION
## The bug: a safety declaration that could never fire

`safety_manifest.rs` declared:

```rust
["review","audit","baseline","refresh"] | ["review","audit","baseline","merge"]
    => metadata.mutating("mutates persisted audit baseline data in component configuration")
```

The manifest walks the **clap** surface (`current_command_surface()`), and clap's
child of `review` is `audit-baseline`, not `audit baseline` — that spelling only
exists in pre-parse argv rewriting (`commands/utils/args.rs`). The arm was
unreachable, so `homeboy contract manifest` reported commands that mutate
persisted audit baseline data as **non-mutating**, with the generic
`"standard CLI output contract"` note. Verified against a real manifest:

```
review audit-baseline refresh | mutates=False | standard CLI output contract
review audit-baseline merge   | mutates=False | standard CLI output contract
review audit-baseline prune   | mutates=False | standard CLI output contract
```

`review audit-baseline prune` had no declaration at all despite existing since
`commands/audit_baseline.rs`. All three are now declared against the real clap
paths and report as mutating.

## The cause: two parallel registries

Safety metadata had two homes producing the same shape:

- **Declarative** — `CommandPathSafetySpec` tables on `CommandSpec.subcommand_safety`
  (9 commands), resolved by `CommandSpec::path_safety()`.
- **Imperative** — one ~330-line `match path.as_slice()` in
  `safety_manifest.rs` with ~90 arms covering ~124 command paths.

Only the declarative side is checkable against clap; the imperative side fails
silently. This PR deletes the imperative registry.

## The migration

All ~90 arms (124 command paths) are migrated into `CommandPathSafetySpec`
tables, one commit per command family: `review`, `self`, `extension`/`runtime`/
`cleanup`, `runs`, `agent-task`, `fuzz`/`rig`/`db`, `git`/`refactor`, `runner`,
`worktree`/`tunnel`/`stack`. Nothing is left behind:

- `command_safety_metadata`, `CommandSafetyMetadata`, and its three mutation
  builders (`mutating`, `operator_mutating`, `guarded_operator_mutating`) are
  deleted. `safety_manifest.rs` drops from 570 to 219 lines.
- Resolution now lives in `resolved_command_safety()`, which only reads
  `COMMAND_SPECS`. `structured_output` was unconditionally `true` in every branch
  of the deleted registry, so it is stated directly.
- Three small `const fn` spec combinators added (`with_dry_run`,
  `with_risk_exemption`, `operator_read_only`) so declarations compose without
  hand-written struct literals.
- An empty path string in `CommandPathSafetySpec.paths` addresses the owning
  command itself; this preserves bare `homeboy fuzz`'s measurement-contract
  output notes without leaking them onto unrelated `fuzz` subcommands.
- The dead no-op arm `["contract","manifest"] => {}` is dropped.

Behavior is otherwise unchanged: the declared safety of all 188 declarative
paths (64 pre-existing + 124 migrated) was diffed field-by-field against a
manifest produced by the pre-change binary. The only deltas are the three
`review audit-baseline` fixes (plus expected drift on `worktree cleanup` from
already-merged #10286, whose arm was migrated verbatim).

## The guard test

`command_path_safety_specs_resolve_to_clap_surface_nodes` asserts every
`CommandPathSafetySpec.paths` entry resolves to a real node in
`current_command_surface()`. This is the most valuable part of the PR: it makes
the entire bug class — safety declared against a path clap does not expose —
impossible to merge again.

It would have failed on the pre-fix entry: resolving
`review audit baseline refresh` against the real clap surface returns `false`,
while `review audit-baseline refresh` returns `true`. Running the same
resolution over all 124 migrated arm paths surfaced **no other unreachable
paths** — `review audit baseline refresh` and `review audit baseline merge`
were the only two.

A companion regression test asserts `review audit-baseline refresh|merge|prune`
are reported as mutating and that `review audit baseline` is absent from the
manifest.

## Verification

`cargo fmt` only; full build/test is left to CI per this host's resource policy.
Path correctness was verified against a real `homeboy contract manifest` dump of
the clap surface rather than by reading the issue text.

Closes #10313
