### PR TITLE
fix: recover stranded release tags without depending on HEAD

### DIFF
--- a/.github/detect-stranded-release.sh
+++ b/.github/detect-stranded-release.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# Detect a *stranded prepared release*: a tag this pipeline already prepared
+# (version bumped, changelog written, tag pushed) whose GitHub Release is
+# missing entirely or is still sitting as a Draft.
+#
+# Why this exists (issue #10441)
+# ------------------------------
+# `release.yml` prepares and pushes the tag in one job and publishes the
+# GitHub Release in later jobs. A transient failure between those two points
+# (v0.320.0: `gh release upload` lost a `gh api release metadata` call) leaves
+# the tag behind with no published release. The workflow already knows how to
+# finish such a release — `recovery-release=true` skips the quality gates and
+# republishes from the tag — but until now that path only fired when either
+#
+#   * a human passed `workflow_dispatch` `release_tag`, or
+#   * `release --dry-run` at HEAD reported `bump-type=recovery`, which requires
+#     HEAD to still be sitting *on* the prepared tag.
+#
+# main moves within minutes, so the second condition evaporates and the
+# stranded tag is never revisited. This script makes the detection
+# **HEAD-independent**: it asks git and the GitHub API what is stranded and
+# never looks at `github.sha`.
+#
+# Safety properties
+# -----------------
+# 1. Only tags this pipeline prepared are eligible. A candidate must have the
+#    exact release tag shape (`vX.Y.Z`, the same regex `release.yml` validates
+#    dispatch input against) *and* the tagged commit's subject must be exactly
+#    `release: <tag>` — the subject `homeboy release` writes. A Draft a human
+#    created for some other purpose cannot satisfy both.
+# 2. The tagged commit must be reachable from the release branch. A tag parked
+#    on an unmerged side branch is not this pipeline's to publish.
+# 3. In-flight releases are held, not recovered *and not overtaken*.
+#    `cargo-dist` creates the GitHub Release as a Draft and publishes it
+#    minutes later, so a healthy running release legitimately looks stranded
+#    while it runs. A tag younger than STRANDED_MIN_AGE_MINUTES therefore
+#    produces `hold-reason` — this run neither recovers it nor prepares a fresh
+#    release on top of it. Waiting one cycle is strictly better than either
+#    double-publishing a live release or burying a fresh one over a tag that
+#    turns out to be stranded.
+# 4. Scanning stops at the first *published* release. Recovery is confined to
+#    the contiguous run of unpublished tags at the head of the tag list.
+#    Resurrecting an ancient orphan sitting below a published release would
+#    ship stale artifacts and disturb `latest`; that is a human decision.
+# 5. Oldest-first. When several tags are stranded the lowest version is chosen
+#    so releases publish in version order — later versions' notes and changelog
+#    ranges assume their predecessors shipped, and GitHub derives "latest" from
+#    the newest published release. One recovery per run; the next push drains
+#    the next one.
+# 6. Bounded retries. A tag already attempted MAX_RECOVERY_ATTEMPTS times is
+#    refused with an error annotation and the run falls through to a normal
+#    fresh release, so an unrecoverable orphan cannot block delivery forever
+#    and cannot spin recovery on every push.
+#
+# Env:
+#   GH_TOKEN                    - required, for `gh release list`
+#   GITHUB_OUTPUT               - required
+#   RECOVERY_ATTEMPTS_FILE      - optional marker file: "<tag> <count>" per line
+#   MAX_RECOVERY_ATTEMPTS       - default 3
+#   STRANDED_SCAN_LIMIT         - default 20 newest tags
+#   STRANDED_MIN_AGE_MINUTES    - default 45 (release pipeline runs ~27m)
+#
+# Outputs (GITHUB_OUTPUT):
+#   stranded-tag      - tag to recover, or empty
+#   stranded-version  - that tag without the leading "v", or empty
+#   stranded-attempts - failed recovery attempts already recorded for that tag
+#   hold-reason       - non-empty when this run must not release at all
+
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+SCAN_LIMIT="${STRANDED_SCAN_LIMIT:-20}"
+MIN_AGE_MINUTES="${STRANDED_MIN_AGE_MINUTES:-45}"
+MAX_ATTEMPTS="${MAX_RECOVERY_ATTEMPTS:-3}"
+ATTEMPTS_FILE="${RECOVERY_ATTEMPTS_FILE:-}"
+
+TAG_SHAPE='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+emit() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
+}
+
+finish() {
+  emit 'stranded-tag' "${1:-}"
+  emit 'stranded-version' "${2:-}"
+  emit 'stranded-attempts' "${3:-0}"
+  emit 'hold-reason' "${4:-}"
+  exit 0
+}
+
+recorded_attempts() {
+  local tag="$1"
+  if [ -z "${ATTEMPTS_FILE}" ] || [ ! -f "${ATTEMPTS_FILE}" ]; then
+    printf '0'
+    return 0
+  fi
+  awk -v tag="${tag}" '$1 == tag { count = $2 } END { printf "%d", count + 0 }' "${ATTEMPTS_FILE}"
+}
+
+RELEASES_JSON="$(mktemp)"
+RELEASES_ERR="$(mktemp)"
+trap 'rm -f "${RELEASES_JSON}" "${RELEASES_ERR}"' EXIT
+
+# One API call answers the question for every candidate. A failed call must
+# never read as "nothing is published" — that would republish healthy releases
+# — so a transient API error simply skips detection for this run.
+if ! gh release list --limit 100 --json tagName,isDraft > "${RELEASES_JSON}" 2> "${RELEASES_ERR}"; then
+  echo "::warning::Could not list GitHub Releases; skipping stranded-release detection this run"
+  sed 's/^/gh: /' "${RELEASES_ERR}" >&2 || true
+  finish '' '' 0 ''
+fi
+
+now_epoch="$(date +%s)"
+min_age_seconds=$(( MIN_AGE_MINUTES * 60 ))
+
+stranded_tags=()
+stranded_reasons=()
+hold_reason=''
+
+while IFS= read -r tag; do
+  [ -n "${tag}" ] || continue
+
+  if [[ ! "${tag}" =~ ${TAG_SHAPE} ]]; then
+    continue
+  fi
+
+  commit="$(git rev-parse -q --verify "${tag}^{commit}" 2>/dev/null || true)"
+  if [ -z "${commit}" ]; then
+    continue
+  fi
+
+  # Provenance: only tags whose commit is a Homeboy release commit are ours.
+  subject="$(git log -1 --format=%s "${commit}")"
+  if [ "${subject}" != "release: ${tag}" ]; then
+    echo "::notice::Ignoring tag ${tag} for recovery: commit subject is '${subject}', not 'release: ${tag}'"
+    continue
+  fi
+
+  # Provenance: the tag must live on the branch this workflow releases from.
+  if ! git merge-base --is-ancestor "${commit}" HEAD; then
+    echo "::notice::Ignoring tag ${tag} for recovery: not reachable from the release branch"
+    continue
+  fi
+
+  entry="$(jq -c --arg tag "${tag}" 'map(select(.tagName == $tag)) | first // empty' "${RELEASES_JSON}")"
+
+  if [ -n "${entry}" ] && [ "$(jq -r '.isDraft' <<< "${entry}")" != "true" ]; then
+    # First published release found. Everything older is either published or a
+    # historical orphan that must not be resurrected automatically.
+    break
+  fi
+
+  tag_epoch="$(git log -1 --format=%ct "${commit}")"
+  age_seconds=$(( now_epoch - tag_epoch ))
+  if [ "${age_seconds}" -lt "${min_age_seconds}" ]; then
+    hold_reason="tag ${tag} has no published release yet but is only $(( age_seconds / 60 ))m old (< ${MIN_AGE_MINUTES}m); its release pipeline may still be running"
+    break
+  fi
+
+  if [ -z "${entry}" ]; then
+    stranded_reasons+=('no GitHub Release')
+  else
+    stranded_reasons+=('Draft GitHub Release')
+  fi
+  stranded_tags+=("${tag}")
+done < <(git tag --list --sort=-v:refname | head -n "${SCAN_LIMIT}")
+
+for index in "${!stranded_tags[@]}"; do
+  echo "::warning::Stranded prepared release: ${stranded_tags[${index}]} (${stranded_reasons[${index}]})"
+done
+
+if [ -n "${hold_reason}" ]; then
+  # Holding beats both alternatives: recovering could double-publish a live
+  # release, and preparing a fresh release would bury the tag under a newer
+  # published one where the contiguous-window scan can never see it again.
+  echo "::notice::Holding this release run — ${hold_reason}"
+  finish '' '' 0 "${hold_reason}"
+fi
+
+if [ "${#stranded_tags[@]}" -eq 0 ]; then
+  finish '' '' 0 ''
+fi
+
+# Oldest-first: the scan is newest-first, so the last entry is the lowest version.
+last_index=$(( ${#stranded_tags[@]} - 1 ))
+target="${stranded_tags[${last_index}]}"
+attempts="$(recorded_attempts "${target}")"
+
+if [ "${attempts}" -ge "${MAX_ATTEMPTS}" ]; then
+  echo "::error::Stranded release ${target} has failed automatic recovery ${attempts} time(s) (limit ${MAX_ATTEMPTS}); not retrying. Recover manually with a workflow_dispatch run using release_tag=${target}, or delete the tag if it should not ship. Fresh releases continue so delivery is not blocked."
+  finish '' '' "${attempts}" ''
+fi
+
+echo "::notice::Selecting stranded release ${target} for automatic recovery (attempt $(( attempts + 1 )) of ${MAX_ATTEMPTS})"
+finish "${target}" "${target#v}" "${attempts}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       should-release: ${{ steps.check.outputs.should-release }}
       bump-type: ${{ steps.check.outputs['release-bump-type'] }}
       recovery-release: ${{ steps.check.outputs.recovery-release }}
+      recovery-attempts: ${{ steps.check.outputs.recovery-attempts }}
       release-version: ${{ steps.check.outputs['release-version'] }}
       release-tag: ${{ steps.check.outputs['release-tag'] }}
     steps:
@@ -78,6 +79,19 @@ jobs:
           restore-keys: |
             release-last-failed-${{ github.ref_name }}-
 
+      # Recovery attempts are counted per TAG, not per SHA. The SHA marker
+      # above only suppresses retrying the same HEAD; a stranded tag outlives
+      # every HEAD, so its retry budget has to travel with the tag.
+      - name: Restore release recovery attempts
+        id: recovery-attempts-cache
+        if: inputs.release_tag == ''
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/homeboy-release-recovery-attempts
+          key: release-recovery-attempts-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            release-recovery-attempts-${{ github.ref_name }}-
+
       - name: Check failed release marker
         id: failed-release
         if: inputs.release_tag == ''
@@ -95,9 +109,39 @@ jobs:
 
           echo "blocked=false" >> "$GITHUB_OUTPUT"
 
+      # ── HEAD-independent stranded-release detection (issue #10441) ──
+      # The `bump-type=recovery` contract below only fires while HEAD is still
+      # sitting on the prepared tag. main moves within minutes, so a tag whose
+      # publish step failed was never revisited: v0.320.0 stranded 188 commits
+      # for three hours while the pipeline was holding the exact repair
+      # command. This step asks git and the GitHub API what is unpublished
+      # instead of asking what HEAD is, so it fires regardless of how far main
+      # has moved. See .github/detect-stranded-release.sh for the provenance,
+      # in-flight, ordering, and retry-budget rules.
+      - name: Detect stranded prepared release
+        id: stranded
+        if: inputs.release_tag == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RECOVERY_ATTEMPTS_FILE: ${{ runner.temp }}/homeboy-release-recovery-attempts
+        run: |
+          # Fail-safe: this detector sits in front of every release. A bug in it
+          # must degrade to "no recovery", never to "no releases". The script
+          # writes all four outputs in one final block, so a crash before that
+          # leaves them unset and this fallback supplies the inert defaults.
+          if ! bash .github/detect-stranded-release.sh; then
+            echo "::warning::Stranded-release detection failed; continuing without recovery"
+            {
+              echo "stranded-tag="
+              echo "stranded-version="
+              echo "stranded-attempts=0"
+              echo "hold-reason="
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Dry-run release check
         id: release-check
-        if: inputs.release_tag == '' && steps.failed-release.outputs.blocked != 'true'
+        if: inputs.release_tag == '' && steps.failed-release.outputs.blocked != 'true' && steps.stranded.outputs['stranded-tag'] == '' && steps.stranded.outputs['hold-reason'] == ''
         uses: Extra-Chill/homeboy-action@v2
         with:
           commands: release
@@ -132,19 +176,44 @@ jobs:
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
           RECOVERY_TAG="${{ steps.recovery.outputs['release-tag'] }}"
+          STRANDED_TAG="${{ steps.stranded.outputs['stranded-tag'] }}"
+          STRANDED_VERSION="${{ steps.stranded.outputs['stranded-version'] }}"
+          STRANDED_ATTEMPTS="${{ steps.stranded.outputs['stranded-attempts'] }}"
+          HOLD_REASON="${{ steps.stranded.outputs['hold-reason'] }}"
           RELEASE_VERSION="${{ steps.recovery.outputs['release-version'] || steps.release-check.outputs['release-version'] }}"
           RELEASE_TAG="${{ steps.recovery.outputs['release-tag'] || steps.release-check.outputs['release-tag'] }}"
           BUMP_TYPE="${{ steps.recovery.outputs['release-bump-type'] || steps.release-check.outputs['release-bump-type'] }}"
 
-          if [ "${{ steps.failed-release.outputs.blocked }}" = "true" ]; then
-            echo "should-release=false" >> "$GITHUB_OUTPUT"
-          elif [ -n "${RECOVERY_TAG}" ]; then
+          echo "recovery-attempts=${STRANDED_ATTEMPTS:-0}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${RECOVERY_TAG}" ]; then
+            # Explicit workflow_dispatch recovery always wins.
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "release-bump-type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
             echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
             echo "release-tag=${RECOVERY_TAG}" >> "$GITHUB_OUTPUT"
             echo "recovery-release=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Release recovery will publish ${RECOVERY_TAG}"
+          elif [ -n "${STRANDED_TAG}" ]; then
+            # Recovery PREEMPTS a fresh release, and preempts the failed-SHA
+            # marker too. The marker is keyed to github.sha and only means
+            # "do not re-prepare this HEAD"; finishing an already-prepared tag
+            # is a different, HEAD-independent action. Preemption is the whole
+            # point: a fresh release prepared on top of a stranded tag buries
+            # it under a newer published release, where the contiguous-window
+            # scan can never find it again — permanently orphaning a version
+            # whose artifacts were already built and paid for.
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "release-bump-type=recovery" >> "$GITHUB_OUTPUT"
+            echo "release-version=${STRANDED_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "release-tag=${STRANDED_TAG}" >> "$GITHUB_OUTPUT"
+            echo "recovery-release=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Self-recovery: publishing stranded prepared tag ${STRANDED_TAG} instead of preparing a fresh release"
+          elif [ -n "${HOLD_REASON}" ]; then
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Holding release — ${HOLD_REASON}"
+          elif [ "${{ steps.failed-release.outputs.blocked }}" = "true" ]; then
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
           elif [ -z "${RELEASE_VERSION}" ]; then
             echo "should-release=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No releasable commits at HEAD ${HEAD_SHA:0:8}"
@@ -402,9 +471,12 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
+      # A push-triggered self-recovery has no `inputs.release_tag`, and main has
+      # normally moved well past the stranded tag by now. Check out the tag
+      # being recovered so every job in the publish chain agrees on the tree.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag || (needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag']) || github.ref }}
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -441,7 +513,7 @@ jobs:
       # Rust toolchain needed so run-release.sh can regenerate Cargo.lock
       # after bumping Cargo.toml version
       - name: Install Rust toolchain
-        if: inputs.release_tag == ''
+        if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Preflight release workspace build
@@ -905,14 +977,55 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The SHA marker means "do not re-PREPARE this HEAD". A recovery run
+      # never prepares anything — it finishes an already-prepared tag — so
+      # recording HEAD there would wrongly suppress the fresh release this
+      # HEAD still deserves.
       - name: Save failed SHA
+        if: needs.check.outputs.recovery-release != 'true'
         run: git rev-parse HEAD > "${RUNNER_TEMP}/homeboy-release-last-failed"
 
       - name: Cache failed SHA
+        if: needs.check.outputs.recovery-release != 'true'
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/homeboy-release-last-failed
           key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
+
+      # A failed recovery is charged to the TAG, so a stranded tag that cannot
+      # be published gets a bounded retry budget instead of re-firing on every
+      # push forever. `detect-stranded-release.sh` refuses a tag once it hits
+      # MAX_RECOVERY_ATTEMPTS and falls through to a normal fresh release.
+      - name: Restore recovery attempts
+        if: needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag'] != ''
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/homeboy-release-recovery-attempts
+          key: release-recovery-attempts-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            release-recovery-attempts-${{ github.ref_name }}-
+
+      - name: Record failed recovery attempt
+        if: needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag'] != ''
+        env:
+          RELEASE_TAG: ${{ needs.check.outputs['release-tag'] }}
+        run: |
+          set -euo pipefail
+          MARKER="${RUNNER_TEMP}/homeboy-release-recovery-attempts"
+          touch "${MARKER}"
+          NEXT="$(awk -v tag="${RELEASE_TAG}" '$1 == tag { count = $2 } END { printf "%d", count + 1 }' "${MARKER}")"
+          awk -v tag="${RELEASE_TAG}" '$1 != tag' "${MARKER}" > "${MARKER}.next"
+          printf '%s %s\n' "${RELEASE_TAG}" "${NEXT}" >> "${MARKER}.next"
+          mv "${MARKER}.next" "${MARKER}"
+          echo "::warning::Automatic recovery of ${RELEASE_TAG} failed (attempt ${NEXT})"
+          cat "${MARKER}"
+
+      - name: Cache recovery attempts
+        if: needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag'] != ''
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/homeboy-release-recovery-attempts
+          key: release-recovery-attempts-${{ github.ref_name }}-${{ github.run_id }}
 
   clear-failure:
     name: Clear failed release SHA cache
@@ -934,9 +1047,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear failed SHA cache
+        if: needs.check.outputs.recovery-release != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh cache list --json id,key --jq '.[] | select(.key | startswith("release-last-failed-${{ github.ref_name }}-")) | .id' | while read -r id; do
+            gh cache delete "$id" 2>/dev/null || true
+          done
+
+      # Only a SUCCESSFUL recovery clears the retry budget. Clearing it after a
+      # successful *fresh* release would reset the counter of a tag that keeps
+      # failing, turning the bounded retry into a slow infinite loop.
+      - name: Clear recovery attempts cache
+        if: needs.check.outputs.recovery-release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache list --json id,key --jq '.[] | select(.key | startswith("release-recovery-attempts-${{ github.ref_name }}-")) | .id' | while read -r id; do
             gh cache delete "$id" 2>/dev/null || true
           done

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -760,17 +760,104 @@ fn release_failure_digest(data: &Value) -> Option<CommandFailureDigest> {
         })
         .unwrap_or("release step failed without a reported error");
 
+    // The step already classified itself (`reason: "gh-upload-failed"`) and
+    // already computed the repair command. Dropping both here is what left CI
+    // printing `Release failed: Unknown error` while holding the exact fix
+    // (#10441), so lift the classification into the summary and the repair
+    // commands into next_actions.
+    let step_data = failed_step.get("data");
+    let cause = match step_data
+        .and_then(|data| data.get("reason"))
+        .and_then(Value::as_str)
+        .filter(|reason| !reason.trim().is_empty())
+    {
+        Some(reason) => format!("{reason} — {cause}"),
+        None => cause.to_string(),
+    };
+
+    let mut next_actions = release_repair_actions(step_data);
+    if next_actions.is_empty() {
+        next_actions.push(release_gate_repro_action(step_id, step_type, component_id));
+    }
+
     Some(CommandFailureDigest {
         summary: format!(
             "Release step {step_id} ({step_type}) failed: {}",
-            bounded_text(cause, 1000)
+            bounded_text(&cause, 1000)
         ),
         stdout_tail: None,
         stderr_tail: None,
         artifact_refs: Vec::new(),
-        next_actions: vec![release_gate_repro_action(step_id, step_type, component_id)],
+        next_actions,
         retryable: None,
     })
+}
+
+/// Lift a failed release step's own `repair` block into executable next
+/// actions.
+///
+/// A publish failure is not a quality-gate failure: re-running a gate does
+/// nothing for it, and the plan-only `--dry-run` fallback actively misleads.
+/// The step already knows whether the GitHub Release object exists, which
+/// decides the repair: an existing Draft must be *finished* (upload + publish),
+/// never re-created, or the release ends up duplicated.
+fn release_repair_actions(step_data: Option<&Value>) -> Vec<CommandNextAction> {
+    let Some(repair) = step_data
+        .and_then(|data| data.get("repair"))
+        .and_then(Value::as_object)
+    else {
+        return Vec::new();
+    };
+
+    let command = |key: &str| {
+        repair
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    };
+
+    let release_created = step_data
+        .and_then(|data| data.get("release_created"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut actions = Vec::new();
+
+    if release_created {
+        if let Some(upload) = command("upload_command") {
+            actions.push(
+                CommandNextAction::new(
+                    "attach the built artifacts to the release that already exists",
+                    upload,
+                )
+                .with_kind(CommandNextActionKind::Repair),
+            );
+        }
+        if let Some(publish) = command("publish_command") {
+            actions.push(
+                CommandNextAction::new("publish that release once its assets verify", publish)
+                    .with_kind(CommandNextActionKind::Repair),
+            );
+        }
+    } else if let Some(create) = command("create_command") {
+        actions.push(
+            CommandNextAction::new(
+                "create the GitHub Release from the pushed tag and built artifacts (no new tag)",
+                create,
+            )
+            .with_kind(CommandNextActionKind::Repair),
+        );
+    }
+
+    if let Some(view) = command("view_command").filter(|_| !actions.is_empty()) {
+        actions.push(
+            CommandNextAction::new("verify the release and its assets", view)
+                .with_kind(CommandNextActionKind::Repair),
+        );
+    }
+
+    actions
 }
 
 /// Map a failed release step to a non-mutating command that actually executes
@@ -1166,6 +1253,88 @@ mod tests {
             "dry-run fallback must be labeled plan-only, got: {}",
             action.label
         );
+    }
+
+    fn github_release_failure_payload(step_data: Value) -> Value {
+        json!({
+            "command": "release",
+            "result": {
+                "component_id": "homeboy",
+                "run": { "result": { "steps": [{
+                    "id": "github.release",
+                    "type": "github.release",
+                    "status": "failed",
+                    "error": "`gh release upload` failed for v0.320.0: gh api release metadata exited with status 1",
+                    "data": step_data
+                }] } }
+            }
+        })
+    }
+
+    /// #10441: the step classified itself (`reason`) and computed the repair
+    /// command, then the envelope threw both away — which is how CI ended up
+    /// printing "Release failed: Unknown error" while holding the exact fix.
+    #[test]
+    fn failed_publish_surfaces_its_classified_reason_and_repair_commands() {
+        let digest = release_failure_digest(&github_release_failure_payload(json!({
+            "reason": "gh-upload-failed",
+            "release_created": true,
+            "repair": {
+                "upload_command": "gh release upload 'v0.320.0' 'a.tar.gz' --clobber -R 'Extra-Chill/homeboy'",
+                "publish_command": "gh release edit 'v0.320.0' --draft=false -R 'Extra-Chill/homeboy'",
+                "create_command": "gh release create 'v0.320.0' --title 'v0.320.0'",
+                "view_command": "gh release view 'v0.320.0' -R 'Extra-Chill/homeboy'"
+            }
+        })))
+        .expect("release digest");
+
+        assert!(
+            digest.summary.contains("gh-upload-failed"),
+            "classified reason must reach the envelope summary, got: {}",
+            digest.summary
+        );
+
+        let commands: Vec<&str> = digest
+            .next_actions
+            .iter()
+            .map(|action| action.command.as_str())
+            .collect();
+        assert_eq!(
+            commands,
+            vec![
+                "gh release upload 'v0.320.0' 'a.tar.gz' --clobber -R 'Extra-Chill/homeboy'",
+                "gh release edit 'v0.320.0' --draft=false -R 'Extra-Chill/homeboy'",
+                "gh release view 'v0.320.0' -R 'Extra-Chill/homeboy'",
+            ],
+            "an existing release must be finished, never re-created"
+        );
+        assert!(
+            !commands.iter().any(|command| command.contains("--dry-run")),
+            "a publish failure must not be handed a plan-only dry run"
+        );
+    }
+
+    /// When no GitHub Release object exists yet, the repair is to create it
+    /// from the already-pushed tag — not to cut a second tag.
+    #[test]
+    fn failed_publish_without_a_release_object_recommends_creating_it() {
+        let digest = release_failure_digest(&github_release_failure_payload(json!({
+            "reason": "gh-create-failed",
+            "release_created": false,
+            "repair": {
+                "create_command": "gh release create 'v0.320.0' --title 'v0.320.0' --notes-file 'notes.md'",
+                "upload_command": "gh release upload 'v0.320.0' --clobber",
+                "view_command": "gh release view 'v0.320.0'"
+            }
+        })))
+        .expect("release digest");
+
+        let first = digest.next_actions.first().expect("next action");
+        assert_eq!(
+            first.command,
+            "gh release create 'v0.320.0' --title 'v0.320.0' --notes-file 'notes.md'"
+        );
+        assert!(digest.summary.contains("gh-create-failed"));
     }
 
     #[test]


### PR DESCRIPTION
A transient `gh` API error stranded 188 commits for three hours while the pipeline was holding the exact repair command.

`v0.320.0` was tagged, all five platform artifacts built, and all 15 assets uploaded to a Draft release. The only thing that failed was the final publish: `gh release upload` → `gh api release metadata exited with status 1`. Homeboy diagnosed it perfectly — `reason: "gh-upload-failed"`, `release_created: true`, `missing: 0`, plus a `repair.create_command` — and `verify-published` printed the exact fix: *"recover with a workflow_dispatch run using release_tag=v0.320.0"*.

Then nothing happened until a human ran that dispatch by hand. `v0.319.3` has been orphaned the same way since Jul 26.

## Why the existing recovery never fired

The mechanism works. `release.yml` already handles `recovery-release=true`, skips the quality gates, and republishes from the tag. It just could not *see* the stranded tag, because it only fires when:

- a human passes `inputs.release_tag`, or
- `release --dry-run` at HEAD reports `bump-type=recovery` — which requires **HEAD to still be sitting on the prepared tag**.

main moved 43 commits past `v0.320.0` within minutes. Every later run computed a fresh version and never looked back.

`record-failure` doesn't help: it's keyed to `${{ github.sha }}`, so it only suppresses retrying the *same HEAD*. It carries no memory of "there is an unpublished prepared tag that needs finishing."

## The fix

`.github/detect-stranded-release.sh` runs at the top of the `check` job and asks git and the GitHub API what is unpublished — **never `github.sha`**. One `gh release list --json tagName,isDraft` call answers it for every candidate. When it finds one it sets `recovery-release=true` and targets that tag; the branch that consumes that contract already exists.

### Not hijacking foreign drafts

A candidate must satisfy **all three**:

1. Tag shape `^v[0-9]+\.[0-9]+\.[0-9]+$` — the same regex `release.yml:118` already validates dispatch input against.
2. The tagged commit's subject is exactly `release: <tag>` — the subject `homeboy release` writes (`executor.rs:291`).
3. The tagged commit is reachable from the release branch.

A Draft a human created for another purpose cannot satisfy all three.

### Not double-publishing a live release

`cargo-dist` creates the GitHub Release **as a Draft** and publishes it minutes later, so a healthy in-flight release legitimately *looks* stranded. A tag younger than 45 minutes (the pipeline runs ~27m) therefore produces `hold-reason`: this run neither recovers it **nor prepares a fresh release on top of it**.

Holding beats both alternatives. Recovering could double-publish a live release. Preparing a fresh release would bury the tag under a newer published one, where the contiguous-window scan can never find it again — permanently orphaning a version whose artifacts were already built and paid for. Cost is at most one skipped cycle.

### Picking the right tag

**Oldest-first.** `v0.319.3` and `v0.320.0` are both orphaned right now; `v0.319.3` goes first. Later versions' release notes and changelog ranges assume their predecessors shipped, and GitHub derives `latest` from the newest published release — publishing `v0.320.0` first and `v0.319.3` after would leave `latest` pointing at the older version. One recovery per run; the next push drains the next one.

Scanning **stops at the first published release**, confining recovery to the contiguous unpublished run at the head of the tag list. Resurrecting an ancient orphan sitting below a published release would ship stale artifacts and disturb `latest`; that stays a human decision.

### Not looping forever

Expressed through the existing marker jobs rather than new machinery. The SHA marker cannot express this — a stranded tag outlives every HEAD — so a failed recovery is charged to the **tag**:

- `record-failure` restores the marker, increments the count for `needs.check.outputs['release-tag']`, and saves it. It also **stops recording the SHA marker on recovery runs**: a recovery never *prepares* anything, so blocking that HEAD would wrongly suppress the fresh release it still deserves.
- `clear-failure` clears the retry budget **only after a successful recovery**. Clearing it after a successful *fresh* release would reset the counter of a tag that keeps failing, turning the bounded retry into a slow infinite loop.
- After 3 attempts the detector refuses the tag with an `::error::` naming the manual dispatch, and the run falls through to a normal fresh release — an unrecoverable orphan is loud but never blocks delivery.

### Preemption vs. starvation

Recovery **preempts** a fresh release, and preempts the failed-SHA marker too (that marker means "do not re-prepare this HEAD", which is a different question from "finish this already-prepared tag"). Starvation is bounded: one stranded tag drains per run, and the exhausted-budget path hands the pipeline back to fresh releases.

Detection failure degrades to *no recovery*, never to *no releases* — the step wraps the script and supplies inert defaults if it crashes.

## Last-mile message: "Release failed: Unknown error"

`Create GitHub Release` printed `##[error]Release failed: Unknown error` while the payload held `reason: "gh-upload-failed"` and a repair command. Two layers were dropping the answer:

- **Here (`response.rs`):** `release_failure_digest` read the step's `error` string and ignored its `reason` and its whole `repair` block, then offered `homeboy release <c> --dry-run` — which only renders a plan. Now the classified reason reaches `summary`/`diagnostics.message`, and the step's own repair commands become the next actions. Crucially it respects `release_created`: an existing Draft is *finished* (upload → publish → view), never re-created, so recovery can't duplicate the release.
- **`homeboy-action`:** the wrapper read `.error.message`, which only exists on the legacy error envelope — a release that runs and then fails a step returns the v3 envelope, which has no `.error` at all. Fixed in Extra-Chill/homeboy-action#302, which also prints the repair commands as annotations.

## `v0.319.3`

**Self-recovers.** Verified by running the detector against live repo state on this branch:

```
::warning::Stranded prepared release: v0.320.0 (Draft GitHub Release)
::warning::Stranded prepared release: v0.319.3 (no GitHub Release)
::notice::Selecting stranded release v0.319.3 for automatic recovery (attempt 1 of 3)
stranded-tag=v0.319.3
```

`v0.319.3` (tagged Jul 26, no release) is picked first, then `v0.320.0` (Draft) on the following push. No one-off dispatch needed.

## Verification

Detector exercised against real repo state — no release was run:

- both orphans detected, `v0.319.3` selected oldest-first
- a `v9.9.9` tag on a non-release commit → rejected on subject
- the same tag on an unreachable side branch → rejected on reachability
- exhausted retry budget → error annotation, falls through to fresh release
- hold path → `hold-reason` set, no recovery and no fresh release
- attempt-counter arithmetic (increment, multi-tag coexistence, read-back)
- `python3 -c "import yaml; yaml.safe_load(...)"` on `release.yml`

Rust side has two new tests in `response.rs` covering the existing-Draft and no-release-object repair shapes, plus the reason reaching the summary. `cargo fmt` clean; build/test left to CI per repo policy.

Refs #10441
