### PR TITLE
Reap stale synthetic materialized workspace leases

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -65,6 +65,7 @@ const METADATA_SSH_RECOVERY_ATTEMPTS: usize = 2;
 const WORKSPACE_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_METADATA_OUTPUT_LIMIT: usize = 4 * 1024;
 const WORKSPACE_PRUNE_TIMEOUT: Duration = Duration::from_secs(30);
+const STALE_MATERIALIZED_WORKSPACE_REASON: &str = "stale_materialized_workspace_lifecycle";
 // A page must leave time for its transport timeout and advance past a directory
 // whose size cannot be measured. Size is advisory, never a deletion proof.
 const WORKSPACE_PRUNE_SCAN_BUDGET: Duration = Duration::from_secs(20);
@@ -2660,12 +2661,56 @@ fn prune_candidate_reason(
     if !Path::new(source_path).exists() {
         return Ok(Some("source_path_missing".to_string()));
     }
+    if is_stale_materialized_workspace_lifecycle(metadata, path) {
+        return Ok(Some(STALE_MATERIALIZED_WORKSPACE_REASON.to_string()));
+    }
     Ok(None)
 }
 
+fn is_stale_materialized_workspace_lifecycle(metadata: &serde_json::Value, path: &Path) -> bool {
+    let absent_owner = |key: &str| {
+        metadata
+            .get(key)
+            .and_then(|value| value.as_str())
+            .is_none_or(|value| value.trim().is_empty())
+    };
+    let Some(resource) = metadata
+        .get("resource_lifecycle")
+        .and_then(|value| value.as_object())
+    else {
+        return false;
+    };
+
+    absent_owner("run_id")
+        && absent_owner("job_id")
+        && metadata.get("sync_mode").and_then(|value| value.as_str()) == Some("snapshot")
+        && metadata
+            .get("snapshot_identity")
+            .and_then(|value| value.as_str())
+            .is_some_and(|identity| identity.starts_with("snapshot:"))
+        && metadata.get("remote_path").and_then(|value| value.as_str()) == path.to_str()
+        && resource.get("owner").and_then(|value| value.as_str()) == Some("runner.workspace")
+        && resource.get("run_id").and_then(|value| value.as_str()) == Some("materialized-workspace")
+        && resource.get("kind").and_then(|value| value.as_str()) == Some("runner_workspace")
+        && resource
+            .get("cleanup_policy")
+            .and_then(|value| value.as_str())
+            == Some("delete_on_success")
+        && resource.get("status").and_then(|value| value.as_str()) == Some("active")
+        && resource.get("path").and_then(|value| value.as_str()) == path.to_str()
+}
+
+pub(crate) fn encoded_materialized_workspace_metadata_is_valid(encoded: &str, path: &Path) -> bool {
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()
+        .and_then(|contents| serde_json::from_slice(&contents).ok())
+        .is_some_and(|metadata| is_stale_materialized_workspace_lifecycle(&metadata, path))
+}
+
 /// Bulk pruning is intentionally stricter than run-owned reaping.  Age and a
-/// missing controller source identify an orphan candidate, but they cannot
-/// prove that no independently surviving workload still owns its files.
+/// an orphan reason identify a candidate, but they cannot prove that no
+/// independently surviving workload still owns its files.
 fn workspace_liveness(
     runner: &super::super::Runner,
     metadata: &serde_json::Value,
@@ -3035,7 +3080,11 @@ fn prune_candidates_ssh(
         let Some(source_path) = metadata.get("local_path").and_then(|value| value.as_str()) else {
             continue;
         };
-        let reason = prune_candidate_reason_from_decoded_metadata(&metadata, age_seconds);
+        let reason = prune_candidate_reason_from_decoded_metadata(
+            &metadata,
+            age_seconds,
+            Path::new(&parts[2]),
+        );
         let Some(reason) = reason else {
             continue;
         };
@@ -3099,6 +3148,7 @@ fn prune_candidates_ssh(
 fn prune_candidate_reason_from_decoded_metadata(
     metadata: &serde_json::Value,
     age_seconds: u64,
+    path: &Path,
 ) -> Option<String> {
     if let Some(resource) = metadata.get("resource_lifecycle") {
         if resource
@@ -3119,7 +3169,11 @@ fn prune_candidate_reason_from_decoded_metadata(
     let source_path = metadata
         .get("local_path")
         .and_then(|value| value.as_str())?;
-    (!Path::new(source_path).exists()).then(|| "source_path_missing".to_string())
+    if !Path::new(source_path).exists() {
+        return Some("source_path_missing".to_string());
+    }
+    is_stale_materialized_workspace_lifecycle(metadata, path)
+        .then(|| STALE_MATERIALIZED_WORKSPACE_REASON.to_string())
 }
 
 pub(crate) fn prune_scan_command(
@@ -3179,6 +3233,20 @@ fn remove_prune_candidate(
 ) -> Result<Option<RunnerWorkspaceLivenessEvidence>> {
     match runner.kind {
         RunnerKind::Local => {
+            if candidate.reason == STALE_MATERIALIZED_WORKSPACE_REASON {
+                let path = Path::new(&candidate.remote_path);
+                let metadata = fs::read(path.join(WORKSPACE_METADATA_FILE))
+                    .ok()
+                    .and_then(|contents| serde_json::from_slice(&contents).ok());
+                if !metadata.is_some_and(|metadata| {
+                    is_stale_materialized_workspace_lifecycle(&metadata, path)
+                }) {
+                    return Ok(Some(liveness(
+                        "unknown",
+                        vec!["materialized_workspace_lifecycle_changed".to_string()],
+                    )));
+                }
+            }
             remove_workspace(runner, root, &candidate.remote_path)?;
             Ok(None)
         }
@@ -3193,18 +3261,43 @@ fn remove_ssh_prune_candidate(
 ) -> Result<Option<RunnerWorkspaceLivenessEvidence>> {
     let (_server, mut client) = ssh_client_for_runner(runner)?;
     client.env.extend(runner.env.clone());
-    let terminal_owner_run_id = candidate.run_id.as_deref().filter(|run_id| {
-        homeboy_agents::agent_task_lifecycle::exact_record(run_id)
-            .is_ok_and(|record| record.state.is_terminal())
-    });
-    let output = client.execute_with_timeout(
-        &ssh_prune_delete_command_with_terminal_owner(
+    let command = if candidate.reason == STALE_MATERIALIZED_WORKSPACE_REASON {
+        let metadata_path = Path::new(&candidate.remote_path).join(WORKSPACE_METADATA_FILE);
+        let metadata_command = format!(
+            "meta={}; [ -f \"$meta\" ] && base64 < \"$meta\" | tr -d '\\n'",
+            shell::quote_arg(&metadata_path.display().to_string())
+        );
+        let metadata_output =
+            client.execute_with_timeout(&metadata_command, WORKSPACE_PRUNE_TIMEOUT);
+        let encoded_metadata = metadata_output.stdout.trim();
+        if !metadata_output.success
+            || !encoded_materialized_workspace_metadata_is_valid(
+                encoded_metadata,
+                Path::new(&candidate.remote_path),
+            )
+        {
+            return Ok(Some(liveness(
+                "unknown",
+                vec!["materialized_workspace_lifecycle_changed".to_string()],
+            )));
+        }
+        ssh_prune_delete_materialized_workspace_command(
+            root,
+            &candidate.remote_path,
+            encoded_metadata,
+        )
+    } else {
+        let terminal_owner_run_id = candidate.run_id.as_deref().filter(|run_id| {
+            homeboy_agents::agent_task_lifecycle::exact_record(run_id)
+                .is_ok_and(|record| record.state.is_terminal())
+        });
+        ssh_prune_delete_command_with_terminal_owner(
             root,
             &candidate.remote_path,
             terminal_owner_run_id,
-        ),
-        WORKSPACE_PRUNE_TIMEOUT,
-    );
+        )
+    };
+    let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
     if !output.success {
         return Err(Error::internal_unexpected(format!(
             "remove runner workspace failed: {}",
@@ -3247,6 +3340,35 @@ pub(crate) fn ssh_prune_delete_command_with_terminal_owner(
         root = shell::quote_arg(root),
         path = shell::quote_arg(remote_path),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
+    )
+}
+
+pub(crate) fn ssh_prune_delete_materialized_workspace_command(
+    root: &str,
+    remote_path: &str,
+    expected_metadata: &str,
+) -> String {
+    format!(
+        concat!(
+            "root={root}; p={path}; meta_rel={meta}; expected={expected}; ",
+            "case \"$p\" in \"$root\"/*) ;; *) printf unknown:workspace_path; exit 0 ;; esac; ",
+            "meta=\"$p/$meta_rel\"; [ -f \"$meta\" ] || {{ printf unknown:metadata; exit 0; }}; ",
+            "actual=$(base64 < \"$meta\" | tr -d '\\n') || {{ printf unknown:metadata; exit 0; }}; ",
+            "[ \"$actual\" = \"$expected\" ] || {{ printf unknown:materialized_workspace_lifecycle_changed; exit 0; }}; ",
+            "command -v ps >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1 || {{ printf unknown:process_probe_unavailable; exit 0; }}; ",
+            "ps_output=$(ps -eo pid=,ppid=,args=) || {{ printf unknown:process_probe_failed; exit 0; }}; ",
+            "printf '%s\n' \"$ps_output\" | awk -v p=\"$p\" -v self=\"$$\" -v parent=\"$PPID\" '$1 != self && $1 != parent && $2 != self && index($0, p) {{ found=1 }} END {{ exit !found }}'; state=$?; ",
+            "[ \"$state\" -eq 0 ] && {{ printf live:remote_process_ownership; exit 0; }}; [ \"$state\" -eq 1 ] || {{ printf unknown:process_probe_failed; exit 0; }}; ",
+            "cwd=$(lsof -w -Fn -a -d cwd +D \"$p\" 2>/dev/null); state=$?; ",
+            "[ \"$state\" -eq 0 ] && [ -n \"$cwd\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$cwd\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; ",
+            "open=$(lsof -w -Fn +D \"$p\" 2>/dev/null); state=$?; ",
+            "[ \"$state\" -eq 0 ] && [ -n \"$open\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$open\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; ",
+            "rm -rf -- \"$p\" && printf removed || printf unknown:delete_failed"
+        ),
+        root = shell::quote_arg(root),
+        path = shell::quote_arg(remote_path),
+        meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
+        expected = shell::quote_arg(expected_metadata),
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -3,11 +3,13 @@ use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+use base64::Engine;
+
 use crate::workspace::sync::{
-    active_resource_lifecycle_liveness, prune_scan_command, prune_workspaces,
-    ssh_process_liveness_command, ssh_prune_delete_command,
-    ssh_prune_delete_command_with_terminal_owner, sync_workspace,
-    update_workspace_resource_lifecycle, workspace_liveness_with_size_observation,
+    active_resource_lifecycle_liveness, encoded_materialized_workspace_metadata_is_valid,
+    prune_scan_command, prune_workspaces, ssh_process_liveness_command, ssh_prune_delete_command,
+    ssh_prune_delete_command_with_terminal_owner, ssh_prune_delete_materialized_workspace_command,
+    sync_workspace, update_workspace_resource_lifecycle, workspace_liveness_with_size_observation,
     ActiveResourceLifecycleLiveness, RunAuthority, WORKSPACE_METADATA_FILE,
 };
 use crate::workspace::types::{
@@ -117,14 +119,17 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
 
         assert_eq!(exit_code, 0);
         assert!(!output.dry_run);
-        assert_eq!(output.removed.len(), 1);
-        assert_eq!(output.total_candidate_count, 1);
+        assert_eq!(output.removed.len(), 2);
+        assert_eq!(output.total_candidate_count, 2);
         assert!(output.total_candidate_bytes >= output.total_removed_bytes);
         assert_eq!(output.remaining_candidate_count, 0);
         assert!(!output.has_more);
-        assert_eq!(output.removed[0].remote_path, orphan.remote_path);
+        assert!(output
+            .removed
+            .iter()
+            .any(|entry| entry.remote_path == orphan.remote_path));
         assert!(!Path::new(&orphan.remote_path).exists());
-        assert!(Path::new(&live.remote_path).exists());
+        assert!(!Path::new(&live.remote_path).exists());
         assert!(unmanaged.exists());
     });
 }
@@ -311,6 +316,51 @@ fn prune_workspaces_reaps_ttl_expired_lifecycle_workspace_with_live_source() {
         assert_eq!(output.candidates[0].remote_path, synced.remote_path);
         assert_eq!(output.candidates[0].reason, "resource_ttl_expired");
         assert!(Path::new(&synced.remote_path).exists());
+        assert!(source.exists());
+    });
+}
+
+#[test]
+fn prune_workspaces_reaps_stale_materialized_workspace_with_live_source() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source_parent = tempfile::tempdir().expect("source parent");
+        let source = source_parent.path().join("live-source");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        fs::create_dir_all(&source).expect("source dir");
+        fs::write(source.join("file.txt"), "live\n").expect("source file");
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-materialized","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let (synced, _) = sync_workspace(
+            "lab-local-prune-materialized",
+            sync_options(source.display().to_string()),
+        )
+        .expect("sync workspace");
+
+        let (output, exit_code) = prune_workspaces(
+            "lab-local-prune-materialized",
+            RunnerWorkspacePruneOptions {
+                apply: true,
+                min_age_hours: 0,
+                limit: 10,
+                passes: 1,
+                cursor: None,
+            },
+        )
+        .expect("prune stale materialized workspace");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.removed.len(), 1);
+        assert_eq!(
+            output.removed[0].reason,
+            "stale_materialized_workspace_lifecycle"
+        );
+        assert!(!Path::new(&synced.remote_path).exists());
         assert!(source.exists());
     });
 }
@@ -1003,6 +1053,85 @@ fn ssh_shaped_prune_delete_revalidates_lifecycle_and_deletes_atomically() {
 }
 
 #[test]
+fn ssh_materialized_workspace_delete_requires_exact_inactive_lifecycle() {
+    let root = tempfile::tempdir().expect("workspace root");
+    let workspaces = root.path().join("_lab_workspaces");
+    let eligible = workspaces.join("eligible");
+    write_materialized_workspace(&eligible);
+    let expected_metadata = encoded_workspace_metadata(&eligible);
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(ssh_prune_delete_materialized_workspace_command(
+            &workspaces.display().to_string(),
+            &eligible.display().to_string(),
+            &expected_metadata,
+        ))
+        .output()
+        .expect("delete stale materialized workspace");
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "removed");
+    assert!(!eligible.exists());
+
+    let ambiguous = workspaces.join("ambiguous");
+    write_materialized_workspace(&ambiguous);
+    let expected_metadata = encoded_workspace_metadata(&ambiguous);
+    let metadata_path = ambiguous.join(WORKSPACE_METADATA_FILE);
+    let mut metadata: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&metadata_path).expect("metadata"))
+            .expect("metadata json");
+    metadata["run_id"] = serde_json::json!("unexpected-owner");
+    fs::write(&metadata_path, metadata.to_string()).expect("write ambiguous metadata");
+    assert!(!encoded_materialized_workspace_metadata_is_valid(
+        &encoded_workspace_metadata(&ambiguous),
+        &ambiguous,
+    ));
+    assert!(!encoded_materialized_workspace_metadata_is_valid(
+        &base64::engine::general_purpose::STANDARD.encode(b"{malformed"),
+        &ambiguous,
+    ));
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(ssh_prune_delete_materialized_workspace_command(
+            &workspaces.display().to_string(),
+            &ambiguous.display().to_string(),
+            &expected_metadata,
+        ))
+        .output()
+        .expect("retain ambiguous materialized workspace");
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "unknown:materialized_workspace_lifecycle_changed"
+    );
+    assert!(ambiguous.exists());
+
+    let process_owned = workspaces.join("process-owned");
+    write_materialized_workspace(&process_owned);
+    let expected_metadata = encoded_workspace_metadata(&process_owned);
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg("sleep 30")
+        .current_dir(&process_owned)
+        .spawn()
+        .expect("hold materialized workspace cwd");
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(ssh_prune_delete_materialized_workspace_command(
+            &workspaces.display().to_string(),
+            &process_owned.display().to_string(),
+            &expected_metadata,
+        ))
+        .output()
+        .expect("retain process-owned materialized workspace");
+    child.kill().expect("stop held process");
+    child.wait().expect("reap held process");
+    assert!(output.status.success(), "{output:?}");
+    assert_ne!(String::from_utf8_lossy(&output.stdout), "removed");
+    assert!(process_owned.exists());
+}
+
+#[test]
 fn ssh_terminal_lifecycle_delete_revalidates_process_ownership() {
     let root = tempfile::tempdir().expect("workspace root");
     let workspace = root.path().join("_lab_workspaces/terminal");
@@ -1112,6 +1241,37 @@ fn write_orphan_workspace(path: &Path) {
         .to_string(),
     )
     .expect("workspace metadata");
+}
+
+fn write_materialized_workspace(path: &Path) {
+    write_orphan_workspace(path);
+    fs::write(
+        path.join(WORKSPACE_METADATA_FILE),
+        serde_json::json!({
+            "schema": "homeboy/runner-workspace/v1",
+            "runner_id": "lab-ssh-prune-materialized",
+            "local_path": "/existing/source",
+            "remote_path": path.display().to_string(),
+            "sync_mode": "snapshot",
+            "snapshot_identity": "snapshot:synthetic",
+            "resource_lifecycle": {
+                "owner": "runner.workspace",
+                "run_id": "materialized-workspace",
+                "path": path.display().to_string(),
+                "kind": "runner_workspace",
+                "cleanup_policy": "delete_on_success",
+                "status": "active"
+            }
+        })
+        .to_string(),
+    )
+    .expect("materialized workspace metadata");
+}
+
+fn encoded_workspace_metadata(path: &Path) -> String {
+    base64::engine::general_purpose::STANDARD.encode(
+        fs::read(path.join(WORKSPACE_METADATA_FILE)).expect("read workspace metadata for compare"),
+    )
 }
 
 fn active_lifecycle_metadata(run_id: &str, resource_run_id: &str) -> serde_json::Value {


### PR DESCRIPTION
## Summary

- recognize aged ownerless `materialized-workspace` snapshot lifecycles as explicit prune candidates even when the controller source still exists
- preserve ordinary run-owned, job-owned, malformed, pending-patch, recent, and process-owned workspaces
- re-read and parse remote metadata in Rust, then require an exact base64 compare-and-delete match immediately before the SSH process probe and removal
- cover local apply behavior and SSH-shaped metadata/process revalidation

Closes #10486

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner workspace::tests::prune` (21 passed)
- `cargo build --bin homeboy`
- candidate-binary preview against the 59,847,446,528-byte Lab workspace
- live preview classified it as `stale_materialized_workspace_lifecycle` with inactive ownership; no deletion performed

## Safety

Eligibility requires minimum age, valid snapshot metadata, absent top-level run/job ownership, exact synthetic lifecycle owner and path, `delete_on_success`, active status, no pending apply-back artifact, and inactive process evidence. SSH apply re-parses the current metadata and deletes only if its encoded bytes remain unchanged through the final process probe.

Residual risk: process ownership can still begin in the narrow interval between the final process probe and recursive deletion, matching the pre-existing prune deletion model.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode drafted the implementation and tests, investigated the live Lab lifecycle records, performed safety review iterations, and ran verification. Chris Huber remains responsible for the submitted change.