### PR TITLE
Fix explicit runner resource guidance

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1171,12 +1171,30 @@ fn preflight_hot_command(
                         })
                     })
             };
-            let warning = resource_policy::evaluate_with_runner_hint(
-                hot_command,
-                &resources,
-                lab_readiness.as_ref(),
-            );
+            let explicit_runner_placement = explicit_runner_placement(cli, hot_command);
+            // An explicit runner resolves workload placement before resource
+            // guidance. Controller pressure still matters for handoff overhead,
+            // but it must not be presented as a local workload warning.
+            let warning = explicit_runner_placement
+                .is_none()
+                .then(|| {
+                    resource_policy::evaluate_with_runner_hint(
+                        hot_command,
+                        &resources,
+                        lab_readiness.as_ref(),
+                    )
+                })
+                .flatten();
             let runner_hosted = resource_policy::is_runner_hosted_exec();
+            if let Some(runner_id) = explicit_runner_placement {
+                if let Some(notice) = resource_policy::explicit_runner_controller_notice(
+                    hot_command,
+                    &resources,
+                    runner_id,
+                ) {
+                    eprintln!("{notice}");
+                }
+            }
             if let Some(warning) = warning.as_ref() {
                 if !matches!(cli.placement, crate::cli_surface::Placement::Local) && !runner_hosted
                 {
@@ -1204,6 +1222,7 @@ fn preflight_hot_command(
                 && !matches!(cli.placement, crate::cli_surface::Placement::Local)
             {
                 resource_policy_context.runner_selection.reason = "explicit_lab_runner".to_string();
+                resource_policy_context.runner_selection.runner_id = cli.runner.clone();
             }
             resource_policy::capture_context(resource_policy_context);
             if let Some(warning) = warning.as_ref() {
@@ -1238,6 +1257,16 @@ fn resource_policy_runner_hint<'a>(
     default_runner: Option<&'a str>,
 ) -> Option<&'a str> {
     cli.runner.as_deref().or(default_runner)
+}
+
+fn explicit_runner_placement<'a>(
+    cli: &'a Cli,
+    hot_command: resource_policy::HotCommand,
+) -> Option<&'a str> {
+    cli.runner.as_deref().filter(|_| {
+        hot_command.lab_offload_supported
+            && !matches!(cli.placement, crate::cli_surface::Placement::Local)
+    })
 }
 
 fn run_startup_update_checks(command: &Commands) {
@@ -2244,6 +2273,42 @@ mod tests {
             assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
             assert!(hot_command.lab_offload_supported);
             assert_eq!(hot_command.label, *label);
+        }
+    }
+
+    #[test]
+    fn explicit_runner_resolves_worktree_cleanup_placement_for_dry_run_and_apply() {
+        for args in [
+            [
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "worktree",
+                "cleanup",
+                "--dry-run",
+            ]
+            .as_slice(),
+            [
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "worktree",
+                "cleanup",
+                "--apply",
+            ]
+            .as_slice(),
+        ] {
+            let cli = Cli::try_parse_from(args).expect("parse runner-pinned cleanup command");
+            let hot_command = resource_policy::hot_command(&cli.command)
+                .expect("worktree cleanup is resource managed");
+
+            assert!(hot_command.lab_offload_supported);
+            assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+            assert_eq!(
+                explicit_runner_placement(&cli, hot_command),
+                Some("homeboy-lab"),
+                "resource preflight resolves explicit runner placement before warning"
+            );
         }
     }
 

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/messages.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/messages.rs
@@ -101,6 +101,20 @@ pub(super) fn warning_message(
     )
 }
 
+pub(super) fn runner_pinned_controller_notice(
+    command: HotCommand,
+    recommendation: ResourceRecommendation,
+    resources: &DoctorOutput,
+    runner_id: &str,
+) -> String {
+    let severity = severity_str(recommendation);
+    let reason = primary_reason(resources);
+    format!(
+        "Resource policy: controller is {severity}. {reason} Workload `{}` is routed to Lab runner `{runner_id}`. Controller preflight and transport overhead remain local; Lab offload reports any authorized local fallback separately.",
+        command.label,
+    )
+}
+
 fn primary_reason(resources: &DoctorOutput) -> String {
     if resources.load.recommendation == ResourceRecommendation::Hot
         || resources.load.recommendation == ResourceRecommendation::Warm

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -12,7 +12,10 @@ use classification::{
     is_bounded_agent_task_metadata_read, is_controller_owned_fanout_coordination,
     is_lab_offloadable_fanout_coordinator, is_local_registry_management, is_plan_only_command,
 };
-use messages::{append_local_placement, primary_action, severity_str, warning_message};
+use messages::{
+    append_local_placement, primary_action, runner_pinned_controller_notice, severity_str,
+    warning_message,
+};
 
 // The captured resource-policy context type, its process-wide store, and the
 // runner-placement environment probes moved to `core::resource_policy_context`
@@ -299,6 +302,22 @@ pub fn evaluate_with_runner_hint(
     })
 }
 
+/// Describe controller-side pressure for a workload explicitly routed to a Lab
+/// runner. This is placement evidence, not a local-execution warning: the
+/// runner handoff owns reporting an authorized fallback if remote preparation
+/// later fails.
+pub fn explicit_runner_controller_notice(
+    command: HotCommand,
+    resources: &DoctorOutput,
+    runner_id: &str,
+) -> Option<String> {
+    command
+        .engages_resource_admission(resources.recommendation)
+        .then(|| {
+            runner_pinned_controller_notice(command, resources.recommendation, resources, runner_id)
+        })
+}
+
 /// Cook keeps durable coordination, promotion, and gates on the controller,
 /// but its provider attempt can be pinned to Lab. An explicitly selected ready
 /// runner lets the controller admit that lightweight coordination under warm or
@@ -564,6 +583,24 @@ mod tests {
         assert!(warning.message.contains("Lab runner `homeboy-lab`"));
         assert!(warning.message.contains("--runner homeboy-lab"));
         assert!(!warning.message.contains("--runner <id>"));
+    }
+
+    #[test]
+    fn explicit_runner_notice_separates_controller_overhead_from_runner_workload() {
+        let notice = explicit_runner_controller_notice(
+            lab_supported_hot("worktree cleanup"),
+            &resources(ResourceRecommendation::Warm),
+            "homeboy-lab",
+        )
+        .expect("warm controller reports its own overhead");
+
+        assert!(notice.contains("controller is warm"));
+        assert!(
+            notice.contains("Workload `worktree cleanup` is routed to Lab runner `homeboy-lab`")
+        );
+        assert!(notice.contains("Controller preflight and transport overhead remain local"));
+        assert!(!notice.contains("starting `worktree cleanup` locally"));
+        assert!(!notice.contains("--runner"));
     }
 
     #[test]

--- a/docs/reference/cli/homeboy-root-command.md
+++ b/docs/reference/cli/homeboy-root-command.md
@@ -42,6 +42,11 @@ commands, Homeboy auto-selects the default runner when `--runner` is omitted.
 Use `--placement local` only when controller-machine execution is intentional;
 use `--placement lab` when local fallback is unacceptable. Removed placement
 flags are rejected with a migration error; Homeboy provides no legacy support.
+When `--runner <RUNNER_ID>` explicitly routes a portable command, resource
+output reports controller preflight and transport overhead separately from the
+runner workload; it does not recommend the supplied runner again or describe
+the workload as starting locally. Any authorized local fallback is reported by
+the Lab offload transition with its exact reason.
 
 Not every hot command is offloadable. Lab offload only applies to commands with
 a portable runner contract; local-only hot commands keep running locally and


### PR DESCRIPTION
## Summary
- resolve explicit portable `--runner` selection before rendering resource-policy guidance
- report controller preflight and transport overhead without claiming the workload starts locally or suggesting the supplied flag
- preserve explicit runner identity in resource-policy evidence and cover dry-run/apply cleanup routing

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli explicit_runner_resolves_worktree_cleanup_placement_for_dry_run_and_apply --lib`
- `cargo test -p homeboy-cli explicit_runner_notice_separates_controller_overhead_from_runner_workload --lib`
- `cargo check -p homeboy-cli`

Closes #10159

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode provided substantive implementation and testing assistance. Chris is responsible for every line.