### PR TITLE
Keep workspace prune size accounting advisory

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -2599,13 +2599,8 @@ fn classify_local_candidate(
         return Ok(None);
     };
     let size = bounded_directory_size(path);
-    let liveness = match size {
-        Some(_) => workspace_liveness(runner, &metadata, path),
-        None => liveness(
-            "unknown",
-            vec!["workspace_size_measurement_unavailable".to_string()],
-        ),
-    };
+    let liveness =
+        workspace_liveness_with_size_observation(runner, &metadata, path, size.is_some());
     Ok(Some(RunnerWorkspacePruneEntry {
         remote_path: path.display().to_string(),
         source_path: source_path.to_string(),
@@ -2717,6 +2712,21 @@ fn workspace_liveness(
         RunnerKind::Local => local_process_liveness(path),
         RunnerKind::Ssh => ssh_process_liveness(runner, &path.display().to_string()),
     }
+}
+
+pub(crate) fn workspace_liveness_with_size_observation(
+    runner: &super::super::Runner,
+    metadata: &serde_json::Value,
+    path: &Path,
+    size_measured: bool,
+) -> RunnerWorkspaceLivenessEvidence {
+    let mut evidence = workspace_liveness(runner, metadata, path);
+    if !size_measured {
+        evidence
+            .observations
+            .push("workspace_size_measurement_unavailable".to_string());
+    }
+    evidence
 }
 
 pub(crate) enum RunAuthority {
@@ -3029,14 +3039,12 @@ fn prune_candidates_ssh(
         let Some(reason) = reason else {
             continue;
         };
-        let liveness = if parts[4] == "measured" {
-            workspace_liveness(runner, &metadata, Path::new(&parts[2]))
-        } else {
-            liveness(
-                "unknown",
-                vec!["workspace_size_measurement_unavailable".to_string()],
-            )
-        };
+        let liveness = workspace_liveness_with_size_observation(
+            runner,
+            &metadata,
+            Path::new(&parts[2]),
+            parts[4] == "measured",
+        );
         let entry = RunnerWorkspacePruneEntry {
             remote_path,
             source_path: source_path.to_string(),

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -7,8 +7,8 @@ use crate::workspace::sync::{
     active_resource_lifecycle_liveness, prune_scan_command, prune_workspaces,
     ssh_process_liveness_command, ssh_prune_delete_command,
     ssh_prune_delete_command_with_terminal_owner, sync_workspace,
-    update_workspace_resource_lifecycle, ActiveResourceLifecycleLiveness, RunAuthority,
-    WORKSPACE_METADATA_FILE,
+    update_workspace_resource_lifecycle, workspace_liveness_with_size_observation,
+    ActiveResourceLifecycleLiveness, RunAuthority, WORKSPACE_METADATA_FILE,
 };
 use crate::workspace::types::{
     RunnerWorkspacePruneOptions, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
@@ -841,6 +841,50 @@ fn ssh_prune_scan_command_advances_past_a_timed_out_size_measurement() {
     );
     assert!(resumed_stdout.contains("\tunknown\n"), "{resumed_stdout}");
     assert!(resumed_stdout.contains("__homeboy_prune_scan__\t1\tcomplete\t\n"));
+}
+
+#[test]
+fn unavailable_size_does_not_override_inactive_ownership_evidence() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let root = tempfile::tempdir().expect("workspace root");
+        let workspace = root.path().join("_lab_workspaces/orphan");
+        write_orphan_workspace(&workspace);
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-advisory-size","kind":"local","workspace_root":"{}"}}"#,
+                root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let runner = crate::load("lab-local-prune-advisory-size").expect("load runner");
+        let mut metadata: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(workspace.join(WORKSPACE_METADATA_FILE)).expect("metadata"),
+        )
+        .expect("metadata json");
+
+        let evidence =
+            workspace_liveness_with_size_observation(&runner, &metadata, &workspace, false);
+
+        assert_eq!(evidence.state, "inactive");
+        assert_eq!(
+            evidence.observations,
+            vec!["workspace_size_measurement_unavailable"]
+        );
+
+        metadata["job_id"] = serde_json::json!("active-job");
+        metadata["resource_lifecycle"] = serde_json::json!({ "status": "active" });
+        let evidence =
+            workspace_liveness_with_size_observation(&runner, &metadata, &workspace, false);
+        assert_eq!(evidence.state, "live");
+        assert_eq!(
+            evidence.observations,
+            vec![
+                "active_resource_lifecycle_lease",
+                "workspace_size_measurement_unavailable"
+            ]
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- evaluate lifecycle, job, and process ownership even when bounded workspace size measurement times out
- preserve unavailable size as an additive diagnostic while retaining the existing zero-byte compatibility fallback
- verify inactive workspaces remain eligible and active lifecycle leases remain withheld

Closes #10479

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner workspace::tests::prune` (19 passed)
- `cargo check -p homeboy-lab-runner`
- live `homeboy-lab` preview against a 59.8 GB workspace
- live ownership probe completed in 0.01 seconds; no deletion performed

## Safety

Deletion eligibility still requires the existing age, metadata, source/TTL reason, apply-back, lifecycle, runner-job, and process ownership gates. Apply mode retains immediate pre-delete liveness revalidation.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode drafted the implementation and tests, analyzed the live Lab behavior, and ran verification. Chris Huber remains responsible for the submitted change.