### PR TITLE
Preserve cloned extension shared assets in Lab

### DIFF
--- a/crates/homeboy-extension/src/lifecycle/install_sources.rs
+++ b/crates/homeboy-extension/src/lifecycle/install_sources.rs
@@ -6,7 +6,7 @@
 //! the lifecycle root stays under the structural line/item thresholds (#5241).
 
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use homeboy_core::config::{self, from_str};
 use homeboy_core::error::{Error, Result};
@@ -44,8 +44,11 @@ impl SharedAssetDeclaration {
     }
 }
 
-pub(crate) fn shared_assets_for_root(source_root: &Path) -> Vec<String> {
-    std::fs::read_to_string(source_root.join("homeboy-extension-root.json"))
+const ROOT_MANIFEST: &str = "homeboy-extension-root.json";
+const INSTALLED_ROOT_MANIFEST: &str = ".homeboy-extension-root.json";
+
+fn shared_assets_for_manifest(manifest_path: &Path) -> Vec<String> {
+    std::fs::read_to_string(manifest_path)
         .ok()
         .and_then(|raw| serde_json::from_str::<ExtensionRootManifest>(&raw).ok())
         .map(|manifest| {
@@ -58,6 +61,45 @@ pub(crate) fn shared_assets_for_root(source_root: &Path) -> Vec<String> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default()
+}
+
+pub(crate) fn shared_assets_for_root(source_root: &Path) -> Vec<String> {
+    shared_assets_for_manifest(&source_root.join(ROOT_MANIFEST))
+}
+
+pub(crate) fn shared_assets_for_extension_source(source: &Path) -> Vec<(String, PathBuf)> {
+    if let Some(source_root) = source.parent() {
+        let declared = shared_assets_for_root(source_root);
+        if !declared.is_empty() {
+            return declared
+                .into_iter()
+                .map(|path| {
+                    let source = source_root.join(&path);
+                    (path, source)
+                })
+                .collect();
+        }
+    }
+
+    let declared = shared_assets_for_root(source);
+    if !declared.is_empty() {
+        return declared
+            .into_iter()
+            .map(|path| {
+                let asset_source = source.join(&path);
+                (path, asset_source)
+            })
+            .collect();
+    }
+
+    shared_assets_for_manifest(&source.join(INSTALLED_ROOT_MANIFEST))
+        .into_iter()
+        .filter_map(|path| {
+            installed_shared_asset_target(source, &path)
+                .ok()
+                .map(|asset_source| (path, asset_source))
+        })
+        .collect()
 }
 
 pub(super) fn install_configured_extension(
@@ -208,6 +250,7 @@ pub(crate) fn resolve_cloned_extension(
 
         // Move just the subdirectory to the final extension location.
         rename_dir(&subdir, extension_dir)?;
+        persist_installed_root_manifest(temp_dir, extension_dir)?;
         return Ok(extension_id.to_string());
     }
 
@@ -274,24 +317,13 @@ fn install_shared_assets_from_root(
     extension_dir: &Path,
     mode: SharedAssetMode,
 ) -> Result<()> {
-    let Some(extensions_dir) = extension_dir.parent() else {
-        return Ok(());
-    };
-
     for shared_dir in shared_assets_for_root(source_root) {
         let source = source_root.join(&shared_dir);
         if !source.is_dir() {
             continue;
         }
 
-        let target = match shared_dir.as_str() {
-            "agent-runtimes" => paths::agent_runtimes()?,
-            "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(&shared_dir),
-            "dependency-adapters" => extensions_dir.join(&shared_dir),
-            // Shared extension libraries install under the extensions root so
-            // installed wrappers can source `../../../scripts/lib/...`.
-            _ => extensions_dir.join(&shared_dir),
-        };
+        let target = installed_shared_asset_target(extension_dir, &shared_dir)?;
         if let Some(parent) = target.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
                 Error::internal_io(
@@ -309,6 +341,37 @@ fn install_shared_assets_from_root(
     }
 
     Ok(())
+}
+
+fn persist_installed_root_manifest(source_root: &Path, extension_dir: &Path) -> Result<()> {
+    let source = source_root.join(ROOT_MANIFEST);
+    if !source.is_file() {
+        return Ok(());
+    }
+
+    std::fs::copy(source, extension_dir.join(INSTALLED_ROOT_MANIFEST)).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("persist installed extension root manifest".to_string()),
+        )
+    })?;
+    Ok(())
+}
+
+fn installed_shared_asset_target(extension_dir: &Path, shared_dir: &str) -> Result<PathBuf> {
+    let extensions_dir = extension_dir.parent().ok_or_else(|| {
+        Error::internal_io(
+            "installed extension has no parent directory",
+            Some("resolve installed shared extension asset".to_string()),
+        )
+    })?;
+    Ok(match shared_dir {
+        "agent-runtimes" => paths::agent_runtimes()?,
+        "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(shared_dir),
+        // Shared extension libraries install under the extensions root so
+        // installed wrappers can source `../../../scripts/lib/...`.
+        _ => extensions_dir.join(shared_dir),
+    })
 }
 
 /// Remove a shared-asset install target if present, handling both real

--- a/crates/homeboy-extension/src/lifecycle/mod.rs
+++ b/crates/homeboy-extension/src/lifecycle/mod.rs
@@ -321,6 +321,10 @@ use install_sources::{install_configured_extension, install_from_path, install_f
 pub fn shared_assets_for_root(source_root: &Path) -> Vec<String> {
     install_sources::shared_assets_for_root(source_root)
 }
+/// Resolves declared shared assets to their current controller-side sources.
+pub fn shared_assets_for_extension_source(source: &Path) -> Vec<(String, PathBuf)> {
+    install_sources::shared_assets_for_extension_source(source)
+}
 pub(crate) use install_sources::{
     install_linked_shared_assets, rename_dir, resolve_cloned_extension,
 };
@@ -368,7 +372,7 @@ mod tests {
 
     use super::{
         install, install_for_component, install_with_revision, is_extension_update_workdir_clean,
-        load_extension, refresh, source_metadata, update,
+        load_extension, refresh, shared_assets_for_extension_source, source_metadata, update,
     };
     use crate::update_all;
     use homeboy_core::component;
@@ -1108,7 +1112,8 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            install(&remote_url.to_string_lossy(), Some("rust")).expect("install cloned extension");
+            let installed = install(&remote_url.to_string_lossy(), Some("rust"))
+                .expect("install cloned extension");
 
             assert!(home
                 .join(".config/homeboy/extensions/rust/rust.json")
@@ -1116,6 +1121,15 @@ exec '{}' "$@"
             assert!(home
                 .join(".config/homeboy/extensions/scripts/lib/test-result-adapters.sh")
                 .exists());
+            assert!(installed.path.join(".homeboy-extension-root.json").exists());
+            assert_eq!(
+                shared_assets_for_extension_source(&installed.path),
+                vec![(
+                    "scripts/lib".to_string(),
+                    home.join(".config/homeboy/extensions/scripts/lib")
+                )],
+                "cloned installs retain enough declaration metadata for Lab to resolve the installed shared asset"
+            );
         });
     }
 
@@ -1215,6 +1229,9 @@ exec '{}' "$@"
                 .exists());
             assert!(home
                 .join(".config/homeboy/extensions/dependency-adapters/examples/nodejs.json")
+                .exists());
+            assert!(home
+                .join(".config/homeboy/extensions/wordpress/.homeboy-extension-root.json")
                 .exists());
         });
     }

--- a/crates/homeboy-lab-runner/src/extension_materialization.rs
+++ b/crates/homeboy-lab-runner/src/extension_materialization.rs
@@ -139,17 +139,10 @@ fn materialize_lab_job_extension_overlay_snapshots(
                 Some(format!("resolve Lab extension source `{id}`")),
             )
         })?;
-        let source_root = resolved_source.parent().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "extensions",
-                format!("Lab extension `{id}` has no source root"),
-                Some(source_path.clone()),
-                None,
-            )
-        })?;
         let mut shared_assets = Vec::new();
-        for asset_path in homeboy_extension::lifecycle::shared_assets_for_root(source_root) {
-            let asset_source = source_root.join(&asset_path);
+        for (asset_path, asset_source) in
+            homeboy_extension::lifecycle::shared_assets_for_extension_source(&resolved_source)
+        {
             if !asset_source.is_dir() {
                 continue;
             }
@@ -1205,6 +1198,64 @@ mod tests {
                 "Node.js test runner did not reach project tests: {}",
                 String::from_utf8_lossy(&output.stderr)
             );
+        });
+    }
+
+    #[test]
+    fn isolated_lab_overlay_stages_shared_assets_from_cloned_install_metadata() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extensions_root = home.path().join(".config/homeboy/extensions");
+            let wordpress = extensions_root.join("wordpress");
+            let scripts_lib = extensions_root.join("scripts/lib");
+            fs::create_dir_all(&wordpress).expect("installed WordPress extension");
+            fs::create_dir_all(&scripts_lib).expect("installed shared scripts");
+            fs::write(
+                wordpress.join("wordpress.json"),
+                r#"{"id":"wordpress","name":"WordPress","version":"1.0.0"}"#,
+            )
+            .expect("WordPress manifest");
+            fs::write(
+                wordpress.join(".homeboy-extension-root.json"),
+                r#"{"shared_assets":["scripts/lib"]}"#,
+            )
+            .expect("persisted root manifest");
+            fs::write(
+                scripts_lib.join("settings.sh"),
+                "homeboy_setting() { :; }\n",
+            )
+            .expect("shared helper");
+
+            let runner_root = tempfile::tempdir().expect("runner root");
+            crate::create(
+                &format!(
+                    r#"{{"id":"lab-cloned-overlay","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+            let runner = crate::load("lab-cloned-overlay").expect("load runner");
+            let runtime_root = runner_root.path().join("extension-runtime");
+            let overlays = materialize_lab_job_extension_overlay_snapshots(
+                &runner,
+                &runtime_root.display().to_string(),
+                &["wordpress".to_string()],
+            )
+            .expect("stage cloned install overlay snapshots");
+            let status = Command::new("sh")
+                .arg("-c")
+                .arg(lab_job_extension_overlay_command(
+                    &runtime_root.display().to_string(),
+                    &overlays,
+                ))
+                .status()
+                .expect("link cloned install overlay");
+            assert!(status.success(), "link cloned install overlay");
+
+            assert_eq!(overlays[0].shared_assets.len(), 1);
+            assert!(runtime_root
+                .join("home/.config/homeboy/extensions/scripts/lib/settings.sh")
+                .exists());
         });
     }
 


### PR DESCRIPTION
## Summary

- persist a monorepo extension root manifest beside cloned extension installs before the source clone is discarded
- resolve declared assets through the same installed-layout mapping used by extension installation
- stage those resolved installed assets in isolated Lab overlays while preserving linked/source-tree behavior
- cover fresh clone, cloned update, cloned isolated overlay, and existing linked overlay paths

Fixes #9577.
Related extension tracker: https://github.com/Extra-Chill/homeboy-extensions/issues/2341
Consumer: https://github.com/Automattic/static-site-importer/pull/739

## Failure Evidence

- persisted run: `runner-exec-review-test-static-site-importer-homeboy-lab-283ec6cb-172a-4185-bdc0-7c08bb7b63f3`
- runner job: `283ec6cb-172a-4185-bdc0-7c08bb7b63f3`
- observed failure: the isolated runtime omitted `extensions/scripts/lib`; WordPress `test-runner.sh` and `parse-test-results.sh` failed before workload execution

## Verification

- `cargo test -p homeboy-extension cloned_monorepo_install_materializes_declared_shared_scripts`
- `cargo test -p homeboy-extension extracted_monorepo_update_materializes_declared_shared_agent_runtimes`
- `cargo test -p homeboy-lab-runner isolated_lab_overlay_stages_shared_assets_from_cloned_install_metadata`
- `cargo test -p homeboy-lab-runner isolated_lab_nodejs_overlay_stages_root_assets_for_project_tests`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode diagnosed the cloned-install metadata loss, drafted the lifecycle and Lab materialization repair with regression coverage, and ran verification. Chris Huber reviewed and remains responsible for every line.