### PR TITLE
cleanup: single sha256 content-hash primitive (#10294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "homeboy-agents",
  "homeboy-cli-contract",
  "homeboy-core",
+ "homeboy-engine-primitives",
  "homeboy-extension",
  "homeboy-extension-contract",
  "homeboy-fuzz",
@@ -940,6 +941,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "toml",
 ]
@@ -982,7 +984,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
  "shellexpand",
  "tempfile",
  "uuid",
@@ -1017,9 +1018,9 @@ name = "homeboy-fuzz"
 version = "0.1.0"
 dependencies = [
  "homeboy-core",
+ "homeboy-engine-primitives",
  "serde",
  "serde_json",
- "sha2",
  "tempfile",
 ]
 
@@ -1064,6 +1065,7 @@ dependencies = [
  "homeboy-agents",
  "homeboy-cli-contract",
  "homeboy-core",
+ "homeboy-engine-primitives",
  "homeboy-extension",
  "homeboy-fuzz",
  "homeboy-lab-runner-contract",
@@ -1175,6 +1177,7 @@ dependencies = [
  "glob",
  "glob-match",
  "homeboy-core",
+ "homeboy-engine-primitives",
  "homeboy-extension",
  "homeboy-product-identity",
  "homeboy-release-contract",
@@ -1217,6 +1220,7 @@ dependencies = [
  "chrono",
  "fs4",
  "homeboy-core",
+ "homeboy-engine-primitives",
  "homeboy-extension",
  "homeboy-lab-runner-contract",
  "homeboy-lifecycle-contract",
@@ -1282,12 +1286,12 @@ dependencies = [
  "chrono",
  "glob-match",
  "homeboy-core",
+ "homeboy-engine-primitives",
  "libc",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
  "uuid",
 ]
 

--- a/crates/homeboy-agents/src/agent_task_aggregate.rs
+++ b/crates/homeboy-agents/src/agent_task_aggregate.rs
@@ -1,6 +1,6 @@
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use std::fmt;
 
 use super::agent_task::{
@@ -434,7 +434,7 @@ fn is_verified_recoverable_patch(outcome: &AgentTaskOutcome, artifact: &AgentTas
     };
     !content.is_empty()
         && artifact.size_bytes == Some(content.len() as u64)
-        && expected_sha256 == format!("{:x}", Sha256::digest(&content))
+        && expected_sha256 == content_hash::sha256_hex(&content)
 }
 
 fn non_empty_metadata_string(artifact: &AgentTaskArtifact, key: &str) -> bool {
@@ -563,6 +563,7 @@ fn aggregate_schema() -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+    use sha2::{Digest, Sha256};
 
     #[test]
     fn aggregate_outcomes_classifies_apply_retry_issue_and_review_candidates() {

--- a/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
@@ -1,8 +1,8 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::Path;
 use std::process::Command;
 
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use homeboy_core::gate_feedback_baseline::{
     register_gate_feedback_baseline_provider, GateFeedbackBaselineProvider,
@@ -102,7 +102,7 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
         std::fs::read(path)
             .map_err(|error| invalid(&format!("recorded patch artifact is unreadable: {error}")))?
     };
-    if format!("{:x}", Sha256::digest(&patch)) != expected_sha256 {
+    if content_hash::sha256_hex(&patch) != expected_sha256 {
         return Err(invalid(
             "recorded patch artifact sha256 does not match its content",
         ));
@@ -163,7 +163,7 @@ fn validate_promotion_chain_baseline(root: &Path, baseline: &Value) -> Result<St
 }
 
 fn valid_sha256(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+    content_hash::is_sha256_hex(value)
 }
 
 fn valid_git_object_id(value: &str) -> bool {
@@ -263,6 +263,7 @@ fn invalid(message: &str) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
 
     #[test]
     fn immutable_candidate_tree_accepts_exact_commit_and_rejects_dirty_state() {

--- a/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
@@ -11,7 +11,6 @@
 use serde::de::{self, DeserializeOwned};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::agent_task::{

--- a/crates/homeboy-agents/src/agent_task_controller_service/proof.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/proof.rs
@@ -26,11 +26,11 @@
 //! argument parsing, calling [`prepare_controller_proof`], running the resolved
 //! dispatch through the existing offload path, and rendering the JSON envelope.
 
+use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use crate::agent_task_provider;
 use homeboy_core::{Error, Result};
@@ -176,9 +176,7 @@ pub fn derive_proof_identity(
 }
 
 fn hex_digest(input: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(input.as_bytes());
-    format!("{:x}", hasher.finalize())
+    content_hash::sha256_hex(input.as_bytes())
 }
 
 /// Build the run inputs the controller materializer consumes: the profile's

--- a/crates/homeboy-agents/src/agent_task_controller_service/spec_compile.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/spec_compile.rs
@@ -3,6 +3,7 @@
 use super::*;
 use homeboy_core::component::{self, TargetSpec};
 use homeboy_core::plan::PlanStepDependencyKind;
+use homeboy_engine_primitives::content_hash;
 
 pub(super) const REPO_LOOP_SPEC_METADATA_KEY: &str = "repo_loop_spec";
 pub(super) const REPO_LOOP_SPEC_WORKFLOW_REASON: &str = "repo loop spec workflow";
@@ -21,9 +22,7 @@ pub(super) fn repo_loop_spec_fingerprint(spec: &AgentTaskRepoLoopSpec) -> Result
             Some("agent-task controller from-spec".to_string()),
         )
     })?;
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    Ok(format!("sha256:{}", content_hash::sha256_hex(&bytes)))
 }
 
 pub(super) fn repo_loop_spec_fingerprint_from_metadata(

--- a/crates/homeboy-agents/src/agent_task_controller_service/spec_source.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/spec_source.rs
@@ -7,6 +7,7 @@
 //! it, and assembles generator evidence. This orchestration belongs in core so
 //! the CLI adapter stays thin.
 
+use homeboy_engine_primitives::content_hash;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
@@ -15,7 +16,6 @@ use std::time::{Duration, Instant};
 
 use serde::Deserialize;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use crate::agent_task_loop_definition::{
     materialize_repo_loop_spec, AgentTaskLoopSpecMaterializationRequest,
@@ -166,7 +166,7 @@ fn load_generated_materialize_spec(
                 Some("controller.materialize.generator.serialize".to_string()),
             )
         })?);
-    let spec_hash = format!("{:x}", Sha256::digest(generated_raw.as_bytes()));
+    let spec_hash = content_hash::sha256_hex(generated_raw.as_bytes());
 
     Ok(MaterializeSpecSource {
         spec,

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/prompt_spec.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/prompt_spec.rs
@@ -5,8 +5,8 @@
 //! stored prompts and deriving deterministic task ids. Extracted from
 //! `agent_task_dispatch_plan` to keep the plan builder focused on plan shape.
 
+use homeboy_engine_primitives::content_hash;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use crate::agent_task_prompts;
 use homeboy_core::{config, Error, Result};
@@ -38,7 +38,7 @@ pub(crate) struct ResolvedPromptSpec {
 pub(crate) fn read_prompt_spec(spec: &str) -> Result<ResolvedPromptSpec> {
     if let Some(id) = agent_task_prompts::stored_prompt_ref_id(spec) {
         let content = agent_task_prompts::read_prompt(id)?;
-        let sha256 = format!("sha256:{:x}", Sha256::digest(content.as_bytes()));
+        let sha256 = format!("sha256:{}", content_hash::sha256_hex(content.as_bytes()));
         let id = agent_task_prompts::prompt_id(id)?;
         return Ok(ResolvedPromptSpec {
             content,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/artifact_materialization.rs
@@ -1,8 +1,8 @@
+use homeboy_engine_primitives::content_hash;
 use std::fs;
 use std::path::PathBuf;
 
 use serde_json::json;
-use sha2::{Digest, Sha256};
 
 use crate::agent_task::AgentTaskArtifact;
 use crate::agent_task_timeout_artifacts::is_patch_artifact_kind;
@@ -226,7 +226,7 @@ fn validate_file(artifact: &AgentTaskArtifact, path: &PathBuf) -> Result<()> {
             "retained artifact size does not match the aggregate",
         ));
     }
-    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let sha256 = content_hash::sha256_hex(&bytes);
     if artifact.sha256.as_deref() != Some(sha256.as_str()) {
         return Err(unavailable(
             artifact,
@@ -275,6 +275,7 @@ fn io_error(path: &PathBuf) -> impl FnOnce(std::io::Error) -> Error + '_ {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
 
     fn artifact(bytes: &[u8]) -> AgentTaskArtifact {
         AgentTaskArtifact {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1,4 +1,5 @@
 use super::*;
+use homeboy_engine_primitives::content_hash;
 use sha2::Digest;
 use std::path::{Path, PathBuf};
 
@@ -732,7 +733,7 @@ pub(crate) fn project_runner_evidence_refs(
             if !evidence.uri.starts_with("file://") {
                 continue;
             }
-            let reference_digest = format!("{:x}", sha2::Sha256::digest(evidence.uri.as_bytes()));
+            let reference_digest = content_hash::sha256_hex(evidence.uri.as_bytes());
             let encoded_task_id =
                 homeboy_core::execution_contract::encode_uri_component(&outcome.task_id);
             evidence.uri = format!(
@@ -1605,7 +1606,7 @@ pub fn verified_controller_artifact_projection(
             None,
         )
     })?;
-    let actual_sha256 = format!("{:x}", sha2::Sha256::digest(&bytes));
+    let actual_sha256 = content_hash::sha256_hex(&bytes);
     if candidate.sha256.as_deref() != Some(expected_sha256)
         || candidate.size_bytes != Some(bytes.len() as i64)
         || actual_sha256 != expected_sha256

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1,6 +1,6 @@
 use super::*;
 use homeboy_core::api_jobs::RemoteRunnerJobRequest;
-use sha2::{Digest, Sha256};
+use homeboy_engine_primitives::content_hash;
 use std::fs::{self, File, OpenOptions};
 
 const LAB_HANDOFF_ACCEPTANCE_TIMEOUT_SECONDS: i64 = 120;
@@ -124,15 +124,16 @@ pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
                             &outcome.task_id,
                             &artifact.id,
                         ));
-                    let valid_sha = artifact.sha256.as_deref().is_some_and(|sha| {
-                        sha.len() == 64 && sha.bytes().all(|byte| byte.is_ascii_hexdigit())
-                    });
+                    let valid_sha = artifact
+                        .sha256
+                        .as_deref()
+                        .is_some_and(content_hash::is_sha256_hex);
                     let content_matches = artifact
                         .path
                         .as_deref()
                         .and_then(|candidate_path| fs::read(candidate_path).ok())
                         .is_some_and(|bytes| {
-                            let actual = format!("{:x}", Sha256::digest(bytes));
+                            let actual = content_hash::sha256_hex(&bytes);
                             artifact.sha256.as_deref() == Some(actual.as_str())
                         });
                     if artifact.schema == crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA

--- a/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
@@ -1,12 +1,12 @@
 //! Owner-only immutable payloads associated with an authoritative agent-task run.
 
+use homeboy_engine_primitives::content_hash;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use homeboy_core::engine::canonical_json::canonical_json_bytes;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::{sanitize_run_id, store, Error, Result};
@@ -69,7 +69,7 @@ fn canonical_bytes<T: Serialize>(payload: &T) -> Result<Vec<u8>> {
 
 fn digest<T: Serialize>(payload: &T) -> Result<String> {
     let bytes = canonical_bytes(payload)?;
-    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+    Ok(format!("sha256:{}", content_hash::sha256_hex(&bytes)))
 }
 
 fn validate<T: Serialize>(

--- a/crates/homeboy-agents/src/agent_task_loop_controller/service.rs
+++ b/crates/homeboy-agents/src/agent_task_loop_controller/service.rs
@@ -3,8 +3,8 @@ use crate::agent_task_lifecycle;
 use chrono::{DateTime, Utc};
 use homeboy_core::engine::local_files::write_json_file as write_json;
 use homeboy_core::{paths, Error, Result};
+use homeboy_engine_primitives::content_hash;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::fs;
 use std::io::ErrorKind;
@@ -456,7 +456,10 @@ fn failed_child_failure_signature(
         diagnostic_class.unwrap_or(""),
         normalized_message
     );
-    let digest = format!("sha256:{:x}", Sha256::digest(signature_material.as_bytes()));
+    let digest = format!(
+        "sha256:{}",
+        content_hash::sha256_hex(signature_material.as_bytes())
+    );
     AgentTaskLoopFailureSignature {
         digest,
         task_id: task_id.or(child_run_id).map(str::to_string),

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -1,8 +1,8 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 
 use homeboy_core::{Error, Result};
 
@@ -100,9 +100,7 @@ pub(crate) fn committed_changes_patch(
     if commits.is_empty() {
         return Ok(None);
     }
-    let mut hasher = Sha256::new();
-    hasher.update(patch.as_bytes());
-    let sha256 = format!("{:x}", hasher.finalize());
+    let sha256 = content_hash::sha256_hex(patch.as_bytes());
     let patch_path = committed_changes_patch_path(options, &sha256)?;
     std::fs::write(&patch_path, patch.as_bytes()).map_err(|error| {
         Error::internal_io(

--- a/crates/homeboy-agents/src/agent_task_promotion/patch.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/patch.rs
@@ -1,6 +1,6 @@
+use homeboy_engine_primitives::content_hash;
 use std::io::Write;
 
-use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 
 use crate::agent_task::AgentTaskArtifact;
@@ -204,9 +204,7 @@ pub(crate) fn validate_artifact_content(artifact: &AgentTaskArtifact, patch: &st
     }
 
     if let Some(expected_sha256) = artifact.sha256.as_deref() {
-        let mut hasher = Sha256::new();
-        hasher.update(patch.as_bytes());
-        let actual_sha256 = format!("{:x}", hasher.finalize());
+        let actual_sha256 = content_hash::sha256_hex(patch.as_bytes());
         if expected_sha256 != actual_sha256 {
             return Err(Error::validation_invalid_argument(
                 "artifact.sha256",

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1,10 +1,10 @@
+use homeboy_engine_primitives::content_hash;
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 
 use crate::agent_task::{
     AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
@@ -1117,7 +1117,7 @@ fn has_recoverable_candidate_provenance(
 }
 
 fn valid_sha256(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+    content_hash::is_sha256_hex(value)
 }
 
 #[cfg(test)]
@@ -1222,7 +1222,7 @@ fn promote_committed_changes(
             )),
         )
     })?;
-    let actual_sha256 = format!("{:x}", Sha256::digest(patch.as_bytes()));
+    let actual_sha256 = content_hash::sha256_hex(patch.as_bytes());
     if actual_sha256 != committed_patch.sha256 {
         return Err(Error::validation_invalid_argument(
             "committed_changes.sha256",
@@ -2320,7 +2320,7 @@ pub fn canonical_recoverable_patch_artifacts(
                 continue;
             }
         };
-        let digest = format!("{:x}", Sha256::digest(normalized.content.as_bytes()));
+        let digest = content_hash::sha256_hex(normalized.content.as_bytes());
         let identity = canonical_patch_identity_with_digest(&artifact, &digest);
         if !canonical.iter().any(|(existing, _)| existing == &identity) {
             canonical.push((identity, artifact));

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -10,7 +10,7 @@ use super::secrets::{
     provider_secret_sources_for_plan_with_providers,
 };
 use super::*;
-use sha2::{Digest, Sha256};
+use homeboy_engine_primitives::content_hash;
 
 #[cfg(not(test))]
 static PROVIDER_CATALOG: OnceLock<RwLock<AgentTaskProviderCatalog>> = OnceLock::new();
@@ -194,7 +194,7 @@ fn provider_catalog_version(
     // detectable without treating an unchanged rediscovery as drift.
     let content = serde_json::to_vec(&(providers, diagnostics))
         .expect("agent-task provider catalog must serialize");
-    format!("resolved:{:x}", Sha256::digest(content))
+    format!("resolved:{}", content_hash::sha256_hex(&content))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -1,8 +1,7 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
-
-use sha2::{Digest, Sha256};
 
 use super::harvest::{
     git_is_repository, git_output_raw, git_output_with_env, git_status_ignoring_runner_metadata,
@@ -770,7 +769,7 @@ pub(crate) fn fingerprint(contents: &[u8]) -> String {
 }
 
 fn sha256_hex(contents: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(contents))
+    content_hash::sha256_hex(contents)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-agents/src/agent_task_scheduler/candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/candidate_adoption.rs
@@ -1,8 +1,7 @@
+use homeboy_engine_primitives::content_hash;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
-
-use sha2::{Digest, Sha256};
 
 use super::*;
 use crate::agent_task_promotion::{normalize_promotion_patch, validate_artifact_content};
@@ -262,7 +261,7 @@ fn candidate_artifact_url(run_id: &str, task_id: &str, artifact_id: &str) -> Str
 }
 
 fn sha256(content: &str) -> String {
-    format!("{:x}", Sha256::digest(content.as_bytes()))
+    content_hash::sha256_hex(content.as_bytes())
 }
 
 fn canonical_repository_identity_for_root(root: Option<&str>) -> Option<String> {

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 use std::sync::{mpsc, Arc};
@@ -1184,8 +1185,6 @@ struct TaskResult {
 pub(super) fn deferred_cleanup_action_artifact(
     running: &RunningTask,
 ) -> Result<AgentTaskArtifact, HarvestError> {
-    use sha2::{Digest, Sha256};
-
     let run_id = running.run_id.as_deref().unwrap_or("unrecorded-run");
     let directory = homeboy_core::artifacts::root()
         .map_err(|error| HarvestError::ArtifactDirectory {
@@ -1230,7 +1229,7 @@ pub(super) fn deferred_cleanup_action_artifact(
         url: None,
         mime: Some("application/json".to_string()),
         size_bytes: Some(content.len() as u64),
-        sha256: Some(format!("{:x}", Sha256::digest(&content))),
+        sha256: Some(content_hash::sha256_hex(&content)),
         metadata: serde_json::json!({ "run_id": running.run_id, "task_id": running.task_id, "attempt": running.attempt }),
     })
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -1,7 +1,6 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-use sha2::{Digest, Sha256};
 
 use super::*;
 
@@ -380,7 +379,7 @@ fn committed_patch_artifact(
 }
 
 fn patch_sha256(contents: impl AsRef<[u8]>) -> String {
-    format!("{:x}", Sha256::digest(contents.as_ref()))
+    content_hash::sha256_hex(contents.as_ref())
 }
 
 fn attempt_patch_path(running: &RunningTask, kind: &str) -> Result<PathBuf, HarvestError> {
@@ -641,6 +640,7 @@ mod committed_harvest_tests {
         AGENT_TASK_REQUEST_SCHEMA,
     };
     use homeboy_core::source_snapshot::SourceSnapshot;
+    use sha2::{Digest, Sha256};
     use std::sync::{Mutex, OnceLock};
     use std::time::Instant;
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -8,8 +8,8 @@
 //! build them from a source root or a prior promotion. The private `git_output`
 //! helpers live here because this cluster is their only user.
 
+use homeboy_engine_primitives::content_hash;
 use serde_json::Value;
-use sha2::Digest;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -238,7 +238,7 @@ pub(crate) fn materialize_initial_candidate_baseline(
             canonical_path,
             commit,
             tree: tree.clone(),
-            artifact_sha256: format!("{:x}", sha2::Sha256::digest(tree.as_bytes())),
+            artifact_sha256: content_hash::sha256_hex(tree.as_bytes()),
             source_run_id: source_run_id.to_string(),
             source_task_id: task_id.to_string(),
             bound_task_id: task_id.to_string(),
@@ -333,7 +333,7 @@ fn materialize_follow_up_baseline_at(
             Some("read promoted patch artifact".to_string()),
         )
     })?;
-    let artifact_sha256 = format!("{:x}", sha2::Sha256::digest(&artifact_bytes));
+    let artifact_sha256 = content_hash::sha256_hex(&artifact_bytes);
     if let Some(expected) = promotion.patch_artifact.sha256.as_deref() {
         if expected != artifact_sha256 {
             return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1,5 +1,6 @@
 //! Durable, versioned input boundary for cook continuation scheduling.
 
+use homeboy_engine_primitives::content_hash;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
@@ -7,7 +8,6 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::Digest;
 
 use crate::agent_task_lifecycle;
 use crate::agent_task_scheduler::AgentTaskPlan;
@@ -873,7 +873,7 @@ pub fn claim_continuation_for(
     run_id: &str,
 ) -> Result<Option<ClaimedCookContinuation>> {
     let key = format!("{cook_id}:{run_id}");
-    let hash = format!("{:x}", sha2::Sha256::digest(key.as_bytes()));
+    let hash = content_hash::sha256_hex(key.as_bytes());
     let root = queue_root()?;
     fs::create_dir_all(&root)
         .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?;
@@ -1230,7 +1230,7 @@ impl DurableCookContinuationQueue {
         fs::create_dir_all(&root).map_err(|error| {
             Error::internal_io(error.to_string(), Some(root.display().to_string()))
         })?;
-        let hash = format!("{:x}", sha2::Sha256::digest(continuation.key.as_bytes()));
+        let hash = content_hash::sha256_hex(continuation.key.as_bytes());
         let path = root.join(format!("{hash}.pending"));
         if root.join(format!("{hash}.completed")).exists()
             || fs::read_dir(&root)
@@ -1506,6 +1506,7 @@ mod tests {
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
         AgentTaskProgressEvent, AgentTaskState,
     };
+    use sha2::Digest;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]

--- a/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
+++ b/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
@@ -3,11 +3,11 @@
 //! This is deliberately below the CLI boundary: durable controller jobs and
 //! interactive commands use the same checkpointed mutation state machine.
 
+use homeboy_engine_primitives::content_hash;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::daemon::controller_job_driver::{
@@ -164,8 +164,8 @@ fn promotion_job_idempotency_key(
     // The digest makes every immutable execution input part of the identity
     // without exposing aggregate content, paths, or gate configuration.
     Ok(format!(
-        "promotion:{source_run_id}:{artifact_id}:{:x}",
-        Sha256::digest(serialized)
+        "promotion:{source_run_id}:{artifact_id}:{}",
+        content_hash::sha256_hex(&serialized)
     ))
 }
 

--- a/crates/homeboy-agents/src/agent_task_timeout_artifacts.rs
+++ b/crates/homeboy-agents/src/agent_task_timeout_artifacts.rs
@@ -1,8 +1,8 @@
+use homeboy_engine_primitives::content_hash;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use crate::agent_task::{
     AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskOutcome,
@@ -588,11 +588,9 @@ fn mime_from_path(path: &Path) -> Option<String> {
 
 fn file_size_and_sha256(path: &Path) -> (Option<u64>, Option<String>) {
     let size_bytes = fs::metadata(path).ok().map(|metadata| metadata.len());
-    let sha256 = fs::read(path).ok().map(|bytes| {
-        let mut hasher = Sha256::new();
-        hasher.update(bytes);
-        format!("{:x}", hasher.finalize())
-    });
+    let sha256 = fs::read(path)
+        .ok()
+        .map(|bytes| content_hash::sha256_hex(&bytes));
     (size_bytes, sha256)
 }
 

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -1,9 +1,9 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::agent_task::AgentTaskOutcome;
 use homeboy_core::observation::ObservationStore;
@@ -1326,14 +1326,11 @@ fn recovered_workspace_matches(resource: &ControllerScratchResource, workspace: 
 }
 
 fn file_sha256(path: &Path) -> Result<String> {
-    let bytes = fs::read(path).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
-    })?;
-    Ok(sha256(&bytes))
+    content_hash::sha256_file(path)
 }
 
 fn sha256(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    content_hash::sha256_hex(bytes)
 }
 
 fn scratch_recovery_command(resource: &ControllerScratchResource) -> Option<String> {

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-process = { version = "0.1.0", path = "../homeboy-process" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1,8 +1,8 @@
 //! Public batch-cook fanout command handlers.
 
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 
 use homeboy::agents::agent_task_provider::AgentTaskProviderProfileDeclaration;
@@ -947,8 +947,8 @@ fn cook_recipe_source_identity(plan: &BatchCookFanoutPlan, cook: &BatchCookSpec)
     }))
     .map_err(|error| Error::internal_json(error.to_string(), None))?;
     Ok(format!(
-        "homeboy://agent-task/fanout-source/{:x}",
-        Sha256::digest(encoded)
+        "homeboy://agent-task/fanout-source/{}",
+        content_hash::sha256_hex(&encoded)
     ))
 }
 
@@ -1079,7 +1079,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
         .unwrap_or_else(|| "empty".to_string());
     let fanout_id = args.fanout_id.clone().unwrap_or_else(|| {
         let encoded = serde_json::to_vec(&cooks).expect("Cook specs serialize");
-        let digest = format!("{:x}", Sha256::digest(encoded));
+        let digest = content_hash::sha256_hex(&encoded);
         format!(
             "cook-batch-{}-{}-{}-{}",
             args.repo,

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -5,9 +5,9 @@
 //! references, and a prominent risk-flag section (#4398). The full verbose
 //! payload is available behind `--full`.
 
+use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 
 use homeboy::agents::agent_task_service as agent_task_service_direct;
@@ -88,8 +88,8 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
 fn bound_full_reader_payload(value: &mut Value) {
     match value {
         Value::String(text) if text.len() > FULL_TEXT_LIMIT => {
-            let digest = Sha256::digest(text.as_bytes());
-            *text = format!("[omitted {} bytes; sha256={:x}]", text.len(), digest);
+            let digest = content_hash::sha256_hex(text.as_bytes());
+            *text = format!("[omitted {} bytes; sha256={digest}]", text.len());
         }
         Value::Array(items) => {
             for item in items {

--- a/crates/homeboy-cli/src/commands/runs/bundle.rs
+++ b/crates/homeboy-cli/src/commands/runs/bundle.rs
@@ -1,8 +1,8 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::{Path, PathBuf};
 
 use clap::Args;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 use homeboy::core::observation::{
     build_bundle, bundle_artifact_uri, extract_directory_artifact_archive, portable_artifact_label,
@@ -240,8 +240,7 @@ fn rewrite_bundle_run_references(bundle: &mut ObservationBundle, from: &str, to:
 }
 
 fn remapped_child_record_id(id: &str, run_id: &str) -> String {
-    let hash = Sha256::digest(format!("{run_id}\0{id}").as_bytes());
-    let hex = format!("{hash:x}");
+    let hex = content_hash::sha256_hex(format!("{run_id}\0{id}").as_bytes());
     format!("{id}-imported-{}", &hex[..16])
 }
 
@@ -256,8 +255,7 @@ fn remapped_lab_run_id(run: &RunRecord) -> homeboy::core::Result<String> {
             run.id, error
         ))
     })?;
-    let hash = Sha256::digest(bytes);
-    let hex = format!("{hash:x}");
+    let hex = content_hash::sha256_hex(&bytes);
     Ok(format!("{}-imported-{}", run.id, &hex[..16]))
 }
 

--- a/crates/homeboy-cli/src/commands/runs/gh_actions.rs
+++ b/crates/homeboy-cli/src/commands/runs/gh_actions.rs
@@ -20,6 +20,7 @@
 //! `runs drift` primitives project arbitrary JSONPath expressions over the
 //! resulting artifact corpus.
 
+use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{Cursor, Read};
@@ -28,7 +29,6 @@ use std::path::PathBuf;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use homeboy::core::git::GhClient;
 use homeboy::core::observation::{ObservationStore, RunRecord};
@@ -205,7 +205,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
                     &file_name,
                     &json_bytes,
                 )?;
-                let sha = format!("{:x}", Sha256::digest(&json_bytes));
+                let sha = content_hash::sha256_hex(&json_bytes);
                 let size = i64::try_from(json_bytes.len()).ok();
                 let artifact_record = homeboy::core::observation::ArtifactRecord {
                     id: artifact_id,
@@ -705,8 +705,7 @@ mod helpers {
 
     pub fn list_runs_cache_key(repo: &str, workflow: &str) -> String {
         let composite = format!("{repo}::{workflow}");
-        let digest = Sha256::digest(composite.as_bytes());
-        format!("{:x}", digest)
+        content_hash::sha256_hex(composite.as_bytes())
     }
 
     pub fn list_runs_cache_path(key: &str, ext: &str) -> homeboy::core::Result<PathBuf> {

--- a/crates/homeboy-cli/src/commands/runs/loop_sync.rs
+++ b/crates/homeboy-cli/src/commands/runs/loop_sync.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -6,7 +7,6 @@ use std::time::SystemTime;
 use homeboy::core::observation::{disk_budget::disk_budget, loop_inventory_run, NewRunRecord};
 use homeboy::core::{Error, Result};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 mod types;
 
@@ -383,7 +383,7 @@ fn is_archive_file(path: &Path) -> bool {
 
 fn patch_fingerprint(path: &Path, size_bytes: u64) -> Result<String> {
     let content = fs::read(path).map_err(|e| io_error("read patch", path, e))?;
-    let digest = format!("{:x}", Sha256::digest(&content));
+    let digest = content_hash::sha256_hex(&content);
     Ok(format!("{}:{size_bytes}", &digest[..16]))
 }
 

--- a/crates/homeboy-cli/src/commands/trace/bundle.rs
+++ b/crates/homeboy-cli/src/commands/trace/bundle.rs
@@ -1,7 +1,7 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 use homeboy::rig::trace_experiment;
 use homeboy_extension::trace as extension_trace;
@@ -406,10 +406,11 @@ fn rig_components(input: &TraceAggregateInput) -> Vec<TraceExperimentComponentMa
 }
 
 fn sha256_file(path: &Path) -> homeboy::core::Result<String> {
+    // Read through the overlay helper rather than hashing the path directly:
+    // it owns the `trace.experiment.overlay.sha256` error context this call
+    // site reports on failure.
     let bytes = trace_experiment::read_experiment_overlay_for_checksum(path)?;
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(content_hash::sha256_hex(&bytes))
 }
 
 fn sanitize_path_component(value: &str) -> String {

--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -548,9 +549,8 @@ fn runtime_generation_identity(
     sources: &[AgentRuntimeMaterializationSource],
     preparation: &[AgentRuntimePreparationAction],
 ) -> String {
-    use sha2::{Digest, Sha256};
     let encoded = serde_json::to_vec(&(runtime_id, sources, preparation)).unwrap_or_default();
-    format!("sha256:{:x}", Sha256::digest(encoded))
+    format!("sha256:{}", content_hash::sha256_hex(&encoded))
 }
 
 fn runtime_source_revision(path: &Path) -> Option<String> {

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::Ordering;
 
-use sha2::{Digest, Sha256};
+use homeboy_engine_primitives::content_hash;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -141,7 +141,7 @@ impl RemoteRunnerJobRequest {
                 Some("fingerprint runner submission".to_string()),
             )
         })?;
-        Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+        Ok(format!("sha256:{}", content_hash::sha256_hex(&bytes)))
     }
 
     pub(crate) fn normalize(&mut self) -> SecretEnvPlan {

--- a/crates/homeboy-core/src/artifact_metadata.rs
+++ b/crates/homeboy-core/src/artifact_metadata.rs
@@ -1,30 +1,13 @@
-use crate::error::{Error, Result};
-use sha2::{Digest, Sha256};
-use std::io::Read;
+use crate::error::Result;
 use std::path::Path;
 
+/// SHA-256 of a file's bytes as lowercase hex.
+///
+/// Retained as the historical entry point for artifact hashing; the streaming
+/// implementation lives in `homeboy_engine_primitives::content_hash` so every
+/// crate produces byte-identical artifact identities.
 pub fn sha256_file(path: &Path) -> Result<String> {
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("open artifact bytes {}", path.display())),
-        )
-    })?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer).map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some(format!("read artifact bytes {}", path.display())),
-            )
-        })?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
+    homeboy_engine_primitives::content_hash::sha256_file(path)
 }
 
 pub fn content_type_from_path(path: &Path) -> Option<String> {

--- a/crates/homeboy-core/src/broker_auth.rs
+++ b/crates/homeboy-core/src/broker_auth.rs
@@ -34,8 +34,8 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::error::{Error, Result};
 use crate::paths;
@@ -419,8 +419,7 @@ pub fn store_path() -> Result<PathBuf> {
 }
 
 fn sha256_hex(token: &str) -> String {
-    let digest = Sha256::digest(token.as_bytes());
-    format!("{digest:x}")
+    content_hash::sha256_hex(token.as_bytes())
 }
 
 /// Length-independent constant-time string compare for hashes to avoid leaking

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use fs4::fs_std::FileExt;
+use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 use crate::{Error, Result};
 
@@ -91,9 +91,10 @@ fn acquire_shared_cargo_target_in(
     owner: &str,
     now: SystemTime,
 ) -> Result<SharedCargoTargetLease> {
-    let mut digest = Sha256::new();
-    digest.update(owner.as_bytes());
-    let target_dir = root.join(format!("homeboy-{:x}", digest.finalize()));
+    let target_dir = root.join(format!(
+        "homeboy-{}",
+        content_hash::sha256_hex(owner.as_bytes())
+    ));
     fs::create_dir_all(&target_dir)
         .map_err(|error| io_error(error, "create shared Cargo target"))?;
     let lock = OpenOptions::new()

--- a/crates/homeboy-core/src/content_diff.rs
+++ b/crates/homeboy-core/src/content_diff.rs
@@ -4,8 +4,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -148,18 +148,7 @@ fn contained(root: &Path, relative: &str) -> crate::Result<PathBuf> {
 }
 
 fn digest(path: &Path) -> crate::Result<String> {
-    use std::io::Read;
-    let mut file = fs::File::open(path).map_err(io_error)?;
-    let mut hash = Sha256::new();
-    let mut buffer = [0; 65536];
-    loop {
-        let read = file.read(&mut buffer).map_err(io_error)?;
-        if read == 0 {
-            break;
-        }
-        hash.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hash.finalize()))
+    content_hash::sha256_file(path)
 }
 
 fn io_error(error: impl std::fmt::Display) -> crate::Error {

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1,8 +1,8 @@
 //! Immutable controller executable provenance for durable orchestration work.
 
 use fs4::fs_std::FileExt;
+use homeboy_engine_primitives::content_hash;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::fs::OpenOptions;
@@ -2014,7 +2014,7 @@ fn executable_digest(path: &Path) -> Result<String> {
             Some("hash pinned controller executable".to_string()),
         )
     })?;
-    Ok(format!("{:x}", Sha256::digest(bytes)))
+    Ok(content_hash::sha256_hex(&bytes))
 }
 
 fn make_executable_read_only(path: &Path) -> Result<()> {

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1,6 +1,6 @@
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -2578,9 +2578,7 @@ fn controller_job_id_from_path(path: &str, suffix: &str) -> Result<Uuid> {
 fn hex_digest(value: &serde_json::Value) -> Result<String> {
     let encoded =
         serde_json::to_vec(value).map_err(|error| Error::internal_unexpected(error.to_string()))?;
-    let mut hasher = Sha256::new();
-    hasher.update(encoded);
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(content_hash::sha256_hex(&encoded))
 }
 
 fn exec_request_run_ref_metadata(
@@ -3802,9 +3800,13 @@ pub(crate) fn current_binary_sha256() -> Result<Option<String>> {
     sha256_file_optional(&exe)
 }
 
+/// Hash a file, treating "does not exist" as absence rather than failure.
+///
+/// The absent-is-not-an-error contract is this call site's own; the digest
+/// itself comes from the shared primitive.
 fn sha256_file_optional(path: &Path) -> Result<Option<String>> {
-    let mut file = match fs::File::open(path) {
-        Ok(file) => file,
+    match fs::File::open(path) {
+        Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
             return Err(Error::internal_io(
@@ -3812,19 +3814,8 @@ fn sha256_file_optional(path: &Path) -> Result<Option<String>> {
                 Some(format!("open {}", path.display())),
             ))
         }
-    };
-    let mut hasher = Sha256::new();
-    let mut buffer = [0; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
-        })?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
     }
-    Ok(Some(format!("{:x}", hasher.finalize())))
+    content_hash::sha256_file(path).map(Some)
 }
 
 fn handle_connection<R>(

--- a/crates/homeboy-core/src/daemon/patch_capture.rs
+++ b/crates/homeboy-core/src/daemon/patch_capture.rs
@@ -1,6 +1,6 @@
+use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
 use serde_json::json;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -229,7 +229,7 @@ fn persist_patch_run(input: PatchRunInput<'_>) -> Result<()> {
             public_url: None,
             viewer_url: None,
             viewer_links: Vec::new(),
-            sha256: Some(format!("{:x}", Sha256::digest(&bytes))),
+            sha256: Some(content_hash::sha256_hex(&bytes)),
             size_bytes: i64::try_from(bytes.len()).ok(),
             mime: Some("text/x-diff".to_string()),
             metadata_json: serde_json::json!({}),

--- a/crates/homeboy-core/src/daemon/runner_files.rs
+++ b/crates/homeboy-core/src/daemon/runner_files.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use base64::Engine;
+use homeboy_engine_primitives::content_hash;
 use serde_json::json;
-use sha2::Digest;
 
 use super::remote_runner;
 use super::runner_workspace_root;
@@ -78,7 +78,7 @@ pub(super) fn upload_runner_file(
             )
         })?;
     if let Some(expected) = request.sha256.as_deref() {
-        let actual = format!("{:x}", sha2::Sha256::digest(&content));
+        let actual = content_hash::sha256_hex(&content);
         if actual != expected {
             return Err(Error::validation_invalid_argument(
                 "sha256",

--- a/crates/homeboy-core/src/git/release_download.rs
+++ b/crates/homeboy-core/src/git/release_download.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use crate::component::{Component, GithubConfig};
 use crate::error::{Error, Result};
 use crate::git::github_cli_env;
+use homeboy_engine_primitives::content_hash;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 const PACKAGE_DEPENDENCY_FIELDS: &[&str] = &[
     "dependencies",
@@ -598,28 +598,7 @@ fn resolve_release_asset_metadata(
 }
 
 fn sha256_file(path: &Path) -> Result<String> {
-    use std::io::Read;
-    let mut file = std::fs::File::open(path).map_err(|error| {
-        Error::internal_io(
-            format!("Failed to hash downloaded artifact: {error}"),
-            Some(path.display().to_string()),
-        )
-    })?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0; 8192];
-    loop {
-        let count = file.read(&mut buffer).map_err(|error| {
-            Error::internal_io(
-                format!("Failed to hash downloaded artifact: {error}"),
-                Some(path.display().to_string()),
-            )
-        })?;
-        if count == 0 {
-            break;
-        }
-        hasher.update(&buffer[..count]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
+    content_hash::sha256_file(path)
 }
 
 fn release_asset_name_matches(asset_name: &str, artifact_name: &str) -> bool {
@@ -857,6 +836,10 @@ pub fn detect_remote_url(repo_path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+
+    // Hashed independently of the shared primitive so this stays a real
+    // cross-check on the digest the downloader records.
+    use sha2::{Digest, Sha256};
 
     use crate::component::GithubHostConfig;
 

--- a/crates/homeboy-core/src/observation/bundle.rs
+++ b/crates/homeboy-core/src/observation/bundle.rs
@@ -10,8 +10,8 @@ use std::fs;
 use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::build_identity;
 use crate::execution_contract::is_reportable_artifact_evidence_path;
@@ -164,7 +164,7 @@ fn portable_artifact_with_bytes(
     archive_format: Option<&str>,
     extension: Option<&str>,
 ) -> crate::Result<(ArtifactRecord, Option<ObservationBundleArtifactBytes>)> {
-    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let sha256 = content_hash::sha256_hex(&bytes);
     let size_bytes = i64::try_from(bytes.len()).map_err(|_| {
         Error::internal_unexpected(format!(
             "artifact {} is too large to record a portable size",
@@ -575,7 +575,7 @@ fn validate_artifact_bytes(
                 Some(format!("read bundled artifact bytes {}", path.display())),
             )
         })?;
-        let sha256 = format!("{:x}", Sha256::digest(&raw));
+        let sha256 = content_hash::sha256_hex(&raw);
         let size_bytes = i64::try_from(raw.len()).map_err(|_| {
             Error::internal_unexpected(format!(
                 "bundled artifact {} is too large to record a portable size",

--- a/crates/homeboy-core/src/observation/context.rs
+++ b/crates/homeboy-core/src/observation/context.rs
@@ -1,5 +1,5 @@
+use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 pub const SOURCE_SNAPSHOT_METADATA_ENV: &str = "HOMEBOY_SOURCE_SNAPSHOT_JSON";
 pub const LAB_OFFLOAD_METADATA_ENV: &str = "HOMEBOY_LAB_OFFLOAD_JSON";
@@ -100,7 +100,7 @@ pub fn resolve_json_value(raw: &str) -> Option<serde_json::Value> {
     let path = value.get("path")?.as_str()?;
     let expected_hash = value.get("sha256")?.as_str()?;
     let contents = std::fs::read(path).ok()?;
-    let actual_hash = format!("{:x}", Sha256::digest(&contents));
+    let actual_hash = content_hash::sha256_hex(&contents);
     (actual_hash == expected_hash)
         .then(|| serde_json::from_slice::<serde_json::Value>(&contents).ok())
         .flatten()
@@ -126,7 +126,7 @@ mod tests {
         resolve_json_value, RunContext, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
         PROVENANCE_REFERENCE_SCHEMA,
     };
-    use sha2::{Digest, Sha256};
+    use homeboy_engine_primitives::content_hash;
 
     #[test]
     fn subprocess_context_reads_generic_preview_metadata_with_public_url_overlay() {
@@ -170,7 +170,7 @@ mod tests {
         let reference = serde_json::json!({
             "schema": PROVENANCE_REFERENCE_SCHEMA,
             "path": path,
-            "sha256": format!("{:x}", Sha256::digest(payload)),
+            "sha256": content_hash::sha256_hex(payload),
         })
         .to_string();
 

--- a/crates/homeboy-core/src/publication_artifacts.rs
+++ b/crates/homeboy-core/src/publication_artifacts.rs
@@ -1,7 +1,7 @@
 use std::path::{Component, Path, PathBuf};
 
+use homeboy_engine_primitives::content_hash;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 
 use crate::execution_contract::{decode_uri_component, EXECUTION_CONTRACT};
 use crate::observation::{ArtifactRecord, ObservationStore};
@@ -475,8 +475,9 @@ fn remote_artifact_runner_context(path: &str) -> Option<(String, String)> {
 }
 
 fn published_artifact_id(source_artifact_id: &str, manifest_id: &str, locator: &str) -> String {
-    let hash = Sha256::digest(format!("{source_artifact_id}\0{manifest_id}\0{locator}").as_bytes());
-    let hex = format!("{hash:x}");
+    let hex = content_hash::sha256_hex(
+        format!("{source_artifact_id}\0{manifest_id}\0{locator}").as_bytes(),
+    );
     format!("{source_artifact_id}-published-{}", &hex[..16])
 }
 

--- a/crates/homeboy-core/src/release_set.rs
+++ b/crates/homeboy-core/src/release_set.rs
@@ -5,8 +5,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 pub const RELEASE_SET_SCHEMA: &str = "homeboy/release-set/v1";
 
@@ -88,7 +88,7 @@ impl ReleaseSetManifest {
         components.sort_by(|left, right| left.id.cmp(&right.id));
         let canonical = serde_json::to_vec(&(RELEASE_SET_SCHEMA, &components))
             .map_err(|error| error.to_string())?;
-        let identity = format!("sha256:{:x}", Sha256::digest(canonical));
+        let identity = format!("sha256:{}", content_hash::sha256_hex(&canonical));
         Ok(NormalizedReleaseSet {
             schema: RELEASE_SET_SCHEMA.to_string(),
             identity,

--- a/crates/homeboy-core/src/schedule/execution.rs
+++ b/crates/homeboy-core/src/schedule/execution.rs
@@ -1,5 +1,6 @@
 //! Running a schedule and deciding whether the result is worth reporting.
 
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
@@ -303,8 +304,7 @@ pub fn sequence_digest(step_digests: &[String]) -> String {
         return step_digests[0].clone();
     }
     let joined = step_digests.join("\u{1e}");
-    let digest = <sha2::Sha256 as sha2::Digest>::digest(joined.as_bytes());
-    format!("{digest:x}")
+    content_hash::sha256_hex(joined.as_bytes())
 }
 
 /// Reduce a command result to the fields the scheduler reasons about.
@@ -349,8 +349,7 @@ fn summarize(result: &ScheduleCommandResult) -> (String, i32, String, Option<Str
 /// Fingerprint an external command's output and exit code.
 pub fn raw_digest(exit_code: i32, output: &str) -> String {
     let rendered = format!("{exit_code}\u{1e}{output}");
-    let digest = <sha2::Sha256 as sha2::Digest>::digest(rendered.as_bytes());
-    format!("{digest:x}")
+    content_hash::sha256_hex(rendered.as_bytes())
 }
 
 /// The tail of a command's output, bounded for a notification.
@@ -377,8 +376,7 @@ pub fn result_digest(value: &serde_json::Value) -> String {
     let mut normalized = value.clone();
     strip_volatile(&mut normalized);
     let rendered = serde_json::to_string(&normalized).unwrap_or_default();
-    let digest = <sha2::Sha256 as sha2::Digest>::digest(rendered.as_bytes());
-    format!("{digest:x}")
+    content_hash::sha256_hex(rendered.as_bytes())
 }
 
 const VOLATILE_KEYS: &[&str] = &[

--- a/crates/homeboy-engine-primitives/Cargo.toml
+++ b/crates/homeboy-engine-primitives/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 toml = "1.0.3"
 regex = "1.11"
 libc = "0.2"
+sha2 = "0.10.9"
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/crates/homeboy-engine-primitives/src/content_hash.rs
+++ b/crates/homeboy-engine-primitives/src/content_hash.rs
@@ -1,0 +1,171 @@
+//! Canonical SHA-256 content hashing.
+//!
+//! Content hashing is an *identity* primitive: artifact addressing, patch
+//! verification, binary provenance, and broker token hashing all compare
+//! digests produced in different crates. Every one of those comparisons is
+//! only sound if the bytes-to-string mapping is byte-identical everywhere, so
+//! there is exactly one implementation and it lives here.
+//!
+//! Output contract:
+//! - Lowercase hex, never uppercase.
+//! - Full 64 characters, never truncated.
+//! - `sha256_file` streams the file in 64 KiB chunks so hashing a multi-gigabyte
+//!   release artifact does not read it into memory.
+//!
+//! Deliberately *not* covered here: digests that hash something other than the
+//! raw bytes (canonicalized overlays, ordered directory trees, salted inputs)
+//! and digests that are intentionally truncated. Those are separate identity
+//! schemes and collapsing them into this primitive would silently change what
+//! they identify.
+
+use std::io::Read;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use homeboy_error::{Error, Result};
+
+/// Chunk size used when streaming a file into the hasher.
+const FILE_CHUNK_BYTES: usize = 64 * 1024;
+
+/// SHA-256 of `bytes`, rendered as lowercase hex.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+/// SHA-256 of the file at `path`, rendered as lowercase hex.
+///
+/// The file is streamed in [`FILE_CHUNK_BYTES`] chunks rather than read whole
+/// into memory, so this is safe for arbitrarily large artifacts.
+pub fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("open {} for sha256", path.display())),
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; FILE_CHUNK_BYTES];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {} for sha256", path.display())),
+            )
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Whether `value` is shaped like a SHA-256 digest: exactly 64 hex characters.
+///
+/// Uppercase hex is **accepted**. This primitive validates values that arrive
+/// from external producers (`git`, `sha256sum`, GitHub release metadata), which
+/// are not all guaranteed to emit lowercase, and it preserves the behavior of
+/// the hand-rolled validators it replaces. Values produced by [`sha256_hex`]
+/// and [`sha256_file`] are always lowercase; use this only for validation, never
+/// as a substitute for comparing canonical digests.
+pub fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// FIPS 180-2 known-answer vector for "abc".
+    const ABC_SHA256: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    /// SHA-256 of the empty input.
+    const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn sha256_hex_matches_known_answer_vector() {
+        assert_eq!(sha256_hex(b"abc"), ABC_SHA256);
+    }
+
+    #[test]
+    fn sha256_hex_of_empty_input_is_the_empty_digest() {
+        assert_eq!(sha256_hex(b""), EMPTY_SHA256);
+    }
+
+    #[test]
+    fn sha256_hex_output_is_lowercase_and_full_length() {
+        let digest = sha256_hex(b"identity primitive");
+        assert_eq!(digest.len(), 64);
+        assert_eq!(digest, digest.to_ascii_lowercase());
+        assert!(digest.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn sha256_file_matches_known_answer_vector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("abc.txt");
+        std::fs::write(&path, b"abc").unwrap();
+        assert_eq!(sha256_file(&path).unwrap(), ABC_SHA256);
+    }
+
+    #[test]
+    fn sha256_file_agrees_with_sha256_hex_across_chunk_boundaries() {
+        // Larger than one read chunk so the streaming loop runs more than once
+        // and a partial final chunk is exercised.
+        let bytes: Vec<u8> = (0..(FILE_CHUNK_BYTES * 2 + 517))
+            .map(|index| (index % 251) as u8)
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.bin");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(&bytes).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        assert_eq!(sha256_file(&path).unwrap(), sha256_hex(&bytes));
+    }
+
+    #[test]
+    fn sha256_file_hashes_an_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+        std::fs::write(&path, b"").unwrap();
+        assert_eq!(sha256_file(&path).unwrap(), EMPTY_SHA256);
+    }
+
+    #[test]
+    fn sha256_file_errors_when_the_path_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(sha256_file(&dir.path().join("absent.bin")).is_err());
+    }
+
+    #[test]
+    fn is_sha256_hex_accepts_canonical_lowercase_digests() {
+        assert!(is_sha256_hex(ABC_SHA256));
+        assert!(is_sha256_hex(&sha256_hex(b"anything")));
+    }
+
+    #[test]
+    fn is_sha256_hex_accepts_uppercase_hex() {
+        assert!(is_sha256_hex(&ABC_SHA256.to_ascii_uppercase()));
+    }
+
+    #[test]
+    fn is_sha256_hex_rejects_wrong_length() {
+        assert!(!is_sha256_hex(""));
+        assert!(!is_sha256_hex(&ABC_SHA256[..63]));
+        assert!(!is_sha256_hex(&format!("{ABC_SHA256}0")));
+        // A 40-char git object id is not a sha256 digest.
+        assert!(!is_sha256_hex("da39a3ee5e6b4b0d3255bfef95601890afd80709"));
+    }
+
+    #[test]
+    fn is_sha256_hex_rejects_non_hex_characters() {
+        let mut value = ABC_SHA256.to_string();
+        value.replace_range(0..1, "z");
+        assert!(!is_sha256_hex(&value));
+        // Correct length, but a prefixed algorithm label is not bare hex.
+        assert!(!is_sha256_hex(&format!("sha256:{}", &ABC_SHA256[7..])));
+    }
+}

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -1,8 +1,9 @@
 //! Low-level execution primitives extracted from the homeboy engine.
 //!
 //! These modules are leaf utilities (shell quoting, command construction,
-//! text helpers, run-directory management, templating, output parsing, and
-//! identifier helpers) that depend only on `homeboy-error`. They live in their
+//! text helpers, run-directory management, templating, output parsing,
+//! content hashing, and identifier helpers) that depend only on
+//! `homeboy-error`. They live in their
 //! own crate so they compile as an independent unit and are re-exported under
 //! `crate::core::engine::*` in the main binary for source compatibility.
 
@@ -11,6 +12,7 @@ pub mod baseline;
 pub mod canonical_json;
 pub mod codebase_scan;
 pub mod command;
+pub mod content_hash;
 pub mod detail_output;
 pub mod edit_op;
 pub mod edit_op_apply;

--- a/crates/homeboy-extension/Cargo.toml
+++ b/crates/homeboy-extension/Cargo.toml
@@ -29,7 +29,6 @@ regex = "1.11"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 glob = "0.3"
 glob-match = "0.2"
-sha2 = "0.10.9"
 libc = "0.2"
 shellexpand = "3.1"
 tempfile = "3.14"

--- a/crates/homeboy-extension/src/bench/run_metadata.rs
+++ b/crates/homeboy-extension/src/bench/run_metadata.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use sha2::{Digest, Sha256};
+use homeboy_engine_primitives::content_hash;
 
 use crate::bench::parsing::{
     BenchResults, BenchRunMetadata, BenchRunnerMetadata, BenchScenario, BenchWorkloadMetadata,
@@ -106,9 +106,7 @@ fn resolve_workload_path(path: &str, component: &Component) -> PathBuf {
 }
 
 fn sha256_file(path: &Path) -> Option<String> {
-    let bytes = std::fs::read(path).ok()?;
-    let hash = Sha256::digest(&bytes);
-    Some(hash.iter().map(|byte| format!("{:02x}", byte)).collect())
+    content_hash::sha256_file(path).ok()
 }
 
 fn bench_warmup_iterations() -> Option<u64> {

--- a/crates/homeboy-extension/src/runtime_helper.rs
+++ b/crates/homeboy-extension/src/runtime_helper.rs
@@ -1,9 +1,9 @@
 use homeboy_core::error::{Error, Result};
 use homeboy_core::paths;
+use homeboy_engine_primitives::content_hash;
 use homeboy_engine_primitives::local_files;
 use homeboy_extension_contract::RuntimeHelperRequirement;
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -154,7 +154,10 @@ fn ensure_helper(runtime_dir: &std::path::Path, helper: &RuntimeHelper) -> Resul
 }
 
 fn helper_revision(helper: &RuntimeHelper) -> String {
-    format!("sha256:{:x}", Sha256::digest(helper.content.as_bytes()))
+    format!(
+        "sha256:{}",
+        content_hash::sha256_hex(helper.content.as_bytes())
+    )
 }
 
 /// Materialize manifest-declared helpers under an identity-and-revision path.

--- a/crates/homeboy-extension/src/trace/overlay_lock.rs
+++ b/crates/homeboy-extension/src/trace/overlay_lock.rs
@@ -1,5 +1,5 @@
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -238,14 +238,9 @@ pub(super) fn normalize_component_path(component_path: &Path) -> PathBuf {
 }
 
 pub(super) fn trace_overlay_lock_id(component_path: &Path) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(component_path.to_string_lossy().as_bytes());
-    let digest = hasher.finalize();
-    let hex = digest
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
-    hex[..24].to_string()
+    // Deliberately truncated: this is a filesystem lock-file name, not a
+    // content identity, so only the leading 24 hex characters are used.
+    content_hash::sha256_hex(component_path.to_string_lossy().as_bytes())[..24].to_string()
 }
 
 fn write_trace_overlay_lock_holder(path: &Path, holder: &TraceOverlayLockHolder) -> Result<()> {

--- a/crates/homeboy-extension/src/trace/probes/http_egress.rs
+++ b/crates/homeboy-extension/src/trace/probes/http_egress.rs
@@ -7,7 +7,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use sha2::{Digest, Sha256};
+use homeboy_engine_primitives::content_hash;
 
 use super::{event, push_event, TraceEvent};
 
@@ -513,7 +513,7 @@ struct CapturedBody {
 fn capture_body(body: &[u8], max: usize, artifact_dir: Option<&Path>) -> CapturedBody {
     let preview_bytes = body.len().min(max);
     let truncated = body.len() > max;
-    let sha256 = format!("{:x}", Sha256::digest(body));
+    let sha256 = content_hash::sha256_hex(body);
     let artifact_ref = if truncated {
         artifact_dir.and_then(|dir| write_body_artifact(dir, &sha256, body).ok())
     } else {

--- a/crates/homeboy-fuzz/Cargo.toml
+++ b/crates/homeboy-fuzz/Cargo.toml
@@ -14,9 +14,9 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.10"
 tempfile = "3.14"
 
 [dev-dependencies]

--- a/crates/homeboy-fuzz/src/payloads.rs
+++ b/crates/homeboy-fuzz/src/payloads.rs
@@ -194,8 +194,7 @@ fn refusal_ref(sha256: &str, size_bytes: u64, reason: &str) -> Value {
 }
 
 fn sha256(bytes: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-    format!("{:x}", Sha256::digest(bytes))
+    homeboy_engine_primitives::content_hash::sha256_hex(bytes)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/Cargo.toml
+++ b/crates/homeboy-lab-runner/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-source-snapshot-contract = { version = "0.1.0", path = "../contracts/homeboy-source-snapshot-contract" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-upgrade = { version = "0.1.0", path = "../homeboy-upgrade" }

--- a/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
+++ b/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
@@ -7,7 +7,7 @@
 //! and building the promoted-output/structured-summary views. It operates on
 //! core runner types, not command types.
 
-use sha2::{Digest, Sha256};
+use homeboy_engine_primitives::content_hash;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -196,8 +196,8 @@ fn runner_exec_directory_child_id(
     relative_child: &str,
 ) -> String {
     format!(
-        "runner-exec-dir-{:x}",
-        Sha256::digest(
+        "runner-exec-dir-{}",
+        content_hash::sha256_hex(
             format!("{run_id}\0{binding}\0artifact_dir\0{declaration}\0{relative_child}")
                 .as_bytes()
         )
@@ -360,8 +360,8 @@ fn record_runner_exec_output(
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
     let artifact_id = format!(
-        "runner-exec-{:x}",
-        Sha256::digest(
+        "runner-exec-{}",
+        content_hash::sha256_hex(
             format!("{run_id}\0{binding}\0{role}\0{declaration}\0{content_hash}").as_bytes()
         )
     );

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -9,7 +10,6 @@ use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::redaction::redact_argv;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use reqwest::blocking::Client;
-use sha2::{Digest, Sha256};
 
 use super::super::broker_http;
 use super::super::evidence::mirror_reverse_broker_evidence;
@@ -526,7 +526,7 @@ fn durable_command_assets(
             Ok(serde_json::json!({
                 "argument": argument,
                 "remote_path": remote_path,
-                "sha256": format!("{:x}", Sha256::digest(&content)),
+                "sha256": content_hash::sha256_hex(&content),
                 "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
             }))
         })

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -15,7 +16,6 @@ use homeboy_core::runner_execution_envelope::{
 use homeboy_core::secret_env_plan::SecretEnvPlan;
 use homeboy_core::server::{self, SshClient};
 use homeboy_core::source_snapshot::SourceSnapshot;
-use sha2::{Digest, Sha256};
 
 use super::super::normalize_runner_command_env_for_homeboy_path;
 use super::super::resource_metrics::{
@@ -806,7 +806,7 @@ fn child_provenance_env(
         if raw.len() <= PROVENANCE_ENV_INLINE_MAX_BYTES {
             continue;
         }
-        let hash = format!("{:x}", Sha256::digest(raw.as_bytes()));
+        let hash = content_hash::sha256_hex(raw.as_bytes());
         let path = stage_dir.join(format!("{hash}.json"));
         publish_provenance(&stage_dir, &path, raw.as_bytes(), &hash)?;
         let reference = serde_json::json!({
@@ -925,7 +925,7 @@ fn validate_published_provenance(path: &Path, expected_hash: &str) -> Result<()>
             Some("read published provenance".to_string()),
         )
     })?;
-    let actual_hash = format!("{:x}", Sha256::digest(&contents));
+    let actual_hash = content_hash::sha256_hex(&contents);
     if actual_hash != expected_hash {
         return Err(provenance_reference_error(
             "existing content-addressed provenance file failed hash verification",

--- a/crates/homeboy-lab-runner/src/execution_bundle.rs
+++ b/crates/homeboy-lab-runner/src/execution_bundle.rs
@@ -1,5 +1,6 @@
 //! Immutable execution facts captured after Lab admission and before dispatch.
 
+use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 
 pub(crate) const LAB_EXECUTION_BUNDLE_ENV: &str = "HOMEBOY_LAB_EXECUTION_BUNDLE";
@@ -67,9 +68,7 @@ pub(crate) fn validate_bundle_env(
                 && overlay
                     .get("content_hash")
                     .and_then(serde_json::Value::as_str)
-                    .is_some_and(|hash| {
-                        hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
-                    })
+                    .is_some_and(content_hash::is_sha256_hex)
         })
     })
 }

--- a/crates/homeboy-lab-runner/src/extension_materialization.rs
+++ b/crates/homeboy-lab-runner/src/extension_materialization.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Read;
@@ -838,11 +839,10 @@ pub(crate) fn git_dirty_fingerprint(path: &Path) -> Option<String> {
         ])
         .output()
         .ok()?;
-    output.status.success().then(|| {
-        let mut hasher = Sha256::new();
-        hasher.update(&output.stdout);
-        format!("{:x}", hasher.finalize())
-    })
+    output
+        .status
+        .success()
+        .then(|| content_hash::sha256_hex(&output.stdout))
 }
 
 fn sanitize_ref(value: &str) -> String {

--- a/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
+++ b/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -437,13 +438,11 @@ fn cache_key_file(
             Some(format!("read dependency cache key file {}", full.display())),
         )
     })?;
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
     Ok(RunnerDependencyCacheKeyFile {
         role: role.to_string(),
         path: normalized,
         status: "present".to_string(),
-        sha256: Some(hex(&hasher.finalize())),
+        sha256: Some(content_hash::sha256_hex(&bytes)),
     })
 }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -6,7 +7,6 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use homeboy_core::engine::shell::{quote_arg, quote_path};
 use homeboy_core::error::{Error, Result};
@@ -2000,26 +2000,16 @@ fn dev_binary_path(workspace_root: &str, sha256: &str) -> String {
 }
 
 fn sha256_file(path: &Path) -> Result<String> {
-    let mut file = fs::File::open(path).map_err(|err| {
+    // Keep this call site's validation-shaped error: callers surface it as a
+    // bad `homeboy_binary` argument, not as an internal IO fault.
+    content_hash::sha256_file(path).map_err(|err| {
         Error::validation_invalid_argument(
             "homeboy_binary",
             format!("could not read binary: {err}"),
             Some(path.display().to_string()),
             None,
         )
-    })?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 8192];
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .map_err(|err| Error::internal_json(err.to_string(), None))?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
+    })
 }
 
 fn validate_dev_sync_binary_for_runner(runner: &super::Runner, binary: &Path) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/lab_args/at_files.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/at_files.rs
@@ -4,10 +4,9 @@
 //! Lab workspaces are clean checkouts, so generated ignored/untracked files must
 //! be materialized explicitly before the runner command executes.
 
+use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-
-use sha2::{Digest, Sha256};
 
 use homeboy_agents::agent_task_prompts;
 use homeboy_core::{Error, Result};
@@ -187,7 +186,7 @@ fn resolve_at_file_spec(
                 Some(format!("read Lab @file {}", local_path.display())),
             )
         })?;
-        let content_sha256 = format!("{:x}", Sha256::digest(&content));
+        let content_sha256 = content_hash::sha256_hex(&content);
         let remote_path =
             remote_path_for_at_file(&content_sha256, local_path.file_name(), remote_cwd);
         return Ok(LabAtFileSpec {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3,6 +3,7 @@
 //! Detached Lab routing constructs this job after the agent-task attempt exists
 //! and before workspace staging begins.
 
+use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -22,7 +23,6 @@ use homeboy_core::lab_contract::{
 };
 use homeboy_core::runner_execution_envelope::PathMaterializationPlan;
 use homeboy_core::{Error, Result};
-use sha2::{Digest, Sha256};
 
 use crate::{LabOffloadCommand, LabOffloadRequest};
 
@@ -1102,7 +1102,7 @@ fn canonical_digest<T: Serialize>(value: &T) -> Result<String> {
             Some("serialize canonical durable Lab workspace state".to_string()),
         )
     })?;
-    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+    Ok(format!("sha256:{}", content_hash::sha256_hex(&bytes)))
 }
 
 /// Shared identity header carried by every durable Lab stage

--- a/crates/homeboy-lab-runner/src/transport.rs
+++ b/crates/homeboy-lab-runner/src/transport.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::fs;
 use std::time::Duration;
 
@@ -6,7 +7,6 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::json;
 use serde_json::Value;
-use sha2::Digest;
 
 use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, ErrorCode, Result};
@@ -262,7 +262,7 @@ impl RunnerFileTransfer {
         let content = fs::read(local_path).map_err(|err| {
             Error::internal_io(err.to_string(), Some(format!("read {local_path}")))
         })?;
-        let actual_sha256 = format!("{:x}", sha2::Sha256::digest(&content));
+        let actual_sha256 = content_hash::sha256_hex(&content);
         if actual_sha256 != expected_sha256 {
             return Err(Error::validation_invalid_argument(
                 "at_file",

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -437,8 +438,6 @@ impl PrivateAtFileCleanup {
 pub(super) fn verify_private_at_files(
     envelope: &mut homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope,
 ) -> Result<PrivateAtFileCleanup> {
-    use sha2::{Digest, Sha256};
-
     #[cfg(not(unix))]
     {
         if envelope.dispatch.as_ref().is_some_and(|dispatch| {
@@ -567,7 +566,7 @@ pub(super) fn verify_private_at_files(
                 );
             }
         };
-        if format!("{:x}", Sha256::digest(&content)) != expected {
+        if content_hash::sha256_hex(&content) != expected {
             return private_at_file_error(
                 &mut cleanup,
                 "private runner @file content does not match its SHA-256 identity",
@@ -810,7 +809,6 @@ fn materialize_command_assets(
     envelope: &mut homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope,
 ) -> homeboy_core::error::Result<Option<CommandAssetDirectory>> {
     use base64::Engine;
-    use sha2::{Digest, Sha256};
 
     let Some(assets) = envelope
         .metadata
@@ -894,7 +892,7 @@ fn materialize_command_assets(
                 None,
             ));
         }
-        let digest = format!("{:x}", Sha256::digest(&content));
+        let digest = content_hash::sha256_hex(&content);
         if asset.get("sha256").and_then(serde_json::Value::as_str) != Some(digest.as_str()) {
             return Err(homeboy_core::error::Error::internal_json(
                 "command asset content identity mismatch",

--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -1,8 +1,7 @@
+use homeboy_engine_primitives::content_hash;
 use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
-
-use sha2::{Digest, Sha256};
 
 use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, Result};
@@ -330,13 +329,7 @@ fn materialize_git_snapshot_from_controller_bundle_fallback(
 }
 
 fn sha256_file(path: &Path) -> Result<String> {
-    let bytes = std::fs::read(path).map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some("read git bundle for digest".to_string()),
-        )
-    })?;
-    Ok(format!("{:x}", Sha256::digest(bytes)))
+    content_hash::sha256_file(path)
 }
 
 /// Resolve the exact object closure locally before `git bundle` can invoke a

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -1,3 +1,4 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
@@ -318,7 +319,10 @@ fn collect_content_hash_entries_v2(
                         &mut manifest,
                         relative,
                         "symlink",
-                        Some(format!("sha256:{:x}", Sha256::digest(target.as_bytes()))),
+                        Some(format!(
+                            "sha256:{}",
+                            content_hash::sha256_hex(target.as_bytes())
+                        )),
                         Some(target.len() as u64),
                         None,
                     );
@@ -385,7 +389,7 @@ fn collect_content_hash_entries_v2(
                 &mut manifest,
                 relative,
                 "file",
-                Some(format!("sha256:{:x}", Sha256::digest(&contents))),
+                Some(format!("sha256:{}", content_hash::sha256_hex(&contents))),
                 Some(contents.len() as u64),
                 executable_capability.owner_value(&metadata),
             );

--- a/crates/homeboy-release/Cargo.toml
+++ b/crates/homeboy-release/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-release-contract = { version = "0.1.0", path = "../contracts/homeboy-release-contract" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/homeboy-release/src/deploy/content_manifest.rs
+++ b/crates/homeboy-release/src/deploy/content_manifest.rs
@@ -1,6 +1,6 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
 
@@ -232,17 +232,7 @@ fn visit(root: &Path, path: &Path, manifest: &mut Manifest) -> Result<(), String
 }
 
 fn sha256(path: &Path) -> Result<String, String> {
-    let mut file = fs::File::open(path).map_err(|e| e.to_string())?;
-    let mut hash = Sha256::new();
-    let mut buffer = [0; 65536];
-    loop {
-        let read = file.read(&mut buffer).map_err(|e| e.to_string())?;
-        if read == 0 {
-            break;
-        }
-        hash.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hash.finalize()))
+    content_hash::sha256_file(path).map_err(|error| error.to_string())
 }
 
 fn remote_manifest(root: &str, client: &SshClient) -> Result<Option<Manifest>, String> {

--- a/crates/homeboy-release/src/deploy/preparation.rs
+++ b/crates/homeboy-release/src/deploy/preparation.rs
@@ -1,8 +1,8 @@
+use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 use homeboy_core::component::Component;
 use homeboy_core::engine::canonical_json::canonical_json;
@@ -113,8 +113,8 @@ impl ComponentPayloadPreparationRequest {
 
 fn digest_json(value: &serde_json::Value) -> String {
     format!(
-        "sha256:{:x}",
-        Sha256::digest(serde_json::to_vec(value).expect("canonical JSON serializes"))
+        "sha256:{}",
+        content_hash::sha256_hex(&serde_json::to_vec(value).expect("canonical JSON serializes"))
     )
 }
 

--- a/crates/homeboy-release/src/deploy/provenance.rs
+++ b/crates/homeboy-release/src/deploy/provenance.rs
@@ -5,10 +5,9 @@
 //! capture (which source/ref produced the payload, whether a fresh build ran, and
 //! the identity of the artifact that shipped).
 
+use homeboy_engine_primitives::content_hash;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
-
-use sha2::{Digest, Sha256};
 
 use homeboy_core::component::Component;
 use homeboy_core::engine::command;
@@ -82,19 +81,7 @@ fn resolve_artifact_identity(path: &Path) -> Option<ArtifactIdentity> {
 }
 
 fn sha256_file(path: &Path) -> Option<String> {
-    use std::io::Read;
-
-    let mut file = std::fs::File::open(path).ok()?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer).ok()?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Some(format!("{:x}", hasher.finalize()))
+    content_hash::sha256_file(path).ok()
 }
 
 pub use homeboy_core::tag_gap::{detect_tag_gap, warn_tag_gap};

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -1,9 +1,8 @@
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::Path;
-use std::{fs, io::Read};
-
-use sha2::{Digest, Sha256};
 
 use homeboy_core::artifact_inputs::ResolvedArtifactInput;
 use homeboy_core::component::Component;
@@ -285,24 +284,7 @@ impl PreparedDeployArtifact {
 }
 
 pub(crate) fn sha256_file(path: &Path) -> Result<String> {
-    let mut file = fs::File::open(path).map_err(|error| {
-        homeboy_core::error::Error::internal_io(error.to_string(), Some(path.display().to_string()))
-    })?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer).map_err(|error| {
-            homeboy_core::error::Error::internal_io(
-                error.to_string(),
-                Some(path.display().to_string()),
-            )
-        })?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
+    content_hash::sha256_file(path)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -1,6 +1,6 @@
 use homeboy_core::error::{Error, Result};
+use homeboy_engine_primitives::content_hash;
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 use super::{step_success, ReleaseArtifact, ReleaseState, ReleaseStepResult};
@@ -170,20 +170,12 @@ fn artifact_target_name(artifact: &ReleaseArtifact) -> Result<String> {
 }
 
 fn sha256_file(path: &str) -> Result<String> {
-    let mut file = std::fs::File::open(path).map_err(|error| {
+    content_hash::sha256_file(std::path::Path::new(path)).map_err(|error| {
         Error::internal_io(
             format!("Failed to hash release artifact '{}': {}", path, error),
             Some(path.to_string()),
         )
-    })?;
-    let mut hasher = Sha256::new();
-    std::io::copy(&mut file, &mut hasher).map_err(|error| {
-        Error::internal_io(
-            format!("Failed to hash release artifact '{}': {}", path, error),
-            Some(path.to_string()),
-        )
-    })?;
-    Ok(format!("{:x}", hasher.finalize()))
+    })
 }
 
 fn is_package_recovery_manifest(manifest_path: &std::path::Path) -> bool {

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -4,6 +4,7 @@ use crate::release::types::ReleaseState;
 use homeboy_core::component::GithubConfig;
 use homeboy_core::engine::shell::quote_arg;
 use homeboy_core::git::release_download::GitHubRepo;
+use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -231,20 +232,8 @@ fn publication_from_path(
 }
 
 fn file_sha256(path: &str) -> Result<String, String> {
-    let mut file = std::fs::File::open(path)
-        .map_err(|error| format!("could not hash release artifact '{path}': {error}"))?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0; 8192];
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .map_err(|error| format!("could not hash release artifact '{path}': {error}"))?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
+    content_hash::sha256_file(std::path::Path::new(path))
+        .map_err(|error| format!("could not hash release artifact '{path}': {error}"))
 }
 
 /// Split publications into assets that must be uploaded and assets already
@@ -455,20 +444,7 @@ pub(crate) fn verify_release_assets(
             .as_deref()
             .and_then(|value| value.strip_prefix("sha256:"))
         {
-            let mut file = std::fs::File::open(path)
-                .map_err(|error| format!("could not hash release artifact '{path}': {error}"))?;
-            let mut hasher = Sha256::new();
-            let mut buffer = [0; 8192];
-            loop {
-                let read = file.read(&mut buffer).map_err(|error| {
-                    format!("could not hash release artifact '{path}': {error}")
-                })?;
-                if read == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..read]);
-            }
-            if format!("{:x}", hasher.finalize()) != digest {
+            if file_sha256(path)? != digest {
                 return Err(format!(
                     "GitHub Release asset '{name}' digest does not match uploaded artifact"
                 ));

--- a/crates/homeboy-rig/Cargo.toml
+++ b/crates/homeboy-rig/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-stack = { version = "0.1.0", path = "../homeboy-stack" }
 homeboy-rig-contract = { version = "0.1.0", path = "../contracts/homeboy-rig-contract" }

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -9,6 +9,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use fs4::fs_std::FileExt;
+use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -641,23 +642,10 @@ fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
     .map_err(|error| io_error("write dependency cache manifest", error))
 }
 fn hash_bytes(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    content_hash::sha256_hex(bytes)
 }
 fn hash_file(path: &Path) -> Result<String> {
-    let mut file =
-        File::open(path).map_err(|error| io_error("read dependency cache file", error))?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0; 8192];
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .map_err(|error| io_error("hash dependency cache file", error))?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
+    content_hash::sha256_file(path)
 }
 fn hash_path(path: &Path) -> Result<String> {
     if path.is_file() {

--- a/crates/homeboy-tunnel/Cargo.toml
+++ b/crates/homeboy-tunnel/Cargo.toml
@@ -14,12 +14,12 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
 regex = "1.11"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
-sha2 = "0.10.9"
 glob-match = "0.2"
 base64 = "0.22"
 uuid = { version = "1.11", features = ["v4"] }

--- a/crates/homeboy-tunnel/src/entity.rs
+++ b/crates/homeboy-tunnel/src/entity.rs
@@ -1,4 +1,4 @@
-use sha2::{Digest, Sha256};
+use homeboy_engine_primitives::content_hash;
 use std::path::PathBuf;
 
 use homeboy_core::config::ConfigEntity;
@@ -10,8 +10,7 @@ use super::validation::validate_service_tunnel;
 use super::{load, save};
 
 pub fn native_preview_token_sha256(token: &str) -> String {
-    let digest = Sha256::digest(token.as_bytes());
-    format!("{digest:x}")
+    content_hash::sha256_hex(token.as_bytes())
 }
 
 pub fn native_preview_token_record(

--- a/crates/homeboy-tunnel/src/preview_client/mod.rs
+++ b/crates/homeboy-tunnel/src/preview_client/mod.rs
@@ -16,6 +16,7 @@ pub use types::{
 };
 
 use base64::Engine;
+use homeboy_engine_primitives::content_hash;
 use reqwest::blocking::Client;
 use serde_json::json;
 use std::io::Read;
@@ -573,9 +574,7 @@ fn post_json(
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-    let digest = Sha256::digest(bytes);
-    format!("{digest:x}")
+    content_hash::sha256_hex(bytes)
 }
 
 fn validate_start_spec(spec: &PreviewClientStartSpec) -> Result<()> {

--- a/crates/homeboy-tunnel/src/preview_ingress/serve.rs
+++ b/crates/homeboy-tunnel/src/preview_ingress/serve.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
+use homeboy_engine_primitives::content_hash;
 use serde::Deserialize;
 use serde_json::json;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Read};
 use std::net::{TcpListener, TcpStream};
@@ -663,8 +663,9 @@ fn authorized_preview_client(request: &IngressHttpRequest, auth: &PreviewIngress
     }) else {
         return false;
     };
-    let digest = Sha256::digest(token.as_bytes());
-    format!("{digest:x}").eq_ignore_ascii_case(expected)
+    // Deliberately case-insensitive: `expected` is operator-supplied config
+    // and is not guaranteed to be lowercase.
+    content_hash::sha256_hex(token.as_bytes()).eq_ignore_ascii_case(expected)
 }
 
 fn parse_json_body<T: for<'de> Deserialize<'de>>(body: &[u8], context: &str) -> Result<T> {

--- a/crates/homeboy-tunnel/src/validation.rs
+++ b/crates/homeboy-tunnel/src/validation.rs
@@ -1,6 +1,7 @@
 use homeboy_core::config;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::server;
+use homeboy_engine_primitives::content_hash;
 
 use super::preview::parse_rfc3339_utc;
 use super::types::*;
@@ -123,12 +124,7 @@ fn validate_native_preview_auth_policy(
                 None,
             ));
         }
-        if token.token_sha256.len() != 64
-            || !token
-                .token_sha256
-                .chars()
-                .all(|character| character.is_ascii_hexdigit())
-        {
+        if !content_hash::is_sha256_hex(&token.token_sha256) {
             return Err(Error::validation_invalid_argument(
                 "policy.native_preview_auth.tokens.token_sha256",
                 "native preview tokens store a SHA-256 digest, not plaintext token material",


### PR DESCRIPTION
Closes #10294

`homeboy_core::artifact_metadata::sha256_file` was already `pub` and was reimplemented anyway, 20+ times. Content hashing is an *identity* primitive — artifact addressing, patch verification, binary provenance, dependency-cache keys, and broker token hashing all compare digests produced in different crates — so every one of those comparisons is only sound if the bytes-to-string mapping is byte-identical everywhere.

There is now exactly one implementation, in `homeboy_engine_primitives::content_hash`:

```rust
pub fn sha256_hex(bytes: &[u8]) -> String
pub fn sha256_file(path: &Path) -> Result<String>
pub fn is_sha256_hex(value: &str) -> bool
```

`homeboy-engine-primitives` depends only on `homeboy-error` and `homeboy-paths`, so every consuming crate can reach it without a `homeboy-core` dependency. Verified per crate; no cycles.

## Streaming behavior

`sha256_file` streams in **64 KiB chunks**, matching the best existing implementation (`homeboy-core`'s `artifact_metadata::sha256_file`) rather than the several 8 KiB variants or the whole-file `std::fs::read` variants. Nothing regressed; two things improved (below).

`homeboy_core::artifact_metadata::sha256_file` keeps its public name and signature and now delegates, so its callers are untouched.

## Scale

| | |
|---|---|
| Sites converted | **96 call sites** across 10 crates |
| Named duplicate `sha256_file` / `file_sha256` / `sha256` helpers collapsed | 13 |
| Duplicate `valid_sha256` / inline `len() == 64 && is_ascii_hexdigit` validators collapsed | 5 |
| Sites deliberately left | 27 (all listed below) |
| Hand-rolled hex encoders removed | 3 |

One commit per crate, so a bad conversion is bisectable.

## Bugs / regressions fixed along the way

These were real, not just duplication:

1. **`homeboy-lab-runner` `workspace::git::sha256_file` read the whole git bundle into memory** via `std::fs::read` before hashing. Git bundles are the largest thing that crate hashes. Now streams.
2. **`homeboy-extension` `bench::run_metadata::sha256_file`** read the whole file into memory *and* rendered the digest through its own per-byte hex encoder. Now streams through the primitive.
3. **`homeboy-lab-runner` `git_dependency_materialization`** rendered its cache-key-file digest through a local `fn hex()` (per-byte `format!("{byte:02x}")`) instead of the `{:x}` formatter used everywhere else. Same output, but a second independently maintained hex encoder sitting on an identity path.
4. **`homeboy-release` `gh_cli`** had a sixth streaming file hasher inlined in `verify_uploaded_release_assets`, twelve lines below the `file_sha256` that does exactly the same thing. Now calls it.
5. **`homeboy-release` `release::executor::artifacts::sha256_file`** used `std::io::copy` (8 KiB default) while the deploy path used 64 KiB. Both now 64 KiB.

Also dropped `sha2` from `homeboy-extension`, `homeboy-fuzz`, and `homeboy-tunnel` — nothing in them hashes directly any more.

## Uppercase decision

**`is_sha256_hex` accepts uppercase hex.** Both `valid_sha256` copies and both inline validators used `is_ascii_hexdigit`, which accepts uppercase, so this preserves behavior exactly rather than silently tightening validation on values arriving from `git`, `sha256sum`, and GitHub release metadata. Documented on the function. `sha256_hex` and `sha256_file` *output* is always lowercase and never truncated; the doc comment says so and a test asserts it.

`homeboy-tunnel`'s `preview_ingress::serve` token check keeps its `eq_ignore_ascii_case` compare — the expected value is operator-supplied config — and that is now an explicit comment instead of an accident of the call site.

## Tests

`content_hash` ships with 11 tests: FIPS 180-2 known-answer vector for `"abc"`, the empty-input digest, lowercase-and-64-chars output assertion, `sha256_file` agreeing with `sha256_hex` across a multi-chunk file with a partial final chunk, empty file, missing path, and `is_sha256_hex` accepting lowercase/uppercase and rejecting wrong length (including a 40-char git object id), non-hex characters, and an `sha256:`-prefixed value.

Existing test modules were deliberately **not** converted: they compute expected digests with `sha2` directly, which keeps their assertions an independent cross-check on the primitive rather than a restatement of it.

## Deliberately NOT collapsed

Each of these hashes something other than raw file/byte content, so collapsing it would change *what it identifies*.

**Out of scope per the issue:**
- `homeboy-code-audit` `core_fingerprint::hash::sha256_hex16` — deliberately truncated to 16 chars.

**Truncated identities (kept truncated; only the duplicated hex encoder was removed where one existed):**
- `homeboy-extension` `trace::overlay_lock::trace_overlay_lock_id` — 24 chars, names a lock file, not a content identity. Now uses the primitive and drops its own hex encoder; truncation commented as intentional.
- `homeboy-core` `publication_artifacts::published_artifact_id`, `homeboy-cli` run/record remap ids, `homeboy-cli` `loop_sync::patch_fingerprint` — all 16-char prefixes, converted but still truncated.

**Domain-separated multi-field digests** (a digest over several labelled inputs, not a content hash):
- `homeboy-core`: `daemon::daemon_lease::daemon_state_identity` (distinguishes missing from empty), `source_snapshot`'s three snapshot hashes, `api_jobs::store::controller_submission_fingerprint`
- `homeboy-agents`: `agent_task_gate` gate-input digest, `agent_task_promotion::fingerprint`, `agent_task_provider::artifact_finalization` token digest, three `agent_task_lifecycle::failure_recording` id digests
- `homeboy-lab-runner`: dependency cache key, `workspace::util` remote-workspace directory digest
- `homeboy-release`: `deploy::content_manifest::Manifest::digest`

**Order-independent / ordered tree hashes:**
- `homeboy-core` `observation::store::artifacts::directory_tree_sha256`
- `homeboy-lab-runner` `extension_materialization::extension_source_content_hash`, `workspace::snapshot`'s four workspace/content hashes
- `homeboy-rig` `dependency_materialization_cache::hash_directory`

**Structurally cannot use a path- or slice-based hash:**
- `homeboy-release` `deploy::content_manifest`'s zip-entry hash — streams a `ZipFile` reader, no file exists.
- `homeboy-release` `gh_cli`'s download hash — hashes asset bytes as they stream out of the `gh` child process, before any file exists.
- `homeboy-agents` `artifact_finalization`'s copy-while-hashing loop — feeds bytes into the destination file and the hasher in one pass; a path-based hash would read the file twice.

**Error-contract preserved rather than collapsed:**
- `homeboy-lab-runner` `homeboy_refresh::sha256_file` still maps failures to `validation_invalid_argument` on `homeboy_binary`; only the digest moved.
- `homeboy-cli` `commands::trace::bundle::sha256_file` still reads through `trace_experiment::read_experiment_overlay_for_checksum`, which owns the `trace.experiment.overlay.sha256` error context; only the digest moved.
- `homeboy-core` `daemon::sha256_file_optional` keeps its own NotFound-is-absence contract and delegates the digest.

**Different scheme, correctly left alone:**
- `homeboy-agents` `agent_task_candidate_baseline::valid_git_object_id` — accepts 40 *or* 64 chars. Not a sha256 validator, untouched.

## Verification

`cargo fmt` clean. Full build/test is left to CI per repo policy (this host cannot run `cargo build`/`test`). `Cargo.lock` refreshed via `cargo metadata` and committed.
