### PR TITLE
Fix fuzz Lab recovery and selector preflight

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -57,6 +57,28 @@ mod replay_tests;
 mod report_tests;
 mod workload_tests;
 
+#[test]
+fn fuzz_run_rejects_profile_and_workload_during_cli_parsing() {
+    let result = Cli::try_parse_from([
+        "homeboy",
+        "fuzz",
+        "run",
+        "--rig",
+        "studio",
+        "--profile",
+        "strict",
+        "--workload",
+        "db-dropin",
+    ]);
+    let Err(error) = result else {
+        panic!("conflicting workload selectors must fail before runtime preflight");
+    };
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    assert!(error.to_string().contains("--profile"));
+    assert!(error.to_string().contains("--workload"));
+}
+
 #[derive(Parser)]
 struct FuzzCli {
     #[command(flatten)]

--- a/crates/homeboy-cli/src/commands/fuzz/types.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types.rs
@@ -281,12 +281,12 @@ pub struct FuzzRunArgs {
     pub(crate) setting_args: SettingArgs,
 
     /// Extension-declared workload id to select.
-    #[arg(long = "workload", value_name = "ID")]
+    #[arg(long = "workload", value_name = "ID", conflicts_with = "profile")]
     pub(crate) workload_id: Option<String>,
 
     /// Rig-defined fuzz profile to select. Without --rig, `lab` expands the
     /// generic safe Lab evidence-run defaults.
-    #[arg(long = "profile", value_name = "ID")]
+    #[arg(long = "profile", value_name = "ID", conflicts_with = "workload_id")]
     pub(crate) profile: Option<String>,
 
     /// Shared state directory handed to the fuzz runner. Homeboy forwards the

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/messages.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/messages.rs
@@ -48,7 +48,10 @@ pub(super) fn primary_action(
     {
         // Portable command, but no Lab runner is configured on this host (#7749):
         // do not point the operator at nonexistent Lab infrastructure.
-        return "No Homeboy Lab runner is configured on this host, so Lab offload is not available. Defer verification to CI, connect a runner with `homeboy runner connect`, or use the local-hot rerun command only if local execution is explicitly authorized.".to_string();
+        return "No Homeboy Lab runner is configured on this host, so this portable command cannot run through Lab. Defer verification to CI or connect a runner with `homeboy runner connect`. Local execution requires an explicit, authorized `--placement local` override.".to_string();
+    }
+    if warning.message.contains("Lab runner inventory is") {
+        return "This portable command requires a ready Lab runner. Follow the listed runner recovery command or defer verification until Lab is available. Local execution requires an explicit, authorized `--placement local` override.".to_string();
     }
     if warning.message.contains("--runner") {
         "Pass --runner <id> when Lab offload supports this mode.".to_string()
@@ -67,11 +70,13 @@ pub(super) fn warning_message(
     let reason = primary_reason(resources);
     if command.lab_offload_supported {
         if let Some(readiness) = lab_readiness {
-            if let Some(runner_id) = readiness.selected_runner_id.as_deref() {
-                return format!(
+            if readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady {
+                if let Some(runner_id) = readiness.selected_runner_id.as_deref() {
+                    return format!(
                 "Resource policy warning: machine is {severity}; starting `{}` locally may skew results or add pressure. {reason} Homeboy found Lab runner `{runner_id}`; use --runner {runner_id} to route this portable command through Lab offload, or omit local-hot overrides so automatic Lab routing can use it.",
                 command.label
             );
+                }
             }
             return format!(
                 "Resource policy warning: machine is {severity}; starting `{}` may skew results or add pressure. {reason} Lab runner inventory is {} (available runner IDs: {}). {}",
@@ -82,7 +87,7 @@ pub(super) fn warning_message(
             );
         }
         return format!(
-            "Resource policy warning: machine is {severity}; starting `{}` may skew results or add pressure. {reason} No Homeboy Lab runner is configured on this host, so Lab offload is not currently available; connect a runner (`homeboy runner connect`) to enable it, defer verification to CI, or use --placement local to run locally without this warning.",
+            "Resource policy warning: machine is {severity}; starting `{}` may skew results or add pressure. {reason} No Homeboy Lab runner is configured on this host, so Lab offload is not currently available; connect a runner (`homeboy runner connect`) or defer verification to CI. Local execution requires an explicit, authorized `--placement local` override.",
             command.label
         );
     }

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -351,9 +351,10 @@ pub fn non_interactive_preflight_error(
     let mut error = crate::core::Error::validation_invalid_argument(
         "resource-policy",
         format!(
-            "Refusing to start `{}` on a {} machine from a non-interactive shell. {} Use a safe Lab/offload path once this command supports it, or rerun later when `homeboy self doctor` reports ok.",
+            "Refusing to start `{}` on a {} machine from a non-interactive shell. {} {}",
             warning.command,
             severity_str(warning.recommendation),
+            warning.message,
             primary_action(warning, None),
         ),
         None,
@@ -387,8 +388,16 @@ pub fn rerun_command(
                 rerun.push("--runner".to_string());
                 rerun.push(runner_id.to_string());
             }
+        } else if args
+            .iter()
+            .any(|arg| arg == "--placement" || arg.starts_with("--placement="))
+        {
+            rerun.extend(args.iter().skip(1).cloned());
+            return Some(crate::core::engine::shell::quote_args(&rerun));
         } else {
-            append_local_placement(&mut rerun, args);
+            // A disconnected or unconfigured Lab must not turn a portable
+            // workload into a suggested local hot-machine retry.
+            return None;
         }
     } else {
         append_local_placement(&mut rerun, args);
@@ -1280,7 +1289,7 @@ mod tests {
     }
 
     #[test]
-    fn portable_refusal_without_runner_uses_explicit_local_last_resort() {
+    fn portable_refusal_without_runner_requires_lab_recovery_or_deferral() {
         let _lock = env_lock();
         let _guard = EnvVarGuard::remove(crate::runner::RUNNER_HOSTED_EXEC_ENV);
         let warning = evaluate(
@@ -1296,18 +1305,61 @@ mod tests {
         let error = non_interactive_preflight_error(&warning, false, false, rerun, false)
             .expect("non-interactive hot runs should fail fast");
 
-        assert_eq!(
-            error.details["rerun_command"].as_str(),
-            Some("homeboy --placement local audit")
-        );
+        assert!(error.details.get("rerun_command").is_none());
         assert!(error
             .message
             .contains("No Homeboy Lab runner is configured on this host"));
-        // #7749: the refusal must not point the operator at Lab infrastructure
-        // that does not exist on this host.
-        assert!(!error
+        assert!(error.message.contains("connect a runner"));
+        assert!(error
             .message
-            .contains("Connect a default Homeboy Lab runner"));
+            .contains("explicit, authorized `--placement local` override"));
+    }
+
+    #[test]
+    fn disconnected_portable_fuzz_requires_lab_recovery_without_local_rerun() {
+        let command = Cli::parse_from([
+            "homeboy",
+            "fuzz",
+            "run",
+            "--rig",
+            "studio",
+            "--workload",
+            "db-dropin",
+        ]);
+        let hot = hot_command(&command.command).expect("fuzz run is resource managed");
+        assert!(hot.lab_offload_supported, "rig-backed fuzz run is portable");
+
+        let disconnected = LabRunnerReadiness {
+            state: crate::runner::runners::LabRunnerReadinessState::Disconnected,
+            selected_runner_id: Some("homeboy-lab".to_string()),
+            available_runner_ids: Vec::new(),
+            reasons: vec!["runner is disconnected".to_string()],
+            remediation_commands: vec!["homeboy runner reconnect homeboy-lab".to_string()],
+        };
+        let warning = evaluate_with_runner_hint(
+            hot,
+            &resources(ResourceRecommendation::Hot),
+            Some(&disconnected),
+        )
+        .expect("hot controller warns");
+        let error = non_interactive_preflight_error(
+            &warning,
+            false,
+            false,
+            rerun_command(
+                hot,
+                &["homeboy".to_string(), "fuzz".to_string(), "run".to_string()],
+                None,
+            ),
+            false,
+        )
+        .expect("disconnected Lab refuses local execution");
+
+        assert!(error.details.get("rerun_command").is_none());
+        assert!(error
+            .message
+            .contains("homeboy runner reconnect homeboy-lab"));
+        assert!(error.message.contains("requires a ready Lab runner"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve portable fuzz Lab recovery guidance when the selected runner is disconnected or unavailable
- remove local hot-machine rerun commands for portable workloads without a ready runner
- reject conflicting fuzz `--profile` and `--workload` selectors during CLI parsing

Closes #10435

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-cli fuzz_run_rejects_profile_and_workload_during_cli_parsing`
- `cargo test -p homeboy-cli disconnected_portable_fuzz_requires_lab_recovery_without_local_rerun`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode assisted with implementation and deterministic test coverage. Chris Huber is responsible for every line.