### PR TITLE
feat(control-plane): project typed repair actions

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides JSON envelope, printing, and exit code mapping.
 
-use homeboy::core::error::Hint;
+use homeboy::core::error::{ExecutableAction, Hint, ACTIONS_DETAILS_KEY};
 use homeboy::core::{Error, ErrorCode, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -169,6 +169,10 @@ pub struct CommandNextAction {
     pub command: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<CommandNextActionKind>,
+    /// The executable form of a repair action. `command` remains the stable
+    /// human-facing rendering for existing consumers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<ExecutableAction>,
 }
 
 impl CommandNextAction {
@@ -177,12 +181,22 @@ impl CommandNextAction {
             label: label.into(),
             command: command.into(),
             kind: None,
+            action: None,
         }
     }
 
     pub fn with_kind(mut self, kind: CommandNextActionKind) -> Self {
         self.kind = Some(kind);
         self
+    }
+
+    pub fn from_action(action: ExecutableAction) -> Self {
+        Self {
+            label: action.label.clone(),
+            command: action.render_command(),
+            kind: Some(CommandNextActionKind::Repair),
+            action: Some(action),
+        }
     }
 }
 
@@ -316,6 +330,7 @@ impl<T: Serialize> CommandResultEnvelope<T> {
 
 impl CommandResultEnvelope<()> {
     fn from_error(identity: &CommandIdentity, err: &Error, exit_code: i32) -> Self {
+        let next_actions = actions_for_error(err);
         Self {
             schema: COMMAND_RESULT_SCHEMA,
             command: identity.command.clone(),
@@ -326,7 +341,7 @@ impl CommandResultEnvelope<()> {
             run: None,
             refs: CommandResultRefs::default(),
             summary: Some(err.message.clone()),
-            next_actions: Vec::new(),
+            next_actions,
             artifacts: Vec::new(),
             evidence: Vec::new(),
             diagnostics: Some(CommandDiagnostics {
@@ -639,13 +654,14 @@ fn failure_diagnostics_for_data(
 }
 
 fn failure_digest_for_error(err: &Error) -> Option<CommandFailureDigest> {
+    let next_actions = actions_for_error(err);
     match err.code {
         ErrorCode::RemoteCommandFailed => Some(CommandFailureDigest {
             summary: remote_failure_summary(&err.details),
             stdout_tail: string_at(&err.details, &["stdout"]).map(tail_text),
             stderr_tail: string_at(&err.details, &["stderr"]).map(tail_text),
             artifact_refs: Vec::new(),
-            next_actions: Vec::new(),
+            next_actions,
             retryable: err.retryable,
         }),
         _ => Some(CommandFailureDigest {
@@ -653,10 +669,21 @@ fn failure_digest_for_error(err: &Error) -> Option<CommandFailureDigest> {
             stdout_tail: None,
             stderr_tail: None,
             artifact_refs: Vec::new(),
-            next_actions: Vec::new(),
+            next_actions,
             retryable: err.retryable,
         }),
     }
+}
+
+fn actions_for_error(err: &Error) -> Vec<CommandNextAction> {
+    err.details
+        .get(ACTIONS_DETAILS_KEY)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|value| serde_json::from_value::<ExecutableAction>(value.clone()).ok())
+        .map(CommandNextAction::from_action)
+        .collect()
 }
 
 fn failure_digest_for_data(data: &Value) -> Option<CommandFailureDigest> {
@@ -1158,6 +1185,50 @@ mod tests {
         assert_eq!(
             payload.expect_err("error payload").code,
             ErrorCode::ValidationMissingArgument
+        );
+    }
+
+    #[test]
+    fn actionable_errors_lift_one_explicit_repair_contract_into_human_and_machine_forms() {
+        let action = ExecutableAction::new(
+            "runner.disconnect",
+            "disconnect runner lab one",
+            "homeboy",
+            ["runner", "disconnect", "lab one"],
+            homeboy::core::error::ActionSafety::Mutating,
+        )
+        .requiring_confirmation("operator")
+        .with_evidence(json!({ "runner_id": "lab one", "lease_id": "lease-123" }));
+        let response = cli_response_for_json_result_for_command(
+            &Err(
+                Error::validation_invalid_argument("runner", "stale daemon", None, None)
+                    .with_action(action),
+            ),
+            2,
+            "agent-task",
+            None,
+        );
+        let value = serde_json::to_value(response).expect("response json");
+        let action = &value["next_actions"][0];
+
+        assert_eq!(action["label"], "disconnect runner lab one");
+        assert_eq!(action["kind"], "repair");
+        assert_eq!(action["command"], "homeboy runner disconnect 'lab one'");
+        assert_eq!(action["action"]["id"], "runner.disconnect");
+        assert_eq!(action["action"]["program"], "homeboy");
+        assert_eq!(
+            action["action"]["args"],
+            json!(["runner", "disconnect", "lab one"])
+        );
+        assert_eq!(action["action"]["safety"], "mutating");
+        assert_eq!(
+            action["action"]["required_confirmations"],
+            json!(["operator"])
+        );
+        assert_eq!(action["action"]["evidence"]["lease_id"], "lease-123");
+        assert_eq!(
+            value["diagnostics"]["failure_digest"]["next_actions"][0]["command"],
+            action["command"]
         );
     }
 

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -1,6 +1,89 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub const ACTIONS_DETAILS_KEY: &str = "_homeboy_actions";
+
+/// An explicit command the caller may execute to repair a reported condition.
+///
+/// This intentionally carries program and arguments separately. Consumers must
+/// execute those fields directly; `render_command` is presentation only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutableAction {
+    pub id: String,
+    pub label: String,
+    pub program: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    pub safety: ActionSafety,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_confirmations: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<Value>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionSafety {
+    ReadOnly,
+    Mutating,
+}
+
+impl ExecutableAction {
+    pub fn new(
+        id: impl Into<String>,
+        label: impl Into<String>,
+        program: impl Into<String>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+        safety: ActionSafety,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            program: program.into(),
+            args: args.into_iter().map(Into::into).collect(),
+            safety,
+            required_confirmations: Vec::new(),
+            evidence: None,
+        }
+    }
+
+    pub fn requiring_confirmation(mut self, confirmation: impl Into<String>) -> Self {
+        self.required_confirmations.push(confirmation.into());
+        self
+    }
+
+    pub fn with_evidence(mut self, evidence: Value) -> Self {
+        self.evidence = Some(evidence);
+        self
+    }
+
+    pub fn render_command(&self) -> String {
+        std::iter::once(self.program.as_str())
+            .chain(self.args.iter().map(String::as_str))
+            .map(posix_quote_arg)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+// Kept byte-for-byte compatible with homeboy-engine-primitives::shell::quote_arg.
+// homeboy-error is below that crate in the dependency graph, so it cannot import it.
+fn posix_quote_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "''".to_string();
+    }
+
+    const SHELL_META: &[char] = &[
+        ' ', '\t', '\n', '\'', '"', '\\', '$', '`', '!', '*', '?', '[', ']', '(', ')', '{', '}',
+        '<', '>', '|', '&', ';', '#', '~',
+    ];
+    if !arg.contains(SHELL_META) {
+        return arg.to_string();
+    }
+
+    format!("'{}'", arg.replace('\'', "'\\''"))
+}
+
 fn format_suggestions(suggestions: &[String]) -> String {
     if suggestions.len() == 1 {
         format!("Did you mean: {}?", suggestions[0])
@@ -1185,6 +1268,30 @@ impl Error {
         self
     }
 
+    /// Attach an explicit action without inferring arguments from ambient error
+    /// details. The CLI lifts this contract into its existing action envelope.
+    pub fn with_action(mut self, action: ExecutableAction) -> Self {
+        if !self.details.is_object() {
+            self.details = serde_json::json!({ "details": self.details });
+        }
+        let details = self
+            .details
+            .as_object_mut()
+            .expect("details was normalized to an object");
+        let actions = match details.entry(ACTIONS_DETAILS_KEY) {
+            serde_json::map::Entry::Vacant(entry) => entry.insert(Value::Array(Vec::new())),
+            serde_json::map::Entry::Occupied(mut entry) if !entry.get().is_array() => {
+                entry.insert(Value::Array(Vec::new()));
+                entry.into_mut()
+            }
+            serde_json::map::Entry::Occupied(entry) => entry.into_mut(),
+        }
+        .as_array_mut()
+        .expect("action entries are initialized as an array");
+        actions.push(to_details(action));
+        self
+    }
+
     pub fn with_retryable(mut self, retryable: bool) -> Self {
         self.retryable = Some(retryable);
         self
@@ -1227,5 +1334,54 @@ mod ergonomic_constructor_tests {
         assert_eq!(short.code, verbose.code);
         assert_eq!(short.message, verbose.message);
         assert_eq!(short.details, verbose.details);
+    }
+
+    #[test]
+    fn executable_action_renders_arguments_with_the_shared_posix_quoting_contract() {
+        let values = ["apostrophe: it's", "two words", "$HOME;*[]"];
+        let action = ExecutableAction::new(
+            "test.argv",
+            "test argv",
+            "sh",
+            std::iter::once("-c")
+                .chain(std::iter::once("printf '%s\\0' \"$@\""))
+                .chain(std::iter::once("action"))
+                .chain(values),
+            ActionSafety::ReadOnly,
+        );
+        let output = std::process::Command::new("sh")
+            .args(["-c", &action.render_command()])
+            .output()
+            .expect("run rendered command");
+
+        assert!(output.status.success());
+        let actual: Vec<_> = output
+            .stdout
+            .split(|byte| *byte == b'\0')
+            .filter(|value| !value.is_empty())
+            .map(|value| std::str::from_utf8(value).expect("utf8 action argument"))
+            .collect();
+        assert_eq!(actual, values);
+    }
+
+    #[test]
+    fn with_action_replaces_a_malformed_reserved_key_deterministically() {
+        let action = ExecutableAction::new(
+            "test.repair",
+            "repair",
+            "homeboy",
+            ["status"],
+            ActionSafety::ReadOnly,
+        );
+        let error = Error::new(
+            ErrorCode::InternalUnexpected,
+            "fixture",
+            serde_json::json!({ ACTIONS_DETAILS_KEY: "foreign value", "kept": true }),
+        )
+        .with_action(action);
+
+        assert_eq!(error.details["kept"], true);
+        assert_eq!(error.details[ACTIONS_DETAILS_KEY][0]["id"], "test.repair");
+        assert!(error.details[ACTIONS_DETAILS_KEY].is_array());
     }
 }

--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -317,6 +317,18 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
         .any(|suggestion| suggestion
             .as_str()
             .is_some_and(|value| value.contains("homeboy runner refresh-homeboy lab --ref "))));
+    let action = &err.details[homeboy_core::error::ACTIONS_DETAILS_KEY][0];
+    assert_eq!(action["id"], "runner.refresh_homeboy");
+    assert_eq!(action["program"], "homeboy");
+    assert_eq!(action["args"][0], "runner");
+    assert_eq!(action["args"][1], "refresh-homeboy");
+    assert_eq!(action["args"][2], "lab");
+    assert_eq!(action["args"][3], "--ref");
+    assert_eq!(action["args"][5], "--reconnect");
+    assert_eq!(
+        action["evidence"]["recovery_plan"][0],
+        err.details["tried"][0]
+    );
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use crate::resolve_lab_runner_hint;
+use homeboy_core::error::{ActionSafety, ExecutableAction};
 use homeboy_core::lab_contract::LabCommandPortability;
 use homeboy_core::{Error, ErrorCode, Result};
 
@@ -531,6 +532,7 @@ pub(super) fn prepare_lab_runner_for_offload_with(
                     selection.runner_id
                 ),
                 daemon_repair_command(&selection.runner_id, &status),
+                daemon_repair_action(&selection.runner_id, &status),
             );
         }
         eprintln!(
@@ -555,6 +557,7 @@ pub(super) fn prepare_lab_runner_for_offload_with(
             ),
             "Start the reverse runner session on the Lab machine before using --runner."
                 .to_string(),
+            None,
         );
     }
 
@@ -591,6 +594,7 @@ pub(super) fn prepare_lab_runner_for_offload_with(
             "Run `homeboy runner connect {}` for full diagnostics.",
             selection.runner_id
         ),
+        None,
     )
 }
 
@@ -610,19 +614,23 @@ fn automatic_fallback_or_explicit_error(
     reason: String,
     explicit_message: String,
     remediation: String,
+    action: Option<ExecutableAction>,
 ) -> Result<LabRunnerPreparation> {
     match selection.source {
         LabRunnerSelectionSource::Default => Ok(LabRunnerPreparation::FallBackLocal { reason }),
-        LabRunnerSelectionSource::Explicit => Err(Error::validation_invalid_argument(
-            "runner",
-            format!("{explicit_message}: {reason}"),
-            Some(selection.runner_id.clone()),
-            Some(vec![
-                remediation,
-                "Use --placement local to run the command locally instead of offloading."
-                    .to_string(),
-            ]),
-        )),
+        LabRunnerSelectionSource::Explicit => {
+            let error = Error::validation_invalid_argument(
+                "runner",
+                format!("{explicit_message}: {reason}"),
+                Some(selection.runner_id.clone()),
+                Some(vec![
+                    remediation,
+                    "Use --placement local to run the command locally instead of offloading."
+                        .to_string(),
+                ]),
+            );
+            Err(action.map_or(error.clone(), |action| error.with_action(action)))
+        }
     }
 }
 
@@ -680,6 +688,55 @@ fn daemon_repair_command(runner_id: &str, status: &RunnerStatusReport) -> String
     } else {
         restart
     }
+}
+
+fn daemon_repair_action(runner_id: &str, status: &RunnerStatusReport) -> Option<ExecutableAction> {
+    let recovery_plan: Vec<&str> = status
+        .daemon_freshness
+        .as_ref()
+        .filter(|report| !report.repair_plan.is_empty())
+        .map(|report| {
+            report
+                .repair_plan
+                .iter()
+                .map(|step| step.command.as_str())
+                .collect()
+        })
+        .or_else(|| {
+            status.stale_daemon.as_ref().map(|warning| {
+                warning
+                    .recovery_commands
+                    .iter()
+                    .map(String::as_str)
+                    .collect()
+            })
+        })?;
+    let recovery_ref = homeboy_product_identity::build_identity()
+        .git_commit
+        .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()));
+    let action = ExecutableAction::new(
+        "runner.refresh_homeboy",
+        format!("refresh runner {runner_id}"),
+        "homeboy",
+        [
+            "runner",
+            "refresh-homeboy",
+            runner_id,
+            "--ref",
+            &recovery_ref,
+            "--reconnect",
+        ],
+        ActionSafety::Mutating,
+    )
+    .requiring_confirmation("operator")
+    .with_evidence(serde_json::json!({
+        "runner_id": runner_id,
+        "recovery_plan": recovery_plan,
+    }));
+
+    // The report exposes shell text, not argv. Only lift a single command that
+    // exactly matches this explicit action; never parse or approximate a plan.
+    (recovery_plan.len() == 1 && recovery_plan[0] == action.render_command()).then_some(action)
 }
 
 pub(super) fn resolve_lab_runner_selection(


### PR DESCRIPTION
## Summary
- add a generic executable-action contract with explicit argv, safety, confirmation, and evidence metadata
- lift structured actions additively into `command-result/v3` while deriving human command rendering from the same data
- apply the primitive to authoritative stale Lab recovery plans without contradicting multi-step or noncanonical guidance

## Verification
- `cargo test -p homeboy-error executable_action_renders_arguments_with_the_shared_posix_quoting_contract`
- `cargo test -p homeboy-cli actionable_errors_lift_one_explicit_repair_contract_into_human_and_machine_forms`
- `cargo test -p homeboy-lab-runner lab::preparation_tests::lab_runner_preparation_errors_for_explicit_stale_daemon_version -- --exact`
- `cargo fmt --all --check`
- `cargo check -p homeboy-error -p homeboy-cli -p homeboy-lab-runner`

Closes #10304.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and iteratively remediated the action contract after independent review. Chris Huber reviewed and owns every line.