### PR TITLE
fix: indexed agent-task activity probe and single-pass report

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -21,6 +21,23 @@ use homeboy_core::Result;
 struct AgentTaskActivityProvider;
 
 impl ActivityAgentTaskProvider for AgentTaskActivityProvider {
+    /// Resolve one durable record by its primary key (`exact_record`, a single
+    /// indexed `get_run`) instead of listing and refreshing every record.
+    ///
+    /// This read is deliberately not `status()`: `activity` is documented as a
+    /// read model that does not mutate persisted state, and `status()` is a
+    /// reconciling read that writes. Resolving one id must not enter that path
+    /// (#10308).
+    ///
+    /// An id that is not a durable agent-task record — an observation run id, a
+    /// daemon job UUID, a malformed record — is `None`, not an error, so id
+    /// resolution falls through to the next provider.
+    fn probe_by_id(&self, id: &str) -> Result<Option<ActivityItem>> {
+        Ok(agent_task_lifecycle::exact_record(id)
+            .ok()
+            .map(item_from_agent_task))
+    }
+
     fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>> {
         Ok(agent_task_lifecycle::list_records()?
             .into_iter()
@@ -150,6 +167,25 @@ pub fn register() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_task_lifecycle::tests::{succeeded_aggregate, test_plan};
+    use homeboy_core::observation::{NewRunRecord, ObservationStore};
+    use homeboy_core::test_support::with_isolated_home;
+
+    fn seed_record(run_id: &str) -> String {
+        let plan = test_plan();
+        let aggregate = succeeded_aggregate(&plan);
+        agent_task_lifecycle::record_completed_run(&plan, &aggregate, Some(run_id))
+            .expect("durable agent-task record")
+            .run_id
+    }
+
+    fn controller_admission_stamped(run_id: &str) -> bool {
+        agent_task_lifecycle::exact_record(run_id)
+            .expect("durable record")
+            .metadata
+            .get("controller_admission")
+            .is_some()
+    }
 
     #[test]
     fn runner_backed_actions_execute_on_the_owning_runner() {
@@ -159,5 +195,80 @@ mod tests {
             action.command
                 == "homeboy runner exec lab-a -- homeboy agent-task reconcile run-1 --dry-run"
         }));
+    }
+
+    #[test]
+    fn probe_by_id_resolves_one_record_without_scanning_or_writing() {
+        // #10308: resolving a single agent-task id must be an indexed read, not
+        // a full-corpus refresh. The scanning path refreshes every record
+        // through `status()`, which stamps `controller_admission` on each one —
+        // so the absence of that stamp is durable evidence that neither the
+        // probed record nor its siblings were scanned or written.
+        with_isolated_home(|_| {
+            let target = seed_record("run-probe-target");
+            let sibling = seed_record("run-probe-sibling");
+            assert!(!controller_admission_stamped(&target));
+            assert!(!controller_admission_stamped(&sibling));
+
+            let item = AgentTaskActivityProvider
+                .probe_by_id(&target)
+                .expect("probe")
+                .expect("agent-task activity item");
+
+            assert_eq!(item.id, target);
+            assert_eq!(item.kind, "agent-task");
+            assert_eq!(item.source_store, "agent-task.lifecycle");
+            assert_eq!(
+                item.refs.agent_task_run_id.as_deref(),
+                Some(target.as_str())
+            );
+            assert!(!controller_admission_stamped(&target));
+            assert!(!controller_admission_stamped(&sibling));
+
+            // Control: the scanning path the probe replaces does refresh — and
+            // therefore write — every record, which is the cost being avoided.
+            agent_task_lifecycle::list_records().expect("records listed");
+            assert!(controller_admission_stamped(&target));
+            assert!(controller_admission_stamped(&sibling));
+        });
+    }
+
+    #[test]
+    fn probe_by_id_ignores_ids_that_are_not_durable_agent_task_records() {
+        // An observation run id or an unknown id is "not found here", not an
+        // error, so core's resolver falls through to the next probe.
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("observation store");
+            let run = store
+                .start_run(NewRunRecord::builder("bench").build())
+                .expect("observation run");
+
+            assert!(AgentTaskActivityProvider
+                .probe_by_id(&run.id)
+                .expect("probe")
+                .is_none());
+            assert!(AgentTaskActivityProvider
+                .probe_by_id("no-such-run")
+                .expect("probe")
+                .is_none());
+        });
+    }
+
+    #[test]
+    fn show_activity_resolves_an_agent_task_id_through_the_indexed_probe() {
+        // End-to-end: `homeboy activity show <agent-task-id>` resolves the
+        // authoritative lifecycle projection — the same source that wins the id
+        // in `activity list` — without entering the reconciling scan.
+        with_isolated_home(|_| {
+            register();
+            let run_id = seed_record("run-show-probe");
+
+            let report = homeboy_core::activity::show_activity(&run_id).expect("show activity");
+
+            assert_eq!(report.items.len(), 1);
+            assert_eq!(report.items[0].id, run_id);
+            assert_eq!(report.items[0].source_store, "agent-task.lifecycle");
+            assert!(!controller_admission_stamped(&run_id));
+        });
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -38,21 +38,19 @@ impl ActivityAgentTaskProvider for AgentTaskActivityProvider {
             .map(item_from_agent_task))
     }
 
-    fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>> {
-        Ok(agent_task_lifecycle::list_records()?
-            .into_iter()
-            .map(item_from_agent_task)
-            .collect())
-    }
-
-    fn agent_task_record_health(&self) -> Result<Value> {
-        let summary = agent_task_lifecycle::record_health_summary()?;
-        serde_json::to_value(summary).map_err(|error| {
+    /// One pass over the durable records yields both the projected items and
+    /// the health summary for the same read, through the single-pass
+    /// `list_records_with_health` (#10308).
+    fn agent_task_activity(&self) -> Result<(Vec<ActivityItem>, Value)> {
+        let (records, health) = agent_task_lifecycle::list_records_with_health()?;
+        let items = records.into_iter().map(item_from_agent_task).collect();
+        let health = serde_json::to_value(health).map_err(|error| {
             homeboy_core::Error::internal_json(
                 error.to_string(),
                 Some("serialize agent-task record health".to_string()),
             )
-        })
+        })?;
+        Ok((items, health))
     }
 }
 
@@ -168,6 +166,7 @@ pub fn register() {
 mod tests {
     use super::*;
     use crate::agent_task_lifecycle::tests::{succeeded_aggregate, test_plan};
+    use homeboy_core::activity::ActivityScope;
     use homeboy_core::observation::{NewRunRecord, ObservationStore};
     use homeboy_core::test_support::with_isolated_home;
 
@@ -230,6 +229,29 @@ mod tests {
             agent_task_lifecycle::list_records().expect("records listed");
             assert!(controller_admission_stamped(&target));
             assert!(controller_admission_stamped(&sibling));
+        });
+    }
+
+    #[test]
+    fn the_report_carries_record_health_from_the_same_pass_that_projects_items() {
+        // Report shape is unchanged: `list` still attaches the record-health
+        // summary — now from the single pass that also projects the items —
+        // and `show` carries the field as null rather than paying for a corpus
+        // scan to fill it (#10308).
+        with_isolated_home(|_| {
+            register();
+            let run_id = seed_record("run-report-health");
+
+            let report = homeboy_core::activity::activity_report(ActivityScope::All, 50)
+                .expect("activity report");
+
+            assert!(report.items.iter().any(|item| item.id == run_id));
+            assert_eq!(report.agent_task_record_health["healthy"], 1);
+
+            let shown = homeboy_core::activity::show_activity(&run_id).expect("show activity");
+
+            assert_eq!(shown.schema, report.schema);
+            assert!(shown.agent_task_record_health.is_null());
         });
     }
 

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -65,11 +65,21 @@ pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityRep
 ///
 /// Ownership note: full-corpus aggregation belongs to `activity list`, so the
 /// fallback is intentionally the last resort here.
+///
+/// Probe order mirrors the collector's source precedence. Agent-task lifecycle
+/// records are also rows in the observation store, so the untyped observation
+/// probe resolves an agent-task id too — but only into the subordinate
+/// observation projection. Probing the authoritative lifecycle source first
+/// keeps `show`/`watch` agreeing with `list`, where the lifecycle projection
+/// wins the same id (#10308).
 fn resolve_activity_item(id: &str) -> Result<Option<ActivityItem>> {
     // Bounded, indexed probes for the id shapes `show`/`watch` are called with.
     // A failing probe (missing store, etc.) must not abort resolution — treat it
     // as "not found here" and continue so a partial-source outage still resolves
     // the id from another provider.
+    if let Ok(Some(item)) = agent_task_provider::probe_by_id(id) {
+        return Ok(Some(item));
+    }
     if let Ok(Some(item)) = observation::probe_by_id(id) {
         return Ok(Some(item));
     }
@@ -558,6 +568,16 @@ mod tests {
                 .expect("probe")
                 .is_none());
         });
+    }
+
+    #[test]
+    fn agent_task_probe_defaults_to_none_without_a_registered_provider() {
+        // The trait default keeps the no-op provider (and any implementor that
+        // has no indexed lookup) out of the resolution path entirely, so id
+        // resolution falls through to the remaining probes (#10308).
+        assert!(agent_task_provider::probe_by_id("agent-task-run-1")
+            .expect("probe")
+            .is_none());
     }
 
     #[test]

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -43,13 +43,16 @@ const RUNNING_HEARTBEAT_STALE_MINUTES: i64 = 30;
 pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityReport> {
     let mut collector = ActivityCollector::default();
     observation::collect(&mut collector, limit)?;
-    for item in agent_task_provider::agent_task_activity_items()? {
+    // Items and record health come from one pass over the durable agent-task
+    // records. Reading them separately walked the corpus twice (#10308).
+    let (agent_task_items, agent_task_record_health) = agent_task_provider::agent_task_activity()?;
+    for item in agent_task_items {
         collector.insert(item);
     }
     daemon_jobs::collect(&mut collector)?;
     runner_sessions::collect(&mut collector);
     let mut report = report_from_items(collector.items(scope, limit), "activity");
-    report.agent_task_record_health = agent_task_provider::agent_task_record_health()?;
+    report.agent_task_record_health = agent_task_record_health;
     Ok(report)
 }
 
@@ -108,11 +111,11 @@ pub fn show_activity(id: &str) -> Result<ActivityReport> {
     let Some(item) = resolve_activity_item(id)? else {
         return Err(activity_item_not_found(id));
     };
-    let mut result = report_from_items(vec![item], "activity.show");
-    // Preserve the record-health field the full-report path attached. This is a
-    // single bounded provider probe, not a corpus scan.
-    result.agent_task_record_health = agent_task_provider::agent_task_record_health()?;
-    Ok(result)
+    // Record health is a full-corpus diagnostic owned by `activity list`.
+    // Attaching it here re-read every durable agent-task record just to answer
+    // one id, so it stays null — the report shape carries the field either way
+    // (#10308).
+    Ok(report_from_items(vec![item], "activity.show"))
 }
 
 pub fn resolve_activity(id: &str) -> Result<ActivityItem> {

--- a/crates/homeboy-core/src/activity/agent_task_provider.rs
+++ b/crates/homeboy-core/src/activity/agent_task_provider.rs
@@ -27,23 +27,21 @@ pub trait ActivityAgentTaskProvider: Send + Sync {
         Ok(None)
     }
 
-    /// Project every durable agent-task record into an activity item.
-    fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>>;
-
-    /// The agent-task record-health summary, serialized as JSON so core does not
-    /// depend on the agent-task health type.
-    fn agent_task_record_health(&self) -> Result<Value>;
+    /// Project every durable agent-task record into an activity item, together
+    /// with the record-health summary for the same records.
+    ///
+    /// Items and health are one call because they are one read of the same
+    /// durable records. Asking for them separately made the activity report
+    /// walk the corpus twice (#10308). The health summary is serialized as JSON
+    /// so core does not depend on the agent-task health type.
+    fn agent_task_activity(&self) -> Result<(Vec<ActivityItem>, Value)>;
 }
 
 struct NoopProvider;
 
 impl ActivityAgentTaskProvider for NoopProvider {
-    fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>> {
-        Ok(Vec::new())
-    }
-
-    fn agent_task_record_health(&self) -> Result<Value> {
-        Ok(Value::Null)
+    fn agent_task_activity(&self) -> Result<(Vec<ActivityItem>, Value)> {
+        Ok((Vec::new(), Value::Null))
     }
 }
 
@@ -64,14 +62,9 @@ pub(crate) fn probe_by_id(id: &str) -> Result<Option<ActivityItem>> {
     with_provider(|p| p.probe_by_id(id))
 }
 
-/// The agent-task activity items via the registered provider (or none when the
-/// agent-task subsystem is absent).
-pub(crate) fn agent_task_activity_items() -> Result<Vec<ActivityItem>> {
-    with_provider(|p| p.agent_task_activity_items())
-}
-
-/// The agent-task record-health summary (as JSON) via the registered provider
-/// (or an empty summary when the agent-task subsystem is absent).
-pub(crate) fn agent_task_record_health() -> Result<Value> {
-    with_provider(|p| p.agent_task_record_health())
+/// The agent-task activity items and record-health summary via the registered
+/// provider (or no items and an empty summary when the agent-task subsystem is
+/// absent).
+pub(crate) fn agent_task_activity() -> Result<(Vec<ActivityItem>, Value)> {
+    with_provider(|p| p.agent_task_activity())
 }

--- a/crates/homeboy-core/src/activity/agent_task_provider.rs
+++ b/crates/homeboy-core/src/activity/agent_task_provider.rs
@@ -17,6 +17,16 @@ use crate::Result;
 
 /// Supplies the agent-task contribution to the activity report.
 pub trait ActivityAgentTaskProvider: Send + Sync {
+    /// Resolve a single agent-task activity item by id through an indexed
+    /// lookup, without listing every durable record.
+    ///
+    /// Defaults to `Ok(None)` so a provider without an indexed lookup — and the
+    /// no-op provider when no agent-task subsystem is present — contributes
+    /// nothing and id resolution falls through to the next probe.
+    fn probe_by_id(&self, _id: &str) -> Result<Option<ActivityItem>> {
+        Ok(None)
+    }
+
     /// Project every durable agent-task record into an activity item.
     fn agent_task_activity_items(&self) -> Result<Vec<ActivityItem>>;
 
@@ -46,6 +56,12 @@ homeboy_engine_primitives::provider_registry! {
     /// Run `f` against the registered provider, or the no-op provider if none
     /// is registered.
     with: fn with_provider,
+}
+
+/// Resolve one agent-task activity item by id via the registered provider's
+/// indexed lookup (or none when the agent-task subsystem is absent).
+pub(crate) fn probe_by_id(id: &str) -> Result<Option<ActivityItem>> {
+    with_provider(|p| p.probe_by_id(id))
 }
 
 /// The agent-task activity items via the registered provider (or none when the

--- a/docs/commands/activity.md
+++ b/docs/commands/activity.md
@@ -24,8 +24,10 @@ JSON output uses the standard command-result envelope with `data.schema = homebo
 - artifact/evidence refs
 - structured `next_actions` with `label` and exact `command`
 
+`agent_task_record_health` is a full-corpus diagnostic attached by `list` only. `show` and `watch` resolve a single id and leave it null rather than scanning every durable agent-task record to fill it.
+
 Human output is a compact table followed by next-action command lines per item.
 
 ## Scope
 
-This is a local read model only. List, show, and watch do not reconcile or otherwise mutate persisted state. Agent-task stale actions target the inspected run with `homeboy agent-task reconcile <run-id> --dry-run`; review the authoritative provider-state preview, then add `--apply` to authorize that one lifecycle mutation. It does not create a daemon, event bus, or offloaded job, and the Lab contract marks it local-only.
+This is a local read model only. List, show, and watch do not reconcile or otherwise mutate persisted state. `show` and `watch` resolve their id through indexed per-provider probes — agent-task lifecycle, observation run, daemon job — and only fall back to a bounded full report when no probe answers. (`list` still refreshes agent-task records through the reconciling lifecycle status read, which writes; making that projection read-only is tracked separately.) Agent-task stale actions target the inspected run with `homeboy agent-task reconcile <run-id> --dry-run`; review the authoritative provider-state preview, then add `--apply` to authorize that one lifecycle mutation. It does not create a daemon, event bus, or offloaded job, and the Lab contract marks it local-only.


### PR DESCRIPTION
`homeboy activity show <agent-task-id>` is both O(all records) and a write amplifier that contends with the running jobs it reports on.

There was no indexed agent-task lookup, so any id the observation and daemon-job probes did not answer fell through to `activity_report(ActivityScope::All, 1000)`. That path refreshes **every** agent-task record through `agent_task_lifecycle::status()` — a reconciling read that performs up to seven `store::write_record` calls per record plus runner-job reconciliation — while the report separately re-read the corpus for record health, and `show` re-read it a third time. Resolving one id degraded to three full passes, one of which took the SQLite WAL writer lock once per record.

## What changed

**1. Indexed probe (`0c1729e`).** `ActivityAgentTaskProvider::probe_by_id` with a default `Ok(None)` body, so the no-op provider and any other implementor are unaffected. The agent-task layer backs it with `exact_record` — a single primary-key `get_run` that never enters `status()`. The probe is therefore **read-only**: it does not trigger the write-amplifying reconciliation at all, which is what makes `activity`'s documented "does not mutate persisted state" contract true for `show`/`watch`.

Placement note, deviating from the issue text: the probe runs **before** the observation probe, not between daemon-jobs and the fallback. Agent-task lifecycle records are rows in the same observation store, so `observation::probe_by_id` (an untyped `get_run`) already answers an agent-task id — with the *subordinate* observation projection, while `activity list` gives the same id to the authoritative lifecycle projection. Ordering the probes after the observation probe would have made this one dead code and left `show` disagreeing with `list`. Probe order now mirrors the collector's source precedence.

**2. Single-pass report (`cfe1517`).** `agent_task_activity_items()` + `agent_task_record_health()` collapse into one `agent_task_activity()` backed by the already-written, previously unused `list_records_with_health()`. `show` no longer attaches record health — it is a full-corpus diagnostic owned by `list`.

Scans to answer one id: **3 → 0** (indexed probe only; the bounded report fallback remains for ids no probe answers). Scans for `activity list`: **2 → 1**.

## Not in scope

`status()` performing up to seven writes per record on a read is the deeper defect. It is untouched here — that is a behavioral change with wide blast radius and deserves its own issue. `list` still refreshes through it; only single-id resolution now avoids it. `docs/commands/activity.md` records that exception rather than leaving the doc's read-only claim silently false.

## Tests

- `probe_by_id_resolves_one_record_without_scanning_or_writing` — seeds two records and asserts the probe resolves the target while neither record gets the `controller_admission` stamp that `status()` writes; the control then runs `list_records()` and asserts both records *do* get stamped, so the assertion has teeth.
- `probe_by_id_ignores_ids_that_are_not_durable_agent_task_records` — an observation run id and an unknown id are `None`, not errors, so the fallback path is preserved.
- `show_activity_resolves_an_agent_task_id_through_the_indexed_probe` — end-to-end, resolves the authoritative lifecycle projection with no reconciling write.
- `the_report_carries_record_health_from_the_same_pass_that_projects_items` — report shape unchanged; health attached by `list`, null on `show`.
- `agent_task_probe_defaults_to_none_without_a_registered_provider` — the trait default keeps non-implementors out of the resolution path.

Closes #10308