### PR TITLE
ci: gate main on the full release-blocking suite after every merge

### DIFF
--- a/.github/report-red-main.sh
+++ b/.github/report-red-main.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Emit an attribution report when a post-merge gate finds `main` red.
+#
+# The whole value of the post-merge gate is knowing WHICH merge broke main, so
+# this prints the merge commit, its author, and the compare range for the push.
+#
+# All untrusted values (commit subject, author name) arrive via the environment
+# and are only ever expanded inside quotes — never interpolated into the script
+# body by the workflow. A commit message is attacker-influenced input.
+
+set -euo pipefail
+
+: "${MERGE_SHA:?MERGE_SHA is required}"
+: "${GATE:?GATE is required}"
+
+merge_before="${MERGE_BEFORE:-}"
+merge_author="${MERGE_AUTHOR:-unknown}"
+
+# First line only — commit bodies can be arbitrarily long.
+subject="$(printf '%s\n' "${MERGE_SUBJECT:-(no subject)}" | head -n 1)"
+
+short_sha="$(printf '%s' "${MERGE_SHA}" | cut -c1-9)"
+short_before="$(printf '%s' "${merge_before}" | cut -c1-9)"
+repo_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}"
+
+{
+  echo "## \`main\` is red after this merge"
+  echo
+  echo "The **${GATE}** gate failed on the merged result. This is the full"
+  echo "release-blocking suite, so the next release would fail at"
+  echo "\`Release Quality Policy\` → \`${GATE}\` unless this is fixed first."
+  echo
+  echo "| | |"
+  echo "| --- | --- |"
+  echo "| Merge commit | [\`${short_sha}\`](${repo_url}/commit/${MERGE_SHA}) |"
+  echo "| Author | ${merge_author} |"
+  echo "| Subject | ${subject} |"
+} >>"${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+# The all-zero SHA is what GitHub sends for a branch's first push.
+if [ -n "${merge_before}" ] && [ "${merge_before}" != "0000000000000000000000000000000000000000" ]; then
+  {
+    echo "| Pushed range | [\`${short_before}...${short_sha}\`](${repo_url}/compare/${merge_before}...${MERGE_SHA}) |"
+    echo
+    echo "> Runs are cancelled by newer merges (\`cancel-in-progress: true\`), so if"
+    echo "> a burst landed together the culprit may be any merge since the last"
+    echo "> green run of this workflow — not necessarily the one named above."
+    echo "> Widen the compare range to that run's commit to see the full candidate set."
+  } >>"${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+fi
+
+echo "::error::main is red after ${short_sha} (${GATE} gate): ${subject}"

--- a/.github/workflows/audit-debt.yml
+++ b/.github/workflows/audit-debt.yml
@@ -1,23 +1,55 @@
-# Full-tree audit debt sweep.
+# Post-merge guard for `main`, plus the weekly full-tree audit debt sweep.
 #
-# The PR pipeline (ci.yml) runs a `--profile=pr --changed-since` audit: fast,
-# scoped to the diff, and it only runs the cheap RootOnly detector families.
-# The whole-tree discovery detectors (duplication, dead code, constant/command
+# (File name is historical — this started life as the audit-only debt sweep and
+# grew the post-merge lint/test gates. Kept as `audit-debt.yml` so the file's
+# git history stays intact.)
+#
+# ── Why the post-merge gates exist (#6807) ──────────────────────────────────
+# Two pipelines guard this repo, and until now BOTH were changed-scope:
+#
+#   * ci.yml (PRs)  — `differential-gating: true`, scoped to the PR diff.
+#   * release.yml   — gate-lint/gate-test pass `--changed-since <before>`, so
+#                     they only re-check what that one push touched.
+#
+# Nothing ever ran the whole suite against the integrated `main`. A change whose
+# blast radius lands OUTSIDE its own diff is invisible to both: the PR never
+# runs the affected tests, and the release only runs them if some later merge
+# happens to touch those same files.
+#
+# That is exactly how 2026-07-27 went. A POSIX-sh portability bug merged green,
+# main went red in `crates/homeboy-lab-runner/src/workspace/tests/prune.rs`, and
+# nobody found out until merge #10425 happened to touch prune.rs and dragged it
+# into the release's changed scope. Release runs 30272803452 and 30271131168
+# both died at `Release Quality Policy` → `Test`. Cost: 188 commits
+# undeliverable, two orphaned tags, ~16 hours of stranded work.
+#
+# The release is the WORST place to discover this: it runs 16-35 minutes and a
+# failure there can strand a tag. So the gates below run the release-blocking
+# command set (RELEASE_BLOCKING_COMMANDS = `review lint,review test`) against
+# `main` on every merge, at FULL scope.
+#
+# Full scope is not an extra flag — homeboy-action's `scope: auto` already
+# resolves to `mode=full` on push events. The release narrows itself by
+# explicitly passing `--changed-since`; we simply do not pass it. That makes
+# this gate a strict superset of the release's blocking scope, which is the
+# point: anything that would fail the release is caught here first, and so is
+# the cross-scope breakage the release would have missed.
+#
+# ── Why the weekly sweep exists ─────────────────────────────────────────────
+# The PR pipeline runs a `--profile=pr --changed-since` audit: fast, scoped to
+# the diff, and it only runs the cheap RootOnly detector families. The
+# whole-tree discovery detectors (duplication, dead code, constant/command
 # bypass, god files, …) are deliberately OFF in the PR profile — they need the
 # entire codebase to work and would re-report repo-wide debt on every unrelated
 # PR.
 #
 # Those discovery detectors are the "code factory" roadmap: each finding kind
 # becomes one deduplicated tracking issue (via homeboy-action's auto-issue
-# filing), and the issue closes when that fix kind gets automated. Nothing was
-# ever running the full-tree audit, so that roadmap was never populated. This
-# workflow does — on a weekly cadence, decoupled from releases so a full audit
-# never taxes the release path — and files/refreshes one issue per finding kind.
-#
-# Scheduled sweeps continue to maintain the debt roadmap. Pushes to `main` run
-# the same full profile as a blocking post-merge guard below.
+# filing), and the issue closes when that fix kind gets automated. The sweep
+# runs weekly, decoupled from releases so a full audit never taxes the release
+# path, and files/refreshes one issue per finding kind.
 
-name: Audit Debt
+name: Main Guard
 
 on:
   push:
@@ -32,26 +64,224 @@ on:
         required: false
         default: 'full'
 
+# Latest merge wins. This gate answers exactly one question — "is main green
+# RIGHT NOW?" — and that answer is a pure function of the current tip, so a
+# superseded run's verdict is worthless. It also produces no artifacts, mutates
+# nothing, and blocks nothing downstream, so cancelling it is free.
+#
+# This is deliberately the OPPOSITE of release.yml's `cancel-in-progress: false`.
+# The release queues because it may be mid-tag/mid-publish and cancelling it
+# strands a tag. Nothing here can strand anything.
+#
+# It is also a capacity requirement, not just a nicety: at ~40 merges/day
+# against a 16-35 minute suite, queueing every merge would serialise into
+# 10-23 hours of backlog and the gate would end up reporting on hours-old main
+# — strictly worse than reporting on the current tip.
+#
+# Trade-off, stated plainly: when a burst of merges collapses into one run, the
+# failure is attributed to the newest merge rather than the one that actually
+# broke it. The failure summary prints the compare range so the candidate set is
+# still bounded (see "Attribute failure to this merge" below).
+#
+# Push and sweep get separate groups so a merge train never cancels the weekly
+# audit sweep (and vice versa).
 concurrency:
-  group: audit-debt
+  group: main-guard-${{ github.event_name == 'push' && 'post-merge' || 'sweep' }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   issues: write
+  # Shared-artifact handoff between gate-build and the gates.
+  actions: read
 
 jobs:
-  full-audit-gate:
-    name: Full-tree audit gate
+  # ── Build once, share with all three post-merge gates ──
+  # Mirrors release.yml's gate-build → artifact → `binary-path` handoff. Before
+  # this, the audit gate compiled homeboy by itself via `cargo run`; adding two
+  # more gates that each did their own build would have tripled compile cost on
+  # every merge. One release build now feeds all three.
+  gate-build:
+    name: Build
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Least privilege: this job compiles and uploads, it never files issues.
     permissions:
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+
+      # Deliberately the same cache key as release.yml's gate-build: both run
+      # `cargo build --release` on `main`, so whichever lands first warms the
+      # cache for the other. A key drift in release.yml only costs a cache miss.
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-gate-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-gate-
+
+      - name: Build homeboy
+        run: cargo build --release --locked
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: homeboy-binary
+          path: target/release/homeboy
+          retention-days: 1
+
+  full-audit-gate:
+    name: Full-tree audit gate
+    if: github.event_name == 'push'
+    needs: gate-build
+    runs-on: ubuntu-latest
+    # Pure pass/fail gate — deliberately cannot file issues, unlike the sweep.
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
+
+      - name: Verify homeboy binary present
+        run: |
+          if [ ! -f .homeboy-bin/homeboy ]; then
+            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not a code finding on main. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
+            exit 1
+          fi
+          chmod +x .homeboy-bin/homeboy
+
       - name: Run blocking full-profile audit
-        run: cargo run --locked -- review audit homeboy --profile=full
+        run: .homeboy-bin/homeboy review audit homeboy --profile=full
+
+  # ── Release-blocking suite, at full scope, on the merged result ──
+  # `review lint` + `review test` is exactly release.yml's RELEASE_BLOCKING_COMMANDS
+  # (default 'review lint,review test'). Split into two jobs, and `review test`
+  # carries `--skip-lint`, both matching release.yml's gate-lint / gate-test
+  # split so lint work is not duplicated.
+  #
+  # The ONE deliberate difference from the release gates: no `--changed-since`.
+  # The release passes `--changed-since ${{ github.event.before }}`; omitting it
+  # lets `scope: auto` resolve to full scope on push. Matching the release's
+  # narrowing here would reproduce the blind spot instead of closing it.
+  #
+  # No `differential-gating` (it only applies to pull_request events anyway) and
+  # no `autofix` input — homeboy-action@v2 has no such input, so there is no
+  # autofix/auto-push path to disable. This gate never mutates the repo.
+  full-lint-gate:
+    name: Full-suite lint gate
+    if: github.event_name == 'push'
+    needs: gate-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
+
+      - name: Verify homeboy binary present
+        run: |
+          if [ ! -f .homeboy-bin/homeboy ]; then
+            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not a lint finding on main. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
+            exit 1
+          fi
+          chmod +x .homeboy-bin/homeboy
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - uses: Extra-Chill/homeboy-action@v2
+        with:
+          binary-path: .homeboy-bin/homeboy
+          commands: review lint
+          expected-commands: review audit,review lint,review test
+          # Durable notification. The failing check is the primary signal, but
+          # nobody watches main's commit list; the issue survives the run.
+          auto-issue: 'true'
+          app-token: ${{ steps.app-token.outputs.token || '' }}
+
+      - name: Attribute failure to this merge
+        if: failure()
+        env:
+          MERGE_SHA: ${{ github.sha }}
+          MERGE_BEFORE: ${{ github.event.before }}
+          MERGE_SUBJECT: ${{ github.event.head_commit.message }}
+          MERGE_AUTHOR: ${{ github.event.head_commit.author.name }}
+          GATE: lint
+        run: bash .github/report-red-main.sh
+
+  full-test-gate:
+    name: Full-suite test gate
+    if: github.event_name == 'push'
+    needs: gate-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
+
+      - name: Verify homeboy binary present
+        run: |
+          if [ ! -f .homeboy-bin/homeboy ]; then
+            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not a test finding on main. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
+            exit 1
+          fi
+          chmod +x .homeboy-bin/homeboy
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - uses: Extra-Chill/homeboy-action@v2
+        with:
+          binary-path: .homeboy-bin/homeboy
+          commands: review test
+          expected-commands: review audit,review lint,review test
+          # Matches release.yml gate-test: lint is its own job above.
+          args: --skip-lint
+          auto-issue: 'true'
+          app-token: ${{ steps.app-token.outputs.token || '' }}
+
+      - name: Attribute failure to this merge
+        if: failure()
+        env:
+          MERGE_SHA: ${{ github.sha }}
+          MERGE_BEFORE: ${{ github.event.before }}
+          MERGE_SUBJECT: ${{ github.event.head_commit.message }}
+          MERGE_AUTHOR: ${{ github.event.head_commit.author.name }}
+          GATE: test
+        run: bash .github/report-red-main.sh
 
   full-audit:
     name: Full-tree audit → tracking issues

--- a/tests/audit_debt_workflow_test.rs
+++ b/tests/audit_debt_workflow_test.rs
@@ -1,35 +1,220 @@
-fn audit_debt_workflow() -> &'static str {
+//! Guards the post-merge `main` gate defined in `.github/workflows/audit-debt.yml`.
+//!
+//! These assertions exist because the gate's value is entirely in its scope. On
+//! 2026-07-27 a POSIX-sh portability bug merged green, turned `main` red in
+//! `homeboy-lab-runner`'s prune tests, and stayed hidden until a later merge
+//! dragged those tests into the release's `--changed-since` window — stranding
+//! 188 commits and two tags. Re-narrowing these gates would silently restore
+//! that blind spot, so the scope properties are asserted, not just documented.
+
+fn main_guard_workflow() -> &'static str {
     include_str!("../.github/workflows/audit-debt.yml")
 }
 
-fn full_audit_gate() -> &'static str {
-    let workflow = audit_debt_workflow();
-    let start = workflow
-        .find("  full-audit-gate:\n")
-        .expect("full audit gate");
-    let end = workflow[start..]
-        .find("  full-audit:\n")
-        .expect("debt triage job")
-        + start;
-    &workflow[start..end]
+/// Compile-time proof that the attribution script the workflow invokes exists.
+fn report_red_main_script() -> &'static str {
+    include_str!("../.github/report-red-main.sh")
+}
+
+/// Extract a single job block: from `  <name>:` up to the next line at exactly
+/// two spaces of indent (the next job key, or a comment introducing it).
+///
+/// Anchoring on indentation keeps neighbouring jobs' explanatory comments out
+/// of the block, so a `contains` assertion cannot pass or fail on prose that
+/// belongs to a different job.
+fn job(name: &str) -> String {
+    let header = format!("  {name}:");
+    let mut block = String::new();
+    let mut in_job = false;
+
+    for line in main_guard_workflow().lines() {
+        if in_job {
+            let starts_new_top_level_entry =
+                line.starts_with("  ") && !line.starts_with("   ") && !line.trim_start().is_empty();
+            if starts_new_top_level_entry {
+                break;
+            }
+            block.push_str(line);
+            block.push('\n');
+        } else if line == header {
+            in_job = true;
+        }
+    }
+
+    assert!(in_job, "job `{name}` not found in audit-debt.yml");
+    block
+}
+
+fn release_blocking_gates() -> [(&'static str, String); 2] {
+    [
+        ("full-lint-gate", job("full-lint-gate")),
+        ("full-test-gate", job("full-test-gate")),
+    ]
+}
+
+#[test]
+fn post_merge_gates_run_the_release_blocking_command_set() {
+    let workflow = main_guard_workflow();
+    assert!(workflow.contains("push:\n    branches: [main]"));
+
+    // release.yml: RELEASE_BLOCKING_COMMANDS default is 'review lint,review test'.
+    // Those two commands are what can block a release, so those two are what a
+    // post-merge gate has to run to be predictive of release outcome.
+    let lint = job("full-lint-gate");
+    assert!(lint.contains("commands: review lint"));
+
+    let test = job("full-test-gate");
+    assert!(test.contains("commands: review test"));
+    // Mirrors release.yml's gate-test: lint is its own job, so don't pay twice.
+    assert!(test.contains("--skip-lint"));
+
+    for (name, gate) in release_blocking_gates() {
+        assert!(
+            gate.contains("if: github.event_name == 'push'"),
+            "{name} must be a post-merge gate"
+        );
+    }
+}
+
+#[test]
+fn post_merge_gates_run_at_full_scope() {
+    for (name, gate) in release_blocking_gates() {
+        // The whole point. homeboy-action's `scope: auto` resolves to mode=full
+        // on push events; release.yml narrows itself by explicitly passing
+        // `--changed-since <before>`. If that flag ever appears here, this gate
+        // degrades to the same changed-scope blind spot the release already has
+        // and stops catching cross-scope breakage.
+        assert!(
+            !gate.contains("--changed-since"),
+            "{name} must run at full scope: --changed-since re-creates the #6807 blind spot"
+        );
+        // Differential gating only applies to pull_request events, and its
+        // "only fail on NEW findings" semantics would let an already-red main
+        // stay green here.
+        assert!(
+            !gate.contains("differential-gating"),
+            "{name} must not use differential gating"
+        );
+    }
+}
+
+#[test]
+fn post_merge_gates_are_blocking() {
+    for (name, gate) in release_blocking_gates() {
+        // `continue-on-error` is legitimate on the optional app-token step, but
+        // must never cover the quality command itself.
+        let occurrences = gate.matches("continue-on-error: true").count();
+        assert_eq!(
+            occurrences, 1,
+            "{name} should mark only the app-token step continue-on-error"
+        );
+
+        let action = gate
+            .find("uses: Extra-Chill/homeboy-action@v2")
+            .unwrap_or_else(|| panic!("{name} must run the homeboy action"));
+        let tolerated = gate
+            .find("continue-on-error: true")
+            .expect("checked above that one exists");
+        assert!(
+            tolerated < action,
+            "{name}: continue-on-error must not apply to the quality command"
+        );
+    }
+}
+
+#[test]
+fn post_merge_gates_share_a_single_build() {
+    // release.yml builds once in gate-build and hands the binary to its gates.
+    // Three independently-compiling gates would triple compile cost on every
+    // merge, which at this repo's merge rate is what makes the gate affordable.
+    let build = job("gate-build");
+    assert!(build.contains("cargo build --release --locked"));
+    assert!(build.contains("name: homeboy-binary"));
+
+    for name in ["full-audit-gate", "full-lint-gate", "full-test-gate"] {
+        let gate = job(name);
+        assert!(
+            gate.contains("needs: gate-build"),
+            "{name} must reuse the build"
+        );
+        assert!(
+            !gate.contains("cargo build") && !gate.contains("cargo run"),
+            "{name} must consume the shared artifact instead of rebuilding"
+        );
+    }
+}
+
+#[test]
+fn post_merge_failures_are_attributable_to_a_merge() {
+    let script = report_red_main_script();
+    // Reports the merge commit and the pushed range so the culprit is bounded
+    // even when `cancel-in-progress` collapses a burst of merges into one run.
+    assert!(script.contains("MERGE_SHA"));
+    assert!(script.contains("compare/"));
+    assert!(script.contains("GITHUB_STEP_SUMMARY"));
+    // Commit subjects/authors are attacker-influenced, so they must reach the
+    // script through the environment rather than workflow interpolation.
+    for (name, gate) in release_blocking_gates() {
+        assert!(
+            gate.contains(".github/report-red-main.sh"),
+            "{name} must report attribution on failure"
+        );
+        assert!(
+            gate.contains("if: failure()"),
+            "{name} must report only on failure"
+        );
+        assert!(
+            !gate.contains("${{ github.event.head_commit.message }}\n        run:"),
+            "{name} must not interpolate commit text into a run: body"
+        );
+    }
+}
+
+#[test]
+fn post_merge_gates_never_mutate_the_repository() {
+    let workflow = main_guard_workflow();
+    // A gate that auto-pushes to `main` on failure would be strictly worse than
+    // the breakage it is reporting.
+    assert!(!workflow.contains("git push"));
+    assert!(!workflow.contains("pr-policy-merge: 'true'"));
+    // `autofix` is not a homeboy-action@v2 input at all; passing it only earns
+    // an "Unexpected input(s)" warning.
+    for (name, gate) in release_blocking_gates() {
+        assert!(
+            !gate.contains("autofix"),
+            "{name} passes a non-existent input"
+        );
+    }
+}
+
+#[test]
+fn superseded_post_merge_runs_are_cancelled() {
+    let workflow = main_guard_workflow();
+    // Opposite of release.yml's `cancel-in-progress: false`: this gate reports
+    // on the current tip and strands nothing, so a superseded run is worthless.
+    assert!(workflow.contains("cancel-in-progress: true"));
+    // Push and sweep are separate groups so a merge train cannot cancel the
+    // weekly audit sweep.
+    assert!(workflow.contains("group: main-guard-"));
+    assert!(workflow.contains("github.event_name == 'push' && 'post-merge' || 'sweep'"));
 }
 
 #[test]
 fn post_merge_full_audit_is_a_blocking_gate() {
-    let workflow = audit_debt_workflow();
-    let gate = full_audit_gate();
+    let gate = job("full-audit-gate");
 
-    assert!(workflow.contains("push:\n    branches: [main]"));
     assert!(gate.contains("if: github.event_name == 'push'"));
-    assert!(gate.contains("cargo run --locked -- review audit homeboy --profile=full"));
+    assert!(gate.contains("review audit homeboy --profile=full"));
     assert!(!gate.contains("continue-on-error: true"));
 }
 
 #[test]
 fn scheduled_debt_triage_remains_non_blocking_and_separate() {
-    let workflow = audit_debt_workflow();
+    let workflow = main_guard_workflow();
 
     assert!(workflow.contains("full-audit:\n    name: Full-tree audit → tracking issues"));
     assert!(workflow.contains("if: github.event_name != 'push'"));
     assert!(workflow.contains("auto-issue: 'true'"));
+    // The sweep must not be dragged into the post-merge path.
+    assert!(job("full-audit").contains("if: github.event_name != 'push'"));
 }


### PR DESCRIPTION
**188 commits were undeliverable today because the only full-suite signal in this repo was the release itself.** Two orphaned tags, ~16 hours of stranded work.

Closes #6807

## What actually happened

Both existing pipelines are changed-scope, so nothing has ever run the whole suite against the *integrated* `main`:

| Pipeline | Scope |
| --- | --- |
| `ci.yml` (PRs) | `differential-gating: true`, scoped to the PR diff |
| `release.yml` | `gate-lint`/`gate-test` pass `--changed-since ${{ github.event.before }}` — only re-checks what that one push touched |

A change whose blast radius lands **outside its own diff** is invisible to both. A POSIX-sh portability bug merged green, `main` went red in `crates/homeboy-lab-runner/src/workspace/tests/prune.rs`, and it stayed hidden until merge #10425 happened to touch `prune.rs` and dragged those tests into the release's changed-scope window:

```
Rust test scope: Scoped to changed files in homeboy-lab-runner: workspace::tests::prune
```

Release runs `30272803452` and `30271131168` then died identically at `Release Quality Policy` → `Test`. Worth stating plainly: had no later merge touched that file, `main` would have stayed silently red for longer. The release is the *worst* place to find this — 16-35 minutes, and a failure there can strand a tag.

## Extended `audit-debt.yml` rather than adding a third workflow

It was already the right home: it already triggers post-merge on `main`, already holds the blocking full-tree audit gate, and already has the `issues: write` + auto-issue plumbing. It had the audit third of the gate; lint and test were missing.

- **`gate-build`** compiles once and hands the binary to all three gates through the same `upload-artifact` → `binary-path` handoff `release.yml` uses. The audit gate now consumes it too instead of doing its own `cargo run` build, so going from one gate to three does **not** triple compile cost. It shares the release gate's cache key on purpose — both run `cargo build --release` on `main`, so whichever lands first warms the cache; a key drift there only costs a miss.
- **`full-lint-gate` / `full-test-gate`** run `review lint` + `review test` — exactly `RELEASE_BLOCKING_COMMANDS` (`'review lint,review test'`) — with the same job split and `--skip-lint` on test that `release.yml` uses, so lint isn't paid for twice.

## How the scope matches — and the one deliberate difference

Full scope isn't an extra flag. `homeboy-action`'s `scope: auto` **already resolves to `mode=full` on push events** (confirmed in today's logs: `Scope resolved: context=push input=auto mode=full`). The release narrows *itself* by explicitly passing `--changed-since`. This gate simply doesn't pass it.

That makes it a **strict superset of the release's blocking scope**: anything that would fail a release fails here first, *plus* the cross-scope breakage the release would only catch by luck. Matching the release's narrowing exactly would have reproduced the blind spot instead of closing it, so that property is asserted in tests rather than just documented.

## Concurrency: `cancel-in-progress: true` — opposite of the release

Deliberate, and justified on two grounds:

1. **Correctness.** This gate answers one question — "is `main` green *right now*?" — and that answer is a pure function of the current tip. It produces no artifacts, mutates nothing, and blocks nothing downstream, so a superseded run's verdict is worthless. The release queues (`cancel-in-progress: false`) because it may be mid-tag/mid-publish and cancelling it strands a tag. Nothing here can strand anything.
2. **Capacity.** At ~40 merges/day against a 16-35 minute suite, queueing every merge serialises into 10-23 hours of backlog — the gate would end up reporting on hours-old `main`, which is strictly worse than reporting on the current tip.

Push and sweep get **separate groups**, so a merge train can never cancel the weekly audit sweep.

**Trade-off, stated plainly:** when a burst collapses into one run, the failure is attributed to the newest merge, not necessarily the one that broke it. Mitigated rather than hidden — the failure summary prints the pushed compare range and says so explicitly.

## On failure

Fails the check **and** files an issue — they solve different halves:

- The **red check on the merge commit** is the attribution signal (`git log` on `main` shows ✗ next to the exact merge).
- The **deduplicated issue** (`auto-issue: 'true'`, the existing `audit-debt.yml` pattern) is the durable one, because nobody watches `main`'s commit list.
- `.github/report-red-main.sh` writes merge SHA, author, subject and compare range to the job summary, and notes that the next release would fail at `Release Quality Policy`.

Explicitly **not** blocking the next release via cross-workflow state — the release already runs its own gates, and that would add coupling for no new signal. **Nothing auto-reverts or auto-pushes.** `autofix` is dropped entirely: it is not a `homeboy-action@v2` input at all (`release.yml` passes it and earns `##[warning]Unexpected input(s) 'autofix'`), so there is no mutation path to disable. Tests assert the workflow contains no `git push` and no auto-merge.

## Noted, not implemented: the cheaper preventive half

The deeper issue is that differential gating let a cross-scope blast radius through. The low-cost fix is **not** a full-suite PR run — that would wreck PR latency and isn't what #6807 asks. The targeted version, following the precedent `ci.yml` already sets with `workspace-tests-compile`, is a `paths`-triggered widening for a small set of high-risk shared paths (shell/command-construction helpers — exactly the class that caused today's failure): if a PR touches one, run the full test suite for that PR only. Left for a follow-up so this PR stays additive and PR latency is untouched.

## Validation

Run on this box is constrained (16GB shared, no `cargo build`/`test`/`check`/`clippy`), so:

- `python3 -c "import yaml; yaml.safe_load(...)"` — parses; job graph, permissions and step wiring dumped and reviewed.
- `bash -n` on the new script, plus **executed** it against real values from run `30272803452`: multi-line commit bodies truncate to the subject, the all-zero first-push SHA omits the compare range, missing `MERGE_SHA` exits non-zero.
- **Injection check:** commit subject/author reach the script only via `env:`, never interpolated into a `run:` body (commit messages are attacker-influenced). Verified with `$(touch /tmp/PWNED)` payloads in both fields — rendered as literal text, no files created.
- `tests/audit_debt_workflow_test.rs` (`include_str!`, so it's a compile-time dep) rewritten with a robust per-job extractor; all 44 assertions were evaluated against the real file via a Python port of the same logic. It now guards the properties that matter: full scope, blocking, shared build, no mutation, concurrency.
- `cargo fmt` clean (`cargo fmt --check` exits 0).
- `release.yml` and `ci.yml` are **untouched** — confirmed by `git diff --name-only`. No conflict with #10471.

Refs #6807
