### PR TITLE
fix(lab-runner): keep snapshot materialization POSIX-sh portable

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -1703,11 +1703,30 @@ fn materialize_snapshot_piped(
     action: &str,
     scratch: Option<&Path>,
 ) -> Result<()> {
-    let mut command = snapshot_archive_command(local_path, target_command, excludes);
-    if let Some(scratch) = scratch {
-        command = scratch_scoped_command(&command, scratch);
-    }
+    let command = snapshot_materialization_command(local_path, target_command, excludes, scratch);
     run_shell_command(&command, action)
+}
+
+/// Build the exact shell program a snapshot materialization hands to `sh -c`.
+///
+/// This is the single construction point for that program so a test can assert
+/// against the byte-for-byte string production runs. Composing the archive
+/// pipeline and scratch scoping inline in the caller left the assembled command
+/// unobservable: `scratch_scoped_command` was individually well-formed, yet the
+/// only thing that ever exercised the *composition* was a full materialization,
+/// so a shell-syntax regression reached `sh -c` with no test able to see it and
+/// surfaced as ten unrelated workspace-prune behavior failures (#10399).
+pub(super) fn snapshot_materialization_command(
+    local_path: &Path,
+    target_command: &str,
+    excludes: &[String],
+    scratch: Option<&Path>,
+) -> String {
+    let command = snapshot_archive_command(local_path, target_command, excludes);
+    match scratch {
+        Some(scratch) => scratch_scoped_command(&command, scratch),
+        None => command,
+    }
 }
 
 /// Scope one snapshot command to an admitted controller scratch filesystem.
@@ -1825,7 +1844,7 @@ pub(super) fn snapshot_install_command(remote_path: &str) -> String {
         .command()
 }
 
-fn snapshot_overlay_install_command(remote_path: &str) -> String {
+pub(super) fn snapshot_overlay_install_command(remote_path: &str) -> String {
     let remote_path = shell::quote_arg(remote_path);
     format!(
         "dest={remote_path}; tmp=\"${{dest}}.overlay.$$\"; rm -rf \"$tmp\" && mkdir -p \"$tmp\" && trap 'rm -rf \"$tmp\"' EXIT && tar -C \"$tmp\" -xf - && find \"$dest\" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {{}} + && cp -a \"$tmp\"/. \"$dest\"/"

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -7,12 +7,52 @@ use std::sync::{Mutex, OnceLock};
 use crate::workspace::snapshot::{
     copy_snapshot_to_directory, ensure_no_runner_workspace_metadata_collision,
     scratch_scoped_command, snapshot_archive_command, snapshot_install_command,
-    synthetic_checkout_value, workspace_content_hash, workspace_content_hash_algorithm,
-    workspace_content_hash_for_policy, workspace_content_hash_v1,
-    workspace_content_manifest_for_policy, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
-    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    snapshot_materialization_command, snapshot_overlay_install_command, synthetic_checkout_value,
+    workspace_content_hash, workspace_content_hash_algorithm, workspace_content_hash_for_policy,
+    workspace_content_hash_v1, workspace_content_manifest_for_policy,
+    WORKSPACE_CONTENT_PERMISSION_PORTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
     WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
 };
+
+/// Parse `command` without executing it, under every POSIX shell on the host.
+///
+/// `sh -n` alone is a weak portability check. Where `/bin/sh` is bash, its
+/// parser accepts bash-only syntax that dash rejects outright -- process
+/// substitution `<(...)`, the `function` keyword, and array assignments -- so a
+/// developer machine reports green while the runner's dash refuses the same
+/// program. Preferring `dash` when it is installed makes the check as strict as
+/// the shell that actually executes these commands (#10399).
+///
+/// A parse check cannot catch every bashism: `[[ ... ]]` and `((...))` parse as
+/// ordinary words under dash and only fail when run. It does reliably catch the
+/// structural errors this boundary keeps producing, including the assignment
+/// prefix on a `(...)` subshell that both shells reject.
+fn assert_parses_under_posix_shells(command: &str, label: &str) {
+    let mut parsed_by = Vec::new();
+    for shell in ["dash", "sh"] {
+        let output = match std::process::Command::new(shell)
+            .arg("-n")
+            .arg("-c")
+            .arg(command)
+            .output()
+        {
+            Ok(output) => output,
+            // `dash` is not installed everywhere; `sh` always is.
+            Err(_) if shell == "dash" => continue,
+            Err(error) => panic!("failed to run `{shell} -n` for {label}: {error}"),
+        };
+        assert!(
+            output.status.success(),
+            "{label} must parse under `{shell}`: {}\ncommand: {command}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        parsed_by.push(shell);
+    }
+    assert!(
+        parsed_by.contains(&"sh"),
+        "{label} was never parsed by a shell"
+    );
+}
 
 #[test]
 fn snapshot_git_readback_failure_fails_materialization_contract() {
@@ -1381,16 +1421,73 @@ fn scratch_scoped_snapshot_command_parses_under_posix_sh() {
             "scratch scoping must export rather than prefix an assignment: {scoped}"
         );
 
-        let parsed = std::process::Command::new("sh")
-            .arg("-n")
-            .arg("-c")
-            .arg(&scoped)
-            .output()
-            .expect("run sh -n");
-        assert!(
-            parsed.status.success(),
-            "scratch-scoped snapshot command must parse under POSIX sh: {}\ncommand: {scoped}",
-            String::from_utf8_lossy(&parsed.stderr)
+        assert_parses_under_posix_shells(&scoped, "scratch-scoped snapshot command");
+    }
+}
+
+/// Cover the command production actually executes, not a re-composition of its
+/// parts. `materialize_snapshot_piped` used to assemble the archive pipeline and
+/// the scratch prefix inline, so no test observed the assembled program; the
+/// scratch branch is taken unconditionally by `sync_workspace`, which is why a
+/// malformed composition took out every workspace-prune behavior test at once
+/// instead of a single targeted assertion (#10399).
+#[test]
+fn snapshot_materialization_command_parses_under_posix_shells() {
+    use homeboy_core::engine::shell;
+
+    let local_target = format!(
+        "sh -c {}",
+        shell::quote_arg(&snapshot_install_command(
+            "/var/lib/sampleplugin/workspace/_lab_workspaces/homeboy-abc"
+        ))
+    );
+
+    for excludes in [
+        vec![],
+        vec!["node_modules".to_string()],
+        vec!["./target".to_string(), "node_modules".to_string()],
+    ] {
+        for target in [local_target.as_str(), "ssh runner 'tar -xf -'"] {
+            for scratch in [
+                None,
+                Some(Path::new("/var/lib/homeboy/scratch dir")),
+                Some(Path::new("/var/lib/homeboy/scratch")),
+            ] {
+                let command = snapshot_materialization_command(
+                    Path::new("/Users/user/Developer/wp-site-generator"),
+                    target,
+                    &excludes,
+                    scratch,
+                );
+
+                assert_eq!(
+                    scratch.is_some(),
+                    command.starts_with("export TMPDIR="),
+                    "scratch scoping must be applied exactly when a scratch filesystem is admitted: {command}"
+                );
+
+                assert_parses_under_posix_shells(&command, "snapshot materialization command");
+            }
+        }
+    }
+}
+
+/// The install commands cross the same `sh -c` boundary as the archive
+/// pipeline, on both the local and the SSH runner path, so hold them to the
+/// same portability contract (#10399).
+#[test]
+fn snapshot_install_commands_parse_under_posix_shells() {
+    for remote_path in [
+        "/var/lib/sampleplugin/workspace/_lab_workspaces/homeboy-abc",
+        "/var/lib/homeboy/work spaces/homeboy-abc",
+    ] {
+        assert_parses_under_posix_shells(
+            &snapshot_install_command(remote_path),
+            "snapshot install command",
+        );
+        assert_parses_under_posix_shells(
+            &snapshot_overlay_install_command(remote_path),
+            "snapshot overlay install command",
         );
     }
 }


### PR DESCRIPTION
## RELEASE-BLOCKING

No release has shipped since **v0.319.2** (Jul 26 22:39). Every release run since has failed the Test gate on ten workspace-prune tests, so multiple merged fixes — including a fanout repair the operator is waiting on — have never reached users. This PR clears that gate.

`Closes #10399`

## The offending construct

Scratch admission wrapped the snapshot command with a `TMPDIR=<dir>` **assignment prefix**, but `snapshot_archive_command` always emits a leading `(...)` subshell. POSIX allows assignment prefixes only on *simple* commands, so the whole program is a parse error before a byte is transferred:

```
$ dash -c 'TMPDIR=/tmp/x (cd /tmp && echo hi)'
dash: 1: Syntax error: "(" unexpected
```

`sync_workspace` passes `Some(scratch)` **unconditionally**, so every local materialization took this path — which is why ten prune tests all died with the same `sh: 1: Syntax error: "(" unexpected`.

Worth recording: this was **not** a bash-vs-dash divergence. Bash rejects the construct too. The tests never caught it because nothing exercised the assembled command except a full materialization.

## What this changes

The prefix itself was already corrected. What remained — and what this PR fixes — is the reason no test could see it.

- **`snapshot_materialization_command`** is now the single construction point for the program `materialize_snapshot_piped` hands to `sh -c`. The archive pipeline and scratch scoping were composed inline in the runner, so each part was individually well-formed while the *composition* was unobservable. Tests now assert against the byte-for-byte string production runs, across exclude shapes, both runner targets, and scratch admitted or not.
- **Validate under `dash` when present**, not just `sh -n`. Where `/bin/sh` is bash, its parser accepts bash-only syntax dash rejects — process substitution, the `function` keyword, array assignments — so the old check could pass locally and fail on the runner. Measured:

  | construct | `dash -n` | `bash -n` |
  |---|---|---|
  | `TMPDIR=x (cd ...)` | REJECT | REJECT |
  | `cat <(echo hi)` | REJECT | accept |
  | `function f() { :; }` | REJECT | accept |
  | `a+=(1)` | REJECT | accept |

  The comment is explicit that a parse check cannot catch `[[ ... ]]` or `((...))`, which parse as ordinary words under dash and only fail at run time.
- **`snapshot_install_command` and `snapshot_overlay_install_command`** are held to the same contract; they cross the same boundary.

Fix direction is POSIX portability, not switching the executor to bash — bash is not guaranteed on an SSH runner, and the SSH path (`client.execute`) has no control over the remote login shell.

## Verification

Per this host's resource rules, no `cargo build`/`test`/`check`/`clippy` was run — only `cargo fmt`. Commands were reconstructed faithfully and syntax-checked directly:

- Reproduced the exact CI error from the old shape under `dash -n`.
- Confirmed the current archive shapes (plain + root-anchored excludes), with and without scratch scoping, and both install commands (including space-containing paths) all parse cleanly.
- Audited the lab-runner shell literals for `<(`, `>(`, `[[`, `function `, `mapfile`, `readarray` — no other live non-POSIX construct.

**CI passing is the acceptance criterion here.** Full build and test are left to CI.
