### PR TITLE
fix: reconcile parallel Cook admission and Lab placement contracts

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -623,10 +623,12 @@ fn delegate_agent_task_cook_to_pinned_runtime(
         }
     }
 
-    let pinned = crate::agents::agent_tasks::lifecycle::pin_current_controller_runtime(
-        &format!("seal-{}", Uuid::new_v4()),
-        || Ok(false),
-    )?;
+    let request_id = format!("seal-{}", Uuid::new_v4());
+    let pinned =
+        crate::agents::agent_tasks::lifecycle::pin_current_controller_runtime(&request_id, || {
+            Ok(false)
+        })
+        .map_err(|error| annotate_cook_seal_failure(error, &request_id, normalized_args))?;
     let status = ProcessCommand::new(&pinned)
         .args(&normalized_args[1..])
         .env(COOK_PINNED_RUNTIME_ENV, &pinned)
@@ -641,6 +643,31 @@ fn delegate_agent_task_cook_to_pinned_runtime(
             )
         })?;
     Ok(Some(status.code().unwrap_or(1)))
+}
+
+/// The runtime seal runs before a cook has any durable run record — controller
+/// admission is what creates one — so a failed seal leaves the error itself as
+/// the only evidence the operator gets.
+///
+/// Carry the admission request identity and the exact command to re-submit, so
+/// a contended parallel wave produces a resumable instruction instead of a bare
+/// retryable failure (#9373). Admission is FIFO, so re-running the identical
+/// command queues rather than races.
+fn annotate_cook_seal_failure(
+    mut error: homeboy::core::Error,
+    request_id: &str,
+    normalized_args: &[String],
+) -> homeboy::core::Error {
+    if !error.details.is_object() {
+        error.details = serde_json::json!({});
+    }
+    error.details["controller_admission_phase"] = serde_json::json!("cook_runtime_seal");
+    error.details["controller_admission_request_id"] = serde_json::json!(request_id);
+    error.details["next_actions"] =
+        serde_json::json!([homeboy::core::engine::shell::quote_args(normalized_args)]);
+    error.with_hint(
+        "Controller admission is FIFO: re-running the identical cook command queues behind the current owner instead of racing it.",
+    )
 }
 
 /// Durable lifecycle mutations remain owned by the runtime that admitted the

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -26,13 +26,13 @@ use crate::command_contract::{
 const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 pub(crate) const AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON: &str =
-    "agent-task cook is a controller-owned coordinator: it resolves the managed target, ingests provider artifacts, promotes candidates, runs deterministic gates, and finalizes. Its provider attempt is routed to the configured Lab runner automatically, so `--placement lab` is unnecessary; pass `--runner <runner-id>` to pin a specific Lab runner for that attempt.";
+    "agent-task cook is a controller-owned coordinator: it resolves the managed target, ingests provider artifacts, promotes candidates, runs deterministic gates, and finalizes. Only its provider attempt is portable, and that attempt is dispatched to the selected Lab runner: `--placement lab` selects the runner for the attempt (never offloading the coordinator), and `--runner <runner-id>` pins a specific one.";
 pub(crate) const AGENT_TASK_PROMOTION_RUN_CONTROLLER_REASON: &str =
     "agent-task promote with a durable run id is controller-owned: it resolves authoritative lifecycle state and finalized artifact projections on the controller.";
 const AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON: &str =
     "agent-task fanout cook-batch --dry-run is controller-local planning; it does not execute cooks and should not offload or materialize the controller cwd";
 pub(crate) const AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON: &str =
-    "agent-task fanout coordination is controller-owned so durable batch state, worktree ownership, and recovery remain available; generated independent cooks may use their own Lab placement";
+    "agent-task fanout coordination is controller-owned so durable batch state, worktree ownership, and recovery remain available; `--placement lab` (or `--runner <runner-id>`) selects the Lab runner each child provider attempt is dispatched to, and never offloads the coordinator itself";
 
 impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -116,6 +116,18 @@ pub fn route_after_parse(
         None
     };
 
+    // A split-placement coordinator honors `--placement lab`; it must never fall
+    // through to the generic local-only portability rejection, which contradicts
+    // the documented guidance for Cook waves (#9373).
+    if let Some(error) = split_placement_lab_runner_unavailable_error(
+        &cli.command,
+        cli.placement,
+        inferred_runner_id.as_deref(),
+        lab_readiness.as_ref(),
+    ) {
+        return Err(error);
+    }
+
     if let Some(exit_code) = run_split_placement_cook(
         cli,
         normalized_args,
@@ -303,6 +315,96 @@ fn runner_resident_execution(cli: &Cli) -> bool {
             })
         ) || cli.runner.as_deref() == Some(runner_id.as_str())
     })
+}
+
+/// The coordinators that implement split placement: the coordinator itself
+/// stays controller-owned while each provider attempt is dispatched to the
+/// selected Lab runner (`run_split_placement_cook` /
+/// `run_split_placement_fanout`).
+///
+/// For these commands `--placement lab` is supported and documented guidance,
+/// even though their portability contract is `LocalOnly` — the contract
+/// describes the *coordinator*, not the attempt.
+fn split_placement_coordinator_label(command: &Commands) -> Option<&'static str> {
+    use crate::commands::agent_task::{
+        AgentTaskArgs, AgentTaskCommand, AgentTaskFanoutArgs, AgentTaskFanoutCommand,
+    };
+
+    match command {
+        Commands::AgentTask(AgentTaskArgs {
+            command: AgentTaskCommand::Cook(cook),
+        }) if !cook.dispatch.core.queue_only => Some("agent-task cook"),
+        Commands::AgentTask(AgentTaskArgs {
+            command:
+                AgentTaskCommand::Fanout(AgentTaskFanoutArgs {
+                    command: AgentTaskFanoutCommand::RunPlan(_),
+                }),
+        }) => Some("agent-task fanout run-plan"),
+        Commands::AgentTask(AgentTaskArgs {
+            command:
+                AgentTaskCommand::Fanout(AgentTaskFanoutArgs {
+                    command: AgentTaskFanoutCommand::CookBatch(args),
+                }),
+        }) if args.run_plan => Some("agent-task fanout cook-batch --run-plan"),
+        _ => None,
+    }
+}
+
+/// Explain a Lab placement that cannot be served, without contradicting the
+/// documented guidance.
+///
+/// Docs recommend global `--placement lab` for Cook waves, and the runtime
+/// honors it: the coordinator stays controller-owned while provider attempts go
+/// to the selected runner. When no runner can be selected, the generic
+/// portability rejection ("`--placement lab` is unavailable for this local-only
+/// command") is a contradiction the operator has to reverse-engineer (#9373).
+/// Report the real cause — no ready Lab runner — with the readiness verdict and
+/// its remediation commands instead.
+///
+/// `--placement lab-or-local` intentionally does not reach here: it authorizes
+/// controller execution when Lab cannot be served.
+fn split_placement_lab_runner_unavailable_error(
+    command: &Commands,
+    placement: homeboy::cli_surface::Placement,
+    inferred_runner_id: Option<&str>,
+    readiness: Option<&runners::LabRunnerReadiness>,
+) -> Option<Error> {
+    if placement != homeboy::cli_surface::Placement::Lab || inferred_runner_id.is_some() {
+        return None;
+    }
+    let label = split_placement_coordinator_label(command)?;
+    let state = readiness
+        .map(|readiness| readiness.state.as_str())
+        .unwrap_or("unknown");
+    let mut hints = Vec::new();
+    if let Some(readiness) = readiness {
+        hints.extend(
+            readiness
+                .reasons
+                .iter()
+                .map(|reason| format!("Lab runner readiness: {reason}")),
+        );
+        hints.extend(readiness.remediation_commands.iter().cloned());
+    }
+    hints.push(format!(
+        "`--placement lab` is the supported spelling for {label} waves: it selects the Lab runner for each provider attempt while the coordinator stays on this controller."
+    ));
+    hints.push(
+        "Pin one runner explicitly with `--runner <runner-id>` when several are configured."
+            .to_string(),
+    );
+    hints.push(
+        "Use `--placement lab-or-local` to authorize controller execution when no Lab runner is ready."
+            .to_string(),
+    );
+    Some(Error::validation_invalid_argument(
+        "placement",
+        format!(
+            "{label} accepts `--placement lab`, but no ready Lab runner could be selected (readiness: {state}); no provider attempt was dispatched"
+        ),
+        Some("lab".to_string()),
+        Some(hints),
+    ))
 }
 
 /// Fanout keeps durable batch state, worktree ownership, artifact ingestion,

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1953,3 +1953,155 @@ fn batch_fanout_exposes_placement_arguments() {
         }
     }
 }
+
+/// #9373: docs recommend global `--placement lab` for Cook waves and the
+/// runtime honors it, so a cook that CAN be served must never be reported as a
+/// command for which Lab placement is unavailable.
+#[test]
+fn split_placement_cook_accepts_lab_placement_when_a_runner_is_selected() {
+    let cli = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "lab",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "fixture@wave",
+        "--verify",
+        "true",
+        "--prompt",
+        "route this attempt to Lab",
+    ]);
+
+    assert!(
+        split_placement_lab_runner_unavailable_error(
+            &cli.command,
+            cli.placement,
+            Some("homeboy-lab"),
+            None,
+        )
+        .is_none(),
+        "a selected runner serves --placement lab instead of refusing it"
+    );
+}
+
+/// The failure an operator actually hits is "no ready Lab runner", not
+/// "`--placement lab` is unavailable for this local-only command". Reporting the
+/// portability contract there contradicts the documented wave guidance (#9373).
+#[test]
+fn split_placement_cook_without_a_runner_reports_readiness_not_a_placement_contradiction() {
+    let cli = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "lab",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "fixture@wave",
+        "--verify",
+        "true",
+        "--prompt",
+        "route this attempt to Lab",
+    ]);
+    let readiness = runners::LabRunnerReadiness {
+        state: runners::LabRunnerReadinessState::Disconnected,
+        selected_runner_id: None,
+        available_runner_ids: vec!["homeboy-lab".to_string()],
+        reasons: vec!["homeboy-lab is disconnected".to_string()],
+        remediation_commands: vec!["homeboy runner connect homeboy-lab".to_string()],
+    };
+
+    let error = split_placement_lab_runner_unavailable_error(
+        &cli.command,
+        cli.placement,
+        None,
+        Some(&readiness),
+    )
+    .expect("lab placement with no runner must be explained");
+
+    assert_eq!(error.details["field"].as_str(), Some("placement"));
+    let problem = error.details["problem"].as_str().expect("problem");
+    assert!(
+        problem.contains("accepts `--placement lab`"),
+        "guidance and runtime must agree: {problem}"
+    );
+    assert!(
+        problem.contains("disconnected"),
+        "the readiness verdict is the real cause: {problem}"
+    );
+    let hints = error.details["tried"]
+        .as_array()
+        .expect("remediation hints")
+        .iter()
+        .filter_map(|hint| hint.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        hints
+            .iter()
+            .any(|hint| hint.contains("homeboy runner connect homeboy-lab")),
+        "readiness remediation must be carried through: {hints:?}"
+    );
+    assert!(
+        hints
+            .iter()
+            .any(|hint| hint.contains("`--placement lab` is the supported spelling")),
+        "remediation must confirm the documented spelling: {hints:?}"
+    );
+}
+
+/// `--placement lab-or-local` authorizes controller execution, so it must keep
+/// falling back instead of failing when no runner is ready.
+#[test]
+fn lab_or_local_placement_still_falls_back_without_a_runner() {
+    let cli = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "lab-or-local",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "fixture@wave",
+        "--verify",
+        "true",
+        "--prompt",
+        "fall back locally",
+    ]);
+
+    assert!(
+        split_placement_lab_runner_unavailable_error(&cli.command, cli.placement, None, None)
+            .is_none()
+    );
+}
+
+/// Batch fanout is the documented one-command path for a wave, so it resolves
+/// Lab placement through the same contract as a single cook.
+#[test]
+fn split_placement_covers_batch_fanout_run_plan_coordinators() {
+    let batch = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "lab",
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "https://github.com/o/r/issues/1",
+        "https://github.com/o/r/issues/2",
+        "--repo",
+        "r",
+        "--verify",
+        "cargo test",
+        "--run-plan",
+    ]);
+
+    assert_eq!(
+        split_placement_coordinator_label(&batch.command),
+        Some("agent-task fanout cook-batch --run-plan")
+    );
+    assert!(split_placement_lab_runner_unavailable_error(
+        &batch.command,
+        batch.placement,
+        None,
+        None,
+    )
+    .is_some());
+}

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -33,6 +33,10 @@ const ADMISSION_QUEUE_POLL: Duration = Duration::from_millis(250);
 const ADMISSION_QUEUE_LEASE: Duration = Duration::from_secs(30);
 const ADMISSION_QUEUE_HEARTBEAT: Duration = Duration::from_secs(5);
 const ADMISSION_QUEUE_WAIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+/// How long an uncoordinated admission caller queues before reporting
+/// contention. Queued cook submissions use [`ADMISSION_QUEUE_WAIT_TIMEOUT`];
+/// this bound covers callers that hold no durable request identity.
+const ADMISSION_BUSY_WAIT: Duration = Duration::from_secs(30);
 
 fn admission_queue_lease() -> Duration {
     test_admission_duration(
@@ -52,6 +56,13 @@ fn admission_queue_wait_timeout() -> Duration {
     test_admission_duration(
         "HOMEBOY_TEST_CONTROLLER_ADMISSION_WAIT_TIMEOUT_MS",
         ADMISSION_QUEUE_WAIT_TIMEOUT,
+    )
+}
+
+fn admission_busy_wait() -> Duration {
+    test_admission_duration(
+        "HOMEBOY_TEST_CONTROLLER_ADMISSION_BUSY_WAIT_MS",
+        ADMISSION_BUSY_WAIT,
     )
 }
 
@@ -1067,8 +1078,34 @@ fn write_active_generation(path: &Path, runtime: &Value) -> Result<()> {
     })
 }
 
+/// Acquire admission for an uncoordinated caller: cleanup, generation
+/// activation, and pin migration/recovery carry no durable request ID, so they
+/// cannot join the FIFO queue that cook submissions use.
+///
+/// They must still not fast-fail the instant a parallel cook wave holds
+/// admission. Bounded queueing is strictly better than an immediate retryable
+/// error the operator has to re-run by hand (#9373): wait out a normal
+/// admission critical section (which is short — selection plus durable record
+/// creation), then surface the contention with a named owner.
 fn acquire_admission_lock(path: &Path) -> Result<AdmissionLock> {
-    acquire_admission_lock_for(path, &format!("controller-{}", Uuid::new_v4()))
+    acquire_admission_lock_bounded(path, admission_busy_wait())
+}
+
+fn acquire_admission_lock_bounded(path: &Path, wait: Duration) -> Result<AdmissionLock> {
+    let request_id = format!("controller-{}", Uuid::new_v4());
+    let started = std::time::Instant::now();
+    loop {
+        match acquire_admission_lock_for(path, &request_id) {
+            Ok(lock) => return Ok(lock),
+            Err(error) if error.retryable == Some(true) => {
+                if started.elapsed() >= wait {
+                    return Err(error);
+                }
+                std::thread::sleep(ADMISSION_QUEUE_POLL.min(wait));
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 fn acquire_admission_lock_for(path: &Path, request_id: &str) -> Result<AdmissionLock> {
@@ -1274,11 +1311,35 @@ fn replace_admission_owner_after_snapshot_for_test(_path: &Path) -> Result<()> {
 }
 
 fn admission_busy_error(path: &Path) -> Error {
-    Error::internal_unexpected(format!(
+    let mut error = Error::internal_unexpected(format!(
         "controller generation admission is currently owned by {}",
         admission_owner_summary(path)
     ))
-    .with_retryable(true)
+    .with_retryable(true);
+    error.details["controller_admission"] = admission_contention_evidence(path);
+    error
+}
+
+/// Structured contention evidence for an admission failure.
+///
+/// The rendered summary is the operator-facing sentence; this is the
+/// machine-readable form durable records and follow-up commands can join on, so
+/// a failed admission attempt is inspectable after the process exits (#9373).
+fn admission_contention_evidence(path: &Path) -> Value {
+    let queue = read_admission_queue(path).unwrap_or_else(
+        |_| json!({ "schema": ADMISSION_QUEUE_SCHEMA, "requests": [], "owner": null }),
+    );
+    let waiting = queue["requests"]
+        .as_array()
+        .map(|requests| requests.len())
+        .unwrap_or(0);
+    json!({
+        "owner_summary": admission_owner_summary(path),
+        "owner": queue["owner"],
+        "waiting_requests": waiting,
+        "advisory_lock_held": admission_lock_is_held(path),
+        "queueing": "controller admission is FIFO; concurrent requests wait their turn instead of racing",
+    })
 }
 
 #[cfg(test)]
@@ -1337,12 +1398,20 @@ fn acquire_queued_admission_lock_with_timeout(
             );
         }
         if started.elapsed() >= wait_timeout {
+            // Name the holder before the waiter is removed: an expired wait
+            // whose diagnostic cannot say who held admission is unactionable
+            // (#9373).
+            let owner = admission_owner_summary(path);
+            let evidence = admission_contention_evidence(path);
             remove_admission_request(path, request_id)?;
-            return Err(Error::internal_unexpected(format!(
-                "controller generation admission queue wait exceeded {}ms",
+            let mut error = Error::internal_unexpected(format!(
+                "controller generation admission queue wait exceeded {}ms; current owner: {owner}",
                 wait_timeout.as_millis()
             ))
-            .with_retryable(true));
+            .with_retryable(true);
+            error.details["controller_admission"] = evidence;
+            error.details["request_id"] = json!(request_id);
+            return Err(error);
         }
         if last_heartbeat.elapsed() >= admission_queue_heartbeat() {
             heartbeat_admission_waiter(path, request_id)?;
@@ -1654,19 +1723,97 @@ fn admission_owner_token(path: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Describe who currently holds controller-generation admission.
+///
+/// An admission error that cannot name its holder is unactionable by
+/// construction: `owned by unavailable` told operators nothing about whether to
+/// wait, retry, or repair (#9373). Resolution is therefore layered and always
+/// ends in a concrete, actionable state:
+///
+/// 1. the published owner record, including a verified liveness verdict;
+/// 2. the durable admission queue, which names the owning request even while
+///    the owner record is being rewritten between claim and publication;
+/// 3. the observable advisory-lock state, which distinguishes "held by a
+///    process that has not published ownership yet" from "free, retry now".
 fn admission_owner_summary(path: &Path) -> String {
-    let Ok(owner) = serde_json::from_slice::<Value>(&fs::read(path).unwrap_or_default()) else {
-        return "unavailable".to_string();
-    };
-    let pid = owner.get("pid").and_then(Value::as_u64);
-    let token = owner.get("token").and_then(Value::as_str);
+    admission_owner_record_summary(path)
+        .or_else(|| admission_queue_owner_summary(path))
+        .unwrap_or_else(|| admission_lock_state_summary(path))
+}
+
+fn admission_owner_record_summary(path: &Path) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    if bytes.is_empty() {
+        return None;
+    }
+    let owner = serde_json::from_slice::<Value>(&bytes).ok()?;
+    let token = owner.get("token").and_then(Value::as_str)?;
     let starttime = owner.get("linux_starttime_ticks").and_then(Value::as_u64);
-    match (pid, token, starttime) {
-        (Some(pid), Some(token), Some(starttime)) => {
-            format!("pid={pid}, linux_starttime_ticks={starttime}, token={token}")
+    let Some(pid) = owner
+        .get("pid")
+        .and_then(Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())
+    else {
+        // A legacy record fences a generation without naming a local process.
+        // It cannot protect a live owner, so the next attempt reclaims it.
+        return Some(format!(
+            "token={token} (legacy owner record with no PID; no live local process holds admission, so the next attempt reclaims it)"
+        ));
+    };
+    let liveness = admission_owner_liveness(pid, starttime);
+    Some(match starttime {
+        Some(starttime) => {
+            format!("pid={pid} ({liveness}), linux_starttime_ticks={starttime}, token={token}")
         }
-        (Some(pid), Some(token), None) => format!("pid={pid}, token={token}"),
-        _ => "unavailable".to_string(),
+        None => format!("pid={pid} ({liveness}), token={token}"),
+    })
+}
+
+fn admission_owner_liveness(pid: u32, starttime: Option<u64>) -> &'static str {
+    match crate::process::process_identity_state(pid, starttime) {
+        crate::process::ProcessIdentityState::Live => "live; wait for it to release admission",
+        crate::process::ProcessIdentityState::Dead => {
+            "already exited; the next attempt reclaims admission"
+        }
+        crate::process::ProcessIdentityState::IdentityMismatch => {
+            "PID reused by a different process; the next attempt reclaims admission"
+        }
+        crate::process::ProcessIdentityState::Unverifiable => {
+            "liveness unverifiable on this platform; admission stays protected until the owner record is reclaimed"
+        }
+    }
+}
+
+/// Name the owner recorded in the durable queue when the owner record itself is
+/// absent or mid-rewrite. The queue survives the owning process, so it is the
+/// only evidence that can name a holder across a controller restart.
+fn admission_queue_owner_summary(path: &Path) -> Option<String> {
+    let queue = read_admission_queue(path).ok()?;
+    let owner = queue.get("owner")?.as_object()?;
+    let request_id = owner.get("request_id").and_then(Value::as_str)?;
+    let Some(pid) = owner
+        .get("pid")
+        .and_then(Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())
+    else {
+        return Some(format!(
+            "admission request `{request_id}` (durable queue owner with no recorded PID; the queue entry outlives its process, so cancelling or completing that request releases admission)"
+        ));
+    };
+    let liveness = admission_owner_liveness(
+        pid,
+        owner.get("linux_starttime_ticks").and_then(Value::as_u64),
+    );
+    Some(format!(
+        "admission request `{request_id}`, pid={pid} ({liveness})"
+    ))
+}
+
+fn admission_lock_state_summary(path: &Path) -> String {
+    if admission_lock_is_held(path) {
+        "a controller that holds the advisory lock but has not published its owner record yet (it is still running, so retry — concurrent requests queue in FIFO order)".to_string()
+    } else {
+        "no live owner (the advisory lock is free and the owner record is absent or unreadable, so retry immediately)".to_string()
     }
 }
 
@@ -2497,6 +2644,126 @@ mod tests {
         assert!(error.message.contains("waited"));
         assert!(error.message.contains("pid="));
         assert!(error.message.contains("token="));
+    }
+
+    /// #9373: an admission diagnostic that cannot name its holder is
+    /// unactionable by construction. No resolution path may print the old
+    /// `unavailable` placeholder.
+    #[test]
+    fn admission_owner_summary_never_reports_unavailable() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let path = temporary.path().join(ADMISSION_LOCK_DIR);
+
+        let absent = admission_owner_summary(&path);
+        assert!(!absent.contains("unavailable"), "{absent}");
+        assert!(absent.contains("no live owner"), "{absent}");
+        assert!(absent.contains("retry"), "{absent}");
+
+        // A released guard truncates the record; the lock is free, so the
+        // summary must say retry rather than name a placeholder.
+        fs::write(&path, b"").expect("truncate owner record");
+        let released = admission_owner_summary(&path);
+        assert!(!released.contains("unavailable"), "{released}");
+        assert!(released.contains("retry"), "{released}");
+
+        // An unreadable record still resolves to observable lock state.
+        fs::write(&path, b"{ not json").expect("write malformed owner record");
+        let malformed = admission_owner_summary(&path);
+        assert!(!malformed.contains("unavailable"), "{malformed}");
+        assert!(malformed.contains("retry"), "{malformed}");
+
+        // A record without a PID names the fence and its reclaim consequence
+        // instead of dropping to a placeholder.
+        write_admission_owner(&path, &stale_admission_owner(None, None, "pidless"));
+        let pidless = admission_owner_summary(&path);
+        assert!(!pidless.contains("unavailable"), "{pidless}");
+        assert!(pidless.contains("token=pidless"), "{pidless}");
+        assert!(pidless.contains("reclaims"), "{pidless}");
+
+        // A live owner is named with a verified liveness verdict.
+        write_admission_owner(&path, &admission_owner_record("live-token"));
+        let live = admission_owner_summary(&path);
+        assert!(!live.contains("unavailable"), "{live}");
+        assert!(
+            live.contains(&format!("pid={}", std::process::id())),
+            "{live}"
+        );
+        assert!(live.contains("token=live-token"), "{live}");
+        assert!(live.contains("(live;"), "{live}");
+    }
+
+    /// The durable queue outlives the owning process, so it can name a holder
+    /// even while the owner record is being rewritten between claim and
+    /// publication (#9373).
+    #[test]
+    fn admission_owner_summary_falls_back_to_the_durable_queue_owner() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let path = temporary.path().join(ADMISSION_LOCK_DIR);
+        update_admission_queue(&path, |queue| {
+            queue["owner"] = json!({
+                "request_id": "agent-task-queued",
+                "pid": 4_294_967_294u64,
+                "linux_starttime_ticks": null,
+                "advisory_lock": true,
+            });
+        })
+        .expect("persist durable queue owner");
+
+        let summary = admission_owner_summary(&path);
+
+        assert!(!summary.contains("unavailable"), "{summary}");
+        assert!(summary.contains("agent-task-queued"), "{summary}");
+        assert!(summary.contains("pid=4294967294"), "{summary}");
+    }
+
+    /// A contended admission failure must carry machine-readable evidence, not
+    /// just a sentence: durable records and follow-up commands join on it.
+    #[test]
+    fn admission_busy_error_carries_named_owner_evidence() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let path = temporary.path().join(ADMISSION_LOCK_DIR);
+        write_admission_owner(&path, &admission_owner_record("busy-token"));
+
+        let error = admission_busy_error(&path);
+
+        assert_eq!(error.retryable, Some(true));
+        assert!(!error.message.contains("unavailable"), "{}", error.message);
+        assert!(error.message.contains("token=busy-token"));
+        assert!(error.details["controller_admission"]["owner_summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("token=busy-token")));
+        assert!(error.details["controller_admission"]["queueing"]
+            .as_str()
+            .is_some_and(|queueing| queueing.contains("FIFO")));
+    }
+
+    /// Uncoordinated callers (cleanup, generation activation, pin recovery)
+    /// carry no durable request ID and cannot join the FIFO queue. They must
+    /// still queue for a bounded window instead of fast-failing the moment a
+    /// parallel cook wave holds admission (#9373).
+    #[test]
+    fn uncoordinated_admission_queues_for_a_bounded_window_before_reporting_contention() {
+        let temporary = tempfile::tempdir().expect("temporary runtime directory");
+        let path = temporary.path().join(ADMISSION_LOCK_DIR);
+        let child = spawn_admission_lock_holder(&path, temporary.path(), false);
+
+        let started = std::time::Instant::now();
+        let attempt = acquire_admission_lock_bounded(&path, Duration::from_millis(400));
+        let waited = started.elapsed();
+        release_admission_lock_holder(child, temporary.path());
+        let error = attempt.expect_err("a live holder still wins the bounded wait");
+
+        assert!(
+            waited >= Duration::from_millis(400),
+            "bounded admission must queue, waited {waited:?}"
+        );
+        assert_eq!(error.retryable, Some(true));
+        assert!(error.message.contains("pid="), "{}", error.message);
+
+        // Once the holder releases, the same bounded acquisition succeeds.
+        let admission =
+            acquire_admission_lock_bounded(&path, Duration::ZERO).expect("released lock is free");
+        drop(admission);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -880,9 +880,16 @@ pub(super) fn resolve_lab_runner_selection_from_placement(
 /// The generic "portable commands are ..." hint left operators guessing which
 /// spelling was correct (#9373). This surfaces command-specific remediation so
 /// runtime behavior and guidance agree: for a cook/agent-task coordinator it
-/// explains that the coordinator stays local while its provider attempt already
-/// routes to Lab automatically, and points at the real levers
-/// (`--runner <runner-id>` to pin the Lab runner, `fanout` for waves).
+/// explains that the coordinator stays controller-owned while its provider
+/// attempt is dispatched to the selected Lab runner, and names the levers that
+/// select it (`--placement lab`, `--runner <runner-id>`, `fanout` for waves).
+///
+/// A split-placement coordinator that can serve `--placement lab` never reaches
+/// here: `route_after_parse` dispatches it (or reports that no Lab runner is
+/// ready) before placement resolution. What remains are the cases where the
+/// coordinator genuinely cannot place a provider attempt at all — for example a
+/// cook with no deterministic gate, or controller-local batch planning — so the
+/// remediation must not claim Lab placement is meaningless for cook waves.
 fn local_only_flag_rejection(
     field: &'static str,
     message: String,
@@ -892,13 +899,13 @@ fn local_only_flag_rejection(
     let mut hints = Vec::new();
     if hot_label.starts_with("agent-task cook") || hot_label.starts_with("agent-task fanout") {
         hints.push(
-            "The cook coordinator is controller-owned by design; its provider attempt already routes to the configured Lab runner automatically — no --placement lab needed.".to_string(),
+            "The cook coordinator is controller-owned by design: only its provider attempt is placed. `--placement lab` and `--runner <runner-id>` select the Lab runner for that attempt; neither offloads the coordinator.".to_string(),
         );
         hints.push(
-            "To pin a specific Lab runner for the provider attempt, pass `--runner <runner-id>` (not `--placement lab`).".to_string(),
+            "This invocation has no placeable provider attempt, so resolve the reason above first (for example, add a deterministic `--verify` gate to a cook).".to_string(),
         );
         hints.push(
-            "To fan out many independent cooks in one operation, use `homeboy agent-task fanout` so the batch coordinator dispatches each child cook's provider attempt to Lab.".to_string(),
+            "To fan out many independent cooks in one operation, use `homeboy agent-task fanout cook-batch --run-plan --placement lab` so the batch coordinator dispatches each child cook's provider attempt to Lab.".to_string(),
         );
     } else {
         hints.push(resolve_lab_runner_hint().hint);
@@ -991,10 +998,11 @@ mod placement_rejection_tests {
 
     #[test]
     fn placement_lab_on_cook_yields_cook_aware_remediation() {
-        // #9373: `--placement lab` on the controller-owned cook coordinator must
-        // not just report a generic "portable commands are ..." hint. It must
-        // explain that the provider attempt already routes to Lab and point at
-        // the correct lever (`--runner`), so guidance and runtime agree.
+        // #9373: `--placement lab` on a cook coordinator that has no placeable
+        // provider attempt must not report a generic "portable commands are ..."
+        // hint, and must not claim Lab placement is meaningless for cook waves
+        // (the documented spelling for a wave). It explains that placement
+        // selects the runner for the attempt and names the levers.
         let command = local_only_command(
             "agent-task cook/run-plan/retry --run",
             "agent-task cook is a controller-owned coordinator.",
@@ -1028,8 +1036,14 @@ mod placement_rejection_tests {
         assert!(
             hints
                 .iter()
-                .any(|hint| hint.contains("routes to the configured Lab runner automatically")),
-            "cook remediation must explain automatic Lab routing, got {hints:?}"
+                .any(|hint| hint.contains("select the Lab runner for that attempt")),
+            "cook remediation must explain what placement selects, got {hints:?}"
+        );
+        assert!(
+            !hints
+                .iter()
+                .any(|hint| hint.contains("no --placement lab needed")),
+            "cook remediation must not contradict documented wave guidance, got {hints:?}"
         );
         assert!(
             hints.iter().any(|hint| hint.contains("fanout")),

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -276,6 +276,22 @@ patch-producing `agent-task cook` waves that must not execute
 provider processes on the controller. If Lab routing cannot select or prepare a
 runner, Homeboy fails before local execution instead of falling back.
 
+`cook` and the batch fanout coordinators (`fanout run-plan`, `fanout cook-batch
+--run-plan`) use *split placement*: the coordinator always stays on the
+controller — it owns target resolution, the durable record, artifact ingestion,
+promotion, gates, and finalization — while each provider attempt is dispatched
+to the selected Lab runner. `--placement lab` and `--runner <runner-id>` select
+the runner for those attempts; neither offloads the coordinator itself. When no
+Lab runner is ready, these commands report the runner readiness verdict and its
+remediation commands rather than claiming Lab placement is unsupported. Use
+`--placement lab-or-local` to authorize controller execution as a fallback.
+
+Concurrent single-cook submissions do not race: controller-generation admission
+is a FIFO queue, so parallel cooks wait their turn and re-running an identical
+command after a contended attempt queues rather than collides. Admission
+diagnostics always name the current holder (PID, verified liveness, and the
+owning admission request) or the actionable lock state.
+
 Use global `--detach-after-handoff` with `--runner <runner-id>` when the Lab job is
 expected to outlive the local shell. Homeboy returns after the runner daemon
 accepts the job and prints follow/cancel commands instead of waiting for remote


### PR DESCRIPTION
Refs #9373

Verified the field report against current `main` first: much of it is already fixed. This PR reports what was already true and fixes what remained.

## Current admission locking model (as found on `main`)

`controller_runtime.rs` owns one admission critical section per Homeboy runtime root, built from three layers:

1. **Advisory lock** — `flock` on `<runtime-root>/admission.lock`. Authoritative while a process is alive.
2. **Owner record** — that same file's contents: `{schema, token, pid, linux_starttime_ticks}`. A stale owner is reclaimed only when its process identity is *provably* dead (PID + Linux starttime); `Live`, `IdentityMismatch`, and `Unverifiable` all fail closed.
3. **Durable FIFO queue** — `admission-queue.json` + `admission-queue.lock`, with per-waiter leases (30s), heartbeats (5s), and a bounded wait (10min). `admit_current_for*` and `pin_current_queued` enqueue, poll to head, then claim under the queue lock. `admission_status` / `cancel_admission` make a waiter observable and cancellable from another process.

Cook uses that queue twice: the pre-cook runtime seal (`pin_current_controller_runtime`) and the durable submission (`submit_plan` → `admit_current_for_with_cancellation_check`).

## Already fixed on `main` (not re-fixed here)

- **Concurrent Cooks colliding on the generation lock.** The FIFO queue landed in #9232 (2026-07-20) and the pre-cook seal was routed through it in `7665a333c` (2026-07-22). The field report's binary (`0.299.2+48ec12c76444`, 2026-07-21) predates the seal fix, which is exactly where `controller generation admission is currently owned by pid=...` came from: the seal used the non-queued `pin_current()`.
- **`--placement lab` on cook being rejected outright.** `run_split_placement_cook` / `run_split_placement_fanout` (#10283) already keep the coordinator controller-owned and dispatch the provider attempt to the selected Lab runner.
- **Durable evidence for a failed *submission* admission.** `submit_plan_with_runtime_admission` writes the run record and the `controller_admission` queue view *before* admitting, then `record_pre_execution_failure` terminalizes with a retryable classification.

## What this PR changes

**1. `owned by unavailable` is gone (`homeboy-core`).**
The placeholder was printed whenever the owner record was absent, empty (a released guard truncates it), or mid-rewrite between claiming the advisory lock and publishing ownership. Resolution is now layered and always ends in a concrete state:
- the published owner record, now with a verified liveness verdict (`live` / `already exited` / `PID reused` / `liveness unverifiable`);
- the durable admission queue, which names the owning *request* even across a controller restart;
- the observable advisory-lock state, distinguishing "held but not yet published — retry, requests queue FIFO" from "free — retry immediately".

Contended errors also carry machine-readable `details.controller_admission` (owner, waiting-request count, advisory-lock state), and the FIFO queue-wait timeout now names the owner it waited on instead of only reporting the elapsed budget.

**2. Bounded queueing for the remaining fast-fail callers (`homeboy-core`).**
`cleanup`, generation activation, and pin migration/recovery carry no durable request ID, so they cannot join the FIFO queue — they fast-failed the instant a cook wave held admission. They now queue for a bounded 30s window (`ADMISSION_BUSY_WAIT`, test-overridable) and only then report contention with a named owner. Cook's own paths keep the existing FIFO queue.

**3. `--placement lab` guidance and runtime now agree (`homeboy-cli` / `homeboy-lab-runner`).**
Split placement serves `--placement lab` when a runner is selectable, but when none was, cook and the fanout coordinators fell through to the generic portability rejection — *"`--placement lab` is unavailable for this local-only command"* — which contradicts the documented Cook-wave guidance and hides the real cause. `route_after_parse` now resolves Lab placement for split-placement coordinators (`cook`, `fanout run-plan`, `fanout cook-batch --run-plan`) before generic placement resolution and, when no runner can be selected, reports the Lab runner **readiness verdict plus its remediation commands**. `--placement lab-or-local` still falls back to the controller. The coordinator portability reasons and the local-only remediation hints no longer claim `--placement lab` is unnecessary, and `docs/commands/agent-task.md` documents split placement and FIFO admission.

**4. Resumable evidence when the *seal* loses admission (`homeboy-cli`).**
The pre-cook seal runs before any durable record exists, so its failure previously produced a bare retryable error. It now carries the admission request identity, the exact re-submittable command, and a hint that admission is FIFO. (Deliberately kept at the call site in `cli_runtime.rs` — the record-writing path is owned by #10419/#9163.)

## Tests

- `admission_owner_summary_never_reports_unavailable` — absent / empty / malformed / PID-less / live records all resolve to an actionable state.
- `admission_owner_summary_falls_back_to_the_durable_queue_owner`.
- `admission_busy_error_carries_named_owner_evidence`.
- `uncoordinated_admission_queues_for_a_bounded_window_before_reporting_contention` — asserts it *waits* rather than fast-fails, then succeeds once released.
- `split_placement_cook_accepts_lab_placement_when_a_runner_is_selected`, `..._reports_readiness_not_a_placement_contradiction`, `lab_or_local_placement_still_falls_back_without_a_runner`, `split_placement_covers_batch_fanout_run_plan_coordinators`.
- Updated `placement_lab_on_cook_yields_cook_aware_remediation` so the remediation can no longer contradict the documented wave guidance.

`cargo fmt` clean. Build/test intentionally left to CI.

## Remainder (not covered by this PR)

- **One-command wave over *existing* managed worktrees.** #9373 also asks for an ergonomic path for already-created worktrees, not just `cook-batch` worktree creation. Not addressed here.
- **End-to-end test with N existing issue-bound worktrees + a live Lab runner.** The acceptance test in the issue needs runner fixtures beyond this change's scope.
- **`fanout cook-batch` without `--run-plan`** (plan compilation only) still refuses a global `--placement lab`: it has no provider attempt to place. Accepting-and-ignoring the flag would silently discard operator intent, so it is left as-is; if a global wave flag should be tolerated there, that is a separate contract decision.