### PR TITLE
fix(rig): preflight package installs

### DIFF
--- a/crates/homeboy-rig/src/discovery.rs
+++ b/crates/homeboy-rig/src/discovery.rs
@@ -5,7 +5,7 @@
 //! in a sibling module so the install root stays under the structural
 //! item-count threshold (#5241).
 
-use homeboy_core::error::{Error, Result};
+use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_extension as extension;
 use homeboy_stack::stack;
 use serde::Serialize;
@@ -36,7 +36,7 @@ pub(crate) fn discover_rigs_for_install(
     all: bool,
 ) -> Result<Vec<DiscoveredRig>> {
     if all {
-        return discover_rigs(package_path);
+        return discover_rigs_with_preflight(package_path);
     }
     let Some(id) = id else {
         return discover_rigs(package_path);
@@ -44,19 +44,99 @@ pub(crate) fn discover_rigs_for_install(
     discover_rigs_matching(package_path, Some(&extension::slugify_id(id)?))
 }
 
+/// Discover every package member before returning a schema failure so `--all`
+/// can report every incompatible rig without changing installed state.
+fn discover_rigs_with_preflight(package_path: &Path) -> Result<Vec<DiscoveredRig>> {
+    let candidates = discover_rig_paths(package_path, None)?;
+    let mut rigs = Vec::new();
+    let mut outcomes = Vec::new();
+
+    for (path, fallback_name) in candidates {
+        let fallback_id = fallback_name
+            .as_deref()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+        match discovered_from_path(&path, fallback_name.as_deref(), package_path) {
+            Ok(rig) => {
+                outcomes.push(serde_json::json!({
+                    "id": rig.id,
+                    "spec_path": rig.rig_path,
+                    "status": "preflight_passed",
+                }));
+                rigs.push(rig);
+            }
+            Err(error) => outcomes.push(serde_json::json!({
+                "id": fallback_id,
+                "spec_path": path,
+                "status": if error.message.contains("schema is not compatible") {
+                    "incompatible"
+                } else {
+                    "failed"
+                },
+                "schema_failure_path": error.details.get("field").cloned().unwrap_or_else(|| serde_json::json!("rig_spec")),
+                "error": error.message,
+                "active_homeboy_version": homeboy_product_identity::product_version(),
+                "upgrade_guidance": "Run `homeboy upgrade` to install a binary that supports this rig schema, then retry.",
+            })),
+        }
+    }
+
+    if outcomes
+        .iter()
+        .any(|outcome| outcome["status"] != "preflight_passed")
+    {
+        return Err(Error::new(
+            ErrorCode::ValidationMultipleErrors,
+            "Rig package preflight failed; no rigs were installed",
+            serde_json::json!({
+                "atomic": true,
+                "active_homeboy_version": homeboy_product_identity::product_version(),
+                "outcomes": outcomes,
+            }),
+        ));
+    }
+
+    rigs.sort_by(|a, b| a.id.cmp(&b.id));
+    rigs.dedup_by(|a, b| a.id == b.id);
+    if rigs.is_empty() {
+        return no_rigs_found(package_path);
+    }
+    Ok(rigs)
+}
+
 fn discover_rigs_matching(
     package_path: &Path,
     only_id: Option<&str>,
 ) -> Result<Vec<DiscoveredRig>> {
-    let mut rigs = Vec::new();
+    let mut rigs = discover_rig_paths(package_path, only_id)?
+        .into_iter()
+        .map(|(path, fallback_name)| {
+            discovered_from_path(&path, fallback_name.as_deref(), package_path)
+        })
+        .collect::<Result<Vec<_>>>()?;
 
+    rigs.sort_by(|a, b| a.id.cmp(&b.id));
+    rigs.dedup_by(|a, b| a.id == b.id);
+
+    if rigs.is_empty() {
+        if only_id.is_some() {
+            return Ok(rigs);
+        }
+        return no_rigs_found(package_path);
+    }
+
+    Ok(rigs)
+}
+
+fn discover_rig_paths(
+    package_path: &Path,
+    only_id: Option<&str>,
+) -> Result<Vec<(PathBuf, Option<std::ffi::OsString>)>> {
+    let mut rigs = Vec::new();
     let single = package_path.join("rig.json");
     if single.is_file() {
-        rigs.push(discovered_from_path(
-            &single,
-            package_path.file_name(),
-            package_path,
-        )?);
+        rigs.push((single, package_path.file_name().map(ToOwned::to_owned)));
     }
 
     let rigs_dir = package_path.join("rigs");
@@ -83,23 +163,17 @@ fn discover_rigs_matching(
                         continue;
                     }
                 }
-                rigs.push(discovered_from_path(
-                    &rig_path,
-                    path.file_name(),
-                    package_path,
-                )?);
+                rigs.push((rig_path, path.file_name().map(ToOwned::to_owned)));
             }
         }
     }
 
-    rigs.sort_by(|a, b| a.id.cmp(&b.id));
-    rigs.dedup_by(|a, b| a.id == b.id);
+    rigs.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(rigs)
+}
 
-    if rigs.is_empty() {
-        if only_id.is_some() {
-            return Ok(rigs);
-        }
-        return Err(Error::validation_invalid_argument(
+fn no_rigs_found(package_path: &Path) -> Result<Vec<DiscoveredRig>> {
+    Err(Error::validation_invalid_argument(
             "source",
             format!(
                 "No rig specs found at {} (expected rig.json or rigs/<id>/rig.json)",
@@ -115,10 +189,7 @@ fn discover_rigs_matching(
                 "Install a package-shaped source with: homeboy rig install <package-path> --id <rig-id>".to_string(),
                 "For command-local package discovery, run Homeboy from inside a checkout that contains rigs/<id>/rig.json.".to_string(),
             ]),
-        ));
-    }
-
-    Ok(rigs)
+        ))
 }
 
 pub fn discover_stacks(package_path: &Path) -> Result<Vec<DiscoveredStack>> {

--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -115,6 +115,18 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
         discover_stacks(&prepared.discovery_path)?
     };
 
+    // `--all` is atomic: validate every selected spec and every replaceable
+    // target before the registry directories or configs are changed.
+    if all {
+        preflight_all_install(&selected, &prepared.package_path)?;
+        for rig in &selected {
+            let target = paths::rig_config(&rig.id)?;
+            if target.exists() || fs::symlink_metadata(&target).is_ok() {
+                ensure_rig_refreshable(rig, &target)?;
+            }
+        }
+    }
+
     fs::create_dir_all(paths::rigs()?)
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rigs dir".into())))?;
     fs::create_dir_all(paths::stacks()?)
@@ -134,7 +146,9 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
     let mut installed = Vec::new();
     for rig in selected {
         let target = paths::rig_config(&rig.id)?;
-        validate_rig_spec_file(&rig.rig_path, &prepared.package_path, &rig.id)?;
+        if !all {
+            validate_rig_spec_file(&rig.rig_path, &prepared.package_path, &rig.id)?;
+        }
         if target.exists() || fs::symlink_metadata(&target).is_ok() {
             ensure_rig_refreshable(&rig, &target)?;
             remove_existing_config(&target, "replace rig config link")?;
@@ -202,6 +216,49 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
         installed,
         installed_stacks,
     })
+}
+
+fn preflight_all_install(rigs: &[DiscoveredRig], source_root: &Path) -> Result<()> {
+    let mut outcomes = Vec::with_capacity(rigs.len());
+    for rig in rigs {
+        match validate_rig_spec_file(&rig.rig_path, source_root, &rig.id) {
+            Ok(()) => outcomes.push(serde_json::json!({
+                "id": rig.id,
+                "spec_path": rig.rig_path,
+                "status": "preflight_passed",
+            })),
+            Err(error) => outcomes.push(serde_json::json!({
+                "id": rig.id,
+                "spec_path": rig.rig_path,
+                "status": if error.code == homeboy_core::error::ErrorCode::RigSchemaUnsupported {
+                    "incompatible"
+                } else {
+                    "failed"
+                },
+                "schema_failure_path": error.details.get("context").cloned().unwrap_or_else(|| serde_json::json!("rig_spec")),
+                "error": error.message,
+                "active_homeboy_version": homeboy_product_identity::product_version(),
+                "upgrade_guidance": "Run `homeboy upgrade` to install a binary that supports this rig schema, then retry.",
+            })),
+        }
+    }
+
+    if outcomes
+        .iter()
+        .all(|outcome| outcome["status"] == "preflight_passed")
+    {
+        return Ok(());
+    }
+
+    Err(Error::new(
+        homeboy_core::error::ErrorCode::ValidationMultipleErrors,
+        "Rig package preflight failed; no rigs were installed",
+        serde_json::json!({
+            "atomic": true,
+            "active_homeboy_version": homeboy_product_identity::product_version(),
+            "outcomes": outcomes,
+        }),
+    ))
 }
 
 fn validate_rig_spec_file(path: &Path, source_root: &Path, rig_id: &str) -> Result<()> {

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -1306,6 +1306,39 @@ mod multi_rig {
         assert!(homeboy_core::paths::rig_config("alpha").unwrap().exists());
         assert!(homeboy_core::paths::rig_config("beta").unwrap().exists());
     }
+
+    #[test]
+    fn install_all_reports_every_incompatible_rig_without_partial_install() {
+        let _home = HomeGuard::new();
+        let package = tempfile::tempdir().expect("package");
+        write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+        write_rig(package.path(), "beta", &minimal_rig("beta"));
+        write_rig(
+            package.path(),
+            "unsupported-cleanup",
+            r#"{"id":"unsupported-cleanup","lifecycle":{"cleanup":42}}"#,
+        );
+
+        let error = install(package.path().to_str().unwrap(), None, true)
+            .expect_err("package preflight should reject incompatible member");
+
+        assert_eq!(error.code, ErrorCode::ValidationMultipleErrors);
+        assert_eq!(error.details["atomic"], true);
+        assert_eq!(error.details["outcomes"].as_array().unwrap().len(), 3);
+        assert!(error.details["outcomes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|outcome| {
+                outcome["id"] == "unsupported-cleanup"
+                    && outcome["status"] == "incompatible"
+                    && outcome["spec_path"].as_str().is_some()
+                    && outcome["active_homeboy_version"]
+                        == homeboy_product_identity::product_version()
+            }));
+        assert!(!homeboy_core::paths::rig_config("alpha").unwrap().exists());
+        assert!(!homeboy_core::paths::rig_config("beta").unwrap().exists());
+    }
 }
 
 mod refresh_and_identity {


### PR DESCRIPTION
## Summary
- preflight every `rig install --all` package member and return deterministic per-rig outcomes before registry mutation
- identify incompatible specs with rig ID, spec path, active version, and upgrade guidance
- preserve scoped `--id` installation and verify all target conflicts before atomic all-package installation

Closes #10438

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-rig install_all_reports_every_incompatible_rig_without_partial_install`
- `cargo test -p homeboy-rig multi_rig`
- `cargo test -p homeboy-rig` (429 passed; 2 unrelated nested WP Codebox observation tests failed)

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode assisted with implementation and testing. Chris Huber is responsible for every line.