### PR TITLE
fix(lab): durably hand off detached bench runs

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -279,6 +279,11 @@ pub fn route_after_parse(
                     retry_handoff
                         .as_ref()
                         .map(|handoff| handoff.primary_workspace.as_path())
+                })
+                .or_else(|| {
+                    generic_detached_handoff
+                        .as_ref()
+                        .map(|handoff| handoff.source_path.as_path())
                 }),
             verified_cook_baseline: None,
             require_controller_git_bundle: false,
@@ -1066,6 +1071,7 @@ fn materialize_agent_task_cook_plan(
 struct GenericDetachedLabHandoff {
     run_id: String,
     plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+    source_path: PathBuf,
 }
 
 /// Give detached portable commands a controller-owned identity before Lab
@@ -1079,8 +1085,24 @@ fn materialize_generic_detached_lab_handoff(
         format!("lab-offload-{run_id}"),
         Vec::new(),
     );
-    agent_task_lifecycle::submit_plan(&plan, Some(&run_id))?;
-    Ok(GenericDetachedLabHandoff { run_id, plan })
+    if agent_task_lifecycle::run_record_exists(&run_id)? {
+        if agent_task_lifecycle::load_plan(&run_id)? != plan {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                "detached Lab run id already belongs to a different immutable handoff",
+                Some(run_id),
+                None,
+            ));
+        }
+    } else {
+        agent_task_lifecycle::submit_plan(&plan, Some(&run_id))?;
+    }
+    let source_path = source_path_for_generic_detached_lab_handoff(args)?;
+    Ok(GenericDetachedLabHandoff {
+        run_id,
+        plan,
+        source_path,
+    })
 }
 
 fn explicit_run_id(args: &[String]) -> Option<String> {
@@ -1092,6 +1114,38 @@ fn explicit_run_id(args: &[String]) -> Option<String> {
                     .then(|| args.get(index + 1).cloned())
                     .flatten()
             })
+    })
+}
+
+fn source_path_for_generic_detached_lab_handoff(args: &[String]) -> homeboy::core::Result<PathBuf> {
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--path" || arg == "--cwd" {
+            let path = args.next().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "path",
+                    "Lab handoff source flag requires a value",
+                    None,
+                    None,
+                )
+            })?;
+            return Ok(PathBuf::from(shellexpand::tilde(path).to_string()));
+        }
+        if let Some(path) = arg
+            .strip_prefix("--path=")
+            .or_else(|| arg.strip_prefix("--cwd="))
+        {
+            return Ok(PathBuf::from(shellexpand::tilde(path).to_string()));
+        }
+    }
+    std::env::current_dir().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read cwd for Lab handoff".to_string()),
+        )
     })
 }
 

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -182,6 +182,17 @@ pub fn route_after_parse(
         None
     };
     let normalized_args = inject_agent_task_cook_attempt_plan(normalized_args, cook_plan.as_ref())?;
+    let generic_detached_handoff = if lab_command.is_some()
+        && inferred_runner_id.is_some()
+        && cli.detach_after_handoff
+        && run_handoff.is_none()
+        && retry_handoff.is_none()
+        && cook_plan.is_none()
+    {
+        Some(materialize_generic_detached_lab_handoff(&normalized_args)?)
+    } else {
+        None
+    };
     // Lab routing carries the durable plan opaquely as JSON (core does not
     // depend on the agent-task subsystem); serialize the selected typed plan.
     let durable_agent_task_plan = run_handoff
@@ -193,6 +204,11 @@ pub fn route_after_parse(
                 .map(|handoff| &handoff.plan)
                 .or(cook_plan.as_ref())
         })
+        .or_else(|| {
+            generic_detached_handoff
+                .as_ref()
+                .map(|handoff| &handoff.plan)
+        })
         .map(|plan| {
             serde_json::to_value(plan).map_err(|error| {
                 Error::internal_json(
@@ -202,6 +218,9 @@ pub fn route_after_parse(
             })
         })
         .transpose()?;
+    let durable_run_id = generic_detached_handoff
+        .as_ref()
+        .map(|handoff| handoff.run_id.as_str());
     let observer = lab_dispatch_observer(cli, &normalized_args, inferred_runner_id.as_deref());
     let active_run_id = observer
         .run_id()
@@ -249,6 +268,7 @@ pub fn route_after_parse(
                 .is_some_and(|contract| contract.command.routing_policy.read_only_polling),
             local_output_file: output_file,
             durable_agent_task_plan: durable_agent_task_plan.as_ref(),
+            durable_run_id,
             // A serialized run-plan has no workspace CLI argument. Carry its
             // canonical plan root through the portable source channel so Lab
             // snapshots it before remapping nested plan/config paths.
@@ -805,6 +825,7 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
                     reuse_compatible_snapshot: false,
                     local_output_file: None,
                     durable_agent_task_plan: Some(&durable_agent_task_plan),
+                    durable_run_id: None,
                     // A retry's baseline is controller-owned capability, not plan
                     // data. Stage that exact clean checkout; never substitute the
                     // controller's original workspace during nested Lab dispatch.
@@ -1040,6 +1061,38 @@ fn materialize_agent_task_cook_plan(
     crate::commands::agent_task::run::validate_cook_request(cook)?;
     let provision = crate::commands::agent_task::run::provision_cook_destination(cook)?;
     crate::commands::agent_task::run::compile_cook_plan(cook, provision).map(Some)
+}
+
+struct GenericDetachedLabHandoff {
+    run_id: String,
+    plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+}
+
+/// Give detached portable commands a controller-owned identity before Lab
+/// admission. Agent-task commands retain their richer command-specific plans.
+fn materialize_generic_detached_lab_handoff(
+    args: &[String],
+) -> homeboy::core::Result<GenericDetachedLabHandoff> {
+    let run_id =
+        explicit_run_id(args).unwrap_or_else(|| format!("lab-offload-{}", uuid::Uuid::new_v4()));
+    let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+        format!("lab-offload-{run_id}"),
+        Vec::new(),
+    );
+    agent_task_lifecycle::submit_plan(&plan, Some(&run_id))?;
+    Ok(GenericDetachedLabHandoff { run_id, plan })
+}
+
+fn explicit_run_id(args: &[String]) -> Option<String> {
+    args.iter().enumerate().find_map(|(index, arg)| {
+        arg.strip_prefix("--run-id=")
+            .map(str::to_string)
+            .or_else(|| {
+                (arg == "--run-id")
+                    .then(|| args.get(index + 1).cloned())
+                    .flatten()
+            })
+    })
 }
 
 fn lab_route_dispatch_timeout(command: &Commands) -> Option<std::time::Duration> {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -3,6 +3,42 @@
 use super::*;
 
 #[test]
+fn detached_planless_handoff_persists_explicit_bench_label_before_handoff() {
+    crate::test_support::with_isolated_home(|_| {
+        let handoff = materialize_generic_detached_lab_handoff(&[
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--run-id".to_string(),
+            "ssi-fixture-37-20260727-runtime-fixed".to_string(),
+        ])
+        .expect("persist detached bench handoff");
+
+        assert_eq!(handoff.run_id, "ssi-fixture-37-20260727-runtime-fixed");
+        let record = agent_task_lifecycle::status(&handoff.run_id)
+            .expect("interrupted caller leaves a discoverable run");
+        assert!(!record.state.is_terminal());
+        assert_eq!(record.plan_id, handoff.plan.plan_id);
+    });
+}
+
+#[test]
+fn detached_planless_handoff_reuses_the_same_explicit_bench_label() {
+    crate::test_support::with_isolated_home(|_| {
+        let args = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--run-id=ssi-fixture-37-20260727-runtime-fixed".to_string(),
+        ];
+        let first = materialize_generic_detached_lab_handoff(&args).expect("first handoff");
+        let second = materialize_generic_detached_lab_handoff(&args).expect("replayed handoff");
+
+        assert_eq!(first.run_id, second.run_id);
+        assert_eq!(first.plan.plan_id, second.plan.plan_id);
+        assert!(agent_task_lifecycle::status(&first.run_id).is_ok());
+    });
+}
+
+#[test]
 fn explicit_local_promotion_defers_target_resolution_to_promotion() {
     let args = [
         "homeboy",

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -64,6 +64,8 @@ pub struct LabRoutingRequest<'a> {
     /// subsystem. Only its presence is consulted along the routing path; the
     /// agent-task layer owns the typed plan.
     pub durable_agent_task_plan: Option<&'a serde_json::Value>,
+    /// Stable controller-owned identity for a detached planless command.
+    pub durable_run_id: Option<&'a str>,
     /// Controller checkout selected independently of CLI argv, such as the
     /// logical primary workspace of a materialized retry plan.
     pub source_path: Option<&'a std::path::Path>,
@@ -670,6 +672,7 @@ fn execute_lab_offload_with_timeout(
     let read_only_polling = request.read_only_polling;
     let local_output_file = request.local_output_file.map(str::to_string);
     let durable_agent_task_plan = request.durable_agent_task_plan.cloned();
+    let durable_run_id = request.durable_run_id.map(str::to_string);
     let source_path = request.source_path.map(std::path::Path::to_path_buf);
     let verified_cook_baseline = request.verified_cook_baseline.cloned();
     let require_controller_git_bundle = request.require_controller_git_bundle;
@@ -695,6 +698,7 @@ fn execute_lab_offload_with_timeout(
             read_only_polling,
             local_output_file: local_output_file.as_deref(),
             durable_agent_task_plan: durable_agent_task_plan.as_ref(),
+            durable_run_id: durable_run_id.as_deref(),
             source_path: source_path.as_deref(),
             verified_cook_baseline: verified_cook_baseline.as_ref(),
             require_controller_git_bundle,
@@ -888,6 +892,7 @@ mod tests {
             read_only_polling: false,
             local_output_file: None,
             durable_agent_task_plan: None,
+            durable_run_id: None,
             source_path: None,
             verified_cook_baseline: None,
             require_controller_git_bundle: false,
@@ -1251,6 +1256,7 @@ mod tests {
                 read_only_polling: false,
                 local_output_file: None,
                 durable_agent_task_plan: None,
+                durable_run_id: None,
                 source_path: None,
                 verified_cook_baseline: None,
                 require_controller_git_bundle: false,

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1114,6 +1114,72 @@ pub(crate) fn run_lab_offload_inner(
         ));
     }
 
+    // Detached commands without an agent-task argv shape receive their durable
+    // plan and identity from routing. Admit the controller job before capacity
+    // checks or remote preparation so caller loss cannot orphan staging.
+    if request.detach_after_handoff
+        && request.durable_agent_task_plan.is_some()
+        && request.durable_run_id.is_some()
+    {
+        let run_id = request.durable_run_id.expect("checked durable run id");
+        emit_durable_run_id_before_execution(
+            run_id,
+            runner_id,
+            request.local_output_file,
+            &mut messages,
+        );
+        let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
+            run_id,
+            runner_id,
+            selection.mode.clone(),
+            &request,
+        ) {
+            Ok(controller_job_id) => controller_job_id,
+            Err(error) => {
+                if error.retryable != Some(true) {
+                    if let Some(durable_plan) = request.durable_agent_task_plan {
+                        let _ = agent_task_lifecycle::record_pre_execution_failure(
+                            run_id,
+                            durable_plan,
+                            "lab_staging_submission",
+                            &error,
+                        );
+                    }
+                }
+                return Err(
+                    error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))
+                );
+            }
+        };
+        let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
+        let stdout = serde_json::to_string_pretty(&serde_json::json!({
+            "success": true,
+            "data": {
+                "status": "materializing",
+                "durable_run_id": run_id,
+                "controller_job_id": controller_job_id,
+                "retrieval_commands": {
+                    "status": format!("homeboy agent-task status {run_id}"),
+                    "controller_job": controller_job_commands.show,
+                    "controller_job_watch": controller_job_commands.watch,
+                },
+            }
+        }))
+        .unwrap_or_else(|_| {
+            format!("Lab staging controller job {controller_job_id} accepted for {run_id}")
+        });
+        return Ok(LabOffloadOutcome::InFlight {
+            plan,
+            stdout: format!("{stdout}\n"),
+            stderr: format!(
+                "Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\nNext: {}\nNext: {}\n",
+                controller_job_commands.show, controller_job_commands.watch,
+            ),
+            exit_code: 0,
+            output_file_content: Some(format!("{stdout}\n")),
+        });
+    }
+
     require_available_lab_runner(
         runner_id,
         &runner_status,

--- a/crates/homeboy-lab-runner/src/lab/offload/types.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/types.rs
@@ -30,6 +30,8 @@ pub struct LabOffloadRequest<'a> {
     /// The controller-materialized task plan to retain if this offload creates
     /// a durable agent-task record before the runner accepts its child job.
     pub durable_agent_task_plan: Option<&'a homeboy_agents::agent_task_scheduler::AgentTaskPlan>,
+    /// Stable controller-owned identity for detached planless commands.
+    pub durable_run_id: Option<&'a str>,
     /// Controller checkout selected independently of the remote command argv.
     /// This keeps process cwd in the runner job while retaining an exact local
     /// source for Git materialization and path remapping.
@@ -66,6 +68,7 @@ impl<'a> LabOffloadRequest<'a> {
             read_only_polling: false,
             local_output_file: None,
             durable_agent_task_plan: None,
+            durable_run_id: None,
             source_path: None,
             verified_cook_baseline: None,
             require_controller_git_bundle: false,
@@ -100,6 +103,7 @@ mod tests {
             read_only_polling,
             local_output_file,
             durable_agent_task_plan,
+            durable_run_id,
             source_path,
             verified_cook_baseline,
             require_controller_git_bundle,
@@ -122,6 +126,7 @@ mod tests {
         assert!(!read_only_polling);
         assert!(local_output_file.is_none());
         assert!(durable_agent_task_plan.is_none());
+        assert!(durable_run_id.is_none());
         assert!(source_path.is_none());
         assert!(verified_cook_baseline.is_none());
         assert!(!require_controller_git_bundle);

--- a/crates/homeboy-lab-runner/src/lab_offload_provider.rs
+++ b/crates/homeboy-lab-runner/src/lab_offload_provider.rs
@@ -49,6 +49,7 @@ impl LabOffloadProvider for RunnerLabOffload {
             read_only_polling: request.read_only_polling,
             local_output_file: request.local_output_file,
             durable_agent_task_plan: durable_agent_task_plan.as_ref(),
+            durable_run_id: request.durable_run_id,
             source_path: request.source_path,
             verified_cook_baseline: request.verified_cook_baseline,
             require_controller_git_bundle: request.require_controller_git_bundle,

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -164,7 +164,7 @@ impl LabStagingRecipe {
         let command = request.command.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "command",
-                "Lab staging requires a resolved agent-task Lab command",
+                "Lab staging requires a resolved portable Lab command",
                 None,
                 None,
             )
@@ -220,19 +220,16 @@ impl LabStagingRecipe {
     }
 
     fn validate(&self) -> Result<()> {
-        // Canonical argv may contain the executable and global options before
-        // the resolved subcommand token.
-        let normalized_agent_task = self.normalized_args.iter().any(|arg| arg == "agent-task");
         if self.schema != LAB_STAGING_RECIPE_SCHEMA
             || self.run_id.trim().is_empty()
             || self.runner_id.trim().is_empty()
             || !self.command.portable
-            || !self.command.hot_label.starts_with("agent-task")
-            || !normalized_agent_task
+            || self.normalized_args.is_empty()
+            || self.source_path.is_none()
         {
             return Err(Error::validation_invalid_argument(
                 "lab_staging_recipe",
-                "Lab staging requires its v1 schema, bound run and runner identities, and an agent-task command shape",
+                "Lab staging requires its v1 schema, bound run and runner identities, portable argv, and a controller source path",
                 None,
                 None,
             ));
@@ -3908,6 +3905,42 @@ mod tests {
             LabStagingCheckpoint::initial(&envelope).phase,
             LabStagingPhase::AcceptedMaterializeWorkspace
         );
+    }
+
+    #[test]
+    fn generic_bench_recipe_keeps_controller_source_private() {
+        let args = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--run-id".to_string(),
+            "ssi-fixture-37-20260727-runtime-fixed".to_string(),
+            "--path".to_string(),
+            "/controller/private/static-site-importer".to_string(),
+        ];
+        let mut command = recipe_command();
+        command.command = LabCommandContract::portable("bench", None, false, &[]);
+        let recipe = LabStagingRecipe::from_request(
+            "ssi-fixture-37-20260727-runtime-fixed",
+            "lab-1",
+            &recipe_request(Some(command), &args, HashMap::new()),
+        )
+        .expect("generic bench recipe is accepted");
+
+        assert_eq!(
+            recipe.source_path.as_deref(),
+            Some(std::path::Path::new("/work/source"))
+        );
+        let envelope = LabStagingDispatchEnvelope::new(
+            recipe.run_id.clone(),
+            recipe.runner_id.clone(),
+            LabStagingInputRef::AgentTaskAttempt {
+                run_id: recipe.run_id.clone(),
+                recipe: recipe_ref(),
+            },
+        );
+        let public = envelope.public_projection();
+        assert!(!public.to_string().contains("/controller/private"));
+        assert!(!public.to_string().contains("/work/source"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3596,9 +3596,12 @@ pub(crate) fn routing_ready() -> bool {
 /// registration. Keeping this explicit prevents partial embedders from routing
 /// detached work before they initialize the Lab runtime.
 pub fn enable_production_routing() {
-    install_production_execution_adapter(Arc::new(StageExecutionAdapter::new(Arc::new(
-        ProductionLabStagingOperations,
-    ))));
+    static ENABLED: OnceLock<()> = OnceLock::new();
+    ENABLED.get_or_init(|| {
+        install_production_execution_adapter(Arc::new(StageExecutionAdapter::new(Arc::new(
+            ProductionLabStagingOperations,
+        ))));
+    });
 }
 
 fn cancellations() -> &'static Mutex<HashMap<String, LabStagingCancellationToken>> {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -2577,6 +2577,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             read_only_polling: request.recipe.read_only_polling,
             local_output_file: None,
             durable_agent_task_plan: Some(&request.durable_agent_task_plan),
+            durable_run_id: Some(&request.recipe.run_id),
             source_path: Some(source_path),
             verified_cook_baseline: request.recipe.verified_cook_baseline.as_ref(),
             require_controller_git_bundle: request.recipe.require_controller_git_bundle,


### PR DESCRIPTION
## Summary

- create a durable controller-owned lifecycle for detached planless Lab commands before slow runner work
- preserve explicit bench `--run-id` as an immediately queryable identity
- admit generic portable bench recipes through the existing controller staging driver
- keep controller source paths private while materializing the required snapshot
- make repeated explicit run IDs idempotent and preserve terminal/cancelled/handoff state
- reject changed immutable recipes with a typed run-ID conflict
- initialize the production staging adapter once across CLI/daemon startup

## Verification

- `cargo test -p homeboy-cli detached_planless_handoff --lib`
- `cargo test -p homeboy-lab-runner generic_bench_recipe_keeps_controller_source_private --lib`
- controller caller-loss and exact-once recovery tests
- `cargo check -p homeboy-cli -p homeboy-lab-runner`
- `cargo fmt --all -- --check`
- `git diff --check`

## Compatibility

Attached bench behavior and agent-task Cook routing remain unchanged. Public controller-job projections expose run/runner/state, not controller source paths.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the five-minute detached bench gap, implemented durable generic staging, and repaired public-route, privacy, idempotency, and production-adapter findings through independent review. Chris Huber reviewed and remains responsible for every line.

Fixes #10500.