### PR TITLE
cleanup: delete dead extension-manifest surface

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -165,7 +165,7 @@ pub struct ExtensionManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequirementsConfig>,
 
-    // Multi-extension composition: role ownership used to disambiguate a
+    // Multi-extension composition: `includes` primacy is used to disambiguate a
     // capability provided by more than one linked extension.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub composition: Option<CompositionConfig>,
@@ -179,33 +179,20 @@ pub struct ExtensionManifest {
     pub extension_path: Option<String>,
 }
 
-/// Multi-extension composition metadata. Declares how a component's linked
-/// extensions relate so Homeboy can resolve a capability that more than one of
-/// them provides without requiring manual `capability_extensions` selection.
+/// Multi-extension composition metadata.
+///
+/// `includes` is the sole ownership signal: when several linked extensions
+/// provide the same capability, an extension that composes all the others is
+/// resolved as the primary owner. See
+/// `homeboy_core::extension_execution::disambiguate_capability_owner`.
+///
+/// Unknown keys are ignored rather than rejected, so manifests still carrying
+/// the retired `roles`/`optional`/`conflicts` metadata continue to load.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CompositionConfig {
-    /// Extensions this one composes with (informational).
+    /// Extensions this one composes with. Used to resolve capability ownership.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub includes: Vec<String>,
-    /// Optional companion assets (informational).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub optional: Vec<String>,
-    /// Role name -> owning extension(s). A role with a single owner designates
-    /// the extension that owns that role's capabilities across the composition.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub roles: BTreeMap<String, RoleOwners>,
-    /// Extensions that must not be linked together (informational).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub conflicts: Vec<String>,
-}
-
-/// Owner(s) of a composition role. Manifests use both a single owner
-/// (`"javascript": "nodejs"`) and a list (`"project": ["a", "b"]`).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum RoleOwners {
-    One(String),
-    Many(Vec<String>),
 }
 
 impl ExtensionManifest {
@@ -574,7 +561,22 @@ mod composition_tests {
     use super::*;
 
     #[test]
-    fn deserializes_mixed_single_and_list_role_owners() {
+    fn deserializes_includes() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "wordpress",
+            "version": "1.0.0",
+            "composition": { "includes": ["nodejs"] }
+        }))
+        .expect("manifest with composition deserializes");
+
+        let composition = manifest.composition.expect("composition present");
+        assert_eq!(composition.includes, vec!["nodejs".to_string()]);
+    }
+
+    /// Manifests published before `roles`/`optional`/`conflicts` were retired
+    /// must still load — the keys are simply ignored rather than rejected.
+    #[test]
+    fn retired_composition_keys_are_tolerated() {
         let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
             "name": "wordpress",
             "version": "1.0.0",
@@ -588,25 +590,10 @@ mod composition_tests {
                 "conflicts": []
             }
         }))
-        .expect("manifest with composition deserializes");
+        .expect("manifest with retired composition keys still deserializes");
 
         let composition = manifest.composition.expect("composition present");
         assert_eq!(composition.includes, vec!["nodejs".to_string()]);
-        // A bare string owner deserializes into the single-owner shape.
-        assert_eq!(
-            composition.roles.get("javascript"),
-            Some(&RoleOwners::One("nodejs".to_string()))
-        );
-        // A list owner deserializes into the multi-owner shape.
-        assert_eq!(
-            composition.roles.get("project"),
-            Some(&RoleOwners::Many(vec![
-                "wordpress-plugin".to_string(),
-                "wordpress-theme".to_string(),
-            ]))
-        );
-        // Absent role.
-        assert_eq!(composition.roles.get("missing"), None);
     }
 
     #[test]

--- a/crates/contracts/homeboy-extension-contract/src/manifest_capability_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest_capability_config.rs
@@ -36,16 +36,20 @@ pub struct ComponentEnvConfig {
     pub detect_script: String,
 }
 
-/// What a extension provides: file extensions it handles and capabilities it supports.
+/// What an extension provides: file extensions it handles and how it is discovered.
+///
+/// Unknown keys are ignored rather than rejected. This struct previously used
+/// `deny_unknown_fields`, which made retiring any key a hard break: an older
+/// published manifest carrying a since-removed key would fail to deserialize
+/// entirely, taking `file_extensions` and `discovery_markers` down with it.
+/// Extensions ship on their own release cadence, so tolerance here matches the
+/// forward-compatibility policy the parent `ExtensionManifest` already sets
+/// with its `#[serde(flatten)] extra`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ProvidesConfig {
     /// File extensions this extension can process.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub file_extensions: Vec<String>,
-    /// Capabilities this extension supports (e.g., ["fingerprint", "refactor"]).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub capabilities: Vec<String>,
     /// Component-root marker rules used to suggest this extension for an
     /// unattached component. Core evaluates these generically; extension
     /// manifests own the ecosystem-specific file/glob knowledge.
@@ -80,12 +84,6 @@ pub struct ScriptsConfig {
     /// Receives `{file_path, content}` on stdin and outputs `{artifacts:[...]}` on stdout.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topology: Option<String>,
-    /// Script that validates written code compiles/parses correctly.
-    /// Receives `{root, changed_files}` JSON on stdin, exits 0 on success, non-zero with
-    /// compiler output on stderr on failure.
-    ///
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub validate: Option<String>,
     /// Script that formats source code after automated writes.
     /// Runs from the project root. Exit 0 on success, non-zero on failure.
     /// Formatting failure is non-fatal — it logs a warning but never rolls back.
@@ -103,13 +101,6 @@ pub struct ScriptsConfig {
     /// Outputs `{fixes:[...]}` JSON using Homeboy's generic fix envelope.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compiler_warning_fixes: Option<String>,
-    /// Script that extracts function contracts from source files.
-    /// Receives `{file, content}` JSON on stdin, outputs `{file, contracts: [...]}` JSON on stdout.
-    /// Each contract describes a function's signature, control flow branches, effects, and calls.
-    ///
-    /// Used by the test generator, doc generator, and refactor safety checker.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub contract: Option<String>,
 }
 
 /// Extension-declared release preflight.

--- a/crates/homeboy-core/src/extension_execution.rs
+++ b/crates/homeboy-core/src/extension_execution.rs
@@ -513,7 +513,7 @@ mod tests {
         std::fs::write(
             extension_dir.join(format!("{extension_id}.json")),
             format!(
-                r#"{{"name":"{extension_id}","version":"1.0.0","{capability}":{{"extension_script":"{capability}.sh"}},"composition":{{"includes":[{includes_json}],"roles":{{"javascript":"nodejs","project":["a","b"]}}}}}}"#
+                r#"{{"name":"{extension_id}","version":"1.0.0","{capability}":{{"extension_script":"{capability}.sh"}},"composition":{{"includes":[{includes_json}]}}}}"#
             ),
         )
         .expect("extension manifest");

--- a/docs/internals/development/contracts/compiler-warning-extension.md
+++ b/docs/internals/development/contracts/compiler-warning-extension.md
@@ -1,6 +1,6 @@
 # Compiler Warning Extension Contract Gap
 
-Issue #2242 asks Homeboy core to move compiler-warning collection and compiler-warning fix generation behind extension-owned contracts. Validation and formatting already have extension script contracts (`scripts.validate` and `scripts.format`), but compiler warnings do not.
+Issue #2242 asks Homeboy core to move compiler-warning collection and compiler-warning fix generation behind extension-owned contracts. Formatting already has an extension script contract (`scripts.format`), but compiler warnings do not.
 
 ## Required Upstream Contract
 


### PR DESCRIPTION
Closes #10299

Companion PR (must merge together): Extra-Chill/homeboy-extensions#2455

## What was already gone

The `#10292` sweep had **already removed every accessor** named in the issue —
`role_owner()`, `validate_script()`, `contract_script()`, and
`ExtensionManifest::provided_capabilities()` are all absent from `main`. What
remained was the serde surface itself: the wire-schema fields, still declared by
shipped manifests and read by nothing.

So this PR is about the **fields, manifests, and scripts**, not the accessors.

## Removed

- `CompositionConfig::roles` / `optional` / `conflicts`, and the `RoleOwners`
  enum that existed solely to type `roles`.
- `ScriptsConfig::validate` / `contract` — superseded by the live `autofix_verify`.
- `ProvidesConfig::capabilities` — documentation-as-config competing with the
  real `ExtensionCapability` enum.

Kept, as the issue instructs: `provided_file_extensions()` (live in
`extension_store` / `homeboy-refactor`) and `homeboy-rig`'s unrelated
`pipeline::ordering::provided_capabilities()`.

## Decision on `roles`: deleted, not wired

The issue suggested making `roles` real by having `composition_primary_extension`
consult `role_owner(capability.label())`. **That cannot work against the manifests
we actually ship.**

- Capability labels are `lint`, `test`, `build`, `bench`, `fuzz`, `trace`, `deps`
  (`ExtensionCapability::descriptor`).
- The shipped `roles` keys are `project` and `javascript`.

Zero overlap — `role_owner(capability.label())` would never match, in any shipped
manifest, on day one. It would be dead code at birth.

The values are incoherent too: `project` maps to **component type** names
(`wordpress-plugin`, `wordpress-theme`, `rust-crate`, `go-module`), while
`javascript` maps to an **extension id** (`nodejs`). Two different kinds of thing
in one map. `roles` is not a capability-ownership map; turning it into one is a
schema redesign plus a rewrite of all 5 declarations, not the wiring change the
issue envisioned. Deleting it and leaving `composition.includes` as the single
documented ownership signal is the honest state.

The misleading doc comment is fixed: `CompositionConfig` now says `includes` is
the sole ownership signal and points at `disambiguate_capability_owner`.

## One non-obvious change: `ProvidesConfig` loses `deny_unknown_fields`

The issue assumed `#[serde(flatten)] extra` makes these removals non-breaking.
That is true for `ScriptsConfig` and `CompositionConfig` (both tolerate unknown
keys), but **`ProvidesConfig` was `#[serde(deny_unknown_fields)]`** — `extra` is
on the parent `ExtensionManifest`, and does not protect a nested struct.

Removing `capabilities` while keeping `deny_unknown_fields` would mean any
already-published manifest carrying `provides.capabilities` fails to deserialize
*entirely*, taking `file_extensions` and `discovery_markers` down with it.
Extensions ship on their own release cadence, so that skew is guaranteed during
rollout. Dropping `deny_unknown_fields` makes `ProvidesConfig` consistent with the
forward-compatibility policy `ExtensionManifest` already sets.

## Tests

`retired_composition_keys_are_tolerated` is a new regression test proving a
manifest still carrying `roles`/`optional`/`conflicts` deserializes cleanly.

Per repo policy no cargo build/test was run locally; CI is the gate. Verified by
exhaustive reference grep (`RoleOwners` → 0 hits; no `ProvidesConfig` struct
literals exist, so the field removal has no construction sites).

Refs #10299
