### PR TITLE
refactor: promote Scope to a shared ScopeArgs clap group (triage, build, status)

### DIFF
--- a/crates/homeboy-cli/src/commands/build.rs
+++ b/crates/homeboy-cli/src/commands/build.rs
@@ -6,6 +6,7 @@ use homeboy::core::scope::{self, Scope};
 use homeboy_extension::build;
 use homeboy_extension::ExtensionCapability;
 
+use crate::commands::utils::args::ScopeArgs;
 use crate::commands::utils::resolve::resolve_project_components;
 use crate::commands::CmdResult;
 
@@ -25,9 +26,13 @@ pub struct BuildArgs {
     #[arg(long)]
     pub all: bool,
 
-    /// Override local_path for this build (use a workspace clone or temp checkout)
-    #[arg(long)]
-    pub path: Option<String>,
+    // Entity selection. `--path` keeps its historical build meaning — override
+    // local_path for this build (a workspace clone or temp checkout) — so it
+    // still composes with the positional target and CWD discovery below. The
+    // registry selectors (--component/--project/--fleet/--rig/--workspace) are
+    // resolved through the shared scope resolver instead.
+    #[command(flatten)]
+    pub scope: ScopeArgs,
 
     /// Ask the build provider to resolve the build scope from files changed since this git ref
     #[arg(long)]
@@ -52,12 +57,24 @@ pub fn run(
         return build::run(json);
     }
 
+    // An explicit registry selector resolves through the shared scope
+    // resolver. `Scope::Path` is deliberately excluded: `--path` on build is a
+    // local_path override for the positional/CWD paths below, not a standalone
+    // entity selector, and rerouting it here would change what `--path` means.
+    match args.scope.selection() {
+        None | Some(Scope::Path { .. }) => {}
+        Some(selected) => {
+            let components = scope::resolve_scope_component_records(&selected)?;
+            return run_components(&components);
+        }
+    }
+
     // No target_id: try CWD auto-discovery (registered component or homeboy.json)
     if args.target_id.is_none() && args.component_ids.is_empty() && !args.all {
         let ctx = execution_context::resolve(&ResolveOptions::with_capability(
             // Use empty string for CWD auto-discovery — resolve_effective handles this
             component::resolve(None)?.id.as_str(),
-            args.path.clone(),
+            args.scope.path.clone(),
             ExtensionCapability::Build,
             Vec::new(),
         ))?;
@@ -160,9 +177,124 @@ pub fn run(
     }
 
     // Single target_id: treat as component ID
-    if let Some(ref path) = args.path {
+    if let Some(ref path) = args.scope.path {
         build::run_with_path_changed_since(target_id, path, args.changed_since.as_deref())
     } else {
         build::run_changed_since(target_id, args.changed_since.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BuildArgs;
+    use clap::Parser;
+    use homeboy::core::scope::Scope;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: BuildArgs,
+    }
+
+    fn parse(argv: &[&str]) -> BuildArgs {
+        TestCli::try_parse_from(argv)
+            .expect("build invocation should parse")
+            .args
+    }
+
+    /// Every shape `homeboy build` accepted before `ScopeArgs` must still
+    /// parse into the same fields. `--path` in particular keeps its
+    /// local_path-override meaning; it only moved into the shared group.
+    #[test]
+    fn previously_valid_invocations_still_parse() {
+        let single = parse(&["build", "my-comp"]);
+        assert_eq!(single.target_id.as_deref(), Some("my-comp"));
+        assert!(single.component_ids.is_empty());
+        assert!(!single.all);
+        assert!(single.scope.path.is_none());
+
+        let project_all = parse(&["build", "my-project", "--all"]);
+        assert_eq!(project_all.target_id.as_deref(), Some("my-project"));
+        assert!(project_all.all);
+
+        let multi = parse(&["build", "my-project", "comp-a", "comp-b"]);
+        assert_eq!(multi.target_id.as_deref(), Some("my-project"));
+        assert_eq!(multi.component_ids, vec!["comp-a", "comp-b"]);
+
+        let with_path = parse(&["build", "my-comp", "--path", "/tmp/checkout"]);
+        assert_eq!(with_path.target_id.as_deref(), Some("my-comp"));
+        assert_eq!(with_path.scope.path.as_deref(), Some("/tmp/checkout"));
+
+        let bare_path = parse(&["build", "--path", "/tmp/checkout"]);
+        assert!(bare_path.target_id.is_none());
+        assert_eq!(bare_path.scope.path.as_deref(), Some("/tmp/checkout"));
+
+        let json = parse(&["build", "--json", r#"{"componentIds":["a"]}"#]);
+        assert_eq!(json.json.as_deref(), Some(r#"{"componentIds":["a"]}"#));
+
+        let changed = parse(&["build", "my-comp", "--changed-since", "origin/main"]);
+        assert_eq!(changed.changed_since.as_deref(), Some("origin/main"));
+
+        let cwd = parse(&["build"]);
+        assert!(cwd.target_id.is_none());
+        assert!(cwd.scope.is_unscoped());
+    }
+
+    /// `--path` stays out of the shared-resolver branch so it keeps composing
+    /// with the positional target and CWD discovery.
+    #[test]
+    fn path_still_reads_as_a_local_path_override() {
+        let args = parse(&["build", "my-comp", "--path", "/tmp/checkout"]);
+        assert_eq!(
+            args.scope.selection(),
+            Some(Scope::Path {
+                path: "/tmp/checkout".to_string(),
+                component_id: None,
+            })
+        );
+        assert_eq!(args.target_id.as_deref(), Some("my-comp"));
+    }
+
+    #[test]
+    fn registry_selectors_resolve_to_their_scope_variants() {
+        assert_eq!(
+            parse(&["build", "--component", "my-comp"])
+                .scope
+                .selection(),
+            Some(Scope::Component("my-comp".to_string()))
+        );
+        assert_eq!(
+            parse(&["build", "--project", "my-project"])
+                .scope
+                .selection(),
+            Some(Scope::Project("my-project".to_string()))
+        );
+        assert_eq!(
+            parse(&["build", "--fleet", "growth"]).scope.selection(),
+            Some(Scope::Fleet("growth".to_string()))
+        );
+        assert_eq!(
+            parse(&["build", "--rig", "studio"]).scope.selection(),
+            Some(Scope::Rig("studio".to_string()))
+        );
+        assert_eq!(
+            parse(&["build", "--workspace"]).scope.selection(),
+            Some(Scope::Workspace)
+        );
+    }
+
+    #[test]
+    fn scope_selectors_conflict_with_each_other() {
+        for argv in [
+            vec!["build", "--component", "a", "--project", "b"],
+            vec!["build", "--component", "a", "--path", "/tmp/a"],
+            vec!["build", "--project", "a", "--workspace"],
+            vec!["build", "--fleet", "a", "--rig", "b"],
+        ] {
+            assert!(
+                TestCli::try_parse_from(&argv).is_err(),
+                "conflicting build scopes should be rejected: {argv:?}"
+            );
+        }
     }
 }

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -42,12 +42,23 @@ pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusRes
         .then(|| homeboy::core::runtime_promotion::acquire("status refresh", "status"))
         .transpose()?;
 
-    if args.path.is_some() {
-        return run_path_status(&args);
+    // Explicit scope selection. `--path` and `--project` keep their historical
+    // routes (checkout inspection and the project dashboard); the remaining
+    // selectors resolve through the shared scope resolver into the same
+    // component summary the default view builds.
+    match args.scope.selection() {
+        Some(Scope::Path { .. }) => return run_path_status(&args),
+        Some(Scope::Project(ref project_id)) => return run_project_dashboard(project_id, &args),
+        Some(selected) => {
+            let timer = StatusTimer::new(args.timings);
+            let components = scope::resolve_scope_component_records(&selected)?;
+            return summarize_components(components, &args, timer);
+        }
+        None => {}
     }
 
     // Project dashboard mode: `homeboy status <project-id>`
-    if let Some(ref project_id) = args.project {
+    if let Some(ref project_id) = args.target {
         return run_project_dashboard(project_id, &args);
     }
 
@@ -237,10 +248,10 @@ fn summarize_components(
 
 /// Path override mode: inspect one checkout without requiring registry membership.
 fn run_path_status(args: &StatusArgs) -> CmdResult<StatusResult> {
-    let path = args.path.as_deref();
+    let path = args.scope.path.as_deref();
     let mut timer = StatusTimer::new(args.timings);
     timer.begin("resolve_path_component");
-    let component = component::resolve_effective(args.project.as_deref(), path, None)?;
+    let component = component::resolve_effective(args.target.as_deref(), path, None)?;
     timer.finish("resolve_path_component");
 
     if args.full {
@@ -542,8 +553,11 @@ mod tests {
 
     fn status_args(project: Option<String>, path: String, full: bool) -> StatusArgs {
         StatusArgs {
-            project,
-            path: Some(path),
+            target: project,
+            scope: crate::commands::utils::args::ScopeArgs {
+                path: Some(path),
+                ..Default::default()
+            },
             full,
             uncommitted: false,
             needs_release: false,
@@ -559,8 +573,8 @@ mod tests {
 
     fn default_status_args() -> StatusArgs {
         StatusArgs {
-            project: None,
-            path: None,
+            target: None,
+            scope: crate::commands::utils::args::ScopeArgs::default(),
             full: false,
             uncommitted: false,
             needs_release: false,
@@ -730,8 +744,8 @@ mod tests {
 
         match cli.command {
             Commands::Status(args) => {
-                assert_eq!(args.project, None);
-                assert_eq!(args.path.as_deref(), Some("/tmp/example"));
+                assert_eq!(args.target, None);
+                assert_eq!(args.scope.path.as_deref(), Some("/tmp/example"));
                 assert!(args.full);
             }
             _ => panic!("expected status command"),
@@ -752,11 +766,111 @@ mod tests {
 
         match cli.command {
             Commands::Status(args) => {
-                assert_eq!(args.project.as_deref(), Some("wordpress-playground"));
-                assert_eq!(args.path.as_deref(), Some("/tmp/wp-playground"));
+                assert_eq!(args.target.as_deref(), Some("wordpress-playground"));
+                assert_eq!(args.scope.path.as_deref(), Some("/tmp/wp-playground"));
                 assert!(args.full);
             }
             _ => panic!("expected status command"),
+        }
+    }
+
+    fn parse_status(argv: &[&str]) -> StatusArgs {
+        match Cli::try_parse_from(argv)
+            .expect("status invocation should parse")
+            .command
+        {
+            Commands::Status(args) => args,
+            _ => panic!("expected status command"),
+        }
+    }
+
+    /// Every filter/positional spelling `homeboy status` accepted before
+    /// `ScopeArgs` must still parse the same way.
+    #[test]
+    fn previously_valid_status_invocations_still_parse() {
+        let bare = parse_status(&["homeboy", "status"]);
+        assert!(bare.target.is_none());
+        assert!(bare.scope.is_unscoped());
+
+        let positional = parse_status(&["homeboy", "status", "wordpress-playground"]);
+        assert_eq!(positional.target.as_deref(), Some("wordpress-playground"));
+        assert!(positional.scope.is_unscoped());
+
+        let filters = parse_status(&[
+            "homeboy",
+            "status",
+            "--all",
+            "--uncommitted",
+            "--needs-release",
+            "--ready",
+            "--docs-only",
+            "--outdated",
+            "--unreleased",
+            "--timings",
+            "--refresh",
+            "--full",
+        ]);
+        assert!(filters.all);
+        assert!(filters.uncommitted);
+        assert!(filters.needs_release);
+        assert!(filters.ready);
+        assert!(filters.docs_only);
+        assert!(filters.outdated);
+        assert!(filters.unreleased);
+        assert!(filters.timings);
+        assert!(filters.refresh);
+        assert!(filters.full);
+
+        let short_all = parse_status(&["homeboy", "status", "-a"]);
+        assert!(short_all.all);
+    }
+
+    #[test]
+    fn status_scope_selectors_resolve_to_their_variants() {
+        assert_eq!(
+            parse_status(&["homeboy", "status", "--project", "growth"])
+                .scope
+                .selection(),
+            Some(Scope::Project("growth".to_string()))
+        );
+        assert_eq!(
+            parse_status(&["homeboy", "status", "--component", "homeboy"])
+                .scope
+                .selection(),
+            Some(Scope::Component("homeboy".to_string()))
+        );
+        assert_eq!(
+            parse_status(&["homeboy", "status", "--fleet", "growth"])
+                .scope
+                .selection(),
+            Some(Scope::Fleet("growth".to_string()))
+        );
+        assert_eq!(
+            parse_status(&["homeboy", "status", "--rig", "studio"])
+                .scope
+                .selection(),
+            Some(Scope::Rig("studio".to_string()))
+        );
+        assert_eq!(
+            parse_status(&["homeboy", "status", "--workspace"])
+                .scope
+                .selection(),
+            Some(Scope::Workspace)
+        );
+    }
+
+    #[test]
+    fn status_scope_selectors_conflict_with_each_other() {
+        for argv in [
+            vec!["homeboy", "status", "--project", "a", "--component", "b"],
+            vec!["homeboy", "status", "--component", "a", "--path", "/tmp/a"],
+            vec!["homeboy", "status", "--project", "a", "--workspace"],
+            vec!["homeboy", "status", "--fleet", "a", "--rig", "b"],
+        ] {
+            assert!(
+                Cli::try_parse_from(&argv).is_err(),
+                "conflicting status scopes should be rejected: {argv:?}"
+            );
         }
     }
 

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -6,14 +6,20 @@ use std::time::Instant;
 
 use clap::Args;
 
+use crate::commands::utils::args::ScopeArgs;
+
 #[derive(Args)]
 pub struct StatusArgs {
     /// Project ID — show version dashboard for a project's components
-    pub project: Option<String>,
+    #[arg(value_name = "PROJECT")]
+    pub target: Option<String>,
 
-    /// Inspect this checkout path instead of the registered component path
-    #[arg(long, value_name = "PATH")]
-    pub path: Option<String>,
+    // Entity selection. `--path` is the pre-existing "inspect this checkout
+    // instead of the registered component path" override and keeps composing
+    // with the positional target; the registry selectors resolve through the
+    // shared scope resolver.
+    #[command(flatten)]
+    pub scope: ScopeArgs,
 
     /// Show the full workspace/context report (the old init behavior)
     #[arg(long)]

--- a/crates/homeboy-cli/src/commands/triage.rs
+++ b/crates/homeboy-cli/src/commands/triage.rs
@@ -6,6 +6,7 @@ use homeboy_triage::{
 use homeboy::core::Error;
 use std::path::PathBuf;
 
+use super::utils::args::ScopeArgs;
 use super::CmdResult;
 
 #[derive(Args)]
@@ -135,25 +136,11 @@ enum TriageCommand {
         #[arg(long)]
         ordered: bool,
 
-        /// Landing scope: project id.
-        #[arg(long, conflicts_with_all = ["fleet", "component", "path", "workspace"])]
-        project: Option<String>,
-
-        /// Landing scope: fleet id.
-        #[arg(long, conflicts_with_all = ["project", "component", "path", "workspace"])]
-        fleet: Option<String>,
-
-        /// Landing scope: registered component id.
-        #[arg(long, conflicts_with_all = ["project", "fleet", "path", "workspace"])]
-        component: Option<String>,
-
-        /// Landing scope: checkout path, bypassing the registry.
-        #[arg(long, conflicts_with_all = ["project", "fleet", "component", "workspace"])]
-        path: Option<String>,
-
-        /// Landing scope: all configured workspace repos. This is the default when no scope is supplied.
-        #[arg(long, conflicts_with_all = ["project", "fleet", "component", "path"])]
-        workspace: bool,
+        // Landing scope. Defaults to every configured workspace repo when no
+        // selector is supplied, which is what the removed `--workspace` bool
+        // already meant.
+        #[command(flatten)]
+        scope: ScopeArgs,
     },
 }
 
@@ -193,16 +180,11 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCom
         branch,
         source_issue,
         ordered,
-        project,
-        fleet,
-        component,
-        path,
-        workspace: _,
+        scope,
     } = command
     {
-        let target = resolve_landing_target(project, fleet, component, path)?;
         let output = triage::landing(TriageLandingOptions {
-            target,
+            target: scope.resolve(),
             repo,
             pr_refs,
             branch_patterns: branch,
@@ -249,30 +231,6 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageCom
         TriageCommandOutput::Report(triage::run(target, options)?),
         0,
     ))
-}
-
-fn resolve_landing_target(
-    project: Option<String>,
-    fleet: Option<String>,
-    component: Option<String>,
-    path: Option<String>,
-) -> Result<TriageTarget, Error> {
-    if let Some(project) = project {
-        return Ok(TriageTarget::Project(project));
-    }
-    if let Some(fleet) = fleet {
-        return Ok(TriageTarget::Fleet(fleet));
-    }
-    if let Some(component) = component {
-        return Ok(TriageTarget::Component(component));
-    }
-    if let Some(path) = path {
-        return Ok(TriageTarget::Path {
-            path,
-            component_id: None,
-        });
-    }
-    Ok(TriageTarget::Workspace)
 }
 
 fn parse_watch_duration(name: &str, raw: &str) -> Result<std::time::Duration, Error> {
@@ -360,7 +318,7 @@ fn canonicalize_for_compare(path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_component_target, TriageArgs};
+    use super::{resolve_component_target, TriageArgs, TriageCommand};
     use clap::Parser;
     use homeboy_triage::TriageTarget;
 
@@ -406,6 +364,138 @@ mod tests {
                 assert_eq!(component_id, None);
             }
             other => panic!("expected TriageTarget::Path, got {other:?}"),
+        }
+    }
+
+    fn landing_scope(argv: &[&str]) -> TriageTarget {
+        let cli = TestCli::try_parse_from(argv).expect("landing invocation should parse");
+        match cli.args.command.expect("landing subcommand") {
+            TriageCommand::Landing { scope, .. } => scope.resolve(),
+            other => panic!("expected landing subcommand, got {other:?}"),
+        }
+    }
+
+    /// Every landing scope spelling that parsed before `ScopeArgs` must still
+    /// parse to the same target. These are user-facing flags other tooling
+    /// invokes; a silently changed spelling is a breaking change.
+    #[test]
+    fn landing_scope_flags_keep_their_previous_spellings() {
+        assert_eq!(
+            landing_scope(&["triage", "landing", "--project", "growth"]),
+            TriageTarget::Project("growth".to_string())
+        );
+        assert_eq!(
+            landing_scope(&["triage", "landing", "--fleet", "growth"]),
+            TriageTarget::Fleet("growth".to_string())
+        );
+        assert_eq!(
+            landing_scope(&["triage", "landing", "--component", "homeboy"]),
+            TriageTarget::Component("homeboy".to_string())
+        );
+        assert_eq!(
+            landing_scope(&["triage", "landing", "--path", "/src/homeboy"]),
+            TriageTarget::Path {
+                path: "/src/homeboy".to_string(),
+                component_id: None,
+            }
+        );
+        assert_eq!(
+            landing_scope(&["triage", "landing", "--workspace"]),
+            TriageTarget::Workspace
+        );
+    }
+
+    #[test]
+    fn landing_without_a_scope_still_defaults_to_workspace() {
+        assert_eq!(
+            landing_scope(&["triage", "landing"]),
+            TriageTarget::Workspace
+        );
+    }
+
+    /// The documented landing invocations from `docs/commands/triage.md`.
+    #[test]
+    fn documented_landing_invocations_still_parse() {
+        for argv in [
+            vec![
+                "triage",
+                "landing",
+                "Extra-Chill/homeboy#2238",
+                "Automattic/static-site-importer#118",
+                "--drilldown",
+            ],
+            vec![
+                "triage",
+                "landing",
+                "--repo",
+                "Extra-Chill/homeboy",
+                "--branch",
+                "fixture/*",
+                "--drilldown",
+            ],
+            vec![
+                "triage",
+                "landing",
+                "--workspace",
+                "--branch",
+                "e2e/*",
+                "--limit",
+                "100",
+            ],
+            vec![
+                "triage", "landing", "--repo", "Extra-Chill/homeboy", "--ordered", "2238", "2239",
+                "2240",
+            ],
+        ] {
+            assert!(
+                TestCli::try_parse_from(&argv).is_ok(),
+                "documented invocation should parse: {argv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn landing_scope_selectors_still_conflict() {
+        for argv in [
+            vec!["triage", "landing", "--project", "a", "--fleet", "b"],
+            vec!["triage", "landing", "--project", "a", "--component", "b"],
+            vec!["triage", "landing", "--component", "a", "--path", "/src/a"],
+            vec!["triage", "landing", "--fleet", "a", "--workspace"],
+            vec!["triage", "landing", "--path", "/src/a", "--workspace"],
+        ] {
+            assert!(
+                TestCli::try_parse_from(&argv).is_err(),
+                "conflicting landing scopes should be rejected: {argv:?}"
+            );
+        }
+    }
+
+    /// `--rig` is the one selector landing did not previously accept. It comes
+    /// free with the shared group and resolves through the same
+    /// `resolve_target_components` path every other scope uses.
+    #[test]
+    fn landing_gains_the_rig_scope_from_the_shared_group() {
+        assert_eq!(
+            landing_scope(&["triage", "landing", "--rig", "studio"]),
+            TriageTarget::Rig("studio".to_string())
+        );
+    }
+
+    /// The scope *subcommands* are a separate, still-supported surface.
+    #[test]
+    fn scope_subcommands_are_unchanged() {
+        for argv in [
+            vec!["triage", "component", "homeboy"],
+            vec!["triage", "component", "--path", "/src/homeboy"],
+            vec!["triage", "project", "growth"],
+            vec!["triage", "fleet", "growth"],
+            vec!["triage", "rig", "studio"],
+            vec!["triage", "workspace"],
+        ] {
+            assert!(
+                TestCli::try_parse_from(&argv).is_ok(),
+                "scope subcommand should parse: {argv:?}"
+            );
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -10,6 +10,7 @@ use clap::{Arg, ArgAction, Args, Command, CommandFactory};
 
 use crate::cli_surface::Cli;
 use homeboy::core::component::{self, Component};
+use homeboy::core::scope::{Scope, ScopeKind};
 
 pub(crate) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
 
@@ -658,6 +659,235 @@ mod normalize_tests {
             super::filter_passthrough_args(super::PassthroughCommand::Test, &args),
             argv(&["--coverage", "--baseline", "runner-value"])
         );
+    }
+}
+
+// ============================================================================
+// ScopeArgs: --project + --fleet + --component + --rig + --path + --workspace
+// ============================================================================
+
+/// The shared six-way entity selector.
+///
+/// [`Scope`] is already the single entity primitive commands resolve against
+/// (`resolve_scope_components`, `resolve_scope_component_records`), but every
+/// command that let an operator *choose* an entity re-declared the same
+/// six-way switch by hand — `triage` declared it twice inside one command
+/// (#10312). This group owns the spelling once so a command only has to
+/// flatten it and call [`ScopeArgs::resolve`].
+///
+/// The selectors are mutually exclusive by construction: a scope is one
+/// entity, not a set. Commands that genuinely operate on several components at
+/// once (`refactor --component a --component b`) are a different shape and
+/// keep their own args.
+///
+/// Deliberately long-flag-only. Short flags are already spoken for by several
+/// of the commands this group is flattened into (`deploy -c`, `refactor -c`),
+/// and adding a short here would silently change what those letters mean.
+#[derive(Args, Debug, Clone, Default)]
+pub struct ScopeArgs {
+    /// Scope: project id.
+    #[arg(long, value_name = "ID", conflicts_with_all = ["fleet", "component", "rig", "path", "workspace"])]
+    pub project: Option<String>,
+
+    /// Scope: fleet id.
+    #[arg(long, value_name = "ID", conflicts_with_all = ["project", "component", "rig", "path", "workspace"])]
+    pub fleet: Option<String>,
+
+    /// Scope: registered component id.
+    #[arg(long, value_name = "ID", conflicts_with_all = ["project", "fleet", "rig", "path", "workspace"])]
+    pub component: Option<String>,
+
+    /// Scope: local rig id.
+    #[arg(long, value_name = "ID", conflicts_with_all = ["project", "fleet", "component", "path", "workspace"])]
+    pub rig: Option<String>,
+
+    /// Scope: checkout path, bypassing the registry.
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["project", "fleet", "component", "rig", "workspace"])]
+    pub path: Option<String>,
+
+    /// Scope: every configured workspace repo.
+    #[arg(long, conflicts_with_all = ["project", "fleet", "component", "rig", "path"])]
+    pub workspace: bool,
+}
+
+impl ScopeArgs {
+    /// The explicitly selected scope, or `None` when the operator supplied no
+    /// selector at all. Commands whose unscoped default is CWD discovery (or
+    /// anything else that is not the workspace) branch on this.
+    pub fn selection(&self) -> Option<Scope> {
+        if let Some(project) = &self.project {
+            return Some(Scope::Project(project.clone()));
+        }
+        if let Some(fleet) = &self.fleet {
+            return Some(Scope::Fleet(fleet.clone()));
+        }
+        if let Some(component) = &self.component {
+            return Some(Scope::Component(component.clone()));
+        }
+        if let Some(rig) = &self.rig {
+            return Some(Scope::Rig(rig.clone()));
+        }
+        if let Some(path) = &self.path {
+            return Some(Scope::Path {
+                path: path.clone(),
+                component_id: None,
+            });
+        }
+        if self.workspace {
+            return Some(Scope::Workspace);
+        }
+        None
+    }
+
+    /// Resolve the selected scope, defaulting to the whole workspace.
+    ///
+    /// `--workspace` is therefore explicit *and* implicit: passing it is the
+    /// same as passing nothing, which is what the commands using this group
+    /// already documented.
+    pub fn resolve(&self) -> Scope {
+        self.selection().unwrap_or(Scope::Workspace)
+    }
+
+    /// True when no selector was supplied.
+    pub fn is_unscoped(&self) -> bool {
+        self.selection().is_none()
+    }
+
+    /// The selected scope kind, if any.
+    pub fn kind(&self) -> Option<ScopeKind> {
+        self.selection().map(|scope| scope.kind())
+    }
+}
+
+#[cfg(test)]
+mod scope_args_tests {
+    use super::ScopeArgs;
+    use clap::Parser;
+    use homeboy::core::scope::{Scope, ScopeKind};
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        scope: ScopeArgs,
+    }
+
+    fn parse(args: &[&str]) -> ScopeArgs {
+        TestCli::try_parse_from(args)
+            .expect("scope selector should parse")
+            .scope
+    }
+
+    #[test]
+    fn each_selector_resolves_to_its_scope_variant() {
+        assert_eq!(
+            parse(&["scoped", "--project", "growth"]).resolve(),
+            Scope::Project("growth".to_string())
+        );
+        assert_eq!(
+            parse(&["scoped", "--fleet", "growth"]).resolve(),
+            Scope::Fleet("growth".to_string())
+        );
+        assert_eq!(
+            parse(&["scoped", "--component", "homeboy"]).resolve(),
+            Scope::Component("homeboy".to_string())
+        );
+        assert_eq!(
+            parse(&["scoped", "--rig", "studio"]).resolve(),
+            Scope::Rig("studio".to_string())
+        );
+        assert_eq!(
+            parse(&["scoped", "--path", "/src/homeboy"]).resolve(),
+            Scope::Path {
+                path: "/src/homeboy".to_string(),
+                component_id: None,
+            }
+        );
+        assert_eq!(
+            parse(&["scoped", "--workspace"]).resolve(),
+            Scope::Workspace
+        );
+    }
+
+    #[test]
+    fn inline_value_forms_parse_identically() {
+        assert_eq!(
+            parse(&["scoped", "--project=growth"]).resolve(),
+            Scope::Project("growth".to_string())
+        );
+        assert_eq!(
+            parse(&["scoped", "--path=/src/homeboy"]).resolve(),
+            Scope::Path {
+                path: "/src/homeboy".to_string(),
+                component_id: None,
+            }
+        );
+    }
+
+    #[test]
+    fn no_selector_is_unscoped_and_defaults_to_workspace() {
+        let args = parse(&["scoped"]);
+        assert!(args.is_unscoped());
+        assert!(args.selection().is_none());
+        assert!(args.kind().is_none());
+        assert_eq!(args.resolve(), Scope::Workspace);
+    }
+
+    #[test]
+    fn explicit_workspace_is_scoped() {
+        let args = parse(&["scoped", "--workspace"]);
+        assert!(!args.is_unscoped());
+        assert_eq!(args.kind(), Some(ScopeKind::Workspace));
+    }
+
+    #[test]
+    fn kind_matches_the_selected_variant() {
+        assert_eq!(
+            parse(&["scoped", "--project", "growth"]).kind(),
+            Some(ScopeKind::Project)
+        );
+        assert_eq!(
+            parse(&["scoped", "--fleet", "growth"]).kind(),
+            Some(ScopeKind::Fleet)
+        );
+        assert_eq!(
+            parse(&["scoped", "--component", "homeboy"]).kind(),
+            Some(ScopeKind::Component)
+        );
+        assert_eq!(
+            parse(&["scoped", "--rig", "studio"]).kind(),
+            Some(ScopeKind::Rig)
+        );
+        assert_eq!(
+            parse(&["scoped", "--path", "/src/homeboy"]).kind(),
+            Some(ScopeKind::Path)
+        );
+    }
+
+    #[test]
+    fn selectors_are_mutually_exclusive() {
+        let valued = ["--project", "--fleet", "--component", "--rig", "--path"];
+        for (index, first) in valued.iter().enumerate() {
+            for second in valued.iter().skip(index + 1) {
+                let argv = vec!["scoped", first, "a", second, "b"];
+                assert!(
+                    TestCli::try_parse_from(&argv).is_err(),
+                    "{first} and {second} should conflict"
+                );
+            }
+
+            let with_workspace = vec!["scoped", first, "a", "--workspace"];
+            assert!(
+                TestCli::try_parse_from(&with_workspace).is_err(),
+                "{first} and --workspace should conflict"
+            );
+        }
+    }
+
+    #[test]
+    fn default_is_an_unscoped_group() {
+        let args = ScopeArgs::default();
+        assert!(args.is_unscoped());
+        assert_eq!(args.resolve(), Scope::Workspace);
     }
 }
 

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -866,8 +866,8 @@ mod scope_args_tests {
     #[test]
     fn selectors_are_mutually_exclusive() {
         let valued = ["--project", "--fleet", "--component", "--rig", "--path"];
-        for (index, first) in valued.iter().enumerate() {
-            for second in valued.iter().skip(index + 1) {
+        for (index, first) in valued.iter().copied().enumerate() {
+            for second in valued.iter().copied().skip(index + 1) {
                 let argv = vec!["scoped", first, "a", second, "b"];
                 assert!(
                     TestCli::try_parse_from(&argv).is_err(),

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -98,6 +98,12 @@ after `--`.
 
 Runs the build quality gate for one component or all project components.
 
+Accepts the shared scope selectors — `--component`, `--project`, `--fleet`,
+`--rig`, `--workspace` — in addition to the positional target forms
+(`<component-id>`, `<project-id> --all`, `<project-id> <component-id>...`).
+`--path` keeps its build-specific meaning: it overrides `local_path` for the
+positional or auto-discovered target rather than selecting an entity.
+
 ### `review ci`
 
 Owns CI reproduction profile and action-support utilities:

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -77,6 +77,17 @@ and look at `outdated`. Together, `unreleased_merges` (tag-vs-merged),
 - `--outdated` — (project mode) show only components whose installed-on-target version is behind the latest release
 - `--timings` — emit phase progress to stderr and include phase timings in JSON, useful when diagnosing slow status runs
 
+## Scope selectors
+
+Status takes the shared scope selectors, which are mutually exclusive:
+
+- `--project <ID>` — the project dashboard, same as the positional `[PROJECT]`
+- `--component <ID>` — summarize one registered component
+- `--fleet <ID>` / `--rig <ID>` / `--workspace` — summarize every component the
+  scope resolves to
+- `--path <PATH>` — inspect this checkout instead of the registered component
+  path; composes with the positional target
+
 ## Related
 
 - [component](component.md)

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -76,6 +76,10 @@ homeboy triage landing --workspace --branch 'e2e/*' --limit 100 --output ./landi
 homeboy triage landing --repo Extra-Chill/homeboy --ordered 2238 2239 2240
 ```
 
+Landing takes the shared scope selectors — `--project`, `--fleet`, `--component`,
+`--rig`, `--path`, `--workspace` — which are mutually exclusive and default to
+`--workspace` when none is supplied.
+
 When a PR head branch matches a persisted `homeboy worktree` record for the same GitHub repo, the JSON row gains `local_worktrees` entries with the task worktree ID, local path, branch, base ref, dirty state, unpushed commit count, safety reasons, and optional task/run provenance. The summary also reports `local_worktrees`, `local_worktrees_dirty`, and `local_worktrees_unpushed` counts so an orchestrator can quickly see which PRs need local cleanup or pushes before landing.
 
 ## Output Signals


### PR DESCRIPTION
Promotes `homeboy_core::scope::Scope` to a shared clap arg group and migrates three commands onto it.

## `ScopeArgs`

New `#[derive(Args)]` group in `commands/utils/args.rs`, alongside `PositionalComponentArgs` / `BaselineArgs` / `SettingArgs`:

- `--project` / `--fleet` / `--component` / `--rig` / `--path` / `--workspace`, mutually exclusive
- `resolve() -> Scope` (defaults to `Scope::Workspace`), plus `selection() -> Option<Scope>` for commands whose unscoped default is CWD discovery, `is_unscoped()`, `kind()`
- Deliberately **long-flag-only**. `deploy` uses `-c`/`-p`/`-f`/`-s` and `refactor` uses `-c` for different things; adding a short here would silently change what those letters mean in commands the group gets flattened into.

No new contract — `Scope`/`ScopeKind` were already public and serialized.

## Migrated

| Command | What changed |
|---|---|
| `triage landing` | The five hand-written `--project`/`--fleet`/`--component`/`--path`/`--workspace` flags (each with its own `conflicts_with_all` list) and `resolve_landing_target()` are gone. This was the double declaration — `triage` declared the same six-way choice as subcommands *and* as flags inside one command. |
| `build` | Bespoke `--path` field replaced by the group; explicit registry selectors resolve through `scope::resolve_scope_component_records()` into the same `run_components()` tail `--all` already used. |
| `status` | Positional-project + `--path` replaced by the group; `--project` routes to the same project dashboard as the positional, other selectors resolve through the shared resolver into the existing component summary. |

## No previously-valid invocation changed

Every migration is additive; parse tests assert this per command.

- **`triage landing`** — all five spellings resolve to the same `TriageTarget`, selectors still conflict, scope subcommands untouched. Additionally accepts `--rig`, which comes free with the group and resolves through the same `resolve_target_components()` path.
- **`build`** — `--path` is deliberately **excluded** from the shared-resolver branch so it keeps its "override `local_path` for this build" meaning and still composes with the positional target and CWD auto-discovery. Bare / `<component>` / `<project> --all` / `<project> <comp>...` / `--json` / `--changed-since` / `--path` all covered.
- **`status`** — the positional field was renamed `project` → `target` to free the `--project` arg id, but keeps `value_name = "PROJECT"`, so usage still reads `homeboy status [PROJECT]`. `status <id>`, `status --path <p>`, `status <id> --path <p>`, `-a`, and every filter flag covered.

## Deferred, with reasons

- **`refactor` / `RefactorTargetArgs` — not deleted.** It is a genuinely different shape: `-c/--component` is `ArgAction::Append` and `--components` is comma-delimited, i.e. a *multi*-component target resolving to `Vec<RefactorTarget>`. `ScopeArgs` is one entity. Collapsing it would break `--component a --component b`, and it cannot be flattened *alongside* the group either — `component` and `path` arg ids would collide. Needs a product decision about whether refactor's multi-target selection should become a single scope; not a mechanical migration.
- **`cleanup`** — has no entity selection at all. `CleanupArtifactsArgs` has `--path: PathBuf` and `--self`; no component/project/fleet concept. Flattening would change `--path`'s type and add five flags with no code behind them.
- **`deploy`** — the most bespoke shape: `--project`, `--component` (`Option<Vec>`), `--projects`, `--fleet`, `--shared` and positional target/component ids are **combined**, not mutually exclusive (`deploy --project P --component C`). It is not a single-scope selector.
- **`release`** — `--project` composes with `--outdated` release-state filtering, and release is a mutating operator action; adding fleet/rig/workspace release paths is feature work, not consolidation.
- **`review`** — the umbrella already delegates to `PositionalComponentArgs`; no six-way declaration to remove.

## `strip_component_target_args` — **cannot** be deleted

`route.rs` needs to hand a **rewritten argv** to a remote Lab runner, and clap cannot re-serialize a parsed `Commands` back to argv. Constructing `Scope::Path{..}` locally does not produce the `Vec<String>` the offload path requires, so the argv surgery is still load-bearing. It also has callers beyond the issue's list (four tests in `route/tests/handoff.rs`). It only fires for `Commands::Refactor` and `Commands::Review(Lint)` — neither migrated here — so nothing about it regressed. Unblocking it needs an argv-emission story for `Commands`, which is its own issue.

Refs #10312. Remaining: `refactor`, `cleanup`, `deploy`, `release`, and the `route.rs` argv cleanup.
