### PR TITLE
fix(cook): classify missing provider worktrees for provisioning

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -2,6 +2,8 @@
 
 use super::support::*;
 use crate::agents::agent_task_service::DerivedCookBaselineCapability;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 #[test]
 fn promotion_source_resolves_completed_run_id() {
@@ -445,19 +447,64 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
             .status()
             .expect("fetch source base");
         assert!(status.success());
-        let status = Command::new("git")
-            .args([
-                "-C",
-                source.to_str().expect("source path"),
-                "worktree",
-                "add",
-                "-b",
-                "fixture-promoted",
-                target.to_str().expect("target path"),
-            ])
-            .status()
-            .expect("create target worktree");
-        assert!(status.success());
+        let provider = temp.path().join("worktree-provider.sh");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nset -eu\nif [ \"$1\" = resolve ]; then\n  if [ -d '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@promoted\",\"path\":\"{}\",\"branch\":\"fixture-promoted\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    exit 1\n  fi\nelse\n  git -C '{}' worktree add -b \"$5\" '{}' \"$4\" >/dev/null\nfi\n",
+                target.display(),
+                target.display(),
+                source.display(),
+                target.display(),
+            ),
+        )
+        .expect("write worktree provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("worktree provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions)
+            .expect("make worktree provider executable");
+        let mut config = homeboy::core::defaults::load_config();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        provider.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    resolve_not_found_exit_codes: vec![1],
+                    ensure: Some(vec![
+                        provider.display().to_string(),
+                        "ensure".to_string(),
+                        "{handle}".to_string(),
+                        "{repo}".to_string(),
+                        "{base}".to_string(),
+                        "{head}".to_string(),
+                        "{task_url}".to_string(),
+                        "{idempotency_key}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                    },
+                ),
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save worktree provider config");
         std::fs::write(source.join("pre-existing-candidate.txt"), "preserve me\n")
             .expect("write pre-existing candidate");
         let expected_patch = temp.path().join("expected.patch");
@@ -492,7 +539,9 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                     cwd: Some(source.display().to_string()),
                     workspace: None,
                     repo: Some("fixture-component".to_string()),
-                    task_url: None,
+                    task_url: Some(
+                        "https://github.com/Extra-Chill/homeboy/issues/9908".to_string(),
+                    ),
                     backend: Some("fixture".to_string()),
                     selector: None,
                     model: None,
@@ -516,7 +565,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 attempt_run_id: None,
                 attempt_plan: None,
                 goal: None,
-                to_worktree: target.display().to_string(),
+                to_worktree: "fixture@promoted".to_string(),
                 provider_command: None,
                 provider_argv: vec!["sh".to_string(), provider.display().to_string()],
                 gates: VerifyGateArgs {
@@ -538,7 +587,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 no_finalize: true,
                 full: true,
                 base: "main".to_string(),
-                head: None,
+                head: Some("fixture-promoted".to_string()),
                 title: None,
                 commit_message: None,
                 protected_branches: review::default_protected_branches(),
@@ -565,6 +614,10 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
             .as_str()
             .expect("cook report attempt run id");
         let lifecycle = lifecycle_status(attempt_run_id).expect("local cook lifecycle");
+        assert_eq!(
+            lifecycle.metadata["worktree_provision"]["action"],
+            "ensured"
+        );
         assert_eq!(lifecycle.lifecycle.provider_runtime.len(), 1);
         assert_eq!(
             lifecycle.lifecycle.provider_runtime[0].metadata["model"],
@@ -605,7 +658,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
             request["schema"],
             "homeboy/agent-task-promotion-apply-request/v1"
         );
-        assert_eq!(request["to_workspace"], target.display().to_string());
+        assert_eq!(request["to_workspace"], "fixture@promoted");
         assert_eq!(request["changed_files"], json!(["agent-change.txt"]));
         assert!(request["patch"]
             .as_str()

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -323,6 +323,10 @@ pub struct WorktreeProviderCommands {
     /// requested handle. The result uses `list_result_mapping` and may contain one item.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolve: Option<Vec<String>>,
+    /// Provider-native resolve exit statuses that mean the requested handle is
+    /// absent. All other non-zero statuses remain lookup failures.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolve_not_found_exit_codes: Vec<i32>,
     /// Discovery command and compatibility fallback for providers without
     /// `resolve`. Exact handle lookups prefer `resolve` when it is configured.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -578,7 +578,13 @@ fn run_provider_resolve_command(
         .iter()
         .map(|argument| argument.replace("{handle}", handle))
         .collect::<Vec<_>>();
-    run_provider_lookup_command(provider_id, provider, &command, "resolve")
+    run_provider_lookup_command(
+        provider_id,
+        provider,
+        &command,
+        "resolve",
+        &provider.commands.resolve_not_found_exit_codes,
+    )
 }
 
 fn run_provider_list_command(
@@ -586,7 +592,7 @@ fn run_provider_list_command(
     provider: &WorktreeProviderConfig,
     command: &[String],
 ) -> Result<Vec<WorktreeProviderHandle>> {
-    run_provider_lookup_command(provider_id, provider, command, "list")
+    run_provider_lookup_command(provider_id, provider, command, "list", &[])
 }
 
 fn run_provider_lookup_command(
@@ -594,6 +600,7 @@ fn run_provider_lookup_command(
     provider: &WorktreeProviderConfig,
     command: &[String],
     operation: &str,
+    not_found_exit_codes: &[i32],
 ) -> Result<Vec<WorktreeProviderHandle>> {
     let (program, args) = command
         .split_first()
@@ -656,6 +663,13 @@ fn run_provider_lookup_command(
     }
     let output = output.output.into_output();
     if !output.status.success() {
+        if output
+            .status
+            .code()
+            .is_some_and(|code| not_found_exit_codes.contains(&code))
+        {
+            return Ok(Vec::new());
+        }
         return Err(Error::validation_invalid_argument_with_evidence(
             "to_worktree",
             format!(
@@ -1756,7 +1770,7 @@ mod tests {
         fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    printf '%s\\n' '{{\"worktrees\":[]}}'\n  fi\nelse\n  git init -b fix/9908 '{}' >/dev/null\n  printf '%s|%s|%s|%s|%s|%s' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" > '{}'\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    exit 1\n  fi\nelse\n  git init -b fix/9908 '{}' >/dev/null\n  printf '%s|%s|%s|%s|%s|%s' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" > '{}'\nfi\n",
                 state.display(),
                 workspace.display(),
                 workspace.display(),
@@ -1780,6 +1794,7 @@ mod tests {
                         "resolve".to_string(),
                         "{handle}".to_string(),
                     ]),
+                    resolve_not_found_exit_codes: vec![1],
                     ensure: Some(vec![
                         script.display().to_string(),
                         "create".to_string(),

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -105,6 +105,8 @@ variables.
 
 ### `WorktreeProviderCommands`
 
+- `resolve` — Targeted handle lookup. Configure `resolve_not_found_exit_codes` when the provider signals an absent handle with a non-zero status; all statuses not listed remain hard lookup failures.
+- `resolve_not_found_exit_codes` — Provider-native statuses that mean `resolve` found no matching handle.
 - `list`
 - `ensure` — Atomic create-or-return-existing argv template. Homeboy invokes it only after an explicit typed provider no-match, expands `{handle}`, `{repo}`, `{base}`, `{head}`, `{task_url}`, and `{idempotency_key}`, and requires `apply_enabled: true`.
 - `cleanup_preview`


### PR DESCRIPTION
## Summary

- add an opt-in generic provider contract for resolve exit codes that mean a destination is absent
- route only explicitly classified absence into the existing idempotent `ensure` flow
- preserve fail-closed behavior for every unclassified provider failure
- document the provider field and cover absent-destination Cook promotion through a fake provider

## Context

This is the Homeboy-owned generic half of #9908. The DMC integration recipe is tracked in Extra-Chill/wp-coding-agents#310 and will configure typed absence plus `commands.ensure` after this contract lands.

## Verification

- focused generic provider provisioning test
- focused Cook fake-provider promotion test
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`

## Compatibility

The new field is serde-defaulted and opt-in. Existing providers retain current behavior; nonzero resolve exits remain hard failures unless the provider explicitly classifies them.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and tested the generic provider contract, rebased the candidate, and performed review-driven verification. Chris Huber reviewed and remains responsible for every line.

Part of #9908.