### PR TITLE
fix(cook): clarify Lab wait and detach observation

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -60,9 +60,17 @@ pub struct Cli {
     )]
     pub placement: Placement,
 
-    /// Return after a runner daemon accepts the job instead of waiting for remote completion.
-    #[arg(long, global = true)]
+    /// Submit to Lab and return after durable controller handoff. Use --wait to
+    /// keep observing the remote lifecycle. The default remains --wait for
+    /// compatibility with existing automation.
+    #[arg(long, global = true, conflicts_with = "wait")]
     pub detach_after_handoff: bool,
+
+    /// Keep observing a Lab submission until the remote lifecycle completes.
+    /// This is the legacy default; specify it when callers need the wait policy
+    /// to be explicit. Use --detach-after-handoff to submit and return.
+    #[arg(long, global = true, conflicts_with = "detach_after_handoff")]
+    pub wait: bool,
 
     /// Directory where persisted run artifacts are copied.
     /// Overrides HOMEBOY_ARTIFACT_ROOT and global config /artifact_root.

--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -5,6 +5,7 @@ use clap::Command;
 const LAB_CLI_ARGUMENT_IDS: &[&str] = &[
     "placement",
     "detach_after_handoff",
+    "wait",
     "artifact_root",
     "runner",
     "allow_dirty_lab_workspace",

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -58,15 +58,39 @@ pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
                 run::announce_durable_cook_identity(cook_id, run_id);
             }
         }
+        emit_cook_progress(phase, cook_id, run_id);
+        Ok(())
+    };
+    run_with_cook_progress(args, Some(&progress))
+}
+
+fn cook_progress_message(phase: &str, cook_id: Option<&str>, run_id: Option<&str>) -> String {
+    let identity = match (cook_id, run_id) {
+        (_, Some(run_id)) => format!(" [{run_id}]"),
+        (Some(cook_id), None) => format!(" [{cook_id}]"),
+        (None, None) => String::new(),
+    };
+    match run_id {
+        Some(run_id) => format!(
+            "Cook {phase}: durable run `{run_id}`. Status: `homeboy agent-task status {run_id}`. Evidence: `homeboy agent-task evidence {run_id} --full`."
+        ),
+        None => format!("Cook {phase}{identity}."),
+    }
+}
+
+/// Non-TTY callers need durable recovery coordinates in their captured stderr,
+/// not transient terminal-only status. TTY output stays compact.
+pub(crate) fn emit_cook_progress(phase: &str, cook_id: Option<&str>, run_id: Option<&str>) {
+    if crate::commands::utils::tty::is_stdout_tty() {
         let identity = match (cook_id, run_id) {
             (_, Some(run_id)) => format!(" [{run_id}]"),
             (Some(cook_id), None) => format!(" [{cook_id}]"),
             (None, None) => String::new(),
         };
         crate::commands::utils::tty::status(&format!("cook: {phase}{identity}"));
-        Ok(())
-    };
-    run_with_cook_progress(args, Some(&progress))
+    } else {
+        eprintln!("{}", cook_progress_message(phase, cook_id, run_id));
+    }
 }
 
 pub(crate) fn run_with_cook_progress(
@@ -153,6 +177,20 @@ pub(crate) fn run_with_cook_progress(
                 ))
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod progress_tests {
+    use super::cook_progress_message;
+
+    #[test]
+    fn non_tty_cook_progress_includes_durable_reconnect_commands() {
+        // The formatter is the non-TTY client contract: callers can reconnect
+        // after an interrupted observation without guessing the run identity.
+        let message = cook_progress_message("provider_ready", None, Some("run-123"));
+        assert!(message.contains("agent-task status run-123"));
+        assert!(message.contains("agent-task evidence run-123 --full"));
     }
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -282,6 +282,28 @@ mod tests {
         assert!(!help.contains("--task <"), "{help}");
         assert!(!help.contains("--tasks <"), "{help}");
     }
+
+    #[test]
+    fn lab_wait_and_detach_are_explicit_and_mutually_exclusive() {
+        let result = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "--wait",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--to-worktree",
+            "repo@branch",
+            "--verify",
+            "true",
+            "--prompt",
+            "test",
+        ]);
+        let error = match result {
+            Ok(_) => panic!("wait and detach must conflict"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("cannot be used with"));
+    }
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -16,7 +16,9 @@ use homeboy::core::Error;
 use homeboy::runner::runners::{self, RunnerExecOptions};
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::agents::agent_task_service::DerivedCookBaselineCapability;
 use crate::core::io::output_file::write_output_file;
@@ -560,11 +562,16 @@ fn run_split_placement_cook(
         source_path,
         job_overrides: lab_job_overrides(cli)?,
     });
+    let progress = |phase: &str, cook_id: Option<&str>, run_id: Option<&str>| {
+        crate::commands::agent_task::emit_cook_progress(phase, cook_id, run_id);
+        Ok(())
+    };
     let (value, exit_code) =
-        crate::commands::agent_task::run::run_cook_with_executor_and_dispatcher(
+        crate::commands::agent_task::run::run_cook_with_executor_and_dispatcher_with_progress(
             controller,
             homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
             Some(dispatcher),
+            Some(&progress),
         )?;
     let stdout = serde_json::to_string_pretty(&value).map_err(|error| {
         Error::internal_json(
@@ -763,40 +770,58 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
             &provider_args,
             &plan,
         )?;
-        let outcome = match lab_routing::dispatch_lab_offload(
-            LabRoutingRequest {
-                command: lab_offload_command(&provider_cli.command)?,
-                normalized_args: &provider_args,
-                explicit_runner: Some(&self.runner_id),
-                placement: homeboy::cli_surface::Placement::Lab,
-                allow_local_fallback: self.allow_local_fallback,
-                allow_dirty_lab_workspace: self.allow_dirty_lab_workspace,
-                skip_deps_hydration: self.skip_deps_hydration,
-                preserve_workspace_on_failure: false,
-                capture_patch: false,
-                mutation_flag: None,
-                timeout: None,
-                active_run_id: Some(run_id),
-                detach_after_handoff: self.detach_after_handoff,
-                output_file_requested: false,
-                read_only_polling: false,
-                require_controller_git_bundle: false,
-                reuse_compatible_snapshot: false,
-                local_output_file: None,
-                durable_agent_task_plan: Some(&durable_agent_task_plan),
-                // A retry's baseline is controller-owned capability, not plan
-                // data. Stage that exact clean checkout; never substitute the
-                // controller's original workspace during nested Lab dispatch.
-                source_path: cook_attempt_source_path(
-                    derived_cook_baseline,
-                    self.source_path.as_deref(),
-                ),
-                verified_cook_baseline: verified_cook_baseline.as_ref(),
-                job_overrides: self.job_overrides.clone(),
-            },
-            Some(&self.runner_id),
-            Box::new(NoopLabDispatchObserver),
-        ) {
+        let (heartbeat_stop, heartbeat_wait) = mpsc::channel();
+        let heartbeat_run_id = run_id.to_string();
+        let outcome = std::thread::scope(|scope| {
+            scope.spawn(move || {
+                while let Err(mpsc::RecvTimeoutError::Timeout) =
+                    heartbeat_wait.recv_timeout(Duration::from_secs(15))
+                {
+                    crate::commands::agent_task::emit_cook_progress(
+                        "heartbeat",
+                        None,
+                        Some(&heartbeat_run_id),
+                    );
+                }
+            });
+            let outcome = lab_routing::dispatch_lab_offload(
+                LabRoutingRequest {
+                    command: lab_offload_command(&provider_cli.command)?,
+                    normalized_args: &provider_args,
+                    explicit_runner: Some(&self.runner_id),
+                    placement: homeboy::cli_surface::Placement::Lab,
+                    allow_local_fallback: self.allow_local_fallback,
+                    allow_dirty_lab_workspace: self.allow_dirty_lab_workspace,
+                    skip_deps_hydration: self.skip_deps_hydration,
+                    preserve_workspace_on_failure: false,
+                    capture_patch: false,
+                    mutation_flag: None,
+                    timeout: None,
+                    active_run_id: Some(run_id),
+                    detach_after_handoff: self.detach_after_handoff,
+                    output_file_requested: false,
+                    read_only_polling: false,
+                    require_controller_git_bundle: false,
+                    reuse_compatible_snapshot: false,
+                    local_output_file: None,
+                    durable_agent_task_plan: Some(&durable_agent_task_plan),
+                    // A retry's baseline is controller-owned capability, not plan
+                    // data. Stage that exact clean checkout; never substitute the
+                    // controller's original workspace during nested Lab dispatch.
+                    source_path: cook_attempt_source_path(
+                        derived_cook_baseline,
+                        self.source_path.as_deref(),
+                    ),
+                    verified_cook_baseline: verified_cook_baseline.as_ref(),
+                    job_overrides: self.job_overrides.clone(),
+                },
+                Some(&self.runner_id),
+                Box::new(NoopLabDispatchObserver),
+            );
+            let _ = heartbeat_stop.send(());
+            outcome
+        });
+        let outcome = match outcome {
             Ok(outcome) => outcome,
             Err(_error) if agent_task_lifecycle::has_accepted_runner_handoff(run_id)? => {
                 // The daemon owns an accepted job. A controller session can

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -297,6 +297,31 @@ expected to outlive the local shell. Homeboy returns after the runner daemon
 accepts the job and prints follow/cancel commands instead of waiting for remote
 provider completion.
 
+Lab Cook has two explicit observation modes. Submit and return when an
+interruptible client should hand the provider attempt to the Lab controller:
+
+```bash
+homeboy --runner homeboy-lab --detach-after-handoff agent-task cook \
+  --to-worktree homeboy@fix-issue-6453 --verify 'cargo test --lib' --prompt @task.txt
+```
+
+Wait for the completed Cook when the caller owns a synchronous workflow:
+
+```bash
+homeboy --runner homeboy-lab --wait agent-task cook \
+  --to-worktree homeboy@fix-issue-6453 --verify 'cargo test --lib' --prompt @task.txt
+```
+
+`--wait` is the compatibility default for existing scripts. A future migration to
+submit-by-default can therefore update callers mechanically; new interruptible
+clients should specify `--detach-after-handoff`. Both modes print bounded phase
+heartbeats with the durable run id. Reconnect and retrieve durable state with:
+
+```bash
+homeboy agent-task status <run-id>
+homeboy agent-task evidence <run-id> --full
+```
+
 `--placement local` is safe only when local execution on this
 controller is intentional. For agent-task waves with concurrency greater than 1
 or multiple tasks, Homeboy prints `HOMEBOY_LOCAL_FANOUT_WARNING` before provider

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -62,6 +62,33 @@ fn cook_rejects_local_detach_before_worktree_resolution() {
 }
 
 #[test]
+fn non_tty_client_must_choose_one_lab_observation_mode() {
+    // Command::output supplies pipes, matching an interruptible bridge client
+    // rather than an interactive terminal. Reject ambiguity before any worktree
+    // or provider work can begin.
+    let output = homeboy()
+        .args([
+            "--wait",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "missing@worktree",
+            "--verify",
+            "true",
+        ])
+        .output()
+        .expect("run homeboy");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot be used with"), "{stderr}");
+    assert!(!stderr.contains("worktree provider"), "{stderr}");
+}
+
+#[test]
 fn cook_rejects_queue_only_before_worktree_resolution() {
     let output = homeboy()
         .args([
@@ -92,5 +119,8 @@ fn cook_help_does_not_advertise_queue_only() {
         .expect("run homeboy help");
 
     assert!(output.status.success());
-    assert!(!String::from_utf8_lossy(&output.stdout).contains("\n      --queue-only\n"));
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(!help.contains("\n      --queue-only\n"));
+    assert!(help.contains("--detach-after-handoff"), "{help}");
+    assert!(help.contains("--wait"), "{help}");
 }


### PR DESCRIPTION
## Summary

- add explicit `--wait` semantics while preserving the existing blocking default
- make `--wait` and `--detach-after-handoff` mutually exclusive
- emit bounded attached Lab handoff heartbeats with status/evidence recovery commands
- preserve durable identity delivery from merged PR #10447
- document submit-return, submit-wait, status, evidence, and migration behavior

## Context

PR #10447 closed #10419 and #9163 by publishing durable identity before materialization and reconciling Lab admissions. This PR completes the remaining UX explicitly deferred there: unambiguous wait/detach intent and bounded attached observation.

## Verification

- focused wait/detach parser test
- focused non-TTY reconnect-progress test
- `cargo test --test cook_lab_handoff_test`
- `cargo check -p homeboy-cli`
- `cargo fmt --all -- --check`
- `git diff --check`

## Compatibility

Existing callers remain synchronous by default. `--wait` makes that behavior explicit; detached callers retain existing semantics. Progress remains on stderr, preserving structured stdout.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented, independently reviewed, rebased against #10447/current main, and verified this UX layer. Chris Huber reviewed and remains responsible for every line.

Completes the remaining UX from #10419.