### PR TITLE
fix(artifacts): return exact controller reviewer references

### DIFF
--- a/crates/homeboy-core/src/artifact_links.rs
+++ b/crates/homeboy-core/src/artifact_links.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 use std::path::Path;
 use std::time::Duration;
 
+use crate::error::{Error, Result};
 use crate::execution_contract::encode_uri_component;
 use crate::observation::{ArtifactRecord, ArtifactViewerLink};
 
@@ -84,21 +85,74 @@ pub fn public_artifact_url(artifact: &ArtifactRecord) -> Option<String> {
 /// Return the controller's stable artifact route rather than a filesystem
 /// layout URL. Terminal handoffs use this route because it remains valid when
 /// the runner's artifact layout is unavailable after completion.
-pub fn controller_artifact_url(artifact: &ArtifactRecord) -> Option<String> {
+pub fn controller_artifact_url(artifact: &ArtifactRecord) -> Result<String> {
     if artifact.artifact_type != "file" {
-        return None;
+        return Err(Error::validation_invalid_argument(
+            "artifact.type",
+            "reviewer artifact URLs require a controller-owned file",
+            Some(artifact.id.clone()),
+            None,
+        ));
     }
-    let base = std::env::var(PUBLIC_ARTIFACT_BASE_URL_ENV).ok()?;
-    let base = base.trim().trim_end_matches('/');
-    if base.is_empty() {
-        return None;
-    }
-    Some(format!(
+    let base = reviewer_public_artifact_base_url()?;
+    Ok(format!(
         "{}/runs/{}/artifacts/{}",
         base,
         encode_uri_component(&artifact.run_id),
         encode_uri_component(&artifact.id)
     ))
+}
+
+/// Resolve the public artifact origin once at the configuration boundary.
+/// Terminal handoffs only advertise HTTPS URLs on reviewer-reachable hosts.
+pub fn reviewer_public_artifact_base_url() -> Result<String> {
+    let value = std::env::var(PUBLIC_ARTIFACT_BASE_URL_ENV).map_err(|_| {
+        Error::validation_invalid_argument(
+            PUBLIC_ARTIFACT_BASE_URL_ENV,
+            "a public HTTPS artifact origin is required before returning reviewer references",
+            None,
+            None,
+        )
+    })?;
+    let value = value.trim().trim_end_matches('/');
+    let url = reqwest::Url::parse(value).map_err(|error| {
+        Error::validation_invalid_argument(
+            PUBLIC_ARTIFACT_BASE_URL_ENV,
+            "public artifact origin must be a valid HTTPS URL",
+            Some(error.to_string()),
+            None,
+        )
+    })?;
+    let host = url.host_str().unwrap_or_default();
+    if url.scheme() != "https" || host.is_empty() || non_public_host(host) {
+        return Err(Error::validation_invalid_argument(
+            PUBLIC_ARTIFACT_BASE_URL_ENV,
+            "public artifact origin must use HTTPS with a reviewer-reachable host",
+            Some(value.to_string()),
+            None,
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn non_public_host(host: &str) -> bool {
+    let host = host.trim_matches(['[', ']']);
+    let lower = host.to_ascii_lowercase();
+    if lower == "localhost" || lower.ends_with(".localhost") || lower.ends_with(".local") {
+        return true;
+    }
+    match host.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(ip)) => {
+            ip.is_loopback() || ip.is_private() || ip.is_link_local() || ip.is_unspecified()
+        }
+        Ok(std::net::IpAddr::V6(ip)) => {
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || (ip.segments()[0] & 0xfe00) == 0xfc00
+                || (ip.segments()[0] & 0xffc0) == 0xfe80
+        }
+        Err(_) => false,
+    }
 }
 
 pub fn public_artifact_path_url(root: &Path, base: &str, path: &Path) -> Option<String> {
@@ -261,7 +315,9 @@ fn artifact_is_fetchable(artifact: &ArtifactRecord) -> bool {
         || artifact.artifact_type == "remote_file"
 }
 
-fn probe_public_artifact_url(public_url: &str) -> Result<reqwest::StatusCode, reqwest::Error> {
+fn probe_public_artifact_url(
+    public_url: &str,
+) -> std::result::Result<reqwest::StatusCode, reqwest::Error> {
     crate::http_probe::blocking_client(PUBLIC_ARTIFACT_URL_PROBE_TIMEOUT)?
         .get(public_url)
         .header(reqwest::header::RANGE, "bytes=0-0")
@@ -273,6 +329,9 @@ fn probe_public_artifact_url(public_url: &str) -> Result<reqwest::StatusCode, re
 mod tests {
     use super::*;
     use crate::observation::ArtifactRecord;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn derives_viewer_link_from_public_artifact_url_metadata() {
@@ -367,6 +426,33 @@ mod tests {
     }
 
     #[test]
+    fn controller_url_requires_a_public_https_origin_and_encodes_ids() {
+        let _env = EnvGuard::set(
+            PUBLIC_ARTIFACT_BASE_URL_ENV,
+            "https://artifacts.example.test/reviewer/",
+        );
+        let artifact = ArtifactRecord {
+            id: "source /?%".to_string(),
+            run_id: "run /?%".to_string(),
+            artifact_type: "file".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            controller_artifact_url(&artifact).expect("reviewer URL"),
+            "https://artifacts.example.test/reviewer/runs/run%20%2F%3F%25/artifacts/source%20%2F%3F%25"
+        );
+    }
+
+    #[test]
+    fn reviewer_public_artifact_base_rejects_local_or_non_https_origins() {
+        for value in ["http://artifacts.example.test", "https://127.0.0.1:7351"] {
+            let _env = EnvGuard::set(PUBLIC_ARTIFACT_BASE_URL_ENV, value);
+            assert!(reviewer_public_artifact_base_url().is_err(), "{value}");
+        }
+    }
+
+    #[test]
     fn directory_artifact_public_url_requires_artifact_root_path() {
         let _env = EnvGuard::set(
             PUBLIC_ARTIFACT_BASE_URL_ENV,
@@ -419,13 +505,19 @@ mod tests {
     struct EnvGuard {
         key: &'static str,
         prior: Option<String>,
+        _lock: MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
+            let lock = ENV_LOCK.lock().expect("environment lock");
             let prior = std::env::var(key).ok();
             std::env::set_var(key, value);
-            Self { key, prior }
+            Self {
+                key,
+                prior,
+                _lock: lock,
+            }
         }
     }
 

--- a/crates/homeboy-core/src/artifact_links.rs
+++ b/crates/homeboy-core/src/artifact_links.rs
@@ -85,7 +85,7 @@ pub fn public_artifact_url(artifact: &ArtifactRecord) -> Option<String> {
 /// Return the controller's stable artifact route rather than a filesystem
 /// layout URL. Terminal handoffs use this route because it remains valid when
 /// the runner's artifact layout is unavailable after completion.
-pub fn controller_artifact_url(artifact: &ArtifactRecord) -> Result<String> {
+pub fn controller_artifact_url(artifact: &ArtifactRecord) -> Result<Option<String>> {
     if artifact.artifact_type != "file" {
         return Err(Error::validation_invalid_argument(
             "artifact.type",
@@ -94,27 +94,31 @@ pub fn controller_artifact_url(artifact: &ArtifactRecord) -> Result<String> {
             None,
         ));
     }
-    let base = reviewer_public_artifact_base_url()?;
-    Ok(format!(
+    let Some(base) = reviewer_public_artifact_base_url()? else {
+        return Ok(None);
+    };
+    Ok(Some(format!(
         "{}/runs/{}/artifacts/{}",
         base,
         encode_uri_component(&artifact.run_id),
         encode_uri_component(&artifact.id)
-    ))
+    )))
 }
 
 /// Resolve the public artifact origin once at the configuration boundary.
 /// Terminal handoffs only advertise HTTPS URLs on reviewer-reachable hosts.
-pub fn reviewer_public_artifact_base_url() -> Result<String> {
-    let value = std::env::var(PUBLIC_ARTIFACT_BASE_URL_ENV).map_err(|_| {
-        Error::validation_invalid_argument(
-            PUBLIC_ARTIFACT_BASE_URL_ENV,
-            "a public HTTPS artifact origin is required before returning reviewer references",
-            None,
-            None,
-        )
-    })?;
+pub fn reviewer_public_artifact_base_url() -> Result<Option<String>> {
+    let configured = crate::defaults::load_config()
+        .artifact_origin
+        .public_base_url;
+    let value = configured.or_else(|| std::env::var(PUBLIC_ARTIFACT_BASE_URL_ENV).ok());
+    let Some(value) = value else {
+        return Ok(None);
+    };
     let value = value.trim().trim_end_matches('/');
+    if value.is_empty() {
+        return Ok(None);
+    }
     let url = reqwest::Url::parse(value).map_err(|error| {
         Error::validation_invalid_argument(
             PUBLIC_ARTIFACT_BASE_URL_ENV,
@@ -132,7 +136,7 @@ pub fn reviewer_public_artifact_base_url() -> Result<String> {
             None,
         ));
     }
-    Ok(value.to_string())
+    Ok(Some(value.to_string()))
 }
 
 fn non_public_host(host: &str) -> bool {
@@ -439,8 +443,10 @@ mod tests {
         };
 
         assert_eq!(
-            controller_artifact_url(&artifact).expect("reviewer URL"),
-            "https://artifacts.example.test/reviewer/runs/run%20%2F%3F%25/artifacts/source%20%2F%3F%25"
+            controller_artifact_url(&artifact)
+                .expect("valid reviewer origin")
+                .as_deref(),
+            Some("https://artifacts.example.test/reviewer/runs/run%20%2F%3F%25/artifacts/source%20%2F%3F%25")
         );
     }
 
@@ -450,6 +456,42 @@ mod tests {
             let _env = EnvGuard::set(PUBLIC_ARTIFACT_BASE_URL_ENV, value);
             assert!(reviewer_public_artifact_base_url().is_err(), "{value}");
         }
+    }
+
+    #[test]
+    fn controller_origin_uses_typed_config_before_legacy_environment() {
+        crate::test_support::with_isolated_home(|_| {
+            let _env = EnvGuard::set(PUBLIC_ARTIFACT_BASE_URL_ENV, "https://runner.example.test");
+            let mut config = crate::defaults::HomeboyConfig::default();
+            config.artifact_origin.public_base_url =
+                Some("https://controller.example.test/".to_string());
+            crate::defaults::save_config(&config).expect("save controller config");
+
+            assert_eq!(
+                reviewer_public_artifact_base_url()
+                    .expect("configured origin")
+                    .as_deref(),
+                Some("https://controller.example.test")
+            );
+        });
+    }
+
+    #[test]
+    fn controller_url_is_absent_without_controller_origin() {
+        crate::test_support::with_isolated_home(|_| {
+            let _env = EnvGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
+            let artifact = ArtifactRecord {
+                id: "artifact-1".to_string(),
+                run_id: "run-1".to_string(),
+                artifact_type: "file".to_string(),
+                ..Default::default()
+            };
+
+            assert_eq!(
+                controller_artifact_url(&artifact).expect("optional URL"),
+                None
+            );
+        });
     }
 
     #[test]
@@ -513,6 +555,17 @@ mod tests {
             let lock = ENV_LOCK.lock().expect("environment lock");
             let prior = std::env::var(key).ok();
             std::env::set_var(key, value);
+            Self {
+                key,
+                prior,
+                _lock: lock,
+            }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let lock = ENV_LOCK.lock().expect("environment lock");
+            let prior = std::env::var(key).ok();
+            std::env::remove_var(key);
             Self {
                 key,
                 prior,

--- a/crates/homeboy-core/src/artifact_links.rs
+++ b/crates/homeboy-core/src/artifact_links.rs
@@ -81,6 +81,26 @@ pub fn public_artifact_url(artifact: &ArtifactRecord) -> Option<String> {
     ))
 }
 
+/// Return the controller's stable artifact route rather than a filesystem
+/// layout URL. Terminal handoffs use this route because it remains valid when
+/// the runner's artifact layout is unavailable after completion.
+pub fn controller_artifact_url(artifact: &ArtifactRecord) -> Option<String> {
+    if artifact.artifact_type != "file" {
+        return None;
+    }
+    let base = std::env::var(PUBLIC_ARTIFACT_BASE_URL_ENV).ok()?;
+    let base = base.trim().trim_end_matches('/');
+    if base.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}/runs/{}/artifacts/{}",
+        base,
+        encode_uri_component(&artifact.run_id),
+        encode_uri_component(&artifact.id)
+    ))
+}
+
 pub fn public_artifact_path_url(root: &Path, base: &str, path: &Path) -> Option<String> {
     let base = base.trim().trim_end_matches('/');
     if base.is_empty() {

--- a/crates/homeboy-core/src/artifact_origin.rs
+++ b/crates/homeboy-core/src/artifact_origin.rs
@@ -678,6 +678,42 @@ mod tests {
     }
 
     #[test]
+    fn serves_nested_visual_compare_reviewer_paths_over_http() {
+        let root = tempfile::tempdir().expect("artifact root");
+        let fixture = [
+            ("source.png", b"source bytes".as_slice()),
+            ("candidate.png", b"candidate bytes".as_slice()),
+            ("diff.png", b"diff bytes".as_slice()),
+        ];
+        let path = root.path().join("visual-compare/37-art-gallery-exhibition");
+        std::fs::create_dir_all(&path).expect("artifact directory");
+        for (name, bytes) in fixture {
+            std::fs::write(path.join(name), bytes).expect("visual artifact");
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("listener address");
+        let root_path = root.path().to_path_buf();
+        let server = std::thread::spawn(move || {
+            for stream in listener.incoming().take(3) {
+                handle_stream(stream.expect("request stream"), &root_path).expect("serve request");
+            }
+        });
+        let client = reqwest::blocking::Client::new();
+        for (name, bytes) in fixture {
+            let response = client
+                .get(format!(
+                    "http://{address}/visual-compare/37-art-gallery-exhibition/{name}"
+                ))
+                .send()
+                .expect("reviewer request");
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            assert_eq!(response.bytes().expect("response bytes").as_ref(), bytes);
+        }
+        server.join().expect("origin server");
+    }
+
+    #[test]
     fn inspect_reports_404_for_missing_workflow_bench_bundle_path() {
         let temp = tempfile::tempdir().expect("tempdir");
 

--- a/crates/homeboy-core/src/artifact_origin.rs
+++ b/crates/homeboy-core/src/artifact_origin.rs
@@ -714,6 +714,83 @@ mod tests {
     }
 
     #[test]
+    fn serves_generated_canonical_reviewer_urls_over_http() {
+        crate::test_support::with_isolated_home(|home| {
+            let _env = EnvGuard::set(
+                crate::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV,
+                "https://artifacts.example.test",
+            );
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("runner-exec").build())
+                .expect("run");
+            let fixture = [
+                ("source", "source.png", b"source bytes".as_slice()),
+                ("candidate", "candidate.png", b"candidate bytes".as_slice()),
+                ("diff", "diff.png", b"diff bytes".as_slice()),
+            ];
+            let source_dir = home.path().join("visual-compare/37-art-gallery-exhibition");
+            std::fs::create_dir_all(&source_dir).expect("artifact directory");
+            let artifacts = fixture
+                .iter()
+                .map(|(id, name, bytes)| {
+                    let source = source_dir.join(name);
+                    std::fs::write(&source, bytes).expect("visual artifact");
+                    store
+                        .record_artifact_with_id(
+                            &run.id,
+                            "visual_compare",
+                            &source,
+                            id,
+                            serde_json::json!({}),
+                        )
+                        .expect("controller artifact")
+                })
+                .collect::<Vec<_>>();
+
+            let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+            let address = listener.local_addr().expect("listener address");
+            let root = home.path().to_path_buf();
+            let server = std::thread::spawn(move || {
+                for stream in listener.incoming().take(3) {
+                    handle_stream(stream.expect("request stream"), &root).expect("serve request");
+                }
+            });
+            let client = reqwest::blocking::Client::new();
+            for ((id, _, bytes), artifact) in fixture.iter().zip(artifacts) {
+                let public_url = crate::artifact_links::controller_artifact_url(&artifact)
+                    .expect("public reviewer URL");
+                assert_eq!(
+                    public_url,
+                    format!(
+                        "https://artifacts.example.test/runs/{}/artifacts/{id}",
+                        run.id
+                    )
+                );
+                let path = reqwest::Url::parse(&public_url)
+                    .expect("public URL")
+                    .path()
+                    .to_string();
+                let response = client
+                    .get(format!("http://{address}{path}"))
+                    .send()
+                    .expect("unauthenticated reviewer request");
+                assert_eq!(response.status(), reqwest::StatusCode::OK);
+                assert_eq!(
+                    response.headers()[reqwest::header::CONTENT_TYPE],
+                    "image/png"
+                );
+                assert_eq!(
+                    response.headers()["x-homeboy-artifact-sha256"],
+                    artifact.sha256.as_deref().expect("checksum")
+                );
+                assert_eq!(response.bytes().expect("response bytes").as_ref(), *bytes);
+            }
+            server.join().expect("origin server");
+        });
+    }
+
+    #[test]
     fn inspect_reports_404_for_missing_workflow_bench_bundle_path() {
         let temp = tempfile::tempdir().expect("tempdir");
 

--- a/crates/homeboy-core/src/artifact_origin.rs
+++ b/crates/homeboy-core/src/artifact_origin.rs
@@ -759,7 +759,8 @@ mod tests {
             let client = reqwest::blocking::Client::new();
             for ((id, _, bytes), artifact) in fixture.iter().zip(artifacts) {
                 let public_url = crate::artifact_links::controller_artifact_url(&artifact)
-                    .expect("public reviewer URL");
+                    .expect("valid reviewer origin")
+                    .expect("configured public reviewer URL");
                 assert_eq!(
                     public_url,
                     format!(

--- a/crates/homeboy-core/src/daemon/artifact_download.rs
+++ b/crates/homeboy-core/src/daemon/artifact_download.rs
@@ -32,11 +32,17 @@ pub(crate) fn route(path: &str) -> Option<HttpResponse> {
     let result = match segments.as_slice() {
         ["artifacts", artifact_token] => resolve_artifact_download(None, artifact_token),
         ["runs", run_id, "artifacts", "sync"] => artifact_sync_manifest(run_id),
-        ["runs", run_id, "artifacts", artifact_token] => {
-            resolve_artifact_download(Some(run_id), artifact_token)
+        ["runs", run_id, "artifacts", artifact_id] => {
+            resolve_exact_artifact_download(run_id, artifact_id)
         }
-        ["runs", run_id, "artifacts", artifact_token, "content"] => {
-            resolve_artifact_download(Some(run_id), artifact_token)
+        ["runs", run_id, "artifacts", artifact_id, "content"] => {
+            resolve_exact_artifact_download(run_id, artifact_id)
+        }
+        ["runs", run_id, "artifacts", "aliases", artifact_token] => {
+            resolve_alias_artifact_download(run_id, artifact_token)
+        }
+        ["runs", run_id, "artifacts", "store", artifact_token] => {
+            resolve_artifact_store_download(run_id, artifact_token)
         }
         _ => return None,
     };
@@ -127,6 +133,10 @@ fn resolve_artifact_download(
             })?
     };
 
+    resolve_downloaded_artifact(artifact)
+}
+
+fn resolve_downloaded_artifact(artifact: ArtifactRecord) -> Result<ResolvedArtifactResponse> {
     if artifact.artifact_type != "file" {
         if artifact.artifact_type == "remote_file"
             || crate::execution_contract::is_remote_runner_artifact_path(&artifact.path)
@@ -210,6 +220,55 @@ fn resolve_artifact_download(
             filename,
         },
     )))
+}
+
+fn resolve_exact_artifact_download(
+    run_id: &str,
+    artifact_id: &str,
+) -> Result<ResolvedArtifactResponse> {
+    let store = ObservationStore::open_initialized()?;
+    if store.get_run(run_id)?.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("run record not found: {run_id}"),
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    crate::artifacts::index_remote_published_artifact_refs_for_run(&store, run_id)?;
+    let artifact_id = decode_uri_component(artifact_id);
+    let artifact = store.get_artifact(&artifact_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!("artifact record not found: {artifact_id}"),
+            Some(artifact_id.clone()),
+            None,
+        )
+    })?;
+    if artifact.run_id != run_id {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "artifact does not belong to requested run",
+            Some(artifact_id),
+            None,
+        ));
+    }
+    resolve_downloaded_artifact(artifact)
+}
+
+fn resolve_alias_artifact_download(
+    run_id: &str,
+    artifact_token: &str,
+) -> Result<ResolvedArtifactResponse> {
+    resolve_artifact_download(Some(run_id), artifact_token)
+}
+
+fn resolve_artifact_store_download(
+    run_id: &str,
+    artifact_token: &str,
+) -> Result<ResolvedArtifactResponse> {
+    let decoded = decode_uri_component(artifact_token);
+    artifact_store_download(run_id, artifact_token, &decoded)
 }
 
 fn artifact_store_download(

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -98,6 +98,14 @@ pub struct HomeboyConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_root: Option<String>,
 
+    /// Controller-owned public origin for canonical run artifact routes.
+    ///
+    /// Runner environment is not configuration for this origin. The legacy
+    /// `HOMEBOY_PUBLIC_ARTIFACT_BASE_URL` is read only as a controller-process
+    /// compatibility input when this setting is absent.
+    #[serde(default)]
+    pub artifact_origin: ArtifactOriginConfig,
+
     /// Enable automatic update check on startup (default: true).
     /// Disable with `homeboy config set /update_check false`
     /// or set HOMEBOY_NO_UPDATE_CHECK=1.
@@ -158,10 +166,19 @@ impl Default for HomeboyConfig {
             release_gate: ReleaseGateConfig::default(),
             retention: RetentionConfig::default(),
             artifact_root: None,
+            artifact_origin: ArtifactOriginConfig::default(),
             update_check: true,
             resident_services: Vec::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ArtifactOriginConfig {
+    /// Public HTTPS base URL owned by this controller, for example
+    /// `https://artifacts.example.test`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_base_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -81,20 +81,26 @@ pub fn controller_artifact_metadata(runs: &[RunRecord]) -> Result<Vec<JobArtifac
             validate_controller_artifact(&artifact)?;
             let controller_run_id = artifact.run_id.clone();
             let url = homeboy_core::artifact_links::controller_artifact_url(&artifact)?;
+            let fetch_command = format!(
+                "homeboy runs artifact get {} {} -o <path>",
+                controller_run_id, artifact.id
+            );
             Ok(JobArtifactMetadata {
                 id: artifact.id,
                 name: None,
                 path: Some(artifact.path),
-                url: Some(url),
+                url,
                 mime: artifact.mime,
                 size_bytes: artifact
                     .size_bytes
                     .and_then(|size| u64::try_from(size).ok()),
                 sha256: artifact.sha256,
                 content_base64: None,
-                metadata: Some(
-                    json!({ "controller_run_id": controller_run_id, "controller_owned": true }),
-                ),
+                metadata: Some(json!({
+                    "controller_run_id": controller_run_id,
+                    "controller_owned": true,
+                    "fetch_command": fetch_command,
+                })),
             })
         })
         .collect()

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -80,12 +80,12 @@ pub fn controller_artifact_metadata(runs: &[RunRecord]) -> Result<Vec<JobArtifac
         .map(|artifact| {
             validate_controller_artifact(&artifact)?;
             let controller_run_id = artifact.run_id.clone();
-            let url = homeboy_core::artifact_links::controller_artifact_url(&artifact);
+            let url = homeboy_core::artifact_links::controller_artifact_url(&artifact)?;
             Ok(JobArtifactMetadata {
                 id: artifact.id,
                 name: None,
                 path: Some(artifact.path),
-                url,
+                url: Some(url),
                 mime: artifact.mime,
                 size_bytes: artifact
                     .size_bytes

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -78,12 +78,14 @@ pub fn controller_artifact_metadata(runs: &[RunRecord]) -> Result<Vec<JobArtifac
     artifacts
         .into_iter()
         .map(|artifact| {
+            validate_controller_artifact(&artifact)?;
             let controller_run_id = artifact.run_id.clone();
+            let url = homeboy_core::artifact_links::controller_artifact_url(&artifact);
             Ok(JobArtifactMetadata {
                 id: artifact.id,
                 name: None,
                 path: Some(artifact.path),
-                url: artifact.public_url.or(artifact.url),
+                url,
                 mime: artifact.mime,
                 size_bytes: artifact
                     .size_bytes
@@ -96,6 +98,68 @@ pub fn controller_artifact_metadata(runs: &[RunRecord]) -> Result<Vec<JobArtifac
             })
         })
         .collect()
+}
+
+fn validate_controller_artifact(artifact: &ArtifactRecord) -> Result<()> {
+    if artifact.artifact_type != "file" {
+        return Err(Error::validation_invalid_argument(
+            "artifact.type",
+            "terminal artifact must be a controller-owned file",
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    let expected_size = artifact.size_bytes.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact.size_bytes",
+            "terminal artifact is missing controller size metadata",
+            Some(artifact.id.clone()),
+            None,
+        )
+    })?;
+    let expected_sha256 = artifact
+        .sha256
+        .as_deref()
+        .filter(|sha| !sha.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact.sha256",
+                "terminal artifact is missing controller checksum metadata",
+                Some(artifact.id.clone()),
+                None,
+            )
+        })?;
+    if artifact.mime.as_deref().is_none_or(str::is_empty) {
+        return Err(Error::validation_invalid_argument(
+            "artifact.mime",
+            "terminal artifact is missing controller media type metadata",
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    let path = std::path::Path::new(&artifact.path);
+    let size_matches = std::fs::metadata(path)
+        .ok()
+        .filter(|metadata| metadata.is_file())
+        .and_then(|metadata| i64::try_from(metadata.len()).ok())
+        == Some(expected_size);
+    if !size_matches {
+        return Err(Error::validation_invalid_argument(
+            "artifact.size_bytes",
+            "terminal artifact bytes are missing or do not match controller metadata",
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    if homeboy_core::artifact_metadata::sha256_file(path)? != expected_sha256 {
+        return Err(Error::validation_invalid_argument(
+            "artifact.sha256",
+            "terminal artifact bytes do not match controller checksum metadata",
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 pub fn mirror_daemon_evidence(

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -146,6 +146,37 @@ fn controller_terminal_metadata_uses_exact_visual_artifact_shape_and_validates_b
 }
 
 #[test]
+fn controller_terminal_metadata_keeps_fetch_fallback_without_public_origin() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let prior_public_base = std::env::var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL").ok();
+        std::env::remove_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(NewRunRecord::builder("runner-exec").build())
+            .expect("run");
+        let path = home.path().join("report.txt");
+        fs::write(&path, b"controller bytes").expect("artifact");
+        store
+            .record_artifact_with_id(&run.id, "report", &path, "report", json!({}))
+            .expect("controller artifact");
+
+        let metadata = controller_artifact_metadata(&[run.clone()]).expect("terminal metadata");
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata[0].id, "report");
+        assert_eq!(metadata[0].url, None);
+        assert_eq!(
+            metadata[0].metadata.as_ref().expect("metadata")["fetch_command"],
+            format!("homeboy runs artifact get {} report -o <path>", run.id)
+        );
+
+        match prior_public_base {
+            Some(value) => std::env::set_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL", value),
+            None => std::env::remove_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"),
+        }
+    });
+}
+
+#[test]
 fn test_download_remote_artifact_rejects_non_runner_token() {
     let err = download_remote_artifact("/tmp/raw-file", None).expect_err("reject raw path");
     assert_eq!(err.code.as_str(), "validation.invalid_argument");

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -11,7 +11,7 @@ use homeboy_core::api_jobs::{
     RunnerJobLifecycleMetadata, RunnerJobProjection,
 };
 use homeboy_core::error::{Error, ErrorCode};
-use homeboy_core::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use homeboy_core::observation::{ArtifactRecord, NewRunRecord, ObservationStore, RunRecord};
 use homeboy_core::server::{RunnerPolicy, RunnerSettings};
 
 use super::detail::{
@@ -19,8 +19,8 @@ use super::detail::{
 };
 use super::download::{content_disposition_filename, download_remote_artifact};
 use super::mirror::{
-    bounded_remote_events, import_mirrored_artifact_with_downloader, mirror_job_run,
-    mirror_remote_observation_runs_by_id_with,
+    bounded_remote_events, controller_artifact_metadata, import_mirrored_artifact_with_downloader,
+    mirror_job_run, mirror_remote_observation_runs_by_id_with,
     mirror_remote_observation_runs_by_id_with_downloader, mirror_reverse_broker_evidence,
     mirror_terminal_job_artifacts_with, mirrored_patch_result, primary_mirrored_run,
     refresh_mirrored_daemon_evidence_with, MIRRORED_REMOTE_EVENT_LIMIT,
@@ -72,6 +72,58 @@ fn terminal_runner_job() -> Job {
         artifacts: Vec::new(),
         runner_job_projection: None,
     }
+}
+
+#[test]
+fn controller_terminal_metadata_uses_exact_visual_artifact_shape_and_validates_bytes() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(NewRunRecord::builder("runner-exec").build())
+            .expect("run");
+        let source_dir = home.path().join("visual-compare/37-art-gallery-exhibition");
+        fs::create_dir_all(&source_dir).expect("visual artifact directory");
+        for (id, name, bytes) in [
+            ("source", "source.png", b"source bytes".as_slice()),
+            ("candidate", "candidate.png", b"candidate bytes".as_slice()),
+            ("diff", "diff.png", b"diff bytes".as_slice()),
+        ] {
+            let path = source_dir.join(name);
+            fs::write(&path, bytes).expect("visual artifact");
+            store
+                .record_artifact_with_id(&run.id, "visual_compare", &path, id, json!({}))
+                .expect("controller artifact");
+        }
+
+        let metadata = controller_artifact_metadata(&[run.clone()]).expect("terminal metadata");
+        assert_eq!(
+            metadata
+                .iter()
+                .map(|artifact| artifact.id.as_str())
+                .collect::<Vec<_>>(),
+            ["source", "candidate", "diff"]
+        );
+        for artifact in &metadata {
+            assert!(artifact
+                .path
+                .as_deref()
+                .is_some_and(|path| path.contains(&run.id)));
+            assert_eq!(artifact.mime.as_deref(), Some("image/png"));
+            assert!(artifact.size_bytes.is_some());
+            assert!(artifact
+                .sha256
+                .as_deref()
+                .is_some_and(|sha| !sha.is_empty()));
+        }
+
+        let source = store
+            .get_artifact("source")
+            .expect("source lookup")
+            .expect("source");
+        fs::write(&source.path, b"corrupted").expect("corrupt controller bytes");
+        let error = controller_artifact_metadata(&[run]).expect_err("checksum mismatch");
+        assert_eq!(error.details["field"], "artifact.size_bytes");
+    });
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -77,6 +77,11 @@ fn terminal_runner_job() -> Job {
 #[test]
 fn controller_terminal_metadata_uses_exact_visual_artifact_shape_and_validates_bytes() {
     homeboy_core::test_support::with_isolated_home(|home| {
+        let prior_public_base = std::env::var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL").ok();
+        std::env::set_var(
+            "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL",
+            "https://artifacts.example.test",
+        );
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(NewRunRecord::builder("runner-exec").build())
@@ -114,15 +119,29 @@ fn controller_terminal_metadata_uses_exact_visual_artifact_shape_and_validates_b
                 .sha256
                 .as_deref()
                 .is_some_and(|sha| !sha.is_empty()));
+            assert_eq!(
+                artifact.url.as_deref(),
+                Some(
+                    format!(
+                        "https://artifacts.example.test/runs/{}/artifacts/{}",
+                        run.id, artifact.id
+                    )
+                    .as_str()
+                )
+            );
         }
 
         let source = store
             .get_artifact("source")
             .expect("source lookup")
             .expect("source");
-        fs::write(&source.path, b"corrupted").expect("corrupt controller bytes");
+        fs::write(&source.path, b"corrupt data").expect("corrupt controller bytes");
         let error = controller_artifact_metadata(&[run]).expect_err("checksum mismatch");
-        assert_eq!(error.details["field"], "artifact.size_bytes");
+        assert_eq!(error.details["field"], "artifact.sha256");
+        match prior_public_base {
+            Some(value) => std::env::set_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL", value),
+            None => std::env::remove_var("HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"),
+        }
     });
 }
 

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -323,7 +323,7 @@ pub(super) fn exec_via_reverse_broker(
     }
 
     let runner_job = RunnerJob::from_job(&runner.id, "broker", &command, Some(cwd.clone()), &job);
-    let runner_result = runner_result(
+    let mut runner_result = runner_result(
         Some(&job),
         exit_code,
         &stdout,
@@ -331,6 +331,10 @@ pub(super) fn exec_via_reverse_broker(
         mirror_run_id.as_deref(),
         mutation_artifacts.clone(),
     );
+    runner_result.artifact_refs = artifacts
+        .iter()
+        .map(crate::session::runner_artifact_ref_from_metadata)
+        .collect();
     let provenance_extensions = required_extensions_for_command(
         &command,
         &super::super::workload::merge_lab_runner_workload_required_extensions(

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -366,7 +366,7 @@ pub(super) fn exec_via_daemon(
     }
 
     let runner_job = RunnerJob::from_job(&runner.id, "daemon", &command, Some(cwd.clone()), &job);
-    let runner_result = runner_result(
+    let mut runner_result = runner_result(
         Some(&job),
         exit_code,
         &stdout,
@@ -374,6 +374,10 @@ pub(super) fn exec_via_daemon(
         mirror_run_id.as_deref(),
         mutation_artifacts.clone(),
     );
+    runner_result.artifact_refs = artifacts
+        .iter()
+        .map(crate::session::runner_artifact_ref_from_metadata)
+        .collect();
     let provenance_extensions = required_extensions_for_command(
         &command,
         &super::super::workload::merge_lab_runner_workload_required_extensions(

--- a/docs/operations/artifact-loop-runner-matrix.md
+++ b/docs/operations/artifact-loop-runner-matrix.md
@@ -156,12 +156,13 @@ worker command and the output directory is enough to understand the result.
 
 ## Public Links
 
-Set `HOMEBOY_PUBLIC_ARTIFACT_BASE_URL` on the runner only when promoted artifact
-files are mirrored to a stable HTTP(S) origin. With that variable configured,
-Homeboy can derive public links for fetchable run artifacts and `runs evidence`
-can expose reviewer-visible URLs after validation.
+Set the controller's `artifact_origin.public_base_url` only when its persisted
+artifacts are served from a stable HTTPS origin. With that controller setting,
+Homeboy can derive canonical reviewer links for fetchable run artifacts. The
+legacy `HOMEBOY_PUBLIC_ARTIFACT_BASE_URL` remains a controller-process
+compatibility input; setting it on a runner has no effect on reviewer links.
 
-If the variable is absent, evidence remains valid but non-public: reviewers use
+If the controller origin is absent, evidence remains valid but non-public: reviewers use
 `homeboy runs artifact get <run-id> <artifact-id> -o <path>` or CI-provided
 artifact downloads.
 

--- a/docs/workflows/set-up-lab-runners.md
+++ b/docs/workflows/set-up-lab-runners.md
@@ -51,9 +51,7 @@ Runner config separates printable environment from secret references:
 
 ```json
 {
-  "env": {
-    "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL": "https://artifacts.example.test"
-  },
+  "env": {},
   "secret_env": {
     "GITHUB_TOKEN": { "env": "GITHUB_TOKEN" }
   }
@@ -61,6 +59,17 @@ Runner config separates printable environment from secret references:
 ```
 
 `env` values are diagnostic. `secret_env` values are resolved at execution time and are never printed as secret values.
+
+Configure the controller's reviewer artifact origin in `homeboy.json`; runner
+environment never supplies it:
+
+```json
+{
+  "artifact_origin": {
+    "public_base_url": "https://artifacts.example.test"
+  }
+}
+```
 
 ## 5. Verify Lab-Offload Readiness
 

--- a/tests/core/daemon/artifact_download_test.rs
+++ b/tests/core/daemon/artifact_download_test.rs
@@ -55,14 +55,45 @@ fn route_serves_run_scoped_artifact_store_tokens() {
         .expect("artifact token")
         .to_string();
 
-    let response =
-        route(&format!("/runs/{}/artifacts/{}", run.id, token)).expect("artifact-store route");
+    let response = route(&format!("/runs/{}/artifacts/store/{}", run.id, token))
+        .expect("artifact-store route");
 
     assert_eq!(response.status_code, 200);
     let artifact = response.artifact.expect("artifact download");
     assert_eq!(artifact.filename, "summary.json");
     assert_eq!(artifact.size_bytes, 11);
     assert_eq!(response.body["artifact"]["run_id"], run.id);
+}
+
+#[test]
+fn canonical_run_scoped_route_does_not_resolve_friendly_aliases() {
+    let _home = HomeGuard::new();
+    let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
+    let store = ObservationStore::open_initialized().expect("store");
+    let run = store
+        .start_run(NewRunRecord::builder("bench").build())
+        .expect("run");
+    let path = home_path.join("source.png");
+    fs::write(&path, b"source bytes").expect("source artifact");
+    let artifact = store
+        .record_artifact_with_id(
+            &run.id,
+            "visual_source",
+            &path,
+            "source-id",
+            serde_json::json!({}),
+        )
+        .expect("artifact");
+
+    let canonical =
+        route(&format!("/runs/{}/artifacts/{}", run.id, artifact.id)).expect("canonical route");
+    assert_eq!(canonical.status_code, 200);
+    let alias = route(&format!("/runs/{}/artifacts/visual_source", run.id))
+        .expect("canonical route response");
+    assert_eq!(alias.status_code, 404);
+    let friendly =
+        route(&format!("/runs/{}/artifacts/aliases/visual_source", run.id)).expect("alias route");
+    assert_eq!(friendly.status_code, 200);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- rebuild direct and reverse terminal refs from validated controller-owned artifacts
- use exact artifact-ID canonical routes and separate friendly/store alias namespaces
- add typed controller-owned `artifact_origin.public_base_url` configuration
- emit canonical reviewer URLs only when a valid public HTTPS controller origin is configured
- preserve successful private runs with `url: null` plus an explicit `homeboy runs artifact get` fallback
- validate bytes, size, SHA-256, MIME, encoding, and equal-length corruption before publication

## Verification

- `cargo build -p homeboy`
- `cargo check -p homeboy-core -p homeboy-lab-runner`
- artifact-link/config tests
- exact canonical/alias/store route tests
- real TCP HTTP source/candidate/diff retrieval with MIME, checksum headers, and bytes
- direct daemon and reverse broker terminal tests
- `cargo fmt --all -- --check`

## Rollout

Configure the controller with `artifact_origin.public_base_url=https://<reviewer-origin>` and proxy canonical `/runs/<run>/artifacts/<id>` GETs to the controller artifact-origin service. Runner-only environment configuration no longer controls reviewer links.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the post-#10493 404s, repaired controller route ownership, and iteratively addressed collision/config/fallback review findings. Chris Huber reviewed and remains responsible for every line.

Fixes #10408.