### PR TITLE
fix: derive agent-task diagnose next actions from the diagnosis

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -11,11 +11,13 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 use homeboy::agents::agent_task_service as agent_task_service_direct;
-use homeboy::agents::agent_tasks::lifecycle as agent_task_lifecycle;
+use homeboy::agents::agent_tasks::lifecycle::{self as agent_task_lifecycle, AgentTaskRunRecord};
 use homeboy::agents::agent_tasks::promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 use homeboy::agents::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use homeboy::agents::agent_tasks::service as agent_task_service;
-use homeboy::agents::agent_tasks::{AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
+use homeboy::agents::agent_tasks::{
+    AgentTaskEvidenceRef, AgentTaskFailureClassification, AgentTaskOutcomeStatus,
+};
 use homeboy::core::engine::shell::quote_arg;
 use homeboy::core::output::{budget_json_values, OutputBudget};
 use homeboy::runner::runners::{self as runner, RunnerKind};
@@ -27,8 +29,9 @@ use super::args::{
 };
 use super::candidate::{classify_candidates, CandidateState};
 use crate::commands::utils::response::{
-    CommandActionableMetadata, CommandAgentTaskRef, CommandNextAction, CommandNextActionKind,
-    CommandResultRefs, ACTIONABLE_METADATA_KEY,
+    CommandActionableMetadata, CommandAgentTaskRef, CommandArtifactRef, CommandEvidenceRef,
+    CommandNextAction, CommandNextActionKind, CommandResultRefs, CommandRunRef,
+    ACTIONABLE_METADATA_KEY,
 };
 
 /// Cap the number of detail refs rendered in the compact summary so a noisy
@@ -738,11 +741,11 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
 
     let mut value = json!({
         "schema": "homeboy/agent-task-diagnose/v1",
-        "run_id": record.run_id,
+        "run_id": record.run_id.clone(),
         "state": record.state,
         "root_cause": root_cause,
         "causal_chain": causal_chain,
-        "missing_artifacts": missing_artifacts,
+        "missing_artifacts": missing_artifacts.clone(),
         "hydrated_evidence": hydrated_evidence,
         "hydrated_evidence_total": total_hydrated_evidence,
         "next_commands": next_commands,
@@ -761,7 +764,724 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
             ),
         );
     }
+    // The diagnosis is only useful if it leaves the caller with the exact next
+    // command for THIS failure. Everything above is already computed; this
+    // projects it into the shared actionable envelope instead of discarding it.
+    attach_diagnose_actionable(
+        &mut value,
+        &record,
+        aggregate.as_ref(),
+        &missing_artifacts,
+        record.runner_id(),
+    );
     Ok((value, 0))
+}
+
+/// Basis marker for `next_actions`: the diagnosis mapped a typed failure
+/// classification (or a concrete missing-artifact set) to specific commands.
+const DIAGNOSE_ACTION_BASIS_DIAGNOSIS: &str = "diagnosis";
+/// Basis marker for `next_actions`: nothing in the diagnosis was specific
+/// enough to act on, so the generic recovery set is emitted as an explicit
+/// fallback rather than as the only behavior.
+const DIAGNOSE_ACTION_BASIS_FALLBACK: &str = "generic_fallback";
+
+/// One failed task and how its executor classified the failure. This is the
+/// typed input to the classification→action table: it is read from durable
+/// outcome state, never from provider prose, so an emitted action can always be
+/// substantiated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DiagnosedFailure {
+    task_id: String,
+    classification: AgentTaskFailureClassification,
+}
+
+/// Collect the distinct failure classifications a run actually recorded, first
+/// implicated task wins. Successful and no-op outcomes are never a failure
+/// signal even if a stale classification survived on them.
+fn diagnosed_failures(aggregate: &AgentTaskAggregate) -> Vec<DiagnosedFailure> {
+    let mut failures: Vec<DiagnosedFailure> = Vec::new();
+    for outcome in &aggregate.outcomes {
+        if matches!(
+            outcome.status,
+            AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp
+        ) {
+            continue;
+        }
+        let Some(classification) = outcome.failure_classification else {
+            continue;
+        };
+        if failures
+            .iter()
+            .any(|failure| failure.classification == classification)
+        {
+            continue;
+        }
+        failures.push(DiagnosedFailure {
+            task_id: outcome.task_id.clone(),
+            classification,
+        });
+    }
+    failures
+}
+
+fn attach_diagnose_actionable(
+    value: &mut Value,
+    record: &AgentTaskRunRecord,
+    aggregate: Option<&AgentTaskAggregate>,
+    missing_artifacts: &[Value],
+    runner_id: Option<&str>,
+) {
+    let run_id = record.run_id.as_str();
+    let failures = aggregate.map(diagnosed_failures).unwrap_or_default();
+    let (next_actions, basis) =
+        diagnose_next_actions(run_id, &failures, missing_artifacts, runner_id);
+    if let Value::Object(map) = value {
+        map.insert(
+            "next_action_basis".to_string(),
+            Value::String(basis.to_string()),
+        );
+    }
+    let metadata = CommandActionableMetadata {
+        run: Some(diagnose_run_ref(record, runner_id)),
+        refs: CommandResultRefs {
+            agent_tasks: vec![agent_task_ref(run_id)],
+            ..Default::default()
+        },
+        next_actions,
+        artifacts: aggregate.map(diagnose_artifact_refs).unwrap_or_default(),
+        evidence: aggregate.map(diagnose_evidence_refs).unwrap_or_default(),
+    };
+    attach_actionable_metadata(value, metadata);
+}
+
+/// Derive the recovery commands for this exact failure. Returns the generic set
+/// ONLY when neither a classification nor a missing-artifact set produced a
+/// specific step, and labels which of the two happened.
+fn diagnose_next_actions(
+    run_id: &str,
+    failures: &[DiagnosedFailure],
+    missing_artifacts: &[Value],
+    runner_id: Option<&str>,
+) -> (Vec<CommandNextAction>, &'static str) {
+    let mut actions: Vec<CommandNextAction> = Vec::new();
+    for failure in failures {
+        for action in classification_next_actions(run_id, failure, runner_id) {
+            push_unique_next_action(&mut actions, action);
+        }
+    }
+    for action in missing_artifact_next_actions(run_id, missing_artifacts) {
+        push_unique_next_action(&mut actions, action);
+    }
+    if actions.is_empty() {
+        return (
+            generic_diagnose_next_actions(run_id),
+            DIAGNOSE_ACTION_BASIS_FALLBACK,
+        );
+    }
+    (actions, DIAGNOSE_ACTION_BASIS_DIAGNOSIS)
+}
+
+fn push_unique_next_action(actions: &mut Vec<CommandNextAction>, action: CommandNextAction) {
+    if actions
+        .iter()
+        .any(|existing| existing.command == action.command)
+    {
+        return;
+    }
+    actions.push(action);
+}
+
+/// The classification→action table. Each arm answers "what do I run next for
+/// THIS kind of failure?" with commands that exist in the CLI surface and are
+/// scoped to the run and task the diagnosis implicates.
+fn classification_next_actions(
+    run_id: &str,
+    failure: &DiagnosedFailure,
+    runner_id: Option<&str>,
+) -> Vec<CommandNextAction> {
+    let run = quote_arg(run_id);
+    let task = quote_arg(&failure.task_id);
+    let failure_evidence = CommandNextAction::new(
+        format!("show failure evidence for {}", failure.task_id),
+        format!("homeboy agent-task evidence {run} --task {task} --failure-only"),
+    )
+    .with_kind(CommandNextActionKind::Show);
+    let retry = CommandNextAction::new(
+        "retry the run from its plan",
+        format!("homeboy agent-task retry {run} --run"),
+    )
+    .with_kind(CommandNextActionKind::Repair);
+    let review = CommandNextAction::new(
+        "review the candidate this attempt left behind",
+        format!("homeboy agent-task review {run}"),
+    )
+    .with_kind(CommandNextActionKind::Show);
+    let list_providers = CommandNextAction::new(
+        "list registered providers",
+        "homeboy agent-task providers".to_string(),
+    )
+    .with_kind(CommandNextActionKind::Show);
+
+    match failure.classification {
+        // The provider itself errored or was not resolvable: prove which
+        // provider was asked for, and whether it is registered and ready.
+        AgentTaskFailureClassification::Provider => {
+            let mut actions = vec![failure_evidence, list_providers];
+            actions.extend(provider_readiness_actions(runner_id));
+            actions.push(retry);
+            actions
+        }
+        // Documented as safe to retry with bounded backoff: lead with the retry.
+        AgentTaskFailureClassification::Transient => vec![retry, failure_evidence],
+        // A wall-clock timeout can still have left a complete candidate patch,
+        // so review comes before spending another attempt.
+        AgentTaskFailureClassification::Timeout => vec![failure_evidence, review, retry],
+        // A silent hang: the durable record is likely still `running` and the
+        // owning runner is the thing to interrogate.
+        AgentTaskFailureClassification::Stalled => {
+            let mut actions = vec![CommandNextAction::new(
+                "reconcile the stalled run against authoritative state",
+                format!("homeboy agent-task reconcile {run} --dry-run"),
+            )
+            .with_kind(CommandNextActionKind::Repair)];
+            actions.extend(lost_runner_actions(runner_id));
+            actions.push(failure_evidence);
+            actions.push(retry);
+            actions
+        }
+        // Throttled: the evidence carries the retry-after hint, and another
+        // registered provider may be able to take the work now.
+        AgentTaskFailureClassification::RateLimited => {
+            vec![
+                failure_evidence,
+                CommandNextAction::new(
+                    "list registered providers to rotate to",
+                    "homeboy agent-task providers".to_string(),
+                )
+                .with_kind(CommandNextActionKind::Show),
+                retry,
+            ]
+        }
+        // Policy refused this request. Retrying an identical request is denied
+        // identically, so no retry action is emitted.
+        AgentTaskFailureClassification::PolicyDenied => vec![
+            failure_evidence,
+            CommandNextAction::new(
+                "show the full run record including the policy that denied it",
+                format!("homeboy agent-task status {run} --full"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        ],
+        // A required capability/tool was not resolvable: the readiness chain is
+        // the repair, not another attempt.
+        AgentTaskFailureClassification::CapabilityMissing => {
+            let mut actions = vec![
+                failure_evidence,
+                CommandNextAction::new(
+                    "show provider declarations and discovery diagnostics",
+                    "homeboy agent-task providers --full".to_string(),
+                )
+                .with_kind(CommandNextActionKind::Show),
+            ];
+            actions.extend(provider_readiness_actions(runner_id));
+            actions
+        }
+        // The request the provider received was malformed. Replaying the
+        // boundary shows the exact rejected input; a retry would resend it.
+        AgentTaskFailureClassification::InvalidInput => vec![
+            failure_evidence,
+            CommandNextAction::new(
+                format!("replay the provider boundary for {}", failure.task_id),
+                format!("homeboy agent-task replay-provider-boundary {run} --task {task}"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        ],
+        // The work ran and failed (gate/verify failure, harvest failure,
+        // required typed artifacts missing): show what the failing step
+        // recorded and what it produced before deciding to retry.
+        AgentTaskFailureClassification::ExecutionFailed => vec![
+            failure_evidence,
+            review,
+            CommandNextAction::new(
+                "list the artifacts the run produced",
+                format!("homeboy agent-task artifacts {run} --full"),
+            )
+            .with_kind(CommandNextActionKind::Artifacts),
+            retry,
+        ],
+        // Deliberately unmapped: an unclassified failure has no substantiable
+        // specific step, so the caller gets the explicit generic fallback.
+        AgentTaskFailureClassification::Unknown => Vec::new(),
+    }
+}
+
+/// Provider/runner readiness chain for the runner that owns the run. Emitted
+/// only when a runner id is known, because `agent-task doctor` requires one.
+fn provider_readiness_actions(runner_id: Option<&str>) -> Vec<CommandNextAction> {
+    let Some(runner_id) = runner_id else {
+        return Vec::new();
+    };
+    let runner = quote_arg(runner_id);
+    vec![
+        CommandNextAction::new(
+            format!("check provider and runner readiness on {runner_id}"),
+            format!("homeboy agent-task doctor --runner {runner}"),
+        )
+        .with_kind(CommandNextActionKind::Show),
+        CommandNextAction::new(
+            format!("repair provider and runner readiness on {runner_id}"),
+            format!("homeboy agent-task doctor --runner {runner} --repair"),
+        )
+        .with_kind(CommandNextActionKind::Repair),
+    ]
+}
+
+/// Runner session inspection and repair for a run whose runner went quiet.
+fn lost_runner_actions(runner_id: Option<&str>) -> Vec<CommandNextAction> {
+    let Some(runner_id) = runner_id else {
+        return Vec::new();
+    };
+    let runner = quote_arg(runner_id);
+    vec![
+        CommandNextAction::new(
+            format!("show runner session state for {runner_id}"),
+            format!("homeboy runner status {runner}"),
+        )
+        .with_kind(CommandNextActionKind::Show),
+        CommandNextAction::new(
+            format!("diagnose and repair runner {runner_id}"),
+            format!("homeboy runner doctor {runner} --repair"),
+        )
+        .with_kind(CommandNextActionKind::Repair),
+    ]
+}
+
+/// Actions for the specific artifacts a task declared and did not produce.
+fn missing_artifact_next_actions(
+    run_id: &str,
+    missing_artifacts: &[Value],
+) -> Vec<CommandNextAction> {
+    if missing_artifacts.is_empty() {
+        return Vec::new();
+    }
+    let run = quote_arg(run_id);
+    let mut actions = vec![CommandNextAction::new(
+        "list the artifacts the run actually produced",
+        format!("homeboy agent-task artifacts {run} --full"),
+    )
+    .with_kind(CommandNextActionKind::Artifacts)];
+    for entry in missing_artifacts.iter().take(COMPACT_REF_LIMIT) {
+        let Some(task_id) = entry.get("task_id").and_then(Value::as_str) else {
+            continue;
+        };
+        let names = entry
+            .get("missing")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_default();
+        if names.is_empty() {
+            continue;
+        }
+        let task = quote_arg(task_id);
+        actions.push(
+            CommandNextAction::new(
+                format!("show the declarations {task_id} was given for {names}"),
+                format!("homeboy agent-task replay-provider-boundary {run} --task {task}"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        );
+        actions.push(
+            CommandNextAction::new(
+                format!("show failure evidence for {task_id}"),
+                format!("homeboy agent-task evidence {run} --task {task} --failure-only"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        );
+    }
+    actions
+}
+
+/// The pre-existing static set, retained as the explicit fallback for a failure
+/// the diagnosis could not classify.
+fn generic_diagnose_next_actions(run_id: &str) -> Vec<CommandNextAction> {
+    let run = quote_arg(run_id);
+    vec![
+        CommandNextAction::new(
+            "show the full run record",
+            format!("homeboy agent-task status {run} --full"),
+        )
+        .with_kind(CommandNextActionKind::Show),
+        CommandNextAction::new(
+            "list the artifacts the run produced",
+            format!("homeboy agent-task artifacts {run}"),
+        )
+        .with_kind(CommandNextActionKind::Artifacts),
+        CommandNextAction::new("review run", format!("homeboy agent-task review {run}"))
+            .with_kind(CommandNextActionKind::Show),
+        CommandNextAction::new(
+            "retry the run from its plan",
+            format!("homeboy agent-task retry {run} --run"),
+        )
+        .with_kind(CommandNextActionKind::Repair),
+    ]
+}
+
+fn diagnose_run_ref(record: &AgentTaskRunRecord, runner_id: Option<&str>) -> CommandRunRef {
+    let run = quote_arg(&record.run_id);
+    CommandRunRef {
+        id: record.run_id.clone(),
+        kind: "agent_task".to_string(),
+        source: "homeboy-agent-task-lifecycle".to_string(),
+        location: Some(
+            runner_id
+                .map(|runner_id| format!("runner:{runner_id}"))
+                .unwrap_or_else(|| "local".to_string()),
+        ),
+        started_at: Some(record.submitted_at.clone()),
+        updated_at: record.updated_at.clone(),
+        finished_at: None,
+        status_command: format!("homeboy agent-task status {run} --full"),
+        watch_command: format!("homeboy agent-task logs {run}"),
+    }
+}
+
+fn diagnose_artifact_refs(aggregate: &AgentTaskAggregate) -> Vec<CommandArtifactRef> {
+    aggregate
+        .outcomes
+        .iter()
+        .flat_map(|outcome| outcome.artifacts.iter())
+        .take(COMPACT_REF_LIMIT)
+        .map(|artifact| CommandArtifactRef {
+            id: artifact.id.clone(),
+            kind: artifact.kind.clone(),
+            uri: artifact
+                .url
+                .clone()
+                .or_else(|| artifact.path.clone())
+                .unwrap_or_default(),
+            semantic_key: artifact.semantic_key.clone(),
+        })
+        .collect()
+}
+
+fn diagnose_evidence_refs(aggregate: &AgentTaskAggregate) -> Vec<CommandEvidenceRef> {
+    aggregate
+        .outcomes
+        .iter()
+        .flat_map(|outcome| {
+            outcome
+                .evidence_refs
+                .iter()
+                .map(move |evidence| (outcome.task_id.as_str(), evidence))
+        })
+        .take(COMPACT_REF_LIMIT)
+        .map(|(task_id, evidence)| CommandEvidenceRef {
+            id: format!("{task_id}:{}", evidence.kind),
+            kind: evidence.kind.clone(),
+            uri: evidence.uri.clone(),
+            semantic_key: None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod diagnose_actionable_tests {
+    use super::*;
+
+    fn failure(classification: AgentTaskFailureClassification) -> DiagnosedFailure {
+        DiagnosedFailure {
+            task_id: "task-a".to_string(),
+            classification,
+        }
+    }
+
+    fn commands(actions: &[CommandNextAction]) -> Vec<&str> {
+        actions
+            .iter()
+            .map(|action| action.command.as_str())
+            .collect()
+    }
+
+    fn repair_commands(actions: &[CommandNextAction]) -> Vec<&str> {
+        actions
+            .iter()
+            .filter(|action| matches!(action.kind, Some(CommandNextActionKind::Repair)))
+            .map(|action| action.command.as_str())
+            .collect()
+    }
+
+    fn actions_for(
+        classification: AgentTaskFailureClassification,
+        runner_id: Option<&str>,
+    ) -> Vec<CommandNextAction> {
+        let (actions, basis) =
+            diagnose_next_actions("run-1", &[failure(classification)], &[], runner_id);
+        assert_eq!(basis, DIAGNOSE_ACTION_BASIS_DIAGNOSIS);
+        actions
+    }
+
+    #[test]
+    fn a_provider_failure_asks_which_provider_was_registered_before_retrying() {
+        let actions = actions_for(AgentTaskFailureClassification::Provider, None);
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task providers",
+                "homeboy agent-task retry run-1 --run",
+            ]
+        );
+        assert_eq!(
+            repair_commands(&actions),
+            vec!["homeboy agent-task retry run-1 --run"]
+        );
+    }
+
+    #[test]
+    fn a_transient_failure_leads_with_the_retry_it_is_documented_to_survive() {
+        let actions = actions_for(AgentTaskFailureClassification::Transient, None);
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task retry run-1 --run",
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_timeout_reviews_the_candidate_before_spending_another_attempt() {
+        let actions = actions_for(AgentTaskFailureClassification::Timeout, None);
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task review run-1",
+                "homeboy agent-task retry run-1 --run",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_stalled_run_reconciles_and_repairs_the_runner_that_went_quiet() {
+        let actions = actions_for(AgentTaskFailureClassification::Stalled, Some("homeboy-lab"));
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task reconcile run-1 --dry-run",
+                "homeboy runner status homeboy-lab",
+                "homeboy runner doctor homeboy-lab --repair",
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task retry run-1 --run",
+            ]
+        );
+        assert_eq!(
+            repair_commands(&actions),
+            vec![
+                "homeboy agent-task reconcile run-1 --dry-run",
+                "homeboy runner doctor homeboy-lab --repair",
+                "homeboy agent-task retry run-1 --run",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_stalled_run_without_a_known_runner_never_names_one() {
+        let actions = actions_for(AgentTaskFailureClassification::Stalled, None);
+
+        assert!(!commands(&actions)
+            .iter()
+            .any(|command| command.starts_with("homeboy runner ")));
+    }
+
+    #[test]
+    fn a_rate_limited_failure_offers_provider_rotation() {
+        let actions = actions_for(AgentTaskFailureClassification::RateLimited, None);
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task providers",
+                "homeboy agent-task retry run-1 --run",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_policy_denial_never_suggests_replaying_the_denied_request() {
+        let actions = actions_for(AgentTaskFailureClassification::PolicyDenied, None);
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task status run-1 --full",
+            ]
+        );
+        assert!(repair_commands(&actions).is_empty());
+    }
+
+    #[test]
+    fn a_missing_capability_runs_the_readiness_repair_chain_not_another_attempt() {
+        let actions = actions_for(
+            AgentTaskFailureClassification::CapabilityMissing,
+            Some("homeboy-lab"),
+        );
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task providers --full",
+                "homeboy agent-task doctor --runner homeboy-lab",
+                "homeboy agent-task doctor --runner homeboy-lab --repair",
+            ]
+        );
+        assert_eq!(
+            repair_commands(&actions),
+            vec!["homeboy agent-task doctor --runner homeboy-lab --repair"]
+        );
+    }
+
+    #[test]
+    fn invalid_input_replays_the_rejected_boundary_instead_of_resending_it() {
+        let actions = actions_for(AgentTaskFailureClassification::InvalidInput, None);
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task replay-provider-boundary run-1 --task task-a",
+            ]
+        );
+        assert!(repair_commands(&actions).is_empty());
+    }
+
+    #[test]
+    fn an_execution_failure_shows_the_failing_step_and_what_it_produced() {
+        let actions = actions_for(AgentTaskFailureClassification::ExecutionFailed, None);
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence run-1 --task task-a --failure-only",
+                "homeboy agent-task review run-1",
+                "homeboy agent-task artifacts run-1 --full",
+                "homeboy agent-task retry run-1 --run",
+            ]
+        );
+    }
+
+    #[test]
+    fn an_unclassifiable_failure_falls_back_to_the_generic_set() {
+        let (actions, basis) = diagnose_next_actions(
+            "run-1",
+            &[failure(AgentTaskFailureClassification::Unknown)],
+            &[],
+            None,
+        );
+
+        assert_eq!(basis, DIAGNOSE_ACTION_BASIS_FALLBACK);
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task status run-1 --full",
+                "homeboy agent-task artifacts run-1",
+                "homeboy agent-task review run-1",
+                "homeboy agent-task retry run-1 --run",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_run_with_no_diagnosis_at_all_falls_back_to_the_generic_set() {
+        let (actions, basis) = diagnose_next_actions("run-1", &[], &[], None);
+
+        assert_eq!(basis, DIAGNOSE_ACTION_BASIS_FALLBACK);
+        assert_eq!(actions.len(), 4);
+    }
+
+    #[test]
+    fn missing_artifacts_name_the_task_and_the_artifacts_that_were_not_produced() {
+        let missing = vec![json!({
+            "task_id": "task-b",
+            "missing": ["concept_packet", "design_packet"],
+        })];
+
+        let (actions, basis) = diagnose_next_actions("run-1", &[], &missing, None);
+
+        assert_eq!(basis, DIAGNOSE_ACTION_BASIS_DIAGNOSIS);
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task artifacts run-1 --full",
+                "homeboy agent-task replay-provider-boundary run-1 --task task-b",
+                "homeboy agent-task evidence run-1 --task task-b --failure-only",
+            ]
+        );
+        assert!(actions[1].label.contains("concept_packet, design_packet"));
+    }
+
+    #[test]
+    fn classification_and_missing_artifact_actions_are_merged_without_duplicates() {
+        let missing = vec![json!({ "task_id": "task-a", "missing": ["patch"] })];
+
+        let (actions, _) = diagnose_next_actions(
+            "run-1",
+            &[failure(AgentTaskFailureClassification::ExecutionFailed)],
+            &missing,
+            None,
+        );
+
+        let commands = commands(&actions);
+        assert_eq!(
+            commands
+                .iter()
+                .filter(|command| **command
+                    == "homeboy agent-task evidence run-1 --task task-a --failure-only")
+                .count(),
+            1
+        );
+        assert_eq!(
+            commands
+                .iter()
+                .filter(|command| **command == "homeboy agent-task artifacts run-1 --full")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn run_and_task_ids_are_shell_quoted_in_every_emitted_command() {
+        let (actions, _) = diagnose_next_actions(
+            "run with spaces",
+            &[DiagnosedFailure {
+                task_id: "task with spaces".to_string(),
+                classification: AgentTaskFailureClassification::InvalidInput,
+            }],
+            &[],
+            None,
+        );
+
+        assert_eq!(
+            commands(&actions),
+            vec![
+                "homeboy agent-task evidence 'run with spaces' --task 'task with spaces' --failure-only",
+                "homeboy agent-task replay-provider-boundary 'run with spaces' --task 'task with spaces'",
+            ]
+        );
+    }
 }
 
 /// Apply the shared output primitive to a JSON collection while retaining every

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -830,6 +830,174 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 }
 
 #[test]
+fn diagnose_derives_next_actions_from_the_failure_classification() {
+    with_temp_home(|| {
+        let run_id = "run-cli-diagnose-actionable-timeout";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            ClassifiedFailureExecutor {
+                classification: AgentTaskFailureClassification::Timeout,
+            },
+        )
+        .expect("run completed with a classified failure");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose loaded");
+
+        assert_eq!(exit_code, 0);
+        // Pre-existing fields are unchanged: the actionable envelope is additive.
+        assert_eq!(value["schema"], "homeboy/agent-task-diagnose/v1");
+        assert_eq!(value["run_id"], run_id);
+        assert_eq!(
+            value["causal_chain"][0]["failure_classification"],
+            "timeout"
+        );
+        assert_eq!(
+            value["next_commands"],
+            json!([
+                format!("homeboy agent-task status {run_id} --full"),
+                format!("homeboy agent-task artifacts {run_id}"),
+                format!("homeboy agent-task review {run_id}"),
+                format!("homeboy agent-task retry {run_id} --run"),
+            ])
+        );
+
+        assert_eq!(value["next_action_basis"], "diagnosis");
+        let actionable = &value["_homeboy_actionable"];
+        assert_eq!(actionable["run"]["id"], run_id);
+        assert_eq!(actionable["run"]["kind"], "agent_task");
+        assert_eq!(actionable["run"]["location"], "local");
+        assert_eq!(
+            actionable["run"]["status_command"],
+            format!("homeboy agent-task status {run_id} --full")
+        );
+        assert_eq!(actionable["refs"]["agent_tasks"][0]["id"], run_id);
+        assert!(actionable["evidence"]
+            .as_array()
+            .expect("evidence refs")
+            .iter()
+            .any(|evidence| {
+                evidence["uri"] == "target/agent-task-review/transcript.log"
+                    && evidence["id"] == "task-a:transcript"
+            }));
+
+        let commands: Vec<&str> = actionable["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .iter()
+            .map(|action| action["command"].as_str().expect("command"))
+            .collect();
+        assert_eq!(
+            commands,
+            vec![
+                format!("homeboy agent-task evidence {run_id} --task task-a --failure-only"),
+                format!("homeboy agent-task review {run_id}"),
+                format!("homeboy agent-task retry {run_id} --run"),
+            ]
+        );
+        assert_eq!(actionable["next_actions"][2]["kind"], "repair");
+    });
+}
+
+#[test]
+fn diagnose_falls_back_to_the_generic_set_for_an_unclassified_failure() {
+    with_temp_home(|| {
+        let run_id = "run-cli-diagnose-actionable-unknown";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            ClassifiedFailureExecutor {
+                classification: AgentTaskFailureClassification::Unknown,
+            },
+        )
+        .expect("run completed with an unclassified failure");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose loaded");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["next_action_basis"], "generic_fallback");
+        let commands: Vec<&str> = value["_homeboy_actionable"]["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .iter()
+            .map(|action| action["command"].as_str().expect("command"))
+            .collect();
+        assert_eq!(
+            commands,
+            vec![
+                format!("homeboy agent-task status {run_id} --full"),
+                format!("homeboy agent-task artifacts {run_id}"),
+                format!("homeboy agent-task review {run_id}"),
+                format!("homeboy agent-task retry {run_id} --run"),
+            ]
+        );
+    });
+}
+
+#[test]
+fn diagnose_next_actions_name_the_artifacts_that_were_not_produced() {
+    with_temp_home(|| {
+        let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let evidence_path = evidence_dir.path().join("executor-result.json");
+        std::fs::write(
+            &evidence_path,
+            serde_json::to_string(&json!({ "status": "provider_error" })).expect("evidence json"),
+        )
+        .expect("write evidence");
+
+        let run_id = "run-cli-diagnose-actionable-missing-artifacts";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            ExecutorResultEvidenceFailureExecutor {
+                evidence_uri: format!("file://{}", evidence_path.display()),
+            },
+        )
+        .expect("run completed with missing declared artifacts");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose loaded");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            value["missing_artifacts"][0]["missing"],
+            json!(["concept_packet", "design_packet"])
+        );
+        assert_eq!(value["next_action_basis"], "diagnosis");
+
+        let actions = value["_homeboy_actionable"]["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .clone();
+        assert!(actions.iter().any(|action| {
+            action["command"]
+                == json!(format!(
+                    "homeboy agent-task replay-provider-boundary {run_id} --task task-a"
+                ))
+                && action["label"]
+                    .as_str()
+                    .expect("label")
+                    .contains("concept_packet, design_packet")
+        }));
+        assert!(actions.iter().any(|action| {
+            action["command"] == json!(format!("homeboy agent-task artifacts {run_id} --full"))
+                && action["kind"] == "artifacts"
+        }));
+    });
+}
+
+#[test]
 fn replay_provider_boundary_projects_latest_executor_input() {
     with_temp_home(|| {
         let evidence_dir = tempfile::tempdir().expect("evidence dir");

--- a/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/support.rs
@@ -203,6 +203,44 @@ impl AgentTaskExecutorAdapter for DiagnosticFailureExecutor {
     }
 }
 
+/// Fail with one exact typed failure classification so the read-side recovery
+/// mapping can be exercised end to end from a durable run.
+pub(crate) struct ClassifiedFailureExecutor {
+    pub(crate) classification: AgentTaskFailureClassification,
+}
+
+impl AgentTaskExecutorAdapter for ClassifiedFailureExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id,
+            status: AgentTaskOutcomeStatus::Failed,
+            summary: Some("classified failure fixture".to_string()),
+            failure_classification: Some(self.classification),
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: vec![AgentTaskEvidenceRef {
+                kind: "transcript".to_string(),
+                uri: "target/agent-task-review/transcript.log".to_string(),
+                label: Some("transcript".to_string()),
+            }],
+            diagnostics: vec![AgentTaskDiagnostic {
+                class: "fixture.classified_failure".to_string(),
+                message: "classified failure fixture".to_string(),
+                data: Value::Null,
+            }],
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }
+    }
+}
+
 pub(crate) struct ExecutorResultEvidenceFailureExecutor {
     pub(crate) evidence_uri: String,
 }

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -1207,3 +1207,35 @@ The deterministic smoke and existing provider path expose these failure classes:
 | missing secrets/preflight | `agent_task.secret_env_missing`, `failure_classification: "invalid_input"` |
 | empty runtime bundle | `agent_task.fixture_empty_runtime_bundle` |
 | stale/non-terminal status | `status` annotates running records with `metadata.stale_running` and `metadata.stale_running_reason` |
+
+### Diagnose derives its next actions from the classification
+
+`agent-task diagnose` computes a root cause, a causal chain, the recorded
+failure classification, and the declared artifacts that were not produced. It
+projects that diagnosis into the shared `_homeboy_actionable` envelope (`run`,
+`refs`, `next_actions`, `artifacts`, `evidence`) instead of returning only
+prose. The existing `next_commands` field is unchanged.
+
+`next_action_basis` reports how `next_actions` was produced: `diagnosis` when a
+classification or a concrete missing-artifact set mapped to specific commands,
+`generic_fallback` when nothing in the diagnosis was specific enough to act on.
+
+| `failure_classification` | Derived next actions |
+| --- | --- |
+| `provider` | failure evidence for the task, `agent-task providers`, the runner readiness chain when a runner owns the run, then retry |
+| `transient` | retry first (documented as safe to retry), then failure evidence |
+| `timeout` | failure evidence, `agent-task review` (a timeout can still leave a candidate patch), then retry |
+| `stalled` | `agent-task reconcile --dry-run`, `runner status`/`runner doctor --repair` for the owning runner, failure evidence, then retry |
+| `rate_limited` | failure evidence (retry-after hint), `agent-task providers` to rotate to, then retry |
+| `policy_denied` | failure evidence and the full run record. No retry: an identical request is denied identically |
+| `capability_missing` | failure evidence, `agent-task providers --full`, and `agent-task doctor --runner <id>` with its `--repair` form |
+| `invalid_input` | failure evidence and `agent-task replay-provider-boundary` for the rejected input. No retry: the same input fails the same way |
+| `execution_failed` | failure evidence for the failing step (gate/verify, harvest, required typed artifacts), `agent-task review`, `agent-task artifacts --full`, then retry |
+| `unknown` | no specific step is substantiable; the generic fallback set is emitted |
+
+Declared-but-missing artifacts add their own actions regardless of
+classification: `agent-task artifacts --full`, plus a task-scoped
+`agent-task replay-provider-boundary` and failure-evidence command naming the
+artifacts that were not produced. Repair-class actions carry
+`kind: "repair"`; runner-scoped actions are emitted only when the run records a
+runner id.


### PR DESCRIPTION
`agent-task diagnose` already computes a root cause. It computes a causal chain, the recorded `failure_classification`, the declared artifacts that were not produced, and hydrated evidence — and then throws all of it away:

```rust
fn diagnose_next_commands(run_id: &str) -> Vec<String> {
    vec![ status --full, artifacts, review, retry --run ]   // static
}
```

The same four commands whether the failure was a gate failure, a provider timeout, a missing artifact, or a lost runner. It also never called `attach_actionable_metadata`, so `run`, `refs`, `next_actions`, `artifacts`, and `evidence` were all absent from the one command an operator or orchestrator runs when something failed overnight.

This maps the typed classification to the commands that actually advance recovery for that failure, and projects the result into the existing `homeboy/command-result/v3` actionable envelope.

## Classification → action table

| `failure_classification` | Derived next actions |
| --- | --- |
| `provider` | failure evidence for the task, `agent-task providers`, the runner readiness chain when a runner owns the run, then retry |
| `transient` | retry first — the contract documents it as safe to retry with bounded backoff — then failure evidence |
| `timeout` | failure evidence, `agent-task review` (a timeout can still leave a `CandidateRecoverable` patch), then retry |
| `stalled` | `agent-task reconcile --dry-run`, `runner status` / `runner doctor --repair` for the owning runner, failure evidence, then retry |
| `rate_limited` | failure evidence (carries the retry-after hint), `agent-task providers` to rotate to, then retry |
| `policy_denied` | failure evidence and the full run record. **No retry** — an identical request is denied identically |
| `capability_missing` | failure evidence, `agent-task providers --full`, `agent-task doctor --runner <id>` and its `--repair` form |
| `invalid_input` | failure evidence and `agent-task replay-provider-boundary --task <id>`. **No retry** — the same input fails the same way |
| `execution_failed` | failure evidence for the failing step (gate/verify, harvest, required typed artifacts), `agent-task review`, `agent-task artifacts --full`, then retry |
| `unknown` | deliberately unmapped — no substantiable specific step |

Declared-but-missing artifacts contribute their own actions independent of classification: `agent-task artifacts --full`, plus a task-scoped `replay-provider-boundary` (which shows the artifact declarations the provider actually received) and failure-evidence command whose label names the artifacts that were not produced.

There is no `Gate` variant in `AgentTaskFailureClassification` — gate/verify failures are recorded as `ExecutionFailed`, which is why that arm leads with the failing step's evidence and the candidate review.

## Repair tagging and the fallback

Repair-class actions carry `CommandNextActionKind::Repair`, following the stale-run actions `agent-task status` already emits. Runner-scoped actions (`runner status`, `runner doctor`, `agent-task doctor --runner`) are emitted **only** when the run records a runner id, because `agent-task doctor` requires `--runner` and naming a runner we cannot substantiate would be worse than prose.

When neither a classification nor a missing-artifact set yields a specific step, the previous generic set is emitted — but now as an explicit fallback. A new `next_action_basis` field reports which happened (`diagnosis` or `generic_fallback`).

## No new contract

`CommandActionableMetadata`, `CommandNextAction`, `CommandNextActionKind::Repair`, and the v3 envelope all already exist. This is a producer change only — no new schema, no version bump. Every pre-existing diagnose field, including `next_commands`, is emitted unchanged; the envelope is additive.

## Tests

- Unit tests for each of the ten classifications, asserting the exact ordered command list and which actions are `Repair`-kinded.
- A stalled run with no known runner never names one.
- Unclassifiable failure falls back to the generic set, and so does a run with no diagnosis at all.
- Classification and missing-artifact actions merge without duplicates.
- Run and task ids are shell-quoted in every emitted command.
- End-to-end fixture tests (following the existing `run_loaded_plan` style) confirm `diagnose` output now carries `_homeboy_actionable` with `run`, `refs`, `evidence`, and `next_actions` populated, and that `schema`, `run_id`, `causal_chain`, and `next_commands` are unchanged.

Every emitted command string was verified against `crates/homeboy-cli/src/commands/agent_task/args/definitions/` and `crates/homeboy-cli/src/commands/runner/cli.rs`.

Closes #10300