### PR TITLE
Fix cook continuation controller runtime identity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -448,7 +448,11 @@ where
                 record.metadata[key] = value.clone();
             }
         }
-        if execution_runner_id.as_deref() == existing.runner_id() {
+        if execution_runner_id.as_deref().is_some_and(|runner_id| {
+            existing
+                .runner_id()
+                .is_none_or(|existing_runner_id| existing_runner_id == runner_id)
+        }) {
             // A foreground daemon binds its job before launching runner-local
             // `run-plan`. Keep that transport identity when run-plan replaces
             // the staged record, or terminal projection cannot join its daemon
@@ -456,14 +460,20 @@ where
             if let Some(runner_job_id) = existing.runner_job_id() {
                 record.metadata["runner_job_id"] = json!(runner_job_id);
             }
+            // The runner can re-submit after its workspace has been reaped,
+            // including before the handoff acceptance projection is durable.
+            // Its local pin is execution evidence only; continuations remain
+            // owned by the controller seat that created this record. Fail closed
+            // if that controller pin is unavailable rather than replacing it
+            // with the runner's host-local executable.
+            preserved_controller_runtime = Some(controller_runtime_for_runner_execution(
+                &existing,
+                execution_runner_id.as_deref(),
+            )?);
             if existing.lab_handoff.as_ref().is_some_and(|handoff| {
                 handoff.state == AgentTaskLabHandoffState::Accepted
                     && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
             }) {
-                preserved_controller_runtime = Some(controller_runtime_for_runner_execution(
-                    &existing,
-                    execution_runner_id.as_deref(),
-                )?);
                 record.lab_handoff = existing.lab_handoff;
             }
         }
@@ -524,14 +534,12 @@ pub(crate) fn controller_runtime_for_runner_execution(
     existing: &AgentTaskRunRecord,
     execution_runner_id: Option<&str>,
 ) -> Result<Value> {
-    if execution_runner_id != existing.runner_id()
-        || !existing.lab_handoff.as_ref().is_some_and(|handoff| {
-            handoff.state == AgentTaskLabHandoffState::Accepted
-                && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
-        })
+    if existing
+        .runner_id()
+        .is_some_and(|runner_id| Some(runner_id) != execution_runner_id)
     {
         return Err(Error::internal_unexpected(
-            "runner execution identity was requested for a non-accepted Lab handoff",
+            "runner execution identity does not match the controller-owned Lab handoff",
         ));
     }
     existing

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -368,6 +368,62 @@ fn accepted_lab_runner_execution_preserves_controller_runtime_pin_across_host_id
 }
 
 #[test]
+fn planned_lab_runner_execution_preserves_controller_runtime_pin_before_acceptance() {
+    with_isolated_home(|_| {
+        let run_id = "cross-host-controller-pin-planned";
+        let controller_runtime = json!({
+            "schema": "homeboy/controller-runtime-pin/v2",
+            "originating": {
+                "build_identity": "homeboy 0.300.0+macos",
+                "pinned_executable": "/Users/chubes/.local/share/homeboy/controller-runtimes/macos/homeboy",
+                "sha256": "macos-controller-sha256"
+            }
+        });
+        let runner_runtime = json!({
+            "schema": "homeboy/controller-runtime-pin/v2",
+            "originating": {
+                "build_identity": "homeboy 0.300.0+linux",
+                "pinned_executable": "/home/chubes/.local/share/homeboy/controller-runtimes/linux/homeboy",
+                "sha256": "linux-runner-sha256"
+            }
+        });
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ];
+
+        submit_plan_with_runtime_admission(&test_plan(), Some(run_id), |_| {
+            Ok(controller_runtime.clone())
+        })
+        .expect("controller submits the durable run");
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id,
+            runner_id: "linux-lab",
+            remote_workspace: "/home/chubes/homeboy",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("controller records planned handoff");
+
+        submit_plan_with_runtime_admission_on_runner(
+            &test_plan(),
+            Some(run_id),
+            Some("linux-lab".to_string()),
+            |_| Ok(runner_runtime.clone()),
+        )
+        .expect("runner preserves controller-seat runtime before acceptance");
+
+        let record = status(run_id).expect("controller record");
+        assert_eq!(
+            record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY],
+            controller_runtime
+        );
+        assert_eq!(record.metadata["runner_execution_runtime"], runner_runtime);
+    });
+}
+
+#[test]
 fn accepted_lab_runner_execution_rejects_missing_controller_runtime_pin() {
     with_isolated_home(|_| {
         let run_id = "missing-cross-host-controller-pin";

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5190,6 +5190,42 @@ fn finalization_operation_claim_revalidates_completed_publication() {
 }
 
 #[test]
+fn review_form_follow_up_finalization_replays_its_durable_claim_after_restart() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-review-form-restart";
+        let run_id = "cook-review-form-restart-attempt-2";
+        let plan = AgentTaskPlan::new(cook_id, Vec::new());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, run_id).unwrap();
+        let options = promotion_claim_options(cook_id, run_id);
+        let promotion = promotion(run_id);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..2 {
+            let calls = Arc::clone(&calls);
+            let mut finalize =
+                move |_: &AgentTaskCookServiceOptions, _: &str, _: &AgentTaskPromotionReport| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(serde_json::json!({"status": "review_ready", "review_form": true}))
+                };
+            finalize_with_operation_claim(&options, run_id, &promotion, &mut finalize).unwrap();
+        }
+
+        let operation_key = finalization_operation_key(run_id, &promotion);
+        let claim = agent_task_lifecycle::operation_claim(run_id, &operation_key)
+            .unwrap()
+            .expect("review-form finalization claim");
+        assert_eq!(claim.state, agent_task_lifecycle::ClaimState::Completed);
+        assert_eq!(claim.result.unwrap()["review_form"], true);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "restart only revalidates publication"
+        );
+    });
+}
+
+#[test]
 fn duplicate_controller_passes_revalidate_one_promoted_candidate() {
     // #8357 acceptance (AC5 + AC7): duplicate/concurrent controller passes over
     // the same candidate must produce exactly one promotion checkpoint and


### PR DESCRIPTION
## Summary

Preserve the originating controller's immutable runtime pin when a Lab runner re-submits a cook attempt, including the planned-before-acceptance race. The runner's host-local executable remains execution evidence and can no longer strand controller-side `cook-continue` after the runner workspace is reaped.

Fixes #10497.

## What changed

- recognize authenticated runner resubmission before handoff acceptance is projected
- retain controller and runner runtime identities separately across host path asymmetry
- fail closed when the controller runtime pin is missing instead of replacing it with the runner path
- cover restart after review-form follow-up through the durable finalization claim

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents accepted_lab_runner_execution_rejects_missing_controller_runtime_pin`
- `cargo test -p homeboy-agents planned_lab_runner_execution_preserves_controller_runtime_pin_before_acceptance`
- `cargo test -p homeboy-agents accepted_lab_runner_execution_preserves_controller_runtime_pin_across_host_identity_divergence`
- `cargo test -p homeboy-agents review_form_follow_up_finalization_replays_its_durable_claim_after_restart`

The full `homeboy-agents` suite ran 1,084 passing tests and exposed 69 pre-existing shared-state/isolation failures; the focused changed contracts above pass independently.

## Compatibility

Command schemas and continuation contracts are unchanged. Existing accepted handoffs retain their behavior; planned handoffs now preserve the same controller authority earlier. Missing controller provenance continues to fail closed.

## AI assistance

- **Model:** OpenAI gpt-5.6-sol and gpt-5.6-terra
- **Tool:** OpenCode with Homeboy
- **Used for:** Reproduced the downstream Lab/controller path mismatch, drafted the lifecycle repair and tests, reviewed the generated candidate, found and corrected its initial fail-open regression, and ran deterministic verification. Chris Huber directed and reviewed the work and remains responsible for every line.