### PR TITLE
Reconcile terminal Lab workspace lifecycle leases

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -826,7 +826,7 @@ impl AgentTaskRunState {
     /// enumerate this set inline (`matches!(state, Succeeded | CandidateRecoverable
     /// | ...)`) delegates here, so adding or reclassifying a run state cannot
     /// leave a stale copy behind.
-    pub(crate) fn is_terminal(self) -> bool {
+    pub fn is_terminal(self) -> bool {
         matches!(
             self,
             AgentTaskRunState::Succeeded

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -2676,40 +2676,99 @@ fn workspace_liveness(
     metadata: &serde_json::Value,
     path: &Path,
 ) -> RunnerWorkspaceLivenessEvidence {
-    if (metadata
-        .get("job_id")
-        .and_then(|value| value.as_str())
-        .is_some()
-        || metadata
-            .get("run_id")
-            .and_then(|value| value.as_str())
-            .is_some())
-        && metadata
-            .get("resource_lifecycle")
-            .and_then(|value| value.get("status"))
-            .and_then(|value| value.as_str())
-            == Some("active")
-    {
-        return liveness("live", vec!["active_resource_lifecycle_lease".to_string()]);
-    }
+    let terminal_lifecycle_owner = match active_resource_lifecycle_liveness(metadata, |run_id| {
+        match homeboy_agents::agent_task_lifecycle::exact_record(run_id) {
+            Ok(record) if record.state.is_terminal() => RunAuthority::Terminal,
+            Ok(_) => RunAuthority::Active,
+            Err(_) => RunAuthority::Unavailable,
+        }
+    }) {
+        ActiveResourceLifecycleLiveness::Terminal(owner) => Some(owner),
+        ActiveResourceLifecycleLiveness::Live => {
+            return liveness("live", vec!["active_resource_lifecycle_lease".to_string()]);
+        }
+        ActiveResourceLifecycleLiveness::Unknown(observation) => {
+            return liveness("unknown", vec![observation.to_string()]);
+        }
+        ActiveResourceLifecycleLiveness::NotActive => None,
+    };
 
-    if let Some(job_id) = metadata.get("job_id").and_then(|value| value.as_str()) {
-        match super::super::status(&runner.id) {
-            Ok(report)
-                if report.active_job_state == super::super::RunnerActiveJobState::Available =>
-            {
-                if report.active_jobs.iter().any(|job| job.job_id == job_id) {
-                    return liveness("live", vec![format!("active_runner_job:{job_id}")]);
+    if terminal_lifecycle_owner.is_none() {
+        if let Some(job_id) = metadata.get("job_id").and_then(|value| value.as_str()) {
+            match super::super::status(&runner.id) {
+                Ok(report)
+                    if report.active_job_state == super::super::RunnerActiveJobState::Available =>
+                {
+                    if report.active_jobs.iter().any(|job| job.job_id == job_id) {
+                        return liveness("live", vec![format!("active_runner_job:{job_id}")]);
+                    }
+                }
+                Ok(_) => {
+                    return liveness("unknown", vec!["runner_job_probe_unavailable".to_string()]);
+                }
+                Err(_) => {
+                    return liveness("unknown", vec!["runner_job_probe_failed".to_string()]);
                 }
             }
-            Ok(_) => return liveness("unknown", vec!["runner_job_probe_unavailable".to_string()]),
-            Err(_) => return liveness("unknown", vec!["runner_job_probe_failed".to_string()]),
         }
     }
 
     match runner.kind {
         RunnerKind::Local => local_process_liveness(path),
         RunnerKind::Ssh => ssh_process_liveness(runner, &path.display().to_string()),
+    }
+}
+
+pub(crate) enum RunAuthority {
+    Terminal,
+    Active,
+    Unavailable,
+}
+
+pub(crate) enum ActiveResourceLifecycleLiveness {
+    NotActive,
+    Terminal(String),
+    Live,
+    Unknown(&'static str),
+}
+
+/// A run-owned active workspace lease is only superseded by its exact durable
+/// run. Conflicting ownership or unavailable run authority remains fail-closed.
+pub(crate) fn active_resource_lifecycle_liveness(
+    metadata: &serde_json::Value,
+    authority: impl FnOnce(&str) -> RunAuthority,
+) -> ActiveResourceLifecycleLiveness {
+    let Some(resource) = metadata.get("resource_lifecycle") else {
+        return ActiveResourceLifecycleLiveness::NotActive;
+    };
+    if resource.get("status").and_then(|value| value.as_str()) != Some("active") {
+        return ActiveResourceLifecycleLiveness::NotActive;
+    }
+    if metadata
+        .get("job_id")
+        .and_then(|value| value.as_str())
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        return ActiveResourceLifecycleLiveness::Live;
+    }
+    let Some(run_id) = metadata
+        .get("run_id")
+        .and_then(|value| value.as_str())
+        .filter(|id| !id.trim().is_empty())
+    else {
+        return ActiveResourceLifecycleLiveness::NotActive;
+    };
+    if resource.get("run_id").and_then(|value| value.as_str()) != Some(run_id) {
+        return ActiveResourceLifecycleLiveness::Unknown(
+            "active_resource_lifecycle_owner_ambiguous",
+        );
+    }
+    match authority(run_id) {
+        RunAuthority::Terminal => ActiveResourceLifecycleLiveness::Terminal(run_id.to_string()),
+        RunAuthority::Active => ActiveResourceLifecycleLiveness::Live,
+        RunAuthority::Unavailable => ActiveResourceLifecycleLiveness::Unknown(
+            "active_resource_lifecycle_authority_unavailable",
+        ),
     }
 }
 
@@ -3115,19 +3174,27 @@ fn remove_prune_candidate(
             remove_workspace(runner, root, &candidate.remote_path)?;
             Ok(None)
         }
-        RunnerKind::Ssh => remove_ssh_prune_candidate(runner, root, &candidate.remote_path),
+        RunnerKind::Ssh => remove_ssh_prune_candidate(runner, root, candidate),
     }
 }
 
 fn remove_ssh_prune_candidate(
     runner: &super::super::Runner,
     root: &str,
-    remote_path: &str,
+    candidate: &RunnerWorkspacePruneEntry,
 ) -> Result<Option<RunnerWorkspaceLivenessEvidence>> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
+    let terminal_owner_run_id = candidate.run_id.as_deref().filter(|run_id| {
+        homeboy_agents::agent_task_lifecycle::exact_record(run_id)
+            .is_ok_and(|record| record.state.is_terminal())
+    });
     let output = client.execute_with_timeout(
-        &ssh_prune_delete_command(root, remote_path),
+        &ssh_prune_delete_command_with_terminal_owner(
+            root,
+            &candidate.remote_path,
+            terminal_owner_run_id,
+        ),
         WORKSPACE_PRUNE_TIMEOUT,
     );
     if !output.success {
@@ -3158,8 +3225,17 @@ fn remove_ssh_prune_candidate(
 }
 
 pub(crate) fn ssh_prune_delete_command(root: &str, remote_path: &str) -> String {
+    ssh_prune_delete_command_with_terminal_owner(root, remote_path, None)
+}
+
+pub(crate) fn ssh_prune_delete_command_with_terminal_owner(
+    root: &str,
+    remote_path: &str,
+    terminal_owner_run_id: Option<&str>,
+) -> String {
+    let owner = shell::quote_arg(terminal_owner_run_id.unwrap_or(""));
     format!(
-        "root={root}; p={path}; meta_rel={meta}; case \"$p\" in \"$root\"/*) ;; *) printf unknown:workspace_path; exit 0 ;; esac; meta=\"$p/$meta_rel\"; [ -f \"$meta\" ] && grep -Eq '\"schema\"[[:space:]]*:[[:space:]]*\"homeboy/runner-workspace/v1\"' \"$meta\" || {{ printf unknown:metadata; exit 0; }}; if grep -Eq '\"status\"[[:space:]]*:[[:space:]]*\"active\"' \"$meta\"; then printf live:active_resource_lifecycle_lease; exit 0; fi; command -v ps >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1 || {{ printf unknown:process_probe_unavailable; exit 0; }}; ps_output=$(ps -eo pid=,ppid=,args=) || {{ printf unknown:process_probe_failed; exit 0; }}; printf '%s\\n' \"$ps_output\" | awk -v p=\"$p\" -v self=\"$$\" -v parent=\"$PPID\" '$1 != self && $1 != parent && $2 != self && index($0, p) {{ found=1 }} END {{ exit !found }}'; state=$?; [ \"$state\" -eq 0 ] && {{ printf live:remote_process_ownership; exit 0; }}; [ \"$state\" -eq 1 ] || {{ printf unknown:process_probe_failed; exit 0; }}; cwd=$(lsof -Fn -a -d cwd +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$cwd\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$cwd\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; open=$(lsof -Fn +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$open\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$open\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; rm -rf -- \"$p\" && printf removed || printf unknown:delete_failed",
+        "root={root}; p={path}; meta_rel={meta}; owner={owner}; case \"$p\" in \"$root\"/*) ;; *) printf unknown:workspace_path; exit 0 ;; esac; meta=\"$p/$meta_rel\"; [ -f \"$meta\" ] && grep -Eq '\"schema\"[[:space:]]*:[[:space:]]*\"homeboy/runner-workspace/v1\"' \"$meta\" || {{ printf unknown:metadata; exit 0; }}; if grep -Eq '\"status\"[[:space:]]*:[[:space:]]*\"active\"' \"$meta\"; then compact=$(tr -d '[:space:]' < \"$meta\") || {{ printf unknown:metadata; exit 0; }}; [ -n \"$owner\" ] && [ \"$(printf '%s' \"$compact\" | grep -Fo -- \"\\\"run_id\\\":\\\"$owner\\\"\" | wc -l | tr -d ' ')\" -ge 2 ] || {{ printf live:active_resource_lifecycle_lease; exit 0; }}; fi; command -v ps >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1 || {{ printf unknown:process_probe_unavailable; exit 0; }}; ps_output=$(ps -eo pid=,ppid=,args=) || {{ printf unknown:process_probe_failed; exit 0; }}; printf '%s\\n' \"$ps_output\" | awk -v p=\"$p\" -v self=\"$$\" -v parent=\"$PPID\" '$1 != self && $1 != parent && $2 != self && index($0, p) {{ found=1 }} END {{ exit !found }}'; state=$?; [ \"$state\" -eq 0 ] && {{ printf live:remote_process_ownership; exit 0; }}; [ \"$state\" -eq 1 ] || {{ printf unknown:process_probe_failed; exit 0; }}; cwd=$(lsof -Fn -a -d cwd +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$cwd\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$cwd\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; open=$(lsof -Fn +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$open\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$open\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; rm -rf -- \"$p\" && printf removed || printf unknown:delete_failed",
         root = shell::quote_arg(root),
         path = shell::quote_arg(remote_path),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -4,8 +4,11 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use crate::workspace::sync::{
-    prune_scan_command, prune_workspaces, ssh_process_liveness_command, ssh_prune_delete_command,
-    sync_workspace, update_workspace_resource_lifecycle, WORKSPACE_METADATA_FILE,
+    active_resource_lifecycle_liveness, prune_scan_command, prune_workspaces,
+    ssh_process_liveness_command, ssh_prune_delete_command,
+    ssh_prune_delete_command_with_terminal_owner, sync_workspace,
+    update_workspace_resource_lifecycle, ActiveResourceLifecycleLiveness, RunAuthority,
+    WORKSPACE_METADATA_FILE,
 };
 use crate::workspace::types::{
     RunnerWorkspacePruneOptions, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
@@ -222,6 +225,44 @@ fn prune_preserves_active_job_lifecycle_lease() {
         assert_eq!(output.skipped_live_count, 1);
         assert!(workspace.exists());
     });
+}
+
+#[test]
+fn active_lifecycle_lease_requires_unambiguous_terminal_run_authority() {
+    let metadata = active_lifecycle_metadata("run-terminal", "run-terminal");
+    assert!(matches!(
+        active_resource_lifecycle_liveness(&metadata, |_| RunAuthority::Terminal),
+        ActiveResourceLifecycleLiveness::Terminal(owner) if owner == "run-terminal"
+    ));
+    assert!(matches!(
+        active_resource_lifecycle_liveness(&metadata, |_| RunAuthority::Active),
+        ActiveResourceLifecycleLiveness::Live
+    ));
+    assert!(matches!(
+        active_resource_lifecycle_liveness(&metadata, |_| RunAuthority::Unavailable),
+        ActiveResourceLifecycleLiveness::Unknown("active_resource_lifecycle_authority_unavailable")
+    ));
+
+    let absent = serde_json::json!({ "resource_lifecycle": { "status": "active" } });
+    assert!(matches!(
+        active_resource_lifecycle_liveness(&absent, |_| RunAuthority::Terminal),
+        ActiveResourceLifecycleLiveness::NotActive
+    ));
+
+    let job_owned = serde_json::json!({
+        "job_id": "active-job",
+        "resource_lifecycle": { "status": "active" }
+    });
+    assert!(matches!(
+        active_resource_lifecycle_liveness(&job_owned, |_| RunAuthority::Terminal),
+        ActiveResourceLifecycleLiveness::Live
+    ));
+
+    let ambiguous = active_lifecycle_metadata("run-terminal", "other-run");
+    assert!(matches!(
+        active_resource_lifecycle_liveness(&ambiguous, |_| RunAuthority::Terminal),
+        ActiveResourceLifecycleLiveness::Unknown("active_resource_lifecycle_owner_ambiguous")
+    ));
 }
 
 #[test]
@@ -917,6 +958,91 @@ fn ssh_shaped_prune_delete_revalidates_lifecycle_and_deletes_atomically() {
     assert!(active.exists());
 }
 
+#[test]
+fn ssh_terminal_lifecycle_delete_revalidates_process_ownership() {
+    let root = tempfile::tempdir().expect("workspace root");
+    let workspace = root.path().join("_lab_workspaces/terminal");
+    write_orphan_workspace(&workspace);
+    let metadata_path = workspace.join(WORKSPACE_METADATA_FILE);
+    fs::write(
+        &metadata_path,
+        active_lifecycle_metadata("terminal-run", "terminal-run").to_string(),
+    )
+    .expect("write terminal lifecycle metadata");
+
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg("sleep 30")
+        .current_dir(&workspace)
+        .spawn()
+        .expect("hold workspace cwd after terminal authority");
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(ssh_prune_delete_command_with_terminal_owner(
+            &root.path().join("_lab_workspaces").display().to_string(),
+            &workspace.display().to_string(),
+            Some("terminal-run"),
+        ))
+        .output()
+        .expect("revalidate process ownership before terminal lifecycle delete");
+
+    child.kill().expect("stop held process");
+    child.wait().expect("reap held process");
+    assert!(output.status.success(), "{output:?}");
+    assert_ne!(String::from_utf8_lossy(&output.stdout), "removed");
+    assert!(workspace.exists());
+}
+
+#[test]
+fn ssh_terminal_lifecycle_delete_requires_matching_owner_in_pretty_metadata() {
+    let root = tempfile::tempdir().expect("workspace root");
+    let workspaces = root.path().join("_lab_workspaces");
+    let terminal = workspaces.join("terminal");
+    write_orphan_workspace(&terminal);
+    fs::write(
+        terminal.join(WORKSPACE_METADATA_FILE),
+        serde_json::to_string_pretty(&active_lifecycle_metadata("terminal-run", "terminal-run"))
+            .expect("pretty terminal metadata"),
+    )
+    .expect("write terminal lifecycle metadata");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(ssh_prune_delete_command_with_terminal_owner(
+            &workspaces.display().to_string(),
+            &terminal.display().to_string(),
+            Some("terminal-run"),
+        ))
+        .output()
+        .expect("delete terminal-owned workspace");
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "removed");
+    assert!(!terminal.exists());
+
+    let ambiguous = workspaces.join("ambiguous");
+    write_orphan_workspace(&ambiguous);
+    fs::write(
+        ambiguous.join(WORKSPACE_METADATA_FILE),
+        active_lifecycle_metadata("terminal-run", "other-run").to_string(),
+    )
+    .expect("write ambiguous lifecycle metadata");
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(ssh_prune_delete_command_with_terminal_owner(
+            &workspaces.display().to_string(),
+            &ambiguous.display().to_string(),
+            Some("terminal-run"),
+        ))
+        .output()
+        .expect("retain ambiguous workspace");
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "live:active_resource_lifecycle_lease"
+    );
+    assert!(ambiguous.exists());
+}
+
 fn sync_options(path: String) -> RunnerWorkspaceSyncOptions {
     RunnerWorkspaceSyncOptions {
         path,
@@ -942,4 +1068,16 @@ fn write_orphan_workspace(path: &Path) {
         .to_string(),
     )
     .expect("workspace metadata");
+}
+
+fn active_lifecycle_metadata(run_id: &str, resource_run_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "schema": "homeboy/runner-workspace/v1",
+        "run_id": run_id,
+        "local_path": "/missing/source",
+        "resource_lifecycle": {
+            "run_id": resource_run_id,
+            "status": "active"
+        }
+    })
 }


### PR DESCRIPTION
## Summary

- reconcile stale active Lab workspace lifecycle markers only when the exact durable owning run is terminal
- preserve active job, unavailable authority, ambiguous ownership, and process/open-file safety gates
- atomically revalidate terminal ownership for SSH deletion across compact and pretty metadata

## Verification

- `cargo fmt --check`
- `env -u TMPDIR cargo test -p homeboy-lab-runner workspace::tests::prune` (18 passed)
- real `homeboy-lab` preview: 3 terminal-owned candidates in the first 25 entries, zero live/unknown selections

Closes #10443

## AI assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode with Homeboy
- Used for: investigated Lab lifecycle evidence, drafted and refined the implementation, added deterministic safety coverage, and validated the candidate against the real Lab preview. Chris Huber reviewed the resulting diff and remains responsible for every line.