### PR TITLE
cleanup: trim the artifacts.rs facade to symbols with real consumers

### DIFF
--- a/crates/homeboy-core/src/artifacts.rs
+++ b/crates/homeboy-core/src/artifacts.rs
@@ -1,7 +1,11 @@
-//! Stable facade for artifact contracts, links, manifests, and publication helpers.
+//! Convenience re-exports for the artifact APIs that callers reach for most.
 //!
-//! New command/core code should import artifact APIs from this module instead of
-//! reaching into individual artifact implementation modules.
+//! This is a shortcut, not a boundary. The implementation modules
+//! (`artifact_manifest`, `artifact_links`, `artifact_postprocess`, ...) stay
+//! public, and importing from them directly is equally supported — roughly half
+//! of the current call sites already do. Only symbols with a real consumer
+//! through this path are re-exported here, so the list stays honest instead of
+//! mirroring every artifact type in core.
 
 pub use super::artifact_dom_boxes::{
     capture as capture_dom_boxes, DomBoxCaptureSpec, DomBoxReport,

--- a/crates/homeboy-core/src/artifacts.rs
+++ b/crates/homeboy-core/src/artifacts.rs
@@ -3,30 +3,15 @@
 //! New command/core code should import artifact APIs from this module instead of
 //! reaching into individual artifact implementation modules.
 
-pub use super::artifact_address::{
-    validated_public_url, ArtifactAddress, ArtifactAddressKind, ArtifactAddressValidation,
-    ARTIFACT_ADDRESS_SCHEMA,
-};
-pub use super::artifact_contract::{
-    ArtifactContract, EvidenceContract, ARTIFACT_CONTRACT_SCHEMA, EVIDENCE_CONTRACT_SCHEMA,
-};
 pub use super::artifact_dom_boxes::{
-    capture as capture_dom_boxes, plan_capture as plan_dom_box_capture, DomBoxCaptureSpec,
-    DomBoxElement, DomBoxEntrypointReport, DomBoxReport, DomBoxViewport, ARTIFACT_DOM_BOXES_SCHEMA,
+    capture as capture_dom_boxes, DomBoxCaptureSpec, DomBoxReport,
 };
-pub use super::artifact_inputs::ResolvedArtifactInput;
 pub use super::artifact_links::{
-    annotate_public_artifact_url_validation, cached_validated_viewer_links,
-    public_artifact_path_url, public_artifact_url, public_artifact_url_validation_json,
-    validate_public_artifact_url, validated_viewer_links, viewer_links,
-    PublicArtifactUrlValidation, PUBLIC_ARTIFACT_BASE_URL_ENV,
+    cached_validated_viewer_links, public_artifact_path_url, public_artifact_url,
+    PUBLIC_ARTIFACT_BASE_URL_ENV,
 };
 pub use super::artifact_manifest::{
-    manifest_for_existing_files, manifest_path, normalize_relative_artifact_path,
-    read_manifest_from_root, write_manifest_to_root, ArtifactManifest, ArtifactManifestEntry,
-    ArtifactManifestProvenance, ArtifactManifestPublicUrlState, ArtifactManifestViewer,
-    ArtifactManifestViewerLink, ArtifactRedactionState, ValidatedArtifactManifestEntry,
-    ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA, RUNTIME_AGENT_ARTIFACT_PATHS_SCHEMA,
+    ArtifactManifest, ARTIFACT_MANIFEST_SCHEMA, RUNTIME_AGENT_ARTIFACT_PATHS_SCHEMA,
     RUNTIME_AGENT_FINAL_OUTPUT_ARTIFACT_PATH, RUNTIME_AGENT_PATCH_DIFF_ARTIFACT_FILE,
     RUNTIME_AGENT_PATCH_PATCH_ARTIFACT_FILE, RUNTIME_AGENT_RESULT_ARTIFACT_FILE,
     RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_FILE, RUNTIME_AGENT_TRANSCRIPT_ARTIFACT_PATH,
@@ -39,8 +24,7 @@ pub use super::artifact_origin::{
     ArtifactOriginServeSpec, ArtifactOriginStatus,
 };
 pub use super::artifact_postprocess::{
-    describe_artifact_postprocess_plan, record_artifact_postprocess_outputs,
-    run_artifact_postprocess_plan, run_artifact_postprocess_plan_for_persisted_root,
+    record_artifact_postprocess_outputs, run_artifact_postprocess_plan_for_persisted_root,
     run_artifact_postprocess_steps, validate_artifact_postprocess_plan, ArtifactPostprocessAction,
     ArtifactPostprocessContext, ArtifactPostprocessOutput, ArtifactPostprocessPlan,
     ArtifactPostprocessPlanDescription, ArtifactPostprocessProducedArtifact,
@@ -49,33 +33,12 @@ pub use super::artifact_postprocess::{
     ARTIFACT_POSTPROCESS_SCHEMA,
 };
 pub use super::artifact_preview::{html_preview_entrypoints, ArtifactPreviewEntrypoint};
-pub use super::artifact_ref::{
-    ArtifactReference, METADATA_ONLY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
-};
-pub use super::browser_evidence::{
-    validate_bench_results_payload, validate_trace_results_payload, BrowserArtifactMetadata,
-    BrowserBottleneckRow, BrowserNetworkRequestRow, BrowserOriginDeclaredService,
-    BrowserOriginEvidence, BrowserPerformanceProfileEnvelope, BrowserPhaseMark, BrowserPhaseWindow,
-    BrowserRedirectEvidence, BrowserTimingRow, BrowserWindowLocationEvidence, TraceAssertion,
-    TraceAssertionStatus, TraceAssertions, TraceEnvelope, TraceEnvelopeStatus, TraceEvent,
-    TraceTimeline, BROWSER_EVIDENCE_SCHEMA_VERSION,
-};
-pub use super::change_artifact::{
-    ChangeApplyResult, ChangeApplyStatus, ChangeArtifact, ChangeArtifactDigest,
-    ChangeArtifactProvenance, ChangeArtifactSummary, ChangeDelta, ChangeDeltaFile, ChangePatch,
-    CHANGE_APPLY_RESULT_SCHEMA, CHANGE_ARTIFACT_SCHEMA,
-};
 pub use super::matrix_artifact_summary::{
     generic_matrix_summary_from_artifacts, is_matrix_summary_artifact,
     render_matrix_artifact_summary_markdown, summarize_matrix_artifacts, GenericMatrixSummary,
-    MatrixArtifactSummary, MatrixSummaryCount, GENERIC_MATRIX_SUMMARY_SCHEMA,
-    MATRIX_ARTIFACT_SUMMARY_SCHEMA,
+    MatrixArtifactSummary,
 };
 pub use super::publication_artifacts::index_remote_published_artifact_refs_for_run;
-pub use super::structured_sidecar::{
-    default_path, default_producer, default_schema_version, registry, schema, validate_payload,
-    StructuredSidecarSchema, StructuredSidecarShape, REGISTRY,
-};
 
 /// Resolve the artifact root used for copied/downloaded run artifacts.
 pub fn root() -> super::Result<std::path::PathBuf> {

--- a/crates/homeboy-core/src/browser_evidence.rs
+++ b/crates/homeboy-core/src/browser_evidence.rs
@@ -3,11 +3,11 @@ use serde_json::{Map, Value};
 
 use crate::{Error, Result};
 
-pub const BROWSER_EVIDENCE_SCHEMA_VERSION: u64 = 1;
+pub(crate) const BROWSER_EVIDENCE_SCHEMA_VERSION: u64 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserPerformanceProfileEnvelope {
+pub(crate) struct BrowserPerformanceProfileEnvelope {
     #[serde(default = "default_schema_version")]
     pub schema_version: u64,
     #[serde(default, alias = "url")]
@@ -40,7 +40,7 @@ pub struct BrowserPerformanceProfileEnvelope {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserNetworkRequestRow {
+pub(crate) struct BrowserNetworkRequestRow {
     #[serde(default, alias = "name")]
     pub url: String,
     #[serde(default)]
@@ -71,7 +71,7 @@ pub struct BrowserNetworkRequestRow {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserTimingRow {
+pub(crate) struct BrowserTimingRow {
     pub url: String,
     #[serde(default, alias = "normalizedUrl")]
     pub normalized_url: String,
@@ -97,7 +97,7 @@ pub struct BrowserTimingRow {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserPhaseMark {
+pub(crate) struct BrowserPhaseMark {
     pub name: String,
     #[serde(alias = "startTime", alias = "start_ms", alias = "startMs")]
     pub start_time_ms: f64,
@@ -105,7 +105,7 @@ pub struct BrowserPhaseMark {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserPhaseWindow {
+pub(crate) struct BrowserPhaseWindow {
     pub start_time_ms: f64,
     #[serde(default)]
     pub end_time_ms: Option<f64>,
@@ -114,7 +114,7 @@ pub struct BrowserPhaseWindow {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserArtifactMetadata {
+pub(crate) struct BrowserArtifactMetadata {
     pub path: String,
     #[serde(default)]
     pub kind: Option<String>,
@@ -124,7 +124,7 @@ pub struct BrowserArtifactMetadata {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserOriginEvidence {
+pub(crate) struct BrowserOriginEvidence {
     #[serde(default = "default_schema_version")]
     pub schema_version: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -153,7 +153,7 @@ pub struct BrowserOriginEvidence {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserOriginDeclaredService {
+pub(crate) struct BrowserOriginDeclaredService {
     pub host: String,
     pub port: u16,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -162,7 +162,7 @@ pub struct BrowserOriginDeclaredService {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserWindowLocationEvidence {
+pub(crate) struct BrowserWindowLocationEvidence {
     pub origin: String,
     pub hostname: String,
     pub protocol: String,
@@ -173,7 +173,7 @@ pub struct BrowserWindowLocationEvidence {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserRedirectEvidence {
+pub(crate) struct BrowserRedirectEvidence {
     pub from_url: String,
     pub to_url: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -182,7 +182,7 @@ pub struct BrowserRedirectEvidence {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct BrowserBottleneckRow {
+pub(crate) struct BrowserBottleneckRow {
     pub kind: String,
     pub phase: String,
     pub message: String,
@@ -192,7 +192,7 @@ pub struct BrowserBottleneckRow {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct TraceEvent {
+pub(crate) struct TraceEvent {
     pub t_ms: f64,
     pub source: String,
     pub event: String,
@@ -202,7 +202,7 @@ pub struct TraceEvent {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum TraceAssertionStatus {
+pub(crate) enum TraceAssertionStatus {
     Pass,
     Fail,
     Skip,
@@ -211,7 +211,7 @@ pub enum TraceAssertionStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct TraceAssertion {
+pub(crate) struct TraceAssertion {
     pub id: String,
     pub status: TraceAssertionStatus,
     pub message: String,
@@ -220,20 +220,20 @@ pub struct TraceAssertion {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-pub struct TraceTimeline {
+pub(crate) struct TraceTimeline {
     #[serde(default)]
     pub timeline: Vec<TraceEvent>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-pub struct TraceAssertions {
+pub(crate) struct TraceAssertions {
     #[serde(default)]
     pub assertions: Vec<TraceAssertion>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum TraceEnvelopeStatus {
+pub(crate) enum TraceEnvelopeStatus {
     Pass,
     Fail,
     Error,
@@ -242,7 +242,7 @@ pub enum TraceEnvelopeStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct TraceEnvelope {
+pub(crate) struct TraceEnvelope {
     pub component_id: String,
     pub scenario_id: String,
     pub status: TraceEnvelopeStatus,


### PR DESCRIPTION
Closes #10311

`crates/homeboy-core/src/artifacts.rs` re-exported ~110 symbols from 12 modules and documented itself as the required import path. Only ~40 were ever imported through the facade, two whole blocks had zero consumers anywhere, and roughly half the real call sites bypassed the facade entirely — so the "required path" claim was never true.

**83 → 50 lines** in `artifacts.rs` (13 added / 46 removed), plus 19 visibility narrowings in `browser_evidence.rs`. No implementation module was deleted, moved, or made private.

## Re-verified before deleting

Line numbers in the issue were from an older tree, so every removal was located by content and re-grepped against the **whole source root** (`crates/`, `src/`, `tests/`), covering multi-line `use` groups, aliased imports and nested import groups. Two things the naive grep gets wrong, both checked:

- **Name collisions.** Grepping `TraceEnvelope|TraceAssertion|TraceEvent|BrowserOriginEvidence` looks like it has consumers everywhere — but those hits are `homeboy-extension-contract::trace_parsing` and `homeboy-extension::trace::parsing`, unrelated types that merely share names. Zero of them resolve to `homeboy-core::browser_evidence`.
- **An aliased facade import.** `homeboy-extension/src/bench/artifact_persistence.rs:17` does `use homeboy_core::artifacts as artifact_links;`, so `public_artifact_url` and `cached_validated_viewer_links` *are* facade consumers despite never appearing next to the token `artifacts::`. Both are retained.

## Dead blocks — still dead, both removed

- **`browser_evidence` (19 symbols).** Confirmed never constructed and never read as typed values outside their own file; they exist solely as `validate_optional_array::<T>` turbofish targets. The only cross-module reference to the module anywhere is `structured_sidecar.rs` calling its two `validate_*_payload` entry points, inside the same crate.
- **`structured_sidecar` (9 symbols).** No `artifacts::registry`, `artifacts::validate_payload` or `artifacts::REGISTRY` call sites. The **module is very much alive** — `homeboy-extension` uses it heavily via the direct path (`homeboy_core::structured_sidecar::validate_payload` / `default_schema_version` / `default_path` / `default_producer`). Only the re-export block was dead.

Also dropped the fully-unconsumed `artifact_address`, `artifact_contract`, `artifact_inputs`, `artifact_ref` and `change_artifact` blocks, plus unused entries from surviving blocks. Everything dropped is still `pub` in its defining module and still importable from there.

## `browser_evidence` narrowed to `pub(crate)`

Yes — nothing outside `homeboy-core` names these types, so all 19 (`BROWSER_EVIDENCE_SCHEMA_VERSION` + 16 structs + 2 enums) are now `pub(crate)`. The two `validate_*_payload` functions stay `pub` as the module's contract surface.

Worth flagging for review, since it can't be compiled locally on the machine this was prepared on: narrowing serde shapes whose fields are only ever *written* by `Deserialize` is exactly the shape that trips `field is never read`. It should be safe here because every one of these types also derives `Serialize`, and serde's derived impls are not `#[rustc_trivial_field_reads]` — so unlike a bare `#[derive(Debug)]`, they count as genuine field reads, and `Deserialize` constructs every enum variant. CI is the verifier; if it does warn, the narrowing is isolated in the first commit and trivial to drop on its own.

## Facade claim: dropped, no detector added

Picked **dropping the claim** over adding a `homeboy-code-audit` detector.

The facade has no boundary to defend: every implementation module is `pub` and stays `pub` in this PR, so a detector forbidding direct `crate::artifact_*` imports would police style rather than encapsulation — and would immediately flag ~58 existing call sites that aren't actually wrong, including `cli/src/command_contract/registry.rs`, which hardcodes the non-facade path as a string contract (`rust_type: "homeboy::core::artifact_manifest::ArtifactManifest"`). Making the boundary real means moving the modules under `artifacts/` as private submodules so reach-through *cannot compile*; that is a large mechanical change, is explicitly out of scope here, and would conflict with work in flight. Until someone does that, documenting this module as what it actually is — a convenience shortcut — is the honest state, and it removes the half-rule that made both import styles look correct.

## Out of scope (deliberately)

- No `artifacts/mod.rs` restructure / `git mv` of the 14 files.
- No ~37-artifact-type convergence (#10310) — this PR is its prerequisite.
- No deletion of `artifact_dom_boxes`, `artifact_preview`, `matrix_artifact_summary`, `publication_artifacts`, `artifact_links` or `browser_visual_compare`; all verified live.

## Minor, not fixed here

There are **two** modules named `artifact_preview` — `core/src/artifact_preview.rs` and `core/src/observation/artifact_preview.rs` — doing unrelated jobs. Worth renaming one, but not in this PR.

`cargo fmt` is clean at HEAD. Per repo policy no local `cargo build`/`test`/`clippy` was run; CI is the merge gate.