### PR TITLE
fix(runner): keep workspace prune below ARG_MAX

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -415,6 +415,21 @@ impl SshClient {
         self.execute_ssh_with_timeout(&effective, None, timeout)
     }
 
+    /// Execute a command with replayable bytes delivered over stdin and a hard
+    /// wall-clock deadline.
+    pub fn execute_with_input_and_timeout(
+        &self,
+        command: &str,
+        input: &[u8],
+        timeout: Duration,
+    ) -> CommandOutput {
+        let effective = self.prepend_env(command);
+        if self.is_local {
+            return execute_local_command_with_stdin_and_timeout(&effective, input, timeout);
+        }
+        self.execute_ssh_with_timeout(&effective, Some(input), timeout)
+    }
+
     /// Execute `command` with secret env vars delivered over stdin instead of
     /// interpolated into the SSH command argv.
     ///

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -3281,11 +3281,16 @@ fn remove_ssh_prune_candidate(
                 vec!["materialized_workspace_lifecycle_changed".to_string()],
             )));
         }
-        ssh_prune_delete_materialized_workspace_command(
-            root,
-            &candidate.remote_path,
-            encoded_metadata,
-        )
+        let expected_metadata = base64::engine::general_purpose::STANDARD
+            .decode(encoded_metadata)
+            .map_err(|error| Error::internal_unexpected(error.to_string()))?;
+        let command = ssh_prune_delete_materialized_workspace_command(root, &candidate.remote_path);
+        let output = client.execute_with_input_and_timeout(
+            &command,
+            &expected_metadata,
+            WORKSPACE_PRUNE_TIMEOUT,
+        );
+        return parse_ssh_prune_delete_output(output);
     } else {
         let terminal_owner_run_id = candidate.run_id.as_deref().filter(|run_id| {
             homeboy_agents::agent_task_lifecycle::exact_record(run_id)
@@ -3298,6 +3303,12 @@ fn remove_ssh_prune_candidate(
         )
     };
     let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
+    parse_ssh_prune_delete_output(output)
+}
+
+fn parse_ssh_prune_delete_output(
+    output: CommandOutput,
+) -> Result<Option<RunnerWorkspaceLivenessEvidence>> {
     if !output.success {
         return Err(Error::internal_unexpected(format!(
             "remove runner workspace failed: {}",
@@ -3346,15 +3357,15 @@ pub(crate) fn ssh_prune_delete_command_with_terminal_owner(
 pub(crate) fn ssh_prune_delete_materialized_workspace_command(
     root: &str,
     remote_path: &str,
-    expected_metadata: &str,
 ) -> String {
     format!(
         concat!(
-            "root={root}; p={path}; meta_rel={meta}; expected={expected}; ",
+            "root={root}; p={path}; meta_rel={meta}; ",
             "case \"$p\" in \"$root\"/*) ;; *) printf unknown:workspace_path; exit 0 ;; esac; ",
+            "expected=$(mktemp \"${{TMPDIR:-/tmp}}/homeboy-prune-delete.XXXXXX\") || {{ printf unknown:metadata_transport; exit 0; }}; ",
+            "trap 'rm -f \"$expected\"' EXIT HUP INT TERM; cat > \"$expected\" || {{ printf unknown:metadata_transport; exit 0; }}; ",
             "meta=\"$p/$meta_rel\"; [ -f \"$meta\" ] || {{ printf unknown:metadata; exit 0; }}; ",
-            "actual=$(base64 < \"$meta\" | tr -d '\\n') || {{ printf unknown:metadata; exit 0; }}; ",
-            "[ \"$actual\" = \"$expected\" ] || {{ printf unknown:materialized_workspace_lifecycle_changed; exit 0; }}; ",
+            "cmp -s \"$meta\" \"$expected\" || {{ printf unknown:materialized_workspace_lifecycle_changed; exit 0; }}; ",
             "command -v ps >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1 || {{ printf unknown:process_probe_unavailable; exit 0; }}; ",
             "ps_output=$(ps -eo pid=,ppid=,args=) || {{ printf unknown:process_probe_failed; exit 0; }}; ",
             "printf '%s\n' \"$ps_output\" | awk -v p=\"$p\" -v self=\"$$\" -v parent=\"$PPID\" '$1 != self && $1 != parent && $2 != self && index($0, p) {{ found=1 }} END {{ exit !found }}'; state=$?; ",
@@ -3368,7 +3379,6 @@ pub(crate) fn ssh_prune_delete_materialized_workspace_command(
         root = shell::quote_arg(root),
         path = shell::quote_arg(remote_path),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),
-        expected = shell::quote_arg(expected_metadata),
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -1,6 +1,7 @@
 use std::fs;
+use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -1058,24 +1059,22 @@ fn ssh_materialized_workspace_delete_requires_exact_inactive_lifecycle() {
     let workspaces = root.path().join("_lab_workspaces");
     let eligible = workspaces.join("eligible");
     write_materialized_workspace(&eligible);
-    let expected_metadata = encoded_workspace_metadata(&eligible);
+    let metadata_path = eligible.join(WORKSPACE_METADATA_FILE);
+    let mut metadata: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&metadata_path).expect("metadata"))
+            .expect("metadata json");
+    metadata["large_comparison_payload"] = serde_json::json!("x".repeat(3 * 1024 * 1024));
+    fs::write(&metadata_path, metadata.to_string()).expect("write large metadata");
+    let expected_metadata = workspace_metadata(&eligible);
 
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(ssh_prune_delete_materialized_workspace_command(
-            &workspaces.display().to_string(),
-            &eligible.display().to_string(),
-            &expected_metadata,
-        ))
-        .output()
-        .expect("delete stale materialized workspace");
+    let output = run_materialized_workspace_delete(&workspaces, &eligible, &expected_metadata);
     assert!(output.status.success(), "{output:?}");
     assert_eq!(String::from_utf8_lossy(&output.stdout), "removed");
     assert!(!eligible.exists());
 
     let ambiguous = workspaces.join("ambiguous");
     write_materialized_workspace(&ambiguous);
-    let expected_metadata = encoded_workspace_metadata(&ambiguous);
+    let expected_metadata = workspace_metadata(&ambiguous);
     let metadata_path = ambiguous.join(WORKSPACE_METADATA_FILE);
     let mut metadata: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&metadata_path).expect("metadata"))
@@ -1090,15 +1089,7 @@ fn ssh_materialized_workspace_delete_requires_exact_inactive_lifecycle() {
         &base64::engine::general_purpose::STANDARD.encode(b"{malformed"),
         &ambiguous,
     ));
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(ssh_prune_delete_materialized_workspace_command(
-            &workspaces.display().to_string(),
-            &ambiguous.display().to_string(),
-            &expected_metadata,
-        ))
-        .output()
-        .expect("retain ambiguous materialized workspace");
+    let output = run_materialized_workspace_delete(&workspaces, &ambiguous, &expected_metadata);
     assert!(output.status.success(), "{output:?}");
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
@@ -1106,24 +1097,29 @@ fn ssh_materialized_workspace_delete_requires_exact_inactive_lifecycle() {
     );
     assert!(ambiguous.exists());
 
+    let malformed = workspaces.join("malformed");
+    write_materialized_workspace(&malformed);
+    let expected_metadata = workspace_metadata(&malformed);
+    fs::write(malformed.join(WORKSPACE_METADATA_FILE), "{malformed")
+        .expect("write malformed metadata");
+    let output = run_materialized_workspace_delete(&workspaces, &malformed, &expected_metadata);
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "unknown:materialized_workspace_lifecycle_changed"
+    );
+    assert!(malformed.exists());
+
     let process_owned = workspaces.join("process-owned");
     write_materialized_workspace(&process_owned);
-    let expected_metadata = encoded_workspace_metadata(&process_owned);
+    let expected_metadata = workspace_metadata(&process_owned);
     let mut child = Command::new("sh")
         .arg("-c")
         .arg("sleep 30")
         .current_dir(&process_owned)
         .spawn()
         .expect("hold materialized workspace cwd");
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(ssh_prune_delete_materialized_workspace_command(
-            &workspaces.display().to_string(),
-            &process_owned.display().to_string(),
-            &expected_metadata,
-        ))
-        .output()
-        .expect("retain process-owned materialized workspace");
+    let output = run_materialized_workspace_delete(&workspaces, &process_owned, &expected_metadata);
     child.kill().expect("stop held process");
     child.wait().expect("reap held process");
     assert!(output.status.success(), "{output:?}");
@@ -1269,9 +1265,41 @@ fn write_materialized_workspace(path: &Path) {
 }
 
 fn encoded_workspace_metadata(path: &Path) -> String {
-    base64::engine::general_purpose::STANDARD.encode(
-        fs::read(path.join(WORKSPACE_METADATA_FILE)).expect("read workspace metadata for compare"),
-    )
+    base64::engine::general_purpose::STANDARD.encode(workspace_metadata(path))
+}
+
+fn workspace_metadata(path: &Path) -> Vec<u8> {
+    fs::read(path.join(WORKSPACE_METADATA_FILE)).expect("read workspace metadata for compare")
+}
+
+fn run_materialized_workspace_delete(
+    root: &Path,
+    workspace: &Path,
+    expected_metadata: &[u8],
+) -> std::process::Output {
+    let command = ssh_prune_delete_materialized_workspace_command(
+        &root.display().to_string(),
+        &workspace.display().to_string(),
+    );
+    assert!(
+        command.len() < 16 * 1024,
+        "comparison data must not be embedded in argv"
+    );
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start materialized workspace delete");
+    child
+        .stdin
+        .take()
+        .expect("delete stdin")
+        .write_all(expected_metadata)
+        .expect("stream expected metadata");
+    child.wait_with_output().expect("finish workspace delete")
 }
 
 fn active_lifecycle_metadata(run_id: &str, resource_run_id: &str) -> serde_json::Value {


### PR DESCRIPTION
## Summary
Stream expected workspace metadata over SSH stdin so compare-and-delete remains bounded below ARG\_MAX.

## What changed
- Adds timeout-bounded SSH stdin execution, compares a temporary expected-metadata file byte-for-byte immediately before deletion, and covers multi-megabyte, changed, malformed, and process-owned metadata cases.

## How to test
1. Run `cargo fmt --check`; expect Formatting passes.
2. Run `cargo test -p homeboy-lab-runner ssh_materialized_workspace_delete_requires_exact_inactive_lifecycle --lib`; expect The ARG\_MAX and fail-closed lifecycle test passes.

## Compatibility
Preserves existing workspace classification, process ownership probes, lifecycle liveness checks, output tokens, and fail-closed behavior; only comparison-data transport moves from argv to stdin.

## Evidence
- Base unchanged since verification: main remains at 3db0127284ec75e05d13e2f540a03ad64b54c910.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/10492
- Verified finalization base: main at 3db0127284ec75e05d13e2f540a03ad64b54c910
- format: passed (cargo fmt --check) (Passed)
- targeted-test: passed (1 passed) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode analyzed the workspace-prune SSH deletion path, implemented stdin-based metadata transport, extended fail-closed lifecycle tests, and reviewed the resulting diff; Chris directed the operational requirements and verified the exact candidate.

## Source relationships
- Closes #10492
