### PR TITLE
fix(lab): persist evidence before returning references

### DIFF
--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -13,7 +13,8 @@ use homeboy_api_jobs_contract::types;
 pub(crate) use persistence::timestamp_ms;
 pub use remote_runner::{
     JobArtifactMetadata, RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,
-    RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata, RunnerJobProjectionCancelRequest,
+    RemoteRunnerObservationRunDetail, RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata,
+    RunnerJobProjectionCancelRequest,
 };
 pub(crate) use runner_job_preparation::with_runner_job_preparation;
 pub use runner_job_preparation::{

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -1,10 +1,10 @@
-use std::collections::{HashMap, HashSet};
 use std::sync::atomic::Ordering;
 
 use homeboy_engine_primitives::content_hash;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use super::persistence::{
@@ -427,6 +427,15 @@ pub struct RemoteRunnerJobResult {
     pub data: Option<Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub observation_run_ids: Vec<String>,
+    /// Durable terminal observations retained by a reverse worker. Each record
+    /// carries its complete artifact metadata so disconnected reconciliation
+    /// never needs a live runner endpoint.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub observation_run_details: Vec<RemoteRunnerObservationRunDetail>,
+    /// Set by the broker when a legacy worker declared run IDs without the
+    /// typed terminal records needed for disconnected reconciliation.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub observation_run_details_compatibility_degraded: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<JobArtifactMetadata>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -435,6 +444,96 @@ pub struct RemoteRunnerJobResult {
     pub metrics: Option<RunnerResourceMetrics>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capture: Option<CommandCaptureMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteRunnerObservationRunDetail {
+    pub schema: String,
+    pub run: crate::observation::RunRecord,
+    #[serde(default)]
+    pub artifacts: Vec<crate::observation::ArtifactRecord>,
+}
+
+impl RemoteRunnerObservationRunDetail {
+    pub const SCHEMA_V1: &'static str = "homeboy/remote-runner-observation-run-detail/v1";
+
+    pub fn v1(
+        run: crate::observation::RunRecord,
+        artifacts: Vec<crate::observation::ArtifactRecord>,
+    ) -> Self {
+        Self {
+            schema: Self::SCHEMA_V1.to_string(),
+            run,
+            artifacts,
+        }
+    }
+}
+
+impl RemoteRunnerJobResult {
+    pub fn validate_observation_run_details(&self) -> Result<()> {
+        let declared = self
+            .observation_run_ids
+            .iter()
+            .map(|id| id.trim())
+            .collect::<HashSet<_>>();
+        if declared.len() != self.observation_run_ids.len()
+            || declared.iter().any(|id| id.is_empty())
+        {
+            return Err(Error::validation_invalid_argument(
+                "observation_run_ids",
+                "declared observation run ids must be unique non-empty strings",
+                None,
+                None,
+            ));
+        }
+
+        let mut detail_ids = HashSet::new();
+        for detail in &self.observation_run_details {
+            if detail.schema != RemoteRunnerObservationRunDetail::SCHEMA_V1 {
+                return Err(Error::validation_invalid_argument(
+                    "observation_run_details.schema",
+                    "unsupported observation run detail schema",
+                    Some(detail.schema.clone()),
+                    None,
+                ));
+            }
+            if detail.run.id.trim().is_empty() || !detail_ids.insert(detail.run.id.clone()) {
+                return Err(Error::validation_invalid_argument(
+                    "observation_run_details",
+                    "observation run detail records must have unique non-empty run ids",
+                    None,
+                    None,
+                ));
+            }
+            if detail
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.run_id != detail.run.id)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "observation_run_details.artifacts",
+                    "observation run detail artifacts must belong to their embedded run",
+                    Some(detail.run.id.clone()),
+                    None,
+                ));
+            }
+        }
+        // Legacy workers only published identities. Keep accepting that wire
+        // shape so the controller can use its durable artifact fallback.
+        if self.observation_run_details.is_empty() {
+            return Ok(());
+        }
+        if declared.len() != detail_ids.len() || declared.iter().any(|id| !detail_ids.contains(*id))
+        {
+            return Err(Error::validation_invalid_argument(
+                "observation_run_details",
+                "every declared observation run id requires one matching detail record",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -799,9 +898,12 @@ impl JobStore {
         job_id: Uuid,
         runner_id: &str,
         claim_id: &str,
-        result: RemoteRunnerJobResult,
+        mut result: RemoteRunnerJobResult,
     ) -> Result<Job> {
         self.ensure_remote_runner_claim(job_id, runner_id, claim_id)?;
+        result.validate_observation_run_details()?;
+        result.observation_run_details_compatibility_degraded =
+            !result.observation_run_ids.is_empty() && result.observation_run_details.is_empty();
         let status = if result.exit_code == 0 {
             JobStatus::Succeeded
         } else {
@@ -998,6 +1100,14 @@ impl JobStore {
     }
 
     pub(crate) fn reconcile_expired_remote_runner_claims(&self, now_ms: u64) -> Result<Vec<Job>> {
+        self.reconcile_expired_remote_runner_claims_for_runner(now_ms, None)
+    }
+
+    pub(crate) fn reconcile_expired_remote_runner_claims_for_runner(
+        &self,
+        now_ms: u64,
+        runner_id: Option<&str>,
+    ) -> Result<Vec<Job>> {
         let expired_ids = {
             let inner = self.inner.lock().expect("job store mutex poisoned");
             inner
@@ -1006,6 +1116,9 @@ impl JobStore {
                 .filter(|stored| {
                     stored.remote_runner.is_some()
                         && stored.job.status == JobStatus::Running
+                        && runner_id.is_none_or(|runner_id| {
+                            stored.job.target_runner_id.as_deref() == Some(runner_id)
+                        })
                         && stored
                             .job
                             .claim_expires_at_ms

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -8,6 +8,7 @@ use serde_json::json;
 use super::persistence::recovered_terminal_from_result;
 use super::store::{LinkedDurableRunResolution, RecoveredTerminalJob};
 use super::*;
+use crate::observation::{ArtifactRecord, RunRecord};
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
 use uuid::Uuid;
@@ -204,6 +205,8 @@ fn remote_runner_job_claim_respects_concurrency_limit() {
                 mutation_artifacts: None,
                 data: None,
                 observation_run_ids: Vec::new(),
+                observation_run_details: Vec::new(),
+                observation_run_details_compatibility_degraded: false,
                 artifacts: Vec::new(),
                 artifact_refs: Vec::new(),
                 metrics: None,
@@ -276,6 +279,8 @@ fn remote_runner_job_result_records_terminal_state_and_artifacts() {
                 mutation_artifacts: None,
                 data: Some(json!({ "summary": "passed" })),
                 observation_run_ids: Vec::new(),
+                observation_run_details: Vec::new(),
+                observation_run_details_compatibility_degraded: false,
                 artifacts: vec![JobArtifactMetadata {
                     id: "report".to_string(),
                     name: Some("report.json".to_string()),
@@ -312,6 +317,78 @@ fn remote_runner_job_result_records_terminal_state_and_artifacts() {
 }
 
 #[test]
+fn remote_runner_result_observation_details_are_additive_and_validate_declared_runs() {
+    let legacy: RemoteRunnerJobResult = serde_json::from_value(json!({ "exit_code": 0 }))
+        .expect("old result payload remains readable");
+    assert!(legacy.observation_run_details.is_empty());
+
+    let run = RunRecord {
+        id: "run-1".to_string(),
+        kind: "fuzz".to_string(),
+        component_id: None,
+        started_at: "2026-01-01T00:00:00Z".to_string(),
+        finished_at: Some("2026-01-01T00:01:00Z".to_string()),
+        status: "succeeded".to_string(),
+        command: None,
+        cwd: None,
+        homeboy_version: None,
+        git_sha: None,
+        rig_id: None,
+        metadata_json: json!({}),
+    };
+    let artifact = ArtifactRecord {
+        id: "report".to_string(),
+        run_id: run.id.clone(),
+        kind: "report".to_string(),
+        artifact_type: "file".to_string(),
+        path: "/runner/report.json".to_string(),
+        url: None,
+        public_url: None,
+        viewer_url: None,
+        viewer_links: Vec::new(),
+        sha256: Some("abc123".to_string()),
+        size_bytes: Some(42),
+        mime: Some("application/json".to_string()),
+        metadata_json: json!({ "complete": true }),
+        created_at: "2026-01-01T00:01:00Z".to_string(),
+    };
+    let result = RemoteRunnerJobResult {
+        exit_code: 0,
+        stdout: None,
+        stderr: None,
+        patch: None,
+        mutation_artifacts: None,
+        data: None,
+        observation_run_ids: vec![run.id.clone()],
+        observation_run_details: vec![RemoteRunnerObservationRunDetail::v1(run, vec![artifact])],
+        observation_run_details_compatibility_degraded: false,
+        artifacts: Vec::new(),
+        artifact_refs: Vec::new(),
+        metrics: None,
+        capture: None,
+    };
+    result
+        .validate_observation_run_details()
+        .expect("declared run has exactly one complete detail record");
+    let serialized = serde_json::to_value(&result).expect("serialize result");
+    assert_eq!(
+        serialized["observation_run_details"][0]["schema"],
+        RemoteRunnerObservationRunDetail::SCHEMA_V1
+    );
+
+    let mut unexpected = result.clone();
+    unexpected.observation_run_details[0].run.id = "unexpected-run".to_string();
+    unexpected.observation_run_details[0].artifacts.clear();
+    assert!(unexpected.validate_observation_run_details().is_err());
+
+    let mut missing = result;
+    missing.observation_run_details.clear();
+    missing
+        .validate_observation_run_details()
+        .expect("legacy declared run IDs remain accepted for fallback reconciliation");
+}
+
+#[test]
 fn remote_runner_job_failed_result_records_error_and_terminal_state() {
     let store = JobStore::default();
     let job = store
@@ -336,6 +413,8 @@ fn remote_runner_job_failed_result_records_error_and_terminal_state() {
                 mutation_artifacts: None,
                 data: None,
                 observation_run_ids: Vec::new(),
+                observation_run_details: Vec::new(),
+                observation_run_details_compatibility_degraded: false,
                 artifacts: Vec::new(),
                 artifact_refs: Vec::new(),
                 metrics: None,
@@ -595,6 +674,8 @@ fn dead_daemon_recovery_preserves_remote_work_and_uses_broker_claim_reconciliati
                 mutation_artifacts: None,
                 data: None,
                 observation_run_ids: Vec::new(),
+                observation_run_details: Vec::new(),
+                observation_run_details_compatibility_degraded: false,
                 artifacts: Vec::new(),
                 artifact_refs: Vec::new(),
                 metrics: None,

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -40,18 +40,17 @@ impl BrokerAuthContext {
         &self,
         required: BrokerScope,
         runner_id: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<Option<crate::broker_auth::BrokerAuthGrant>> {
         if self.trusted_local {
-            return Ok(());
+            return Ok(None);
         }
         let store = BrokerAuthStore::load()?;
-        store.authorize(
+        Ok(Some(store.authorize(
             self.loopback_bind,
             self.token.as_deref(),
             required,
             runner_id,
-        )?;
-        Ok(())
+        )?))
     }
 }
 
@@ -130,15 +129,15 @@ pub(in crate::daemon) fn route(
             Ok(body) => daemon_endpoint_response("runner.jobs.submissions.lookup", body),
             Err(err) => auth_or_bad_request(err),
         },
-        ("POST", "/runner/jobs/reconcile") => match reconcile(job_store) {
+        ("POST", "/runner/jobs/reconcile") => match reconcile(body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.reconcile", body),
-            Err(err) => error_response(400, err),
+            Err(err) => auth_or_bad_request(err),
         },
         ("POST", "/runner/jobs/claim") => match claim(body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.claim", body),
             Err(err) => auth_or_bad_request(err),
         },
-        ("GET", path) if path.starts_with("/runner/jobs/") => lookup(path, job_store),
+        ("GET", path) if path.starts_with("/runner/jobs/") => lookup(path, job_store, auth),
         ("POST", path) if path.starts_with("/runner/jobs/") => update(path, body, job_store, auth),
         _ => error_response(
             404,
@@ -156,7 +155,13 @@ pub(in crate::daemon) fn route(
     }
 }
 
-fn lookup(path: &str, job_store: &JobStore) -> HttpResponse {
+fn lookup(path: &str, job_store: &JobStore, auth: &BrokerAuthContext) -> HttpResponse {
+    if let Some((job_id, run_id)) = job_run_path(path) {
+        return match lookup_run(job_id, &run_id, job_store, auth) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.runs.lookup", body),
+            Err(err) => lookup_run_error_response(err),
+        };
+    }
     let Some((job_id, artifact_id, content)) = job_artifact_path(path) else {
         return error_response(
             404,
@@ -172,17 +177,114 @@ fn lookup(path: &str, job_store: &JobStore) -> HttpResponse {
     };
 
     let result = if content {
-        lookup_artifact_content(job_id, &artifact_id, job_store)
+        lookup_artifact_content(job_id, &artifact_id, job_store, auth)
     } else {
-        lookup_artifact(job_id, &artifact_id, job_store)
+        lookup_artifact(job_id, &artifact_id, job_store, auth)
     };
     match result {
         Ok(body) => daemon_endpoint_response("runner.jobs.artifacts.lookup", body),
-        Err(err) => error_response(404, err),
+        Err(err) => lookup_run_error_response(err),
     }
 }
 
-fn lookup_artifact(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Result<Value> {
+fn lookup_run(
+    job_id: Uuid,
+    run_id: &str,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    authorize_job_read(job_id, job_store, auth)?;
+    let result = job_store
+        .events(job_id)?
+        .into_iter()
+        .rev()
+        .find(|event| event.kind == JobEventKind::Result)
+        .and_then(|event| event.data)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                "terminal job result is unavailable",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    let result: RemoteRunnerJobResult = serde_json::from_value(result).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse persisted reverse runner result".to_string()),
+        )
+    })?;
+    result.validate_observation_run_details().map_err(|error| {
+        Error::internal_json(
+            error.message,
+            Some("validate persisted reverse runner run details".to_string()),
+        )
+    })?;
+    let detail = result
+        .observation_run_details
+        .iter()
+        .find(|detail| detail.run.id == run_id)
+        .cloned()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                "declared observation run not found for job",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    Ok(json!({ "job_id": job_id.to_string(), "run": detail }))
+}
+
+fn lookup_run_error_response(err: Error) -> HttpResponse {
+    let status = match err.code {
+        crate::error::ErrorCode::BrokerAuthDenied => 401,
+        crate::error::ErrorCode::RunnerPolicyDenied => 403,
+        crate::error::ErrorCode::InternalIoError
+        | crate::error::ErrorCode::InternalJsonError
+        | crate::error::ErrorCode::InternalUnexpected => 500,
+        _ => 404,
+    };
+    error_response(status, err)
+}
+
+fn job_run_path(path: &str) -> Option<(Uuid, String)> {
+    let parts = path
+        .strip_prefix("/runner/jobs/")?
+        .split('/')
+        .collect::<Vec<_>>();
+    (parts.len() == 3 && parts[1] == "runs")
+        .then(|| Some((Uuid::parse_str(parts[0]).ok()?, parts[2].to_string())))?
+}
+
+fn authorize_job_read(job_id: Uuid, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<()> {
+    // Authenticate before revealing whether the broker holds this job.
+    let grant = match auth.authorize(BrokerScope::Work, None) {
+        Ok(grant) => grant,
+        // Controllers need to observe jobs they submit, but that must not give
+        // their Submit credential any unrelated worker privileges.
+        Err(_) => auth.authorize(BrokerScope::Submit, None)?,
+    };
+    let job = job_store.get(job_id)?;
+    if let Some(grant) = grant {
+        if job.target_runner_id.as_deref() != Some(grant.runner_id.as_str()) {
+            return Err(Error::new(
+                crate::error::ErrorCode::RunnerPolicyDenied,
+                "remote runner job is not owned by this runner",
+                json!({ "runner_id": grant.runner_id }),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn lookup_artifact(
+    job_id: Uuid,
+    artifact_id: &str,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    authorize_job_read(job_id, job_store, auth)?;
     let job = job_store.get(job_id)?;
     let encoded_artifact_id = crate::execution_contract::encode_uri_component(artifact_id);
     let content_path = format!("/runner/jobs/{job_id}/artifacts/{encoded_artifact_id}/content");
@@ -222,7 +324,13 @@ fn lookup_artifact(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Res
     }))
 }
 
-fn lookup_artifact_content(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Result<Value> {
+fn lookup_artifact_content(
+    job_id: Uuid,
+    artifact_id: &str,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    authorize_job_read(job_id, job_store, auth)?;
     let artifact = mirrored_artifact_content(job_id, artifact_id, job_store)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "artifact_id",
@@ -293,9 +401,20 @@ fn inline_content_retrieval() -> Value {
     })
 }
 
-fn reconcile(job_store: &JobStore) -> Result<Value> {
+#[derive(Debug, Clone, Deserialize)]
+struct ReconcileRequest {
+    #[serde(default)]
+    runner_id: Option<String>,
+}
+
+fn reconcile(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
+    let request: ReconcileRequest = parse_body(body, "remote runner reconcile request")?;
+    let grant = auth.authorize(BrokerScope::Submit, request.runner_id.as_deref())?;
     let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
-    let reconciled = job_store.reconcile_expired_remote_runner_claims(now_ms)?;
+    let reconciled = job_store.reconcile_expired_remote_runner_claims_for_runner(
+        now_ms,
+        grant.as_ref().map(|grant| grant.runner_id.as_str()),
+    )?;
     Ok(json!({
         "command": "api.runner.jobs.reconcile",
         "reconciled": reconciled,
@@ -362,8 +481,8 @@ fn register_session(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Val
 }
 
 fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
-    auth.authorize(BrokerScope::Submit, None)?;
     let mut request: RemoteRunnerJobRequest = parse_body(body, "remote runner job request")?;
+    auth.authorize(BrokerScope::Submit, Some(request.runner_id.as_str()))?;
     request.normalize();
     let public_request = request.public_metadata();
     let job = job_store.submit_remote_runner_job(request)?;
@@ -380,6 +499,7 @@ fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) 
 
 #[derive(Deserialize)]
 struct SubmissionLookupRequest {
+    runner_id: String,
     submission_key: String,
 }
 
@@ -388,11 +508,23 @@ fn submission_lookup(
     job_store: &JobStore,
     auth: &BrokerAuthContext,
 ) -> Result<Value> {
-    auth.authorize(BrokerScope::Submit, None)?;
     let request: SubmissionLookupRequest = parse_body(body, "remote runner submission lookup")?;
+    let grant = auth.authorize(BrokerScope::Submit, Some(request.runner_id.as_str()))?;
+    let result = job_store.lookup_remote_runner_submission(&request.submission_key);
+    if let crate::api_jobs::RemoteRunnerSubmissionLookup::Accepted { job } = &result {
+        if let Some(grant) = grant {
+            if job.target_runner_id.as_deref() != Some(grant.runner_id.as_str()) {
+                return Err(Error::new(
+                    crate::error::ErrorCode::RunnerPolicyDenied,
+                    "remote runner submission is not owned by this runner",
+                    json!({ "runner_id": grant.runner_id }),
+                ));
+            }
+        }
+    }
     Ok(json!({
         "command": "api.runner.jobs.submissions.lookup",
-        "result": job_store.lookup_remote_runner_submission(&request.submission_key),
+        "result": result,
     }))
 }
 
@@ -559,7 +691,7 @@ fn heartbeat(
 }
 
 fn cancel(job_id: Uuid, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
-    auth.authorize(BrokerScope::Submit, None)?;
+    authorize_job_submit(job_id, job_store, auth)?;
     let job = job_store.cancel_remote_runner_job(job_id, "cancel requested via broker API")?;
     let events = job_store.events(job_id)?;
     Ok(json!({
@@ -567,6 +699,25 @@ fn cancel(job_id: Uuid, job_store: &JobStore, auth: &BrokerAuthContext) -> Resul
         "job": job,
         "events": events,
     }))
+}
+
+fn authorize_job_submit(
+    job_id: Uuid,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<()> {
+    let grant = auth.authorize(BrokerScope::Submit, None)?;
+    let job = job_store.get(job_id)?;
+    if let Some(grant) = grant {
+        if job.target_runner_id.as_deref() != Some(grant.runner_id.as_str()) {
+            return Err(Error::new(
+                crate::error::ErrorCode::RunnerPolicyDenied,
+                "remote runner job is not owned by this submitting controller",
+                json!({ "runner_id": grant.runner_id }),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Map a handler error to an HTTP response. Broker auth rejections become
@@ -663,6 +814,277 @@ mod auth_tests {
             "command": ["homeboy", "test", "sample"],
             "cwd": "/tmp/sample"
         })
+    }
+
+    fn typed_result(run_id: &str) -> Value {
+        json!({
+            "exit_code": 0,
+            "observation_run_ids": [run_id],
+            "observation_run_details": [{
+                "schema": "homeboy/remote-runner-observation-run-detail/v1",
+                "run": {
+                    "id": run_id,
+                    "kind": "test",
+                    "component_id": null,
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "finished_at": "2026-01-01T00:01:00Z",
+                    "status": "succeeded",
+                    "command": null,
+                    "cwd": null,
+                    "homeboy_version": null,
+                    "git_sha": null,
+                    "rig_id": null,
+                    "metadata_json": {}
+                },
+                "artifacts": []
+            }]
+        })
+    }
+
+    fn terminal_typed_job(store: &JobStore, runner_id: &str, run_id: &str) -> String {
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(json!({
+                "runner_id": runner_id,
+                "command": ["homeboy", "test"],
+                "cwd": "/tmp/x"
+            })),
+            store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id")
+            .to_string();
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({ "runner_id": runner_id, "lease_ms": 30000 })),
+            store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
+            .as_str()
+            .expect("claim id")
+            .to_string();
+        let finish = route(
+            "POST",
+            &format!("/runner/jobs/{job_id}/finish"),
+            Some(json!({
+                "runner_id": runner_id,
+                "claim_id": claim_id,
+                "result": typed_result(run_id)
+            })),
+            store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(finish.status_code, 200, "finish body: {}", finish.body);
+        job_id
+    }
+
+    #[test]
+    fn run_detail_requires_a_bearer_token() {
+        let _home = HomeGuard::new();
+        pair("runner-a", BrokerScope::Work);
+        let response = route(
+            "GET",
+            &format!("/runner/jobs/{}/runs/run-1", Uuid::new_v4()),
+            None,
+            &JobStore::default(),
+            &enforcing_auth(None),
+        );
+        assert_eq!(response.status_code, 401);
+        assert_eq!(response.body["error"], "broker.auth_denied");
+    }
+
+    #[test]
+    fn run_detail_rejects_an_invalid_bearer_token() {
+        let _home = HomeGuard::new();
+        pair("runner-a", BrokerScope::Work);
+        let response = route(
+            "GET",
+            &format!("/runner/jobs/{}/runs/run-1", Uuid::new_v4()),
+            None,
+            &JobStore::default(),
+            &enforcing_auth(Some("not-a-paired-token")),
+        );
+        assert_eq!(response.status_code, 401);
+        assert_eq!(response.body["error"], "broker.auth_denied");
+    }
+
+    #[test]
+    fn run_detail_rejects_a_valid_token_for_a_different_runner() {
+        let _home = HomeGuard::new();
+        let token = pair("runner-b", BrokerScope::Work);
+        let store = JobStore::default();
+        let job_id = terminal_typed_job(&store, "runner-a", "run-1");
+
+        let response = route(
+            "GET",
+            &format!("/runner/jobs/{job_id}/runs/run-not-owned"),
+            None,
+            &store,
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(response.status_code, 403);
+        assert_eq!(response.body["error"], "runner.policy_denied");
+    }
+
+    #[test]
+    fn run_detail_returns_not_found_for_a_missing_job_or_run() {
+        let _home = HomeGuard::new();
+        let token = pair("runner-a", BrokerScope::Work);
+        let store = JobStore::default();
+        let missing_job = route(
+            "GET",
+            &format!("/runner/jobs/{}/runs/run-1", Uuid::new_v4()),
+            None,
+            &store,
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(missing_job.status_code, 404);
+
+        let job_id = terminal_typed_job(&store, "runner-a", "run-1");
+        let missing_run = route(
+            "GET",
+            &format!("/runner/jobs/{job_id}/runs/run-missing"),
+            None,
+            &store,
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(missing_run.status_code, 404);
+    }
+
+    #[test]
+    fn run_detail_returns_typed_details_to_the_owning_runner() {
+        let _home = HomeGuard::new();
+        let token = pair("runner-a", BrokerScope::Work);
+        let store = JobStore::default();
+        let job_id = terminal_typed_job(&store, "runner-a", "run-1");
+
+        let response = route(
+            "GET",
+            &format!("/runner/jobs/{job_id}/runs/run-1"),
+            None,
+            &store,
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(
+            response.status_code, 200,
+            "response body: {}",
+            response.body
+        );
+        assert_eq!(
+            response.body["body"]["run"]["schema"],
+            "homeboy/remote-runner-observation-run-detail/v1"
+        );
+        assert_eq!(response.body["body"]["run"]["run"]["id"], "run-1");
+    }
+
+    #[test]
+    fn submit_token_reads_its_own_job_but_not_another_runners_job() {
+        let _home = HomeGuard::new();
+        let submit_token = pair("runner-a", BrokerScope::Submit);
+        let store = JobStore::default();
+        let owned_job = terminal_typed_job(&store, "runner-a", "run-1");
+        let foreign_job = terminal_typed_job(&store, "runner-b", "run-2");
+
+        let owned = route(
+            "GET",
+            &format!("/runner/jobs/{owned_job}/runs/run-1"),
+            None,
+            &store,
+            &enforcing_auth(Some(&submit_token)),
+        );
+        assert_eq!(owned.status_code, 200);
+
+        let foreign = route(
+            "GET",
+            &format!("/runner/jobs/{foreign_job}/runs/run-2"),
+            None,
+            &store,
+            &enforcing_auth(Some(&submit_token)),
+        );
+        assert_eq!(foreign.status_code, 403);
+        assert_eq!(foreign.body["error"], "runner.policy_denied");
+    }
+
+    #[test]
+    fn artifact_routes_require_the_owning_work_bearer_and_preserve_not_found() {
+        let _home = HomeGuard::new();
+        let owner_token = pair("runner-a", BrokerScope::Work);
+        let other_token = pair_extra("runner-b-work", "runner-b", BrokerScope::Work);
+        let store = JobStore::default();
+        let job_id = terminal_typed_job(&store, "runner-a", "run-1");
+
+        for suffix in ["artifacts/missing", "artifacts/missing/content"] {
+            let path = format!("/runner/jobs/{job_id}/{suffix}");
+            let unauthenticated = route("GET", &path, None, &store, &enforcing_auth(None));
+            assert_eq!(unauthenticated.status_code, 401, "{suffix}");
+            assert_eq!(unauthenticated.body["error"], "broker.auth_denied");
+
+            let foreign = route(
+                "GET",
+                &path,
+                None,
+                &store,
+                &enforcing_auth(Some(&other_token)),
+            );
+            assert_eq!(foreign.status_code, 403, "{suffix}");
+            assert_eq!(foreign.body["error"], "runner.policy_denied");
+
+            let missing = route(
+                "GET",
+                &path,
+                None,
+                &store,
+                &enforcing_auth(Some(&owner_token)),
+            );
+            assert_eq!(missing.status_code, 404, "{suffix}");
+        }
+    }
+
+    #[test]
+    fn run_detail_reports_malformed_persisted_details_as_a_server_error() {
+        let _home = HomeGuard::new();
+        let token = pair("runner-a", BrokerScope::Work);
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(json!({
+                "runner_id": "runner-a",
+                "command": ["homeboy", "test"],
+                "cwd": "/tmp/x"
+            })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id")
+            .to_string();
+        let mut malformed = typed_result("run-1");
+        malformed["observation_run_details"][0]["schema"] = json!("invalid-schema");
+        store
+            .append_event(
+                Uuid::parse_str(&job_id).expect("valid job id"),
+                JobEventKind::Result,
+                None,
+                Some(malformed),
+            )
+            .expect("persist malformed result for lookup regression coverage");
+
+        let response = route(
+            "GET",
+            &format!("/runner/jobs/{job_id}/runs/run-1"),
+            None,
+            &store,
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(response.status_code, 500);
+        assert_eq!(response.body["error"], "internal.json_error");
     }
 
     #[test]
@@ -846,6 +1268,103 @@ mod auth_tests {
             content.body["body"]["content_base64"],
             json!("d29ya2VyIGFydGlmYWN0IGJ5dGVz")
         );
+    }
+
+    #[test]
+    fn broker_retains_every_declared_run_artifact_after_reverse_worker_completion() {
+        let _home = HomeGuard::new();
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id")
+            .to_string();
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({ "runner_id": "homeboy-lab", "lease_ms": 30000 })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
+            .as_str()
+            .expect("claim id")
+            .to_string();
+        let artifacts = [
+            ("direct-first", "ZGlyZWN0IGZpcnN0"),
+            ("direct-second", "ZGlyZWN0IHNlY29uZA=="),
+        ];
+        let detail_artifacts = artifacts
+            .iter()
+            .map(|(id, _)| {
+                json!({
+                    "id": id,
+                    "run_id": "declared-run",
+                    "kind": "test_output",
+                    "artifact_type": "file",
+                    "path": format!("/worker/{id}"),
+                    "metadata_json": {},
+                    "created_at": "2026-01-01T00:01:00Z"
+                })
+            })
+            .collect::<Vec<_>>();
+        let transported_artifacts = artifacts
+            .iter()
+            .map(|(id, content_base64)| {
+                json!({
+                    "id": id,
+                    "name": format!("{id}.txt"),
+                    "path": format!("/worker/{id}"),
+                    "mime": "text/plain",
+                    "size_bytes": 12,
+                    "content_base64": content_base64
+                })
+            })
+            .collect::<Vec<_>>();
+        let finish = route(
+            "POST",
+            &format!("/runner/jobs/{job_id}/finish"),
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "result": {
+                    "exit_code": 0,
+                    "observation_run_ids": ["declared-run"],
+                    "observation_run_details": [{
+                        "schema": "homeboy/remote-runner-observation-run-detail/v1",
+                        "run": {
+                            "id": "declared-run", "kind": "test", "component_id": null,
+                            "started_at": "2026-01-01T00:00:00Z", "finished_at": "2026-01-01T00:01:00Z",
+                            "status": "pass", "command": null, "cwd": null, "homeboy_version": null,
+                            "git_sha": null, "rig_id": null, "metadata_json": {}
+                        },
+                        "artifacts": detail_artifacts
+                    }],
+                    "artifacts": transported_artifacts
+                }
+            })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(finish.status_code, 200, "finish body: {}", finish.body);
+
+        for (id, direct_output) in artifacts {
+            let content = route(
+                "GET",
+                &format!("/runner/jobs/{job_id}/artifacts/{id}/content"),
+                None,
+                &store,
+                &BrokerAuthContext::trusted_local(),
+            );
+            assert_eq!(content.status_code, 200, "content body: {}", content.body);
+            assert_eq!(content.body["body"]["content_base64"], direct_output);
+        }
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/mod.rs
+++ b/crates/homeboy-core/src/observation/mod.rs
@@ -59,8 +59,8 @@ pub use records::{
 };
 pub use run_failure_causes::{nested_failure_causes_from_run_detail, RunFailureCause};
 pub use store::{
-    directory_tree_sha256, ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION,
-    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+    directory_tree_sha256, ArtifactPublication, ObservationDbStatus, ObservationStore,
+    CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
     SOURCE_SNAPSHOT_METADATA_ENV,
 };
 pub use test_findings::{

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -8,7 +8,286 @@ use uuid::Uuid;
 
 use super::*;
 
+const PUBLICATION_LEASE_MS: i64 = 5 * 60 * 1000;
+
+/// A file staged by a caller for atomic publication with its run record.
+/// The store computes controller-owned integrity metadata from `source_path`.
+#[derive(Debug, Clone)]
+pub struct ArtifactPublication {
+    pub id: String,
+    pub kind: String,
+    pub source_path: PathBuf,
+    pub mime: Option<String>,
+    pub metadata_json: serde_json::Value,
+    /// Provenance advertised by the producer. Terminal projections require
+    /// both fields; other store callers may omit them for local files.
+    pub expected_size_bytes: Option<i64>,
+    pub expected_sha256: Option<String>,
+}
+
 impl ObservationStore {
+    /// Publish a run and all of its file artifacts as one reader-visible unit.
+    ///
+    /// Files are copied and verified before the SQLite transaction begins. The
+    /// rows become visible together at commit; files created for a failed
+    /// publication are removed so a retry starts from the same durable state.
+    pub fn publish_run_artifacts_atomically(
+        &self,
+        run: &RunRecord,
+        publications: &[ArtifactPublication],
+    ) -> Result<Vec<ArtifactRecord>> {
+        validate_required("run.id", &run.id)?;
+        let mut seen = HashSet::new();
+        let publication_id = Uuid::new_v4().to_string();
+        let owner_token = Uuid::new_v4().to_string();
+        let lease_expires_at_ms = chrono::Utc::now().timestamp_millis() + PUBLICATION_LEASE_MS;
+        let mut prepared = Vec::with_capacity(publications.len());
+        let mut staged_paths = Vec::new();
+
+        let result = (|| -> Result<()> {
+            for publication in publications {
+                validate_required("artifact.id", &publication.id)?;
+                validate_required("artifact.kind", &publication.kind)?;
+                if !seen.insert(&publication.id) {
+                    return Err(Error::validation_invalid_argument(
+                        "artifact.id",
+                        "an atomic publication contains duplicate artifact ids",
+                        Some(publication.id.clone()),
+                        None,
+                    ));
+                }
+                let source = &publication.source_path;
+                let metadata = fs::symlink_metadata(source).map_err(|error| {
+                    Error::internal_io(
+                        error.to_string(),
+                        Some(format!("inspect staged artifact {}", source.display())),
+                    )
+                })?;
+                if !metadata.is_file() {
+                    return Err(Error::validation_invalid_argument(
+                        "artifact.path",
+                        "atomic artifact publication requires a regular file",
+                        Some(source.display().to_string()),
+                        None,
+                    ));
+                }
+                let stored_path = persisted_artifact_path(&run.id, &publication.id, source)?;
+                let size_bytes = i64::try_from(metadata.len()).ok();
+                let sha256 = crate::artifact_metadata::sha256_file(source)?;
+                if publication.expected_size_bytes.is_some()
+                    && publication.expected_size_bytes != size_bytes
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "artifact.size_bytes",
+                        "artifact bytes do not match the advertised provenance",
+                        size_bytes.map(|value| value.to_string()),
+                        None,
+                    ));
+                }
+                if let Some(expected_sha256) = &publication.expected_sha256 {
+                    if expected_sha256 != &sha256 {
+                        return Err(Error::validation_invalid_argument(
+                            "artifact.sha256",
+                            "artifact bytes do not match the advertised provenance",
+                            Some(sha256),
+                            None,
+                        ));
+                    }
+                }
+                if let Some(existing) = self.get_artifact(&publication.id)? {
+                    let matches = existing.run_id == run.id
+                        && existing.kind == publication.kind
+                        && existing.artifact_type == "file"
+                        && existing.size_bytes == size_bytes
+                        && existing.sha256.as_deref() == Some(sha256.as_str())
+                        && Path::new(&existing.path).is_file();
+                    if !matches {
+                        return Err(Error::validation_invalid_argument(
+                            "artifact.id",
+                            "an existing artifact has different controller ownership or bytes",
+                            Some(publication.id.clone()),
+                            None,
+                        ));
+                    }
+                    prepared.push((existing, None, None));
+                    continue;
+                }
+                let staged_path = staged_artifact_path(&stored_path, Uuid::new_v4());
+                staged_paths.push(staged_path.clone());
+                copy_artifact_file(source, &staged_path)?;
+                if crate::artifact_metadata::sha256_file(&staged_path)? != sha256 {
+                    return Err(Error::internal_unexpected(
+                        "staged artifact checksum changed before publication",
+                    ));
+                }
+                let mut artifact = ArtifactRecord {
+                    id: publication.id.clone(),
+                    run_id: run.id.clone(),
+                    kind: publication.kind.clone(),
+                    artifact_type: "file".to_string(),
+                    path: stored_path.display().to_string(),
+                    url: None,
+                    public_url: None,
+                    viewer_url: None,
+                    viewer_links: Vec::new(),
+                    sha256: Some(sha256),
+                    size_bytes,
+                    mime: publication
+                        .mime
+                        .clone()
+                        .or_else(|| crate::artifact_metadata::content_type_from_path(source)),
+                    metadata_json: publication.metadata_json.clone(),
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                };
+                crate::artifact_links::annotate_public_artifact_url_validation(&mut artifact);
+                prepared.push((artifact, Some(staged_path), Some(stored_path)));
+            }
+            // Journal the owned staging paths before they can become final.
+            // Readers only consult `runs` and `artifacts`, neither of which is
+            // written until the complete finalization transaction below.
+            let tx = self
+                .connection
+                .unchecked_transaction()
+                .map_err(sqlite_error("begin atomic observation publication"))?;
+            for (artifact, staged_path, final_path) in &prepared {
+                let (Some(staged_path), Some(final_path)) = (staged_path, final_path) else {
+                    continue;
+                };
+                tx.execute(
+                    "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![publication_id, artifact.id, staged_path.display().to_string(), final_path.display().to_string(), owner_token, lease_expires_at_ms],
+                ).map_err(sqlite_error("journal artifact publication"))?;
+            }
+            tx.commit()
+                .map_err(sqlite_error("commit artifact publication intent"))?;
+
+            for (_, staged_path, final_path) in &prepared {
+                let (Some(staged_path), Some(final_path)) = (staged_path, final_path) else {
+                    continue;
+                };
+                fs::rename(staged_path, final_path).map_err(|error| {
+                    Error::internal_io(
+                        error.to_string(),
+                        Some("finalize staged artifact".to_string()),
+                    )
+                })?;
+            }
+
+            let tx = self
+                .connection
+                .unchecked_transaction()
+                .map_err(sqlite_error("begin artifact publication finalization"))?;
+            let metadata_json = serialize_metadata(&run.metadata_json)?;
+            tx.execute(
+                r#"INSERT INTO runs(id, kind, component_id, started_at, finished_at, status, command, cwd, homeboy_version, git_sha, rig_id, metadata_json)
+                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                   ON CONFLICT(id) DO UPDATE SET kind=excluded.kind, component_id=excluded.component_id, started_at=excluded.started_at, finished_at=excluded.finished_at, status=excluded.status, command=excluded.command, cwd=excluded.cwd, homeboy_version=excluded.homeboy_version, git_sha=excluded.git_sha, rig_id=excluded.rig_id, metadata_json=excluded.metadata_json"#,
+                params![run.id, run.kind, run.component_id, run.started_at, run.finished_at, run.status, run.command, run.cwd, run.homeboy_version, run.git_sha, run.rig_id, metadata_json],
+            ).map_err(sqlite_error("publish observation run"))?;
+            for (artifact, staged_path, _) in &prepared {
+                if staged_path.is_none() {
+                    continue;
+                }
+                tx.execute(
+                    "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, url, public_url, viewer_url, viewer_links_json, sha256, size_bytes, mime, metadata_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                    params![artifact.id, artifact.run_id, artifact.kind, artifact.artifact_type, artifact.path, artifact.url, artifact.public_url, artifact.viewer_url, serialize_metadata(&serde_json::json!(artifact.viewer_links))?, artifact.sha256, artifact.size_bytes, artifact.mime, serialize_metadata(&artifact.metadata_json)?, artifact.created_at],
+                ).map_err(sqlite_error("publish observation artifact"))?;
+            }
+            tx.execute(
+                "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND owner_token = ?2",
+                params![publication_id, owner_token],
+            )
+            .map_err(sqlite_error("clear artifact publication intent"))?;
+            tx.commit()
+                .map_err(sqlite_error("commit artifact publication finalization"))?;
+            Ok(())
+        })();
+        if let Err(error) = result {
+            for path in staged_paths {
+                fs::remove_file(path).ok();
+            }
+            self.reconcile_artifact_publication(&publication_id, &owner_token)
+                .ok();
+            return Err(error);
+        }
+        prepared
+            .into_iter()
+            .map(|(artifact, _, _)| {
+                self.get_artifact(&artifact.id)?.ok_or_else(|| {
+                    Error::internal_unexpected("committed artifact record is unreadable")
+                })
+            })
+            .collect()
+    }
+
+    /// Remove only abandoned journal entries. A second store opening while a
+    /// publisher holds a live lease must leave its staging and final paths
+    /// alone; recovery is bounded by the recorded expiry timestamp.
+    pub(super) fn reconcile_unfinished_artifact_publications(&self) -> Result<()> {
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut statement = self
+            .connection
+            .prepare("SELECT staging_path, final_path FROM artifact_publication_intents WHERE lease_expires_at_ms < ?1")
+            .map_err(sqlite_error("read unfinished artifact publications"))?;
+        let paths = statement
+            .query_map([now], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(sqlite_error("query unfinished artifact publications"))?;
+        let paths = collect_rows(paths, "collect unfinished artifact publications")?;
+        for (staging_path, final_path) in paths {
+            fs::remove_file(staging_path).ok();
+            fs::remove_file(final_path).ok();
+        }
+        self.connection
+            .execute(
+                "DELETE FROM artifact_publication_intents WHERE lease_expires_at_ms < ?1",
+                [now],
+            )
+            .map_err(sqlite_error("clear unfinished artifact publications"))?;
+        Ok(())
+    }
+
+    fn reconcile_artifact_publication(
+        &self,
+        publication_id: &str,
+        owner_token: &str,
+    ) -> Result<()> {
+        let mut statement = self.connection.prepare(
+            "SELECT staging_path, final_path FROM artifact_publication_intents WHERE publication_id = ?1 AND owner_token = ?2",
+        ).map_err(sqlite_error("read owned artifact publication"))?;
+        let paths = statement
+            .query_map(params![publication_id, owner_token], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(sqlite_error("query owned artifact publication"))?;
+        for (staging_path, final_path) in collect_rows(paths, "collect owned artifact publication")?
+        {
+            fs::remove_file(staging_path).ok();
+            fs::remove_file(final_path).ok();
+        }
+        self.connection.execute(
+            "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND owner_token = ?2",
+            params![publication_id, owner_token],
+        ).map_err(sqlite_error("clear owned artifact publication"))?;
+        Ok(())
+    }
+
+    /// Roll back a synthetic controller run when its terminal artifact
+    /// publication cannot complete. Callers must never use this for a run
+    /// identity owned by another lifecycle.
+    pub fn discard_synthetic_run(&self, run_id: &str) -> Result<()> {
+        let tx = self
+            .connection
+            .unchecked_transaction()
+            .map_err(sqlite_error("begin synthetic run rollback"))?;
+        tx.execute("DELETE FROM artifacts WHERE run_id = ?1", [run_id])
+            .map_err(sqlite_error("delete synthetic run artifacts"))?;
+        tx.execute("DELETE FROM runs WHERE id = ?1", [run_id])
+            .map_err(sqlite_error("delete synthetic run"))?;
+        tx.commit()
+            .map_err(sqlite_error("commit synthetic run rollback"))
+    }
     pub fn import_artifact(&self, artifact: &ArtifactRecord) -> Result<()> {
         let artifact = artifact_with_link_metadata(artifact);
         validate_required("artifact.id", &artifact.id)?;
@@ -1245,6 +1524,105 @@ mod tests {
                     .file_name()
                     .to_string_lossy()
                     .starts_with(".artifact-")));
+        });
+    }
+
+    #[test]
+    fn atomic_publication_rolls_back_earlier_artifacts_and_retries_cleanly() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("test").cwd_path(home.path()).build())
+                .expect("run");
+            let first = home.path().join("first.json");
+            let second = home.path().join("second.json");
+            fs::write(&first, b"first").expect("first bytes");
+            fs::write(&second, b"second").expect("second bytes");
+            let publication = |id: &str, source_path: PathBuf| ArtifactPublication {
+                id: id.to_string(),
+                kind: "test".to_string(),
+                source_path,
+                mime: None,
+                metadata_json: serde_json::json!({}),
+                expected_size_bytes: None,
+                expected_sha256: None,
+            };
+
+            let error = store
+                .publish_run_artifacts_atomically(
+                    &run,
+                    &[
+                        publication("first", first.clone()),
+                        publication("second", home.path().join("missing.json")),
+                    ],
+                )
+                .expect_err("later source failure rolls back earlier publication");
+            assert_eq!(error.code.as_str(), "internal.io_error");
+            assert!(store.get_artifact("first").expect("first lookup").is_none());
+
+            let published = store
+                .publish_run_artifacts_atomically(
+                    &run,
+                    &[publication("first", first), publication("second", second)],
+                )
+                .expect("retry publishes complete set");
+            assert_eq!(published.len(), 2);
+            assert!(published
+                .iter()
+                .all(|artifact| Path::new(&artifact.path).is_file()));
+        });
+    }
+
+    #[test]
+    fn opening_store_recovers_unfinished_journaled_finalization() {
+        with_isolated_home(|home| {
+            let database = home.path().join("observation.sqlite");
+            let store = ObservationStore::open_initialized_at(&database).expect("store");
+            let staging = home.path().join("orphan.staging");
+            let final_path = home.path().join("orphan.final");
+            fs::write(&staging, b"staged").expect("staging bytes");
+            fs::write(&final_path, b"finalized before crash").expect("final bytes");
+            store.connection.execute(
+                "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES ('crash', 'artifact', ?1, ?2, 'dead-owner', 0)",
+                params![staging.display().to_string(), final_path.display().to_string()],
+            ).expect("journal intent");
+            drop(store);
+
+            let recovered =
+                ObservationStore::open_initialized_at(&database).expect("recover store");
+            assert!(!staging.exists());
+            assert!(!final_path.exists());
+            let intents: i64 = recovered
+                .connection
+                .query_row(
+                    "SELECT COUNT(*) FROM artifact_publication_intents",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("count intents");
+            assert_eq!(intents, 0);
+        });
+    }
+
+    #[test]
+    fn opening_second_store_preserves_a_live_publication_lease() {
+        with_isolated_home(|home| {
+            let database = home.path().join("observation.sqlite");
+            let store = ObservationStore::open_initialized_at(&database).expect("store");
+            let staging = home.path().join("live.staging");
+            let final_path = home.path().join("live.final");
+            fs::write(&staging, b"staged").expect("staging bytes");
+            store.connection.execute(
+                "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES ('live', 'artifact', ?1, ?2, 'owner', ?3)",
+                params![staging.display().to_string(), final_path.display().to_string(), chrono::Utc::now().timestamp_millis() + PUBLICATION_LEASE_MS],
+            ).expect("journal live intent");
+
+            let second = ObservationStore::open_initialized_at(&database).expect("second store");
+            assert!(staging.exists());
+            let intents: i64 = second.connection.query_row(
+                "SELECT COUNT(*) FROM artifact_publication_intents WHERE publication_id = 'live'", [], |row| row.get(0),
+            ).expect("count live intent");
+            assert_eq!(intents, 1);
         });
     }
 

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -43,6 +43,7 @@ impl ObservationStore {
         let lease_expires_at_ms = chrono::Utc::now().timestamp_millis() + PUBLICATION_LEASE_MS;
         let mut prepared = Vec::with_capacity(publications.len());
         let mut staged_paths = Vec::new();
+        let mut intent_count = 0usize;
 
         let result = (|| -> Result<()> {
             for publication in publications {
@@ -71,7 +72,11 @@ impl ObservationStore {
                         None,
                     ));
                 }
-                let stored_path = persisted_artifact_path(&run.id, &publication.id, source)?;
+                // A concurrent publisher may be preparing the same logical
+                // artifact before either SQLite transaction commits. Its final
+                // bytes must therefore be owned by this publication token.
+                let stored_path =
+                    publication_artifact_path(&run.id, &publication.id, source, &publication_id)?;
                 let size_bytes = i64::try_from(metadata.len()).ok();
                 let sha256 = crate::artifact_metadata::sha256_file(source)?;
                 if publication.expected_size_bytes.is_some()
@@ -142,7 +147,9 @@ impl ObservationStore {
                 crate::artifact_links::annotate_public_artifact_url_validation(&mut artifact);
                 prepared.push((artifact, Some(staged_path), Some(stored_path)));
             }
-            // Journal the owned staging paths before they can become final.
+            // Copying can be slow. Journal only after all staging completes so
+            // recovery never reaps an active copy that has not yet entered its
+            // finalization window.
             // Readers only consult `runs` and `artifacts`, neither of which is
             // written until the complete finalization transaction below.
             let tx = self
@@ -157,6 +164,7 @@ impl ObservationStore {
                     "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                     params![publication_id, artifact.id, staged_path.display().to_string(), final_path.display().to_string(), owner_token, lease_expires_at_ms],
                 ).map_err(sqlite_error("journal artifact publication"))?;
+                intent_count += 1;
             }
             tx.commit()
                 .map_err(sqlite_error("commit artifact publication intent"))?;
@@ -165,6 +173,7 @@ impl ObservationStore {
                 let (Some(staged_path), Some(final_path)) = (staged_path, final_path) else {
                     continue;
                 };
+                self.renew_artifact_publication_lease(&publication_id, &owner_token, intent_count)?;
                 fs::rename(staged_path, final_path).map_err(|error| {
                     Error::internal_io(
                         error.to_string(),
@@ -173,10 +182,23 @@ impl ObservationStore {
                 })?;
             }
 
+            self.renew_artifact_publication_lease(&publication_id, &owner_token, intent_count)?;
             let tx = self
                 .connection
                 .unchecked_transaction()
                 .map_err(sqlite_error("begin artifact publication finalization"))?;
+            // Revoking the exact leased intents is the final ownership check.
+            // It happens before durable rows are inserted, so a reclaimer that
+            // won after the last renewal leaves no visible run or artifact rows.
+            let released = tx.execute(
+                "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND owner_token = ?2 AND lease_expires_at_ms >= ?3",
+                params![publication_id, owner_token, chrono::Utc::now().timestamp_millis()],
+            ).map_err(sqlite_error("claim artifact publication finalization"))?;
+            if released != intent_count {
+                return Err(Error::internal_unexpected(
+                    "artifact publication lost its durable finalization lease",
+                ));
+            }
             let metadata_json = serialize_metadata(&run.metadata_json)?;
             tx.execute(
                 r#"INSERT INTO runs(id, kind, component_id, started_at, finished_at, status, command, cwd, homeboy_version, git_sha, rig_id, metadata_json)
@@ -193,11 +215,6 @@ impl ObservationStore {
                     params![artifact.id, artifact.run_id, artifact.kind, artifact.artifact_type, artifact.path, artifact.url, artifact.public_url, artifact.viewer_url, serialize_metadata(&serde_json::json!(artifact.viewer_links))?, artifact.sha256, artifact.size_bytes, artifact.mime, serialize_metadata(&artifact.metadata_json)?, artifact.created_at],
                 ).map_err(sqlite_error("publish observation artifact"))?;
             }
-            tx.execute(
-                "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND owner_token = ?2",
-                params![publication_id, owner_token],
-            )
-            .map_err(sqlite_error("clear artifact publication intent"))?;
             tx.commit()
                 .map_err(sqlite_error("commit artifact publication finalization"))?;
             Ok(())
@@ -220,31 +237,49 @@ impl ObservationStore {
             .collect()
     }
 
-    /// Remove only abandoned journal entries. A second store opening while a
-    /// publisher holds a live lease must leave its staging and final paths
-    /// alone; recovery is bounded by the recorded expiry timestamp.
+    /// Remove only expired publication-token paths. Final paths are immutable
+    /// and token-scoped, so reclaiming an expired owner can never remove bytes
+    /// selected by a competing publisher for the same logical artifact.
     pub(super) fn reconcile_unfinished_artifact_publications(&self) -> Result<()> {
         let now = chrono::Utc::now().timestamp_millis();
         let mut statement = self
             .connection
-            .prepare("SELECT staging_path, final_path FROM artifact_publication_intents WHERE lease_expires_at_ms < ?1")
+            .prepare("SELECT publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms FROM artifact_publication_intents WHERE lease_expires_at_ms IS NULL OR lease_expires_at_ms < ?1")
             .map_err(sqlite_error("read unfinished artifact publications"))?;
         let paths = statement
             .query_map([now], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<i64>>(5)?,
+                ))
             })
             .map_err(sqlite_error("query unfinished artifact publications"))?;
         let paths = collect_rows(paths, "collect unfinished artifact publications")?;
-        for (staging_path, final_path) in paths {
-            fs::remove_file(staging_path).ok();
-            fs::remove_file(final_path).ok();
+        for (
+            publication_id,
+            artifact_id,
+            staging_path,
+            final_path,
+            owner_token,
+            lease_expires_at,
+        ) in paths
+        {
+            // Revocation is the ownership boundary: delete the exact snapshot
+            // first. A renewal that wins changes its lease and this CAS deletes
+            // nothing, so this recovery pass must not touch either path.
+            let claimed = self.connection.execute(
+                "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND artifact_id = ?2 AND ((owner_token IS NULL AND ?3 IS NULL) OR owner_token = ?3) AND ((lease_expires_at_ms IS NULL AND ?4 IS NULL) OR lease_expires_at_ms = ?4) AND (lease_expires_at_ms IS NULL OR lease_expires_at_ms < ?5)",
+                params![publication_id, artifact_id, owner_token, lease_expires_at, now],
+            ).map_err(sqlite_error("claim expired artifact publication"))?;
+            if claimed == 1 {
+                fs::remove_file(staging_path).ok();
+                fs::remove_file(final_path).ok();
+            }
         }
-        self.connection
-            .execute(
-                "DELETE FROM artifact_publication_intents WHERE lease_expires_at_ms < ?1",
-                [now],
-            )
-            .map_err(sqlite_error("clear unfinished artifact publications"))?;
         Ok(())
     }
 
@@ -273,14 +308,41 @@ impl ObservationStore {
         Ok(())
     }
 
+    fn renew_artifact_publication_lease(
+        &self,
+        publication_id: &str,
+        owner_token: &str,
+        expected_intents: usize,
+    ) -> Result<()> {
+        let expires_at = chrono::Utc::now().timestamp_millis() + PUBLICATION_LEASE_MS;
+        let updated = self.connection.execute(
+            "UPDATE artifact_publication_intents SET lease_expires_at_ms = ?1 WHERE publication_id = ?2 AND owner_token = ?3",
+            params![expires_at, publication_id, owner_token],
+        ).map_err(sqlite_error("renew artifact publication lease"))?;
+        if updated != expected_intents {
+            return Err(Error::internal_unexpected(
+                "artifact publication lost its durable finalization lease",
+            ));
+        }
+        Ok(())
+    }
+
     /// Roll back a synthetic controller run when its terminal artifact
     /// publication cannot complete. Callers must never use this for a run
     /// identity owned by another lifecycle.
-    pub fn discard_synthetic_run(&self, run_id: &str) -> Result<()> {
+    pub fn discard_synthetic_run(&self, run_id: &str, publication_token: &str) -> Result<()> {
         let tx = self
             .connection
             .unchecked_transaction()
             .map_err(sqlite_error("begin synthetic run rollback"))?;
+        let owned: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1 AND json_extract(metadata_json, '$.lab.synthetic_publication_token') = ?2)",
+            params![run_id, publication_token],
+            |row| row.get(0),
+        ).map_err(sqlite_error("read synthetic run ownership"))?;
+        if !owned {
+            return Ok(());
+        }
         tx.execute("DELETE FROM artifacts WHERE run_id = ?1", [run_id])
             .map_err(sqlite_error("delete synthetic run artifacts"))?;
         tx.execute("DELETE FROM runs WHERE id = ?1", [run_id])
@@ -1359,6 +1421,20 @@ impl ObservationStore {
     }
 }
 
+fn publication_artifact_path(
+    run_id: &str,
+    artifact_id: &str,
+    source: &Path,
+    publication_id: &str,
+) -> Result<PathBuf> {
+    let canonical = persisted_artifact_path(run_id, artifact_id, source)?;
+    let file_name = canonical
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| Error::internal_unexpected("persisted artifact path has no filename"))?;
+    Ok(canonical.with_file_name(format!("{publication_id}-{file_name}")))
+}
+
 /// Hash a directory tree independent of traversal order. Paths and entry types
 /// are included so a rename or file/directory swap cannot reuse prior evidence.
 pub fn directory_tree_sha256(path: &Path) -> Result<String> {
@@ -1605,6 +1681,27 @@ mod tests {
     }
 
     #[test]
+    fn opening_store_reclaims_v10_null_lease_intent_as_stale() {
+        with_isolated_home(|home| {
+            let database = home.path().join("observation.sqlite");
+            let store = ObservationStore::open_initialized_at(&database).expect("store");
+            let staging = home.path().join("legacy.staging");
+            let final_path = home.path().join("legacy.final");
+            fs::write(&staging, b"staged").expect("staging bytes");
+            fs::write(&final_path, b"final").expect("final bytes");
+            store.connection.execute(
+                "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES ('legacy', 'artifact', ?1, ?2, NULL, NULL)",
+                params![staging.display().to_string(), final_path.display().to_string()],
+            ).expect("legacy intent");
+            drop(store);
+
+            ObservationStore::open_initialized_at(&database).expect("reopen migrated store");
+            assert!(!staging.exists());
+            assert!(!final_path.exists());
+        });
+    }
+
+    #[test]
     fn opening_second_store_preserves_a_live_publication_lease() {
         with_isolated_home(|home| {
             let database = home.path().join("observation.sqlite");
@@ -1623,6 +1720,119 @@ mod tests {
                 "SELECT COUNT(*) FROM artifact_publication_intents WHERE publication_id = 'live'", [], |row| row.get(0),
             ).expect("count live intent");
             assert_eq!(intents, 1);
+        });
+    }
+
+    #[test]
+    fn finalization_after_lease_expiry_and_reclaim_never_advertises_files() {
+        with_isolated_home(|home| {
+            let database = home.path().join("observation.sqlite");
+            let store = ObservationStore::open_initialized_at(&database).expect("store");
+            let staging = home.path().join("paused.staging");
+            let final_path = home.path().join("paused.final");
+            fs::write(&staging, b"staged").expect("staging bytes");
+            fs::write(&final_path, b"renamed before pause").expect("final bytes");
+            store.connection.execute(
+                "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES ('paused', 'artifact', ?1, ?2, 'owner', 0)",
+                params![staging.display().to_string(), final_path.display().to_string()],
+            ).expect("journal intent");
+
+            // Simulate a publisher paused past its lease while a second store
+            // reclaims its exact intent and the already-renamed bytes.
+            let reclaimer = ObservationStore::open_initialized_at(&database).expect("reclaimer");
+            assert!(!staging.exists());
+            assert!(!final_path.exists());
+            let tx = reclaimer
+                .connection
+                .unchecked_transaction()
+                .expect("begin delayed finalization");
+            let released = tx.execute(
+                "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND owner_token = ?2 AND lease_expires_at_ms >= ?3",
+                params!["paused", "owner", chrono::Utc::now().timestamp_millis()],
+            ).expect("verify delayed ownership");
+            assert_eq!(released, 0, "reclaimed intent cannot finalize rows");
+            tx.rollback().expect("rollback delayed finalization");
+            assert!(reclaimer
+                .get_run("paused-run")
+                .expect("run lookup")
+                .is_none());
+            assert!(reclaimer
+                .get_artifact("artifact")
+                .expect("artifact lookup")
+                .is_none());
+        });
+    }
+
+    #[test]
+    fn synthetic_cleanup_is_scoped_to_its_publication_token() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            for (id, token) in [("synthetic-a", "token-a"), ("synthetic-b", "token-b")] {
+                store
+                    .import_run(&RunRecord {
+                        id: id.to_string(),
+                        kind: "runner-exec".to_string(),
+                        component_id: None,
+                        started_at: "2026-01-01T00:00:00Z".to_string(),
+                        finished_at: None,
+                        status: "running".to_string(),
+                        command: None,
+                        cwd: Some(home.path().display().to_string()),
+                        homeboy_version: None,
+                        git_sha: None,
+                        rig_id: None,
+                        metadata_json: serde_json::json!({"lab": {"synthetic_publication_token": token}}),
+                    })
+                    .expect("synthetic run");
+            }
+
+            store
+                .discard_synthetic_run("synthetic-a", "token-a")
+                .expect("discard owned run");
+            assert!(store.get_run("synthetic-a").expect("first run").is_none());
+            assert!(store.get_run("synthetic-b").expect("second run").is_some());
+            store
+                .discard_synthetic_run("synthetic-b", "unrelated-token")
+                .expect("ignore unowned run");
+            assert!(store.get_run("synthetic-b").expect("second run").is_some());
+        });
+    }
+
+    #[test]
+    fn synthetic_run_claim_loser_cannot_discard_the_concurrent_winner() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let synthetic = |token: &str| RunRecord {
+                id: "synthetic-concurrent".to_string(),
+                kind: "runner-exec".to_string(),
+                component_id: None,
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                finished_at: None,
+                status: "running".to_string(),
+                command: None,
+                cwd: Some(home.path().display().to_string()),
+                homeboy_version: None,
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({"lab": {"synthetic_publication_token": token}}),
+            };
+            let winner = synthetic("winner-token");
+            let loser = synthetic("loser-token");
+
+            assert!(store
+                .import_synthetic_run(&winner, "winner-token")
+                .expect("winner claims synthetic run"));
+            assert!(!store
+                .import_synthetic_run(&loser, "loser-token")
+                .expect("loser observes winner"));
+            store
+                .discard_synthetic_run(&loser.id, "loser-token")
+                .expect("loser rollback is idempotent");
+            assert!(store.get_run(&winner.id).expect("winner run").is_some());
+            store
+                .discard_synthetic_run(&winner.id, "winner-token")
+                .expect("winner rollback");
+            assert!(store.get_run(&winner.id).expect("winner removed").is_none());
         });
     }
 

--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -23,10 +23,11 @@ use super::records::{
 };
 use crate::{paths, Error, Result};
 pub use artifacts::directory_tree_sha256;
+pub use artifacts::ArtifactPublication;
 
 pub(crate) use helpers::*;
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 9;
+pub const CURRENT_SCHEMA_VERSION: i64 = 11;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ObservationDbStatus {

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -599,6 +599,47 @@ impl ObservationStore {
         Ok(())
     }
 
+    /// Insert a synthetic controller run exactly once. The caller that wins the
+    /// insert owns `publication_token`; concurrent readers must not inherit it.
+    pub fn import_synthetic_run(&self, run: &RunRecord, publication_token: &str) -> Result<bool> {
+        validate_required("run.id", &run.id)?;
+        let token = run
+            .metadata_json
+            .pointer("/lab/synthetic_publication_token")
+            .and_then(serde_json::Value::as_str);
+        if token != Some(publication_token) {
+            return Err(Error::internal_unexpected(
+                "synthetic run publication token does not match its metadata",
+            ));
+        }
+        let metadata_json = serialize_metadata(&run.metadata_json)?;
+        execute_with_retry("import synthetic run record", || {
+            self.connection.execute(
+                r#"
+                INSERT OR IGNORE INTO runs(
+                    id, kind, component_id, started_at, finished_at, status,
+                    command, cwd, homeboy_version, git_sha, rig_id, metadata_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                "#,
+                params![
+                    run.id,
+                    run.kind,
+                    run.component_id,
+                    run.started_at,
+                    run.finished_at,
+                    run.status,
+                    run.command,
+                    run.cwd,
+                    run.homeboy_version,
+                    run.git_sha,
+                    run.rig_id,
+                    metadata_json,
+                ],
+            )
+        })
+        .map(|inserted| inserted == 1)
+    }
+
     pub fn upsert_imported_run(&self, run: &RunRecord) -> Result<()> {
         self.upsert_imported_run_with_terminal_guard(run, false)
     }

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -24,11 +24,13 @@ impl ObservationStore {
 
         let connection = schema::open_connection(&path)?;
         schema::apply_migrations(&connection)?;
-        Ok(Self {
+        let store = Self {
             connection,
             path,
             readonly: false,
-        })
+        };
+        store.reconcile_unfinished_artifact_publications()?;
+        Ok(store)
     }
 
     /// Open an existing observation database without any initialization work.

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -193,6 +193,31 @@ const MIGRATIONS: &[Migration] = &[
             ON runs(json_extract(metadata_json, '$.agent_task_run.metadata.retry_of'));
         "#,
     },
+    Migration {
+        version: 11,
+        sql: r#"
+        -- A publication is journaled before final paths are materialized. On
+        -- startup unfinished intents are removed with their unowned files.
+        CREATE TABLE IF NOT EXISTS artifact_publication_intents (
+            publication_id TEXT NOT NULL,
+            artifact_id TEXT NOT NULL,
+            staging_path TEXT NOT NULL,
+            final_path TEXT NOT NULL,
+            PRIMARY KEY(publication_id, artifact_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_artifact_publication_intents_publication
+            ON artifact_publication_intents(publication_id);
+        "#,
+    },
+    Migration {
+        version: 12,
+        sql: r#"
+        ALTER TABLE artifact_publication_intents ADD COLUMN owner_token TEXT;
+        ALTER TABLE artifact_publication_intents ADD COLUMN lease_expires_at_ms INTEGER;
+        CREATE INDEX IF NOT EXISTS idx_artifact_publication_intents_lease
+            ON artifact_publication_intents(lease_expires_at_ms);
+        "#,
+    },
 ];
 
 static MIGRATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1801,7 +1801,7 @@ pub fn reverse_broker_reconcile(runner_id: &str) -> Result<Value> {
         &client,
         &broker_url,
         "/runner/jobs/reconcile",
-        Value::Null,
+        serde_json::json!({ "runner_id": runner_id }),
         "reconcile reverse runner broker jobs",
         broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )
@@ -1858,7 +1858,7 @@ pub fn lookup_reverse_broker_submission(
         &client,
         &broker_url,
         "/runner/jobs/submissions/lookup",
-        serde_json::json!({ "submission_key": submission_key }),
+        serde_json::json!({ "runner_id": runner_id, "submission_key": submission_key }),
         "look up reverse runner submission",
         broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )?;

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1896,11 +1896,23 @@ pub fn reverse_broker_artifact_content(
     artifact_id: &str,
 ) -> Result<Value> {
     let broker_url = reverse_broker_url(runner_id)?;
+    reverse_broker_artifact_content_at(&broker_url, runner_id, job_id, artifact_id)
+}
+
+/// Fetch terminal artifact bytes from an already-authorized reverse broker.
+/// Terminal reconciliation receives this endpoint directly, so it must not
+/// depend on a still-live runner session lookup.
+pub(crate) fn reverse_broker_artifact_content_at(
+    broker_url: &str,
+    runner_id: &str,
+    job_id: &str,
+    artifact_id: &str,
+) -> Result<Value> {
     let artifact_id = homeboy_core::execution_contract::encode_uri_component(artifact_id);
     let client = broker_client("build broker artifact content client")?;
     broker_http::get_json(
         &client,
-        &broker_url,
+        broker_url,
         &format!("/runner/jobs/{job_id}/artifacts/{artifact_id}/content"),
         "fetch reverse runner broker artifact content",
         broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),

--- a/crates/homeboy-lab-runner/src/evidence/detail.rs
+++ b/crates/homeboy-lab-runner/src/evidence/detail.rs
@@ -86,7 +86,12 @@ pub(super) fn remote_detail_artifacts(
         let mut mirrored_type = artifact_type.to_string();
         let path = if artifact_type == "file" {
             mirrored_type = "remote_file".to_string();
-            runner_artifact_token(&runner.id, remote_run_id, &id)
+            artifact
+                .get("path")
+                .and_then(Value::as_str)
+                .filter(|path| RemoteArtifactToken::parse(path).is_ok())
+                .map(str::to_string)
+                .unwrap_or_else(|| runner_artifact_token(&runner.id, remote_run_id, &id))
         } else {
             artifact
                 .get("url")

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -1,3 +1,6 @@
+use std::io::Write;
+
+use base64::Engine;
 use serde_json::{json, Value};
 
 use crate::agent_task_lifecycle_event::{
@@ -5,10 +8,12 @@ use crate::agent_task_lifecycle_event::{
     agent_task_run_plan_lifecycle_event_from_value,
 };
 use homeboy_core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus, RunnerJobLogSnapshot};
-use homeboy_core::error::{Error, Result};
-use homeboy_core::execution_contract::{encode_uri_component, EXECUTION_CONTRACT};
+use homeboy_core::error::{Error, ErrorCode, Result};
+use homeboy_core::execution_contract::encode_uri_component;
 use homeboy_core::notification_route::NotificationRoute;
-use homeboy_core::observation::{ArtifactRecord, ObservationStore, RunRecord, RunStatus};
+use homeboy_core::observation::{
+    ArtifactPublication, ArtifactRecord, ObservationStore, RunRecord, RunStatus,
+};
 use homeboy_core::redaction::redact_argv_shell_display;
 
 use super::super::execution::{canonical_daemon_body, daemon_api_get, result_event_data};
@@ -16,7 +21,6 @@ use super::super::{load, Runner};
 use super::detail::{
     explicit_observation_run_ids, remote_detail_artifacts, remote_detail_to_run_record,
 };
-use super::tokens::{is_retrievable_runner_artifact, runner_artifact_token};
 use super::util::{
     job_status_as_run_status, local_job_run_id, ms_to_rfc3339, result_summary,
     runner_exec_run_label, runner_metadata, source_snapshot_from_result,
@@ -28,7 +32,39 @@ pub(super) const MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT: usize = 1_024;
 #[derive(Debug)]
 pub struct MirroredDaemonEvidence {
     pub run: RunRecord,
+    pub runs: Vec<RunRecord>,
     pub patch: Option<Value>,
+}
+
+/// Terminal responses expose only controller-owned records, never the runner's
+/// original artifact metadata or paths.
+pub fn controller_artifact_metadata(runs: &[RunRecord]) -> Result<Vec<JobArtifactMetadata>> {
+    let store = ObservationStore::open_initialized()?;
+    let artifacts = runs.iter().try_fold(Vec::new(), |mut artifacts, run| {
+        artifacts.extend(store.list_artifacts(&run.id)?);
+        Ok::<_, Error>(artifacts)
+    })?;
+    artifacts
+        .into_iter()
+        .map(|artifact| {
+            let controller_run_id = artifact.run_id.clone();
+            Ok(JobArtifactMetadata {
+                id: artifact.id,
+                name: None,
+                path: Some(artifact.path),
+                url: artifact.public_url.or(artifact.url),
+                mime: artifact.mime,
+                size_bytes: artifact
+                    .size_bytes
+                    .and_then(|size| u64::try_from(size).ok()),
+                sha256: artifact.sha256,
+                content_base64: None,
+                metadata: Some(
+                    json!({ "controller_run_id": controller_run_id, "controller_owned": true }),
+                ),
+            })
+        })
+        .collect()
 }
 
 pub fn mirror_daemon_evidence(
@@ -54,11 +90,33 @@ pub fn mirror_daemon_evidence(
         notification_route,
     )?;
     let remote_runs =
-        mirror_remote_observation_runs(&store, runner, job, result, notification_route)?;
+        match mirror_remote_observation_runs(&store, runner, job, result, notification_route) {
+            Ok(runs) => runs,
+            Err(error) => {
+                if run_id.is_none() {
+                    store.discard_synthetic_run(&local_job_run.id).ok();
+                }
+                return Err(error);
+            }
+        };
+    if remote_runs.is_empty() {
+        if let Err(error) = mirror_terminal_job_artifacts(&store, runner, job, &local_job_run) {
+            if run_id.is_none() {
+                store.discard_synthetic_run(&local_job_run.id).ok();
+            }
+            return Err(error);
+        }
+    }
     let patch = mirrored_patch_result(&store, runner, job, result.get("patch"))?;
-    let primary_run = primary_mirrored_run(&remote_runs).unwrap_or(local_job_run);
+    let runs = if remote_runs.is_empty() {
+        vec![local_job_run.clone()]
+    } else {
+        remote_runs
+    };
+    let primary_run = primary_mirrored_run(&runs).unwrap_or_else(|| runs[0].clone());
     Ok(Some(MirroredDaemonEvidence {
         run: primary_run,
+        runs,
         patch,
     }))
 }
@@ -86,7 +144,17 @@ pub fn mirror_reverse_broker_evidence(
         run_id,
         notification_route,
     )?;
-    let artifacts = mirror_reverse_broker_artifacts(&store, runner, broker_url, &run.id, job)?;
+    let artifacts = mirror_terminal_job_artifacts_with(&store, runner, job, &run, |artifact_id| {
+        terminal_artifact_bytes(
+            crate::connection::reverse_broker_artifact_content_at(
+                broker_url,
+                &runner.id,
+                &job.id.to_string(),
+                artifact_id,
+            )?,
+            artifact_id,
+        )
+    })?;
 
     let mut metadata = run.metadata_json.clone();
     metadata["lab"]["reverse_broker"] = json!({
@@ -108,7 +176,11 @@ pub fn mirror_reverse_broker_evidence(
             .get("patch")
             .or_else(|| result.pointer("/data/patch")),
     )?;
-    Ok(Some(MirroredDaemonEvidence { run, patch }))
+    Ok(Some(MirroredDaemonEvidence {
+        run: run.clone(),
+        runs: vec![run],
+        patch,
+    }))
 }
 
 pub fn mirror_daemon_job_progress(
@@ -303,26 +375,21 @@ pub(super) fn mirrored_patch_result(
         return Ok(Some(patch.clone()));
     }
 
-    let expected_run_id = format!("runner-exec-{}", job.id);
     let artifact = store
         .get_artifact(artifact_id)?
-        .filter(|artifact| artifact.run_id == expected_run_id)
         .ok_or_else(|| {
             Error::internal_unexpected(format!(
-                "runner capture-patch artifact {artifact_id} was reported by remote run {expected_run_id}, but no mirrored artifact record is available"
+                "runner capture-patch artifact {artifact_id} was reported by job '{}', but no controller-owned artifact record is available",
+                job.id
             ))
         })?;
 
     let mut patched = patch.clone();
     if let Some(object) = patched.as_object_mut() {
-        // The controller cannot rely on the runner-local artifact path. Keep
-        // the patch on the daemon artifact route so promotion can fetch it.
-        let path = if is_retrievable_runner_artifact(&artifact.path) {
-            artifact.path
-        } else {
-            runner_artifact_token(&runner.id, &expected_run_id, artifact_id)
-        };
-        object.insert("patch_artifact_path".to_string(), Value::String(path));
+        object.insert(
+            "patch_artifact_path".to_string(),
+            Value::String(artifact.path),
+        );
     }
     Ok(Some(patched))
 }
@@ -463,6 +530,131 @@ fn mirror_remote_observation_runs(
     Ok(Vec::new())
 }
 
+/// Legacy terminal producers may advertise artifacts without a durable
+/// observation run. Their controller-owned runner-exec mirror is the stable
+/// terminal identity, and every advertised job artifact must be materialized
+/// before that terminal response can be returned.
+fn mirror_terminal_job_artifacts(
+    store: &ObservationStore,
+    runner: &Runner,
+    job: &Job,
+    run: &RunRecord,
+) -> Result<Vec<ArtifactRecord>> {
+    mirror_terminal_job_artifacts_with(store, runner, job, run, |artifact_id| {
+        terminal_artifact_bytes(
+            crate::runner_artifact_content(&runner.id, &job.id.to_string(), artifact_id)?,
+            artifact_id,
+        )
+    })
+}
+
+fn terminal_artifact_bytes(response: Value, artifact_id: &str) -> Result<Vec<u8>> {
+    let content = response
+        .get("content_base64")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact.content_base64",
+                "terminal artifact retrieval did not return bytes",
+                Some(artifact_id.to_string()),
+                None,
+            )
+        })?;
+    base64::engine::general_purpose::STANDARD
+        .decode(content)
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "artifact.content_base64",
+                format!("terminal artifact bytes are not valid base64: {error}"),
+                Some(artifact_id.to_string()),
+                None,
+            )
+        })
+}
+
+pub(super) fn mirror_terminal_job_artifacts_with<F>(
+    store: &ObservationStore,
+    runner: &Runner,
+    job: &Job,
+    run: &RunRecord,
+    mut fetch: F,
+) -> Result<Vec<ArtifactRecord>>
+where
+    F: FnMut(&str) -> Result<Vec<u8>>,
+{
+    let mut staged = Vec::with_capacity(job.artifacts.len());
+    let mut publications = Vec::with_capacity(job.artifacts.len());
+    for artifact in &job.artifacts {
+        let size_bytes = artifact
+            .size_bytes
+            .and_then(|size| i64::try_from(size).ok());
+        let sha256 = artifact.sha256.clone().filter(|sha| !sha.is_empty());
+        if size_bytes.is_none() || sha256.is_none() {
+            return Err(artifact_projection_error(
+                runner,
+                job,
+                &run.id,
+                Error::validation_invalid_argument(
+                    "artifact.provenance",
+                    "terminal artifact is missing required size_bytes or sha256 provenance",
+                    Some(artifact.id.clone()),
+                    None,
+                ),
+            ));
+        }
+        let mut file = tempfile::NamedTempFile::new().map_err(|error| {
+            artifact_projection_error(
+                runner,
+                job,
+                &run.id,
+                Error::internal_io(
+                    error.to_string(),
+                    Some("stage terminal artifact".to_string()),
+                ),
+            )
+        })?;
+        file.write_all(
+            &fetch(&artifact.id)
+                .map_err(|error| artifact_projection_error(runner, job, &run.id, error))?,
+        )
+        .map_err(|error| {
+            artifact_projection_error(
+                runner,
+                job,
+                &run.id,
+                Error::internal_io(
+                    error.to_string(),
+                    Some("write terminal artifact".to_string()),
+                ),
+            )
+        })?;
+        publications.push(ArtifactPublication {
+            id: artifact.id.clone(),
+            kind: artifact
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("kind"))
+                .and_then(Value::as_str)
+                .unwrap_or("runner_job_artifact")
+                .to_string(),
+            source_path: file.path().to_path_buf(),
+            mime: artifact.mime.clone(),
+            metadata_json: json!({
+                "runner_id": runner.id,
+                "runner_job_id": job.id.to_string(),
+                "name": artifact.name,
+                "terminal_artifact": true,
+            }),
+            expected_size_bytes: size_bytes,
+            expected_sha256: sha256,
+        });
+        staged.push(file);
+    }
+    store
+        .publish_run_artifacts_atomically(run, &publications)
+        .map_err(|error| artifact_projection_error(runner, job, &run.id, error))
+}
+
 fn mirror_remote_observation_runs_by_id(
     store: &ObservationStore,
     runner: &Runner,
@@ -487,38 +679,187 @@ fn mirror_remote_observation_runs_by_id(
     )
 }
 
+/// Project terminal runner observations and their artifacts into controller
+/// storage before terminal command output can expose their references.
+///
+/// A runner result that declares an observation run ID has made that run part
+/// of its reviewer-facing contract. Treating a missing `/runs/<id>` response as
+/// optional leaves callers with URLs that only existed on the disconnected
+/// runner, so reconciliation must fail closed instead.
 pub(super) fn mirror_remote_observation_runs_by_id_with<F>(
     store: &ObservationStore,
     runner: &Runner,
     job: &Job,
     run_ids: &[String],
     notification_route: Option<&NotificationRoute>,
-    mut fetch_detail: F,
+    fetch_detail: F,
 ) -> Result<Vec<RunRecord>>
 where
     F: FnMut(&str) -> Result<Option<Value>>,
+{
+    mirror_remote_observation_runs_by_id_with_downloader(
+        store,
+        runner,
+        job,
+        run_ids,
+        notification_route,
+        fetch_detail,
+        |path| Ok(super::download::download_remote_artifact(path, None)?.output_path),
+    )
+}
+
+pub(super) fn mirror_remote_observation_runs_by_id_with_downloader<F, D>(
+    store: &ObservationStore,
+    runner: &Runner,
+    job: &Job,
+    run_ids: &[String],
+    notification_route: Option<&NotificationRoute>,
+    mut fetch_detail: F,
+    mut download: D,
+) -> Result<Vec<RunRecord>>
+where
+    F: FnMut(&str) -> Result<Option<Value>>,
+    D: FnMut(&str) -> Result<std::path::PathBuf>,
 {
     let mut mirrored = Vec::new();
     for run_id in run_ids {
         let detail = match fetch_detail(run_id) {
             Ok(Some(detail)) => detail,
-            Ok(None) => continue,
-            // The terminal daemon job and its events are authoritative. A
-            // durable-run projection is optional and can be unavailable.
-            Err(error) if missing_optional_run_projection(&error, run_id) => continue,
+            Ok(None) => return Err(missing_required_run_projection(runner, job, run_id, None)),
+            Err(error) if missing_optional_run_projection(&error, run_id) => {
+                return Err(missing_required_run_projection(
+                    runner,
+                    job,
+                    run_id,
+                    Some(error),
+                ))
+            }
             Err(error) => return Err(error),
         };
         let mut run = remote_detail_to_run_record(&detail, runner, Some(job))?;
         if let Some(notification_route) = notification_route {
             notification_route.insert_into_metadata(&mut run.metadata_json);
         }
-        import_run_if_absent(store, &run)?;
-        for artifact in remote_detail_artifacts(&detail, runner, &run.id)? {
-            import_mirrored_artifact(store, &artifact)?;
-        }
-        mirrored.push(run);
+        let publications = remote_detail_artifacts(&detail, runner, &run.id)?
+            .into_iter()
+            .map(|artifact| {
+                if artifact.size_bytes.is_none()
+                    || artifact.sha256.as_deref().is_none_or(str::is_empty)
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "artifact.provenance",
+                        "declared terminal artifact is missing required size_bytes or sha256 provenance",
+                        Some(artifact.id),
+                        None,
+                    ));
+                }
+                let source_path = download(&artifact.path)?;
+                Ok(ArtifactPublication {
+                    id: artifact.id,
+                    kind: artifact.kind,
+                    source_path,
+                    mime: artifact.mime,
+                    metadata_json: artifact.metadata_json,
+                    expected_size_bytes: artifact.size_bytes,
+                    expected_sha256: artifact.sha256,
+                })
+            })
+            .collect::<Result<Vec<_>>>()
+            .map_err(|error| artifact_projection_error(runner, job, run_id, error))?;
+        store
+            .publish_run_artifacts_atomically(&run, &publications)
+            .map_err(|error| artifact_projection_error(runner, job, run_id, error))?;
+        mirrored.push(
+            store.get_run(&run.id)?.ok_or_else(|| {
+                Error::internal_unexpected("published controller run is unreadable")
+            })?,
+        );
     }
     Ok(mirrored)
+}
+
+fn artifact_projection_error(runner: &Runner, job: &Job, run_id: &str, source: Error) -> Error {
+    let retryable = !permanent_artifact_provenance_error(&source);
+    Error::new(
+        source.code,
+        format!(
+            "controller could not durably project all artifacts for Lab runner job '{}' run '{}'; terminal output is withheld",
+            job.id, run_id
+        ),
+        json!({
+            "runner_id": runner.id,
+            "runner_job_id": job.id.to_string(),
+            "run_id": run_id,
+            "source_error": { "code": source.code.as_str(), "message": source.message, "details": source.details },
+            "reconciliation_command": format!("homeboy runs show {run_id}"),
+            "artifact_reconciliation_command": format!("homeboy runs artifacts {run_id}"),
+        }),
+    )
+    .with_retryable(retryable)
+    .with_hint(if retryable {
+        format!("Reconnect runner '{}' and retry job '{}' to reconcile its complete artifact set.", runner.id, job.id)
+    } else {
+        format!("Repair the malformed artifact provenance reported for job '{}' before retrying.", job.id)
+    })
+}
+
+/// Only invalid producer provenance is terminal. Transport/session errors may
+/// use validation-shaped public errors (for example an absent live session),
+/// so code alone cannot turn every invalid-argument into a permanent result.
+fn permanent_artifact_provenance_error(error: &Error) -> bool {
+    matches!(error.code, ErrorCode::ValidationInvalidArgument)
+        && matches!(
+            error.details.get("field").and_then(Value::as_str),
+            Some("artifact.provenance")
+                | Some("artifact.size_bytes")
+                | Some("artifact.sha256")
+                | Some("artifact.content_base64")
+        )
+}
+
+fn missing_required_run_projection(
+    runner: &Runner,
+    job: &Job,
+    run_id: &str,
+    source: Option<Error>,
+) -> Error {
+    let permanently_missing = source
+        .as_ref()
+        .is_some_and(|error| missing_optional_run_projection(error, run_id));
+    let mut details = json!({
+        "runner_id": runner.id,
+        "runner_job_id": job.id.to_string(),
+        "run_id": run_id,
+        "reconciliation_command": format!("homeboy runs show {run_id}"),
+        "artifact_reconciliation_command": format!("homeboy runs artifacts {run_id}"),
+    });
+    if let Some(source) = source {
+        details["source_error"] = json!({
+            "code": source.code.as_str(),
+            "message": source.message,
+            "details": source.details,
+        });
+    }
+    Error::new(
+        ErrorCode::InternalUnexpected,
+        format!(
+            "Lab runner job '{}' completed, but controller durability projection for declared run '{}' is unavailable; terminal output is withheld until its run and artifacts are persisted",
+            job.id, run_id
+        ),
+        details,
+    )
+    .with_retryable(!permanently_missing)
+    .with_hint(if permanently_missing {
+        format!(
+            "The runner no longer has declared run '{run_id}'. Repair the producer provenance for job '{}' and rerun it before sharing artifact URLs.",
+            job.id
+        )
+    } else {
+        format!(
+            "Reconnect runner '{}' and retry the command to reconcile job '{}' before sharing artifact URLs.",
+            runner.id, job.id
+        )
+    })
 }
 
 fn missing_optional_run_projection(error: &Error, run_id: &str) -> bool {
@@ -597,76 +938,6 @@ where
 
 pub(super) fn primary_mirrored_run(remote_runs: &[RunRecord]) -> Option<RunRecord> {
     remote_runs.iter().find(|run| run.kind == "fuzz").cloned()
-}
-
-fn mirror_reverse_broker_artifacts(
-    store: &ObservationStore,
-    runner: &Runner,
-    broker_url: &str,
-    run_id: &str,
-    job: &Job,
-) -> Result<Vec<ArtifactRecord>> {
-    let mut mirrored = Vec::new();
-    for artifact in &job.artifacts {
-        let record = reverse_broker_artifact_record(runner, broker_url, run_id, job, artifact);
-        import_artifact_if_absent(store, &record)?;
-        mirrored.push(record);
-    }
-    Ok(mirrored)
-}
-
-fn reverse_broker_artifact_record(
-    runner: &Runner,
-    broker_url: &str,
-    run_id: &str,
-    job: &Job,
-    artifact: &JobArtifactMetadata,
-) -> ArtifactRecord {
-    ArtifactRecord {
-        id: artifact.id.clone(),
-        run_id: run_id.to_string(),
-        kind: artifact
-            .metadata
-            .as_ref()
-            .and_then(|metadata| metadata.get("kind"))
-            .and_then(Value::as_str)
-            .unwrap_or("reverse_broker_artifact")
-            .to_string(),
-        artifact_type: "metadata".to_string(),
-        path: EXECUTION_CONTRACT.artifacts.metadata_only_ref(&artifact.id),
-        url: artifact.url.clone(),
-        public_url: None,
-        viewer_url: None,
-        viewer_links: Vec::new(),
-        sha256: artifact.sha256.clone(),
-        size_bytes: artifact
-            .size_bytes
-            .and_then(|size| i64::try_from(size).ok()),
-        mime: artifact.mime.clone(),
-        metadata_json: json!({
-            "runner_id": runner.id.clone(),
-            "job_id": job.id.to_string(),
-            "broker_url": broker_url,
-            "name": artifact.name.clone(),
-            "remote_path": artifact.path.clone(),
-            "url": artifact.url.clone(),
-            "broker_artifact_metadata_path": format!(
-                "/runner/jobs/{}/artifacts/{}",
-                job.id,
-                encode_uri_component(&artifact.id)
-            ),
-            "content_available": false,
-            "broker_artifact_retrieval": {
-                "mode": "metadata_only",
-                "content_available": false,
-                "content_url": null,
-                "fetch_command": null,
-                "hint": "Reverse broker artifact mirroring preserves metadata only; broker byte retrieval is a future content-proxy slice."
-            },
-            "metadata": artifact.metadata.clone(),
-        }),
-        created_at: ms_to_rfc3339(job.finished_at_ms.unwrap_or(job.updated_at_ms)),
-    }
 }
 
 fn mirrored_reverse_patch_result(

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -1,7 +1,9 @@
 use std::io::Write;
+use std::ops::Deref;
 
 use base64::Engine;
 use serde_json::{json, Value};
+use uuid::Uuid;
 
 use crate::agent_task_lifecycle_event::{
     agent_task_run_plan_lifecycle_event_from_job_events,
@@ -21,6 +23,7 @@ use super::super::{load, Runner};
 use super::detail::{
     explicit_observation_run_ids, remote_detail_artifacts, remote_detail_to_run_record,
 };
+use super::tokens::RemoteArtifactToken;
 use super::util::{
     job_status_as_run_status, local_job_run_id, ms_to_rfc3339, result_summary,
     runner_exec_run_label, runner_metadata, source_snapshot_from_result,
@@ -34,6 +37,34 @@ pub struct MirroredDaemonEvidence {
     pub run: RunRecord,
     pub runs: Vec<RunRecord>,
     pub patch: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct SyntheticRunOwnership {
+    run_id: String,
+    publication_token: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct MirroredJobRun {
+    pub(super) run: RunRecord,
+    synthetic_ownership: Option<SyntheticRunOwnership>,
+}
+
+impl Deref for MirroredJobRun {
+    type Target = RunRecord;
+
+    fn deref(&self) -> &Self::Target {
+        &self.run
+    }
+}
+
+fn discard_owned_synthetic_run(store: &ObservationStore, run: &MirroredJobRun) {
+    if let Some(ownership) = &run.synthetic_ownership {
+        store
+            .discard_synthetic_run(&ownership.run_id, &ownership.publication_token)
+            .ok();
+    }
 }
 
 /// Terminal responses expose only controller-owned records, never the runner's
@@ -89,36 +120,29 @@ pub fn mirror_daemon_evidence(
         run_id,
         notification_route,
     )?;
-    let remote_runs =
-        match mirror_remote_observation_runs(&store, runner, job, result, notification_route) {
-            Ok(runs) => runs,
-            Err(error) => {
-                if run_id.is_none() {
-                    store.discard_synthetic_run(&local_job_run.id).ok();
-                }
-                return Err(error);
-            }
-        };
-    if remote_runs.is_empty() {
-        if let Err(error) = mirror_terminal_job_artifacts(&store, runner, job, &local_job_run) {
-            if run_id.is_none() {
-                store.discard_synthetic_run(&local_job_run.id).ok();
-            }
-            return Err(error);
+    let result = (|| {
+        let remote_runs =
+            mirror_remote_observation_runs(&store, runner, job, result, notification_route)?;
+        if remote_runs.is_empty() {
+            mirror_terminal_job_artifacts(&store, runner, job, &local_job_run)?;
         }
+        let patch = mirrored_patch_result(&store, runner, job, result.get("patch"))?;
+        let runs = if remote_runs.is_empty() {
+            vec![local_job_run.run.clone()]
+        } else {
+            remote_runs
+        };
+        let primary_run = primary_mirrored_run(&runs).unwrap_or_else(|| runs[0].clone());
+        Ok(Some(MirroredDaemonEvidence {
+            run: primary_run,
+            runs,
+            patch,
+        }))
+    })();
+    if result.is_err() {
+        discard_owned_synthetic_run(&store, &local_job_run);
     }
-    let patch = mirrored_patch_result(&store, runner, job, result.get("patch"))?;
-    let runs = if remote_runs.is_empty() {
-        vec![local_job_run.clone()]
-    } else {
-        remote_runs
-    };
-    let primary_run = primary_mirrored_run(&runs).unwrap_or_else(|| runs[0].clone());
-    Ok(Some(MirroredDaemonEvidence {
-        run: primary_run,
-        runs,
-        patch,
-    }))
+    result
 }
 
 pub fn mirror_reverse_broker_evidence(
@@ -133,7 +157,7 @@ pub fn mirror_reverse_broker_evidence(
     notification_route: Option<&NotificationRoute>,
 ) -> Result<Option<MirroredDaemonEvidence>> {
     let store = ObservationStore::open_initialized()?;
-    let mut run = mirror_job_run(
+    let local_job_run = mirror_job_run(
         &store,
         runner,
         cwd,
@@ -144,7 +168,152 @@ pub fn mirror_reverse_broker_evidence(
         run_id,
         notification_route,
     )?;
-    let artifacts = mirror_terminal_job_artifacts_with(&store, runner, job, &run, |artifact_id| {
+    let result = (|| {
+        let declared_run_ids = explicit_observation_run_ids(result, job);
+        let terminal_result: homeboy_core::api_jobs::RemoteRunnerJobResult =
+            serde_json::from_value(result.clone()).map_err(|error| {
+                Error::validation_invalid_argument(
+                "result.observation_run_details",
+                "reverse runner terminal result is not a valid typed observation detail contract",
+                Some(error.to_string()),
+                None,
+            )
+            })?;
+        let runs;
+        if declared_run_ids.is_empty() {
+            let artifacts =
+                mirror_reverse_terminal_artifacts(&store, runner, broker_url, job, &local_job_run)?;
+            runs = vec![record_reverse_broker_metadata(
+                &store,
+                local_job_run.run.clone(),
+                runner,
+                broker_url,
+                job,
+                events,
+                result,
+                artifacts,
+                None,
+            )?];
+        } else if terminal_result.observation_run_details.is_empty() {
+            // Older workers declared remote run identities without retaining
+            // typed details. Their job artifacts remain durable controller
+            // evidence, while the declared identities are explicitly retained
+            // as unresolved provenance rather than fabricated run records.
+            let artifacts =
+                mirror_reverse_terminal_artifacts(&store, runner, broker_url, job, &local_job_run)?;
+            runs = vec![record_reverse_broker_metadata(
+                &store,
+                local_job_run.run.clone(),
+                runner,
+                broker_url,
+                job,
+                events,
+                result,
+                artifacts,
+                Some(&declared_run_ids),
+            )?];
+        } else {
+            terminal_result.validate_observation_run_details()?;
+            runs = mirror_remote_observation_runs_by_id_with_downloader(
+                &store,
+                runner,
+                job,
+                &declared_run_ids,
+                notification_route,
+                |declared_run_id| {
+                    terminal_result
+                        .observation_run_details
+                        .iter()
+                        .find(|detail| detail.run.id == declared_run_id)
+                        .map(|detail| {
+                            let mut run =
+                                serde_json::to_value(&detail.run).expect("run record serializes");
+                            run["artifacts"] = serde_json::to_value(&detail.artifacts)
+                                .expect("artifact records serialize");
+                            run
+                        })
+                        .map(Some)
+                        .ok_or_else(|| {
+                            missing_required_run_projection(runner, job, declared_run_id, None)
+                        })
+                },
+                |artifact_path| {
+                    let token = RemoteArtifactToken::parse(artifact_path).map_err(|_| {
+                        Error::validation_invalid_argument(
+                            "artifact.path",
+                            "reverse declared artifact is not a runner artifact token",
+                            Some(artifact_path.to_string()),
+                            None,
+                        )
+                    })?;
+                    if token.runner_id != runner.id || token.run_id != job.id.to_string() {
+                        return Err(Error::validation_invalid_argument(
+                            "artifact.path",
+                            "reverse declared artifact token is not bound to this runner job",
+                            Some(artifact_path.to_string()),
+                            None,
+                        ));
+                    }
+                    let bytes = terminal_artifact_bytes(
+                        crate::connection::reverse_broker_artifact_content_at(
+                            broker_url,
+                            &runner.id,
+                            &job.id.to_string(),
+                            &token.artifact_id,
+                        )?,
+                        &token.artifact_id,
+                    )?;
+                    let mut file = tempfile::NamedTempFile::new().map_err(|error| {
+                        Error::internal_io(
+                            error.to_string(),
+                            Some("stage reverse artifact".to_string()),
+                        )
+                    })?;
+                    file.write_all(&bytes).map_err(|error| {
+                        Error::internal_io(
+                            error.to_string(),
+                            Some("write reverse artifact".to_string()),
+                        )
+                    })?;
+                    let (_, path) = file.keep().map_err(|error| {
+                        Error::internal_io(
+                            error.error.to_string(),
+                            Some("persist reverse artifact stage".to_string()),
+                        )
+                    })?;
+                    Ok(path)
+                },
+            )?;
+        }
+        let patch = mirrored_patch_result(
+            &store,
+            runner,
+            job,
+            result
+                .get("patch")
+                .or_else(|| result.pointer("/data/patch")),
+        )?;
+        let primary_run = primary_mirrored_run(&runs).unwrap_or_else(|| runs[0].clone());
+        Ok(Some(MirroredDaemonEvidence {
+            run: primary_run,
+            runs,
+            patch,
+        }))
+    })();
+    if result.is_err() {
+        discard_owned_synthetic_run(&store, &local_job_run);
+    }
+    result
+}
+
+fn mirror_reverse_terminal_artifacts(
+    store: &ObservationStore,
+    runner: &Runner,
+    broker_url: &str,
+    job: &Job,
+    run: &RunRecord,
+) -> Result<Vec<ArtifactRecord>> {
+    mirror_terminal_job_artifacts_with(store, runner, job, run, |artifact_id| {
         terminal_artifact_bytes(
             crate::connection::reverse_broker_artifact_content_at(
                 broker_url,
@@ -154,33 +323,29 @@ pub fn mirror_reverse_broker_evidence(
             )?,
             artifact_id,
         )
-    })?;
+    })
+}
 
+fn record_reverse_broker_metadata(
+    store: &ObservationStore,
+    run: RunRecord,
+    runner: &Runner,
+    broker_url: &str,
+    job: &Job,
+    events: &[JobEvent],
+    result: &Value,
+    artifacts: Vec<ArtifactRecord>,
+    unresolved_run_refs: Option<&[String]>,
+) -> Result<RunRecord> {
     let mut metadata = run.metadata_json.clone();
     metadata["lab"]["reverse_broker"] = json!({
-        "runner_id": runner.id.clone(),
-        "job_id": job.id.to_string(),
-        "broker_url": broker_url,
-        "status": job.status,
-        "events": bounded_remote_events(events),
-        "event_count": events.len(),
-        "result_summary": result_summary(result),
-        "artifacts": artifacts,
+        "runner_id": runner.id.clone(), "job_id": job.id.to_string(), "broker_url": broker_url,
+        "status": job.status, "events": bounded_remote_events(events), "event_count": events.len(),
+        "result_summary": result_summary(result), "artifacts": artifacts,
+        "observation_run_details": if unresolved_run_refs.is_some() { json!("unavailable_legacy") } else { Value::Null },
+        "unresolved_run_refs": unresolved_run_refs,
     });
-    run = store.update_run_metadata(&run.id, metadata)?;
-
-    let patch = mirrored_reverse_patch_result(
-        &store,
-        &run.id,
-        result
-            .get("patch")
-            .or_else(|| result.pointer("/data/patch")),
-    )?;
-    Ok(Some(MirroredDaemonEvidence {
-        run: run.clone(),
-        runs: vec![run],
-        patch,
-    }))
+    store.update_run_metadata(&run.id, metadata)
 }
 
 pub fn mirror_daemon_job_progress(
@@ -203,6 +368,7 @@ pub fn mirror_daemon_job_progress(
         run_id,
         None,
     )
+    .map(|run| run.run)
 }
 
 /// Records that the controller can no longer observe an accepted runner job.
@@ -231,7 +397,7 @@ pub fn terminalize_mirrored_daemon_job(
         run_id,
         None,
     )?;
-    let mut metadata = run.metadata_json;
+    let mut metadata = run.metadata_json.clone();
     metadata["lab"]["controller_terminal"] = json!({
         "status": "failed",
         "reason": "runner_job_unobservable",
@@ -258,19 +424,63 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
         .as_ref()
         .map(|command| vec![command.clone()])
         .unwrap_or_default();
-    mirror_job_run(
-        &store, &runner, cwd, &command, &job, &events, &result, None, None,
+    refresh_mirrored_daemon_evidence_with(
+        &store,
+        &runner,
+        cwd,
+        &command,
+        &job,
+        &events,
+        &result,
+        (run.kind == "runner-exec").then_some(run_id),
+        || {
+            if matches!(
+                job.status,
+                JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+            ) {
+                let report = super::super::status(&runner_id)?;
+                super::super::generation_store::reconcile(&runner_id, report.session.as_ref())?;
+            }
+            Ok(())
+        },
+    )
+}
+
+pub(super) fn refresh_mirrored_daemon_evidence_with<F>(
+    store: &ObservationStore,
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    events: &[JobEvent],
+    result: &Value,
+    run_id: Option<&str>,
+    reconcile: F,
+) -> Result<Option<Vec<RunRecord>>>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let local_job_run = mirror_job_run(
+        store, runner, cwd, command, job, events, result, run_id, None,
     )?;
-    if matches!(
-        job.status,
-        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
-    ) {
-        let report = super::super::status(&runner_id)?;
-        super::super::generation_store::reconcile(&runner_id, report.session.as_ref())?;
+    let result = (|| {
+        reconcile()?;
+        let remote_runs = mirror_remote_observation_runs(store, runner, job, result, None)?;
+        if remote_runs.is_empty()
+            && matches!(
+                job.status,
+                JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+            )
+        {
+            mirror_terminal_job_artifacts(store, runner, job, &local_job_run)?;
+            return Ok(Some(vec![local_job_run.run.clone()]));
+        }
+        Ok(Some(remote_runs))
+    })();
+    if result.is_err() {
+        discard_owned_synthetic_run(store, &local_job_run);
     }
-    Ok(Some(mirror_remote_observation_runs(
-        &store, &runner, &job, &result, None,
-    )?))
+    result
 }
 
 pub fn mirror_connected_runner_run(run_id: &str) -> Result<Option<RunRecord>> {
@@ -383,6 +593,31 @@ pub(super) fn mirrored_patch_result(
                 job.id
             ))
         })?;
+    let advertised = job
+        .artifacts
+        .iter()
+        .any(|candidate| candidate.id == artifact_id);
+    let owned_by_job = store.get_run(&artifact.run_id)?.is_some_and(|run| {
+        run.metadata_json
+            .pointer("/lab/runner/id")
+            .or_else(|| run.metadata_json.pointer("/lab/runner_id"))
+            .and_then(Value::as_str)
+            == Some(runner.id.as_str())
+            && run
+                .metadata_json
+                .pointer("/lab/remote_job/id")
+                .or_else(|| run.metadata_json.pointer("/lab/remote_job_id"))
+                .and_then(Value::as_str)
+                == Some(job.id.to_string().as_str())
+    });
+    if !advertised || !owned_by_job || artifact.artifact_type != "file" {
+        return Err(Error::validation_invalid_argument(
+            "patch.patch_artifact_id",
+            "patch artifact must be a controller-owned local file advertised by this exact runner job",
+            Some(artifact_id.to_string()),
+            None,
+        ));
+    }
 
     let mut patched = patch.clone();
     if let Some(object) = patched.as_object_mut() {
@@ -404,8 +639,22 @@ pub(super) fn mirror_job_run(
     result: &Value,
     run_id: Option<&str>,
     notification_route: Option<&NotificationRoute>,
-) -> Result<RunRecord> {
+) -> Result<MirroredJobRun> {
     let inferred_label = runner_exec_run_label(command);
+    let synthetic_token = if run_id.is_none() {
+        let synthetic_id = local_job_run_id(&runner.id, &job.id.to_string(), &inferred_label);
+        store
+            .get_run(&synthetic_id)?
+            .and_then(|run| {
+                run.metadata_json
+                    .pointer("/lab/synthetic_publication_token")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| Uuid::new_v4().to_string())
+    } else {
+        String::new()
+    };
     let agent_task_lifecycle_event = agent_task_run_plan_lifecycle_event_from_value(result)
         .or_else(|| agent_task_run_plan_lifecycle_event_from_job_events(Some(events)))
         .and_then(|event| serde_json::to_value(event).ok());
@@ -424,6 +673,9 @@ pub(super) fn mirror_job_run(
     });
     if let Some(event) = agent_task_lifecycle_event {
         lab["agent_task_lifecycle_event"] = event;
+    }
+    if run_id.is_none() {
+        lab["synthetic_publication_token"] = Value::String(synthetic_token.clone());
     }
     if let Some(run_id) = run_id {
         if store
@@ -451,7 +703,12 @@ pub(super) fn mirror_job_run(
             if let Some(notification_route) = notification_route {
                 notification_route.insert_into_metadata(&mut metadata_json);
             }
-            return store.update_run_metadata(run_id, metadata_json);
+            return store
+                .update_run_metadata(run_id, metadata_json)
+                .map(|run| MirroredJobRun {
+                    run,
+                    synthetic_ownership: None,
+                });
         }
     }
     let run = RunRecord {
@@ -474,13 +731,29 @@ pub(super) fn mirror_job_run(
     if let Some(notification_route) = notification_route {
         notification_route.insert_into_metadata(&mut run.metadata_json);
     }
-    import_run_if_absent(store, &run)?;
-    store.get_run(&run.id)?.ok_or_else(|| {
-        Error::internal_unexpected(format!(
-            "mirrored runner run {} but could not read it back",
-            run.id
-        ))
-    })
+    let synthetic_ownership = if run_id.is_none() {
+        store
+            .import_synthetic_run(&run, &synthetic_token)?
+            .then(|| SyntheticRunOwnership {
+                run_id: run.id.clone(),
+                publication_token: synthetic_token,
+            })
+    } else {
+        import_run_if_absent(store, &run)?;
+        None
+    };
+    store
+        .get_run(&run.id)?
+        .map(|run| MirroredJobRun {
+            run,
+            synthetic_ownership,
+        })
+        .ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "mirrored runner run {} but could not read it back",
+                run.id
+            ))
+        })
 }
 
 pub(super) fn bounded_remote_events(events: &[JobEvent]) -> Vec<Value> {
@@ -938,34 +1211,4 @@ where
 
 pub(super) fn primary_mirrored_run(remote_runs: &[RunRecord]) -> Option<RunRecord> {
     remote_runs.iter().find(|run| run.kind == "fuzz").cloned()
-}
-
-fn mirrored_reverse_patch_result(
-    store: &ObservationStore,
-    run_id: &str,
-    patch: Option<&Value>,
-) -> Result<Option<Value>> {
-    let Some(patch) = patch.filter(|patch| !patch.is_null()) else {
-        return Ok(None);
-    };
-    let Some(artifact_id) = patch.get("patch_artifact_id").and_then(Value::as_str) else {
-        return Ok(Some(patch.clone()));
-    };
-    if artifact_id.is_empty() {
-        return Ok(Some(patch.clone()));
-    }
-    let Some(artifact) = store
-        .get_artifact(artifact_id)?
-        .filter(|artifact| artifact.run_id == run_id)
-    else {
-        return Ok(Some(patch.clone()));
-    };
-    let mut patched = patch.clone();
-    if let Some(object) = patched.as_object_mut() {
-        object.insert(
-            "patch_artifact_path".to_string(),
-            Value::String(artifact.path),
-        );
-    }
-    Ok(Some(patched))
 }

--- a/crates/homeboy-lab-runner/src/evidence/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mod.rs
@@ -21,8 +21,8 @@ pub use download::{download_remote_artifact, RemoteArtifactDownload};
 pub use homeboy_core::api_jobs::RunnerJobLogSnapshot;
 pub use mirror::runner_job_log_snapshot_for_session;
 pub use mirror::{
-    mirror_connected_runner_run, mirror_daemon_evidence, mirror_daemon_job_progress,
-    mirror_reverse_broker_evidence, mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
-    runner_job_log_snapshot, terminalize_mirrored_daemon_job,
+    controller_artifact_metadata, mirror_connected_runner_run, mirror_daemon_evidence,
+    mirror_daemon_job_progress, mirror_reverse_broker_evidence, mirrored_runner_job_identity,
+    refresh_mirrored_daemon_evidence, runner_job_log_snapshot, terminalize_mirrored_daemon_job,
 };
 pub(crate) use util::{local_job_run_id, runner_exec_run_label};

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -20,8 +20,10 @@ use super::detail::{
 use super::download::{content_disposition_filename, download_remote_artifact};
 use super::mirror::{
     bounded_remote_events, import_mirrored_artifact_with_downloader, mirror_job_run,
-    mirror_remote_observation_runs_by_id_with, mirrored_patch_result, primary_mirrored_run,
-    MIRRORED_REMOTE_EVENT_LIMIT, MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
+    mirror_remote_observation_runs_by_id_with,
+    mirror_remote_observation_runs_by_id_with_downloader, mirror_terminal_job_artifacts_with,
+    mirrored_patch_result, primary_mirrored_run, MIRRORED_REMOTE_EVENT_LIMIT,
+    MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
 };
 use super::tokens::{
     is_reportable_artifact_evidence_path, is_retrievable_runner_artifact, runner_artifact_token,
@@ -567,7 +569,7 @@ fn test_mirrored_patch_result_fails_when_patch_artifact_was_not_mirrored() {
 
         assert!(err
             .message
-            .contains("no mirrored artifact record is available"));
+            .contains("no controller-owned artifact record is available"));
     });
 }
 
@@ -915,7 +917,7 @@ fn terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifac
                         "started_at": "2023-11-14T22:13:20Z",
                         "finished_at": "2023-11-14T22:13:21Z",
                         "status": "pass",
-                        "artifacts": [{"id": "first-result", "kind": "fuzz_results"}]
+                        "artifacts": [{"id": "first-result", "kind": "fuzz_results", "type": "file", "size_bytes": 1, "sha256": "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"}]
                     }),
                 ),
                 (
@@ -926,19 +928,32 @@ fn terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifac
                         "started_at": "2023-11-14T22:13:20Z",
                         "finished_at": "2023-11-14T22:13:21Z",
                         "status": "fail",
-                        "artifacts": [{"id": "second-result", "kind": "fuzz_results"}]
+                        "artifacts": [{"id": "second-result", "kind": "fuzz_results", "type": "file", "size_bytes": 1, "sha256": "3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d"}]
                     }),
                 ),
             ]);
 
             let run_ids = explicit_observation_run_ids(&json!({}), job);
-            let mirrored = mirror_remote_observation_runs_by_id_with(
+            let downloaded = tempfile::tempdir().expect("download directory");
+            let mirrored = mirror_remote_observation_runs_by_id_with_downloader(
                 &store,
                 &runner,
                 job,
                 &run_ids,
                 None,
                 |run_id| Ok(details.get(run_id).cloned()),
+                |artifact_path| {
+                    let path = downloaded
+                        .path()
+                        .join(artifact_path.rsplit('/').next().expect("artifact id"));
+                    let bytes = if artifact_path.ends_with("first-result") {
+                        b"a".as_slice()
+                    } else {
+                        b"b".as_slice()
+                    };
+                    fs::write(&path, bytes).expect("artifact bytes");
+                    Ok(path)
+                },
             )
             .expect("mirror submitted terminal run");
 
@@ -965,7 +980,7 @@ fn terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifac
 }
 
 #[test]
-fn terminal_mirroring_accepts_two_missing_optional_durable_run_projections() {
+fn terminal_mirroring_withholds_output_when_declared_run_projection_is_missing() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let store = ObservationStore::open_initialized().expect("store");
         let run_ids = vec![
@@ -975,7 +990,7 @@ fn terminal_mirroring_accepts_two_missing_optional_durable_run_projections() {
         let job = terminal_runner_job();
         let mut requested = Vec::new();
 
-        let mirrored = mirror_remote_observation_runs_by_id_with(
+        let error = mirror_remote_observation_runs_by_id_with(
             &store,
             &ssh_runner(),
             &job,
@@ -990,10 +1005,229 @@ fn terminal_mirroring_accepts_two_missing_optional_durable_run_projections() {
                 ))
             },
         )
-        .expect("terminal jobs succeed when optional durable projections are missing");
+        .expect_err("terminal output requires controller-visible run projections");
 
-        assert!(mirrored.is_empty());
-        assert_eq!(requested, run_ids);
+        assert_eq!(requested, vec!["concurrent-run-a"]);
+        assert_eq!(error.details["runner_id"], "lab");
+        assert_eq!(error.details["run_id"], "concurrent-run-a");
+        assert_eq!(error.details["source_error"]["details"]["http_status"], 404);
+        assert!(!error.retryable.unwrap_or(true));
+    });
+}
+
+#[test]
+fn terminal_mirroring_persists_declared_run_and_artifact_for_controller_review() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("controller store");
+        let run_id = "bench-controller-review".to_string();
+        let bytes = b"reviewable visual evidence";
+        let digest = format!("{:x}", Sha256::digest(bytes));
+        let download_dir = tempfile::tempdir().expect("download directory");
+        let download_path = download_dir.path().join("diff.png");
+        let job = terminal_runner_job();
+
+        let mirrored = mirror_remote_observation_runs_by_id_with_downloader(
+            &store,
+            &ssh_runner(),
+            &job,
+            std::slice::from_ref(&run_id),
+            None,
+            |requested| {
+                assert_eq!(requested, run_id);
+                Ok(Some(json!({
+                    "id": run_id,
+                    "kind": "bench",
+                    "started_at": "2023-11-14T22:13:20Z",
+                    "finished_at": "2023-11-14T22:13:21Z",
+                    "status": "fail",
+                    "artifacts": [{
+                        "id": "visual-diff",
+                        "kind": "visual_compare",
+                        "type": "file",
+                        "size_bytes": bytes.len(),
+                        "sha256": digest,
+                        "mime": "image/png"
+                    }]
+                })))
+            },
+            |_| {
+                fs::write(&download_path, bytes).expect("write downloaded artifact");
+                Ok(download_path.clone())
+            },
+        )
+        .expect("terminal runner evidence projects to the controller");
+
+        assert_eq!(mirrored[0].id, run_id);
+        assert_eq!(
+            store
+                .get_run(&run_id)
+                .expect("controller run lookup")
+                .expect("controller run"),
+            mirrored[0]
+        );
+        let artifact = store
+            .get_artifact("visual-diff")
+            .expect("controller artifact lookup")
+            .expect("controller artifact");
+        assert_eq!(artifact.run_id, run_id);
+        assert_eq!(artifact.artifact_type, "file");
+        assert_eq!(
+            fs::read(&artifact.path).expect("reviewer reads artifact"),
+            bytes
+        );
+    });
+}
+
+#[test]
+fn legacy_terminal_artifacts_use_the_controller_runner_run_and_survive_runner_disconnect() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut job = terminal_runner_job();
+        let bytes = b"legacy terminal evidence";
+        job.artifacts = vec![JobArtifactMetadata {
+            id: "legacy-result".to_string(),
+            name: Some("result.json".to_string()),
+            path: Some("/runner-only/result.json".to_string()),
+            url: Some("https://runner.invalid/result.json".to_string()),
+            mime: Some("application/json".to_string()),
+            size_bytes: Some(bytes.len() as u64),
+            sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+            content_base64: None,
+            metadata: None,
+        }];
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/runner/project",
+            &["homeboy".to_string(), "test".to_string()],
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("synthetic terminal run");
+
+        mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |artifact_id| {
+            assert_eq!(artifact_id, "legacy-result");
+            Ok(bytes.to_vec())
+        })
+        .expect("project all legacy terminal artifacts");
+
+        let artifacts = super::mirror::controller_artifact_metadata(&[run])
+            .expect("controller artifact response");
+        assert_eq!(artifacts.len(), 1);
+        assert_ne!(
+            artifacts[0].path.as_deref(),
+            Some("/runner-only/result.json")
+        );
+        assert_eq!(
+            fs::read(artifacts[0].path.as_ref().expect("controller path")).expect("bytes"),
+            bytes
+        );
+    });
+}
+
+#[test]
+fn terminal_artifacts_missing_integrity_are_permanent_provenance_errors() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut job = terminal_runner_job();
+        job.artifacts = vec![JobArtifactMetadata {
+            id: "missing-digest".to_string(),
+            name: None,
+            path: None,
+            url: None,
+            mime: None,
+            size_bytes: Some(1),
+            sha256: None,
+            content_base64: None,
+            metadata: None,
+        }];
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/runner",
+            &[],
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("synthetic run");
+        let error =
+            mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |_| Ok(vec![1]))
+                .expect_err("missing provenance is not retryable");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(!error.retryable.unwrap_or(true));
+        assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
+    });
+}
+
+#[test]
+fn terminal_artifact_download_failure_rolls_back_every_artifact_and_retry_is_idempotent() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut job = terminal_runner_job();
+        let first = b"first terminal artifact";
+        let second = b"second terminal artifact";
+        job.artifacts = [("first", first.as_slice()), ("second", second.as_slice())]
+            .into_iter()
+            .map(|(id, bytes)| JobArtifactMetadata {
+                id: id.to_string(),
+                name: None,
+                path: None,
+                url: None,
+                mime: None,
+                size_bytes: Some(bytes.len() as u64),
+                sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+                content_base64: None,
+                metadata: None,
+            })
+            .collect();
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/runner",
+            &[],
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("synthetic run");
+        let error = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
+            if id == "second" {
+                Err(Error::internal_io("runner disconnected", None))
+            } else {
+                Ok(first.to_vec())
+            }
+        })
+        .expect_err("later artifact download fails the complete projection");
+        assert!(error.retryable.unwrap_or(false));
+        assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
+
+        let first_projection =
+            mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
+                Ok(if id == "first" {
+                    first.to_vec()
+                } else {
+                    second.to_vec()
+                })
+            })
+            .expect("retry projects complete artifact set");
+        let replay = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
+            Ok(if id == "first" {
+                first.to_vec()
+            } else {
+                second.to_vec()
+            })
+        })
+        .expect("identical retry is idempotent");
+        assert_eq!(first_projection, replay);
+        assert_eq!(store.list_artifacts(&run.id).expect("artifacts").len(), 2);
     });
 }
 

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 
 use crate::{Runner, RunnerKind};
 use homeboy_core::api_jobs::{
-    Job, JobArtifactMetadata, JobEvent, JobEventKind, JobStatus, RunnerJobLifecycleMetadata,
-    RunnerJobProjection,
+    Job, JobArtifactMetadata, JobEvent, JobEventKind, JobStatus, RemoteRunnerObservationRunDetail,
+    RunnerJobLifecycleMetadata, RunnerJobProjection,
 };
 use homeboy_core::error::{Error, ErrorCode};
 use homeboy_core::observation::{ArtifactRecord, ObservationStore, RunRecord};
@@ -21,8 +21,9 @@ use super::download::{content_disposition_filename, download_remote_artifact};
 use super::mirror::{
     bounded_remote_events, import_mirrored_artifact_with_downloader, mirror_job_run,
     mirror_remote_observation_runs_by_id_with,
-    mirror_remote_observation_runs_by_id_with_downloader, mirror_terminal_job_artifacts_with,
-    mirrored_patch_result, primary_mirrored_run, MIRRORED_REMOTE_EVENT_LIMIT,
+    mirror_remote_observation_runs_by_id_with_downloader, mirror_reverse_broker_evidence,
+    mirror_terminal_job_artifacts_with, mirrored_patch_result, primary_mirrored_run,
+    refresh_mirrored_daemon_evidence_with, MIRRORED_REMOTE_EVENT_LIMIT,
     MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
 };
 use super::tokens::{
@@ -221,6 +222,44 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
             run.metadata_json["notification_route"]["route"],
             "opaque-origin-route"
         );
+    });
+}
+
+#[test]
+fn synthetic_runner_run_identity_is_stable_across_repeated_progress_mirrors() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let runner = ssh_runner();
+        let job = terminal_runner_job();
+        let command = vec!["homeboy".to_string(), "test".to_string()];
+
+        let first = mirror_job_run(
+            &store,
+            &runner,
+            "/runner/project",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("first progress mirror");
+        let second = mirror_job_run(
+            &store,
+            &runner,
+            "/runner/project",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("repeated progress mirror");
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(store.list_artifacts(&first.id).expect("artifacts").len(), 0);
     });
 }
 
@@ -448,11 +487,11 @@ fn mirroring_lab_job_preserves_agent_task_lifecycle_metadata() {
 
 #[test]
 fn test_mirrored_patch_result_reports_accessible_artifact_token() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    homeboy_core::test_support::with_isolated_home(|home| {
         let store = ObservationStore::open_initialized().expect("store");
         let runner = ssh_runner();
         let job_id = Uuid::new_v4();
-        let job = Job {
+        let mut job = Job {
             id: job_id,
             operation: "exec".to_string(),
             status: JobStatus::Succeeded,
@@ -474,43 +513,39 @@ fn test_mirrored_patch_result_reports_accessible_artifact_token() {
             artifacts: Vec::new(),
             runner_job_projection: None,
         };
-        let run_id = format!("runner-exec-{job_id}");
         let artifact_id = format!("runner-fix-patch-{job_id}");
+        job.artifacts.push(JobArtifactMetadata {
+            id: artifact_id.clone(),
+            name: Some("patch.diff".to_string()),
+            path: None,
+            url: None,
+            mime: Some("text/x-diff".to_string()),
+            size_bytes: Some(12),
+            sha256: None,
+            content_base64: None,
+            metadata: None,
+        });
+        let run = mirror_job_run(
+            &store,
+            &runner,
+            "/srv/project",
+            &[
+                "homeboy".to_string(),
+                "runner".to_string(),
+                "exec".to_string(),
+            ],
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("mirror job");
+        let source = home.path().join("patch.diff");
+        fs::write(&source, b"patch bytes!!").expect("patch bytes");
         store
-            .import_run(&RunRecord {
-                id: run_id.clone(),
-                kind: "runner-exec".to_string(),
-                component_id: None,
-                started_at: "2026-05-16T00:00:00Z".to_string(),
-                finished_at: Some("2026-05-16T00:00:01Z".to_string()),
-                status: "pass".to_string(),
-                command: Some("homeboy runner exec".to_string()),
-                cwd: Some("/srv/project".to_string()),
-                homeboy_version: None,
-                git_sha: None,
-                rig_id: None,
-                metadata_json: json!({}),
-            })
-            .expect("import run");
-        let token = runner_artifact_token(&runner.id, &run_id, &artifact_id);
-        store
-            .import_artifact(&ArtifactRecord {
-                id: artifact_id.clone(),
-                run_id: run_id.clone(),
-                kind: "lab_fix_patch".to_string(),
-                artifact_type: "remote_file".to_string(),
-                path: token.clone(),
-                url: None,
-                public_url: None,
-                viewer_url: None,
-                viewer_links: Vec::new(),
-                sha256: Some("abc".to_string()),
-                size_bytes: Some(12),
-                mime: Some("text/x-diff".to_string()),
-                metadata_json: json!({}),
-                created_at: "2026-05-16T00:00:01Z".to_string(),
-            })
-            .expect("import artifact");
+            .record_artifact_with_id(&run.id, "lab_fix_patch", &source, &artifact_id, json!({}))
+            .expect("record controller artifact");
 
         let patch = json!({
             "patch_artifact_id": artifact_id,
@@ -521,12 +556,9 @@ fn test_mirrored_patch_result_reports_accessible_artifact_token() {
             .expect("mirror patch")
             .expect("patch");
 
-        assert_eq!(mirrored["patch_artifact_path"], token);
-        assert!(is_retrievable_runner_artifact(
-            mirrored["patch_artifact_path"]
-                .as_str()
-                .expect("projected patch artifact token")
-        ));
+        assert!(mirrored["patch_artifact_path"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("patch.diff")));
     });
 }
 
@@ -1079,6 +1111,76 @@ fn terminal_mirroring_persists_declared_run_and_artifact_for_controller_review()
 }
 
 #[test]
+fn reverse_broker_lookup_projects_only_embedded_typed_run_details() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let job = terminal_runner_job();
+        let run = RunRecord {
+            id: "embedded-run".to_string(),
+            kind: "bench".to_string(),
+            component_id: None,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            finished_at: Some("2026-01-01T00:01:00Z".to_string()),
+            status: "succeeded".to_string(),
+            command: None,
+            cwd: None,
+            homeboy_version: None,
+            git_sha: None,
+            rig_id: None,
+            metadata_json: json!({}),
+        };
+        let result = json!({
+            "exit_code": 0,
+            "observation_run_ids": [run.id.clone()],
+            "observation_run_details": [RemoteRunnerObservationRunDetail::v1(run, Vec::new())],
+        });
+
+        let mirrored = mirror_reverse_broker_evidence(
+            &ssh_runner(),
+            "http://127.0.0.1:1",
+            "/runner/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            &result,
+            None,
+            None,
+        )
+        .expect("embedded terminal detail does not request a broker run endpoint")
+        .expect("terminal evidence is mirrored");
+        assert_eq!(mirrored.run.id, "embedded-run");
+
+        let legacy = json!({ "exit_code": 0, "observation_run_ids": ["legacy-run"] });
+        let mirrored = mirror_reverse_broker_evidence(
+            &ssh_runner(),
+            "http://127.0.0.1:1",
+            "/runner/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            &legacy,
+            None,
+            None,
+        )
+        .expect("old worker terminal result retains controller-owned evidence")
+        .expect("terminal evidence is mirrored");
+        assert_ne!(mirrored.run.id, "legacy-run");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .get_run(&mirrored.run.id)
+            .expect("run lookup")
+            .expect("controller synthetic run");
+        assert_eq!(
+            run.metadata_json["lab"]["reverse_broker"]["unresolved_run_refs"],
+            json!(["legacy-run"])
+        );
+        assert_eq!(
+            run.metadata_json["lab"]["reverse_broker"]["observation_run_details"],
+            json!("unavailable_legacy")
+        );
+    });
+}
+
+#[test]
 fn legacy_terminal_artifacts_use_the_controller_runner_run_and_survive_runner_disconnect() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let store = ObservationStore::open_initialized().expect("store");
@@ -1114,7 +1216,7 @@ fn legacy_terminal_artifacts_use_the_controller_runner_run_and_survive_runner_di
         })
         .expect("project all legacy terminal artifacts");
 
-        let artifacts = super::mirror::controller_artifact_metadata(&[run])
+        let artifacts = super::mirror::controller_artifact_metadata(&[run.run.clone()])
             .expect("controller artifact response");
         assert_eq!(artifacts.len(), 1);
         assert_ne!(
@@ -1228,6 +1330,88 @@ fn terminal_artifact_download_failure_rolls_back_every_artifact_and_retry_is_ide
         .expect("identical retry is idempotent");
         assert_eq!(first_projection, replay);
         assert_eq!(store.list_artifacts(&run.id).expect("artifacts").len(), 2);
+    });
+}
+
+#[test]
+fn failed_refresh_discards_its_synthetic_run_after_artifact_projection_error() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut job = terminal_runner_job();
+        job.artifacts = vec![JobArtifactMetadata {
+            id: "malformed".to_string(),
+            name: None,
+            path: None,
+            url: None,
+            mime: None,
+            size_bytes: Some(1),
+            sha256: None,
+            content_base64: None,
+            metadata: None,
+        }];
+        let command = vec!["homeboy".to_string(), "test".to_string()];
+        let synthetic_id = super::util::local_job_run_id("lab", &job.id.to_string(), "test");
+        refresh_mirrored_daemon_evidence_with(
+            &store,
+            &ssh_runner(),
+            "/runner",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            None,
+            || Ok(()),
+        )
+        .expect_err("malformed terminal artifact fails refresh");
+        assert!(store
+            .get_run(&synthetic_id)
+            .expect("synthetic lookup")
+            .is_none());
+    });
+}
+
+#[test]
+fn failed_refresh_preserves_a_concurrent_synthetic_winner() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut job = terminal_runner_job();
+        job.artifacts = vec![JobArtifactMetadata {
+            id: "malformed".to_string(),
+            name: None,
+            path: None,
+            url: None,
+            mime: None,
+            size_bytes: Some(1),
+            sha256: None,
+            content_base64: None,
+            metadata: None,
+        }];
+        let command = vec!["homeboy".to_string(), "test".to_string()];
+        let winner = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/runner",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("concurrent winner");
+        refresh_mirrored_daemon_evidence_with(
+            &store,
+            &ssh_runner(),
+            "/runner",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            None,
+            || Ok(()),
+        )
+        .expect_err("malformed terminal artifact fails refresh");
+        assert!(store.get_run(&winner.id).expect("winner lookup").is_some());
     });
 }
 

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -305,7 +305,11 @@ pub(super) fn exec_via_reverse_broker(
             .as_ref()
             .and_then(|workload| workload.notification_route.as_ref()),
     );
-    let artifacts = job.artifacts.clone();
+    let artifacts = mirror
+        .as_ref()
+        .map(|evidence| crate::evidence::controller_artifact_metadata(&evidence.runs))
+        .transpose()?
+        .unwrap_or_default();
     let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
 
     if print_handoff_output {

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -341,7 +341,11 @@ pub(super) fn exec_via_daemon(
             .as_ref()
             .and_then(|workload| workload.notification_route.as_ref()),
     );
-    let artifacts = job.artifacts.clone();
+    let artifacts = mirror
+        .as_ref()
+        .map(|evidence| crate::evidence::controller_artifact_metadata(&evidence.runs))
+        .transpose()?
+        .unwrap_or_default();
     if let Some(session) = accepted_session.as_ref() {
         super::super::generation_store::record_job_artifacts(
             &runner.id,

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -1,7 +1,9 @@
 use super::*;
+use base64::Engine;
 use homeboy_core::api_jobs::JobEventKind;
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::time::Duration;
 
 #[test]
@@ -1187,6 +1189,7 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
         let broker_url = format!("http://{addr}");
         let worker_broker_url = broker_url.clone();
         let worker = std::thread::spawn(move || {
+            let artifact_bytes = b"reverse patch";
             let client = Client::builder()
                 .timeout(Duration::from_secs(10))
                 .build()
@@ -1242,8 +1245,9 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
                             "name": "reverse.patch",
                             "path": "/srv/homeboy/.homeboy/artifacts/reverse.patch",
                             "mime": "text/x-diff",
-                            "size_bytes": 12,
-                            "sha256": "abc123",
+                            "size_bytes": artifact_bytes.len(),
+                            "sha256": format!("{:x}", Sha256::digest(artifact_bytes)),
+                            "content_base64": base64::engine::general_purpose::STANDARD.encode(artifact_bytes),
                             "metadata": { "kind": "lab_fix_patch" }
                         }]
                     }
@@ -1282,13 +1286,12 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
         assert!(output.job_id.is_some());
         let mirror_run_id = output.mirror_run_id.as_deref().expect("mirror run id");
         assert!(mirror_run_id.starts_with("runner-exec-test-lab-"));
-        assert_eq!(
-            output
-                .patch
-                .as_ref()
-                .and_then(|patch| patch.get("patch_artifact_path").and_then(Value::as_str)),
-            Some("metadata-only:reverse-patch")
-        );
+        let patch_path = output
+            .patch
+            .as_ref()
+            .and_then(|patch| patch.get("patch_artifact_path").and_then(Value::as_str))
+            .expect("controller patch path");
+        assert!(!patch_path.starts_with("metadata-only:"));
         assert_eq!(
             output
                 .mutation_artifacts
@@ -1339,7 +1342,11 @@ fn reverse_broker_exec_submits_job_and_polls_result() {
             .expect("read reverse artifact")
             .expect("reverse artifact");
         assert_eq!(artifact.run_id, mirror_run_id);
-        assert_eq!(artifact.path, "metadata-only:reverse-patch");
+        assert_eq!(artifact.path, patch_path);
+        assert_eq!(
+            std::fs::read(&artifact.path).expect("controller patch bytes"),
+            b"reverse patch"
+        );
     });
 }
 

--- a/crates/homeboy-lab-runner/src/worker/result.rs
+++ b/crates/homeboy-lab-runner/src/worker/result.rs
@@ -1,10 +1,13 @@
 use base64::Engine;
 use serde_json::json;
+use std::collections::HashSet;
 
 use crate::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events;
 use homeboy_core::api_jobs::{
     Job, JobArtifactMetadata, RemoteRunnerJobRequest, RemoteRunnerJobResult,
+    RemoteRunnerObservationRunDetail,
 };
+use homeboy_core::execution_contract::EXECUTION_CONTRACT;
 use homeboy_core::run_outcome_envelope::RunOutcomeEnvelope;
 
 use super::super::capabilities::RunnerCapabilityPreflight;
@@ -105,7 +108,25 @@ pub(super) fn remote_runner_result_from_exec_output(
         );
     }
     data["outcome"] = serde_json::to_value(outcome).unwrap_or(serde_json::Value::Null);
-    let artifacts = mirror_file_artifact_content(exec_output.artifacts, &exec_output.remote_cwd);
+    let observation_run_ids: Vec<String> = exec_output.mirror_run_id.into_iter().collect();
+    let durable_details = durable_observation_run_details(&observation_run_ids);
+    let artifacts = mirror_file_artifact_content(
+        durable_detail_artifacts(&durable_details)
+            .into_iter()
+            .chain(exec_output.artifacts)
+            .collect(),
+        &exec_output.remote_cwd,
+    );
+    let observation_run_details = canonicalize_detail_artifact_paths(
+        durable_details,
+        &exec_output.runner_id,
+        exec_output.job_id.as_deref(),
+    );
+    let artifacts = canonicalize_broker_artifact_paths(
+        artifacts,
+        &exec_output.runner_id,
+        exec_output.job_id.as_deref(),
+    );
     RemoteRunnerJobResult {
         exit_code,
         stdout: Some(exec_output.stdout),
@@ -113,7 +134,9 @@ pub(super) fn remote_runner_result_from_exec_output(
         patch,
         mutation_artifacts,
         data: Some(data),
-        observation_run_ids: exec_output.mirror_run_id.into_iter().collect(),
+        observation_run_details,
+        observation_run_details_compatibility_degraded: false,
+        observation_run_ids,
         artifacts,
         artifact_refs: exec_output
             .runner_result
@@ -140,12 +163,98 @@ pub(super) fn remote_runner_result_from_exec_output(
     }
 }
 
+fn canonicalize_detail_artifact_paths(
+    mut details: Vec<RemoteRunnerObservationRunDetail>,
+    runner_id: &str,
+    job_id: Option<&str>,
+) -> Vec<RemoteRunnerObservationRunDetail> {
+    let Some(job_id) = job_id.filter(|id| !id.trim().is_empty()) else {
+        return details;
+    };
+    for detail in &mut details {
+        for artifact in &mut detail.artifacts {
+            if artifact.artifact_type == "file" {
+                artifact.path = broker_artifact_token(runner_id, job_id, &artifact.id);
+            }
+        }
+    }
+    details
+}
+
+fn canonicalize_broker_artifact_paths(
+    mut artifacts: Vec<JobArtifactMetadata>,
+    runner_id: &str,
+    job_id: Option<&str>,
+) -> Vec<JobArtifactMetadata> {
+    let Some(job_id) = job_id.filter(|id| !id.trim().is_empty()) else {
+        return artifacts;
+    };
+    for artifact in &mut artifacts {
+        artifact.path = Some(broker_artifact_token(runner_id, job_id, &artifact.id));
+    }
+    artifacts
+}
+
+fn broker_artifact_token(runner_id: &str, job_id: &str, artifact_id: &str) -> String {
+    EXECUTION_CONTRACT
+        .artifacts
+        .runner_artifact_ref(runner_id, job_id, artifact_id)
+}
+
+/// The broker retains terminal result payloads after the worker exits. Mirror
+/// every durable file artifact into that payload so its authenticated content
+/// route remains a byte source for every declared observation detail.
+fn durable_detail_artifacts(
+    details: &[RemoteRunnerObservationRunDetail],
+) -> Vec<JobArtifactMetadata> {
+    let mut ids = HashSet::new();
+    details
+        .iter()
+        .flat_map(|detail| detail.artifacts.iter())
+        .filter(|artifact| artifact.artifact_type == "file" && ids.insert(artifact.id.clone()))
+        .map(|artifact| JobArtifactMetadata {
+            id: artifact.id.clone(),
+            name: std::path::Path::new(&artifact.path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string),
+            path: Some(artifact.path.clone()),
+            url: artifact.public_url.clone().or_else(|| artifact.url.clone()),
+            mime: artifact.mime.clone(),
+            size_bytes: artifact
+                .size_bytes
+                .and_then(|size| u64::try_from(size).ok()),
+            sha256: artifact.sha256.clone(),
+            content_base64: None,
+            metadata: Some(artifact.metadata_json.clone()),
+        })
+        .collect()
+}
+
+pub(super) fn durable_observation_run_details(
+    run_ids: &[String],
+) -> Vec<RemoteRunnerObservationRunDetail> {
+    let Ok(store) = homeboy_core::observation::ObservationStore::open_initialized() else {
+        return Vec::new();
+    };
+    run_ids
+        .iter()
+        .filter_map(|run_id| {
+            let run = store.get_run(run_id).ok()??;
+            let artifacts = store.list_artifacts(run_id).ok()?;
+            Some(RemoteRunnerObservationRunDetail::v1(run, artifacts))
+        })
+        .collect()
+}
+
 fn mirror_file_artifact_content(
     artifacts: Vec<JobArtifactMetadata>,
     remote_cwd: &str,
 ) -> Vec<JobArtifactMetadata> {
+    let mut ids = HashSet::new();
     artifacts
         .into_iter()
+        .filter(|artifact| ids.insert(artifact.id.clone()))
         .map(|mut artifact| {
             if artifact.content_base64.is_none() {
                 if let Some(path) = artifact.path.as_deref().map(|path| {

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -341,6 +341,8 @@ fn run_once_output(
                     "error": err.to_string(),
                 })),
                 observation_run_ids: Vec::new(),
+                observation_run_details: Vec::new(),
+                observation_run_details_compatibility_degraded: false,
                 artifacts: Vec::new(),
                 artifact_refs: Vec::new(),
                 metrics: None,

--- a/crates/homeboy-lab-runner/src/worker/tests/result_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/result_tests.rs
@@ -5,11 +5,14 @@ use crate::{
     RunnerResourceMetrics,
 };
 use homeboy_core::api_jobs::{JobArtifactMetadata, JobEvent, JobEventKind};
+use homeboy_core::observation::{ObservationStore, RunRecord};
 use homeboy_core::runner_execution_envelope::{
     BinaryProvenance, OrchestrationTargetProvenance, RunnerExecutionRecord,
 };
 
-use super::super::result::remote_runner_result_from_exec_output;
+use super::super::result::{
+    durable_observation_run_details, remote_runner_result_from_exec_output,
+};
 
 #[test]
 fn reverse_worker_result_preserves_exec_patch_and_artifacts() {
@@ -91,6 +94,135 @@ fn reverse_worker_result_preserves_exec_patch_and_artifacts() {
             .map(|artifact| artifact.artifact_id.as_str()),
         Some("patch.diff")
     );
+}
+
+#[test]
+fn reverse_worker_result_reads_persisted_observation_run_details() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let run = RunRecord {
+            id: "durable-run".to_string(),
+            kind: "fuzz".to_string(),
+            component_id: None,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            finished_at: Some("2026-01-01T00:01:00Z".to_string()),
+            status: "succeeded".to_string(),
+            command: None,
+            cwd: None,
+            homeboy_version: None,
+            git_sha: None,
+            rig_id: None,
+            metadata_json: json!({}),
+        };
+        ObservationStore::open_initialized()
+            .expect("store")
+            .import_run(&run)
+            .expect("persist terminal run");
+
+        let details = durable_observation_run_details(&[run.id.clone()]);
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0].run, run);
+        assert!(details[0].artifacts.is_empty());
+    });
+}
+
+#[test]
+fn reverse_worker_result_transports_every_durable_file_artifact_once() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = RunRecord {
+            id: "durable-multi-artifact-run".to_string(),
+            kind: "test".to_string(),
+            component_id: None,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            finished_at: Some("2026-01-01T00:01:00Z".to_string()),
+            status: "pass".to_string(),
+            command: None,
+            cwd: None,
+            homeboy_version: None,
+            git_sha: None,
+            rig_id: None,
+            metadata_json: json!({}),
+        };
+        store.import_run(&run).expect("persist run");
+        for (id, bytes) in [
+            ("first", b"direct first".as_slice()),
+            ("second", b"direct second".as_slice()),
+        ] {
+            let source = home.path().join(id);
+            std::fs::write(&source, bytes).expect("write direct artifact");
+            store
+                .record_artifact_with_id(&run.id, "test_output", &source, id, json!({}))
+                .expect("persist durable artifact");
+        }
+
+        let result = remote_runner_result_from_exec_output(
+            RunnerExecOutput {
+                variant: "exec",
+                command: "runner.exec",
+                runner_id: "lab".to_string(),
+                dry_run: false,
+                mode: RunnerExecMode::Local,
+                argv: vec!["true".to_string()],
+                remote_cwd: home.path().display().to_string(),
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+                source_snapshot: None,
+                job: None,
+                runner_job: None,
+                job_id: Some("broker-job-1".to_string()),
+                job_events: None,
+                mirror_run_id: Some(run.id.clone()),
+                patch: None,
+                mutation_artifacts: None,
+                artifacts: vec![JobArtifactMetadata {
+                    id: "first".to_string(),
+                    name: None,
+                    path: None,
+                    url: None,
+                    mime: None,
+                    size_bytes: None,
+                    sha256: None,
+                    content_base64: None,
+                    metadata: None,
+                }],
+                promoted_outputs: Vec::new(),
+                structured_summaries: Vec::new(),
+                metrics: None,
+                capture: None,
+                execution_record: None,
+                runner_result: None,
+                handoff: None,
+                diagnostics: None,
+            },
+            0,
+            None,
+        );
+
+        assert_eq!(result.observation_run_details[0].artifacts.len(), 2);
+        assert_eq!(
+            result.observation_run_details[0].artifacts[0].path,
+            "runner-artifact://lab/broker-job-1/first"
+        );
+        assert!(!result.observation_run_details[0].artifacts[0]
+            .path
+            .starts_with(home.path().to_str().expect("home path")));
+        assert_eq!(result.artifacts.len(), 2);
+        assert_eq!(
+            result.artifacts[0].path.as_deref(),
+            Some("runner-artifact://lab/broker-job-1/first")
+        );
+        assert_eq!(result.artifacts[0].id, "first");
+        assert_eq!(
+            result.artifacts[0].content_base64.as_deref(),
+            Some("ZGlyZWN0IGZpcnN0")
+        );
+        assert_eq!(result.artifacts[1].id, "second");
+        assert_eq!(
+            result.artifacts[1].content_base64.as_deref(),
+            Some("ZGlyZWN0IHNlY29uZA==")
+        );
+    });
 }
 
 #[test]

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -112,8 +112,8 @@ mod store_init_tests {
 
             assert!(status.exists);
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 9);
-            assert_eq!(status.table_count, 7);
+            assert_eq!(status.migration_count, 11);
+            assert_eq!(status.table_count, 8);
         });
     }
 
@@ -127,8 +127,8 @@ mod store_init_tests {
             let status = second.status().expect("status");
 
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 9);
-            assert_eq!(status.table_count, 7);
+            assert_eq!(status.migration_count, 11);
+            assert_eq!(status.table_count, 8);
         });
     }
 
@@ -149,7 +149,7 @@ mod store_init_tests {
             let status = reopened.status().expect("status");
 
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 9);
+            assert_eq!(status.migration_count, 11);
         });
     }
 
@@ -175,7 +175,7 @@ mod store_init_tests {
             for handle in handles {
                 let status = handle.join().expect("worker joined");
                 assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-                assert_eq!(status.migration_count, 9);
+                assert_eq!(status.migration_count, 11);
             }
         });
     }
@@ -229,7 +229,7 @@ mod store_init_tests {
             let store = ObservationStore::open_initialized_at(&path).expect("migrate version 8");
             let status = store.status().expect("status");
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 9);
+            assert_eq!(status.migration_count, 11);
 
             let db = rusqlite::Connection::open(path).expect("inspect migrated db");
             let indexes = db
@@ -1080,7 +1080,13 @@ mod store_artifact_tests {
                 std::fs::read_to_string(persisted.join("nested/detail.txt")).expect("read nested"),
                 "detail"
             );
-            assert_eq!(artifact.url, None);
+            assert_eq!(
+                artifact.url,
+                Some(
+                    crate::observation::directory_tree_sha256(&persisted)
+                        .expect("directory digest")
+                )
+            );
             assert_eq!(artifact.size_bytes, None);
             assert_eq!(artifact.mime, None);
             assert_eq!(artifact.sha256, None);


### PR DESCRIPTION
## Summary
- require terminal Lab evidence and artifact bytes to be durably controller-owned before returning reviewer references
- publish run/artifact sets through token-scoped leased intents with atomic ownership checks, crash recovery, and concurrent publisher safety
- preserve direct/reverse and mixed-version behavior with typed authenticated run details, durable legacy fallback, exact patch ownership, and token-scoped rollback

## Verification
- `cargo test -p homeboy-core observation::store::artifacts --lib`
- `cargo test -p homeboy-core daemon::remote_runner --lib`
- `cargo test -p homeboy-lab-runner evidence::tests --lib`
- `cargo test -p homeboy-lab-runner worker::tests::result_tests --lib`
- `cargo fmt --all --check`
- `cargo check -p homeboy-core -p homeboy-lab-runner`

Closes #10408.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the durability boundary and iteratively remediated publication races, reverse-broker compatibility, authentication, and rollback after independent reviews. Chris Huber reviewed and owns every line.