### PR TITLE
fix(runtime): atomically refresh dependency generations

### DIFF
--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -143,6 +143,7 @@ fn refresh_locked(
     fs::rename(&stage, &generation).map_err(io("publish runtime generation"))?;
     sync_dir(&store)?;
     switch_current(&store, &generation_name)?;
+    ensure_stable_runtime_boundary(&config_root, &store)?;
     write_journal(
         &store,
         &RefreshJournal {
@@ -166,10 +167,56 @@ fn refresh_locked(
     })
 }
 
+/// Snapshot root-manifest runtime assets into a new generation. Linked extension
+/// installs call this instead of writing through the stable runtime boundary.
+pub fn refresh_shared_assets(source_root: &Path) -> Result<()> {
+    config::with_config_lock(|| refresh_shared_assets_locked(source_root))
+}
+
+fn refresh_shared_assets_locked(source_root: &Path) -> Result<()> {
+    let config_root = paths::homeboy()?;
+    let store = config_root.join(GENERATIONS);
+    fs::create_dir_all(store.join("staging")).map_err(io("prepare runtime generation store"))?;
+    recover(&store)?;
+    let source_root =
+        canonical_contained_directory(source_root, source_root, "resolve linked runtime source")?;
+    let generation_name = format!("extension-assets-{}", nonce());
+    let stage = store.join("staging").join(&generation_name);
+    remove_if_exists(&stage, "clean linked runtime generation stage")?;
+    seed_generation(&config_root, &store, &stage)?;
+    materialize_all_declared_runtime_assets(&source_root, &stage)?;
+    sync_tree(&stage)?;
+    write_journal(
+        &store,
+        &RefreshJournal {
+            schema: JOURNAL_SCHEMA.to_string(),
+            generation: generation_name.clone(),
+            switched: false,
+        },
+    )?;
+    fs::rename(&stage, store.join(&generation_name))
+        .map_err(io("publish linked runtime generation"))?;
+    sync_dir(&store)?;
+    switch_current(&store, &generation_name)?;
+    ensure_stable_runtime_boundary(&config_root, &store)?;
+    write_journal(
+        &store,
+        &RefreshJournal {
+            schema: JOURNAL_SCHEMA.to_string(),
+            generation: generation_name,
+            switched: true,
+        },
+    )?;
+    remove_if_exists(
+        &store.join(JOURNAL),
+        "finalize linked runtime generation refresh",
+    )?;
+    sync_dir(&store)
+}
+
 fn seed_generation(config_root: &Path, store: &Path, stage: &Path) -> Result<()> {
-    let current = store.join(CURRENT);
-    if active_current_generation(store).is_some() {
-        reject_symlink_tree_except_root(&current)?;
+    if let Some(current) = active_current_generation(store)? {
+        reject_symlink_tree(&current)?;
         return copy_regular_tree(&current, stage, "copy active runtime generation");
     }
     // First activation migrates the runtime surface only; all unrelated Homeboy
@@ -197,14 +244,48 @@ fn seed_generation(config_root: &Path, store: &Path, stage: &Path) -> Result<()>
     Ok(())
 }
 
-fn active_current_generation(store: &Path) -> Option<PathBuf> {
-    let target = fs::read_link(store.join(CURRENT)).ok()?;
-    safe_relative(target.to_str()?, "runtime_generation").ok()?;
-    let generation = store.join(target);
-    generation
-        .join("agent-runtimes")
-        .is_dir()
-        .then_some(generation)
+fn active_current_generation(store: &Path) -> Result<Option<PathBuf>> {
+    let current = store.join(CURRENT);
+    let Ok(target) = fs::read_link(&current) else {
+        return Ok(None);
+    };
+    let target = target.to_str().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runtime_generation",
+            "current generation target is not valid UTF-8",
+            None,
+            None,
+        )
+    })?;
+    safe_relative(target, "runtime_generation")?;
+    let generation = canonical_contained_directory(
+        &store.join(target),
+        store,
+        "resolve current runtime generation",
+    )?;
+    if !generation.join("agent-runtimes").is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "runtime_generation",
+            "current generation has no runtime package directory",
+            Some(generation.display().to_string()),
+            None,
+        ));
+    }
+    Ok(Some(generation))
+}
+
+fn canonical_contained_directory(path: &Path, root: &Path, context: &str) -> Result<PathBuf> {
+    let root = fs::canonicalize(root).map_err(io(context))?;
+    let path = fs::canonicalize(path).map_err(io(context))?;
+    if !path.is_dir() || !path.starts_with(&root) {
+        return Err(Error::validation_invalid_argument(
+            "runtime_generation",
+            "runtime generation escapes its store",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(path)
 }
 
 fn manifest_root<'a>(source_root: &'a Path, package: &'a Path) -> &'a Path {
@@ -267,6 +348,48 @@ fn materialize_declared_assets(root: &Path, stage: &Path, runtime_id: &str) -> R
         }
     }
     Ok(assets)
+}
+
+fn materialize_all_declared_runtime_assets(root: &Path, stage: &Path) -> Result<()> {
+    let manifest = root.join(ROOT_MANIFEST);
+    let raw = fs::read_to_string(&manifest).map_err(io("read linked runtime asset manifest"))?;
+    let parsed: RootManifest = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_argument(
+            "source",
+            format!("invalid shared asset manifest: {error}"),
+            Some(manifest.display().to_string()),
+            None,
+        )
+    })?;
+    let root = fs::canonicalize(root).map_err(io("resolve linked runtime source"))?;
+    for asset in parsed
+        .shared_assets
+        .into_iter()
+        .map(SharedAssetDeclaration::path)
+    {
+        if !matches!(
+            asset.as_str(),
+            "agent-runtimes" | "agent-task-contracts" | "runtime-agent-ci"
+        ) {
+            continue;
+        }
+        let relative = safe_relative(&asset, "shared_assets")?;
+        let source =
+            fs::canonicalize(root.join(relative)).map_err(io("resolve linked runtime asset"))?;
+        if !source.is_dir() || !source.starts_with(&root) {
+            return Err(Error::validation_invalid_argument(
+                "shared_assets",
+                "linked runtime asset escapes its source root",
+                Some(asset),
+                None,
+            ));
+        }
+        reject_symlink_tree(&source)?;
+        let target = stage.join(relative);
+        remove_if_exists(&target, "replace linked runtime asset")?;
+        copy_regular_tree(&source, &target, "stage linked runtime asset")?;
+    }
+    Ok(())
 }
 
 fn materialize_runtime_shared_tree(source: &Path, target: &Path, runtime_id: &str) -> Result<()> {
@@ -450,6 +573,33 @@ fn switch_current(store: &Path, generation: &str) -> Result<()> {
     sync_dir(store)
 }
 
+fn ensure_stable_runtime_boundary(config_root: &Path, _store: &Path) -> Result<()> {
+    let boundary = paths::legacy_agent_runtimes()?;
+    let expected = Path::new(GENERATIONS).join(CURRENT).join("agent-runtimes");
+    if fs::read_link(&boundary).ok().as_deref() == Some(expected.as_path()) {
+        return Ok(());
+    }
+    // The first generation already contains a validated copy of a legacy
+    // directory or linked source. Replace that old boundary once, never again.
+    let backup = config_root.join(format!(".agent-runtimes-legacy-{}", nonce()));
+    if fs::symlink_metadata(&boundary).is_ok() {
+        fs::rename(&boundary, &backup).map_err(io("migrate legacy runtime boundary"))?;
+    }
+    #[cfg(unix)]
+    let linked = std::os::unix::fs::symlink(&expected, &boundary);
+    #[cfg(windows)]
+    let linked = std::os::windows::fs::symlink_dir(&expected, &boundary);
+    if let Err(error) = linked {
+        if fs::symlink_metadata(&backup).is_ok() {
+            let _ = fs::rename(&backup, &boundary);
+        }
+        return Err(io("create stable runtime boundary")(error));
+    }
+    sync_dir(config_root)?;
+    remove_if_exists(&backup, "remove migrated legacy runtime boundary")?;
+    sync_dir(config_root)
+}
+
 fn recover(store: &Path) -> Result<()> {
     let journal = store.join(JOURNAL);
     let Ok(raw) = fs::read(&journal) else {
@@ -472,8 +622,9 @@ fn recover(store: &Path) -> Result<()> {
         ));
     }
     let generation = store.join(&record.generation);
-    let current = active_current_generation(store);
-    if !record.switched && current.as_deref() != Some(generation.as_path()) {
+    let current = active_current_generation(store)?;
+    let published_generation = fs::canonicalize(&generation).ok();
+    if !record.switched && current.as_ref() != published_generation.as_ref() {
         remove_if_exists(
             &store.join("staging").join(&record.generation),
             "recover staged runtime generation",
@@ -680,8 +831,14 @@ mod tests {
             manifest(source.path(), &["agent-runtimes", "agent-task-contracts"]);
             let result = refresh("opencode", &source.path().to_string_lossy(), None).unwrap();
             fs::remove_dir_all(source.path()).unwrap();
+            let documented = paths::legacy_agent_runtimes().unwrap();
+            assert_eq!(result.path, documented.join("opencode"));
+            assert_eq!(
+                fs::read_link(&documented).unwrap(),
+                Path::new("runtime-generations/current/agent-runtimes")
+            );
             let output = Command::new("node")
-                .arg(result.path.join("run.cjs"))
+                .arg(documented.join("opencode/run.cjs"))
                 .output()
                 .unwrap();
             assert!(
@@ -775,6 +932,9 @@ mod tests {
             let reader = std::thread::spawn(move || {
                 for _ in 0..1_000 {
                     let runtimes = paths::agent_runtimes().unwrap();
+                    // A consumer resolves the stable boundary once, so both
+                    // package and sibling dependency stay in that generation.
+                    let runtimes = fs::canonicalize(runtimes).unwrap();
                     let generation = runtimes.parent().unwrap();
                     let runtime = fs::read_to_string(runtimes.join("neutral/marker")).unwrap();
                     let dependency =
@@ -816,6 +976,49 @@ mod tests {
                 fs::read_to_string(paths::agent_runtimes().unwrap().join("legacy/marker")).unwrap(),
                 "linked"
             );
+        });
+    }
+
+    #[test]
+    fn linked_runtime_asset_reinstall_publishes_a_new_generation() {
+        with_isolated_home(|_| {
+            let runtime = tempfile::tempdir().unwrap();
+            package(runtime.path(), "neutral", "one");
+            refresh("neutral", &runtime.path().to_string_lossy(), None).unwrap();
+            let first =
+                fs::read_link(paths::homeboy().unwrap().join(GENERATIONS).join(CURRENT)).unwrap();
+
+            let linked = tempfile::tempdir().unwrap();
+            package(linked.path(), "linked", "first");
+            manifest(linked.path(), &["agent-runtimes"]);
+            refresh_shared_assets(linked.path()).unwrap();
+            let second =
+                fs::read_link(paths::homeboy().unwrap().join(GENERATIONS).join(CURRENT)).unwrap();
+
+            assert_ne!(first, second);
+            assert_eq!(
+                fs::read_to_string(paths::agent_runtimes().unwrap().join("linked/marker")).unwrap(),
+                "first"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_nested_current_generation_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        with_isolated_home(|_| {
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "working");
+            refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
+            let store = paths::homeboy().unwrap().join(GENERATIONS);
+            let outside = tempfile::tempdir().unwrap();
+            fs::create_dir_all(outside.path().join("agent-runtimes")).unwrap();
+            fs::remove_file(store.join(CURRENT)).unwrap();
+            symlink(outside.path(), store.join(CURRENT)).unwrap();
+
+            assert!(refresh("neutral", &source.path().to_string_lossy(), None).is_err());
         });
     }
 

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -1,5 +1,7 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
-use std::{collections::BTreeSet, fs};
 
 use crate::agent_runtime_manifest::AgentRuntimeManifest;
 use crate::config;
@@ -8,6 +10,12 @@ use crate::engine::local_files;
 use crate::error::{Error, Result};
 use crate::io::{copy_tree, EntryPolicy};
 use crate::{git, paths};
+
+const ROOT_MANIFEST: &str = "homeboy-extension-root.json";
+const GENERATIONS: &str = "runtime-generations";
+const CURRENT: &str = "current";
+const JOURNAL: &str = "refresh.json";
+const JOURNAL_SCHEMA: &str = "homeboy/runtime-generation-refresh/v1";
 
 #[derive(Debug, Clone)]
 pub struct RuntimePackageRefreshResult {
@@ -19,34 +27,70 @@ pub struct RuntimePackageRefreshResult {
     pub replaced_existing: bool,
 }
 
+#[derive(Debug, Deserialize)]
+struct RootManifest {
+    #[serde(default)]
+    shared_assets: Vec<SharedAssetDeclaration>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum SharedAssetDeclaration {
+    Path(String),
+    Object { path: String },
+}
+
+impl SharedAssetDeclaration {
+    fn path(self) -> String {
+        match self {
+            Self::Path(path) | Self::Object { path } => path,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Provenance<'a> {
+    schema: &'static str,
+    source: &'a str,
+    source_revision: Option<&'a str>,
+    shared_assets: &'a [String],
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RefreshJournal {
+    schema: String,
+    generation: String,
+    #[serde(default)]
+    switched: bool,
+}
+
 pub fn refresh(
     runtime_id: &str,
     source: &str,
     revision: Option<&str>,
 ) -> Result<RuntimePackageRefreshResult> {
+    config::with_config_lock(|| refresh_locked(runtime_id, source, revision))
+}
+
+fn refresh_locked(
+    runtime_id: &str,
+    source: &str,
+    revision: Option<&str>,
+) -> Result<RuntimePackageRefreshResult> {
     let runtime_id = identifier::slugify_id(runtime_id, "runtime_id")?;
-    let runtime_root = paths::agent_runtimes()?;
-    local_files::ensure_app_dirs()?;
-    let runtime_parent = runtime_root.parent().ok_or_else(|| {
-        Error::internal_io(
-            "runtime package directory has no parent".to_string(),
-            Some("prepare runtime package directory".to_string()),
-        )
-    })?;
-    std::fs::create_dir_all(runtime_parent).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("prepare runtime package directory".to_string()),
-        )
-    })?;
+    let config_root = paths::homeboy()?;
+    let store = config_root.join(GENERATIONS);
+    fs::create_dir_all(store.join("staging")).map_err(io("prepare runtime generation store"))?;
+    recover(&store)?;
 
-    let temp_dir = runtime_parent.join(format!(".refresh-tmp-{runtime_id}"));
-    remove_path_if_exists(&temp_dir, "clean stale runtime package refresh temp")?;
-
+    let source_stage = store.join(format!("source-{}-{}", runtime_id, nonce()));
+    remove_if_exists(&source_stage, "clean runtime refresh source")?;
     let (source_root, source_revision) = if crate::extension_update_check::is_git_url(source) {
-        git::clone_repo_at_ref(source, &temp_dir, revision)?;
-        let source_revision = git::short_head_revision(&temp_dir);
-        (temp_dir.as_path(), source_revision)
+        git::clone_repo_at_ref(source, &source_stage, revision)?;
+        (
+            source_stage.as_path(),
+            git::short_head_revision(&source_stage),
+        )
     } else {
         if revision.is_some() {
             return Err(Error::validation_invalid_argument(
@@ -56,218 +100,264 @@ pub fn refresh(
                 None,
             ));
         }
-        let source_path = Path::new(source);
-        let source_revision = git::short_head_revision(source_path);
-        (source_path, source_revision)
+        (
+            Path::new(source),
+            git::short_head_revision(Path::new(source)),
+        )
     };
 
-    let package_source = resolve_runtime_package_source(source_root, &runtime_id)?;
-    validate_runtime_package(&package_source, &runtime_id)?;
+    let package_source = resolve_package(source_root, &runtime_id)?;
+    let manifest_root = manifest_root(source_root, &package_source);
+    reject_symlink_tree(&package_source)?;
+    validate_package(&package_source, &runtime_id)?;
 
-    let target = runtime_root.join(&runtime_id);
-    let staged = runtime_parent.join(format!(".refresh-stage-{runtime_id}"));
-    let backup = runtime_parent.join(format!(".refresh-backup-{runtime_id}"));
-    remove_path_if_exists(&staged, "clean stale runtime package refresh stage")?;
-    remove_path_if_exists(&backup, "clean stale runtime package refresh backup")?;
+    let generation_name = format!("{}-{}", runtime_id, nonce());
+    let stage = store.join("staging").join(&generation_name);
+    remove_if_exists(&stage, "clean runtime generation stage")?;
+    seed_generation(&config_root, &store, &stage)?;
+    let dependencies = materialize_declared_assets(manifest_root, &stage, &runtime_id)?;
 
-    copy_dir_recursive(&package_source, &staged)?;
-    write_source_metadata(&staged, source, source_revision.as_deref())?;
+    let staged_package = stage.join("agent-runtimes").join(&runtime_id);
+    remove_if_exists(&staged_package, "replace staged runtime package")?;
+    copy_regular_tree(&package_source, &staged_package, "stage runtime package")?;
+    write_metadata(
+        &staged_package,
+        source,
+        source_revision.as_deref(),
+        &dependencies,
+    )?;
+    validate_package(&staged_package, &runtime_id)?;
+    validate_local_module_closure(&stage, &staged_package)?;
+    sync_tree(&stage)?;
 
-    if is_symlink(&runtime_root) {
-        let replaced_existing = path_exists_or_symlink(&target);
-        return replace_symlinked_runtime_root(
-            &runtime_root,
-            &runtime_id,
-            &package_source,
-            &staged,
-            &temp_dir,
-            source,
-            source_revision,
-            replaced_existing,
-        );
-    }
+    let replaced_existing = paths::agent_runtimes()?.join(&runtime_id).exists();
+    write_journal(
+        &store,
+        &RefreshJournal {
+            schema: JOURNAL_SCHEMA.to_string(),
+            generation: generation_name.clone(),
+            switched: false,
+        },
+    )?;
+    let generation = store.join(&generation_name);
+    fs::rename(&stage, &generation).map_err(io("publish runtime generation"))?;
+    sync_dir(&store)?;
+    switch_current(&store, &generation_name)?;
+    write_journal(
+        &store,
+        &RefreshJournal {
+            schema: JOURNAL_SCHEMA.to_string(),
+            generation: generation_name,
+            switched: true,
+        },
+    )?;
+    remove_if_exists(&store.join(JOURNAL), "finalize runtime generation refresh")?;
+    sync_dir(&store)?;
+    remove_if_exists(&source_stage, "clean runtime refresh source")?;
 
-    std::fs::create_dir_all(&runtime_root).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("prepare runtime package directory".to_string()),
-        )
-    })?;
-
-    let replaced_existing = path_exists_or_symlink(&target);
-    if replaced_existing {
-        rename_path(&target, &backup, "backup runtime package")?;
-    }
-
-    if let Err(err) = rename_path(&staged, &target, "install runtime package") {
-        if replaced_existing {
-            let _ = rename_path(&backup, &target, "restore runtime package backup");
-        }
-        let _ = remove_path_if_exists(&staged, "clean failed runtime package stage");
-        let _ = remove_path_if_exists(&temp_dir, "clean runtime package refresh temp");
-        return Err(err);
-    }
-
-    remove_path_if_exists(&backup, "remove runtime package backup")?;
-    materialize_local_module_closure(&package_source, runtime_parent, &runtime_root)?;
-    remove_path_if_exists(&temp_dir, "clean runtime package refresh temp")?;
-
+    let path = paths::agent_runtimes()?.join(&runtime_id);
     Ok(RuntimePackageRefreshResult {
         runtime_id: runtime_id.clone(),
         source: source.to_string(),
-        path: target.clone(),
-        manifest_path: target.join(format!("{runtime_id}.json")),
+        manifest_path: path.join(format!("{runtime_id}.json")),
+        path,
         source_revision,
         replaced_existing,
     })
 }
 
-/// Copy local CommonJS dependencies from the runtime source tree.
-///
-/// Runtime packages are installed individually, but their executable wrappers
-/// may import a shared module outside their package directory. Preserve each
-/// resolved module's path beneath Homeboy's config root so Node resolves it
-/// exactly as it did in the source checkout.
-fn materialize_local_module_closure(
-    package_source: &Path,
-    installed_config_root: &Path,
-    installed_runtime_root: &Path,
-) -> Result<()> {
-    let Some(container) = package_source.parent().filter(|path| {
-        path.file_name()
-            .is_some_and(|name| name == "agent-runtimes")
-    }) else {
-        return Ok(());
-    };
-    let source_root = fs::canonicalize(container.parent().expect("runtime container has parent"))
-        .map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("resolve runtime source root".to_string()),
-        )
-    })?;
-    let installed_config_root = fs::canonicalize(installed_config_root).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("resolve installed runtime root".to_string()),
-        )
-    })?;
-    let installed_runtime_root = fs::canonicalize(installed_runtime_root).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("resolve installed runtime root".to_string()),
-        )
-    })?;
-
-    let mut pending = BTreeSet::new();
-    collect_javascript_files(package_source, &mut pending)?;
-    let mut copied = BTreeSet::new();
-    while let Some(source) = pending.pop_first() {
-        let source = match fs::canonicalize(source) {
-            Ok(source) if source.starts_with(&source_root) => source,
-            _ => continue,
-        };
-        for dependency in local_commonjs_dependencies(&source)? {
-            let Some(resolved) = resolve_local_module(&source, &dependency) else {
-                continue;
-            };
-            if !resolved.starts_with(&source_root) || !copied.insert(resolved.clone()) {
-                continue;
-            }
-            let relative = resolved
-                .strip_prefix(&source_root)
-                .expect("checked source root");
-            let (destination_root, relative) = relative
-                .strip_prefix("agent-runtimes")
-                .map(|relative| (&installed_runtime_root, relative))
-                .unwrap_or((&installed_config_root, relative));
-            let destination = safe_runtime_dependency_destination(destination_root, relative)?;
-            fs::copy(&resolved, &destination).map_err(|e| {
-                Error::internal_io(e.to_string(), Some("copy runtime dependency".to_string()))
-            })?;
-            pending.insert(resolved);
+fn seed_generation(config_root: &Path, store: &Path, stage: &Path) -> Result<()> {
+    let current = store.join(CURRENT);
+    if active_current_generation(store).is_some() {
+        reject_symlink_tree_except_root(&current)?;
+        return copy_regular_tree(&current, stage, "copy active runtime generation");
+    }
+    // First activation migrates the runtime surface only; all unrelated Homeboy
+    // configuration remains in place and is never renamed or copied.
+    let legacy = paths::legacy_agent_runtimes()?;
+    if legacy.is_dir() {
+        reject_symlink_tree_except_root(&legacy)?;
+        copy_regular_tree(
+            &legacy,
+            &stage.join("agent-runtimes"),
+            "migrate legacy runtimes",
+        )?;
+    }
+    for shared in ["agent-task-contracts", "runtime-agent-ci"] {
+        let source = config_root.join(shared);
+        if source.is_dir() {
+            reject_symlink_tree_except_root(&source)?;
+            copy_regular_tree(
+                &source,
+                &stage.join(shared),
+                "migrate legacy runtime dependency",
+            )?;
         }
     }
     Ok(())
 }
 
-fn safe_runtime_dependency_destination(installed_root: &Path, relative: &Path) -> Result<PathBuf> {
-    if relative.as_os_str().is_empty()
-        || relative.is_absolute()
-        || relative
-            .components()
-            .any(|component| !matches!(component, std::path::Component::Normal(_)))
-    {
-        return Err(Error::validation_invalid_argument(
-            "runtime_dependency",
-            "runtime dependency path is not a safe relative path",
-            Some(relative.display().to_string()),
-            None,
-        ));
-    }
+fn active_current_generation(store: &Path) -> Option<PathBuf> {
+    let target = fs::read_link(store.join(CURRENT)).ok()?;
+    safe_relative(target.to_str()?, "runtime_generation").ok()?;
+    let generation = store.join(target);
+    generation
+        .join("agent-runtimes")
+        .is_dir()
+        .then_some(generation)
+}
 
-    let destination = installed_root.join(relative);
-    let parent = destination.parent().expect("safe relative path has parent");
-    let mut current = installed_root.to_path_buf();
-    for component in relative.parent().into_iter().flat_map(Path::components) {
-        let std::path::Component::Normal(component) = component else {
-            unreachable!("safe relative path only has normal components");
-        };
-        current.push(component);
-        if fs::symlink_metadata(&current).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+fn manifest_root<'a>(source_root: &'a Path, package: &'a Path) -> &'a Path {
+    if source_root.join(ROOT_MANIFEST).is_file() {
+        source_root
+    } else if package.parent().is_some_and(|parent| {
+        parent
+            .file_name()
+            .is_some_and(|name| name == "agent-runtimes")
+    }) {
+        package
+            .parent()
+            .and_then(Path::parent)
+            .unwrap_or(source_root)
+    } else {
+        source_root
+    }
+}
+
+fn materialize_declared_assets(root: &Path, stage: &Path, runtime_id: &str) -> Result<Vec<String>> {
+    let manifest = root.join(ROOT_MANIFEST);
+    let Ok(raw) = fs::read_to_string(&manifest) else {
+        return Ok(Vec::new());
+    };
+    let parsed: RootManifest = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_argument(
+            "source",
+            format!("invalid shared asset manifest: {error}"),
+            Some(manifest.display().to_string()),
+            None,
+        )
+    })?;
+    let mut assets = parsed
+        .shared_assets
+        .into_iter()
+        .map(SharedAssetDeclaration::path)
+        .collect::<Vec<_>>();
+    assets.sort();
+    assets.dedup();
+    let root = fs::canonicalize(root).map_err(io("resolve runtime source root"))?;
+    for asset in &assets {
+        let relative = safe_relative(asset, "shared_assets")?;
+        let source = fs::canonicalize(root.join(relative))
+            .map_err(io("resolve shared runtime dependency"))?;
+        if !source.starts_with(&root) || !source.is_dir() {
             return Err(Error::validation_invalid_argument(
-                "runtime_dependency",
-                "runtime dependency destination traverses a symbolic link",
-                Some(current.display().to_string()),
+                "shared_assets",
+                "declared shared asset escapes or is missing from its source root",
+                Some(asset.clone()),
                 None,
             ));
         }
+        reject_symlink_tree(&source)?;
+        if asset == "agent-runtimes" {
+            materialize_runtime_shared_tree(&source, &stage.join("agent-runtimes"), runtime_id)?;
+        } else {
+            let target = stage.join(relative);
+            remove_if_exists(&target, "replace staged runtime dependency")?;
+            copy_regular_tree(&source, &target, "stage shared runtime dependency")?;
+        }
     }
-    fs::create_dir_all(parent).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("prepare runtime dependency".to_string()),
-        )
-    })?;
-    let canonical_parent = fs::canonicalize(parent).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("resolve runtime dependency destination".to_string()),
-        )
-    })?;
-    if !canonical_parent.starts_with(installed_root) {
-        return Err(Error::validation_invalid_argument(
-            "runtime_dependency",
-            "runtime dependency destination escapes installed runtime root",
-            Some(destination.display().to_string()),
-            None,
-        ));
-    }
-    if fs::symlink_metadata(&destination).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
-        return Err(Error::validation_invalid_argument(
-            "runtime_dependency",
-            "runtime dependency destination is a symbolic link",
-            Some(destination.display().to_string()),
-            None,
-        ));
-    }
-    Ok(destination)
+    Ok(assets)
 }
 
-fn collect_javascript_files(root: &Path, files: &mut BTreeSet<PathBuf>) -> Result<()> {
-    for entry in fs::read_dir(root)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("read runtime package".to_string())))?
-    {
-        let path = entry
-            .map_err(|e| {
-                Error::internal_io(
-                    e.to_string(),
-                    Some("read runtime package entry".to_string()),
+fn materialize_runtime_shared_tree(source: &Path, target: &Path, runtime_id: &str) -> Result<()> {
+    fs::create_dir_all(target).map_err(io("prepare shared runtime dependency"))?;
+    for entry in fs::read_dir(source).map_err(io("read shared runtime dependency"))? {
+        let entry = entry.map_err(io("read shared runtime dependency"))?;
+        let name = entry.file_name();
+        let child = entry.path();
+        if name == runtime_id
+            || child
+                .join(format!("{}.json", name.to_string_lossy()))
+                .is_file()
+        {
+            continue;
+        }
+        let target = target.join(name);
+        remove_if_exists(&target, "replace shared runtime dependency")?;
+        copy_regular_tree(&child, &target, "stage shared runtime dependency")?;
+    }
+    Ok(())
+}
+
+fn resolve_package(source_root: &Path, runtime_id: &str) -> Result<PathBuf> {
+    if source_root.join(format!("{runtime_id}.json")).is_file() {
+        return Ok(source_root.to_path_buf());
+    }
+    let package = source_root.join("agent-runtimes").join(runtime_id);
+    if package.join(format!("{runtime_id}.json")).is_file() {
+        return Ok(package);
+    }
+    Err(Error::validation_invalid_argument("source", format!("No runtime package manifest '{runtime_id}.json' found at source root or agent-runtimes/{runtime_id}"), Some(source_root.display().to_string()), None))
+}
+
+fn validate_package(package: &Path, runtime_id: &str) -> Result<()> {
+    let manifest: AgentRuntimeManifest =
+        config::from_str(&local_files::local().read(&package.join(format!("{runtime_id}.json")))?)?;
+    if manifest.id != runtime_id {
+        return Err(Error::validation_invalid_argument(
+            "runtime_id",
+            format!(
+                "Runtime package manifest id '{}' does not match requested id '{runtime_id}'",
+                manifest.id
+            ),
+            Some(runtime_id.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_local_module_closure(generation: &Path, package: &Path) -> Result<()> {
+    let mut pending = BTreeSet::new();
+    collect_javascript(package, &mut pending)?;
+    let generation =
+        fs::canonicalize(generation).map_err(io("resolve staged runtime generation"))?;
+    while let Some(module) = pending.pop_first() {
+        for dependency in local_requires(&module)? {
+            let resolved = resolve_local_module(&module, &dependency).ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "runtime_dependency",
+                    "staged runtime has an unresolved local module dependency",
+                    Some(format!("{} -> {dependency}", module.display())),
+                    None,
                 )
-            })?
-            .path();
+            })?;
+            let resolved =
+                fs::canonicalize(resolved).map_err(io("resolve staged runtime dependency"))?;
+            if !resolved.starts_with(&generation) {
+                return Err(Error::validation_invalid_argument(
+                    "runtime_dependency",
+                    "staged runtime dependency escapes its generation",
+                    Some(resolved.display().to_string()),
+                    None,
+                ));
+            }
+            if resolved
+                .extension()
+                .is_some_and(|extension| extension == "js" || extension == "cjs")
+            {
+                pending.insert(resolved);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_javascript(root: &Path, files: &mut BTreeSet<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root).map_err(io("read staged runtime package"))? {
+        let path = entry.map_err(io("read staged runtime package"))?.path();
         if path.is_dir() {
-            collect_javascript_files(&path, files)?;
+            collect_javascript(&path, files)?;
         } else if path
             .extension()
             .is_some_and(|extension| extension == "js" || extension == "cjs")
@@ -278,9 +368,8 @@ fn collect_javascript_files(root: &Path, files: &mut BTreeSet<PathBuf>) -> Resul
     Ok(())
 }
 
-fn local_commonjs_dependencies(source: &Path) -> Result<Vec<String>> {
-    let contents = fs::read_to_string(source)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("read runtime module".to_string())))?;
+fn local_requires(module: &Path) -> Result<Vec<String>> {
+    let contents = fs::read_to_string(module).map_err(io("read runtime module"))?;
     Ok(contents
         .split("require(")
         .skip(1)
@@ -288,15 +377,16 @@ fn local_commonjs_dependencies(source: &Path) -> Result<Vec<String>> {
             let suffix = suffix.trim_start();
             let quote = suffix.chars().next()?;
             (quote == '\'' || quote == '"').then_some(())?;
-            let value = &suffix[1..];
-            value.find(quote).map(|end| value[..end].to_string())
+            suffix[1..]
+                .find(quote)
+                .map(|end| suffix[1..1 + end].to_string())
         })
         .filter(|dependency| dependency.starts_with('.'))
         .collect())
 }
 
-fn resolve_local_module(source: &Path, dependency: &str) -> Option<PathBuf> {
-    let base = source.parent()?.join(dependency);
+fn resolve_local_module(module: &Path, dependency: &str) -> Option<PathBuf> {
+    let base = module.parent()?.join(dependency);
     [
         base.clone(),
         base.with_extension("js"),
@@ -306,205 +396,221 @@ fn resolve_local_module(source: &Path, dependency: &str) -> Option<PathBuf> {
         base.join("index.json"),
     ]
     .into_iter()
-    .find_map(|candidate| {
-        candidate
-            .is_file()
-            .then(|| fs::canonicalize(candidate).ok())
-            .flatten()
-    })
+    .find(|path| path.is_file())
 }
 
-fn replace_symlinked_runtime_root(
-    runtime_root: &Path,
-    runtime_id: &str,
-    package_source: &Path,
-    staged: &Path,
-    temp_dir: &Path,
+fn write_metadata(
+    package: &Path,
     source: &str,
-    source_revision: Option<String>,
-    replaced_existing: bool,
-) -> Result<RuntimePackageRefreshResult> {
-    let runtime_parent = runtime_root.parent().expect("runtime root has parent");
-    let materialized = runtime_parent.join(format!(".refresh-root-stage-{runtime_id}"));
-    let root_backup = runtime_parent.join(format!(".refresh-root-backup-{runtime_id}"));
-    remove_path_if_exists(&materialized, "clean stale runtime root refresh stage")?;
-    remove_path_if_exists(&root_backup, "clean stale runtime root refresh backup")?;
-
-    copy_tree(
-        runtime_root,
-        &materialized,
-        "copy runtime packages for root materialization",
-        EntryPolicy::CopyAnyNonDir,
+    revision: Option<&str>,
+    assets: &[String],
+) -> Result<()> {
+    write_synced(
+        &package.join(".source-url"),
+        source.as_bytes(),
+        "write runtime source",
     )?;
-    let target = materialized.join(runtime_id);
-    remove_path_if_exists(&target, "replace staged runtime package")?;
-    rename_path(
-        staged,
-        &target,
-        "stage runtime package in materialized root",
-    )?;
-    materialize_local_module_closure(package_source, runtime_parent, &materialized)?;
-
-    rename_path(
-        runtime_root,
-        &root_backup,
-        "backup symlinked runtime package root",
-    )?;
-    if let Err(err) = rename_path(
-        &materialized,
-        runtime_root,
-        "install materialized runtime package root",
-    ) {
-        let _ = rename_path(
-            &root_backup,
-            runtime_root,
-            "restore symlinked runtime package root",
-        );
-        let _ = remove_path_if_exists(&materialized, "clean failed runtime root stage");
-        let _ = remove_path_if_exists(temp_dir, "clean runtime package refresh temp");
-        return Err(err);
+    if let Some(revision) = revision {
+        write_synced(
+            &package.join(".source-revision"),
+            revision.as_bytes(),
+            "write runtime source revision",
+        )?;
     }
-
-    remove_path_if_exists(&root_backup, "remove symlinked runtime package root backup")?;
-    remove_path_if_exists(temp_dir, "clean runtime package refresh temp")?;
-
-    Ok(RuntimePackageRefreshResult {
-        runtime_id: runtime_id.to_string(),
-        source: source.to_string(),
-        path: runtime_root.join(runtime_id),
-        manifest_path: runtime_root
-            .join(runtime_id)
-            .join(format!("{runtime_id}.json")),
-        source_revision,
-        replaced_existing,
+    let provenance = serde_json::to_vec_pretty(&Provenance {
+        schema: "homeboy/runtime-package-provenance/v1",
+        source,
+        source_revision: revision,
+        shared_assets: assets,
     })
+    .map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("serialize runtime provenance".to_string()),
+        )
+    })?;
+    write_synced(
+        &package.join(".dependency-provenance.json"),
+        &provenance,
+        "write runtime provenance",
+    )
 }
 
-fn resolve_runtime_package_source<'a>(source_root: &'a Path, runtime_id: &str) -> Result<PathBuf> {
-    let direct_manifest = source_root.join(format!("{runtime_id}.json"));
-    if direct_manifest.is_file() {
-        return Ok(source_root.to_path_buf());
-    }
+fn switch_current(store: &Path, generation: &str) -> Result<()> {
+    let temporary = store.join(format!(".{CURRENT}-{}", nonce()));
+    remove_if_exists(&temporary, "clean runtime current pointer")?;
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(generation, &temporary)
+        .map_err(io("stage runtime current pointer"))?;
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(generation, &temporary)
+        .map_err(io("stage runtime current pointer"))?;
+    sync_dir(store)?;
+    fs::rename(&temporary, store.join(CURRENT)).map_err(io("activate runtime generation"))?;
+    sync_dir(store)
+}
 
-    let monorepo_package = source_root.join("agent-runtimes").join(runtime_id);
-    if monorepo_package
-        .join(format!("{runtime_id}.json"))
-        .is_file()
+fn recover(store: &Path) -> Result<()> {
+    let journal = store.join(JOURNAL);
+    let Ok(raw) = fs::read(&journal) else {
+        return Ok(());
+    };
+    let record: RefreshJournal = serde_json::from_slice(&raw).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read runtime refresh journal".to_string()),
+        )
+    })?;
+    if record.schema != JOURNAL_SCHEMA
+        || safe_relative(&record.generation, "runtime_generation").is_err()
     {
-        return Ok(monorepo_package);
-    }
-
-    Err(Error::validation_invalid_argument(
-        "source",
-        format!(
-            "No runtime package manifest '{}.json' found at source root or agent-runtimes/{}",
-            runtime_id, runtime_id
-        ),
-        Some(source_root.display().to_string()),
-        None,
-    ))
-}
-
-fn validate_runtime_package(package_dir: &Path, runtime_id: &str) -> Result<()> {
-    let manifest_path = package_dir.join(format!("{runtime_id}.json"));
-    let content = local_files::local().read(&manifest_path)?;
-    let manifest: AgentRuntimeManifest = config::from_str(&content)?;
-    if manifest.id != runtime_id {
         return Err(Error::validation_invalid_argument(
-            "runtime_id",
-            format!(
-                "Runtime package manifest id '{}' does not match requested id '{}'",
-                manifest.id, runtime_id
-            ),
-            Some(runtime_id.to_string()),
+            "runtime_generation",
+            "unknown or unsafe runtime refresh journal",
+            Some(record.generation),
             None,
         ));
     }
-    Ok(())
-}
-
-fn write_source_metadata(
-    package_dir: &Path,
-    source: &str,
-    source_revision: Option<&str>,
-) -> Result<()> {
-    std::fs::write(package_dir.join(".source-url"), source).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("write runtime package source".to_string()),
-        )
-    })?;
-    if let Some(revision) = source_revision {
-        std::fs::write(package_dir.join(".source-revision"), revision).map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some("write runtime package source revision".to_string()),
-            )
-        })?;
+    let generation = store.join(&record.generation);
+    let current = active_current_generation(store);
+    if !record.switched && current.as_deref() != Some(generation.as_path()) {
+        remove_if_exists(
+            &store.join("staging").join(&record.generation),
+            "recover staged runtime generation",
+        )?;
+        remove_if_exists(&generation, "recover unpublished runtime generation")?;
     }
-    Ok(())
+    remove_if_exists(&journal, "finalize recovered runtime generation")?;
+    sync_dir(store)
 }
 
-fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
-    std::fs::create_dir_all(target).map_err(|e| {
-        Error::internal_io(e.to_string(), Some("create runtime package".to_string()))
-    })?;
-
-    for entry in std::fs::read_dir(source).map_err(|e| {
+fn write_journal(store: &Path, journal: &RefreshJournal) -> Result<()> {
+    let bytes = serde_json::to_vec(journal).map_err(|error| {
         Error::internal_io(
-            e.to_string(),
-            Some("read runtime package source".to_string()),
+            error.to_string(),
+            Some("serialize runtime refresh journal".to_string()),
         )
-    })? {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some("read runtime package entry".to_string()),
-            )
-        })?;
-        let source_path = entry.path();
-        let target_path = target.join(entry.file_name());
-        let metadata = entry.metadata().map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some("inspect runtime package entry".to_string()),
-            )
-        })?;
-        if metadata.is_dir() {
-            copy_dir_recursive(&source_path, &target_path)?;
-        } else if metadata.is_file() {
-            std::fs::copy(&source_path, &target_path).map_err(|e| {
-                Error::internal_io(e.to_string(), Some("copy runtime package file".to_string()))
-            })?;
+    })?;
+    let temporary = store.join(format!(".{JOURNAL}-{}", nonce()));
+    write_synced(&temporary, &bytes, "write runtime refresh journal")?;
+    fs::rename(&temporary, store.join(JOURNAL)).map_err(io("publish runtime refresh journal"))?;
+    sync_dir(store)
+}
+
+fn safe_relative<'a>(value: &'a str, field: &str) -> Result<&'a Path> {
+    let path = Path::new(value);
+    if value.trim().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|part| !matches!(part, std::path::Component::Normal(_)))
+    {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "path is not a safe relative path",
+            Some(value.to_string()),
+            None,
+        ));
+    }
+    Ok(path)
+}
+
+fn reject_symlink_tree(root: &Path) -> Result<()> {
+    reject_symlink_tree_inner(root, false)
+}
+fn reject_symlink_tree_except_root(root: &Path) -> Result<()> {
+    reject_symlink_tree_inner(root, true)
+}
+fn reject_symlink_tree_inner(root: &Path, allow_root_link: bool) -> Result<()> {
+    if !allow_root_link
+        && fs::symlink_metadata(root)
+            .map_err(io("inspect runtime source"))?
+            .file_type()
+            .is_symlink()
+    {
+        return Err(Error::validation_invalid_argument(
+            "runtime_source",
+            "runtime source contains a symbolic link",
+            Some(root.display().to_string()),
+            None,
+        ));
+    }
+    for entry in fs::read_dir(root).map_err(io("read runtime source"))? {
+        let path = entry.map_err(io("read runtime source"))?.path();
+        let meta = fs::symlink_metadata(&path).map_err(io("inspect runtime source"))?;
+        if meta.file_type().is_symlink() {
+            return Err(Error::validation_invalid_argument(
+                "runtime_source",
+                "runtime source contains a symbolic link",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+        if meta.is_dir() {
+            reject_symlink_tree_inner(&path, false)?;
         }
     }
-
     Ok(())
 }
 
-fn rename_path(from: &Path, to: &Path, context: &str) -> Result<()> {
-    std::fs::rename(from, to)
-        .map_err(|e| Error::internal_io(e.to_string(), Some(context.to_string())))
+fn copy_regular_tree(source: &Path, target: &Path, context: &str) -> Result<()> {
+    copy_tree(source, target, context, EntryPolicy::CopyRegularFilesOnly)
 }
 
-fn remove_path_if_exists(path: &Path, context: &str) -> Result<()> {
-    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+fn remove_if_exists(path: &Path, context: &str) -> Result<()> {
+    let Ok(meta) = fs::symlink_metadata(path) else {
         return Ok(());
     };
-    let result = if metadata.file_type().is_symlink() || metadata.is_file() {
-        std::fs::remove_file(path)
+    let result = if meta.file_type().is_symlink() || meta.is_file() {
+        fs::remove_file(path)
     } else {
-        std::fs::remove_dir_all(path)
+        fs::remove_dir_all(path)
     };
-    result.map_err(|e| Error::internal_io(e.to_string(), Some(context.to_string())))
+    result.map_err(io(context))
 }
 
-fn path_exists_or_symlink(path: &Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok()
+fn write_synced(path: &Path, contents: &[u8], context: &str) -> Result<()> {
+    fs::write(path, contents).map_err(io(context))?;
+    File::open(path)
+        .map_err(io(context))?
+        .sync_all()
+        .map_err(io(context))
 }
 
-fn is_symlink(path: &Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+fn sync_tree(root: &Path) -> Result<()> {
+    for entry in fs::read_dir(root).map_err(io("sync runtime generation"))? {
+        let path = entry.map_err(io("sync runtime generation"))?.path();
+        if path.is_dir() {
+            sync_tree(&path)?;
+        } else {
+            File::open(&path)
+                .map_err(io("sync runtime generation"))?
+                .sync_all()
+                .map_err(io("sync runtime generation"))?;
+        }
+    }
+    sync_dir(root)
+}
+
+fn sync_dir(path: &Path) -> Result<()> {
+    File::open(path)
+        .map_err(io("sync runtime generation directory"))?
+        .sync_all()
+        .map_err(io("sync runtime generation directory"))
+}
+fn io(context: &str) -> impl FnOnce(std::io::Error) -> Error {
+    let context = context.to_string();
+    move |error| Error::internal_io(error.to_string(), Some(context))
+}
+fn nonce() -> String {
+    format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    )
 }
 
 #[cfg(test)]
@@ -513,165 +619,71 @@ mod tests {
     use crate::test_support::with_isolated_home;
     use std::process::Command;
 
-    fn write_runtime_package(root: &Path, runtime_id: &str, marker: &str) {
-        let package = root.join("agent-runtimes").join(runtime_id);
-        std::fs::create_dir_all(&package).expect("runtime package dir");
-        std::fs::write(
-            package.join(format!("{runtime_id}.json")),
-            format!(
-                r#"{{
-  "schema": "homeboy/agent-runtime-manifest/v1",
-  "id": "{}"
-}}"#,
-                runtime_id
-            ),
+    fn package(root: &Path, id: &str, marker: &str) -> PathBuf {
+        let path = root.join("agent-runtimes").join(id);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(
+            path.join(format!("{id}.json")),
+            format!(r#"{{"schema":"homeboy/agent-runtime-manifest/v1","id":"{id}"}}"#),
         )
-        .expect("runtime package manifest");
-        std::fs::write(package.join("marker.txt"), marker).expect("runtime package marker");
+        .unwrap();
+        fs::write(path.join("marker"), marker).unwrap();
+        path
     }
-
-    fn tree_bytes(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
-        fn collect(root: &Path, path: &Path, entries: &mut Vec<(PathBuf, Vec<u8>)>) {
-            let mut children = std::fs::read_dir(path)
-                .expect("read source tree")
-                .map(|entry| entry.expect("source tree entry"))
-                .collect::<Vec<_>>();
-            children.sort_by_key(|entry| entry.file_name());
-            for child in children {
-                let path = child.path();
-                if path.is_dir() {
-                    collect(root, &path, entries);
-                } else {
-                    entries.push((
-                        path.strip_prefix(root)
-                            .expect("source tree relative path")
-                            .to_path_buf(),
-                        std::fs::read(&path).expect("read source tree file"),
-                    ));
-                }
-            }
-        }
-
-        let mut entries = Vec::new();
-        collect(root, root, &mut entries);
-        entries
-    }
-
-    fn commit_source(root: &Path) {
-        for args in [
-            vec!["init", "-q"],
-            vec!["add", "."],
-            vec![
-                "-c",
-                "user.name=Homeboy Test",
-                "-c",
-                "user.email=test@homeboy.invalid",
-                "commit",
-                "-q",
-                "-m",
-                "initial",
-            ],
-        ] {
-            let status = Command::new("git")
-                .args(["-C", root.to_str().expect("source path")])
-                .args(args)
-                .status()
-                .expect("run git");
-            assert!(status.success(), "git command succeeds");
-        }
+    fn manifest(root: &Path, assets: &[&str]) {
+        fs::write(
+            root.join(ROOT_MANIFEST),
+            serde_json::json!({"shared_assets": assets}).to_string(),
+        )
+        .unwrap();
     }
 
     #[test]
-    fn refresh_installs_runtime_package_from_monorepo_source() {
+    fn package_only_refresh_migrates_legacy_runtime_and_preserves_unrelated_config() {
         with_isolated_home(|_| {
-            let source = tempfile::TempDir::new().expect("source tempdir");
-            write_runtime_package(source.path(), "neutral-runtime", "v1");
-
-            let result = refresh("neutral-runtime", &source.path().to_string_lossy(), None)
-                .expect("refresh runtime package");
-
-            assert_eq!(result.runtime_id, "neutral-runtime");
-            assert!(!result.replaced_existing);
-            assert!(result.path.ends_with("agent-runtimes/neutral-runtime"));
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "new");
+            let root = paths::homeboy().unwrap();
+            package(&root, "other", "old");
+            fs::write(root.join("keep"), "yes").unwrap();
+            let result = refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
             assert_eq!(
-                std::fs::read_to_string(result.path.join("marker.txt")).unwrap(),
-                "v1"
+                fs::read_to_string(result.path.join("marker")).unwrap(),
+                "new"
             );
+            assert_eq!(
+                fs::read_to_string(paths::agent_runtimes().unwrap().join("other/marker")).unwrap(),
+                "old"
+            );
+            assert_eq!(fs::read_to_string(root.join("keep")).unwrap(), "yes");
         });
     }
 
     #[test]
-    fn refresh_replaces_existing_runtime_package() {
+    fn installed_runtime_and_declared_dependencies_execute_without_source_siblings() {
         with_isolated_home(|_| {
-            let source = tempfile::TempDir::new().expect("source tempdir");
-            write_runtime_package(source.path(), "neutral-runtime", "v1");
-            refresh("neutral-runtime", &source.path().to_string_lossy(), None)
-                .expect("first refresh");
-
-            write_runtime_package(source.path(), "neutral-runtime", "v2");
-            let result = refresh("neutral-runtime", &source.path().to_string_lossy(), None)
-                .expect("second refresh");
-
-            assert!(result.replaced_existing);
-            assert_eq!(
-                std::fs::read_to_string(result.path.join("marker.txt")).unwrap(),
-                "v2"
-            );
-        });
-    }
-
-    #[test]
-    fn refresh_materializes_local_commonjs_dependency_closure() {
-        with_isolated_home(|_| {
-            let source = tempfile::TempDir::new().expect("source tempdir");
-            let package = source.path().join("agent-runtimes/neutral-runtime");
-            let entrypoint = package.join("scripts/agent/executor.cjs");
-            let shared = source
-                .path()
-                .join("agent-runtimes/lib/cli-agent-task-executor-bin.js");
-            let executor = source
-                .path()
-                .join("agent-runtimes/lib/cli-agent-task-executor.js");
-            let contract = source.path().join("agent-task-contracts/index.js");
-            let outcome = source.path().join("runtime-agent-ci/lib/outcome.json");
-            std::fs::create_dir_all(entrypoint.parent().expect("entrypoint parent"))
-                .expect("entrypoint directory");
-            std::fs::create_dir_all(shared.parent().expect("shared parent"))
-                .expect("shared directory");
-            std::fs::create_dir_all(contract.parent().expect("contract parent"))
-                .expect("contract directory");
-            std::fs::create_dir_all(outcome.parent().expect("outcome parent"))
-                .expect("outcome directory");
-            std::fs::write(
-                package.join("neutral-runtime.json"),
-                r#"{"schema":"homeboy/agent-runtime-manifest/v1","id":"neutral-runtime"}"#,
+            let source = tempfile::tempdir().unwrap();
+            let runtime = package(source.path(), "opencode", "new");
+            fs::create_dir_all(source.path().join("agent-runtimes/lib")).unwrap();
+            fs::create_dir_all(source.path().join("agent-task-contracts")).unwrap();
+            fs::write(runtime.join("run.cjs"), "console.log(require('../lib/shared').value + require('../../agent-task-contracts').value)").unwrap();
+            fs::write(
+                source.path().join("agent-runtimes/lib/shared.js"),
+                "exports.value='installed-'",
             )
-            .expect("manifest");
-            std::fs::write(
-                &entrypoint,
-                "require('../../../lib/cli-agent-task-executor-bin').run();\n",
+            .unwrap();
+            fs::write(
+                source.path().join("agent-task-contracts/index.js"),
+                "exports.value='boundary'",
             )
-            .expect("entrypoint");
-            std::fs::write(
-                &shared,
-                "exports.run = require('./cli-agent-task-executor').run;\n",
-            )
-            .expect("shared dependency");
-            std::fs::write(
-                &executor,
-                "const contract = require('../../agent-task-contracts');\nconst outcome = require('../../runtime-agent-ci/lib/outcome.json');\nexports.run = () => process.stdout.write(`${contract.status}:${outcome.status}\\n`);\n",
-            )
-            .expect("transitive executor dependency");
-            std::fs::write(&contract, "exports.status = 'ready';\n").expect("shared contract");
-            std::fs::write(&outcome, r#"{"status":"normalized"}"#).expect("shared outcome");
-
-            let result = refresh("neutral-runtime", &source.path().to_string_lossy(), None)
-                .expect("refresh runtime package");
+            .unwrap();
+            manifest(source.path(), &["agent-runtimes", "agent-task-contracts"]);
+            let result = refresh("opencode", &source.path().to_string_lossy(), None).unwrap();
+            fs::remove_dir_all(source.path()).unwrap();
             let output = Command::new("node")
-                .arg(result.path.join("scripts/agent/executor.cjs"))
+                .arg(result.path.join("run.cjs"))
                 .output()
-                .expect("execute materialized entrypoint");
-
+                .unwrap();
             assert!(
                 output.status.success(),
                 "{}",
@@ -679,169 +691,156 @@ mod tests {
             );
             assert_eq!(
                 String::from_utf8_lossy(&output.stdout),
-                "ready:normalized\n"
+                "installed-boundary\n"
             );
-            assert!(result
-                .path
-                .parent()
-                .expect("runtime root")
-                .join("lib/cli-agent-task-executor-bin.js")
-                .is_file());
-            assert!(result
-                .path
-                .parent()
-                .and_then(Path::parent)
-                .expect("config root")
-                .join("agent-task-contracts/index.js")
-                .is_file());
-            assert!(result
-                .path
-                .parent()
-                .and_then(Path::parent)
-                .expect("config root")
-                .join("runtime-agent-ci/lib/outcome.json")
-                .is_file());
         });
     }
 
     #[test]
-    fn refresh_skips_local_dependencies_outside_the_runtime_source_root() {
-        with_isolated_home(|home| {
-            let source = tempfile::TempDir::new().expect("source tempdir");
-            let outside = source
-                .path()
-                .parent()
-                .expect("source parent")
-                .join("runtime-package-escape.js");
-            let package = source.path().join("agent-runtimes/neutral-runtime");
-            let entrypoint = package.join("scripts/agent/executor.cjs");
-            std::fs::create_dir_all(entrypoint.parent().expect("entrypoint parent"))
-                .expect("entrypoint directory");
-            std::fs::write(
-                package.join("neutral-runtime.json"),
-                r#"{"schema":"homeboy/agent-runtime-manifest/v1","id":"neutral-runtime"}"#,
+    fn staged_failure_and_pre_switch_crash_keep_previous_generation() {
+        with_isolated_home(|_| {
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "old");
+            refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
+            package(source.path(), "neutral", "broken");
+            manifest(source.path(), &["missing"]);
+            assert!(refresh("neutral", &source.path().to_string_lossy(), None).is_err());
+            assert_eq!(
+                fs::read_to_string(paths::agent_runtimes().unwrap().join("neutral/marker"))
+                    .unwrap(),
+                "old"
+            );
+            let store = paths::homeboy().unwrap().join(GENERATIONS);
+            let staged = store.join("staging/crash");
+            fs::create_dir_all(&staged).unwrap();
+            write_journal(
+                &store,
+                &RefreshJournal {
+                    schema: JOURNAL_SCHEMA.into(),
+                    generation: "crash".into(),
+                    switched: false,
+                },
             )
-            .expect("manifest");
-            std::fs::write(
-                &entrypoint,
-                "require('../../../../../runtime-package-escape');\n",
+            .unwrap();
+            recover(&store).unwrap();
+            assert!(!staged.exists());
+            assert_eq!(
+                fs::read_to_string(paths::agent_runtimes().unwrap().join("neutral/marker"))
+                    .unwrap(),
+                "old"
+            );
+        });
+    }
+
+    #[test]
+    fn post_switch_crash_recovers_idempotently_and_consumers_observe_whole_generation() {
+        with_isolated_home(|_| {
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "one");
+            refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
+            package(source.path(), "neutral", "two");
+            let store = paths::homeboy().unwrap().join(GENERATIONS);
+            let generation = fs::read_link(store.join(CURRENT)).unwrap();
+            write_journal(
+                &store,
+                &RefreshJournal {
+                    schema: JOURNAL_SCHEMA.into(),
+                    generation: generation.to_string_lossy().to_string(),
+                    switched: false,
+                },
             )
-            .expect("entrypoint");
-            std::fs::write(&outside, "exports.run = () => {};\n").expect("outside dependency");
+            .unwrap();
+            recover(&store).unwrap();
+            assert_eq!(
+                fs::read_to_string(paths::agent_runtimes().unwrap().join("neutral/marker"))
+                    .unwrap(),
+                "one"
+            );
+        });
+    }
 
-            refresh("neutral-runtime", &source.path().to_string_lossy(), None)
-                .expect("refresh runtime package");
+    #[test]
+    fn concurrent_consumer_observes_only_complete_generations() {
+        with_isolated_home(|_| {
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "one");
+            fs::create_dir_all(source.path().join("agent-task-contracts")).unwrap();
+            fs::write(source.path().join("agent-task-contracts/marker"), "one").unwrap();
+            manifest(source.path(), &["agent-task-contracts"]);
+            refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
 
-            assert!(!home.path().join(".config/homeboy/escape.js").exists());
-            assert!(!home
-                .path()
-                .join(".config/homeboy/agent-runtimes/escape.js")
-                .exists());
-            std::fs::remove_file(outside).expect("remove outside dependency");
+            package(source.path(), "neutral", "two");
+            fs::write(source.path().join("agent-task-contracts/marker"), "two").unwrap();
+            let store = paths::homeboy().unwrap().join(GENERATIONS);
+            let reader = std::thread::spawn(move || {
+                for _ in 0..1_000 {
+                    let runtimes = paths::agent_runtimes().unwrap();
+                    let generation = runtimes.parent().unwrap();
+                    let runtime = fs::read_to_string(runtimes.join("neutral/marker")).unwrap();
+                    let dependency =
+                        fs::read_to_string(generation.join("agent-task-contracts/marker")).unwrap();
+                    assert_eq!(runtime, dependency);
+                }
+            });
+            refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
+            reader.join().unwrap();
+            assert!(fs::read_link(store.join(CURRENT)).is_ok());
         });
     }
 
     #[cfg(unix)]
     #[test]
-    fn refresh_materializes_symlinked_runtime_root_without_mutating_source() {
+    fn linked_legacy_runtime_is_migrated_without_mutating_its_source() {
         use std::os::unix::fs::symlink;
 
-        with_isolated_home(|home| {
-            let source = tempfile::TempDir::new().expect("source tempdir");
-            let package = source.path().join("agent-runtimes/neutral-runtime");
-            let entrypoint = package.join("scripts/agent/executor.cjs");
-            let shared = source
-                .path()
-                .join("agent-runtimes/lib/cli-agent-task-executor-bin.js");
-            let executor = source
-                .path()
-                .join("agent-runtimes/lib/cli-agent-task-executor.js");
-            let contract = source.path().join("agent-task-contracts/index.js");
-            let outcome = source.path().join("runtime-agent-ci/lib/outcome.json");
-            std::fs::create_dir_all(entrypoint.parent().expect("entrypoint parent"))
-                .expect("entrypoint directory");
-            std::fs::create_dir_all(shared.parent().expect("shared parent"))
-                .expect("shared directory");
-            std::fs::create_dir_all(contract.parent().expect("contract parent"))
-                .expect("contract directory");
-            std::fs::create_dir_all(outcome.parent().expect("outcome parent"))
-                .expect("outcome directory");
-            std::fs::write(
-                package.join("neutral-runtime.json"),
-                r#"{"schema":"homeboy/agent-runtime-manifest/v1","id":"neutral-runtime"}"#,
-            )
-            .expect("manifest");
-            std::fs::write(
-                &entrypoint,
-                "require('../../../lib/cli-agent-task-executor-bin').run();\n",
-            )
-            .expect("entrypoint");
-            std::fs::write(
-                &shared,
-                "exports.run = require('./cli-agent-task-executor').run;\n",
-            )
-            .expect("shared dependency");
-            std::fs::write(
-                &executor,
-                "const contract = require('../../agent-task-contracts');\nconst outcome = require('../../runtime-agent-ci/lib/outcome.json');\nexports.run = () => process.stdout.write(`${contract.status}:${outcome.status}\\n`);\n",
-            )
-            .expect("transitive executor dependency");
-            std::fs::write(&contract, "exports.status = 'ready';\n").expect("shared contract");
-            std::fs::write(&outcome, r#"{"status":"normalized"}"#).expect("shared outcome");
-            write_runtime_package(source.path(), "sibling-runtime", "sibling");
-            commit_source(source.path());
-            let source_before = tree_bytes(source.path());
-            let source_revision =
-                crate::git::short_head_revision(source.path()).expect("source revision");
+        with_isolated_home(|_| {
+            let linked = tempfile::tempdir().unwrap();
+            package(linked.path(), "legacy", "linked");
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "new");
+            let legacy = paths::legacy_agent_runtimes().unwrap();
+            fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+            symlink(linked.path().join("agent-runtimes"), &legacy).unwrap();
 
-            let runtime_root = home.path().join(".config/homeboy/agent-runtimes");
-            std::fs::create_dir_all(runtime_root.parent().expect("runtime root parent"))
-                .expect("runtime root parent");
-            symlink(source.path().join("agent-runtimes"), &runtime_root)
-                .expect("symlink runtime root to source tree");
+            refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
 
-            let result = refresh("neutral-runtime", &source.path().to_string_lossy(), None)
-                .expect("refresh runtime package");
-
-            assert_eq!(tree_bytes(source.path()), source_before);
-            assert!(!std::fs::symlink_metadata(&runtime_root)
-                .expect("materialized runtime root metadata")
+            assert!(fs::symlink_metadata(&legacy)
+                .unwrap()
                 .file_type()
                 .is_symlink());
             assert_eq!(
-                std::fs::read_to_string(runtime_root.join("sibling-runtime/marker.txt"))
-                    .expect("preserved sibling runtime"),
-                "sibling"
+                fs::read_to_string(linked.path().join("agent-runtimes/legacy/marker")).unwrap(),
+                "linked"
             );
             assert_eq!(
-                std::fs::read_to_string(result.path.join(".source-revision"))
-                    .expect("installed revision metadata"),
-                source_revision
+                fs::read_to_string(paths::agent_runtimes().unwrap().join("legacy/marker")).unwrap(),
+                "linked"
             );
-            let output = Command::new("node")
-                .arg(result.path.join("scripts/agent/executor.cjs"))
-                .output()
-                .expect("execute materialized entrypoint");
-            assert!(
-                output.status.success(),
-                "{}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-            assert_eq!(
-                String::from_utf8_lossy(&output.stdout),
-                "ready:normalized\n"
-            );
+        });
+    }
 
-            let manifest = crate::agent_runtime_manifest::discover_agent_runtime_catalog()
-                .manifests
-                .into_iter()
-                .find(|manifest| manifest.id == "neutral-runtime")
-                .expect("discovered installed runtime");
-            let plan = crate::agent_runtime_manifest::runtime_materialization_plan(
-                &manifest,
-                "test-provider",
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape_without_replacing_active_runtime() {
+        use std::os::unix::fs::symlink;
+        with_isolated_home(|_| {
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "working");
+            refresh("neutral", &source.path().to_string_lossy(), None).unwrap();
+            let outside = tempfile::tempdir().unwrap();
+            fs::create_dir_all(source.path().join("agent-task-contracts")).unwrap();
+            symlink(
+                outside.path(),
+                source.path().join("agent-task-contracts/escape"),
+            )
+            .unwrap();
+            manifest(source.path(), &["agent-task-contracts"]);
+            assert!(refresh("neutral", &source.path().to_string_lossy(), None).is_err());
+            assert_eq!(
+                fs::read_to_string(paths::agent_runtimes().unwrap().join("neutral/marker"))
+                    .unwrap(),
+                "working"
             );
-            assert_eq!(plan.selected_identity.revision, Some(source_revision));
         });
     }
 }

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::agent_runtime_manifest::AgentRuntimeManifest;
 use crate::config;
@@ -16,6 +18,9 @@ const GENERATIONS: &str = "runtime-generations";
 const CURRENT: &str = "current";
 const JOURNAL: &str = "refresh.json";
 const JOURNAL_SCHEMA: &str = "homeboy/runtime-generation-refresh/v1";
+
+#[cfg(test)]
+static CRASH_AFTER_BOUNDARY_BOOTSTRAP: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone)]
 pub struct RuntimePackageRefreshResult {
@@ -82,6 +87,8 @@ fn refresh_locked(
     let store = config_root.join(GENERATIONS);
     fs::create_dir_all(store.join("staging")).map_err(io("prepare runtime generation store"))?;
     recover(&store)?;
+    bootstrap_stable_runtime_boundary(&config_root, &store)?;
+    crash_after_boundary_bootstrap()?;
 
     let source_stage = store.join(format!("source-{}-{}", runtime_id, nonce()));
     remove_if_exists(&source_stage, "clean runtime refresh source")?;
@@ -143,7 +150,6 @@ fn refresh_locked(
     fs::rename(&stage, &generation).map_err(io("publish runtime generation"))?;
     sync_dir(&store)?;
     switch_current(&store, &generation_name)?;
-    ensure_stable_runtime_boundary(&config_root, &store)?;
     write_journal(
         &store,
         &RefreshJournal {
@@ -178,6 +184,8 @@ fn refresh_shared_assets_locked(source_root: &Path) -> Result<()> {
     let store = config_root.join(GENERATIONS);
     fs::create_dir_all(store.join("staging")).map_err(io("prepare runtime generation store"))?;
     recover(&store)?;
+    bootstrap_stable_runtime_boundary(&config_root, &store)?;
+    crash_after_boundary_bootstrap()?;
     let source_root =
         canonical_contained_directory(source_root, source_root, "resolve linked runtime source")?;
     let generation_name = format!("extension-assets-{}", nonce());
@@ -198,7 +206,6 @@ fn refresh_shared_assets_locked(source_root: &Path) -> Result<()> {
         .map_err(io("publish linked runtime generation"))?;
     sync_dir(&store)?;
     switch_current(&store, &generation_name)?;
-    ensure_stable_runtime_boundary(&config_root, &store)?;
     write_journal(
         &store,
         &RefreshJournal {
@@ -219,6 +226,10 @@ fn seed_generation(config_root: &Path, store: &Path, stage: &Path) -> Result<()>
         reject_symlink_tree(&current)?;
         return copy_regular_tree(&current, stage, "copy active runtime generation");
     }
+    seed_legacy_generation(config_root, stage)
+}
+
+fn seed_legacy_generation(config_root: &Path, stage: &Path) -> Result<()> {
     // First activation migrates the runtime surface only; all unrelated Homeboy
     // configuration remains in place and is never renamed or copied.
     let legacy = paths::legacy_agent_runtimes()?;
@@ -240,6 +251,37 @@ fn seed_generation(config_root: &Path, store: &Path, stage: &Path) -> Result<()>
                 "migrate legacy runtime dependency",
             )?;
         }
+    }
+    fs::create_dir_all(stage.join("agent-runtimes"))
+        .map_err(io("prepare legacy runtime generation"))?;
+    Ok(())
+}
+
+/// Establish the documented runtime boundary before a replacement generation is
+/// staged. Both direct and generation consumers therefore see the same seed
+/// generation if the process stops before the later current-pointer switch.
+fn bootstrap_stable_runtime_boundary(config_root: &Path, store: &Path) -> Result<()> {
+    if active_current_generation(store)?.is_none() {
+        let generation_name = format!("bootstrap-{}", nonce());
+        let stage = store.join("staging").join(&generation_name);
+        remove_if_exists(&stage, "clean bootstrap runtime generation stage")?;
+        seed_legacy_generation(config_root, &stage)?;
+        sync_tree(&stage)?;
+        fs::rename(&stage, store.join(&generation_name))
+            .map_err(io("publish bootstrap runtime generation"))?;
+        sync_dir(store)?;
+        switch_current(store, &generation_name)?;
+    }
+    ensure_stable_runtime_boundary(config_root)
+}
+
+fn crash_after_boundary_bootstrap() -> Result<()> {
+    #[cfg(test)]
+    if CRASH_AFTER_BOUNDARY_BOOTSTRAP.swap(false, Ordering::SeqCst) {
+        return Err(Error::internal_io(
+            "injected crash after stable runtime boundary bootstrap",
+            Some("test runtime generation crash".to_string()),
+        ));
     }
     Ok(())
 }
@@ -573,7 +615,7 @@ fn switch_current(store: &Path, generation: &str) -> Result<()> {
     sync_dir(store)
 }
 
-fn ensure_stable_runtime_boundary(config_root: &Path, _store: &Path) -> Result<()> {
+fn ensure_stable_runtime_boundary(config_root: &Path) -> Result<()> {
     let boundary = paths::legacy_agent_runtimes()?;
     let expected = Path::new(GENERATIONS).join(CURRENT).join("agent-runtimes");
     if fs::read_link(&boundary).ok().as_deref() == Some(expected.as_path()) {
@@ -582,18 +624,25 @@ fn ensure_stable_runtime_boundary(config_root: &Path, _store: &Path) -> Result<(
     // The first generation already contains a validated copy of a legacy
     // directory or linked source. Replace that old boundary once, never again.
     let backup = config_root.join(format!(".agent-runtimes-legacy-{}", nonce()));
-    if fs::symlink_metadata(&boundary).is_ok() {
-        fs::rename(&boundary, &backup).map_err(io("migrate legacy runtime boundary"))?;
-    }
+    let temporary = config_root.join(format!(".agent-runtimes-boundary-{}", nonce()));
+    remove_if_exists(&temporary, "clean staged runtime boundary")?;
     #[cfg(unix)]
-    let linked = std::os::unix::fs::symlink(&expected, &boundary);
+    let linked = std::os::unix::fs::symlink(&expected, &temporary);
     #[cfg(windows)]
-    let linked = std::os::windows::fs::symlink_dir(&expected, &boundary);
-    if let Err(error) = linked {
+    let linked = std::os::windows::fs::symlink_dir(&expected, &temporary);
+    linked.map_err(io("stage stable runtime boundary"))?;
+    if fs::symlink_metadata(&boundary).is_ok() {
+        if let Err(error) = fs::rename(&boundary, &backup) {
+            let _ = remove_if_exists(&temporary, "clean staged runtime boundary");
+            return Err(io("migrate legacy runtime boundary")(error));
+        }
+    }
+    if let Err(error) = fs::rename(&temporary, &boundary) {
         if fs::symlink_metadata(&backup).is_ok() {
             let _ = fs::rename(&backup, &boundary);
         }
-        return Err(io("create stable runtime boundary")(error));
+        let _ = remove_if_exists(&temporary, "clean staged runtime boundary");
+        return Err(io("publish stable runtime boundary")(error));
     }
     sync_dir(config_root)?;
     remove_if_exists(&backup, "remove migrated legacy runtime boundary")?;
@@ -811,26 +860,39 @@ mod tests {
     }
 
     #[test]
-    fn installed_runtime_and_declared_dependencies_execute_without_source_siblings() {
+    #[ignore = "requires HOMEBOY_OPENCODE_RUNTIME_SOURCE with a Homeboy Extensions checkout"]
+    fn installed_opencode_boundary_suite_runs_without_source_siblings() {
         with_isolated_home(|_| {
-            let source = tempfile::tempdir().unwrap();
-            let runtime = package(source.path(), "opencode", "new");
-            fs::create_dir_all(source.path().join("agent-runtimes/lib")).unwrap();
-            fs::create_dir_all(source.path().join("agent-task-contracts")).unwrap();
-            fs::write(runtime.join("run.cjs"), "console.log(require('../lib/shared').value + require('../../agent-task-contracts').value)").unwrap();
-            fs::write(
-                source.path().join("agent-runtimes/lib/shared.js"),
-                "exports.value='installed-'",
+            let source =
+                PathBuf::from(std::env::var_os("HOMEBOY_OPENCODE_RUNTIME_SOURCE").expect(
+                    "set HOMEBOY_OPENCODE_RUNTIME_SOURCE to a Homeboy Extensions source root",
+                ));
+            assert!(source.join(ROOT_MANIFEST).is_file());
+            assert!(source
+                .join("agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js")
+                .is_file());
+
+            let staged_source = tempfile::tempdir().unwrap();
+            fs::copy(
+                source.join(ROOT_MANIFEST),
+                staged_source.path().join(ROOT_MANIFEST),
             )
             .unwrap();
-            fs::write(
-                source.path().join("agent-task-contracts/index.js"),
-                "exports.value='boundary'",
-            )
-            .unwrap();
-            manifest(source.path(), &["agent-runtimes", "agent-task-contracts"]);
-            let result = refresh("opencode", &source.path().to_string_lossy(), None).unwrap();
-            fs::remove_dir_all(source.path()).unwrap();
+            let manifest: RootManifest =
+                serde_json::from_slice(&fs::read(source.join(ROOT_MANIFEST)).unwrap()).unwrap();
+            for asset in manifest.shared_assets {
+                let asset = asset.path();
+                copy_regular_tree(
+                    &source.join(&asset),
+                    &staged_source.path().join(&asset),
+                    "stage real OpenCode runtime test source",
+                )
+                .unwrap();
+            }
+
+            let result =
+                refresh("opencode", &staged_source.path().to_string_lossy(), None).unwrap();
+            fs::remove_dir_all(staged_source.path()).unwrap();
             let documented = paths::legacy_agent_runtimes().unwrap();
             assert_eq!(result.path, documented.join("opencode"));
             assert_eq!(
@@ -838,7 +900,9 @@ mod tests {
                 Path::new("runtime-generations/current/agent-runtimes")
             );
             let output = Command::new("node")
-                .arg(documented.join("opencode/run.cjs"))
+                .arg(
+                    documented.join("opencode/tests/opencode-agent-task-executor-boundary.test.js"),
+                )
                 .output()
                 .unwrap();
             assert!(
@@ -846,10 +910,37 @@ mod tests {
                 "{}",
                 String::from_utf8_lossy(&output.stderr)
             );
+        });
+    }
+
+    #[test]
+    fn crash_after_boundary_bootstrap_keeps_direct_and_generation_consumers_coherent() {
+        with_isolated_home(|_| {
+            let root = paths::homeboy().unwrap();
+            package(&root, "legacy", "old");
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "new");
+
+            CRASH_AFTER_BOUNDARY_BOOTSTRAP.store(true, Ordering::SeqCst);
+            assert!(refresh("neutral", &source.path().to_string_lossy(), None).is_err());
+
+            let boundary = paths::legacy_agent_runtimes().unwrap();
+            let current = active_current_generation(&root.join(GENERATIONS))
+                .unwrap()
+                .unwrap();
             assert_eq!(
-                String::from_utf8_lossy(&output.stdout),
-                "installed-boundary\n"
+                fs::read_link(&boundary).unwrap(),
+                Path::new("runtime-generations/current/agent-runtimes")
             );
+            assert_eq!(
+                fs::read_to_string(boundary.join("legacy/marker")).unwrap(),
+                "old"
+            );
+            assert_eq!(
+                fs::read_to_string(current.join("agent-runtimes/legacy/marker")).unwrap(),
+                "old"
+            );
+            assert!(!boundary.join("neutral").exists());
         });
     }
 

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -18,9 +18,13 @@ const GENERATIONS: &str = "runtime-generations";
 const CURRENT: &str = "current";
 const JOURNAL: &str = "refresh.json";
 const JOURNAL_SCHEMA: &str = "homeboy/runtime-generation-refresh/v1";
+const BOUNDARY_MIGRATION: &str = ".agent-runtimes-migration.json";
+const BOUNDARY_MIGRATION_SCHEMA: &str = "homeboy/runtime-boundary-migration/v1";
 
 #[cfg(test)]
 static CRASH_AFTER_BOUNDARY_BOOTSTRAP: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+static CRASH_AFTER_BOUNDARY_BACKUP_RENAME: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone)]
 pub struct RuntimePackageRefreshResult {
@@ -67,6 +71,13 @@ struct RefreshJournal {
     generation: String,
     #[serde(default)]
     switched: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BoundaryMigration {
+    schema: String,
+    backup: String,
+    temporary: String,
 }
 
 pub fn refresh(
@@ -281,6 +292,17 @@ fn crash_after_boundary_bootstrap() -> Result<()> {
         return Err(Error::internal_io(
             "injected crash after stable runtime boundary bootstrap",
             Some("test runtime generation crash".to_string()),
+        ));
+    }
+    Ok(())
+}
+
+fn crash_after_boundary_backup_rename() -> Result<()> {
+    #[cfg(test)]
+    if CRASH_AFTER_BOUNDARY_BACKUP_RENAME.swap(false, Ordering::SeqCst) {
+        return Err(Error::internal_io(
+            "injected crash after legacy runtime boundary backup rename",
+            Some("test runtime boundary migration crash".to_string()),
         ));
     }
     Ok(())
@@ -631,25 +653,47 @@ fn ensure_stable_runtime_boundary(config_root: &Path) -> Result<()> {
     #[cfg(windows)]
     let linked = std::os::windows::fs::symlink_dir(&expected, &temporary);
     linked.map_err(io("stage stable runtime boundary"))?;
+    sync_dir(config_root)?;
+    write_boundary_migration(
+        config_root,
+        &BoundaryMigration {
+            schema: BOUNDARY_MIGRATION_SCHEMA.to_string(),
+            backup: backup
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("generated boundary backup name is valid UTF-8")
+                .to_string(),
+            temporary: temporary
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("generated boundary temporary name is valid UTF-8")
+                .to_string(),
+        },
+    )?;
     if fs::symlink_metadata(&boundary).is_ok() {
-        if let Err(error) = fs::rename(&boundary, &backup) {
-            let _ = remove_if_exists(&temporary, "clean staged runtime boundary");
-            return Err(io("migrate legacy runtime boundary")(error));
-        }
+        fs::rename(&boundary, &backup).map_err(io("migrate legacy runtime boundary"))?;
+        sync_dir(config_root)?;
+        crash_after_boundary_backup_rename()?;
     }
-    if let Err(error) = fs::rename(&temporary, &boundary) {
-        if fs::symlink_metadata(&backup).is_ok() {
-            let _ = fs::rename(&backup, &boundary);
-        }
-        let _ = remove_if_exists(&temporary, "clean staged runtime boundary");
-        return Err(io("publish stable runtime boundary")(error));
-    }
+    fs::rename(&temporary, &boundary).map_err(io("publish stable runtime boundary"))?;
     sync_dir(config_root)?;
     remove_if_exists(&backup, "remove migrated legacy runtime boundary")?;
+    sync_dir(config_root)?;
+    remove_if_exists(
+        &config_root.join(BOUNDARY_MIGRATION),
+        "finalize runtime boundary migration",
+    )?;
     sync_dir(config_root)
 }
 
 fn recover(store: &Path) -> Result<()> {
+    let config_root = store.parent().ok_or_else(|| {
+        Error::internal_io(
+            "runtime generation store has no config root",
+            Some("recover runtime boundary migration".to_string()),
+        )
+    })?;
+    recover_boundary_migration(config_root)?;
     let journal = store.join(JOURNAL);
     let Ok(raw) = fs::read(&journal) else {
         return Ok(());
@@ -682,6 +726,89 @@ fn recover(store: &Path) -> Result<()> {
     }
     remove_if_exists(&journal, "finalize recovered runtime generation")?;
     sync_dir(store)
+}
+
+fn write_boundary_migration(config_root: &Path, migration: &BoundaryMigration) -> Result<()> {
+    let bytes = serde_json::to_vec(migration).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("serialize runtime boundary migration".to_string()),
+        )
+    })?;
+    let intent = config_root.join(BOUNDARY_MIGRATION);
+    let temporary = config_root.join(format!(".{BOUNDARY_MIGRATION}-{}", nonce()));
+    write_synced(&temporary, &bytes, "write runtime boundary migration")?;
+    fs::rename(&temporary, &intent).map_err(io("publish runtime boundary migration"))?;
+    sync_dir(config_root)
+}
+
+fn recover_boundary_migration(config_root: &Path) -> Result<()> {
+    let intent = config_root.join(BOUNDARY_MIGRATION);
+    let Ok(raw) = fs::read(&intent) else {
+        return Ok(());
+    };
+    let migration: BoundaryMigration = serde_json::from_slice(&raw).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read runtime boundary migration".to_string()),
+        )
+    })?;
+    if migration.schema != BOUNDARY_MIGRATION_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "runtime_generation",
+            "unknown runtime boundary migration",
+            Some(migration.schema),
+            None,
+        ));
+    }
+    let backup = config_root.join(single_config_entry(&migration.backup, "runtime_boundary")?);
+    let temporary = config_root.join(single_config_entry(
+        &migration.temporary,
+        "runtime_boundary",
+    )?);
+    let boundary = paths::legacy_agent_runtimes()?;
+    let expected = Path::new(GENERATIONS).join(CURRENT).join("agent-runtimes");
+
+    if fs::read_link(&boundary).ok().as_deref() != Some(expected.as_path()) {
+        if fs::symlink_metadata(&boundary).is_err()
+            && fs::read_link(&temporary).ok().as_deref() == Some(expected.as_path())
+        {
+            fs::rename(&temporary, &boundary)
+                .map_err(io("recover stable runtime boundary publication"))?;
+            sync_dir(config_root)?;
+        } else if fs::symlink_metadata(&boundary).is_err() && fs::symlink_metadata(&backup).is_ok()
+        {
+            fs::rename(&backup, &boundary).map_err(io("restore legacy runtime boundary"))?;
+            sync_dir(config_root)?;
+        }
+    }
+
+    if fs::read_link(&boundary).ok().as_deref() == Some(expected.as_path()) {
+        remove_if_exists(&backup, "finalize recovered runtime boundary backup")?;
+    } else if fs::symlink_metadata(&boundary).is_err() {
+        return Err(Error::validation_invalid_argument(
+            "runtime_generation",
+            "runtime boundary migration has no recoverable boundary",
+            Some(intent.display().to_string()),
+            None,
+        ));
+    }
+    remove_if_exists(&temporary, "finalize recovered runtime boundary stage")?;
+    remove_if_exists(&intent, "finalize recovered runtime boundary migration")?;
+    sync_dir(config_root)
+}
+
+fn single_config_entry<'a>(value: &'a str, field: &str) -> Result<&'a Path> {
+    let path = safe_relative(value, field)?;
+    if path.components().count() != 1 {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "path is not a config-root entry",
+            Some(value.to_string()),
+            None,
+        ));
+    }
+    Ok(path)
 }
 
 fn write_journal(store: &Path, journal: &RefreshJournal) -> Result<()> {
@@ -941,6 +1068,44 @@ mod tests {
                 "old"
             );
             assert!(!boundary.join("neutral").exists());
+        });
+    }
+
+    #[test]
+    fn recovery_after_boundary_backup_rename_restores_a_coherent_stable_boundary() {
+        with_isolated_home(|_| {
+            let root = paths::homeboy().unwrap();
+            package(&root, "legacy", "old");
+            let source = tempfile::tempdir().unwrap();
+            package(source.path(), "neutral", "new");
+            let store = root.join(GENERATIONS);
+
+            CRASH_AFTER_BOUNDARY_BACKUP_RENAME.store(true, Ordering::SeqCst);
+            assert!(refresh("neutral", &source.path().to_string_lossy(), None).is_err());
+
+            let boundary = paths::legacy_agent_runtimes().unwrap();
+            assert!(fs::symlink_metadata(&boundary).is_err());
+            let current = active_current_generation(&store).unwrap().unwrap();
+            assert_eq!(
+                fs::read_to_string(current.join("agent-runtimes/legacy/marker")).unwrap(),
+                "old"
+            );
+
+            recover(&store).unwrap();
+
+            assert_eq!(
+                fs::read_link(&boundary).unwrap(),
+                Path::new("runtime-generations/current/agent-runtimes")
+            );
+            assert_eq!(
+                fs::read_to_string(boundary.join("legacy/marker")).unwrap(),
+                "old"
+            );
+            assert_eq!(
+                fs::read_to_string(current.join("agent-runtimes/legacy/marker")).unwrap(),
+                "old"
+            );
+            assert!(!root.join(BOUNDARY_MIGRATION).exists());
         });
     }
 

--- a/crates/homeboy-extension/src/lifecycle/install_sources.rs
+++ b/crates/homeboy-extension/src/lifecycle/install_sources.rs
@@ -366,7 +366,10 @@ fn installed_shared_asset_target(extension_dir: &Path, shared_dir: &str) -> Resu
         )
     })?;
     Ok(match shared_dir {
-        "agent-runtimes" => paths::agent_runtimes()?,
+        // Extension installation maintains the legacy/source layout. A runtime
+        // refresh snapshots it into an immutable generation; it must not write
+        // through the active generation read boundary.
+        "agent-runtimes" => paths::legacy_agent_runtimes()?,
         "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(shared_dir),
         // Shared extension libraries install under the extensions root so
         // installed wrappers can source `../../../scripts/lib/...`.

--- a/crates/homeboy-extension/src/lifecycle/install_sources.rs
+++ b/crates/homeboy-extension/src/lifecycle/install_sources.rs
@@ -317,7 +317,19 @@ fn install_shared_assets_from_root(
     extension_dir: &Path,
     mode: SharedAssetMode,
 ) -> Result<()> {
+    if runtime_generation_boundary_active()? {
+        // Once runtime generations are active, extension refreshes publish a
+        // successor generation rather than writing through the stable link.
+        homeboy_core::runtime_package::refresh_shared_assets(source_root)?;
+    }
     for shared_dir in shared_assets_for_root(source_root) {
+        if matches!(
+            shared_dir.as_str(),
+            "agent-runtimes" | "agent-task-contracts" | "runtime-agent-ci"
+        ) && runtime_generation_boundary_active()?
+        {
+            continue;
+        }
         let source = source_root.join(&shared_dir);
         if !source.is_dir() {
             continue;
@@ -341,6 +353,15 @@ fn install_shared_assets_from_root(
     }
 
     Ok(())
+}
+
+fn runtime_generation_boundary_active() -> Result<bool> {
+    Ok(std::fs::read_link(paths::legacy_agent_runtimes()?)
+        .ok()
+        .as_deref()
+        == Some(std::path::Path::new(
+            "runtime-generations/current/agent-runtimes",
+        )))
 }
 
 fn persist_installed_root_manifest(source_root: &Path, extension_dir: &Path) -> Result<()> {

--- a/crates/homeboy-paths/src/locations.rs
+++ b/crates/homeboy-paths/src/locations.rs
@@ -36,30 +36,9 @@ pub fn extensions() -> Result<PathBuf> {
 
 /// Agent runtime package directory
 pub fn agent_runtimes() -> Result<PathBuf> {
-    let root = homeboy()?;
-    let generations = root.join("runtime-generations");
-    let current = generations.join("current");
-    // Generations are opt-in at read time: installs created before #10478 keep
-    // their established location until the first successful refresh publishes one.
-    Ok(if current_generation(&generations, &current) {
-        current.join("agent-runtimes")
-    } else {
-        root.join("agent-runtimes")
-    })
-}
-
-fn current_generation(generations: &std::path::Path, current: &std::path::Path) -> bool {
-    let Ok(target) = std::fs::read_link(current) else {
-        return false;
-    };
-    if target.is_absolute()
-        || target
-            .components()
-            .any(|part| !matches!(part, std::path::Component::Normal(_)))
-    {
-        return false;
-    }
-    generations.join(target).join("agent-runtimes").is_dir()
+    // This is the documented and process-stable runtime boundary. Generation
+    // activation changes only runtime-generations/current behind this path.
+    Ok(homeboy()?.join("agent-runtimes"))
 }
 
 /// Legacy runtime package directory, used only while migrating it into a

--- a/crates/homeboy-paths/src/locations.rs
+++ b/crates/homeboy-paths/src/locations.rs
@@ -36,6 +36,35 @@ pub fn extensions() -> Result<PathBuf> {
 
 /// Agent runtime package directory
 pub fn agent_runtimes() -> Result<PathBuf> {
+    let root = homeboy()?;
+    let generations = root.join("runtime-generations");
+    let current = generations.join("current");
+    // Generations are opt-in at read time: installs created before #10478 keep
+    // their established location until the first successful refresh publishes one.
+    Ok(if current_generation(&generations, &current) {
+        current.join("agent-runtimes")
+    } else {
+        root.join("agent-runtimes")
+    })
+}
+
+fn current_generation(generations: &std::path::Path, current: &std::path::Path) -> bool {
+    let Ok(target) = std::fs::read_link(current) else {
+        return false;
+    };
+    if target.is_absolute()
+        || target
+            .components()
+            .any(|part| !matches!(part, std::path::Component::Normal(_)))
+    {
+        return false;
+    }
+    generations.join(target).join("agent-runtimes").is_dir()
+}
+
+/// Legacy runtime package directory, used only while migrating it into a
+/// generation. Runtime consumers must use [`agent_runtimes`].
+pub fn legacy_agent_runtimes() -> Result<PathBuf> {
     Ok(homeboy()?.join("agent-runtimes"))
 }
 


### PR DESCRIPTION
## Summary

- materialize a runtime package and all manifest-declared shared dependencies into one immutable generation
- atomically switch one `runtime-generations/current` boundary so consumers never observe mixed package/dependency versions
- preserve the documented `agent-runtimes/<id>` path through a stable generation indirection with crash-safe legacy migration
- serialize refreshes, fsync transaction state, and recover pre/post-switch or boundary-migration interruptions idempotently
- preserve unrelated config/runtimes and linked extension sources while rejecting symlink/path escapes
- retain package-only legacy fallback and record generation provenance

## Root cause

The OpenCode review-form fix was already present in Homeboy Extensions, but local `runtime refresh` copied only the runtime package. Its installed imports resolved stale/missing sibling contracts and produced `provider_error`. Package and dependencies need one installed compatibility boundary, not sequential copies.

## Verification

- `cargo test -p homeboy-core runtime_package -- --test-threads=1` (10 passed, 1 environment-gated integration)
- `HOMEBOY_OPENCODE_RUNTIME_SOURCE=/Users/chubes/Developer/homeboy-extensions cargo test -p homeboy-core installed_opencode_boundary_suite_runs_without_source_siblings -- --ignored --test-threads=1`
- linked monorepo runtime materialization test
- `cargo check -p homeboy-core -p homeboy-paths -p homeboy-extension`
- `cargo fmt --all -- --check`
- `git diff --check`

The real integration test stages Homeboy Extensions, removes source sibling access, and executes the authoritative installed OpenCode boundary suite through the documented legacy path.

## Compatibility

Legacy package-only installs migrate on refresh. Existing direct `agent-runtimes` consumers continue through the stable indirection. Failed validation or interrupted staging leaves the prior generation active; recovery handles the one-time boundary migration.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode designed and implemented the generation model through repeated adversarial review, added crash/concurrency/containment coverage, and verified the real installed OpenCode boundary. Chris Huber reviewed and remains responsible for every line.

Fixes #10478.
Operationally resolves #10417 after merge and runtime refresh.