### PR TITLE
fix(agent-task): durable Cook identity before materialization, and self-reconciling Lab admissions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -162,6 +162,47 @@ pub fn record_lab_staging_controller_job(
     Ok(record)
 }
 
+/// Name a reserved Lab admission on the durable run the moment it is taken,
+/// before any further dispatch work can fail.
+///
+/// A reservation that exists only inside the controller process is unfindable:
+/// a caller killed between reservation and runner acceptance leaves capacity
+/// held by an admission nothing can associate with a run id, which is what
+/// forced manual job-ID cancellation in #9163. The daemon's admission-lease
+/// sweep still owns automatic reclaim; this write owns *identity*, so an
+/// operator can see which run holds which reservation and when it self-expires.
+pub fn record_lab_admission_reservation(
+    run_id: &str,
+    runner_id: &str,
+    daemon_lease_id: &str,
+    reservation_job_id: &str,
+    lease_expires_at_ms: u64,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if record.state.is_terminal() {
+        return Ok(record);
+    }
+    record.updated_at = Some(now_timestamp());
+    let reserved_at = record.updated_at.clone().unwrap_or_else(now_timestamp);
+    let record_run_id = record.run_id.clone();
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "lab_admission_reservation".to_string(),
+        json!({
+            "state": "reserved",
+            "runner_id": runner_id,
+            "daemon_lease_id": daemon_lease_id,
+            "reservation_job_id": reservation_job_id,
+            "lease_expires_at_ms": lease_expires_at_ms,
+            "reserved_at": reserved_at,
+            "reclaim": "the runner daemon reconciles this reservation automatically once its lease expires without a live controller",
+            "cancel_command": format!("homeboy agent-task cancel {record_run_id}"),
+        }),
+    );
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 /// Preserve the controller-stage terminal context on the durable parent after
 /// its generic controller job has failed.
 pub fn record_lab_staging_controller_failure(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -565,6 +565,77 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
 }
 
 #[test]
+fn reserved_lab_admission_is_named_on_the_durable_run_before_acceptance() {
+    with_isolated_home(|_| {
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id: "agent-task-admission-identity",
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("controller proxy recorded before admission");
+
+        let reserved = record_lab_admission_reservation(
+            "agent-task-admission-identity",
+            "homeboy-lab",
+            "lease-abc",
+            "job-reservation-9163",
+            1_700_000_000_000,
+        )
+        .expect("reservation named on the durable run");
+
+        // The reservation is findable by run id the moment it is taken, so a
+        // caller killed before runner acceptance never leaves an admission that
+        // only manual job-ID surgery can identify (#9163).
+        assert_eq!(
+            reserved.metadata["lab_admission_reservation"]["reservation_job_id"],
+            "job-reservation-9163"
+        );
+        assert_eq!(
+            reserved.metadata["lab_admission_reservation"]["daemon_lease_id"],
+            "lease-abc"
+        );
+        assert_eq!(
+            reserved.metadata["lab_admission_reservation"]["runner_id"],
+            "homeboy-lab"
+        );
+        assert_eq!(
+            reserved.metadata["lab_admission_reservation"]["lease_expires_at_ms"],
+            1_700_000_000_000u64
+        );
+        assert_eq!(
+            reserved.metadata["lab_admission_reservation"]["cancel_command"],
+            "homeboy agent-task cancel agent-task-admission-identity"
+        );
+        // Naming a reservation is evidence, never acceptance.
+        assert_eq!(reserved.state, AgentTaskRunState::Queued);
+        assert!(reserved.metadata.get("runner_job_id").is_none());
+
+        // A terminal run is never reopened by a late reservation write.
+        cancel_run("agent-task-admission-identity", Some("caller lost"))
+            .expect("cancel the reserved run");
+        let after_cancel = record_lab_admission_reservation(
+            "agent-task-admission-identity",
+            "homeboy-lab",
+            "lease-def",
+            "job-reservation-late",
+            1_700_000_000_001,
+        )
+        .expect("late reservation write is a no-op");
+        assert_eq!(
+            after_cancel.metadata["lab_admission_reservation"]["reservation_job_id"],
+            "job-reservation-9163"
+        );
+    });
+}
+
+#[test]
 fn accepted_handoff_replays_idempotently_and_rejects_a_different_identity() {
     with_isolated_home(|_| {
         let command = vec!["homeboy".to_string(), "agent-task".to_string()];

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1703,6 +1703,21 @@ where
     validate_cook_workspace(&options)?;
     validate_cook_candidate_group(&options.initial_plan)?;
     materialize_initial_cook_attempt(&options)?;
+    // Durable identity now exists and resolves through the Cook alias. Publish
+    // it before every remaining long controller phase — gate toolchain
+    // preflight, transport preparation, and Lab materialization — so a caller
+    // interrupted at any later point can still answer "what did I just start?"
+    // from the first identity-bearing bytes it received. `provider_ready` used
+    // to be the first identity-bearing observer event, which put the operator
+    // handle behind work that can outlive a client timeout (#10419, #9163).
+    report_cook_progress(
+        durable_observer,
+        &options.cook_id,
+        &options.initial_run_id,
+        "durable_identity",
+        1,
+        None,
+    )?;
     let required_toolchains = options.gates.required_toolchains();
     let preflight = required_toolchains
         .is_empty()

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1898,6 +1898,11 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
             observed.lock().expect("observer records lock").as_slice(),
             &[
                 (
+                    "durable_identity".to_string(),
+                    cook_id.to_string(),
+                    run_id.to_string()
+                ),
+                (
                     "provider_ready".to_string(),
                     cook_id.to_string(),
                     run_id.to_string()
@@ -1934,6 +1939,119 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
         assert!(agent_task_lifecycle::logs(cook_id).is_ok());
         assert!(
             agent_task_lifecycle::retry(cook_id, Some("cook-repair-initial-alias-retry")).is_ok()
+        );
+    });
+}
+
+/// Fails at the exact controller boundary where Lab materialization begins,
+/// after recording whether the durable run record was already addressable by
+/// id at that moment. Models the caller-timeout case in #9163/#10419.
+#[derive(Debug)]
+struct MaterializationInterruptingDispatcher {
+    run_id: String,
+    state_at_materialization: Arc<Mutex<Option<String>>>,
+}
+
+impl AgentTaskCookAttemptDispatcher for MaterializationInterruptingDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(serde_json::json!({ "kind": "test-materialization-interruption" }))
+    }
+
+    fn prepare_for_cook(&self) -> Result<()> {
+        // Controller-side Lab materialization starts here. The durable record
+        // must already resolve by id, or an interruption from this point on
+        // strands an unnamed reservation.
+        let record = agent_task_lifecycle::status(&self.run_id)?;
+        *self
+            .state_at_materialization
+            .lock()
+            .expect("materialization state") = Some(format!("{:?}", record.state));
+        Err(Error::internal_unexpected(
+            "fixture caller was interrupted during Lab materialization",
+        ))
+    }
+
+    fn dispatch_attempt(
+        &self,
+        _plan: AgentTaskPlan,
+        _run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        panic!("an interrupted materialization must never reach provider dispatch")
+    }
+}
+
+#[test]
+fn cook_publishes_durable_identity_before_materialization_and_survives_interruption() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-durable-identity-first";
+        let run_id = "cook-durable-identity-first-run";
+        let state_at_materialization = Arc::new(Mutex::new(None));
+        let options = batch_cook_options(
+            cook_id,
+            Arc::new(MaterializationInterruptingDispatcher {
+                run_id: run_id.to_string(),
+                state_at_materialization: state_at_materialization.clone(),
+            }),
+        );
+
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let observer_records = observed.clone();
+        let result =
+            run_cook_with_durable_observer(options, UnusedExecutor, &move |phase, cook, run| {
+                observer_records
+                    .lock()
+                    .expect("observer records lock")
+                    .push((phase.to_string(), run.to_string()));
+                // Every identity-bearing event must be immediately actionable:
+                // the caller can look the run up the moment it is told about it.
+                assert_eq!(
+                    agent_task_lifecycle::status(cook)
+                        .expect("Cook alias resolves in observer")
+                        .run_id,
+                    run
+                );
+                Ok(())
+            })
+            .expect("interrupted materialization returns a durable report");
+
+        // 1. Identity is published before any materialization work.
+        assert_eq!(
+            observed
+                .lock()
+                .expect("observer records lock")
+                .first()
+                .cloned(),
+            Some(("durable_identity".to_string(), run_id.to_string()))
+        );
+
+        // 2. The record was findable by id at the instant materialization began.
+        assert_eq!(
+            state_at_materialization
+                .lock()
+                .expect("materialization state")
+                .as_deref(),
+            Some("Queued")
+        );
+
+        // 3. The interruption left a named, recoverable record — not an
+        //    anonymous reservation an operator has to hunt for.
+        assert_eq!(result.value.status, "durable_failure");
+        let record = agent_task_lifecycle::status(run_id).expect("record survives interruption");
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            serde_json::json!("cook_pre_execution")
+        );
+        assert_eq!(
+            agent_task_lifecycle::status(cook_id)
+                .expect("Cook alias resolves after interruption")
+                .run_id,
+            run_id
+        );
+        assert!(agent_task_lifecycle::logs(run_id).is_ok());
+        // Recoverable, not merely observable: the operator can act on the id.
+        assert!(
+            agent_task_lifecycle::retry(cook_id, Some("cook-durable-identity-first-retry")).is_ok()
         );
     });
 }

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -45,7 +45,19 @@ pub use args::{
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
+    // Announce durable identity exactly once, on the first progress event that
+    // carries a run id, and do it outside the TTY gate. Phase chatter stays
+    // TTY-gated so non-interactive logs are not spammed, but the operator
+    // handle itself must reach every caller — a non-TTY client that is
+    // interrupted mid-cook otherwise has no way to answer "what did I just
+    // start?" (#10419).
+    let announced_identity = std::sync::atomic::AtomicBool::new(false);
     let progress = |phase: &str, cook_id: Option<&str>, run_id: Option<&str>| {
+        if let Some(run_id) = run_id {
+            if !announced_identity.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                run::announce_durable_cook_identity(cook_id, run_id);
+            }
+        }
         let identity = match (cook_id, run_id) {
             (_, Some(run_id)) => format!(" [{run_id}]"),
             (Some(cook_id), None) => format!(" [{cook_id}]"),

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -29,6 +29,39 @@ use super::args::{
 
 const MAX_PROMOTION_PROVIDER_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
 
+/// Operator-facing durable identity block for a Cook that has just become
+/// addressable.
+///
+/// A Cook's run id is the only handle an interrupted caller has. Everything
+/// after durable submission — gate toolchain preflight, transport preparation,
+/// Lab materialization, provider execution — can outlive a client timeout, so
+/// the handle and its follow-up commands are assembled here and printed the
+/// first time the controller reports identity (#10419, #9163).
+pub(crate) fn durable_cook_identity_lines(cook_id: Option<&str>, run_id: &str) -> Vec<String> {
+    let cook_suffix = cook_id
+        .filter(|cook_id| *cook_id != run_id)
+        .map(|cook_id| format!(" (cook `{cook_id}`)"))
+        .unwrap_or_default();
+    vec![
+        format!("cook: durable run id `{run_id}`{cook_suffix} — persisted before materialization."),
+        format!("cook: status -> homeboy agent-task status {run_id}"),
+        format!("cook: logs   -> homeboy agent-task logs {run_id}"),
+        format!("cook: cancel -> homeboy agent-task cancel {run_id}"),
+    ]
+}
+
+/// Print the durable identity block unconditionally.
+///
+/// Deliberately not TTY-gated. The clients that most need this — agent/Discord
+/// bridges, CI, and anything invoking Homeboy as a tool call — are exactly the
+/// non-TTY callers that a TTY-gated status line silently skips, which is how an
+/// interrupted Lab Cook ended up with no reported task identity at all (#10419).
+pub(crate) fn announce_durable_cook_identity(cook_id: Option<&str>, run_id: &str) {
+    for line in durable_cook_identity_lines(cook_id, run_id) {
+        eprintln!("{line}");
+    }
+}
+
 /// Serialize a completed run aggregate and, when the run did not fully succeed,
 /// surface a prominent top-level `failure_reasons` summary so the operator sees
 /// the root cause (recipe validation, PHP fatal, provider registration, missing
@@ -894,7 +927,31 @@ pub(super) fn retry(args: RetryArgs) -> CmdResult<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::cook_report_with_continuation;
+    use super::{cook_report_with_continuation, durable_cook_identity_lines};
+
+    #[test]
+    fn durable_cook_identity_block_leads_with_the_run_id_and_follow_up_commands() {
+        let lines = durable_cook_identity_lines(Some("cook-10419"), "cook-10419-attempt-1");
+
+        // The very first thing an interrupted caller sees must be the handle.
+        assert!(
+            lines[0].contains("cook-10419-attempt-1"),
+            "identity block must lead with the durable run id: {lines:?}"
+        );
+        assert!(lines[0].contains("cook-10419"));
+        let joined = lines.join("\n");
+        assert!(joined.contains("homeboy agent-task status cook-10419-attempt-1"));
+        assert!(joined.contains("homeboy agent-task logs cook-10419-attempt-1"));
+        assert!(joined.contains("homeboy agent-task cancel cook-10419-attempt-1"));
+    }
+
+    #[test]
+    fn durable_cook_identity_block_omits_a_cook_alias_equal_to_the_run_id() {
+        let lines = durable_cook_identity_lines(Some("run-9163"), "run-9163");
+
+        assert!(!lines[0].contains("(cook"), "no redundant alias: {lines:?}");
+        assert!(lines[0].contains("run-9163"));
+    }
 
     #[test]
     fn in_flight_cook_report_keeps_provider_state_and_managed_continuation_separate() {

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -502,6 +502,13 @@ impl DaemonAdmissionReservationAuthority {
         &self.reservation_job_id
     }
 
+    /// When the daemon reclaims this reservation without a controller. Recorded
+    /// on the durable run so an operator can see the automatic-reclaim deadline
+    /// instead of guessing whether a lost caller stranded capacity (#9163).
+    pub(crate) fn lease_expires_at_ms(&self) -> u64 {
+        self.lease_expires_at_ms
+    }
+
     /// Proves that the daemon, rather than local Drop cleanup, still owns the
     /// lease expiry/cancellation contract before the dispatcher submits `/exec`.
     pub(crate) fn prove_server_owned_expiry_or_cancellation_authority(&self) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1953,6 +1953,16 @@ pub(crate) fn run_lab_offload_inner(
     // retry to repeat the entire prep sequence with new identities (#9469).
     // Preserve the prepared workspace so a retry can resume against the current
     // healthy daemon instead; a genuine terminal outcome still reaps as before.
+    //
+    // The lease protocol is REQUIRED here, matching the durable staging
+    // dispatcher (`lab_staging_controller`). A legacy, leaseless reservation is
+    // release-only: its sole reclaim path is this process's `Drop`, so a caller
+    // killed by a timeout leaves a reservation the daemon's existing
+    // `reconcile_expired_admissions` sweep can never see — the orphan that
+    // required manual job-ID surgery in #9163. Requiring the lease puts every
+    // Lab reservation under that automatic reclaim. Rejection is fail-safe:
+    // `strict_admission_rejection` releases the reservation and returns a
+    // remediation-bearing error rather than proceeding.
     let admission_started = std::time::Instant::now();
     let admission = match direct_daemon_admission_coordinates(
         runner_id,
@@ -1968,7 +1978,7 @@ pub(crate) fn run_lab_offload_inner(
                     &redact_argv_shell_display(&command_prefix.argv),
                     expected_daemon_lease_id,
                     agent_task_run_id.as_deref(),
-                    DaemonAdmissionPolicy::LegacyCompatible,
+                    DaemonAdmissionPolicy::DurableLeaseRequired,
                 )
             })
             .transpose()
@@ -1990,6 +2000,21 @@ pub(crate) fn run_lab_offload_inner(
         }
     };
     overhead.record(LabOffloadPhase::QueueAdmission, admission_started.elapsed());
+    // Name the reservation on the durable record before anything else can fail.
+    // Until this write lands the reservation exists only in this process, so an
+    // operator who lost the caller cannot tell which admission belongs to which
+    // run. The daemon lease reclaims it automatically; this makes it findable by
+    // run id in the meantime (#9163).
+    if let (Some(run_id), Some(reservation)) = (agent_task_run_id.as_deref(), admission.as_ref()) {
+        let authority = reservation.authority();
+        agent_task_lifecycle::record_lab_admission_reservation(
+            run_id,
+            runner_id,
+            authority.daemon_lease_id(),
+            authority.reservation_job_id(),
+            authority.lease_expires_at_ms(),
+        )?;
+    }
     lab_metadata["execution_bundle"] = serde_json::json!({
         "schema": crate::execution_bundle::LAB_EXECUTION_BUNDLE_SCHEMA,
         "binary": crate::execution_bundle::binary(

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1520,14 +1520,18 @@ pub(crate) fn run_lab_offload_inner(
             None,
         )
         })?;
-        if request.local_output_file.is_some() {
-            emit_durable_run_id_before_execution(
-                run_id,
-                runner_id,
-                request.local_output_file,
-                &mut messages,
-            );
-        }
+        // Emit unconditionally. `emit_durable_run_id_before_execution` already
+        // treats `--output` as optional and still prints the handle plus its
+        // follow-up commands to stderr. Gating the whole call on `--output`
+        // meant the most common detached invocation — no `--output`, submitted
+        // by an interruptible non-TTY client — got no identity at all before
+        // controller staging began (#10419).
+        emit_durable_run_id_before_execution(
+            run_id,
+            runner_id,
+            request.local_output_file,
+            &mut messages,
+        );
         let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
             run_id,
             runner_id,


### PR DESCRIPTION
## Operator consequence

An interrupted Lab cook currently leaves no way to know what was started.

Launch `agent-task cook --runner <lab>` from an agent bridge, a CI step, or any tool call, get interrupted, and you are left holding nothing: no run id, no cook id, no way to tell whether resubmitting duplicates work. The only recovery is inspecting runner state, processes, and destination worktrees by hand.

This PR makes the attached path safe — identity first, printed up front, recoverable — without changing the blocking default.

## The ordering I found (the key finding)

I mapped the current path before changing it. **Item 1 of the brief — "write the durable record before materialization" — is already correct on `main`.** #9374, #9396 and #9457 landed it. The field reports in #10419/#9163 predate that work.

Controller (`agent_task_service/cook.rs :: run_cook_with_boundaries_observed_inner`):

1. configured-provider preflight
2. `persist_initial_recipe` / load recipe — resumable input, not status-addressable
3. `validate_cook_workspace` / `validate_cook_candidate_group`
4. **`materialize_initial_cook_attempt` → `submit_plan` → durable `Queued` run record exists and resolves through the Cook alias** ✅
5. gate toolchain preflight
6. `materialize_cook_attempt` for the latest recipe attempt, then a `status` read-back
7. `report_cook_progress("provider_ready")` ← **first identity-bearing observer event**
8. `dispatcher.prepare_for_cook()` — Lab transport readiness
9. pin cook generation, then the attempt loop → `dispatch_attempt` → Lab offload

Lab (`homeboy-lab-runner/src/lab/offload/inner.rs :: run_lab_offload_inner`):

a. runner load, `status_for_admission`, availability
b. detached only: `converge_lab_handoff_runtime`
c. source path, host telemetry, idempotency guard
d. `record_lab_offload_phase("validation")`, then `("materializing")`
e. runner binary/build-identity checks, provider preflight on runner, capability preflight
f. **detached short-circuit** → `submit_detached_staging` (controller-owned job) → return
g. otherwise: workspace snapshot/sync, `@`-file transfer, rig sync, runtime + extension overlays, dependency hydration ← **the ~8 minutes**
h. `emit_durable_run_id_before_execution` (attached path)
i. admission reservation
j. `exec_lab_context` → executor preflight → submission intent → `/exec`

So the record and the controller-owned detached staging job both exist before the expensive work. **The real defect is narrower than the brief assumed, and it is entirely in delivery, not ordering.** Three concrete gaps:

1. **The CLI progress emitter is `tty::status`, which writes only when stderr is a terminal.** Non-TTY callers — agent/Discord bridges, CI, tool calls, i.e. exactly the interruptible clients — got *zero* output until the final JSON. The identity was durable; it was simply never printed to the people who needed it. This is the mechanism behind "the initial response contained no durable task/run identity".
2. **The first identity-bearing event was `provider_ready` (step 7)**, behind gate toolchain preflight, rather than at step 4 where identity first exists.
3. **On the detached Lab short-circuit, `emit_durable_run_id_before_execution` was wrapped in `if request.local_output_file.is_some()`** — so `--detach-after-handoff` without `--output`, the common shape, emitted nothing. The helper already treats the output file as optional and prints to stderr regardless, so the guard only suppressed identity.

## What changed

**Identity first (`crates/homeboy-agents/src/agent_task_service/cook.rs`)**
New `durable_identity` progress event emitted the instant `materialize_initial_cook_attempt` returns — before gate toolchain preflight, transport preparation, and all Lab materialization.

**Identity reaches every caller (`crates/homeboy-cli/src/commands/agent_task.rs`, `.../agent_task/run.rs`)**
The run id is announced once, **outside the TTY gate**, on the first progress event that carries it, with `status` / `logs` / `cancel` commands. Ordinary phase chatter stays TTY-gated so non-interactive logs are not spammed.

**Detached handoff always emits (`crates/homeboy-lab-runner/src/lab/offload/inner.rs`)**
Dropped the `--output` guard.

**Orphaned reservations now self-reconcile (`inner.rs`, `execution/daemon.rs`, `agent_task_lifecycle/lab_offload.rs`)**
The daemon already has the reclaim machinery: `JobStore::reconcile_expired_admissions` runs at daemon start and on a background reconciler thread, failing any admission whose lease expires without a live controller renewing it. Attached Lab offload was escaping it by reserving under `DaemonAdmissionPolicy::LegacyCompatible` — a legacy leaseless reservation is release-only, so its *only* reclaim path was this process's `Drop`, which a SIGKILL'd caller never runs. That is the orphan that needed manual job-ID surgery.

Lab offload now reserves under `DurableLeaseRequired`, the same policy the durable staging dispatcher in `lab_staging_controller` already uses, putting every Lab reservation under the existing sweep. This is the one behavioral tightening in the PR; it is fail-closed and safe — `strict_admission_rejection` releases the reservation and returns a remediation-bearing error instead of proceeding.

The reservation is also **named on the durable run record the instant it is taken** (`record_lab_admission_reservation`): runner id, daemon lease id, reservation job id, lease expiry, and cancel command. Automatic reclaim is the daemon's job; this makes the reservation findable by run id in the meantime, which it previously was not.

## Tests

- `cook_publishes_durable_identity_before_materialization_and_survives_interruption` — a dispatcher that fails at the exact controller boundary where Lab materialization begins asserts (a) `durable_identity` is the **first** observer event, (b) the record was already addressable by id at the instant materialization started, (c) the interruption leaves a named, recoverable record that `status`, `logs`, and `retry` all resolve — not an anonymous reservation.
- `cook_repairs_initial_alias_after_submit_before_index_interruption` — updated for the new leading event.
- `durable_cook_identity_block_leads_with_the_run_id_and_follow_up_commands` / `..._omits_a_cook_alias_equal_to_the_run_id` — the announced block leads with the handle and carries status/logs/cancel.
- `reserved_lab_admission_is_named_on_the_durable_run_before_acceptance` — reservation identity lands on the record before acceptance, naming is evidence rather than acceptance, and a late write never reopens a terminal run.

`cargo fmt` clean. Not built locally by policy; CI is the gate.

## Deferred

**The blocking default is unchanged, deliberately.** #10419 argues attached-by-default is wrong for a durable Lab control plane, and it probably is — but flipping it is a behavioral break that deserves its own decision and its own migration. This PR makes the attached path safe instead: identity first, printed up front, resumable. Follow-up question for a separate issue: detached-by-default for `--runner` / `--placement lab` with an explicit `--wait`.

Remaining from #10419 not covered here: bounded phase/progress heartbeats on the synchronous observation stream with a detach/reconnect command, and short help examples for submit-and-return / submit-and-wait / status / evidence.

Closes #10419
Closes #9163
