### PR TITLE
fix: populate daemon repair_plan across the SSH boundary

### DIFF
--- a/crates/homeboy-core/src/daemon/daemon_lease.rs
+++ b/crates/homeboy-core/src/daemon/daemon_lease.rs
@@ -17,9 +17,10 @@ use sha2::{Digest, Sha256};
 
 use super::{
     current_binary_sha256, read_termination_evidence, runtime_path_fingerprint,
-    DaemonFreshnessReport, DaemonRepairStep, DaemonRuntimeSnapshot, DaemonStaleReasonCode,
-    DaemonState, DAEMON_LEASE_SCHEMA,
+    DaemonFreshnessReport, DaemonRecoveryEvidence, DaemonRepairStep, DaemonRuntimeSnapshot,
+    DaemonStaleReasonCode, DaemonState, DAEMON_LEASE_SCHEMA,
 };
+use crate::engine::shell;
 use crate::process::pid_is_running;
 use crate::{build_identity, Error, Result};
 
@@ -167,6 +168,16 @@ pub(crate) fn stale_lease(
     }
 }
 
+/// Build the freshness contract for the daemon running on *this* machine.
+///
+/// Every evidence field is filled, not just the ones this producer finds
+/// convenient: a report with half the contract populated forces consumers to
+/// special-case which producer built it.
+///
+/// The `repair_plan` and `adoption_command` are in this daemon's own local
+/// frame (`homeboy daemon …`), which is correct for `homeboy daemon status` and
+/// wrong anywhere the report is read over a transport. A remote reader must
+/// restate them against whatever handle it uses to reach this machine.
 pub(crate) fn freshness_report_from_validation(
     validation: &DaemonLeaseValidation,
     active_jobs: usize,
@@ -178,6 +189,61 @@ pub(crate) fn freshness_report_from_validation(
             validation.stale_reason_code,
             Some(DaemonStaleReasonCode::LeaseCorrupt | DaemonStaleReasonCode::TransportUnreachable)
         );
+    let lease_id = state.map(|state| state.lease_id.clone());
+    let pid = state.map(|state| state.pid);
+    // The lease names an exact PID the local kernel proved is gone, so its
+    // durable jobs can be reconciled against that one lease rather than guessed
+    // at. `DaemonFreshnessReport` has a second producer that observes a daemon
+    // over a transport; both classify this evidence identically so a consumer
+    // can rely on the field regardless of which one filled it in.
+    let proven_dead = validation.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
+        && lease_id.is_some()
+        && pid.is_some();
+    // No lease owns the store, yet durable jobs remain: the only safe action is
+    // explicit lease-less reconciliation, never an implicit replacement.
+    let leaseless_reconciliation_available = validation.stale_reason_code
+        == Some(DaemonStaleReasonCode::LeaseMissing)
+        && active_jobs > 0;
+    let recoverable_fresh_idle = validation.fresh && active_jobs == 0;
+
+    let mut ownership_evidence = if proven_dead {
+        Some(format!(
+            "daemon lease `{}` records PID {}, which is not running",
+            lease_id.as_deref().expect("proven dead lease"),
+            pid.expect("proven dead PID")
+        ))
+    } else if leaseless_reconciliation_available {
+        Some(format!(
+            "daemon state records no lease while {active_jobs} durable job(s) remain; they require explicit reconciliation before replacement"
+        ))
+    } else if recoverable_fresh_idle {
+        Some("daemon lease is fresh with zero active jobs".to_string())
+    } else {
+        Some(format!(
+            "daemon lease evidence is inconclusive; {active_jobs} active job(s) are protected from implicit replacement"
+        ))
+    };
+    if let Some(stale_reason) = &validation.stale_reason {
+        ownership_evidence = Some(format!(
+            "{}; inspected stale reason: {stale_reason}",
+            ownership_evidence.unwrap_or_default()
+        ));
+    }
+
+    let adoption_command = if proven_dead {
+        Some(format!(
+            "homeboy daemon adopt-orphan --lease-id {} --confirm-pid-dead",
+            shell::quote_arg(lease_id.as_deref().expect("proven dead lease"))
+        ))
+    } else if leaseless_reconciliation_available {
+        Some("homeboy daemon reconcile-leaseless-orphans --confirm-no-daemon-owner".to_string())
+    } else {
+        None
+    };
+
+    // A restartable lease has nothing durable to protect, so a plain stop/start
+    // is the whole repair. Otherwise the repair is exactly the explicit
+    // reconciliation the evidence authorizes; anything else would be prose.
     let repair_plan = if restartable {
         vec![
             DaemonRepairStep {
@@ -189,18 +255,35 @@ pub(crate) fn freshness_report_from_validation(
                 command: "homeboy daemon start".to_string(),
             },
         ]
+    } else if proven_dead {
+        vec![DaemonRepairStep {
+            code: "daemon_adopt_orphan".to_string(),
+            command: adoption_command.clone().expect("proven dead adoption"),
+        }]
+    } else if leaseless_reconciliation_available {
+        vec![DaemonRepairStep {
+            code: "daemon_reconcile_leaseless_orphans".to_string(),
+            command: adoption_command.clone().expect("leaseless adoption"),
+        }]
     } else {
         Vec::new()
     };
+
     DaemonFreshnessReport {
         fresh: validation.fresh,
         stale_reason_code: validation.stale_reason_code,
         restartable,
-        lease_id: state.map(|state| state.lease_id.clone()),
-        pid: state.map(|state| state.pid),
-        recovery_evidence: None,
-        ownership_evidence: None,
-        adoption_command: None,
+        lease_id,
+        pid,
+        recovery_evidence: Some(if proven_dead {
+            DaemonRecoveryEvidence::ProvenDead
+        } else if recoverable_fresh_idle {
+            DaemonRecoveryEvidence::Recoverable
+        } else {
+            DaemonRecoveryEvidence::Unavailable
+        }),
+        ownership_evidence,
+        adoption_command,
         binary_hash: state.and_then(|state| state.binary_sha256.clone()),
         daemon_version: state.map(|state| state.build_identity.version.clone()),
         daemon_build_identity: state.map(|state| state.build_identity.display.clone()),

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1482,6 +1482,7 @@ fn reconcile_terminal_phantom_activity(
         return (active_jobs, stale_jobs, direct_daemon_active_jobs, None);
     };
     let Some(refreshed_count) = daemon_http_freshness(
+        runner_id,
         local_url,
         &session.expect("local URL requires session").homeboy_version,
         session
@@ -1582,6 +1583,7 @@ fn runner_daemon_freshness(
         return Ok(None);
     };
     Ok(daemon_http_freshness(
+        &runner.id,
         local_url,
         &session.homeboy_version,
         session.homeboy_build_identity.as_deref().unwrap_or(""),
@@ -1599,12 +1601,12 @@ fn remote_daemon_recovery_freshness(
     }
     let homeboy = match remote_runner_homeboy_path(runner, "runner status") {
         Ok(homeboy) => homeboy,
-        Err(error) => return Some(unavailable_recovery_freshness(error.message)),
+        Err(error) => return Some(unavailable_recovery_freshness(runner_id, error.message)),
     };
     let (_, _, client) = match resolve_ssh_runner(runner) {
         Ok(Some(connection)) => connection,
         Ok(None) => return None,
-        Err(error) => return Some(unavailable_recovery_freshness(error.message)),
+        Err(error) => return Some(unavailable_recovery_freshness(runner_id, error.message)),
     };
     match bounded_remote_daemon_status(&client, homeboy, runner_id) {
         Ok(mut status) => {
@@ -1613,7 +1615,7 @@ fn remote_daemon_recovery_freshness(
                 runner_id, &status,
             ))
         }
-        Err(error) => Some(unavailable_recovery_freshness(error)),
+        Err(error) => Some(unavailable_recovery_freshness(runner_id, error)),
     }
 }
 

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::daemon_repair;
 use homeboy_core::daemon::{DaemonFreshnessReport, DaemonRecoveryEvidence};
 use std::time::Duration;
 
@@ -473,25 +474,34 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
             ownership_evidence.unwrap_or_default()
         ));
     }
-    let adoption_command = if proven_dead {
-        Some(format!(
-            "homeboy runner connect {} --adopt-orphan-lease {} --confirm-pid-dead",
-            shell::quote_arg(runner_id),
-            shell::quote_arg(lease_id.as_deref().expect("proven dead lease"))
+    // The repair plan and the adoption command are the same action in two
+    // shapes, so they are built from one command and one code. A remote runner
+    // is exactly the daemon an operator cannot look at, so leaving this empty
+    // and falling back to generic reconnect prose discards the evidence the SSH
+    // probe just paid for (#10302).
+    let repair_step = if proven_dead {
+        Some(daemon_repair::step(
+            daemon_repair::RUNNER_ADOPT_ORPHAN_LEASE,
+            daemon_repair::adopt_orphan_lease_command(
+                runner_id,
+                lease_id.as_deref().expect("proven dead lease"),
+            ),
         ))
     } else if leaseless_reconciliation_available {
-        Some(format!(
-            "homeboy runner connect {} --reconcile-leaseless-orphans --confirm-no-daemon-owner",
-            shell::quote_arg(runner_id),
+        Some(daemon_repair::step(
+            daemon_repair::RUNNER_RECONCILE_LEASELESS_ORPHANS,
+            daemon_repair::reconcile_leaseless_orphans_command(runner_id),
         ))
     } else if recoverable_fresh_idle {
-        Some(format!(
-            "homeboy runner connect {}",
-            shell::quote_arg(runner_id),
+        Some(daemon_repair::step(
+            daemon_repair::RUNNER_CONNECT,
+            daemon_repair::connect_command(runner_id),
         ))
     } else {
         None
     };
+    let adoption_command = repair_step.as_ref().map(|step| step.command.clone());
+    let repair_plan: Vec<_> = repair_step.into_iter().collect();
     DaemonFreshnessReport {
         fresh: status.fresh,
         stale_reason_code: status.stale_reason_code,
@@ -513,11 +523,14 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
         runtime_paths: None,
         active_jobs: status.active_jobs,
         termination_evidence: status.termination_evidence.clone(),
-        repair_plan: Vec::new(),
+        repair_plan,
     }
 }
 
-pub(super) fn unavailable_recovery_freshness(error: impl Into<String>) -> DaemonFreshnessReport {
+pub(super) fn unavailable_recovery_freshness(
+    runner_id: &str,
+    error: impl Into<String>,
+) -> DaemonFreshnessReport {
     DaemonFreshnessReport {
         fresh: false,
         stale_reason_code: Some(DaemonStaleReasonCode::TransportUnreachable),
@@ -529,6 +542,10 @@ pub(super) fn unavailable_recovery_freshness(error: impl Into<String>) -> Daemon
             "remote daemon recovery evidence unavailable: {}",
             error.into()
         )),
+        // No lease, PID, or job count survived the transport failure, so no
+        // lease-specific action can be named. Rebuilding the controller session
+        // is the only honest step, and it is emitted as typed steps rather than
+        // left to a downstream prose fallback.
         adoption_command: None,
         binary_hash: None,
         daemon_version: None,
@@ -536,7 +553,7 @@ pub(super) fn unavailable_recovery_freshness(error: impl Into<String>) -> Daemon
         runtime_paths: None,
         active_jobs: 0,
         termination_evidence: None,
-        repair_plan: Vec::new(),
+        repair_plan: daemon_repair::reconnect_plan(runner_id),
     }
 }
 
@@ -576,7 +593,10 @@ pub(super) fn ensure_remote_daemon(
                 .to_string(),
         );
     }
-    let inspected_freshness = remote_daemon_recovery_freshness_from_status("<runner-id>", &status);
+    // The real runner id, not a `<runner-id>` placeholder: this report now
+    // carries an executable repair plan, and a plan naming a command that does
+    // not exist is worse than no plan at all (#10302).
+    let inspected_freshness = remote_daemon_recovery_freshness_from_status(runner_id, &status);
     match remote_daemon_connect_action_for_runner(
         previous_session,
         &status,

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -509,9 +509,85 @@ fn remote_missing_or_corrupt_lease_with_active_jobs_exposes_bounded_reconciliati
     }
 }
 
+fn plan_of(report: &homeboy_core::daemon::DaemonFreshnessReport) -> Vec<(&str, &str)> {
+    report
+        .repair_plan
+        .iter()
+        .map(|step| (step.code.as_str(), step.command.as_str()))
+        .collect()
+}
+
+#[test]
+fn remote_recovery_repair_plan_carries_the_lease_specific_action() {
+    // #10302: the local daemon path composed a tailored repair plan while every
+    // remote constructor hardcoded an empty one, so the runner an operator
+    // cannot look at was the one that fell through to generic reconnect prose.
+    let proven_dead = remote_daemon_status_for_test_with_reason(
+        false,
+        false,
+        1,
+        "lease-dead",
+        4545,
+        Some(DaemonStaleReasonCode::PidDead),
+    );
+    let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &proven_dead);
+    assert_eq!(
+        plan_of(&recovery),
+        vec![(
+            "runner_adopt_orphan_lease",
+            "homeboy runner connect homeboy-lab --adopt-orphan-lease lease-dead --confirm-pid-dead"
+        )]
+    );
+    // The plan and the adoption command are one action in two shapes; they must
+    // never disagree.
+    assert_eq!(
+        recovery.adoption_command.as_deref(),
+        Some(recovery.repair_plan[0].command.as_str())
+    );
+
+    let mut leaseless = remote_daemon_status_for_test_with_reason(
+        false,
+        false,
+        1,
+        "legacy-lease",
+        4545,
+        Some(DaemonStaleReasonCode::LeaseMissing),
+    );
+    leaseless.daemon = None;
+    let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &leaseless);
+    assert_eq!(
+        plan_of(&recovery),
+        vec![(
+            "runner_reconcile_leaseless_orphans",
+            "homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner"
+        )]
+    );
+
+    let mut fresh_idle = remote_daemon_status_for_test(true, true, 0, "lease-live", 4545);
+    fresh_idle.work_evidence = crate::connection::remote_daemon::RemoteDaemonWorkEvidence::idle();
+    let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &fresh_idle);
+    assert_eq!(
+        plan_of(&recovery),
+        vec![("runner_connect", "homeboy runner connect homeboy-lab")]
+    );
+}
+
+#[test]
+fn remote_recovery_without_evidence_emits_no_repair_plan() {
+    // Nothing was proven about ownership or liveness, so no lease-specific step
+    // can be named. An empty plan is the honest answer and is what lets the
+    // generic reconnect fallback fire downstream.
+    let status = remote_daemon_status_for_test(false, false, 1, "lease-unknown", 4545);
+
+    let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &status);
+
+    assert!(recovery.repair_plan.is_empty());
+    assert!(recovery.adoption_command.is_none());
+}
+
 #[test]
 fn unavailable_remote_recovery_is_fail_closed() {
-    let recovery = unavailable_recovery_freshness("remote command timed out");
+    let recovery = unavailable_recovery_freshness("homeboy-lab", "remote command timed out");
 
     assert_eq!(
         recovery.stale_reason_code,
@@ -524,6 +600,20 @@ fn unavailable_remote_recovery_is_fail_closed() {
     assert!(recovery.lease_id.is_none());
     assert!(recovery.pid.is_none());
     assert!(recovery.adoption_command.is_none());
+    // No lease-specific action is knowable, but the controller-side session
+    // rebuild is, and it must arrive as typed steps rather than as prose
+    // assembled by a downstream fallback (#10302).
+    assert_eq!(
+        recovery
+            .repair_plan
+            .iter()
+            .map(|step| (step.code.as_str(), step.command.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("runner_disconnect", "homeboy runner disconnect homeboy-lab"),
+            ("runner_connect", "homeboy runner connect homeboy-lab"),
+        ]
+    );
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -14,6 +14,7 @@ use super::{
     terminate_pid, wait_for_tcp, RemoteDaemon,
 };
 use crate::connection::remote_daemon::parse_json_from_mixed_stdout;
+use crate::daemon_repair;
 use crate::{RunnerConnectReport, RunnerFailureKind};
 use std::collections::BTreeMap;
 
@@ -242,11 +243,12 @@ pub(super) fn daemon_http_runtime_loaded_paths(
 }
 
 pub(super) fn daemon_http_freshness(
+    runner_id: &str,
     local_url: &str,
     expected_version: &str,
     expected_identity: &str,
 ) -> std::result::Result<DaemonFreshnessReport, String> {
-    daemon_freshness_report(local_url, expected_version, expected_identity)
+    daemon_freshness_report(runner_id, local_url, expected_version, expected_identity)
 }
 
 /// A direct-SSH session is live only when its loopback endpoint still serves
@@ -410,7 +412,31 @@ pub(super) fn daemon_runtime_loaded_paths_from_body(body: &Value) -> BTreeMap<St
         .collect()
 }
 
+/// Restate a daemon-authored freshness report in the controller's frame.
+///
+/// A daemon composes its `repair_plan` and `adoption_command` as
+/// `homeboy daemon *`, which is correct on the machine that runs it. Once the
+/// report has crossed the SSH tunnel those commands are actively wrong: running
+/// them here would stop or adopt the *controller's* daemon. The typed evidence
+/// survives the crossing; the actions do not, so they are rebuilt against an
+/// explicit runner id (#10302).
+fn into_controller_frame(
+    mut report: DaemonFreshnessReport,
+    runner_id: &str,
+) -> DaemonFreshnessReport {
+    report.repair_plan = daemon_repair::controller_frame_plan(runner_id, &report);
+    // An adoption command is one explicit, operator-confirmed action. A
+    // multi-step restart sequence is a plan, not an adoption, so it is exposed
+    // only as steps.
+    report.adoption_command = match report.repair_plan.as_slice() {
+        [step] => Some(step.command.clone()),
+        _ => None,
+    };
+    report
+}
+
 fn daemon_freshness_report(
+    runner_id: &str,
     local_url: &str,
     expected_version: &str,
     expected_identity: &str,
@@ -426,38 +452,41 @@ fn daemon_freshness_report(
             )?
             .is_none()
         {
-            return Ok(report);
+            return Ok(into_controller_frame(report, runner_id));
         }
         if report.fresh {
             let mut report = report;
             report.fresh = false;
             report.stale_reason_code = Some(DaemonStaleReasonCode::VersionMismatch);
             report.restartable = true;
-            return Ok(report);
+            return Ok(into_controller_frame(report, runner_id));
         }
-        return Ok(report);
+        return Ok(into_controller_frame(report, runner_id));
     }
     let mismatch =
         daemon_version_identity_mismatch(&body, &raw_body, expected_version, expected_identity)?;
-    Ok(DaemonFreshnessReport {
-        fresh: mismatch.is_none(),
-        stale_reason_code: mismatch.map(|_| DaemonStaleReasonCode::VersionMismatch),
-        // A legacy version response has no daemon-owned job count, so it cannot
-        // authorize replacement while the typed job endpoint is unavailable.
-        restartable: false,
-        lease_id: daemon_lease_id_from_body(&body).map(ToString::to_string),
-        pid: None,
-        recovery_evidence: None,
-        ownership_evidence: None,
-        adoption_command: None,
-        binary_hash: None,
-        daemon_version: daemon_version_from_body(&body).map(str::to_string),
-        daemon_build_identity: daemon_identity_from_body(&body).map(str::to_string),
-        runtime_paths: None,
-        active_jobs: 0,
-        termination_evidence: None,
-        repair_plan: Vec::new(),
-    })
+    Ok(into_controller_frame(
+        DaemonFreshnessReport {
+            fresh: mismatch.is_none(),
+            stale_reason_code: mismatch.map(|_| DaemonStaleReasonCode::VersionMismatch),
+            // A legacy version response has no daemon-owned job count, so it cannot
+            // authorize replacement while the typed job endpoint is unavailable.
+            restartable: false,
+            lease_id: daemon_lease_id_from_body(&body).map(ToString::to_string),
+            pid: None,
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
+            binary_hash: None,
+            daemon_version: daemon_version_from_body(&body).map(str::to_string),
+            daemon_build_identity: daemon_identity_from_body(&body).map(str::to_string),
+            runtime_paths: None,
+            active_jobs: 0,
+            termination_evidence: None,
+            repair_plan: Vec::new(),
+        },
+        runner_id,
+    ))
 }
 
 fn daemon_version_identity_mismatch(

--- a/crates/homeboy-lab-runner/src/daemon_repair.rs
+++ b/crates/homeboy-lab-runner/src/daemon_repair.rs
@@ -1,0 +1,281 @@
+//! Controller-frame daemon repair steps.
+//!
+//! A daemon composes its own `repair_plan` in its own local frame
+//! (`homeboy daemon stop`). That is correct for `homeboy daemon status` on the
+//! machine running the daemon, and wrong the moment the report crosses an SSH
+//! boundary: running `homeboy daemon stop` on the controller stops the
+//! *controller's* daemon, not the runner's. Every plan a lab-runner constructor
+//! emits is therefore restated here in controller-side `homeboy runner`
+//! commands bound to an explicit runner id.
+//!
+//! These builders are the single definition of each command string, so the
+//! `adoption_command` a report carries and the `repair_plan` step that executes
+//! it can never drift apart.
+
+use homeboy_core::daemon::{DaemonFreshnessReport, DaemonRepairStep, DaemonStaleReasonCode};
+use homeboy_core::engine::shell;
+
+pub(crate) const RUNNER_DISCONNECT: &str = "runner_disconnect";
+pub(crate) const RUNNER_CONNECT: &str = "runner_connect";
+pub(crate) const RUNNER_REFRESH_HOMEBOY: &str = "runner_refresh_homeboy";
+pub(crate) const RUNNER_ADOPT_ORPHAN_LEASE: &str = "runner_adopt_orphan_lease";
+pub(crate) const RUNNER_RECONCILE_LEASELESS_ORPHANS: &str = "runner_reconcile_leaseless_orphans";
+pub(crate) const STALE_DAEMON_RECOVERY: &str = "stale_daemon_recovery";
+
+pub(crate) fn step(code: &str, command: String) -> DaemonRepairStep {
+    DaemonRepairStep {
+        code: code.to_string(),
+        command,
+    }
+}
+
+/// `homeboy runner disconnect <id>`.
+pub(crate) fn disconnect_command(runner_id: &str) -> String {
+    format!("homeboy runner disconnect {}", shell::quote_arg(runner_id))
+}
+
+/// `homeboy runner connect <id>`.
+pub(crate) fn connect_command(runner_id: &str) -> String {
+    format!("homeboy runner connect {}", shell::quote_arg(runner_id))
+}
+
+/// `homeboy runner connect <id> --adopt-orphan-lease <lease> --confirm-pid-dead`.
+pub(crate) fn adopt_orphan_lease_command(runner_id: &str, lease_id: &str) -> String {
+    format!(
+        "homeboy runner connect {} --adopt-orphan-lease {} --confirm-pid-dead",
+        shell::quote_arg(runner_id),
+        shell::quote_arg(lease_id)
+    )
+}
+
+/// `homeboy runner connect <id> --reconcile-leaseless-orphans --confirm-no-daemon-owner`.
+pub(crate) fn reconcile_leaseless_orphans_command(runner_id: &str) -> String {
+    format!(
+        "homeboy runner connect {} --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+        shell::quote_arg(runner_id)
+    )
+}
+
+/// `homeboy runner refresh-homeboy <id> --reconnect`.
+pub(crate) fn refresh_homeboy_command(runner_id: &str) -> String {
+    format!(
+        "homeboy runner refresh-homeboy {} --reconnect",
+        shell::quote_arg(runner_id)
+    )
+}
+
+/// The last-resort controller-side repair: drop the session and rebuild it.
+///
+/// This is the plan used when nothing specific is known about the runner's
+/// daemon, so it stays deliberately generic.
+pub(crate) fn reconnect_plan(runner_id: &str) -> Vec<DaemonRepairStep> {
+    vec![
+        step(RUNNER_DISCONNECT, disconnect_command(runner_id)),
+        step(RUNNER_CONNECT, connect_command(runner_id)),
+    ]
+}
+
+/// Restate a daemon-authored freshness report's repair plan in controller frame.
+///
+/// The daemon's own plan is discarded rather than translated step by step: the
+/// controller cannot execute `homeboy daemon *` against a remote lease, and only
+/// the typed evidence in the report (stale reason, lease, PID, durable job
+/// count) is frame-independent enough to rebuild an action from.
+pub(crate) fn controller_frame_plan(
+    runner_id: &str,
+    report: &DaemonFreshnessReport,
+) -> Vec<DaemonRepairStep> {
+    if report.fresh && report.stale_reason_code.is_none() {
+        return Vec::new();
+    }
+    if report.stale_reason_code == Some(DaemonStaleReasonCode::PidDead) {
+        if let Some(lease_id) = report.lease_id.as_deref().filter(|_| report.pid.is_some()) {
+            return vec![step(
+                RUNNER_ADOPT_ORPHAN_LEASE,
+                adopt_orphan_lease_command(runner_id, lease_id),
+            )];
+        }
+    }
+    // Durable jobs outlived the lease that owned them. Reconciliation is the
+    // only action that can retire them, and it is the same explicit,
+    // operator-confirmed command the disconnected remote-recovery path emits.
+    if report.active_jobs > 0
+        && matches!(
+            report.stale_reason_code,
+            Some(
+                DaemonStaleReasonCode::LeaseMissing
+                    | DaemonStaleReasonCode::LeaseCorrupt
+                    | DaemonStaleReasonCode::VersionMismatch
+            )
+        )
+    {
+        return vec![step(
+            RUNNER_RECONCILE_LEASELESS_ORPHANS,
+            reconcile_leaseless_orphans_command(runner_id),
+        )];
+    }
+    // An identity drift is a binary problem, not a lease problem: reconnecting
+    // the same runner-side binary would reproduce the mismatch.
+    if matches!(
+        report.stale_reason_code,
+        Some(
+            DaemonStaleReasonCode::VersionMismatch
+                | DaemonStaleReasonCode::BuildIdentityMismatch
+                | DaemonStaleReasonCode::BinaryHashMismatch
+        )
+    ) {
+        return vec![step(
+            RUNNER_REFRESH_HOMEBOY,
+            refresh_homeboy_command(runner_id),
+        )];
+    }
+    if report.restartable {
+        return reconnect_plan(runner_id);
+    }
+    Vec::new()
+}
+
+/// Render a plan as the `&&`-joined shell text used in operator prose.
+///
+/// Structured steps are the contract; this is presentation only.
+pub(crate) fn render(steps: &[DaemonRepairStep]) -> String {
+    steps
+        .iter()
+        .map(|step| step.command.as_str())
+        .collect::<Vec<_>>()
+        .join(" && ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(
+        stale_reason_code: Option<DaemonStaleReasonCode>,
+        active_jobs: usize,
+        restartable: bool,
+    ) -> DaemonFreshnessReport {
+        DaemonFreshnessReport {
+            fresh: stale_reason_code.is_none(),
+            stale_reason_code,
+            restartable,
+            lease_id: Some("lease-remote".to_string()),
+            pid: Some(4545),
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
+            binary_hash: None,
+            daemon_version: None,
+            daemon_build_identity: None,
+            runtime_paths: None,
+            active_jobs,
+            termination_evidence: None,
+            // A daemon-authored plan in the daemon's own frame. It must never
+            // survive the crossing: `homeboy daemon stop` on the controller
+            // stops the controller's daemon.
+            repair_plan: vec![
+                step("daemon_stop", "homeboy daemon stop".to_string()),
+                step("daemon_start", "homeboy daemon start".to_string()),
+            ],
+        }
+    }
+
+    fn plan(report: &DaemonFreshnessReport) -> Vec<(String, String)> {
+        controller_frame_plan("homeboy-lab", report)
+            .into_iter()
+            .map(|step| (step.code, step.command))
+            .collect()
+    }
+
+    #[test]
+    fn a_fresh_report_needs_no_repair() {
+        assert!(plan(&report(None, 0, false)).is_empty());
+    }
+
+    #[test]
+    fn a_dead_lease_becomes_an_explicit_runner_side_adoption() {
+        assert_eq!(
+            plan(&report(Some(DaemonStaleReasonCode::PidDead), 1, false)),
+            vec![(
+                RUNNER_ADOPT_ORPHAN_LEASE.to_string(),
+                "homeboy runner connect homeboy-lab --adopt-orphan-lease lease-remote --confirm-pid-dead".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn durable_jobs_without_an_owning_lease_become_explicit_reconciliation() {
+        assert_eq!(
+            plan(&report(Some(DaemonStaleReasonCode::LeaseMissing), 2, false)),
+            vec![(
+                RUNNER_RECONCILE_LEASELESS_ORPHANS.to_string(),
+                "homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn identity_drift_refreshes_the_runner_binary_rather_than_reconnecting_it() {
+        assert_eq!(
+            plan(&report(
+                Some(DaemonStaleReasonCode::BuildIdentityMismatch),
+                0,
+                true
+            )),
+            vec![(
+                RUNNER_REFRESH_HOMEBOY.to_string(),
+                "homeboy runner refresh-homeboy homeboy-lab --reconnect".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn a_restartable_lease_rebuilds_the_controller_session() {
+        assert_eq!(
+            plan(&report(
+                Some(DaemonStaleReasonCode::RuntimePathsDrift),
+                0,
+                true
+            )),
+            vec![
+                (
+                    RUNNER_DISCONNECT.to_string(),
+                    "homeboy runner disconnect homeboy-lab".to_string()
+                ),
+                (
+                    RUNNER_CONNECT.to_string(),
+                    "homeboy runner connect homeboy-lab".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_daemon_authored_local_frame_plan_never_survives_the_crossing() {
+        for code in [
+            DaemonStaleReasonCode::PidDead,
+            DaemonStaleReasonCode::LeaseMissing,
+            DaemonStaleReasonCode::VersionMismatch,
+            DaemonStaleReasonCode::RuntimePathsDrift,
+            DaemonStaleReasonCode::TransportUnreachable,
+        ] {
+            for command in plan(&report(Some(code), 1, true))
+                .into_iter()
+                .map(|(_, command)| command)
+            {
+                assert!(
+                    command.starts_with("homeboy runner "),
+                    "{code:?} produced a non-controller-frame command: {command}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn render_matches_the_operator_prose_format() {
+        assert_eq!(
+            render(&reconnect_plan("homeboy-lab")),
+            "homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab"
+        );
+    }
+}

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -3,7 +3,9 @@ use std::process::Stdio;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+use crate::daemon_repair;
 use crate::resolve_lab_runner_hint;
+use homeboy_core::daemon::DaemonRepairStep;
 use homeboy_core::error::{ActionSafety, ExecutableAction};
 use homeboy_core::lab_contract::LabCommandPortability;
 use homeboy_core::{Error, ErrorCode, Result};
@@ -667,50 +669,44 @@ fn connected_runner_not_ready_reason(
     }
 }
 
-fn daemon_repair_command(runner_id: &str, status: &RunnerStatusReport) -> String {
-    if let Some(report) = status.daemon_freshness.as_ref() {
-        let commands: Vec<_> = report
-            .repair_plan
-            .iter()
-            .map(|step| step.command.clone())
-            .collect();
-        if !commands.is_empty() {
-            return commands.join(" && ");
-        }
-    }
-    let restart = status
-        .stale_daemon
-        .as_ref()
-        .map(|warning| warning.recovery_commands.join(" && "))
-        .unwrap_or_default();
-    if restart.is_empty() {
-        format!("homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}")
-    } else {
-        restart
-    }
-}
-
-fn daemon_repair_action(runner_id: &str, status: &RunnerStatusReport) -> Option<ExecutableAction> {
-    let recovery_plan: Vec<&str> = status
+/// The typed repair a caller should surface or execute for this runner's daemon.
+///
+/// Steps, not `&&`-joined text: a consumer that wants to run one step, name its
+/// code, or attach lease/PID/endpoint values to it can do so, and prose is a
+/// rendering of the same list rather than a parallel format. The generic
+/// reconnect is the last resort, reached only when neither the freshness report
+/// nor the stale-daemon warning knows anything specific about this daemon.
+fn daemon_repair_steps(runner_id: &str, status: &RunnerStatusReport) -> Vec<DaemonRepairStep> {
+    if let Some(report) = status
         .daemon_freshness
         .as_ref()
         .filter(|report| !report.repair_plan.is_empty())
-        .map(|report| {
-            report
-                .repair_plan
-                .iter()
-                .map(|step| step.command.as_str())
-                .collect()
-        })
-        .or_else(|| {
-            status.stale_daemon.as_ref().map(|warning| {
-                warning
-                    .recovery_commands
-                    .iter()
-                    .map(String::as_str)
-                    .collect()
+    {
+        return report.repair_plan.clone();
+    }
+    let stale_commands = status
+        .stale_daemon
+        .as_ref()
+        .map(|warning| warning.recovery_commands.as_slice())
+        .unwrap_or_default();
+    if !stale_commands.is_empty() {
+        return stale_commands
+            .iter()
+            .map(|command| {
+                daemon_repair::step(daemon_repair::STALE_DAEMON_RECOVERY, command.clone())
             })
-        })?;
+            .collect();
+    }
+    daemon_repair::reconnect_plan(runner_id)
+}
+
+fn daemon_repair_command(runner_id: &str, status: &RunnerStatusReport) -> String {
+    daemon_repair::render(&daemon_repair_steps(runner_id, status))
+}
+
+fn daemon_repair_action(runner_id: &str, status: &RunnerStatusReport) -> Option<ExecutableAction> {
+    let steps = daemon_repair_steps(runner_id, status);
+    let recovery_plan: Vec<&str> = steps.iter().map(|step| step.command.as_str()).collect();
     let recovery_ref = homeboy_product_identity::build_identity()
         .git_commit
         .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()));
@@ -966,6 +962,137 @@ pub(super) fn status_tunnel_mode(status: &RunnerStatusReport) -> RunnerTunnelMod
         .session
         .as_ref()
         .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone())
+}
+
+#[cfg(test)]
+mod daemon_repair_step_tests {
+    use super::*;
+    use crate::session::RunnerStaleDaemonWarning;
+    use crate::RunnerActiveJobState;
+    use homeboy_core::daemon::DaemonFreshnessReport;
+
+    fn status_report(
+        runner_id: &str,
+        daemon_freshness: Option<DaemonFreshnessReport>,
+        stale_daemon: Option<RunnerStaleDaemonWarning>,
+    ) -> RunnerStatusReport {
+        RunnerStatusReport {
+            runner_id: runner_id.to_string(),
+            connected: true,
+            state: crate::RunnerSessionState::Connected,
+            session: None,
+            stale_daemon,
+            daemon_freshness,
+            active_jobs: Vec::new(),
+            active_runner_jobs: Vec::new(),
+            stale_runner_jobs: Vec::new(),
+            active_job_count: 0,
+            stale_runner_job_count: 0,
+            active_job_state: RunnerActiveJobState::NotQueried,
+            active_job_source: None,
+            active_job_error: None,
+            active_job_recovery_evidence: None,
+            session_path: "/tmp/lab.json".to_string(),
+        }
+    }
+
+    fn freshness_with_plan(repair_plan: Vec<DaemonRepairStep>) -> DaemonFreshnessReport {
+        DaemonFreshnessReport {
+            fresh: false,
+            stale_reason_code: Some(homeboy_core::daemon::DaemonStaleReasonCode::PidDead),
+            restartable: false,
+            lease_id: Some("lease-dead".to_string()),
+            pid: Some(4545),
+            recovery_evidence: None,
+            ownership_evidence: None,
+            adoption_command: None,
+            binary_hash: None,
+            daemon_version: None,
+            daemon_build_identity: None,
+            runtime_paths: None,
+            active_jobs: 1,
+            termination_evidence: None,
+            repair_plan,
+        }
+    }
+
+    #[test]
+    fn repair_steps_preserve_the_reports_structured_plan() {
+        // #10302: the plan the freshness report already carries is returned as
+        // typed steps, so a consumer can name a step's code or attach lease/PID
+        // values to it instead of re-parsing `&&`-joined shell text.
+        let report = status_report(
+            "homeboy-lab",
+            Some(freshness_with_plan(vec![daemon_repair::step(
+                daemon_repair::RUNNER_ADOPT_ORPHAN_LEASE,
+                daemon_repair::adopt_orphan_lease_command("homeboy-lab", "lease-dead"),
+            )])),
+            None,
+        );
+
+        let steps = daemon_repair_steps("homeboy-lab", &report);
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].code, daemon_repair::RUNNER_ADOPT_ORPHAN_LEASE);
+        assert_eq!(
+            steps[0].command,
+            "homeboy runner connect homeboy-lab --adopt-orphan-lease lease-dead --confirm-pid-dead"
+        );
+        assert_eq!(
+            daemon_repair_command("homeboy-lab", &report),
+            steps[0].command
+        );
+    }
+
+    #[test]
+    fn stale_daemon_recovery_commands_become_typed_steps() {
+        let warning = RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            "homeboy 0.218.0".to_string(),
+            "homeboy 0.219.0".to_string(),
+            Some("homeboy 0.218.0+old".to_string()),
+            Some("homeboy 0.219.0+new".to_string()),
+        );
+        let expected = warning.recovery_commands.clone();
+        let report = status_report("homeboy-lab", None, Some(warning));
+
+        let steps = daemon_repair_steps("homeboy-lab", &report);
+
+        assert_eq!(
+            steps
+                .iter()
+                .map(|step| step.command.clone())
+                .collect::<Vec<_>>(),
+            expected
+        );
+        assert!(steps
+            .iter()
+            .all(|step| step.code == daemon_repair::STALE_DAEMON_RECOVERY));
+    }
+
+    #[test]
+    fn generic_reconnect_fires_only_when_nothing_specific_is_known() {
+        let report = status_report("homeboy-lab", Some(freshness_with_plan(Vec::new())), None);
+
+        let steps = daemon_repair_steps("homeboy-lab", &report);
+
+        assert_eq!(
+            steps
+                .iter()
+                .map(|step| (step.code.as_str(), step.command.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("runner_disconnect", "homeboy runner disconnect homeboy-lab"),
+                ("runner_connect", "homeboy runner connect homeboy-lab"),
+            ]
+        );
+        // The rendered prose is the same text the old joined-string fallback
+        // produced, so operator-facing messages are unchanged.
+        assert_eq!(
+            daemon_repair_command("homeboy-lab", &report),
+            "homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -38,6 +38,7 @@ mod continuation_provider;
 mod daemon_exec_driver;
 mod daemon_health;
 mod daemon_http_get;
+mod daemon_repair;
 mod evidence;
 mod execution;
 mod execution_bundle;

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1726,6 +1726,64 @@ fn status_retains_dead_missing_schema_lease_identity_for_explicit_recovery() {
 }
 
 #[test]
+fn local_freshness_report_carries_the_same_evidence_fields_as_the_remote_producer() {
+    // #10302: `recovery_evidence` / `ownership_evidence` / `adoption_command`
+    // used to be hardcoded `None` on the local path and populated only across
+    // SSH, so no consumer could rely on either half of the one contract.
+    let _home = HomeGuard::new();
+    let state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");
+    write_daemon_state_for_test(&state);
+
+    let status = read_status().expect("status");
+
+    assert_eq!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::PidDead)
+    );
+    assert_eq!(
+        status.freshness.recovery_evidence,
+        Some(crate::daemon::DaemonRecoveryEvidence::ProvenDead)
+    );
+    let ownership = status
+        .freshness
+        .ownership_evidence
+        .as_deref()
+        .expect("ownership evidence");
+    assert!(
+        ownership.contains("test-lease") && ownership.contains(&u32::MAX.to_string()),
+        "ownership evidence must name the exact lease and PID it proved dead: {ownership}"
+    );
+    assert_eq!(
+        status.freshness.adoption_command.as_deref(),
+        Some("homeboy daemon adopt-orphan --lease-id test-lease --confirm-pid-dead")
+    );
+}
+
+#[test]
+fn local_freshness_report_plans_explicit_reconciliation_for_a_restartable_lease() {
+    let _home = HomeGuard::new();
+    let state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");
+    write_daemon_state_for_test(&state);
+
+    let status = read_status().expect("status");
+
+    // Zero durable jobs are at risk, so the whole repair is a stop/start.
+    assert!(status.freshness.restartable);
+    assert_eq!(
+        status
+            .freshness
+            .repair_plan
+            .iter()
+            .map(|step| (step.code.as_str(), step.command.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("daemon_stop", "homeboy daemon stop"),
+            ("daemon_start", "homeboy daemon start"),
+        ]
+    );
+}
+
+#[test]
 fn status_keeps_corrupt_lease_fail_closed_without_identity() {
     let _home = HomeGuard::new();
     let path = state_path().expect("state path");


### PR DESCRIPTION
## The asymmetry

`repair_plan` is not dead code. A daemon inspecting itself composes a real two-step plan (`daemon stop`, `daemon start`) in `daemon_lease.rs`, and `lab_selection::daemon_repair_command` reads it.

The defect is narrower and sharper: **the tailored plan exists locally and is empty across SSH.** Every lab-runner constructor that built a `DaemonFreshnessReport` from a remote daemon's response hardcoded `repair_plan: Vec::new()`, so the repair command fell through to a generic `homeboy runner disconnect X && homeboy runner connect X` string — for exactly the case (a remote runner you cannot just look at) where a specific plan is most valuable. The SSH probe had already paid for the evidence; the report just threw it away.

Inversely, `recovery_evidence` / `ownership_evidence` / `adoption_command` were hardcoded `None` on the local path and populated only remotely. One contract, two producers, disjoint field coverage — so no consumer could rely on either half.

## What changed

**Remote reports carry the lease-specific action they already composed.** `remote_daemon_recovery_freshness_from_status` had the values needed all along: it builds an `adoption_command` for proven-dead, lease-less-reconciliation, and fresh-idle-recoverable cases. The plan and the adoption command are now derived from one command string and one code, so they cannot disagree. When nothing is proven, the plan stays empty — that is the honest answer, and it is what lets the generic fallback fire.

**A transport failure emits the typed controller reconnect.** No lease, PID, or job count survives an SSH failure, so no lease-specific step is knowable — but rebuilding the controller session is, and it now arrives as steps rather than as prose assembled downstream.

**Reports ingested over the tunnel are restated in controller frame.** This was a latent hazard, not just an omission: a daemon composes `homeboy daemon stop`, and a controller that surfaces that verbatim is telling an operator to stop *their own* daemon. `into_controller_frame` discards the daemon's action fields and rebuilds them from the frame-independent evidence (stale reason, lease, PID, durable job count) against an explicit runner id.

**`ensure_remote_daemon` passed a literal `"<runner-id>"` placeholder** into the recovery constructor. Harmless while only `ownership_evidence` was read; a fake command once the report carries executable steps. Fixed to the real id.

**The local producer fills the evidence fields**, classifying the same evidence the same way the remote producer does, so a consumer can rely on the field regardless of which producer filled it.

**`daemon_repair_command` → `daemon_repair_steps` returning `Vec<DaemonRepairStep>`.** Both callers wanted prose, so `render()` joins with `&&` for messages — presentation, not a parallel format. `daemon_repair_action` now shares the same steps instead of duplicating the source-selection logic. The rendered text is byte-identical to what the joined-string version produced, so operator-facing messages are unchanged.

## Command verification

Every emitted string was checked against the clap arg structs, not from memory:

| Command | Source |
|---|---|
| `daemon adopt-orphan --lease-id --confirm-pid-dead` | `commands/daemon.rs` `AdoptOrphan` |
| `daemon reconcile-leaseless-orphans --confirm-no-daemon-owner` | `commands/daemon.rs` `ReconcileLeaselessOrphans` |
| `daemon stop` / `daemon start` | `commands/daemon.rs` (pre-existing) |
| `runner connect X --adopt-orphan-lease L --confirm-pid-dead` | `commands/runner/cli.rs` `Connect` |
| `runner connect X --reconcile-leaseless-orphans --confirm-no-daemon-owner` | `commands/runner/cli.rs` `Connect` |
| `runner refresh-homeboy X --reconnect` | `commands/runner/cli.rs` `RefreshHomeboy` (`--ref` is optional) |
| `runner disconnect X` | `commands/runner/cli.rs` `Disconnect` |

## Tests

- `daemon_repair`: fresh needs no repair; dead lease becomes adoption; durable jobs without an owning lease become reconciliation; identity drift refreshes the binary rather than reconnecting it; restartable rebuilds the session; **no daemon-authored `homeboy daemon *` command survives the crossing** for any stale reason.
- `connection/tests/recovery.rs`: remote proven-dead / lease-less / fresh-idle each carry the right typed step and agree with `adoption_command`; no-evidence emits an empty plan; transport-unreachable emits the typed reconnect.
- `lab_selection`: the report's plan is preserved as steps; stale-daemon recovery commands become typed steps; the generic reconnect fires only when nothing specific is known, and renders the same text as before.
- `tests/core/daemon_test.rs`: the local path carries `recovery_evidence` / `ownership_evidence` / `adoption_command` naming the exact lease and PID it proved dead.

Unblocks #10303 (daemon `--confirm-*` de-ceremony), which needs the typed plan to carry lease/pid/endpoint/job-id values.

Closes #10302