### PR TITLE
ci: drop the Windows release target and its pre-tag build gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,24 +198,6 @@ jobs:
           path: target/release/homeboy
           retention-days: 1
 
-  # The artifact matrix includes Windows, so compile the complete workspace on
-  # its native target before preparation creates a release tag.
-  gate-windows-build:
-    name: Windows Build
-    needs: check
-    if: needs.check.outputs.should-release == 'true'
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_tag || github.ref }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Compile Windows workspace
-        run: cargo build --workspace --locked
-
   # ── Step 3: Quality checks (parallel read-only checks + advisory repair) ──
   # Release preparation is gated by release-quality-policy, not by raw job
   # failures. Commands opt in to release blocking through RELEASE_BLOCKING_COMMANDS
@@ -376,11 +358,10 @@ jobs:
     needs:
       - check
       - gate-build
-      - gate-windows-build
       - gate-audit
       - gate-lint
       - gate-test
-    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' && needs.gate-windows-build.result == 'success' }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true' && needs.gate-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workflow event commit
@@ -403,9 +384,8 @@ jobs:
     needs:
       - check
       - gate-build
-      - gate-windows-build
       - release-quality-policy
-    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && needs.gate-windows-build.result == 'success' && (needs.check.outputs.recovery-release == 'true' || inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && (needs.check.outputs.recovery-release == 'true' || inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
     runs-on: ubuntu-latest
     outputs:
       release-version: ${{ steps.outputs.outputs['release-version'] }}
@@ -909,7 +889,6 @@ jobs:
     needs:
       - check
       - gate-build
-      - gate-windows-build
       - gate-audit
       - gate-lint
       - gate-test
@@ -940,7 +919,6 @@ jobs:
     needs:
       - check
       - gate-build
-      - gate-windows-build
       - gate-audit
       - gate-lint
       - gate-test

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,7 +16,7 @@ tap = "Extra-Chill/homebrew-tap"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Allow manual CI edits
 # Allow manual CI edits
 allow-dirty = ["ci"]


### PR DESCRIPTION
Cuts ~27 minutes from every release.

## Measured cost (from release run `30274772050`)

| Job | Time |
|---|---|
| `build (x86_64-pc-windows-msvc)` — artifact | **1265s** |
| `Windows Build` — pre-tag gate | **355s** |
| Build (Linux) | 536s |
| Test | 201s |
| Lint | 148s |
| Audit | 29s |

The Windows artifact was the longest job in the pipeline by a factor of ~2.4 over the next.

## Why this matters beyond speed

Release duration is the mechanism behind the starvation in #10441. With `cancel-in-progress: false`, a new push displaces the *pending* run — so when merges land faster than a release completes, most runs never execute at all. At ~35 minutes per release and merges every ~10-20 minutes, that left **188 commits unreleased** and produced two tags (`v0.319.3`, `v0.320.0`) with no published release.

Dropping ~27 minutes should put a release comfortably inside a normal merge gap.

## Why the target, not just the gate

Homebrew is the only installer configured in `dist-workspace.toml`, and there is no Windows consumer. Removing only the gate would have saved 355s while leaving the 1265s artifact build — and would have removed the pre-tag protection that stops a Windows-only compile error from tagging first and failing afterward, which is exactly the orphaned-tag failure mode #10441 documents.

Removing the target makes the gate moot rather than a lost safety net. `gate-windows-build`'s own comment gave the artifact matrix as its whole justification.

## What is deliberately kept

**`windows-compile` in `ci.yml` stays.** It is:
- in **PR CI, not the release** — removing it would save zero release time
- codegen-free `cargo check --workspace --locked`, cheap enough for every PR
- there because of a **real incident (#10398)**: Unix-only `libc` constants (`SIGKILL` has no Windows definition) compiled fine on Linux and turned `main` red only after merge

The tree still carries **36 `cfg(windows)` sites** and `windows-sys` dependencies in `homeboy-core`, `homeboy-agents`, and `homeboy-release`. That gate is what keeps them compiling for anyone building from source on Windows. Ripping out cross-platform source support is a much larger decision and is not in scope here.

## Verification

`release.yml` parses; no `gate-windows-build` references remain; `prepare` and `release-quality-policy` no longer gate on it; `EXPECTED_ASSETS` is derived from the dist plan so it drops the Windows entries automatically. No docs referenced a Windows binary.