### PR TITLE
fix: record exact linked rig content provenance

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/bench_result.rs
+++ b/crates/contracts/homeboy-extension-contract/src/bench_result.rs
@@ -28,6 +28,9 @@ pub struct RigPackageEvidence {
     pub installed_source_revision: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_source_revision: Option<String>,
+    /// Deterministic SHA-256 identity of the package files used by this run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_content_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ref: Option<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -38,6 +38,10 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     let effective_run_id = effective_fuzz_run_id(args.run_id.as_deref());
     args.run_id = Some(effective_run_id.clone());
     let rig_context = load_rig(args.rig.as_deref(), &args.setting_args)?;
+    let rig_package = rig_context
+        .as_ref()
+        .and_then(|context| rig::package_evidence(&context.spec.id));
+    ensure_strict_rig_source_is_clean(&args, rig_package.as_ref())?;
     if let Some(context) = rig_context.as_ref() {
         let prepare_settings = fuzz_prepare_settings(&args);
         if let Some(prepare) = rig::run_fuzz_prepare(&context.spec, &prepare_settings)? {
@@ -195,6 +199,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         run_id: Some(&effective_run_id),
         component_id: &ctx.component_id,
         rig_id: rig_id.as_deref(),
+        rig_package: rig_package.as_ref(),
         workload_id: workload_id.as_deref(),
         workload_path: workload_path.as_deref(),
         status: &status,
@@ -297,6 +302,25 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     ))
 }
 
+pub(super) fn ensure_strict_rig_source_is_clean(
+    args: &FuzzRunArgs,
+    rig_package: Option<&homeboy_extension::bench::parsing::RigPackageEvidence>,
+) -> homeboy::core::Result<()> {
+    if args.effective_gate_profile().as_core() == FuzzGateProfile::Strict
+        && rig_package.is_some_and(|package| package.linked && package.source_dirty)
+    {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "rig",
+            "strict fuzz runs require a clean linked rig package source",
+            args.rig.clone(),
+            Some(vec![
+                "Commit or stash the linked rig package changes, then reinstall the rig to record its canonical package identity.".to_string(),
+                "Use the evidence gate profile to retain the execution-time package content hash for an intentional dirty development run.".to_string(),
+            ]),
+        ));
+    }
+    Ok(())
+}
 pub(super) fn effective_fuzz_run_id(requested: Option<&str>) -> String {
     requested
         .map(str::trim)
@@ -806,6 +830,7 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) run_id: Option<&'a str>,
     pub(super) component_id: &'a str,
     pub(super) rig_id: Option<&'a str>,
+    pub(super) rig_package: Option<&'a homeboy_extension::bench::parsing::RigPackageEvidence>,
     pub(super) workload_id: Option<&'a str>,
     pub(super) workload_path: Option<&'a str>,
     pub(super) status: &'a str,
@@ -843,6 +868,7 @@ pub(super) fn persist_fuzz_run_evidence(
         "source": "homeboy fuzz run",
         "workload_id": input.workload_id,
         "workload_path": input.workload_path,
+        "rig_package": input.rig_package,
         "seed": input.args.seed.clone(),
         "max_duration": input.args.max_duration.clone(),
         "passthrough_args": input.args.args.clone(),

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -1,5 +1,38 @@
 use super::*;
-use crate::commands::fuzz::execution::effective_fuzz_run_id;
+use crate::commands::fuzz::execution::{effective_fuzz_run_id, ensure_strict_rig_source_is_clean};
+
+#[test]
+fn strict_fuzz_rejects_dirty_linked_rig_packages() {
+    let mut args = fuzz_run_args_with_run_id("dirty-rig");
+    args.gate_profile = FuzzGateProfileArg::Strict;
+    let dirty_linked = homeboy_extension::bench::parsing::RigPackageEvidence {
+        rig_id: "rig".to_string(),
+        package_root: "/tmp/rig".to_string(),
+        source: "/tmp/rig".to_string(),
+        source_root: Some("/tmp/rig".to_string()),
+        rig_path: Some("/tmp/rig/rigs/rig/rig.json".to_string()),
+        discovery_path: Some("/tmp/rig".to_string()),
+        installed_source_revision: Some("abc123".to_string()),
+        current_source_revision: Some("abc123".to_string()),
+        source_content_hash: Some("a".repeat(64)),
+        source_ref: Some("main".to_string()),
+        source_dirty: true,
+        linked: true,
+        materialized: false,
+        freshness: homeboy_extension::bench::parsing::RigPackageFreshness::Stale,
+        freshness_verified: false,
+        freshness_message: Some("content changed".to_string()),
+        refresh_command: None,
+    };
+
+    let error = ensure_strict_rig_source_is_clean(&args, Some(&dirty_linked))
+        .expect_err("strict dirty linked source must fail");
+    assert!(error.message.contains("clean linked rig package source"));
+
+    args.gate_profile = FuzzGateProfileArg::Evidence;
+    ensure_strict_rig_source_is_clean(&args, Some(&dirty_linked))
+        .expect("evidence profile retains exact dirty content provenance");
+}
 
 #[test]
 fn auto_run_ids_scope_identical_payloads_while_explicit_ids_remain_stable() {
@@ -113,6 +146,7 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
+            rig_package: None,
             workload_id: args.workload_id.as_deref(),
             workload_path: Some("/tmp/fuzz/parser.json"),
             status: "passed",
@@ -259,6 +293,7 @@ fn fuzz_execution_request_artifact_records_runner_intent() {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
+            rig_package: None,
             workload_id: args.workload_id.as_deref(),
             workload_path: Some("/tmp/fuzz/parser.json"),
             status: "passed",
@@ -545,6 +580,7 @@ fn fuzz_sequence_plan_flag_records_request_env_and_artifact() {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
+            rig_package: None,
             workload_id: args.workload_id.as_deref(),
             workload_path: Some("/tmp/fuzz/parser.json"),
             status: "passed",
@@ -646,6 +682,7 @@ fn fuzz_run_persists_coverage_reconciliation_artifact() {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
+            rig_package: None,
             workload_id: args.workload_id.as_deref(),
             workload_path: Some("/tmp/fuzz/parser.json"),
             status: "passed",
@@ -722,6 +759,7 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
+            rig_package: None,
             workload_id: args.workload_id.as_deref(),
             workload_path: Some("/tmp/fuzz/parser.json"),
             status: "passed",
@@ -774,6 +812,7 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
+            rig_package: None,
             workload_id: args.workload_id.as_deref(),
             workload_path: Some("/tmp/fuzz/parser.json"),
             status: "passed",
@@ -1333,6 +1372,7 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
             run_id: args.run_id.as_deref(),
             component_id: "component-a",
             rig_id: args.rig.as_deref(),
+            rig_package: None,
             workload_id: args.workload_id.as_deref(),
             workload_path: Some("/tmp/fuzz/parser.json"),
             status: "failed",

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -545,6 +545,9 @@ fn install(
             source: result.source,
             package_path: result.package_path.to_string_lossy().to_string(),
             linked: result.linked,
+            source_revision: result.source_revision,
+            source_dirty: result.source_dirty,
+            source_content_hash: result.source_content_hash,
             installed: result
                 .installed
                 .into_iter()

--- a/crates/homeboy-cli/src/commands/rig/output.rs
+++ b/crates/homeboy-cli/src/commands/rig/output.rs
@@ -134,6 +134,10 @@ pub struct RigInstallOutput {
     pub source: String,
     pub package_path: String,
     pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+    pub source_dirty: bool,
+    pub source_content_hash: String,
     pub installed: Vec<RigInstalledSummary>,
     pub installed_stacks: Vec<RigInstalledStackSummary>,
 }

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1827,6 +1827,7 @@ mod tests {
                     source_revision: None,
                     source_ref: None,
                     source_dirty: false,
+                    source_content_hash: None,
                     linked: true,
                     materialized: false,
                 },

--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -10,6 +10,7 @@ use homeboy_core::{git, paths};
 use homeboy_extension as extension;
 use homeboy_stack::stack;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -28,6 +29,9 @@ pub struct RigInstallResult {
     pub source_root: PathBuf,
     pub package_path: PathBuf,
     pub linked: bool,
+    pub source_revision: Option<String>,
+    pub source_dirty: bool,
+    pub source_content_hash: String,
     pub installed: Vec<InstalledRig>,
     pub installed_stacks: Vec<InstalledStack>,
 }
@@ -42,6 +46,7 @@ pub(crate) struct PreparedSource {
     pub source_revision: Option<String>,
     pub source_ref: Option<String>,
     pub source_dirty: bool,
+    pub source_content_hash: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -80,6 +85,8 @@ pub struct RigSourceMetadata {
     pub source_ref: Option<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub source_dirty: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_content_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -154,6 +161,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
             source_revision: prepared.source_revision.clone(),
             source_ref: prepared.source_ref.clone(),
             source_dirty: prepared.source_dirty,
+            source_content_hash: Some(prepared.source_content_hash.clone()),
         };
         write_source_metadata(&rig.id, &metadata)?;
 
@@ -199,6 +207,9 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
         source_root: prepared.source_root,
         package_path: prepared.package_path,
         linked: prepared.linked,
+        source_revision: prepared.source_revision,
+        source_dirty: prepared.source_dirty,
+        source_content_hash: prepared.source_content_hash,
         installed,
         installed_stacks,
     })
@@ -1055,6 +1066,7 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
     let source_ref = git::current_branch(&package_path).filter(|branch| !branch.is_empty());
     let source_dirty =
         git::status_porcelain_bytes(&package_path).is_some_and(|status| !status.is_empty());
+    let source_content_hash = package_content_hash(&package_path)?;
     let discovery_path = match subpath {
         Some(subpath) => package_path.join(subpath),
         None => package_path.clone(),
@@ -1083,6 +1095,7 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
         source_revision,
         source_ref,
         source_dirty,
+        source_content_hash,
     })
 }
 
@@ -1125,6 +1138,7 @@ fn prepare_local_source(source: &str) -> Result<PreparedSource> {
     let source_ref = git::current_branch(&package_path).filter(|branch| !branch.is_empty());
     let source_dirty =
         git::status_porcelain_bytes(&package_path).is_some_and(|status| !status.is_empty());
+    let source_content_hash = package_content_hash(&package_path)?;
 
     Ok(PreparedSource {
         source: package_path.to_string_lossy().to_string(),
@@ -1135,7 +1149,68 @@ fn prepare_local_source(source: &str) -> Result<PreparedSource> {
         source_revision,
         source_ref,
         source_dirty,
+        source_content_hash,
     })
+}
+
+/// Hash every regular package file in stable relative-path order, excluding the
+/// repository's Git administration directory. This identifies the linked
+/// package content that the runner can actually read, including untracked files.
+pub fn package_content_hash(package_path: &Path) -> Result<String> {
+    let mut files = Vec::new();
+    collect_package_files(package_path, package_path, &mut files)?;
+    files.sort();
+
+    let mut hasher = Sha256::new();
+    for relative in files {
+        let bytes = fs::read(package_path.join(&relative)).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read package file {}", relative.display())),
+            )
+        })?;
+        let path = relative.to_string_lossy();
+        hasher.update((path.len() as u64).to_be_bytes());
+        hasher.update(path.as_bytes());
+        hasher.update((bytes.len() as u64).to_be_bytes());
+        hasher.update(bytes);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn collect_package_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(directory).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read package directory {}", directory.display())),
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read package directory entry".into()),
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("inspect package path {}", path.display())),
+            )
+        })?;
+        if file_type.is_dir() {
+            if entry.file_name() != ".git" {
+                collect_package_files(root, &path, files)?;
+            }
+        } else if file_type.is_file() {
+            files.push(
+                path.strip_prefix(root)
+                    .expect("package child path")
+                    .to_path_buf(),
+            );
+        }
+    }
+    Ok(())
 }
 
 pub fn write_source_metadata(id: &str, metadata: &RigSourceMetadata) -> Result<()> {

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -56,7 +56,7 @@ pub use capabilities::{
 pub use component_resolution::{component_ref, resolve_component, resolve_component_path};
 pub use install::{
     default_materialize_source_root, discover_rigs, discover_stacks, install, materialize_rig_spec,
-    materialize_rig_spec_with_default_source_root, read_source_metadata,
+    materialize_rig_spec_with_default_source_root, package_content_hash, read_source_metadata,
     read_stack_source_metadata, DiscoveredRig, DiscoveredStack, InstalledStack, RigInstallResult,
     RigSourceMetadata, StackSourceMetadata,
 };
@@ -174,6 +174,7 @@ fn local_package_evidence(id: &str, package_root: PathBuf) -> RigPackageEvidence
     let source_ref = git::current_branch(&package_root).filter(|branch| !branch.is_empty());
     let source_dirty =
         git::status_porcelain_bytes(&package_root).is_some_and(|status| !status.is_empty());
+    let source_content_hash = package_content_hash(&package_root).ok();
     RigPackageEvidence {
         rig_id: id.to_string(),
         package_root: source.clone(),
@@ -190,6 +191,7 @@ fn local_package_evidence(id: &str, package_root: PathBuf) -> RigPackageEvidence
         discovery_path: Some(package_root.to_string_lossy().to_string()),
         installed_source_revision: current_source_revision.clone(),
         current_source_revision,
+        source_content_hash,
         source_ref,
         source_dirty,
         linked: true,
@@ -208,23 +210,28 @@ fn package_evidence_from_metadata(id: &str, metadata: RigSourceMetadata) -> RigP
         .clone()
         .unwrap_or_else(|| metadata.package_path.clone());
     let current_source_revision = git::short_head_revision_at(Path::new(&source_root));
+    let current_source_dirty = git::status_porcelain_bytes(Path::new(&source_root))
+        .is_some_and(|status| !status.is_empty());
+    let current_source_content_hash = package_content_hash(Path::new(&package_root)).ok();
     let root_present = Path::new(&source_root).is_dir();
     let (freshness, freshness_message) = if !root_present {
         (
             RigPackageFreshness::Missing,
             Some("installed rig package source path is missing".to_string()),
         )
-    } else if let (Some(installed), Some(current)) = (
+    } else if let (Some(installed), Some(current), Some(installed_hash), Some(current_hash)) = (
         metadata.source_revision.as_deref(),
         current_source_revision.as_deref(),
+        metadata.source_content_hash.as_deref(),
+        current_source_content_hash.as_deref(),
     ) {
-        if installed == current {
+        if installed == current && installed_hash == current_hash {
             (RigPackageFreshness::Verified, None)
         } else {
             (
                 RigPackageFreshness::Stale,
                 Some(format!(
-                    "installed source revision {installed} differs from current source revision {current}"
+                    "installed source identity differs from current package content (revision {installed} -> {current}, content {installed_hash} -> {current_hash})"
                 )),
             )
         }
@@ -255,8 +262,9 @@ fn package_evidence_from_metadata(id: &str, metadata: RigSourceMetadata) -> RigP
         discovery_path: metadata.discovery_path,
         installed_source_revision: metadata.source_revision,
         current_source_revision,
+        source_content_hash: current_source_content_hash,
         source_ref: metadata.source_ref,
-        source_dirty: metadata.source_dirty,
+        source_dirty: current_source_dirty,
         linked: metadata.linked,
         materialized: metadata.materialized,
         freshness,

--- a/crates/homeboy-rig/src/source.rs
+++ b/crates/homeboy-rig/src/source.rs
@@ -342,6 +342,9 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
             source_revision: source_revision.clone(),
             source_ref: source_ref.clone(),
             source_dirty,
+            source_content_hash: Some(super::install::package_content_hash(Path::new(
+                &source.package_path,
+            ))?),
         };
         write_source_metadata(&rig.id, &metadata)?;
 

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -532,6 +532,7 @@ fn write_rig_source_metadata(rig_id: &str) {
             source_revision: Some("abc123".to_string()),
             source_ref: Some("main".to_string()),
             source_dirty: false,
+            source_content_hash: None,
         })
         .expect("serialize source metadata"),
     )

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -63,6 +63,51 @@ fn test_list_sources() {
 }
 
 #[test]
+fn linked_package_provenance_tracks_execution_time_content_and_dirty_state() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    GitFixture::init(package.path()).commit("initial rig");
+
+    let installed = install(package.path().to_str().unwrap(), Some("alpha"), false)
+        .expect("install linked rig");
+    assert!(installed.linked);
+    assert!(!installed.source_dirty);
+    let metadata = crate::read_source_metadata("alpha").expect("source metadata");
+    let installed_hash = metadata
+        .source_content_hash
+        .expect("installed content hash");
+    assert_eq!(installed_hash, installed.source_content_hash);
+
+    fs::write(
+        &rig,
+        minimal_rig("alpha").replace("alpha rig", "changed rig"),
+    )
+    .expect("modify tracked rig");
+    let tracked_change = crate::package_evidence("alpha").expect("execution evidence");
+    assert!(tracked_change.source_dirty);
+    assert_ne!(
+        tracked_change.source_content_hash.as_deref(),
+        Some(installed_hash.as_str())
+    );
+    assert!(!tracked_change.freshness_verified);
+
+    run_git(package.path(), &["checkout", "--", "."]);
+    fs::write(
+        package.path().join("runner.sh"),
+        "#!/bin/sh\necho changed\n",
+    )
+    .expect("add untracked runner");
+    let untracked_change = crate::package_evidence("alpha").expect("execution evidence");
+    assert!(untracked_change.source_dirty);
+    assert_ne!(
+        untracked_change.source_content_hash.as_deref(),
+        Some(installed_hash.as_str())
+    );
+    assert!(!untracked_change.freshness_verified);
+}
+
+#[test]
 fn list_sources_reports_stack_specs_from_package() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- record a deterministic SHA-256 package-content identity alongside linked rig revision and dirty state
- recalculate linked package dirty state and content identity at execution, and persist it in fuzz run evidence
- reject dirty linked packages for strict fuzz runs while evidence-profile development runs retain their exact content identity

## Testing
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli strict_fuzz_rejects_dirty_linked_rig_packages --lib`
- `cargo test -p homeboy-rig --lib linked_package_provenance_tracks_execution_time_content_and_dirty_state`

Closes #10437

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode assisted with implementation and focused test coverage. Chris Huber is responsible for every line.