### PR TITLE
fix(test-scope): select changed sources that carry their own inline tests

### DIFF
--- a/crates/homeboy-extension/src/test/drift.rs
+++ b/crates/homeboy-extension/src/test/drift.rs
@@ -39,6 +39,13 @@ pub struct DriftOptions {
     pub source_patterns: Vec<String>,
     /// Glob patterns for test files.
     pub test_patterns: Vec<String>,
+    /// Whether the language keeps unit tests inside the source file they cover
+    /// (Rust's `#[cfg(test)] mod tests`) rather than in a separate test file.
+    ///
+    /// When true, a changed source file is itself a test target: selecting only
+    /// separate files that reference its symbols would skip the tests sitting
+    /// directly beside the change.
+    pub inline_tests: bool,
 }
 
 impl DriftOptions {
@@ -60,6 +67,7 @@ impl DriftOptions {
             since: since.to_string(),
             source_patterns: glob_patterns(&config.source_dirs, extensions),
             test_patterns: glob_patterns(&config.test_dirs, extensions),
+            inline_tests: config.inline_tests,
         }
     }
 }
@@ -480,6 +488,43 @@ fn matches_any_pattern(path: &str, patterns: &[String]) -> bool {
         glob::Pattern::new(pattern)
             .map(|compiled| compiled.matches_path(Path::new(path)))
             .unwrap_or(false)
+    })
+}
+
+/// True when `path` is a changed production source file that declares its own
+/// unit tests, and the component's language keeps tests inline.
+///
+/// Reads the working-tree file because the tests live in the file's current
+/// contents, not in the diff. A file that cannot be read, is not a production
+/// source file, or declares no test function returns `false` so the caller
+/// never emits a filter that would match zero tests. (#10465)
+pub fn is_inline_test_source(opts: &DriftOptions, path: &str) -> bool {
+    if !opts.inline_tests || is_test_path(path) {
+        return false;
+    }
+    if !matches_any_pattern(path, &opts.source_patterns) {
+        return false;
+    }
+
+    std::fs::read_to_string(opts.root.join(path))
+        .map(|contents| declares_test_function(&contents))
+        .unwrap_or(false)
+}
+
+/// True when Rust-like `contents` declares at least one test function via a
+/// `#[test]` or `#[<path>::test]` (e.g. `#[tokio::test]`) attribute.
+pub fn declares_test_function(contents: &str) -> bool {
+    contents.lines().any(|line| {
+        let Some(attr) = line.trim_start().strip_prefix("#[") else {
+            return false;
+        };
+        let head = attr
+            .trim_start()
+            .split(|c| c == '(' || c == ']' || c == ',')
+            .next()
+            .unwrap_or("")
+            .trim();
+        head == "test" || head.rsplit("::").next() == Some("test")
     })
 }
 
@@ -1025,6 +1070,7 @@ mod tests {
             since: "HEAD".to_string(),
             source_patterns: vec!["src/**/*.rs".to_string()],
             test_patterns: vec!["tests/**/*.rs".to_string()],
+            inline_tests: false,
         };
 
         let report = detect_drift("fixture", &opts).expect("drift report");
@@ -1065,6 +1111,7 @@ mod tests {
             since: "HEAD".to_string(),
             source_patterns: vec!["inc/**/*.php".to_string()],
             test_patterns: vec!["tests/**/*.php".to_string()],
+            inline_tests: false,
         };
 
         let report = detect_drift("fixture", &opts).expect("drift report");
@@ -1113,6 +1160,7 @@ mod tests {
             since: "HEAD".to_string(),
             source_patterns: vec!["src/**/*.rs".to_string()],
             test_patterns: vec!["tests/**/*.rs".to_string()],
+            inline_tests: false,
         };
 
         let relocated = relocation_only_source_files(
@@ -1164,6 +1212,7 @@ mod tests {
             since: "HEAD".to_string(),
             source_patterns: vec!["src/**/*.rs".to_string()],
             test_patterns: vec!["tests/**/*.rs".to_string()],
+            inline_tests: false,
         };
 
         let relocated = relocation_only_source_files(
@@ -1219,6 +1268,7 @@ mod tests {
             since: "HEAD".to_string(),
             source_patterns: Vec::new(),
             test_patterns: Vec::new(),
+            inline_tests: false,
         };
         assert!(!empty.has_usable_patterns());
     }
@@ -1377,6 +1427,20 @@ mod workspace_layout_tests {
         );
     }
 
+    fn rust_extension_options_at(root: &Path) -> DriftOptions {
+        DriftOptions::from_config(
+            root,
+            "HEAD",
+            &TestDriftConfig {
+                source_dirs: vec!["src".to_string()],
+                test_dirs: vec!["tests".to_string()],
+                file_extensions: vec!["rs".to_string()],
+                inline_tests: true,
+            },
+            &["rs".to_string()],
+        )
+    }
+
     fn rust_extension_options() -> DriftOptions {
         // Exactly what `.config/homeboy/extensions/rust/rust.json` declares.
         DriftOptions::from_config(
@@ -1397,6 +1461,84 @@ mod workspace_layout_tests {
     /// those files as source; otherwise a change to any member crate is
     /// invisible to drift detection AND to the `#8340` fail-closed guard, so the
     /// gate reports green without running that crate's tests.
+
+    /// The regression that motivated this: `76c8c99a8` changed
+    /// `crates/homeboy-lab-runner/src/lab/offload/hydration.rs` and broke two
+    /// `#[cfg(test)] mod tests` cases inside that very crate. Drift only maps a
+    /// change to *separate* files referencing its symbols, so the tests beside
+    /// the edit were never selected and the gate reported green.
+    #[test]
+    fn changed_source_with_inline_tests_is_selected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("crates/member/src/lab/offload")).unwrap();
+        let changed = "crates/member/src/lab/offload/hydration.rs";
+        std::fs::write(
+            root.join(changed),
+            "pub fn hydrate() {}\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn hydrates() {}\n}\n",
+        )
+        .unwrap();
+
+        let opts = rust_extension_options_at(root);
+
+        assert!(
+            is_inline_test_source(&opts, changed),
+            "a changed source carrying its own tests must be selectable"
+        );
+    }
+
+    /// A source file with no tests of its own must not be selected: it would
+    /// compile a cargo filter matching zero tests, which the runner treats as a
+    /// failure rather than a pass.
+    #[test]
+    fn changed_source_without_inline_tests_is_not_selected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("crates/member/src")).unwrap();
+        let changed = "crates/member/src/plain.rs";
+        std::fs::write(root.join(changed), "pub fn helper() {}\n").unwrap();
+
+        let opts = rust_extension_options_at(root);
+
+        assert!(!is_inline_test_source(&opts, changed));
+    }
+
+    /// Languages that keep tests in separate files must be unaffected.
+    #[test]
+    fn inline_selection_is_off_when_the_language_does_not_use_inline_tests() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let changed = "src/Thing.php";
+        std::fs::write(root.join(changed), "<?php\n#[test]\nclass Thing {}\n").unwrap();
+
+        let opts = DriftOptions::from_config(
+            root,
+            "HEAD",
+            &TestDriftConfig {
+                source_dirs: vec!["src".to_string()],
+                test_dirs: vec!["tests".to_string()],
+                file_extensions: vec!["php".to_string()],
+                inline_tests: false,
+            },
+            &["php".to_string()],
+        );
+
+        assert!(!is_inline_test_source(&opts, changed));
+    }
+
+    /// Docs and non-source files are never inline test targets, even when the
+    /// language uses inline tests.
+    #[test]
+    fn non_source_changes_are_never_inline_test_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("README.md"), "#[test]\n").unwrap();
+
+        let opts = rust_extension_options_at(root);
+
+        assert!(!is_inline_test_source(&opts, "README.md"));
+    }
 
     /// Drift detection must see a change inside a monorepo member crate as a
     /// production change and route it to the test that references the changed

--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -490,22 +490,11 @@ fn is_inline_test_support_file(component: &Component, test_file: &str, routing_f
 
 /// Detects whether Rust source `contents` declares at least one test function
 /// via a `#[test]` or `#[<path>::test]` (e.g. `#[tokio::test]`) attribute.
+///
+/// Inline-test selection asks the same question, so the detection lives in
+/// `drift` and both callers share it.
 fn file_declares_test_function(contents: &str) -> bool {
-    contents.lines().any(|line| {
-        let trimmed = line.trim_start();
-        let Some(attr) = trimmed.strip_prefix("#[") else {
-            return false;
-        };
-        let attr = attr.trim_start();
-        // Match `#[test]`, `#[test(...)]`, and `#[<path>::test]` /
-        // `#[<path>::test(...)]` such as `#[tokio::test]`.
-        let head = attr
-            .split(|c| c == '(' || c == ']' || c == ',')
-            .next()
-            .unwrap_or("")
-            .trim();
-        head == "test" || head.rsplit("::").next() == Some("test")
-    })
+    drift::declares_test_function(contents)
 }
 
 /// Resolves the module path a test file is actually mounted at when a sibling
@@ -820,7 +809,35 @@ fn compute_changed_test_files_with_drift_options(
         selected.insert(drifted.test_file.clone());
     }
 
+    for file in inline_test_sources(opts, changed_files) {
+        selected.insert(file);
+    }
+
     Ok(selected.into_iter().collect())
+}
+
+/// Select changed source files that carry their own unit tests.
+///
+/// Languages with inline tests (Rust's `#[cfg(test)] mod tests`) keep the tests
+/// that cover a change inside the changed file itself. Drift only ever maps a
+/// change to *separate* files that reference its symbols, so without this the
+/// tests sitting directly beside an edit are the ones least likely to run —
+/// which is how two regressions shipped in `76c8c99a8` with their covering
+/// tests untouched. (#10465)
+///
+/// Only files that actually declare a test function are selected: emitting a
+/// filter for a file with no tests would match zero tests, which the runner
+/// treats as a failure.
+fn inline_test_sources(opts: &DriftOptions, changed_files: &[String]) -> Vec<String> {
+    if !opts.inline_tests {
+        return Vec::new();
+    }
+
+    changed_files
+        .iter()
+        .filter(|file| drift::is_inline_test_source(opts, file))
+        .cloned()
+        .collect()
 }
 
 pub fn compute_changed_test_scope_for_files(
@@ -1095,6 +1112,59 @@ mod tests {
                 "-p\nhomeboy-lab-runner\n--lib\n--\nworkspace::tests::snapshot".to_string()
             )),
             "env: {env:?}"
+        );
+    }
+
+    /// End-to-end proof for #10465: a changed workspace-member source that
+    /// carries its own `#[cfg(test)] mod tests` must route to that crate's lib
+    /// target, filtered to the changed module.
+    ///
+    /// This is the exact shape of `76c8c99a8`, whose two covering unit tests
+    /// lived inside the changed crate and never ran.
+    #[test]
+    fn changed_inline_test_source_routes_to_its_owning_crate_lib() {
+        let dir = TempDir::new().expect("temp dir should be created");
+        let workspace_root = dir.path();
+        fs::write(
+            workspace_root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\"]\n",
+        )
+        .expect("workspace manifest");
+        let member = workspace_root.join("crates/homeboy-lab-runner");
+        fs::create_dir_all(member.join("src/lab/offload")).expect("member dirs");
+        fs::write(
+            member.join("Cargo.toml"),
+            "[package]\nname = \"homeboy-lab-runner\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("member manifest");
+        fs::write(
+            member.join("src/lab/offload/hydration.rs"),
+            "pub fn hydrate() {}\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn hydrates() {}\n}\n",
+        )
+        .expect("changed source with inline tests");
+
+        let component = Component::new(
+            "homeboy".to_string(),
+            workspace_root.to_string_lossy().to_string(),
+            "/tmp/remote".to_string(),
+            None,
+        );
+
+        let env = rust_cargo_changed_test_env(
+            &component,
+            &["crates/homeboy-lab-runner/src/lab/offload/hydration.rs".to_string()],
+        );
+
+        assert!(env.contains(&(
+            "HOMEBOY_TEST_SCOPE_KIND".to_string(),
+            "rust_filter".to_string()
+        )));
+        assert!(
+            env.contains(&(
+                "HOMEBOY_TEST_RUNNER_ARGS".to_string(),
+                "-p\nhomeboy-lab-runner\n--lib\n--\nlab::offload::hydration".to_string()
+            )),
+            "inline tests beside a change must run against their own crate: {env:?}"
         );
     }
 


### PR DESCRIPTION
Fixes #10465. Follow-up to #10450, which fixed *where* the gate looks; this fixes *what it selects* once it looks there.

## The bug

`TestDriftConfig` carries an `inline_tests` flag and the Rust extension sets it to `true`. `DriftOptions::from_config` read the config and never stored it:

```rust
Self {
    root: ...,
    since: ...,
    source_patterns: glob_patterns(&config.source_dirs, extensions),
    test_patterns: glob_patterns(&config.test_dirs, extensions),
    // inline_tests dropped on the floor
}
```

So selection only ever chose (a) recognized test paths and (b) separate files that reference a changed symbol. A `#[cfg(test)] mod tests` inside the changed file matched neither — meaning **for Rust, the tests closest to a change were the ones least likely to run.**

That is precisely how `76c8c99a8` shipped: it changed `crates/homeboy-lab-runner/src/lab/offload/hydration.rs`, broke two unit tests *inside that crate*, and merged green. Both stayed red on `main` for a day (fixed by hand in #10431).

## The fix

Carry `inline_tests` into `DriftOptions`, and select a changed source file when the language keeps tests inline **and the file actually declares a test function**.

That second condition is load-bearing: selecting a file with no tests would compile a cargo filter matching zero tests, which the runner treats as a failure. A file with no `#[test]` is skipped, so it degrades to the previous behavior rather than producing a spurious red.

## What was already working

The routing half needed no changes — `cargo_relative_test_path` + `owning_workspace_member_package` already turn a selected file into the right invocation. Selection was the only missing link. Concretely, `crates/homeboy-lab-runner/src/lab/offload/hydration.rs` now produces:

```
cargo test -p homeboy-lab-runner --lib -- lab::offload::hydration
```

which runs `lab::offload::hydration::tests::*` — the exact tests that `76c8c99a8` broke.

## Verification

I flipped the fix out and back to check each test is non-vacuous. Being precise about which is which:

| test | fails without fix? |
|---|---|
| `changed_source_with_inline_tests_is_selected` | **yes** — this is the regression test |
| `changed_source_without_inline_tests_is_not_selected` | no — guards the zero-filter hazard |
| `inline_selection_is_off_when_the_language_does_not_use_inline_tests` | no — guards non-Rust components |
| `non_source_changes_are_never_inline_test_targets` | no — guards docs/config |
| `changed_inline_test_source_routes_to_its_owning_crate_lib` | no — routing already worked; pins the end-to-end contract |

```
cargo test -p homeboy-extension --lib test::   133 passed, 0 failed
cargo test -p homeboy-extension --lib          610 passed, 10 failed
```

Those 10 are pre-existing and environment-dependent on my host (toolchain path, provider discoverability, lab snapshot evidence) — identical set on unmodified `main`, verified by stashing. Progression across this work: 601 → 605 (#10450) → 610 passed, same 10 throughout.

Also folded the duplicated `#[test]`-attribute detection into one function, since both selection and the existing support-module check need it.

## Expect longer Test runs — and one follow-up

More PRs will now select inline filters. When a change touches **more than one** file with inline tests, the pre-existing multi-filter branch falls back to the full suite:

```
"Changed files include multiple inline test modules; running the full test command."
```

That fallback was rarely reached before and will now be common, so expect the changed-scope Test gate to run the full workspace on most multi-file PRs. It is correct and conservative — just slow.

I deliberately did **not** change that in this PR (one behavior change at a time). The obvious improvement is to collapse multiple inline filters into package-scoped lib runs — `-p A -p B --lib` — which bounds the run to the affected crates instead of the whole workspace. Happy to do that next if the full-suite fallback proves too slow in practice; this PR's own CI timing is the first data point.
