### PR TITLE
fix(lab): validate prepared source outputs

### DIFF
--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -298,6 +298,24 @@ pub struct DependencyInstallPlanStep {
     /// Portable install invocation the runner can execute without receiving a
     /// controller-local extension path.
     pub invocation: DependencyInstallInvocation,
+    /// Filesystem outputs that prove this provider's install/build preparation
+    /// is present in a materialized workspace.
+    pub outputs: Vec<DependencyInstallOutput>,
+}
+
+/// A provider-declared output required before a prepared source can be reused.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyInstallOutput {
+    pub path: String,
+    pub kind: DependencyInstallOutputKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyInstallOutputKind {
+    Path,
+    File,
+    Directory,
 }
 
 /// An install command suitable for crossing a controller/runner boundary.
@@ -357,6 +375,7 @@ pub fn dependency_install_plan(path: &Path) -> Result<Vec<DependencyInstallPlanS
             steps.push(DependencyInstallPlanStep {
                 provider_id: status.package_manager,
                 invocation: dependency_install_invocation(command.argv())?,
+                outputs: provider.install_outputs()?,
             });
         }
     }

--- a/crates/homeboy-core/src/deps_provider.rs
+++ b/crates/homeboy-core/src/deps_provider.rs
@@ -1,5 +1,8 @@
 use crate::component::Component;
-use crate::deps::{DependencyCommandResult, DependencyPackage, DependencyUpdateResult};
+use crate::deps::{
+    DependencyCommandResult, DependencyInstallOutput, DependencyInstallOutputKind,
+    DependencyPackage, DependencyUpdateResult,
+};
 use crate::extension_execution::ExtensionExecutionContext;
 use crate::{paths, Error, Result};
 use homeboy_extension_contract::ExtensionCapability;
@@ -159,6 +162,16 @@ impl DependencyProvider {
             DependencyProvider::Adapter(provider) => provider.install_command(context),
             DependencyProvider::ComponentScript(provider) => provider.install_command(context),
             DependencyProvider::Extension(provider) => provider.install_command(context),
+        }
+    }
+
+    pub(crate) fn install_outputs(&self) -> Result<Vec<DependencyInstallOutput>> {
+        match self {
+            DependencyProvider::Manifest(provider) => provider.install_outputs(),
+            DependencyProvider::Adapter(provider) => provider.install_outputs(),
+            DependencyProvider::Extension(_) | DependencyProvider::ComponentScript(_) => {
+                Ok(Vec::new())
+            }
         }
     }
 }
@@ -357,6 +370,10 @@ impl AdapterDependencyProvider {
             vec!["-c".to_string(), command.command.clone()],
             self.adapter.project_path.clone(),
         )
+    }
+
+    fn install_outputs(&self) -> Result<Vec<DependencyInstallOutput>> {
+        dependency_install_outputs(&self.adapter.package_manager().outputs)
     }
 
     fn run(&self, command: &AdapterCommand, operation: &str) -> Result<DependencyCommandResult> {
@@ -685,6 +702,24 @@ struct AdapterPackageManager {
     commands: AdapterCommands,
     #[serde(default)]
     package_identity: Option<AdapterPackageIdentity>,
+    #[serde(default)]
+    outputs: Vec<DependencyAdapterOutput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DependencyAdapterOutput {
+    path: PathBuf,
+    #[serde(default)]
+    kind: DependencyAdapterOutputKind,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+enum DependencyAdapterOutputKind {
+    #[default]
+    Path,
+    File,
+    Directory,
 }
 
 impl AdapterPackageManager {
@@ -779,6 +814,10 @@ impl ManifestDependencyProvider {
             .map(|cwd| context.path.join(cwd))
             .unwrap_or_else(|| context.path.to_path_buf());
         DependencyProviderCommand::new(program, args, cwd)
+    }
+
+    fn install_outputs(&self) -> Result<Vec<DependencyInstallOutput>> {
+        dependency_install_outputs(&self.manifest.outputs)
     }
 
     fn status_with_filter(&self, package_filter: Option<&str>) -> ProviderDependencyStatus {
@@ -892,6 +931,42 @@ struct DependencyAdapterManifest {
     packages: Vec<DependencyPackage>,
     #[serde(default)]
     commands: DependencyAdapterCommands,
+    #[serde(default)]
+    outputs: Vec<DependencyAdapterOutput>,
+}
+
+fn dependency_install_outputs(
+    outputs: &[DependencyAdapterOutput],
+) -> Result<Vec<DependencyInstallOutput>> {
+    outputs
+        .iter()
+        .map(|output| {
+            if output.path.as_os_str().is_empty()
+                || output.path.is_absolute()
+                || output
+                    .path
+                    .components()
+                    .any(|component| matches!(component, std::path::Component::ParentDir))
+            {
+                return Err(Error::validation_invalid_argument(
+                    "dependency_provider.outputs",
+                    "dependency output paths must be non-empty and relative to the workspace",
+                    Some(output.path.display().to_string()),
+                    None,
+                ));
+            }
+            Ok(DependencyInstallOutput {
+                path: output.path.display().to_string(),
+                kind: match output.kind {
+                    DependencyAdapterOutputKind::Path => DependencyInstallOutputKind::Path,
+                    DependencyAdapterOutputKind::File => DependencyInstallOutputKind::File,
+                    DependencyAdapterOutputKind::Directory => {
+                        DependencyInstallOutputKind::Directory
+                    }
+                },
+            })
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -143,7 +143,7 @@ fn hydrate_lab_workspace_dependencies_for_run(
     // and — because the probe is a raw exec — made hydration fail outright on
     // any runner not explicitly trusted with `allow_raw_exec`, even though
     // those workspaces never needed to reach the runner at all.
-    if prepared_source_view_is_ready(runner_id, remote_path)? {
+    if prepared_source_view_is_ready(runner_id, remote_path, &plan)? {
         return Ok(LabWorkspaceHydrationOutput::reused_prepared_cache(
             remote_path,
         ));
@@ -187,16 +187,35 @@ fn hydrate_lab_workspace_dependencies_for_run(
     })
 }
 
-fn prepared_source_view_is_ready(runner_id: &str, remote_path: &str) -> Result<bool> {
+fn prepared_source_view_is_ready(
+    runner_id: &str,
+    remote_path: &str,
+    plan: &[deps::DependencyInstallPlanStep],
+) -> Result<bool> {
+    let output_tests = plan
+        .iter()
+        .flat_map(|step| &step.outputs)
+        .map(|output| {
+            let path = format!("{}/{}", remote_path.trim_end_matches('/'), output.path);
+            let predicate = match output.kind {
+                deps::DependencyInstallOutputKind::Path => "-e",
+                deps::DependencyInstallOutputKind::File => "-f",
+                deps::DependencyInstallOutputKind::Directory => "-d",
+            };
+            format!("test {predicate} {}", shell::quote_arg(&path))
+        })
+        .collect::<Vec<_>>();
+    let mut checks = vec![format!(
+        "test -f {}/.homeboy/prepared-source-ready",
+        shell::quote_arg(remote_path)
+    )];
+    checks.extend(output_tests);
     let (output, exit_code) = exec(
         runner_id,
         RunnerExecOptions::raw_command(vec![
             "sh".to_string(),
             "-c".to_string(),
-            format!(
-                "test -f {}/.homeboy/prepared-source-ready",
-                shell::quote_arg(remote_path)
-            ),
+            checks.join(" && "),
         ])
         .with_cwd(remote_path)
         .without_evidence_mirror(),
@@ -719,6 +738,102 @@ mod tests {
                     .expect("provider command ran"),
                 "install\n--no-interaction\n--no-progress\n"
             );
+        });
+    }
+
+    #[test]
+    fn stale_prepared_marker_without_dependency_output_hydrates() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let path_guard = FakeBinGuard::install(
+                "fixture-tool",
+                "#!/bin/sh\nmkdir -p node_modules apps/cli/dist/cli\nprintf ready > apps/cli/dist/cli/main.mjs\n",
+            );
+            crate::create(&path_guard.local_runner_spec("lab-local"), false)
+                .expect("create local runner");
+            let project = tempfile::tempdir().expect("project");
+            let manifest = r#"{"provider":"fixture","commands":{"install":{"argv":["fixture-tool","install"]}},"outputs":[{"path":"node_modules","kind":"directory"},{"path":"apps/cli/dist/cli/main.mjs","kind":"file"}]}"#;
+            std::fs::write(project.path().join("homeboy-deps.json"), manifest).expect("manifest");
+            let remote = tempfile::tempdir().expect("remote");
+            std::fs::write(remote.path().join("homeboy-deps.json"), manifest)
+                .expect("remote manifest");
+            std::fs::create_dir_all(remote.path().join(".homeboy")).expect("marker directory");
+            std::fs::write(remote.path().join(".homeboy/prepared-source-ready"), "")
+                .expect("marker");
+
+            let output = hydrate_lab_workspace_dependencies(
+                "lab-local",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("stale marker runs hydration");
+
+            assert_eq!(output.status, "hydrated");
+            assert!(remote.path().join("node_modules").is_dir());
+            assert!(remote.path().join("apps/cli/dist/cli/main.mjs").is_file());
+        });
+    }
+
+    #[test]
+    fn prepared_marker_missing_declared_build_output_hydrates() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let path_guard = FakeBinGuard::install(
+                "fixture-tool",
+                "#!/bin/sh\nmkdir -p apps/cli/dist/cli\nprintf ready > apps/cli/dist/cli/main.mjs\n",
+            );
+            crate::create(&path_guard.local_runner_spec("lab-local"), false)
+                .expect("create local runner");
+            let project = tempfile::tempdir().expect("project");
+            let manifest = r#"{"provider":"fixture","commands":{"install":{"argv":["fixture-tool","install"]}},"outputs":[{"path":"node_modules","kind":"directory"},{"path":"apps/cli/dist/cli/main.mjs","kind":"file"}]}"#;
+            std::fs::write(project.path().join("homeboy-deps.json"), manifest).expect("manifest");
+            let remote = tempfile::tempdir().expect("remote");
+            std::fs::write(remote.path().join("homeboy-deps.json"), manifest)
+                .expect("remote manifest");
+            std::fs::create_dir_all(remote.path().join(".homeboy")).expect("marker directory");
+            std::fs::write(remote.path().join(".homeboy/prepared-source-ready"), "")
+                .expect("marker");
+            std::fs::create_dir(remote.path().join("node_modules")).expect("dependency output");
+
+            let output = hydrate_lab_workspace_dependencies(
+                "lab-local",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("missing build output runs hydration");
+
+            assert_eq!(output.status, "hydrated");
+            assert!(remote.path().join("apps/cli/dist/cli/main.mjs").is_file());
+        });
+    }
+
+    #[test]
+    fn prepared_marker_with_declared_outputs_reuses_cache() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let path_guard = FakeBinGuard::install("fixture-tool", "#!/bin/sh\nexit 99\n");
+            crate::create(&path_guard.local_runner_spec("lab-local"), false)
+                .expect("create local runner");
+            let project = tempfile::tempdir().expect("project");
+            let manifest = r#"{"provider":"fixture","commands":{"install":{"argv":["fixture-tool","install"]}},"outputs":[{"path":"node_modules","kind":"directory"},{"path":"apps/cli/dist/cli/main.mjs","kind":"file"}]}"#;
+            std::fs::write(project.path().join("homeboy-deps.json"), manifest).expect("manifest");
+            let remote = tempfile::tempdir().expect("remote");
+            std::fs::write(remote.path().join("homeboy-deps.json"), manifest)
+                .expect("remote manifest");
+            std::fs::create_dir_all(remote.path().join(".homeboy")).expect("marker directory");
+            std::fs::write(remote.path().join(".homeboy/prepared-source-ready"), "")
+                .expect("marker");
+            std::fs::create_dir_all(remote.path().join("node_modules")).expect("dependency output");
+            std::fs::create_dir_all(remote.path().join("apps/cli/dist/cli"))
+                .expect("build directory");
+            std::fs::write(remote.path().join("apps/cli/dist/cli/main.mjs"), "ready")
+                .expect("build output");
+
+            let output = hydrate_lab_workspace_dependencies(
+                "lab-local",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("validated cache avoids install");
+
+            assert_eq!(output.status, "reused_prepared_cache");
         });
     }
 


### PR DESCRIPTION
## Summary
- require provider-declared dependency and build outputs alongside the prepared-source marker before reuse
- hydrate a stale prepared source rather than executing with excluded outputs missing
- cover stale dependency output, missing build output, and validated reuse

Closes #10453

## Verification
- `cargo test -p homeboy-lab-runner hydration --lib`
- `cargo test -p homeboy-core dependency_install_plan --lib`
- `cargo check -p homeboy-lab-runner`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode provided substantive implementation and testing assistance. Chris Huber remains responsible for every line.