### PR TITLE
fix(test-scope): recognize monorepo member sources in changed-scope drift

### DIFF
--- a/crates/homeboy-extension/src/test/drift.rs
+++ b/crates/homeboy-extension/src/test/drift.rs
@@ -64,16 +64,30 @@ impl DriftOptions {
     }
 }
 
+/// Build match patterns for one set of configured directories.
+///
+/// Each directory yields two patterns: one anchored at the component root and
+/// one that matches the same directory at any depth. A monorepo keeps its real
+/// code in per-member subtrees — `crates/<member>/src`, `packages/<pkg>/src`,
+/// and so on — so a root-anchored `src/**` alone matches only the thin root
+/// package. Everything else silently reads as "not source", which disables both
+/// drift-based test selection and the `#8340` zero-selection guard that is
+/// supposed to fail closed. Matching the directory name at any depth keeps this
+/// language-agnostic: it is driven entirely by the configured directory names,
+/// with no build-system knowledge.
 fn glob_patterns(dirs: &[String], extensions: &[String]) -> Vec<String> {
     dirs.iter()
         .flat_map(|dir| {
-            extensions.iter().map(move |extension| {
+            extensions.iter().flat_map(move |extension| {
                 let extension = extension.trim_start_matches('.');
                 if dir.is_empty() || dir == "." {
-                    format!("**/*.{}", extension)
-                } else {
-                    format!("{}/**/*.{}", dir.trim_end_matches('/'), extension)
+                    return vec![format!("**/*.{}", extension)];
                 }
+                let dir = dir.trim_end_matches('/');
+                vec![
+                    format!("{dir}/**/*.{extension}"),
+                    format!("**/{dir}/**/*.{extension}"),
+                ]
             })
         })
         .collect()
@@ -1341,5 +1355,152 @@ class FooTest extends TestCase {
         let drifted = find_drift_references(&changes, &test_files, root);
         assert_eq!(drifted.len(), 1); // Only the actual code line, not comments
         assert_eq!(drifted[0].line, 4);
+    }
+}
+
+#[cfg(test)]
+mod workspace_layout_tests {
+    use super::*;
+    use crate::TestDriftConfig;
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn rust_extension_options() -> DriftOptions {
+        // Exactly what `.config/homeboy/extensions/rust/rust.json` declares.
+        DriftOptions::from_config(
+            Path::new("/repo"),
+            "HEAD~1",
+            &TestDriftConfig {
+                source_dirs: vec!["src".to_string()],
+                test_dirs: vec!["tests".to_string()],
+                file_extensions: vec!["rs".to_string()],
+                inline_tests: true,
+            },
+            &["rs".to_string()],
+        )
+    }
+
+    /// A Cargo workspace keeps its real code in `crates/<member>/src/**`, not in
+    /// the root package's `src/**`. The changed-scope test gate must recognize
+    /// those files as source; otherwise a change to any member crate is
+    /// invisible to drift detection AND to the `#8340` fail-closed guard, so the
+    /// gate reports green without running that crate's tests.
+
+    /// Drift detection must see a change inside a monorepo member crate as a
+    /// production change and route it to the test that references the changed
+    /// symbol. With only a root-anchored `src/**` pattern, `prod_files` was
+    /// empty for every `crates/<member>/src/**` edit, so `detect_drift` returned
+    /// early with zero drifted tests and the changed-scope gate selected nothing
+    /// from that crate.
+    #[test]
+    fn drift_selects_tests_for_workspace_member_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        run_git(root, &["init", "-q", "-b", "main"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+
+        std::fs::create_dir_all(root.join("crates/member/src")).unwrap();
+        std::fs::create_dir_all(root.join("tests")).unwrap();
+        std::fs::write(
+            root.join("crates/member/src/hydration.rs"),
+            "pub fn prepared_source_view_is_ready() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("tests/hydration_contract.rs"),
+            "fn check() { prepared_source_view_is_ready(); }\n",
+        )
+        .unwrap();
+        run_git(root, &["add", "crates", "tests"]);
+        run_git(root, &["commit", "-q", "-m", "initial"]);
+
+        std::fs::write(
+            root.join("crates/member/src/hydration.rs"),
+            "pub fn prepared_source_cache_is_ready() {}\n",
+        )
+        .unwrap();
+
+        let opts = DriftOptions::from_config(
+            root,
+            "HEAD",
+            &TestDriftConfig {
+                source_dirs: vec!["src".to_string()],
+                test_dirs: vec!["tests".to_string()],
+                file_extensions: vec!["rs".to_string()],
+                inline_tests: true,
+            },
+            &["rs".to_string()],
+        );
+
+        let report = detect_drift("fixture", &opts).expect("drift report");
+
+        assert!(
+            report
+                .production_changes
+                .iter()
+                .any(|change| change.old_symbol == "prepared_source_view_is_ready"),
+            "workspace member source change must be detected as production: {:?}",
+            report.production_changes
+        );
+        assert!(
+            report
+                .drifted_tests
+                .iter()
+                .any(|drifted| drifted.test_file.ends_with("hydration_contract.rs")),
+            "the referencing test must be selected: {:?}",
+            report.drifted_tests
+        );
+    }
+
+    #[test]
+    fn workspace_member_sources_are_source_relevant() {
+        let opts = rust_extension_options();
+
+        for path in [
+            "crates/homeboy-lab-runner/src/lab/offload/hydration.rs",
+            "crates/homeboy-core/src/daemon/stop.rs",
+            "crates/contracts/homeboy-audit-contract/src/finding.rs",
+        ] {
+            assert!(
+                is_source_relevant_change(&opts, path),
+                "workspace member source must be source-relevant: {path}"
+            );
+        }
+    }
+
+    /// The root package still counts, so the fix must widen coverage rather
+    /// than move it.
+    #[test]
+    fn root_package_sources_remain_source_relevant() {
+        let opts = rust_extension_options();
+
+        assert!(is_source_relevant_change(&opts, "src/lib.rs"));
+        assert!(is_source_relevant_change(
+            &opts,
+            "src/bin/bench-audit-self.rs"
+        ));
+    }
+
+    /// Docs and config must stay non-source so documentation-only PRs are not
+    /// forced to select tests.
+    #[test]
+    fn documentation_and_config_remain_non_source() {
+        let opts = rust_extension_options();
+
+        assert!(!is_source_relevant_change(&opts, "README.md"));
+        assert!(!is_source_relevant_change(&opts, "docs/commands/test.md"));
     }
 }

--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -949,8 +949,22 @@ mod tests {
 
         let opts = DriftOptions::from_config(dir.path(), "HEAD~1", &config, &["rs".to_string()]);
 
-        assert_eq!(opts.source_patterns, vec!["src/**/*.php", "inc/**/*.php"]);
-        assert_eq!(opts.test_patterns, vec!["tests/**/*.php"]);
+        // Each configured directory contributes a root-anchored pattern and an
+        // any-depth pattern so monorepo members (`packages/<pkg>/src`, ...) are
+        // recognized as source instead of silently reading as non-source.
+        assert_eq!(
+            opts.source_patterns,
+            vec![
+                "src/**/*.php",
+                "**/src/**/*.php",
+                "inc/**/*.php",
+                "**/inc/**/*.php"
+            ]
+        );
+        assert_eq!(
+            opts.test_patterns,
+            vec!["tests/**/*.php", "**/tests/**/*.php"]
+        );
     }
 
     #[test]
@@ -965,8 +979,11 @@ mod tests {
 
         let opts = DriftOptions::from_config(dir.path(), "HEAD~1", &config, &["rs".to_string()]);
 
-        assert_eq!(opts.source_patterns, vec!["src/**/*.rs"]);
-        assert_eq!(opts.test_patterns, vec!["tests/**/*.rs"]);
+        assert_eq!(opts.source_patterns, vec!["src/**/*.rs", "**/src/**/*.rs"]);
+        assert_eq!(
+            opts.test_patterns,
+            vec!["tests/**/*.rs", "**/tests/**/*.rs"]
+        );
     }
 
     #[test]
@@ -1552,7 +1569,11 @@ mod tests {
     }
 
     fn commit_change(root: &Path, rel: &str, contents: &str) {
-        fs::write(root.join(rel), contents).expect("write change");
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("change parent directory");
+        }
+        fs::write(path, contents).expect("write change");
         for args in [vec!["add", rel], vec!["commit", "-m", "change"]] {
             Command::new("git")
                 .args(&args)


### PR DESCRIPTION
Fixes #10449.

You asked why the differential Test gate didn't block the regressions. It wasn't `baseline_red` — I was wrong about that in the earlier thread. The real cause is worse.

## The gate cannot see `crates/**`

The Rust extension declares `drift.source_dirs: ["src"]`, and `glob_patterns` turned that into one root-anchored pattern, `src/**/*.rs`. `glob::Pattern::matches_path` is anchored, so:

| path | matches `src/**/*.rs` |
|---|---|
| `src/lib.rs` | yes |
| `crates/homeboy-core/src/daemon/stop.rs` | **no** |
| `crates/homeboy-lab-runner/src/lab/offload/hydration.rs` | **no** |

Since homeboy moved into `crates/*`, only the thin root package is visible to the scope engine. Two protections fail together, which is what makes it silent rather than noisy:

1. **Selection** — `detect_drift_for_changed_files` filters `prod_files` through the source patterns, gets an empty list, and returns early with zero drifted tests.
2. **Fail-closed** — `source_changes_without_tests` uses the same patterns, so the change never reaches the `#8340` guard that is supposed to fail closed on "source changed, zero tests selected".

So the gate ran no tests for the changed crate *and* reported that as legitimate.

## Proof from the actual merge

PR #10200 (`76c8c99a8`) changed `hydration.rs` and merged green. In its Test job log, `hydration.rs` appears **only in compiler warnings** — no `homeboy_lab_runner` test binary ran at all. The gate's verdict:

```
##[notice]Differential gate accepted review test: current=1 base=1
```

Both sides' one failure was the same unrelated pre-existing test, so the differential passed. That commit shipped the two regressions I fixed in #10431 — and both are covered by unit tests **inside the crate it edited**, which simply never ran. They stayed red on `main` for a day and were found by hand, not by CI.

## The fix

Emit an any-depth pattern alongside the anchored one for each configured directory (`src/**/*.rs` **and** `**/src/**/*.rs`).

Deliberately not Cargo-aware: it is driven entirely by the configured directory names, so it encodes no build-system knowledge (respecting the `core-agnostic-source` policy) and fixes every `<member>/src` monorepo layout — Rust crates, JS packages, PHP packages — rather than special-casing Cargo.

## Verification

Both new tests fail without the pattern change and pass with it — I flipped the fix out and back to confirm neither is vacuous:

| test | covers |
|---|---|
| `workspace_member_sources_are_source_relevant` | relevance / fail-closed half |
| `drift_selects_tests_for_workspace_member_sources` | selection half — asserts the referencing test is actually chosen |

Plus `root_package_sources_remain_source_relevant` and `documentation_and_config_remain_non_source` to pin that this widens coverage without dragging docs/config in.

```
cargo test -p homeboy-extension --lib test::     127 passed, 0 failed
cargo test -p homeboy-extension --lib            605 passed, 10 failed
```

Those 10 are pre-existing and environment-dependent on my host (toolchain path, provider discoverability, lab snapshot evidence) — identical set on unmodified `main`, which I verified by stashing. Net effect of this PR locally is 601→605 passed, same 10.

I also updated the two tests that pinned the exact pattern list, since the emitted set is the thing that changed.

## Tradeoff to weigh

This makes the gate stricter, and that is the point — but it is a real behavior change for **every** component, not just homeboy. Expect some PRs that previously passed on an empty selection to now either select tests or fail closed with the `#8340` message. That is the safe direction, and the Rust extension already widens to the full suite when a derived scope executes zero tests, so I don't expect a wall of red. Worth your call on timing, since the blast radius is fleet-wide.

Two follow-ups I did **not** touch:

- **`baseline_red` is warning-only** in `enforce-final-status.sh` — never sets `FAILED`. Separate softening, worth reviewing on its own merits.
- **The differential compares failure *counts*, not identities.** A PR that fixes one pre-existing failure and introduces a different one nets zero and passes.
