### PR TITLE
fix(lab): stop the prepared-source cache from breaking dependency-free offloads

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -132,14 +132,19 @@ fn hydrate_lab_workspace_dependencies_for_run(
     remote_path: &str,
     parent_run_id: Option<&str>,
 ) -> Result<LabWorkspaceHydrationOutput> {
-    if prepared_source_view_is_ready(runner_id, remote_path)? {
-        return Ok(LabWorkspaceHydrationOutput::reused_prepared_cache(
-            remote_path,
-        ));
-    }
     let plan = deps::dependency_install_plan(std::path::Path::new(local_path))?;
     if plan.is_empty() {
         return Ok(LabWorkspaceHydrationOutput::skipped_no_provider(
+            remote_path,
+        ));
+    }
+    // Probe only once there is install work the cache could actually replace.
+    // Asking first cost a remote round trip on every dependency-free workspace
+    // and — because the probe is a raw exec — made hydration fail outright on
+    // any runner not explicitly trusted with `allow_raw_exec`, even though
+    // those workspaces never needed to reach the runner at all.
+    if prepared_source_view_is_ready(runner_id, remote_path)? {
+        return Ok(LabWorkspaceHydrationOutput::reused_prepared_cache(
             remote_path,
         ));
     }

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -530,14 +530,13 @@ pub(crate) fn save_prepared_source_cache(
     remote_path: &str,
 ) -> Result<()> {
     let runner = load(runner_id)?;
-    let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "workspace_root",
-            "runner workspace cache requires workspace_root",
-            Some(runner.id.clone()),
-            None,
-        )
-    })?;
+    // The cache is a pure optimization: a hit lets the next same-commit job skip
+    // dependency hydration. A runner with no configured `workspace_root` has
+    // nowhere to keep it, which is a reason to skip caching — not to fail an
+    // otherwise-successful offload that has already hydrated its workspace.
+    let Some(workspace_root) = runner.workspace_root.as_deref() else {
+        return Ok(());
+    };
     let local_path = canonical_workspace_path(local_path)?;
     let commit = git_output(&local_path, &["rev-parse", "HEAD"])?;
     let cache = prepared_source_cache_path(workspace_root, &local_path, &commit);


### PR DESCRIPTION
Follow-up to #10416. With the snapshot shell-syntax bug fixed, the release Test gate's `reverse_cook_queue_acceptance` failure moved on to its real cause:

```text
Diagnostic: Runner 'lab' policy denied execution: remote runner raw exec is denied
by default; explicitly trust this runner with allow_raw_exec=true
```

Both regressions here come from `76c8c99a8` ("fix(lab): reuse immutable prepared source views"), landed 2026-07-26 15:29. The snapshot bug landed ~5h later and masked them.

## 1. Probe runs before the plan-emptiness check

`prepared_source_view_is_ready` was inserted *above* the `plan.is_empty()` early return:

```rust
if prepared_source_view_is_ready(runner_id, remote_path)? {   // <- added here
    return Ok(...reused_prepared_cache...);
}
let plan = deps::dependency_install_plan(...)?;
if plan.is_empty() {
    return Ok(...skipped_no_provider...);                      // previously the first thing that happened
}
```

A workspace with no dependency provider previously never touched the runner. Now it always does — and since the probe is a `raw_command`, it trips `enforce_raw_exec` on any SSH runner not explicitly trusted. The offload dies before doing any work, on a workspace that had no work to do.

Moved the probe below the plan check. It only ever existed to answer "can I skip these install steps?", which is meaningless when there are none. Also saves a remote round trip on every dependency-free offload.

## 2. Missing `workspace_root` hard-failed the cache save

`save_prepared_source_cache` returned `ValidationInvalidArgument` when the runner had no `workspace_root`. The cache is a pure optimization — a hit lets the next same-commit job skip hydration. Having nowhere to put it is a reason to skip caching, not to fail an offload that already hydrated successfully. Now a graceful no-op.

## Verification

Two tests were **already failing on unmodified `main`** and are fixed here — no new tests needed, the contracts were already written down:

| Test | Failure on `main` |
|---|---|
| `hydration_skips_when_linked_extensions_do_not_provide_dependencies` | `RunnerNotFound: unused-runner` — the fixture's runner id literally encodes "this must not reach the runner" |
| `hydration_runs_for_materialized_workspace_jobs` | `Invalid argument 'workspace_root': runner workspace cache requires workspace_root` |

```
cargo test -p homeboy-lab-runner --lib hydration::            13 passed, 0 failed  (was 11/2)
cargo test -p homeboy-lab-runner --lib workspace::tests::snapshots
                                                              16 passed, 0 failed
```

The prepared-source-cache tests (`same_commit_prepared_source_cache_creates_private_job_views`, `prepared_source_cache_retains_a_bounded_completed_working_set`) still pass, so the caching optimization itself is intact.

Worth noting these two unit tests should have blocked `76c8c99a8` — the differential Test gate selects `hydration.rs`. Consistent with the gate hitting `baseline_red` and skipping enforcement while `main` was already broken.
