### PR TITLE
fix(release): resolve draft releases by id so recovery can finish them

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -404,17 +404,64 @@ pub(crate) fn gh_release_metadata(
 ) -> Result<GitHubReleaseMetadata, String> {
     // `gh release view --json` uses GraphQL, whose release asset shape omits
     // the REST digest field. Recovery authority requires that digest, including
-    // for drafts, so read the tag endpoint directly.
+    // for drafts, so read the REST API directly.
     let endpoint = format!("repos/{repo_flag}/releases/tags/{tag}");
     let output = run_gh_command(
         gh_command(github, config, &["api", &endpoint]),
         github_release_upload_timeout(),
     );
-    if output.timed_out || output.exit_code != Some(0) {
+    if !output.timed_out && output.exit_code == Some(0) {
+        return serde_json::from_str(&output.stdout)
+            .map_err(|error| format!("GitHub REST release metadata was invalid: {error}"));
+    }
+    if output.timed_out {
         return Err(gh_failure_detail("gh api release metadata", &output));
     }
-    serde_json::from_str(&output.stdout)
-        .map_err(|error| format!("GitHub REST release metadata was invalid: {error}"))
+
+    // `releases/tags/{tag}` resolves published releases only -- GitHub returns
+    // 404 for a draft, because a draft has no tag association on that endpoint.
+    // A failed publish leaves exactly that state, so looking the release up by
+    // tag made recovery impossible for the one case recovery exists to handle:
+    // every retry 404'd, left the release a draft, and 404'd again forever.
+    // Drafts are visible on the list endpoint, so fall back to resolving by id.
+    gh_draft_release_metadata(github, config, tag, repo_flag)
+        .ok_or_else(|| gh_failure_detail("gh api release metadata", &output))
+}
+
+/// Resolve a draft release by scanning the list endpoint, which -- unlike
+/// `releases/tags/{tag}` -- includes drafts. Returns the REST shape, so the
+/// asset digests recovery depends on are preserved.
+fn gh_draft_release_metadata(
+    github: &GitHubRepo,
+    config: &GithubConfig,
+    tag: &str,
+    repo_flag: &str,
+) -> Option<GitHubReleaseMetadata> {
+    let endpoint = format!("repos/{repo_flag}/releases");
+    let filter = format!(".[] | select(.tag_name == \"{tag}\")");
+    let output = run_gh_command(
+        gh_command(
+            github,
+            config,
+            &["api", "--paginate", &endpoint, "--jq", &filter],
+        ),
+        github_release_upload_timeout(),
+    );
+    if output.timed_out || output.exit_code != Some(0) {
+        return None;
+    }
+    parse_listed_release_metadata(&output.stdout)
+}
+
+/// `gh api --jq` streams one JSON object per match rather than an array, and
+/// `--paginate` concatenates pages. A tag resolves to at most one release, so
+/// take the first non-empty record.
+fn parse_listed_release_metadata(stdout: &str) -> Option<GitHubReleaseMetadata> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .and_then(|line| serde_json::from_str(line).ok())
 }
 
 pub(crate) fn verify_release_assets(
@@ -1033,6 +1080,29 @@ pub(crate) fn github_cli_env(github: &GitHubRepo, config: &GithubConfig) -> Vec<
 mod tests {
     use super::*;
     use std::sync::mpsc;
+
+    /// The list endpoint is the only REST surface that exposes a draft release:
+    /// `releases/tags/{tag}` returns 404 for drafts, which deadlocked recovery
+    /// (a failed publish leaves a draft, every retry 404'd, it stayed a draft).
+    /// This is a real `gh api --paginate --jq` record for a stranded release.
+    #[test]
+    fn draft_release_metadata_parses_from_the_list_endpoint() {
+        let stdout = r#"{"id":360531007,"tag_name":"v0.320.0","draft":true,"assets":[{"id":1,"name":"homeboy-x86_64-unknown-linux-gnu.tar.xz","size":9876543,"digest":"sha256:abc123"}]}"#;
+        let metadata = parse_listed_release_metadata(stdout).expect("draft metadata parses");
+        assert!(metadata.is_draft);
+        assert_eq!(metadata.assets.len(), 1);
+        // Recovery reconciles by digest, so losing it would silently re-upload.
+        assert_eq!(metadata.assets[0].digest.as_deref(), Some("sha256:abc123"));
+    }
+
+    #[test]
+    fn listed_release_metadata_ignores_blank_and_paginated_noise() {
+        let stdout = "\n\n{\"tag_name\":\"v1.2.3\",\"draft\":false,\"assets\":[]}\n";
+        let metadata = parse_listed_release_metadata(stdout).expect("metadata parses");
+        assert!(!metadata.is_draft);
+        assert!(parse_listed_release_metadata("").is_none());
+        assert!(parse_listed_release_metadata("not json").is_none());
+    }
 
     fn remote_asset(name: &str, size: u64, digest: Option<String>) -> GitHubReleaseAsset {
         GitHubReleaseAsset {


### PR DESCRIPTION
**This is why `v0.320.0` would not publish, and why my manual recovery dispatch failed with the identical error.** Not a transient `gh` hiccup — a hard deadlock.

## The bug

`GET /repos/{owner}/{repo}/releases/tags/{tag}` **returns 404 for draft releases.** Verified against this repo:

```
releases/tags/v0.320.0  (draft)      -> 404 Not Found
releases/tags/v0.319.2  (published)  -> 360134052   OK
releases/tags/v0.319.3  (draft/none) -> 404 Not Found
```

while the release plainly exists:

```
$ gh api repos/Extra-Chill/homeboy/releases --jq '.[] | select(.draft==true)'
v0.320.0 id=360531007 draft=true
v0.30.14 id=278459054 draft=true
v0.1.0   id=275634969 draft=true
```

So the loop was:

1. `gh release upload` hits a transient error -> release left **Draft**
2. retry -> `gh_release_metadata` looks up **by tag** -> **404**
3. -> `"gh api release metadata exited with status 1"` -> fail
4. -> still Draft -> **goto 2, forever**

## Why it looked transient

The two probes disagree, and only one of them handles drafts:

| Probe | Mechanism | Draft `v0.320.0` |
|---|---|---|
| `gh_release_exists` | `gh release view` (GraphQL) | **finds it** -> takes the "already exists, reconcile" branch |
| `gh_release_metadata` | REST `releases/tags/{tag}` | **404** -> hard fail |

The code correctly detected the draft, entered the recovery branch, then died fetching the metadata for the release it had just found.

The existing comment asked for precisely the behavior it lacked:

> `gh release view --json` uses GraphQL, whose release asset shape omits the REST digest field. Recovery authority requires that digest, **including for drafts**, so read the tag endpoint directly.

Documented intent, contradicted by the chosen endpoint.

## The fix

Keep `releases/tags/{tag}` as the fast path for published releases (one call, unchanged). On a non-timeout failure, fall back to the list endpoint, which **does** expose drafts and returns the same REST shape — including the asset digests recovery reconciles against, so no re-upload is triggered.

## Verified against the live API

- `v0.320.0` -> resolves via fallback: `draft: true`, **15 assets**, `digest` present
- `v0.319.3` -> resolves to nothing (bare tag, no release object) -> correctly keeps the **create** path
- Timeouts still fail fast rather than falling through to a second network call

## Scope note

This is the *publish* half. #10476 (merged) added HEAD-independent **detection** of stranded tags — its detector works and found both orphans — but the recovery it hands off to died here. Detection was necessary, not sufficient. Together they close the loop.

`v0.30.14` and `v0.1.0` are stranded identically, so this has been quietly unrecoverable for a long time.