### PR TITLE
fix(agent-task): retain Cook retry ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -356,6 +356,26 @@ where
     F: FnOnce(&str) -> Result<A>,
     A: RuntimeAdmissionEvidence,
 {
+    submit_plan_with_runtime_admission_on_runner_with_metadata(
+        plan,
+        requested_run_id,
+        execution_runner_id,
+        None,
+        admit_runtime,
+    )
+}
+
+fn submit_plan_with_runtime_admission_on_runner_with_metadata<F, A>(
+    plan: &AgentTaskPlan,
+    requested_run_id: Option<&str>,
+    execution_runner_id: Option<String>,
+    submission_metadata: Option<serde_json::Map<String, Value>>,
+    admit_runtime: F,
+) -> Result<AgentTaskRunRecord>
+where
+    F: FnOnce(&str) -> Result<A>,
+    A: RuntimeAdmissionEvidence,
+{
     let run_id = requested_run_id
         .map(sanitize_run_id)
         .unwrap_or_else(default_run_id);
@@ -386,6 +406,12 @@ where
     if let Some(route) = homeboy_core::notification_route::current() {
         route.insert_into_metadata(&mut metadata);
     }
+    if let Some(submission_metadata) = submission_metadata {
+        metadata
+            .as_object_mut()
+            .expect("submission metadata is an object")
+            .extend(submission_metadata);
+    }
 
     let mut record = AgentTaskRunRecord {
         schema: schemas::RUN.to_string(),
@@ -414,6 +440,13 @@ where
         // plan-derived state, so replacing the record must retain them.
         if let Some(claims) = existing.metadata.get("cook_operation_claims") {
             record.metadata["cook_operation_claims"] = claims.clone();
+        }
+        // A runner re-submitting a retry must not erase the predecessor identity
+        // that makes the reservation discoverable through the indexed lookup.
+        for key in ["retry_of", "retry_requested_at", "retry_origin"] {
+            if let Some(value) = existing.metadata.get(key) {
+                record.metadata[key] = value.clone();
+            }
         }
         if execution_runner_id.as_deref() == existing.runner_id() {
             // A foreground daemon binds its job before launching runner-local
@@ -1565,8 +1598,7 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
     let mut plan = load_controller_plan(&source.run_id)?;
     super::cook_workspace_restore::restore_initial_cook_candidate_workspace(&mut plan)?;
     super::cook_workspace_restore::restore_follow_up_cook_candidate_workspace(&mut plan)?;
-    let mut retry = submit_plan(&plan, requested_run_id)?;
-    let metadata = retry.ensure_metadata_object();
+    let mut metadata = serde_json::Map::new();
     if let Some(route) =
         homeboy_core::notification_route::NotificationRoute::from_metadata(&source.metadata)
     {
@@ -1599,8 +1631,47 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
     }
     metadata.insert("retry_of".to_string(), json!(source.run_id));
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
-    store::write_record(&retry)?;
-    Ok(retry)
+    submit_plan_with_runtime_admission_on_runner_with_metadata(
+        &plan,
+        requested_run_id,
+        execution_runner_id(),
+        Some(metadata),
+        |run_id| {
+            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
+                run_id,
+                || Ok(store::read_record(run_id)?.state.is_terminal()),
+            )
+        },
+    )
+}
+
+/// Find the one lifecycle-first Cook retry reservation that can be bound to an
+/// unbound recipe attempt. The `retry_of` lookup is backed by the observation
+/// metadata index; the plan and attempt-shaped run id prevent adoption of an
+/// unrelated retry from the same source.
+pub fn find_unbound_cook_retry_successor(
+    source_run_id: &str,
+    cook_id: &str,
+    attempt: u32,
+    plan: &AgentTaskPlan,
+) -> Result<Option<AgentTaskRunRecord>> {
+    let prefix = format!("{}-attempt-{attempt}-", sanitize_run_id(cook_id));
+    let mut matches = store::read_retry_successors(&sanitize_run_id(source_run_id))?
+        .into_iter()
+        .filter(|record| record.run_id.starts_with(&prefix))
+        .filter(|record| record.plan_id == plan.plan_id)
+        .collect::<Vec<_>>();
+    matches.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+    match matches.as_slice() {
+        [] => Ok(None),
+        [record] => Ok(Some(record.clone())),
+        _ => Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "multiple lifecycle retry reservations match this Cook attempt",
+            Some(source_run_id.to_string()),
+            None,
+        )),
+    }
 }
 
 /// Rebuild a gate-failed Cook candidate from its controller-owned promotion

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -18,6 +18,33 @@ use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
 #[test]
+fn retry_first_visible_record_always_has_indexed_predecessor_identity() {
+    with_isolated_home(|_| {
+        let source_id = "retry-atomic-source";
+        let retry_id = "retry-atomic-successor";
+        submit_plan(&test_plan(), Some(source_id)).expect("submit source");
+
+        // The former implementation had a durable submitted record at this
+        // point, then wrote `retry_of` separately. The first record write now
+        // includes retry provenance, so an interruption leaves no successor
+        // visible to the indexed lookup at all.
+        store::fail_next_record_write_for_test();
+        assert!(retry(source_id, Some(retry_id)).is_err());
+        assert!(!run_record_exists(retry_id).expect("retry remains absent"));
+        assert!(store::read_retry_successors(source_id)
+            .expect("indexed retry lookup")
+            .is_empty());
+
+        let retry = retry(source_id, Some(retry_id)).expect("retry after failed first write");
+        let successors = store::read_retry_successors(source_id).expect("indexed retry lookup");
+        assert_eq!(successors.len(), 1);
+        assert_eq!(successors[0].run_id, retry_id);
+        assert_eq!(successors[0].metadata["retry_of"], source_id);
+        assert_eq!(retry.metadata["retry_of"], source_id);
+    });
+}
+
+#[test]
 fn cook_progress_is_durable_across_active_and_terminal_lifecycle_states() {
     with_isolated_home(|_| {
         let run_id = "cook-progress-lifecycle";

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1706,7 +1706,17 @@ pub(crate) fn cook_report(
                 .map(|attempt| attempt.run_id)
                 .collect::<Vec<_>>()
         })
-        .unwrap_or_default();
+        .unwrap_or_else(|_| {
+            super::load_recipe(&cook_id)
+                .map(|recipe| {
+                    recipe
+                        .attempts
+                        .into_iter()
+                        .map(|attempt| attempt.run_id)
+                        .collect()
+                })
+                .unwrap_or_default()
+        });
     let latest_run_id = invocation_latest_run_id
         .map(str::to_string)
         .or_else(|| {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1862,6 +1862,297 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
 }
 
 #[test]
+fn retryable_pre_provider_retry_stays_attached_to_its_cook() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-pre-provider-retry";
+        let options = retryable_pre_provider_cook(cook_id, 2);
+        let first_run_id = options.initial_run_id.as_str();
+
+        let retry = crate::agent_task_service::retry(first_run_id, None, false)
+            .expect("corrected environment retry remains Cook-owned");
+        let retry_run_id = retry.record.run_id.clone();
+        let completed = crate::agent_task_service::execution::run_submitted(
+            retry_run_id.clone(),
+            ReviewFormOnlyExecutor,
+        )
+        .expect("corrected environment retry succeeds");
+
+        assert_eq!(completed.exit_code, 0);
+        assert!(retry_run_id.starts_with(&format!("{cook_id}-attempt-2-")));
+        assert_eq!(retry.record.metadata["retry_of"], first_run_id);
+        assert_eq!(retry.record.metadata["cook_id"], cook_id);
+        assert_eq!(retry.record.metadata["cook_attempt"], 2);
+        let recipe = super::super::load_recipe(cook_id).expect("updated Cook recipe");
+        assert_eq!(recipe.attempts.len(), 2);
+        assert_eq!(recipe.attempts[1].attempt, 2);
+        assert_eq!(recipe.attempts[1].run_id, retry_run_id);
+        assert_eq!(recipe.attempts[1].plan, options.initial_plan);
+        let index = agent_task_lifecycle::cook_index(cook_id).expect("updated Cook index");
+        assert_eq!(index.latest_run_id, retry_run_id);
+        assert_eq!(index.attempts.len(), 2);
+        assert_eq!(
+            agent_task_lifecycle::status(cook_id)
+                .expect("Cook alias resolves successful retry")
+                .state,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        );
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_without_a_recipe_uses_legacy_lifecycle_retry() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = batch_cook_options(
+            "cook-legacy-retry",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        let run_id = "cook-legacy-retry-run";
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+            .expect("persist legacy run");
+        agent_task_lifecycle::record_cook_attempt("cook-legacy-retry", 1, run_id)
+            .expect("mark legacy Cook metadata without a recipe");
+        agent_task_lifecycle::record_pre_execution_failure(
+            run_id,
+            &options.initial_plan,
+            "gate_environment.preserve",
+            &Error::validation_invalid_argument("CARGO_HOME", "unavailable", None, None)
+                .with_retryable(true),
+        )
+        .expect("record retryable legacy failure");
+
+        let retry = crate::agent_task_service::retry(run_id, Some("legacy-retry"), false)
+            .expect("legacy retry remains supported");
+
+        assert_eq!(retry.record.run_id, "legacy-retry");
+        assert_eq!(retry.record.metadata["retry_of"], run_id);
+        assert!(retry.record.metadata["cook_id"].is_null());
+    });
+}
+
+fn retryable_pre_provider_cook(cook_id: &str, max_attempts: u32) -> AgentTaskCookServiceOptions {
+    let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    options.initial_run_id = format!("{cook_id}-attempt-1");
+    options.max_attempts = max_attempts;
+    super::super::persist_initial_recipe(&options).expect("persist Cook recipe");
+    super::super::materialize_initial_cook_attempt(&options).expect("materialize first attempt");
+    agent_task_lifecycle::record_pre_execution_failure(
+        &options.initial_run_id,
+        &options.initial_plan,
+        "gate_environment.preserve",
+        &Error::validation_invalid_argument(
+            "CARGO_HOME",
+            "required environment capability is unavailable",
+            None,
+            None,
+        )
+        .with_retryable(true),
+    )
+    .expect("record retryable environment failure");
+    options
+}
+
+#[test]
+fn retryable_pre_provider_retry_rejects_a_lifecycle_reservation_collision_without_recipe_mutation()
+{
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-collision", 2);
+        let collision_id = "cook-retry-reservation-collision";
+        let unrelated = AgentTaskPlan::new("unrelated-plan", Vec::new());
+        agent_task_lifecycle::submit_plan(&unrelated, Some(collision_id))
+            .expect("submit unrelated run");
+
+        let error =
+            crate::agent_task_service::retry(&options.initial_run_id, Some(collision_id), false)
+                .expect_err("colliding lifecycle reservation is rejected before Cook mutation");
+
+        assert_eq!(error.details["field"], "new_run_id");
+        assert_eq!(
+            agent_task_lifecycle::load_plan(collision_id).expect("unrelated plan remains intact"),
+            unrelated
+        );
+        assert_eq!(
+            super::super::load_recipe(&options.cook_id)
+                .expect("recipe remains intact")
+                .attempts
+                .len(),
+            1
+        );
+        assert_eq!(
+            agent_task_lifecycle::cook_index(&options.cook_id)
+                .expect("index remains intact")
+                .attempts
+                .len(),
+            1
+        );
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_enforces_the_persisted_attempt_budget() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-budget", 1);
+
+        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false)
+            .expect_err("retry cannot exceed the persisted Cook budget");
+
+        assert_eq!(
+            error.details["field"],
+            "cook_recipe.retry_budget.max_attempts"
+        );
+        assert_eq!(
+            super::super::load_recipe(&options.cook_id)
+                .expect("recipe remains intact")
+                .attempts
+                .len(),
+            1
+        );
+        assert_eq!(
+            agent_task_lifecycle::cook_index(&options.cook_id)
+                .expect("index remains intact")
+                .attempts
+                .len(),
+            1
+        );
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_repairs_lifecycle_reserved_attempts_idempotently() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        // Simulate a lifecycle retry that crashed after its durable retry proof
+        // was written but before Cook metadata/index binding.
+        let options = retryable_pre_provider_cook("cook-retry-submitted-repair", 2);
+        let submitted_run_id = agent_task_lifecycle::cook_attempt_run_id(&options.cook_id, 2);
+        super::super::record_recipe_attempt(
+            &options.cook_id,
+            2,
+            &submitted_run_id,
+            &options.initial_plan,
+        )
+        .expect("reserve submitted retry");
+        agent_task_lifecycle::retry(&options.initial_run_id, Some(&submitted_run_id))
+            .expect("submit retry before Cook metadata binding");
+
+        let repaired = crate::agent_task_service::retry(&options.initial_run_id, None, false)
+            .expect("repair submitted retry");
+        assert_eq!(repaired.record.run_id, submitted_run_id);
+        assert_eq!(repaired.record.metadata["cook_id"], options.cook_id);
+        assert_eq!(repaired.record.metadata["cook_attempt"], 2);
+        assert_eq!(
+            super::super::load_recipe(&options.cook_id)
+                .expect("no duplicate recipe attempt")
+                .attempts
+                .len(),
+            2
+        );
+        assert_eq!(
+            agent_task_lifecycle::cook_index(&options.cook_id)
+                .expect("repaired Cook index")
+                .attempts
+                .len(),
+            2
+        );
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_rejects_unowned_same_plan_collision_without_retry_proof() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-unowned-collision", 2);
+        let pending_run_id = agent_task_lifecycle::cook_attempt_run_id(&options.cook_id, 2);
+        super::super::record_recipe_attempt(
+            &options.cook_id,
+            2,
+            &pending_run_id,
+            &options.initial_plan,
+        )
+        .expect("reserve retry in recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&pending_run_id))
+            .expect("occupy pending attempt with same plan");
+
+        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false)
+            .expect_err("unowned same-plan run is not repaired without retry proof");
+
+        assert!(error
+            .to_string()
+            .contains("not the durable retry of its source attempt"));
+        let record = agent_task_lifecycle::exact_record(&pending_run_id)
+            .expect("unowned collision remains intact");
+        assert!(record.metadata["cook_id"].is_null());
+        assert!(record.metadata["retry_of"].is_null());
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_returns_terminal_successor_without_reexecution() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-terminal-success", 2);
+        let successor_run_id = agent_task_lifecycle::cook_attempt_run_id(&options.cook_id, 2);
+        super::super::record_recipe_attempt(
+            &options.cook_id,
+            2,
+            &successor_run_id,
+            &options.initial_plan,
+        )
+        .expect("reserve retry in recipe");
+        agent_task_lifecycle::retry(&options.initial_run_id, Some(&successor_run_id))
+            .expect("persist successor retry proof");
+        crate::agent_task_service::execution::run_submitted(
+            successor_run_id.clone(),
+            ReviewFormOnlyExecutor,
+        )
+        .expect("complete successor successfully");
+
+        let retry = crate::agent_task_service::retry(&options.initial_run_id, None, true)
+            .expect("terminal successor is authoritative");
+
+        assert_eq!(retry.record.run_id, successor_run_id);
+        assert_eq!(
+            retry.record.state,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        );
+        assert!(!retry.run);
+        assert_eq!(
+            agent_task_lifecycle::cook_index(&options.cook_id)
+                .expect("initial Cook index remains intact")
+                .attempts
+                .len(),
+            2
+        );
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_rejects_pending_attempt_owned_by_another_cook() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-owner-collision", 2);
+        let pending_run_id = agent_task_lifecycle::cook_attempt_run_id(&options.cook_id, 2);
+        super::super::record_recipe_attempt(
+            &options.cook_id,
+            2,
+            &pending_run_id,
+            &options.initial_plan,
+        )
+        .expect("reserve retry in recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&pending_run_id))
+            .expect("occupy pending attempt");
+        agent_task_lifecycle::record_cook_attempt("another-cook", 1, &pending_run_id)
+            .expect("mark conflicting Cook ownership");
+
+        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false)
+            .expect_err("conflicting Cook owner must not be rebound");
+
+        assert!(error
+            .to_string()
+            .contains("not the durable retry of its source attempt"));
+        let record = agent_task_lifecycle::exact_record(&pending_run_id)
+            .expect("conflicting pending record remains intact");
+        assert_eq!(record.metadata["cook_id"], "another-cook");
+        assert_eq!(record.metadata["cook_attempt"], 1);
+    });
+}
+
+#[test]
 fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-repair-initial-alias";

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -33,7 +33,7 @@ use homeboy_core::run_lifecycle_record::{
 use sha2::Digest;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Barrier, Condvar};
+use std::sync::{Arc, Barrier, Condvar};
 
 /// Seed a terminal aggregate whose last outcome carries a valid AI-authored
 /// review form under `outputs["review_form"]`, so cook finalization (which now
@@ -2023,13 +2023,6 @@ fn retryable_pre_provider_retry_repairs_lifecycle_reserved_attempts_idempotently
         // was written but before Cook metadata/index binding.
         let options = retryable_pre_provider_cook("cook-retry-submitted-repair", 2);
         let submitted_run_id = agent_task_lifecycle::cook_attempt_run_id(&options.cook_id, 2);
-        super::super::record_recipe_attempt(
-            &options.cook_id,
-            2,
-            &submitted_run_id,
-            &options.initial_plan,
-        )
-        .expect("reserve submitted retry");
         agent_task_lifecycle::retry(&options.initial_run_id, Some(&submitted_run_id))
             .expect("submit retry before Cook metadata binding");
 
@@ -2052,7 +2045,98 @@ fn retryable_pre_provider_retry_repairs_lifecycle_reserved_attempts_idempotently
                 .len(),
             2
         );
+        assert_eq!(
+            agent_task_lifecycle::list_records()
+                .expect("durable lifecycle records")
+                .len(),
+            2,
+            "repair binds the indexed reservation instead of orphaning another run"
+        );
     });
+}
+
+#[test]
+fn retryable_pre_provider_retry_concurrently_claims_one_successor() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-concurrent", 2);
+        let barrier = Arc::new(Barrier::new(4));
+        let retries = (0..4)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                let run_id = options.initial_run_id.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    crate::agent_task_service::retry(&run_id, None, false)
+                        .expect("concurrent retry converges")
+                        .record
+                        .run_id
+                })
+            })
+            .collect::<Vec<_>>();
+        let run_ids = retries
+            .into_iter()
+            .map(|retry| retry.join().expect("retry thread"))
+            .collect::<Vec<_>>();
+
+        assert!(run_ids.iter().all(|run_id| run_id == &run_ids[0]));
+        let recipe = super::super::load_recipe(&options.cook_id).expect("bound recipe");
+        let index = agent_task_lifecycle::cook_index(&options.cook_id).expect("bound index");
+        assert_eq!(recipe.attempts.len(), 2);
+        assert_eq!(recipe.attempts[1].run_id, run_ids[0]);
+        assert_eq!(index.attempts.len(), 2);
+        assert_eq!(index.latest_run_id, run_ids[0]);
+        assert_eq!(
+            agent_task_lifecycle::list_records()
+                .expect("durable lifecycle records")
+                .len(),
+            2,
+            "the source and one bound successor are the only durable runs"
+        );
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_concurrently_claims_one_successor_across_processes() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-process", 2);
+        let test_binary = std::env::current_exe().expect("test binary path");
+        let mut workers = (0..2)
+            .map(|_| {
+                Command::new(&test_binary)
+                    .args([
+                        "--exact",
+                        "agent_task_service::cook::tests::retryable_pre_provider_retry_process_worker",
+                    ])
+                    .env("HOMEBOY_RETRY_PROCESS_WORKER", &options.initial_run_id)
+                    .spawn()
+                    .expect("start retry worker")
+            })
+            .collect::<Vec<_>>();
+        assert!(workers
+            .iter_mut()
+            .all(|worker| worker.wait().expect("wait for retry worker").success()));
+
+        let recipe = super::super::load_recipe(&options.cook_id).expect("bound recipe");
+        let index = agent_task_lifecycle::cook_index(&options.cook_id).expect("bound index");
+        assert_eq!(recipe.attempts.len(), 2);
+        assert_eq!(index.attempts.len(), 2);
+        assert_eq!(recipe.attempts[1].run_id, index.latest_run_id);
+        assert_eq!(
+            agent_task_lifecycle::list_records()
+                .expect("durable lifecycle records")
+                .len(),
+            2,
+            "the source and one bound successor are the only durable runs"
+        );
+    });
+}
+
+#[test]
+fn retryable_pre_provider_retry_process_worker() {
+    let Ok(run_id) = std::env::var("HOMEBOY_RETRY_PROCESS_WORKER") else {
+        return;
+    };
+    crate::agent_task_service::retry(&run_id, None, false).expect("process retry converges");
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -3,7 +3,9 @@
 //! and the shared `AgentTaskRunResult` envelope. Pure move out of the former
 //! `agent_task_service.rs` god-file.
 
-use serde_json::Value;
+use std::time::Duration;
+
+use serde_json::{json, Value};
 
 use crate::agent_task::{AgentTaskRequest, AgentTaskWorkspaceMode};
 use crate::agent_task_lifecycle::{
@@ -389,11 +391,19 @@ pub fn retry(
     let cook_retry = retryable_cook_attempt(&source)?;
     let record = match cook_retry {
         Some(cook_retry) => {
-            let retry_run_id = cook_retry
+            let discovered_run_id = agent_task_lifecycle::find_unbound_cook_retry_successor(
+                &source.run_id,
+                &cook_retry.cook_id,
+                cook_retry.attempt,
+                &cook_retry.plan,
+            )?
+            .map(|record| record.run_id);
+            let mut retry_run_id = cook_retry
                 .pending_run_id
                 .as_deref()
                 .or(new_run_id)
                 .map(str::to_string)
+                .or(discovered_run_id)
                 .unwrap_or_else(|| {
                     agent_task_lifecycle::cook_attempt_run_id(
                         &cook_retry.cook_id,
@@ -415,19 +425,25 @@ pub fn retry(
             // before recipe/index binding, so recovery can prove ownership without
             // adopting an unrelated same-plan run.
             if !retry_exists {
-                agent_task_lifecycle::retry(&source.run_id, Some(&retry_run_id))?;
+                retry_run_id = reserve_cook_retry_lifecycle(&source, &cook_retry, &retry_run_id)?;
             }
-            super::record_recipe_attempt(
-                &cook_retry.cook_id,
-                cook_retry.attempt,
-                &retry_run_id,
-                &cook_retry.plan,
-            )?;
-            agent_task_lifecycle::record_cook_attempt(
-                &cook_retry.cook_id,
-                cook_retry.attempt,
-                &retry_run_id,
-            )?;
+            // Recipe and index are one Cook-owned binding boundary. Serialize
+            // concurrent claim observers so neither can overwrite the other's
+            // append-only recipe revision between its read and write.
+            config::with_config_lock(|| {
+                super::record_recipe_attempt(
+                    &cook_retry.cook_id,
+                    cook_retry.attempt,
+                    &retry_run_id,
+                    &cook_retry.plan,
+                )?;
+                agent_task_lifecycle::record_cook_attempt(
+                    &cook_retry.cook_id,
+                    cook_retry.attempt,
+                    &retry_run_id,
+                )?;
+                Ok(())
+            })?;
             let record = agent_task_lifecycle::status(&retry_run_id)?;
             if record.state.is_terminal() {
                 return Ok(AgentTaskRetryServiceResult { record, run: false });
@@ -437,6 +453,60 @@ pub fn retry(
         None => agent_task_lifecycle::retry(&source.run_id, new_run_id)?,
     };
     Ok(AgentTaskRetryServiceResult { record, run })
+}
+
+fn reserve_cook_retry_lifecycle(
+    source: &agent_task_lifecycle::AgentTaskRunRecord,
+    retry: &CookRetryAttempt,
+    retry_run_id: &str,
+) -> Result<String> {
+    let operation_key = format!("retry:{}:{}", retry.cook_id, retry.attempt);
+    match agent_task_lifecycle::claim_cook_operation(
+        &source.run_id,
+        &operation_key,
+        Duration::from_secs(30),
+    )? {
+        agent_task_lifecycle::ClaimOutcome::Acquired => {
+            agent_task_lifecycle::retry(&source.run_id, Some(retry_run_id))?;
+            agent_task_lifecycle::complete_cook_operation(
+                &source.run_id,
+                &operation_key,
+                json!({ "run_id": retry_run_id }),
+            )?;
+            Ok(retry_run_id.to_string())
+        }
+        agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {
+            let recorded_run_id = result["run_id"].as_str().ok_or_else(|| {
+                Error::internal_unexpected("completed Cook retry claim has no run id")
+            })?;
+            Ok(recorded_run_id.to_string())
+        }
+        agent_task_lifecycle::ClaimOutcome::LeaseHeld => {
+            // The winner writes its lifecycle reservation before completing the
+            // claim. Re-read through the indexed successor path on the next
+            // retry rather than allocating a competing run id.
+            // Controller admission can take up to the normal local lease
+            // handoff window. Bound the observer wait above that window so a
+            // crashed winner remains recoverable rather than waiting forever.
+            for _ in 0..2_000 {
+                if let Some(record) = agent_task_lifecycle::find_unbound_cook_retry_successor(
+                    &source.run_id,
+                    &retry.cook_id,
+                    retry.attempt,
+                    &retry.plan,
+                )? {
+                    return Ok(record.run_id);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(Error::validation_invalid_argument(
+                "run_id",
+                "Cook retry reservation is still being finalized",
+                Some(source.run_id.clone()),
+                None,
+            ))
+        }
+    }
 }
 
 /// A retryable failure before provider execution has no candidate or execution

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -385,8 +385,225 @@ pub fn retry(
     new_run_id: Option<&str>,
     run: bool,
 ) -> Result<AgentTaskRetryServiceResult> {
-    let record = agent_task_lifecycle::retry(run_id, new_run_id)?;
+    let source = agent_task_lifecycle::status(run_id)?;
+    let cook_retry = retryable_cook_attempt(&source)?;
+    let record = match cook_retry {
+        Some(cook_retry) => {
+            let retry_run_id = cook_retry
+                .pending_run_id
+                .as_deref()
+                .or(new_run_id)
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    agent_task_lifecycle::cook_attempt_run_id(
+                        &cook_retry.cook_id,
+                        cook_retry.attempt,
+                    )
+                });
+            let retry_exists = agent_task_lifecycle::run_record_exists(&retry_run_id)?;
+            if retry_exists
+                && !is_exact_retry_reservation(&source, &cook_retry.plan, &retry_run_id)?
+            {
+                return Err(Error::validation_invalid_argument(
+                    "new_run_id",
+                    "retry run id is not the durable retry reservation for this Cook attempt",
+                    Some(retry_run_id),
+                    None,
+                ));
+            }
+            // The lifecycle record is the durable reservation. It writes retry_of
+            // before recipe/index binding, so recovery can prove ownership without
+            // adopting an unrelated same-plan run.
+            if !retry_exists {
+                agent_task_lifecycle::retry(&source.run_id, Some(&retry_run_id))?;
+            }
+            super::record_recipe_attempt(
+                &cook_retry.cook_id,
+                cook_retry.attempt,
+                &retry_run_id,
+                &cook_retry.plan,
+            )?;
+            agent_task_lifecycle::record_cook_attempt(
+                &cook_retry.cook_id,
+                cook_retry.attempt,
+                &retry_run_id,
+            )?;
+            let record = agent_task_lifecycle::status(&retry_run_id)?;
+            if record.state.is_terminal() {
+                return Ok(AgentTaskRetryServiceResult { record, run: false });
+            }
+            record
+        }
+        None => agent_task_lifecycle::retry(&source.run_id, new_run_id)?,
+    };
     Ok(AgentTaskRetryServiceResult { record, run })
+}
+
+/// A retryable failure before provider execution has no candidate or execution
+/// evidence to supersede, so its retry remains an append-only Cook attempt.
+fn retryable_cook_attempt(
+    source: &agent_task_lifecycle::AgentTaskRunRecord,
+) -> Result<Option<CookRetryAttempt>> {
+    if source.metadata["pre_execution_failure"]["retryable"] != serde_json::Value::Bool(true) {
+        return Ok(None);
+    }
+    let Some(cook_id) = source.metadata["cook_id"].as_str() else {
+        return Ok(None);
+    };
+    let Some(source_attempt) = source.metadata["cook_attempt"].as_u64() else {
+        return Ok(None);
+    };
+    let attempt = u32::try_from(source_attempt).map_err(|_| {
+        Error::validation_invalid_argument(
+            "cook_attempt",
+            "durable Cook attempt number exceeds the supported range",
+            Some(source.run_id.clone()),
+            None,
+        )
+    })?;
+    if !super::recipe_exists(cook_id)? {
+        // Legacy runs predate durable recipes. Retain their established generic
+        // lifecycle retry behavior rather than inventing Cook ownership.
+        return Ok(None);
+    }
+    let recipe = super::load_recipe(cook_id)?;
+    let source_recipe_attempt = recipe.attempts.iter().find(|recipe_attempt| {
+        recipe_attempt.attempt == attempt && recipe_attempt.run_id == source.run_id
+    });
+    let Some(source_recipe_attempt) = source_recipe_attempt else {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts",
+            "retryable pre-provider failure is not owned by its durable Cook recipe",
+            Some(source.run_id.clone()),
+            Some(vec![format!(
+                "Continue the owning Cook with: homeboy agent-task cook-continue {}",
+                cook_id
+            )]),
+        ));
+    };
+    let mut pending_attempt = None;
+    for recipe_attempt in recipe
+        .attempts
+        .iter()
+        .filter(|recipe_attempt| recipe_attempt.attempt == attempt.saturating_add(1))
+    {
+        if !agent_task_lifecycle::run_record_exists(&recipe_attempt.run_id)? {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "pending Cook retry recipe entry has no durable lifecycle reservation",
+                Some(recipe_attempt.run_id.clone()),
+                None,
+            ));
+        }
+        let record = agent_task_lifecycle::exact_record(&recipe_attempt.run_id)?;
+        if record.metadata["retry_of"] != source.run_id {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "pending Cook retry run is not the durable retry of its source attempt",
+                Some(recipe_attempt.run_id.clone()),
+                None,
+            ));
+        }
+        if agent_task_lifecycle::load_plan(&recipe_attempt.run_id)? != recipe_attempt.plan {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "pending Cook retry run does not match its durable plan",
+                Some(recipe_attempt.run_id.clone()),
+                None,
+            ));
+        }
+        if record.state.is_terminal() {
+            if record.state == agent_task_lifecycle::AgentTaskRunState::Succeeded {
+                return Ok(Some(CookRetryAttempt {
+                    cook_id: cook_id.to_string(),
+                    attempt: recipe_attempt.attempt,
+                    pending_run_id: Some(recipe_attempt.run_id.clone()),
+                    plan: recipe_attempt.plan.clone(),
+                }));
+            }
+            // A terminal failed successor is authoritative evidence. It cannot
+            // be resumed; a later attempt may be allocated below if the durable
+            // retry budget permits it.
+            continue;
+        }
+        if record.state != agent_task_lifecycle::AgentTaskRunState::Queued {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "pending Cook retry run is already active and must be resumed through its lifecycle",
+                Some(recipe_attempt.run_id.clone()),
+                None,
+            ));
+        }
+        pending_attempt = Some(recipe_attempt);
+        break;
+    }
+    if let Some(pending_attempt) = pending_attempt {
+        return Ok(Some(CookRetryAttempt {
+            cook_id: cook_id.to_string(),
+            attempt: pending_attempt.attempt,
+            pending_run_id: Some(pending_attempt.run_id.clone()),
+            plan: pending_attempt.plan.clone(),
+        }));
+    }
+    let max_attempts = recipe
+        .retry_budget
+        .get("max_attempts")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.retry_budget.max_attempts",
+                "durable Cook recipe is missing a valid max_attempts budget",
+                Some(cook_id.to_string()),
+                None,
+            )
+        })?;
+    let next_attempt = recipe
+        .attempts
+        .iter()
+        .map(|recipe_attempt| recipe_attempt.attempt)
+        .max()
+        .unwrap_or(attempt)
+        .checked_add(1)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "durable Cook attempt sequence is exhausted",
+                Some(cook_id.to_string()),
+                None,
+            )
+        })?;
+    if next_attempt > max_attempts {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.retry_budget.max_attempts",
+            "manual retry would exceed the durable Cook attempt budget",
+            Some(cook_id.to_string()),
+            None,
+        ));
+    }
+    Ok(Some(CookRetryAttempt {
+        cook_id: cook_id.to_string(),
+        attempt: next_attempt,
+        pending_run_id: None,
+        plan: source_recipe_attempt.plan.clone(),
+    }))
+}
+
+fn is_exact_retry_reservation(
+    source: &agent_task_lifecycle::AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+    run_id: &str,
+) -> Result<bool> {
+    let record = agent_task_lifecycle::exact_record(run_id)?;
+    Ok(record.metadata["retry_of"] == source.run_id
+        && agent_task_lifecycle::load_plan(run_id)? == *plan)
+}
+
+struct CookRetryAttempt {
+    cook_id: String,
+    attempt: u32,
+    pending_run_id: Option<String>,
+    plan: AgentTaskPlan,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -283,6 +283,15 @@ pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
     Ok(read_records_with_health()?.0)
 }
 
+pub(super) fn read_retry_successors(source_run_id: &str) -> Result<Vec<AgentTaskRunRecord>> {
+    let runs = ObservationStore::open_initialized()?.list_runs_by_retry_of(
+        "agent-task",
+        source_run_id,
+        16,
+    )?;
+    runs.iter().map(record_from_run).collect()
+}
+
 pub(super) fn read_records_with_health(
 ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
     let mut health = super::AgentTaskRecordHealthSummary::healthy();

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -1203,7 +1203,12 @@ fn materialize_agent_task_retry_handoff(
         return Ok(None);
     }
 
-    let record = agent_task_lifecycle::retry(&retry.run_id, retry.new_run_id.as_deref())?;
+    let retry_result =
+        crate::agents::agent_task_service::retry(&retry.run_id, retry.new_run_id.as_deref(), true)?;
+    if !retry_result.run {
+        return Ok(None);
+    }
+    let record = retry_result.record;
     let plan = agent_task_lifecycle::load_plan(&record.run_id)?;
     let primary_workspace = match retry_plan_primary_workspace(&plan) {
         Ok(workspace) => workspace,

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -932,6 +932,77 @@ fn lab_cook_materializes_goal_and_explicit_task_as_one_durable_cell() {
 }
 
 #[test]
+fn lab_run_retry_keeps_a_retryable_cook_failure_attached_to_its_recipe() {
+    crate::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path());
+        let run_id = "cook-lab-retry-attempt-1";
+        let cook_id = "cook-lab-retry";
+        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+            run_id,
+            vec![serde_json::from_value(serde_json::json!({
+                "task_id": "cook-lab-retry-task",
+                "executor": { "backend": "fixture" },
+                "instructions": "Repair the Lab Cook compiler",
+                "workspace": { "root": workspace.path() }
+            }))
+            .expect("task")],
+        );
+        let options = crate::agents::agent_task_service::AgentTaskCookServiceOptions {
+            cook_id: cook_id.to_string(),
+            initial_run_id: run_id.to_string(),
+            initial_plan: plan.clone(),
+            to_worktree: workspace.path().display().to_string(),
+            source_worktree_path: Some(workspace.path().to_path_buf()),
+            provider_command: None,
+            provider_invocation: None,
+            gates: Default::default(),
+            max_attempts: 2,
+            no_finalize: true,
+            base: "main".to_string(),
+            task_base_sha: None,
+            head: None,
+            title: "Lab Cook retry".to_string(),
+            commit_message: "Lab Cook retry".to_string(),
+            source_refs: Vec::new(),
+            protected_branches: Vec::new(),
+            ai_tool: "fixture".to_string(),
+            ai_model: None,
+            ai_used_for: "test".to_string(),
+            attempt_dispatcher: None,
+            harvest_context:
+                homeboy::agents::agent_task_scheduler::HarvestExecutionContext::from_current_process()
+                    .expect("harvest context"),
+        };
+        crate::agents::agent_task_service::persist_initial_recipe(&options)
+            .expect("persist Cook recipe");
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("persist Cook attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).expect("bind Cook attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            run_id,
+            &plan,
+            "gate_environment.preserve",
+            &Error::validation_invalid_argument("CARGO_HOME", "unavailable", None, None)
+                .with_retryable(true),
+        )
+        .expect("persist retryable Cook failure");
+        let args = ["homeboy", "agent-task", "retry", run_id, "--run"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let handoff = materialize_agent_task_retry_handoff(&Cli::parse_from(&args), &args)
+            .expect("materialize Cook retry handoff")
+            .expect("Cook retry handoff");
+
+        assert!(handoff.run_id.starts_with(&format!("{cook_id}-attempt-2-")));
+        let replacement = agent_task_lifecycle::status(&handoff.run_id)
+            .expect("Cook-aware Lab retry is persisted");
+        assert_eq!(replacement.metadata["cook_id"], cook_id);
+        assert_eq!(replacement.metadata["cook_attempt"], 2);
+    });
+}
+
+#[test]
 fn detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_failure() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -368,6 +368,35 @@ impl ObservationStore {
         collect_rows(rows, "collect run records")
     }
 
+    /// Return a bounded set of runs linked to the given retry predecessor.
+    /// The literal JSON path matches the `idx_runs_metadata_retry_of` index.
+    pub fn list_runs_by_retry_of(
+        &self,
+        kind: &str,
+        retry_of: &str,
+        limit: usize,
+    ) -> Result<Vec<RunRecord>> {
+        let limit = i64::try_from(limit.clamp(1, 1000)).expect("bounded run query limit");
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, kind, component_id, started_at, finished_at, status, command, cwd,
+                       homeboy_version, git_sha, rig_id, metadata_json
+                FROM runs
+                WHERE kind = ?1
+                  AND json_extract(metadata_json, '$.agent_task_run.metadata.retry_of') = ?2
+                ORDER BY started_at DESC, id DESC
+                LIMIT ?3
+                "#,
+            )
+            .map_err(sqlite_error("prepare metadata-indexed run query"))?;
+        let rows = statement
+            .query_map(params![kind, retry_of, limit], row_to_run_record)
+            .map_err(sqlite_error("query metadata-indexed run records"))?;
+        collect_rows(rows, "collect metadata-indexed run records")
+    }
+
     /// List every currently running run so callers can retain active work when
     /// applying a separate display limit to recent history.
     pub fn list_active_runs(&self) -> Result<Vec<RunRecord>> {

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -184,6 +184,15 @@ const MIGRATIONS: &[Migration] = &[
             ON artifacts(created_at ASC, id ASC);
         "#,
     },
+    Migration {
+        version: 10,
+        sql: r#"
+        -- Retry reconciliation starts from its durable predecessor identity.
+        -- Keep this JSON projection indexed so it never walks run history.
+        CREATE INDEX IF NOT EXISTS idx_runs_metadata_retry_of
+            ON runs(json_extract(metadata_json, '$.agent_task_run.metadata.retry_of'));
+        "#,
+    },
 ];
 
 static MIGRATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();


### PR DESCRIPTION
## Summary
- keep corrected pre-provider retries attached to the owning durable Cook recipe and index
- reserve retry provenance atomically and serialize concurrent retry allocation through durable operation claims
- preserve budgets, collision safety, terminal-success behavior, legacy retries, and Lab handoff without duplicate execution

## Verification
- `cargo test -p homeboy-agents retryable_pre_provider_retry --lib`
- `cargo test -p homeboy-cli lab_run_retry_keeps_a_retryable_cook_failure_attached_to_its_recipe --lib`
- `cargo fmt --all --check`
- `cargo check -p homeboy-agents -p homeboy-cli`

Closes #10363.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and iteratively remediated durable Cook retry ownership after multiple independent code reviews. Chris Huber reviewed and owns every line.