### PR TITLE
fix(agent-task): keep unscoped provider discovery controller-local and bounded

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -12,7 +12,8 @@ use std::collections::BTreeMap;
 
 use homeboy_core::agent_runtime_manifest::{
     discover_agent_runtime_catalog, runtime_materialization_plan, AgentRuntimeDiscoveryDiagnostic,
-    AgentRuntimeManifest,
+    AgentRuntimeManifest, AgentRuntimeSelectedIdentity, AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT,
+    AGENT_RUNTIME_REVISION_PROBE_TIMEOUT,
 };
 use homeboy_core::command_invocation::COMMAND_INVOCATION_SCHEMA;
 use homeboy_core::{Error, Result};
@@ -30,11 +31,11 @@ pub(crate) fn discover_agent_task_executor_provider_catalog(
 ) -> AgentTaskExecutorProviderDiscoveryCatalog {
     let catalog = discover_agent_runtime_catalog();
     let mut diagnostics = catalog.diagnostics;
+    let discovered =
+        agent_task_executor_providers_from_runtime_manifests(catalog.manifests, &mut diagnostics);
+    let providers = reject_duplicate_provider_ids(discovered, &mut diagnostics);
     AgentTaskExecutorProviderDiscoveryCatalog {
-        providers: reject_duplicate_provider_ids(
-            agent_task_executor_providers_from_runtime_manifests(catalog.manifests),
-            &mut diagnostics,
-        ),
+        providers,
         diagnostics,
     }
 }
@@ -46,11 +47,46 @@ pub struct AgentTaskExecutorProviderDiscoveryCatalog {
     pub diagnostics: Vec<AgentRuntimeDiscoveryDiagnostic>,
 }
 
+/// Diagnostic class raised when a runtime's bounded revision probe ran out of
+/// budget. The provider stays in the catalog; the diagnostic is what makes the
+/// result an explicitly labelled partial rather than a silent unknown (#9763).
+pub const AGENT_RUNTIME_REVISION_PROBE_TIMEOUT_DIAGNOSTIC: &str =
+    "agent_runtime_manifest.revision_probe_timeout";
+
+/// Turn a timed-out runtime revision probe into a scoped discovery diagnostic.
+///
+/// The provider stays in the catalog: losing a revision must not lose the
+/// provider. What the diagnostic adds is the distinction between "this runtime
+/// has no revision" and "we could not find out inside the budget", so callers
+/// read a labelled partial rather than a confident wrong answer (#9763).
+fn revision_probe_timeout_diagnostic(
+    runtime_manifest: &AgentRuntimeManifest,
+    selected_identity: &AgentRuntimeSelectedIdentity,
+) -> Option<AgentRuntimeDiscoveryDiagnostic> {
+    if selected_identity.revision_probe.as_deref() != Some(AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT) {
+        return None;
+    }
+    Some(AgentRuntimeDiscoveryDiagnostic {
+        class: AGENT_RUNTIME_REVISION_PROBE_TIMEOUT_DIAGNOSTIC.to_string(),
+        message: format!(
+            "runtime revision probe exceeded its {}s budget; this catalog is a partial and the runtime revision is unknown, not absent",
+            AGENT_RUNTIME_REVISION_PROBE_TIMEOUT.as_secs()
+        ),
+        runtime_id: Some(runtime_manifest.id.clone()),
+        extension_id: runtime_manifest.extension_id.clone(),
+        path: runtime_manifest.runtime_path.clone(),
+    })
+}
+
 fn agent_task_executor_providers_from_runtime_manifests(
     runtime_manifests: Vec<AgentRuntimeManifest>,
+    diagnostics: &mut Vec<AgentRuntimeDiscoveryDiagnostic>,
 ) -> Vec<AgentTaskExecutorProvider> {
     let mut providers = Vec::new();
     for runtime_manifest in runtime_manifests {
+        // One runtime yields one probe outcome regardless of how many providers
+        // it declares, so the partial is reported once per runtime.
+        let mut reported_revision_probe_timeout = false;
         for provider_value in runtime_manifest.agent_task_executors.clone() {
             let Ok(mut provider) =
                 serde_json::from_value::<AgentTaskExecutorProvider>(provider_value)
@@ -67,6 +103,15 @@ fn agent_task_executor_providers_from_runtime_manifests(
             provider.runtime_path = runtime_manifest.runtime_path.clone();
             let materialization_plan =
                 runtime_materialization_plan(&runtime_manifest, &provider.id);
+            if !reported_revision_probe_timeout {
+                if let Some(diagnostic) = revision_probe_timeout_diagnostic(
+                    &runtime_manifest,
+                    &materialization_plan.selected_identity,
+                ) {
+                    diagnostics.push(diagnostic);
+                    reported_revision_probe_timeout = true;
+                }
+            }
             if let Ok(value) = serde_json::to_value(&materialization_plan) {
                 provider
                     .extra
@@ -270,4 +315,49 @@ pub fn register() {
     homeboy_core::extension_provider_discovery::register_extension_provider_discovery_validator(
         Box::new(ExtensionProviderDiscoveryValidatorImpl),
     );
+}
+
+#[cfg(test)]
+mod revision_probe_tests {
+    use super::*;
+
+    fn manifest() -> AgentRuntimeManifest {
+        serde_json::from_value(serde_json::json!({
+            "schema": homeboy_core::agent_runtime_manifest::AGENT_RUNTIME_MANIFEST_SCHEMA,
+            "id": "opencode",
+            "extension_id": "homeboy-opencode",
+            "runtime_path": "/runtimes/opencode",
+        }))
+        .expect("valid runtime manifest fixture")
+    }
+
+    #[test]
+    fn a_timed_out_revision_probe_becomes_a_labelled_partial() {
+        // The bounded probe must degrade, not hang and not lie: the provider
+        // stays discoverable and the catalog says the revision is unknown
+        // rather than absent (#9763).
+        let identity = AgentRuntimeSelectedIdentity {
+            revision_probe: Some(AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT.to_string()),
+            ..Default::default()
+        };
+
+        let diagnostic = revision_probe_timeout_diagnostic(&manifest(), &identity)
+            .expect("a timed-out probe must be reported");
+
+        assert_eq!(
+            diagnostic.class,
+            AGENT_RUNTIME_REVISION_PROBE_TIMEOUT_DIAGNOSTIC
+        );
+        assert_eq!(diagnostic.runtime_id.as_deref(), Some("opencode"));
+        assert_eq!(diagnostic.extension_id.as_deref(), Some("homeboy-opencode"));
+        assert_eq!(diagnostic.path.as_deref(), Some("/runtimes/opencode"));
+        assert!(diagnostic.message.contains("unknown, not absent"));
+    }
+
+    #[test]
+    fn an_in_budget_probe_adds_no_diagnostic() {
+        let identity = AgentRuntimeSelectedIdentity::default();
+
+        assert!(revision_probe_timeout_diagnostic(&manifest(), &identity).is_none());
+    }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -794,6 +794,75 @@ fn scope_providers(
 const DEFAULT_PROVIDER_LIMIT: usize = 10;
 const DEFAULT_DIAGNOSTIC_LIMIT: usize = 10;
 const DEFAULT_TEXT_LIMIT: usize = 256;
+const DEFAULT_SCOPE_SOURCE_LIMIT: usize = 20;
+pub(crate) const AGENT_TASK_PROVIDER_SCOPE_SCHEMA: &str = "homeboy/agent-task-provider-scope/v1";
+
+/// The execution scope a provider catalog describes.
+///
+/// Controller and runner carry different extensions, runtime defaults,
+/// secrets, and provider readiness, so a catalog is only interpretable
+/// alongside where it was observed. This is emitted as an additive
+/// `observed_scope` object: the pre-existing `scope` object keeps its meaning
+/// (which slice of the catalog is being presented) so existing parsers are
+/// unaffected (#9763).
+fn observed_provider_scope(all_providers: &[AgentTaskExecutorProvider]) -> Value {
+    let runner_id = homeboy::core::resource_policy_context::lab_execution_runner_id();
+    let identity = homeboy::core::build_identity::current();
+    let label = match runner_id.as_deref() {
+        Some(runner_id) => format!("runner `{runner_id}`"),
+        None => "controller".to_string(),
+    };
+    let location = if runner_id.is_some() {
+        "lab"
+    } else {
+        "controller"
+    };
+
+    let bounded_ids = |values: Vec<String>| {
+        let mut values = values;
+        values.sort();
+        values.dedup();
+        let total = values.len();
+        values.truncate(DEFAULT_SCOPE_SOURCE_LIMIT);
+        (total, values)
+    };
+    let (extension_total, extension_ids) = bounded_ids(
+        all_providers
+            .iter()
+            .filter_map(|provider| provider.extension_id.clone())
+            .collect(),
+    );
+    let (runtime_total, runtime_ids) = bounded_ids(
+        all_providers
+            .iter()
+            .filter_map(|provider| provider.runtime_id.clone())
+            .collect(),
+    );
+
+    serde_json::json!({
+        "schema": AGENT_TASK_PROVIDER_SCOPE_SCHEMA,
+        "location": location,
+        "runner_id": runner_id,
+        "label": label,
+        "homeboy_identity": {
+            "version": identity.version,
+            "display": identity.display,
+            "git_commit": identity.git_commit,
+        },
+        "extension_source": {
+            "total": extension_total,
+            "shown": extension_ids.len(),
+            "extension_ids": extension_ids,
+        },
+        "runtime_source": {
+            "total": runtime_total,
+            "shown": runtime_ids.len(),
+            "runtime_ids": runtime_ids,
+        },
+        "observed_at": chrono::Utc::now().to_rfc3339(),
+        "runner_scoped_command": "homeboy agent-task providers --runner <runner-id>",
+    })
+}
 
 pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     let catalog = if args.refresh {
@@ -884,6 +953,9 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
                 "refreshed": args.refresh,
                 "version": catalog_version,
             },
+            // Where this catalog was observed. Provider readiness is
+            // scope-sensitive, so an unlabelled catalog is ambiguous (#9763).
+            "observed_scope": observed_provider_scope(all_providers),
             "scope": {
                 "backend": scoped_backend,
                 "filtered": scoped_backend.is_some()

--- a/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
@@ -42,6 +42,55 @@ fn providers_output_includes_core_capability_contract() {
 }
 
 #[test]
+fn providers_output_declares_the_scope_it_observed() {
+    // A provider catalog is only interpretable together with where it was
+    // read: controller and runner differ in extensions, runtime defaults,
+    // secrets, and provider readiness (#9763).
+    with_isolated_home(|_| {
+        let execution_runner = homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV;
+        let previous = std::env::var_os(execution_runner);
+        std::env::remove_var(execution_runner);
+
+        let result = review::providers(ProvidersArgs {
+            backend: None,
+            selector: None,
+            runtime: None,
+            status: None,
+            secret_env: Vec::new(),
+            validate_readiness: false,
+            refresh: false,
+            catalog: false,
+            full: false,
+        });
+
+        if let Some(value) = previous {
+            std::env::set_var(execution_runner, value);
+        }
+        let (value, status) = result.expect("providers output");
+
+        assert_eq!(status, 0);
+        let scope = &value["observed_scope"];
+        assert_eq!(scope["schema"], "homeboy/agent-task-provider-scope/v1");
+        assert_eq!(scope["location"], "controller");
+        assert!(scope["runner_id"].is_null());
+        assert_eq!(scope["label"], "controller");
+        assert!(scope["homeboy_identity"]["version"].is_string());
+        assert!(scope["observed_at"].is_string());
+        assert!(scope["extension_source"]["total"].is_number());
+        assert!(scope["runtime_source"]["total"].is_number());
+        assert_eq!(
+            scope["runner_scoped_command"],
+            "homeboy agent-task providers --runner <runner-id>"
+        );
+
+        // Additive only: the pre-existing `scope` object keeps its meaning for
+        // callers that already parse this output.
+        assert_eq!(value["schema"], "homeboy/agent-task-providers/v1");
+        assert_eq!(value["scope"]["filtered"], false);
+    });
+}
+
+#[test]
 fn contract_output_exports_core_agent_task_metadata() {
     let (value, status) = contract::contract(ContractArgs {
         format: ContractFormat::Json,

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -95,9 +95,23 @@ impl Commands {
             // workload run: a merely `warm` controller should not pay the Lab
             // round-trip for it. Only offload when the machine is genuinely hot.
             .cheap(),
+            // Provider discovery is scope-sensitive: controller and runner
+            // carry different extensions, runtime defaults, secrets, and
+            // provider readiness, so *where* the catalog is read changes what
+            // the answer means. An unscoped read therefore stays controller-
+            // local, and a runner catalog is requested explicitly with
+            // `--runner <id>` / `--placement lab`.
+            //
+            // `runner_resident` is what encodes that: it keeps
+            // `default_lab_offload` off (explicit-runner only) and, because its
+            // source path mode is `RunnerResident`, it is exempt from the
+            // warm-controller pressure promotion in the Lab offload executor
+            // that previously flipped this read onto Lab automatically. It also
+            // drops controller-cwd materialization, so the explicit runner
+            // probe answers before any workload workspace is built (#9763).
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Providers(_),
-            }) => LabCommandContract::explicit_runner_simple(AGENT_TASK_PROVIDERS_LAB_LABEL),
+            }) => LabCommandContract::runner_resident(AGENT_TASK_PROVIDERS_LAB_LABEL),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {

--- a/crates/homeboy-cli/src/commands/contract_lab_routing_tests.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing_tests.rs
@@ -248,3 +248,71 @@ fn rig_source_management_explains_lab_setup_boundary() {
         );
     }
 }
+
+#[test]
+fn unscoped_provider_discovery_stays_controller_local() {
+    // The semantic guarantee of #9763: an unscoped `agent-task providers` is a
+    // read of *this* controller's catalog. Controller and runner differ in
+    // extensions, runtime defaults, secrets, and provider readiness, so
+    // automatically relocating the read would change what the answer means.
+    let contract = parsed_command(&["homeboy", "agent-task", "providers"])
+        .lab_contract()
+        .expect("provider discovery keeps a Lab contract for explicit placement");
+
+    assert!(
+        !contract.routing_policy.default_lab_offload,
+        "unscoped provider discovery must not offload automatically"
+    );
+    assert_eq!(contract.source_path_mode, LabSourcePathMode::RunnerResident);
+    assert_eq!(
+        contract.workspace_mode_policy,
+        LabWorkspaceModePolicy::RunnerResident,
+        "a provider catalog read must not materialize a workload workspace"
+    );
+    assert!(
+        contract.is_portable(),
+        "an explicit --runner probe must remain available"
+    );
+}
+
+#[test]
+fn warm_controller_pressure_never_relocates_provider_discovery() {
+    // `explicit_runner_simple` left provider discovery eligible for the
+    // warm-controller pressure promotion in the Lab offload executor, which is
+    // what silently moved the read onto `homeboy-lab`. Runner-resident source
+    // mode is the contract-level exemption from that promotion (#9763).
+    let contract = parsed_command(&["homeboy", "agent-task", "providers"])
+        .lab_contract()
+        .expect("provider discovery contract");
+
+    assert_eq!(
+        contract.source_path_mode,
+        LabSourcePathMode::RunnerResident,
+        "runner-resident reads are exempt from pressure-driven offload promotion"
+    );
+
+    // Guard the shared policy too: no severity may promote a contract that
+    // declares no default offload without an explicit caller request.
+    assert!(!contract.routing_policy.default_lab_offload);
+}
+
+#[test]
+fn explicit_runner_provider_discovery_still_offloads() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "--runner",
+        "homeboy-lab",
+        "agent-task",
+        "providers",
+    ])
+    .expect("CLI args should parse");
+
+    assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+    assert!(
+        cli.command
+            .lab_contract()
+            .expect("provider discovery contract")
+            .is_portable(),
+        "an explicit runner request must still reach the runner"
+    );
+}

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -919,6 +919,18 @@ fn lab_route_dispatch_timeout(command: &Commands) -> Option<std::time::Duration>
     if matches!(command, Commands::Trace(_)) {
         return Some(lab_routing::lab_trace_dispatch_timeout());
     }
+    // An explicitly runner-scoped provider catalog read is still a diagnostic
+    // read. Bound its dispatch so `--runner <id>` degrades to a labelled
+    // dispatch-timeout error, with durable runner/job identity to follow, well
+    // inside a caller's patience (#9763).
+    if matches!(
+        command,
+        Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+            command: crate::commands::agent_task::AgentTaskCommand::Providers(_),
+        })
+    ) {
+        return Some(lab_routing::lab_provider_discovery_dispatch_timeout());
+    }
     None
 }
 

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -728,6 +728,43 @@ fn lab_route_dispatch_timeout_plumbs_core_timeout() {
 }
 
 #[test]
+fn explicit_runner_provider_discovery_dispatch_is_bounded() {
+    // An explicit `--runner` provider read still has to answer inside a
+    // caller's patience: it degrades to the labelled dispatch-timeout error
+    // rather than waiting out the generic workload budget (#9763).
+    let _env = EnvGuard::remove(lab_routing::LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_ENV);
+    let explicit = Cli::parse_from([
+        "homeboy",
+        "--runner",
+        "homeboy-lab",
+        "agent-task",
+        "providers",
+    ]);
+    let unscoped = Cli::parse_from(["homeboy", "agent-task", "providers"]);
+    let budget = lab_routing::lab_provider_discovery_dispatch_timeout();
+
+    assert_eq!(lab_route_dispatch_timeout(&explicit.command), Some(budget));
+    assert_eq!(lab_route_dispatch_timeout(&unscoped.command), Some(budget));
+    assert!(
+        budget < std::time::Duration::from_secs(lab_routing::DEFAULT_LAB_DISPATCH_TIMEOUT_SECS),
+        "provider discovery must not inherit the generic workload dispatch budget"
+    );
+}
+
+#[test]
+fn provider_discovery_dispatch_timeout_reads_env_override() {
+    let _env = EnvGuard::set(
+        lab_routing::LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_ENV,
+        "11",
+    );
+
+    assert_eq!(
+        lab_routing::lab_provider_discovery_dispatch_timeout(),
+        std::time::Duration::from_secs(11)
+    );
+}
+
+#[test]
 fn detached_agent_task_handoffs_do_not_use_trace_dispatch_timeout() {
     let cook = Cli::parse_from([
         "homeboy",

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -540,6 +540,37 @@ fn agent_task_providers_supports_explicit_runner_discovery() {
     assert!(!command.routing_policy.requires_extension_parity);
     assert!(command.required_extensions.is_empty());
     assert!(!command.routing_policy.infer_source_path_tools);
+    // The runner catalog answers from the runner's own installation. Nothing
+    // about a provider read needs the controller's working tree, and building
+    // one is exactly the materialization ceremony that outran the caller's
+    // timeout (#9763).
+    assert_eq!(
+        command.source_path_mode,
+        runners::LabOffloadSourcePathMode::RunnerResident
+    );
+    assert_eq!(
+        command.workspace_mode_policy,
+        runners::LabOffloadWorkspaceModePolicy::RunnerResident
+    );
+}
+
+#[test]
+fn unscoped_provider_discovery_does_not_offload() {
+    // Controller and runner have different extensions, runtime defaults,
+    // secrets, and provider readiness, so relocating an unscoped read changes
+    // the meaning of its answer. Offload stays opt-in (#9763).
+    let cli = Cli::parse_from(["homeboy", "agent-task", "providers"]);
+
+    let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+    assert_eq!(cli.runner, None);
+    assert_eq!(cli.placement, crate::cli_surface::Placement::Auto);
+    assert!(!command.routing_policy.default_lab_offload);
+    assert_eq!(
+        command.source_path_mode,
+        runners::LabOffloadSourcePathMode::RunnerResident,
+        "runner-resident source mode is what exempts this read from warm-controller offload promotion"
+    );
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -54,7 +54,6 @@ pub(super) fn agent_task_resource_behavior(
         | agent_task::AgentTaskCommand::PromotionProvider(_)
         | agent_task::AgentTaskCommand::FinalizePr(_)
         | agent_task::AgentTaskCommand::GateFeedback(_)
-        | agent_task::AgentTaskCommand::Providers(_)
         | agent_task::AgentTaskCommand::Tool(_) => AgentTaskResourceBehavior::AdmittedWorkload,
         agent_task::AgentTaskCommand::Retry(retry) if retry.run => {
             AgentTaskResourceBehavior::AdmittedWorkload
@@ -67,6 +66,13 @@ pub(super) fn agent_task_resource_behavior(
         | agent_task::AgentTaskCommand::Artifacts(_)
         | agent_task::AgentTaskCommand::Evidence(_)
         | agent_task::AgentTaskCommand::Diagnose(_)
+        // Provider discovery reads controller-local extension and runtime
+        // manifests under bounded probes. Classifying it as an admitted
+        // workload put it behind resource admission, which captured a
+        // warm-controller resource context and let Lab routing promote an
+        // unscoped diagnostic read onto a runner — silently changing the scope
+        // the answer describes (#9763).
+        | agent_task::AgentTaskCommand::Providers(_)
         | agent_task::AgentTaskCommand::Review(_) => AgentTaskResourceBehavior::BoundedMetadataRead,
         agent_task::AgentTaskCommand::Active(active) if !active.reconcile => {
             AgentTaskResourceBehavior::BoundedMetadataRead

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -728,6 +728,56 @@ mod tests {
     }
 
     #[test]
+    fn unscoped_provider_discovery_never_interacts_with_a_runner() {
+        // Provider discovery reads controller-local manifests. Treating it as
+        // an admitted workload made a warm controller capture a resource
+        // context, probe Lab readiness, and relocate an unscoped diagnostic
+        // read onto a runner whose provider readiness is a different answer
+        // (#9763). No pressure level may engage resource admission for it.
+        let cli = Cli::parse_from(["homeboy", "agent-task", "providers"]);
+
+        assert!(
+            hot_command(&cli.command).is_none(),
+            "unscoped provider discovery must not enter resource admission"
+        );
+        for recommendation in [
+            ResourceRecommendation::Ok,
+            ResourceRecommendation::Warm,
+            ResourceRecommendation::Hot,
+        ] {
+            let warning = hot_command(&cli.command)
+                .and_then(|command| evaluate(command, &resources(recommendation)));
+            assert!(
+                warning.is_none(),
+                "a {recommendation:?} controller must not steer provider discovery to Lab"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_runner_provider_discovery_keeps_its_lab_contract() {
+        // Staying out of resource admission must not remove the explicit
+        // runner-scoped probe: `--runner <id>` is still the way to ask what a
+        // runner's catalog looks like (#9763).
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "agent-task",
+            "providers",
+        ]);
+
+        assert!(cli
+            .command
+            .portability_contract()
+            .lab_command()
+            .is_some_and(|contract| matches!(
+                contract.portability,
+                LabCommandPortability::Portable
+            )));
+    }
+
+    #[test]
     fn agent_task_mutating_recovery_commands_remain_resource_managed() {
         // Bounded readers are exempt above; replay and promotion still execute
         // provider or worktree operations and retain resource admission.

--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -10,6 +10,20 @@ use crate::{config, paths, Error, Result};
 use homeboy_extension_contract::{ExtensionManifest, RequirementsConfig};
 
 pub const AGENT_RUNTIME_MANIFEST_SCHEMA: &str = "homeboy/agent-runtime-manifest/v1";
+
+/// Deadline for the per-runtime `git rev-parse HEAD` revision probe.
+///
+/// Runtime revisions are derived during agent-runtime/provider catalog
+/// discovery, which is a diagnostic read (`homeboy agent-task providers`). One
+/// wedged runtime checkout must not make the whole catalog unbounded, so the
+/// probe degrades to a labelled partial (#9763).
+pub const AGENT_RUNTIME_REVISION_PROBE_TIMEOUT: std::time::Duration =
+    crate::git::DEFAULT_GIT_READ_PROBE_TIMEOUT;
+
+/// Marker recorded on a selected runtime identity whose bounded revision probe
+/// ran out of budget. Consumers raise this as a scoped discovery diagnostic
+/// instead of reporting the revision as merely absent.
+pub const AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT: &str = "timed_out";
 pub const AGENT_RUNTIME_MATERIALIZATION_PLAN_SCHEMA: &str =
     "homeboy/agent-runtime-materialization-plan/v2";
 
@@ -333,6 +347,12 @@ pub struct AgentRuntimeSelectedIdentity {
     /// installs without that proof are intentionally `unverifiable`.
     #[serde(default = "default_runtime_freshness")]
     pub freshness: String,
+    /// `timed_out` when the bounded revision probe exceeded its budget. Absent
+    /// means the probe answered (positively or negatively) within budget. This
+    /// distinguishes "this runtime has no revision" from "we could not find out
+    /// in time", so discovery can emit a labelled partial (#9763).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision_probe: Option<String>,
 }
 
 fn default_runtime_freshness() -> String {
@@ -360,10 +380,12 @@ pub fn runtime_materialization_plan(
     env_passthrough.sort();
     env_passthrough.dedup();
 
-    let revision = manifest
+    let probe = manifest
         .runtime_path
         .as_deref()
-        .and_then(|path| runtime_source_revision(Path::new(path)));
+        .map(|path| runtime_source_revision_probe(Path::new(path)))
+        .unwrap_or_default();
+    let revision = probe.revision.clone();
     let freshness = if revision.as_deref().is_some_and(is_immutable_revision) {
         "current"
     } else {
@@ -408,6 +430,9 @@ pub fn runtime_materialization_plan(
             source_path: manifest.runtime_path.clone(),
             revision,
             freshness: freshness.to_string(),
+            revision_probe: probe
+                .timed_out
+                .then(|| AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT.to_string()),
         },
         provider_id: provider_id.into(),
         source_selector: runtime_source_description(manifest),
@@ -553,13 +578,36 @@ fn runtime_generation_identity(
     format!("sha256:{}", content_hash::sha256_hex(&encoded))
 }
 
-fn runtime_source_revision(path: &Path) -> Option<String> {
-    crate::git::head_sha(path).or_else(|| {
+/// Bounded outcome of a runtime source-revision probe.
+///
+/// `timed_out` is carried separately from `revision` so callers can label a
+/// partial catalog instead of silently reporting an unknown revision (#9763).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeSourceRevisionProbe {
+    pub revision: Option<String>,
+    pub timed_out: bool,
+}
+
+/// Resolve a runtime checkout's source revision under a bounded deadline.
+///
+/// The git probe is the part that can wedge, so it runs under
+/// [`AGENT_RUNTIME_REVISION_PROBE_TIMEOUT`]. The `.source-revision` file
+/// fallback is a plain file read and stays available even when git timed out —
+/// a timed-out git probe still degrades to whatever the extracted install
+/// recorded, and only reports `timed_out` when no answer was found at all.
+pub fn runtime_source_revision_probe(path: &Path) -> RuntimeSourceRevisionProbe {
+    let probe = crate::git::head_sha_within(path, AGENT_RUNTIME_REVISION_PROBE_TIMEOUT);
+    let timed_out = probe.timed_out();
+    let revision = probe.resolved().or_else(|| {
         std::fs::read_to_string(path.join(".source-revision"))
             .ok()
             .map(|revision| revision.trim().to_string())
             .filter(|revision| !revision.is_empty())
-    })
+    });
+    RuntimeSourceRevisionProbe {
+        timed_out: timed_out && revision.is_none(),
+        revision,
+    }
 }
 
 pub fn discover_agent_runtime_catalog() -> AgentRuntimeDiscoveryCatalog {
@@ -747,7 +795,11 @@ fn load_standalone_agent_runtime_manifest(
     manifest.extension_id = None;
     manifest.extension_path = None;
     manifest.runtime_path = Some(path.to_string_lossy().to_string());
-    manifest.source_revision = crate::git::head_sha(path);
+    // Bounded: catalog discovery must not block on one wedged runtime checkout
+    // (#9763). An unresolved revision keeps the runtime discoverable and merely
+    // unverifiable, which is what the freshness contract already expects.
+    manifest.source_revision =
+        crate::git::head_sha_within(path, AGENT_RUNTIME_REVISION_PROBE_TIMEOUT).resolved();
     if let Some(diagnostic) = mutable_runtime_source_diagnostic(
         &manifest.id,
         None,
@@ -1004,6 +1056,58 @@ mod materialization_tests {
             revision: "ffffffffffffffffffffffffffffffffffffffff".to_string(),
         };
         assert!(validate_runtime_materialization_plan(&invalid).is_err());
+    }
+
+    #[test]
+    fn revision_probe_falls_back_to_the_recorded_source_revision() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join(".source-revision"),
+            "0123456789abcdef0123456789abcdef01234567\n",
+        )
+        .expect("write source revision");
+
+        let probe = runtime_source_revision_probe(dir.path());
+
+        assert_eq!(
+            probe.revision.as_deref(),
+            Some("0123456789abcdef0123456789abcdef01234567")
+        );
+        assert!(!probe.timed_out);
+    }
+
+    #[test]
+    fn revision_probe_reports_no_revision_without_claiming_a_timeout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let probe = runtime_source_revision_probe(dir.path());
+
+        assert_eq!(probe.revision, None);
+        assert!(!probe.timed_out);
+    }
+
+    #[test]
+    fn a_timed_out_probe_labels_the_selected_identity_as_a_partial() {
+        // The probe status, not the absent revision, is what makes the catalog
+        // a labelled partial: `revision_probe` distinguishes "no revision" from
+        // "could not find out in time" (#9763).
+        let identity = AgentRuntimeSelectedIdentity {
+            revision_probe: Some(AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT.to_string()),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(&identity).expect("serialize selected identity");
+
+        assert_eq!(
+            value.get("revision_probe").and_then(Value::as_str),
+            Some(AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT)
+        );
+        assert_eq!(
+            serde_json::to_value(AgentRuntimeSelectedIdentity::default())
+                .expect("serialize default identity")
+                .get("revision_probe"),
+            None,
+            "an in-budget probe must not add the partial marker to existing output"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -90,9 +90,10 @@ pub use primitives::{
 };
 pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{
-    current_branch, head_sha, head_sha_short, output_allow_empty, output_optional,
-    output_optional_bytes, remote_origin_url, remote_url, repo_root, rev_parse,
-    short_head_revision, status_porcelain, status_porcelain_bytes, toplevel,
+    current_branch, head_sha, head_sha_short, head_sha_within, output_allow_empty, output_optional,
+    output_optional_bytes, output_optional_within, remote_origin_url, remote_url, repo_root,
+    rev_parse, short_head_revision, status_porcelain, status_porcelain_bytes, toplevel,
+    BoundedGitRead, DEFAULT_GIT_READ_PROBE_TIMEOUT,
 };
 
 use serde::{Deserialize, Serialize};

--- a/crates/homeboy-core/src/git/primitives_query.rs
+++ b/crates/homeboy-core/src/git/primitives_query.rs
@@ -6,6 +6,98 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, Instant};
+
+use crate::engine::command as engine_command;
+
+/// Default deadline for read-only git probes issued by catalog/discovery code
+/// paths.
+///
+/// A diagnostic read must answer quickly. `git rev-parse` looks cheap but can
+/// block indefinitely on a wedged filesystem, a stuck index lock, a hanging
+/// fsmonitor, or a credential helper, which turned provider-catalog discovery
+/// into an unbounded hang (#9763). Discovery callers use the bounded probes
+/// below so a stuck repository degrades to a labelled partial instead.
+pub const DEFAULT_GIT_READ_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Outcome of a bounded read-only git probe.
+///
+/// `Unresolved` and `TimedOut` are deliberately distinct: the first is a normal
+/// negative answer (not a repo, command failed, empty output), the second is a
+/// missing answer the caller must label rather than silently report as absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoundedGitRead {
+    /// The probe completed with trimmed, non-empty stdout.
+    Resolved(String),
+    /// The probe completed without a usable answer.
+    Unresolved,
+    /// The probe exceeded its deadline; its process group was terminated.
+    TimedOut,
+}
+
+impl BoundedGitRead {
+    /// The resolved value, or `None` for both negative outcomes.
+    pub fn resolved(self) -> Option<String> {
+        match self {
+            Self::Resolved(value) => Some(value),
+            Self::Unresolved | Self::TimedOut => None,
+        }
+    }
+
+    /// Whether the probe ran out of budget rather than answering.
+    pub fn timed_out(&self) -> bool {
+        matches!(self, Self::TimedOut)
+    }
+}
+
+/// Run a read-only git command under a deadline, terminating its isolated
+/// process group on expiry.
+///
+/// Mirrors [`output_optional`] but never blocks past `timeout`.
+pub fn output_optional_within(git_root: &Path, args: &[&str], timeout: Duration) -> BoundedGitRead {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(git_root)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    engine_command::isolate_process_tree(&mut command);
+    let Ok(mut child) = command.spawn() else {
+        return BoundedGitRead::Unresolved;
+    };
+    let started = Instant::now();
+    let mut timed_out = false;
+    let waited = engine_command::wait_with_bounded_output_until_cancelled(
+        &mut child,
+        engine_command::DEFAULT_CAPTURE_LIMIT_BYTES,
+        || {
+            timed_out = started.elapsed() >= timeout;
+            timed_out
+        },
+    );
+    if timed_out {
+        return BoundedGitRead::TimedOut;
+    }
+    let Ok(output) = waited else {
+        return BoundedGitRead::Unresolved;
+    };
+    let output = output.into_output();
+    if !output.status.success() {
+        return BoundedGitRead::Unresolved;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        BoundedGitRead::Unresolved
+    } else {
+        BoundedGitRead::Resolved(value)
+    }
+}
+
+/// Get the full HEAD commit SHA under a deadline.
+pub fn head_sha_within(git_root: &Path, timeout: Duration) -> BoundedGitRead {
+    output_optional_within(git_root, &["rev-parse", "HEAD"], timeout)
+}
 
 /// Resolve a git revision to its commit/object id, returning None when the ref
 /// cannot be resolved.
@@ -165,6 +257,51 @@ mod tests {
         assert_eq!(
             status_porcelain_bytes(dir.path()).as_deref(),
             Some(&b""[..])
+        );
+
+        assert_eq!(
+            head_sha_within(dir.path(), DEFAULT_GIT_READ_PROBE_TIMEOUT).resolved(),
+            head_sha(dir.path()),
+            "the bounded probe must agree with the unbounded one when git answers in time"
+        );
+    }
+
+    #[test]
+    fn bounded_probe_reports_unresolved_outside_a_repository() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        assert_eq!(
+            head_sha_within(dir.path(), DEFAULT_GIT_READ_PROBE_TIMEOUT),
+            BoundedGitRead::Unresolved
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_probe_times_out_instead_of_hanging() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        git(dir.path(), &["init", "--quiet"]);
+
+        // A shell alias that outlives the budget is the deterministic stand-in
+        // for a wedged repository. The probe must terminate the child process
+        // group and return a labelled `TimedOut` rather than block, and that
+        // outcome must never be mistaken for "no revision" (#9763).
+        let started = Instant::now();
+        let probe = output_optional_within(
+            dir.path(),
+            &["-c", "alias.hbprobehang=!sleep 30", "hbprobehang"],
+            Duration::from_millis(200),
+        );
+
+        assert!(
+            probe.timed_out(),
+            "expected a timed-out probe, got {probe:?}"
+        );
+        assert_ne!(probe, BoundedGitRead::Unresolved);
+        assert_eq!(probe.resolved(), None);
+        assert!(
+            started.elapsed() < Duration::from_secs(20),
+            "bounded probe must not wait for the wedged child"
         );
     }
 }

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -19,6 +19,18 @@ pub const DEFAULT_LAB_DISPATCH_TIMEOUT_SECS: u64 = 9 * 60;
 pub const LAB_DISPATCH_TIMEOUT_ENV: &str = "HOMEBOY_LAB_DISPATCH_TIMEOUT_SECS";
 pub const LAB_TRACE_DISPATCH_TIMEOUT_ENV: &str = "HOMEBOY_LAB_TRACE_DISPATCH_TIMEOUT_SECS";
 
+/// Dispatch budget for an explicitly runner-scoped provider catalog read.
+///
+/// Provider discovery is a diagnostic read used to *choose* a backend before
+/// dispatching real work, so it must answer inside a caller's patience rather
+/// than inherit the generic multi-minute workload dispatch budget. 90s keeps it
+/// under the 120s caller timeout that first surfaced the hang, and expiry
+/// yields the labelled dispatch-timeout error (with runner and run-inspection
+/// guidance) instead of an unbounded wait (#9763).
+pub const DEFAULT_LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_SECS: u64 = 90;
+pub const LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_ENV: &str =
+    "HOMEBOY_LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_SECS";
+
 /// Phase tag used for Lab trace dispatch observation metadata payloads. Kept in
 /// core so the routing service owns the observation envelope shape rather than
 /// the CLI adapter.
@@ -485,6 +497,21 @@ pub fn lab_route_plan_from_route_contract(route_contract: LabCommandRouteContrac
 
 pub fn lab_trace_dispatch_timeout() -> Duration {
     lab_dispatch_timeout()
+}
+
+/// The bounded dispatch budget for an explicitly runner-scoped provider
+/// catalog read. Operators may widen or narrow it with
+/// [`LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_ENV`]; it never inherits the
+/// generic workload dispatch budget, which is far longer than a diagnostic
+/// read's caller is willing to wait (#9763).
+pub fn lab_provider_discovery_dispatch_timeout() -> Duration {
+    std::env::var(LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| {
+            Duration::from_secs(DEFAULT_LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_SECS)
+        })
 }
 
 fn lab_dispatch_timeout() -> Duration {

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -658,6 +658,29 @@ constants, instead of copying schema strings into downstream code. Provider
 manifests may omit `schema`, `request_schema`, and `outcome_schema`; Homeboy
 defaults them to the current core contract ids.
 
+### Provider discovery is scope-sensitive
+
+Controller and runner carry different extensions, runtime defaults, secrets, and
+provider readiness, so a provider catalog only means something alongside *where*
+it was read. `agent-task providers` therefore reports an additive
+`observed_scope` object naming the observed location (`controller` or `lab` plus
+`runner_id`), the Homeboy build identity, the extension/runtime sources behind
+the catalog, and the observation timestamp.
+
+Unscoped `homeboy agent-task providers` is always a controller-local read: it is
+never relocated to a Lab runner because the controller is under load, since that
+would silently answer a different question. Ask for a runner's catalog
+explicitly with `homeboy agent-task providers --runner <runner-id>` (or
+`--placement lab`). The explicit runner probe is runner-resident — it
+materializes no workload workspace — and its dispatch is bounded
+(`HOMEBOY_LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_SECS`, default 90s) so it
+returns a labelled timeout with durable runner/job identity instead of hanging.
+
+Per-runtime revision probes (`git rev-parse HEAD`) are bounded too. A wedged
+runtime checkout yields a partial catalog plus an
+`agent_runtime_manifest.revision_probe_timeout` diagnostic naming the runtime,
+rather than an unbounded discovery.
+
 Use `homeboy agent-task providers --backend <backend> --validate-readiness` to
 fail fast when the selected backend is registered but its declared runner
 readiness is not usable in the current environment. Lab offload runs this check


### PR DESCRIPTION
## Why

**Auto-offloading a read changes what the read means.** Controller and runner carry different extensions, runtime defaults, secrets, and provider readiness, so `homeboy agent-task providers` answers a *different question* depending on where it runs. Relocating an unscoped diagnostic read because the controller happened to be warm silently swapped the question — and paid Lab materialization/transport ceremony to do it, blowing past a 120s caller timeout with no catalog at all. That blocked backend selection for a four-issue Cook batch.

## What was actually causing the auto-offload

Two mechanisms conspired:

1. `agent-task providers` was classified as an `AdmittedWorkload` in `resource_policy::classification`, so `preflight_hot_command` ran and captured a warm-controller resource context.
2. Its `LabCommandContract::explicit_runner_simple` contract declares `default_lab_offload: false` — but `lab/offload/execute.rs` **promotes exactly such contracts** to `default_lab_offload: true` when a captured resource context reports `warm`/`hot`. The one contract-level exemption from that promotion is a `RunnerResident` source path mode, which `explicit_runner_simple` does not set.

So "explicit runner" was declared but not honored on a warm controller.

## Fixes (extending existing mechanisms, no new ones)

- **Classification** — `providers` is now a `BoundedMetadataRead`. No resource context is captured, so no pressure level can steer it.
- **Contract** — `explicit_runner_simple` → `runner_resident`. Still explicit-runner-only, now exempt from pressure promotion, and it drops controller-cwd materialization: the explicit `--runner` probe answers *before* any workload workspace is built (an acceptance criterion in the issue). `runner_resident` (not `runner_resident_read_polling`) is deliberate — it keeps the durable evidence mirror / job identity the issue asks for on the explicit probe.
- **Bounded explicit-runner leg** — routed through `lab_route_dispatch_timeout`, the same hook `trace` already uses. Default 90s (under the 120s caller timeout that surfaced this), overridable with `HOMEBOY_LAB_PROVIDER_DISCOVERY_DISPATCH_TIMEOUT_SECS`. Expiry yields the existing labelled dispatch-timeout error with durable runner/job identity and follow-up commands, instead of an unbounded wait.

## The unbounded `git rev-parse` probe

Found and bounded. Provider catalog discovery derived per-runtime revisions through `crate::git::head_sha` → `output_optional_bytes`, a bare `.output()` with **no subprocess deadline** — once per standalone runtime manifest (`load_standalone_agent_runtime_manifest`) and once per provider (`runtime_materialization_plan` → `runtime_source_revision`).

Added `git::head_sha_within` / `output_optional_within` returning a three-state `BoundedGitRead` (`Resolved` / `Unresolved` / `TimedOut`), built on the existing `wait_with_bounded_output_until_cancelled` + `isolate_process_tree` primitives already used by `run_git_with_env_timeout`. Both discovery call sites now run under a 5s budget.

`Unresolved` and `TimedOut` are deliberately distinct: a wedged checkout yields a **partial catalog plus an `agent_runtime_manifest.revision_probe_timeout` diagnostic** naming the runtime/extension/path, because "unknown" and "absent" are different answers. The `.source-revision` file fallback still applies, so a timed-out git probe degrades before it labels.

## Output now declares its scope

It did not before — the existing `scope` object describes which *slice* of the catalog is presented (backend filter), not where it was read. Added an additive top-level `observed_scope`:

```json
"observed_scope": {
  "schema": "homeboy/agent-task-provider-scope/v1",
  "location": "controller",
  "runner_id": null,
  "label": "controller",
  "homeboy_identity": { "version": "...", "display": "...", "git_commit": "..." },
  "extension_source": { "total": 3, "shown": 3, "extension_ids": [...] },
  "runtime_source":   { "total": 3, "shown": 3, "runtime_ids": [...] },
  "observed_at": "2026-...",
  "runner_scoped_command": "homeboy agent-task providers --runner <runner-id>"
}
```

`location` reuses the `controller`/`lab` vocabulary already established by `execution_provenance`. Purely additive — the existing `scope` object and `homeboy/agent-task-providers/v1` schema are unchanged.

## Tests

- Unscoped `providers` performs no runner interaction: `hot_command` is `None` at every pressure level, contract keeps `default_lab_offload: false`, source mode is `RunnerResident`.
- Explicit `--runner` still offloads and stays portable, with runner-resident source/workspace modes asserted.
- Bounded dispatch: providers gets a budget strictly below the generic workload budget, plus env-override coverage.
- Bounded probe: `head_sha_within` agrees with `head_sha` in budget, reports `Unresolved` outside a repo, and returns a labelled `TimedOut` (terminating the child process group) for a deliberately wedged git child instead of hanging.
- A timed-out probe yields a labelled partial: `revision_probe` marker on the selected identity and the scoped `agent_runtime_manifest.revision_probe_timeout` diagnostic; an in-budget probe adds neither.
- `observed_scope` output shape.

## Notes

- Edits kept scoped to the providers path — no shared timeout helper refactor, per coordination with the concurrent #10418 work on `runner status` / `runs list` / `agent-task status`. `lab_route_dispatch_timeout` gained one command arm; `runner_exec_wait_timeout` was left alone. If #10418 wants a generic per-contract read budget, that is the natural place to converge later.
- `cargo fmt` run. Full build/test left to CI per repo policy.

Closes #9763