### PR TITLE
fix(core): unify deploy and harvest tree walks behind one scanner

### DIFF
--- a/crates/homeboy-core/src/content_diff.rs
+++ b/crates/homeboy-core/src/content_diff.rs
@@ -1,4 +1,13 @@
 //! Generic byte-level directory comparison and safe source-to-destination application.
+//!
+//! This module owns the one directory walk every tree comparison in the
+//! codebase is built on. Recovery (`harvest`) and deploy drift detection used
+//! to each carry a privately written walker, and the two could return
+//! contradictory answers for the same directory pair because their divergences
+//! were accidents of two implementations rather than decisions (#10290). The
+//! walk now lives in [`scan_tree`] and every remaining divergence is a named
+//! field on [`TreeScanOptions`], so a behavioural difference between call sites
+//! is reviewable instead of invisible.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -45,7 +54,7 @@ pub fn compare(
                 kind: ContentChangeKind::Deletion,
                 bytes: to.bytes,
             }),
-            (Some(from), Some(to)) if from.digest != to.digest => Some(ContentChange {
+            (Some(from), Some(to)) if !from.matches(to) => Some(ContentChange {
                 path,
                 kind: ContentChangeKind::Modification,
                 bytes: from.bytes,
@@ -76,13 +85,96 @@ pub fn apply(source: &Path, destination: &Path, changes: &[ContentChange]) -> cr
     Ok(())
 }
 
-#[derive(Debug)]
-struct Entry {
-    digest: String,
-    bytes: u64,
+/// What a tree scan records, and what it leaves out.
+///
+/// Recovery and deploy walk the same shape of directory but are answering
+/// different questions about it, so the facts each one needs differ. Every
+/// difference is a field here rather than a separate walker: two call sites can
+/// still behave differently, but only by declaring that they do.
+#[derive(Debug, Clone, Default)]
+pub struct TreeScanOptions {
+    /// Relative glob and directory patterns removed from the scan. `.git` is
+    /// always removed regardless of this set.
+    pub excludes: Vec<String>,
+    /// Record symlinks as entries carrying their link target. When false a
+    /// symlink is neither followed nor recorded, so link-only drift is
+    /// invisible to the caller.
+    pub record_symlinks: bool,
+    /// Record the executable bit as part of each file's identity.
+    pub record_executable_mode: bool,
+    /// Prune this product's own transport scratch files at any depth. They are
+    /// created by the tooling performing the comparison, never by the content
+    /// being compared, so no side of a comparison should report them as drift.
+    pub prune_runtime_artifacts: bool,
 }
 
-fn collect(root: &Path, excludes: &[String]) -> crate::Result<BTreeMap<String, Entry>> {
+/// Whether a scanned path is a regular file or a symlink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TreeEntryKind {
+    File,
+    Symlink,
+}
+
+impl TreeEntryKind {
+    /// Single-character tag used by manifest wire formats and digests.
+    pub fn tag(self) -> char {
+        match self {
+            TreeEntryKind::File => 'f',
+            TreeEntryKind::Symlink => 'l',
+        }
+    }
+}
+
+/// One scanned path and the facts recorded about it.
+#[derive(Debug, Clone)]
+pub struct TreeEntry {
+    pub kind: TreeEntryKind,
+    /// Executable bits in octal (see [`executable_mode_tag`]), or `"0"` when
+    /// the scan does not record mode, the entry is a symlink, or the platform
+    /// has no mode concept.
+    pub mode: String,
+    /// SHA-256 hex digest for files; the link target for symlinks.
+    pub value: String,
+    /// Filesystem byte length, or `0` when the entry did not come from a
+    /// filesystem walk. Deliberately excluded from [`TreeEntry::matches`]:
+    /// manifests parsed from a remote probe or an archive carry content
+    /// identity without a stat size, and comparing a missing size against a
+    /// real one would report drift on identical content.
+    pub bytes: u64,
+}
+
+impl TreeEntry {
+    /// Whether two entries describe the same content at the same path.
+    pub fn matches(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.mode == other.mode && self.value == other.value
+    }
+}
+
+/// The mode semantic that survives a deploy.
+///
+/// Deploy normalizes ownership and group-write/setgid bits on the target, so
+/// only executability is stable enough to compare. Rendering it here — rather
+/// than in each manifest producer — is what keeps a locally walked tree, a
+/// remotely probed tree, and an archive expressing the same bits identically.
+pub fn executable_mode_tag(mode: u32) -> String {
+    format!("{:o}", mode & 0o111)
+}
+
+/// Whether a relative path is one of this product's own transport scratch
+/// files, at any depth.
+pub fn runtime_artifact(path: &str) -> bool {
+    let prefix = crate::product_identity::PRODUCT_IDENTITY.artifact_prefix;
+    path.split('/').any(|part| part.starts_with(prefix))
+}
+
+/// Walk `root` and record one entry per path, honouring `options`.
+///
+/// Entries are keyed by `/`-separated path relative to `root`, so the result is
+/// directly comparable with a manifest produced for a different root.
+pub fn scan_tree(
+    root: &Path,
+    options: &TreeScanOptions,
+) -> crate::Result<BTreeMap<String, TreeEntry>> {
     if !root.is_dir() {
         return Err(crate::Error::validation_invalid_argument(
             "path",
@@ -92,15 +184,26 @@ fn collect(root: &Path, excludes: &[String]) -> crate::Result<BTreeMap<String, E
         ));
     }
     let mut entries = BTreeMap::new();
-    visit(root, root, excludes, &mut entries)?;
+    scan_directory(root, root, options, &mut entries)?;
     Ok(entries)
 }
 
-fn visit(
+fn collect(root: &Path, excludes: &[String]) -> crate::Result<BTreeMap<String, TreeEntry>> {
+    scan_tree(
+        root,
+        &TreeScanOptions {
+            excludes: excludes.to_vec(),
+            prune_runtime_artifacts: true,
+            ..TreeScanOptions::default()
+        },
+    )
+}
+
+fn scan_directory(
     root: &Path,
     directory: &Path,
-    excludes: &[String],
-    entries: &mut BTreeMap<String, Entry>,
+    options: &TreeScanOptions,
+    entries: &mut BTreeMap<String, TreeEntry>,
 ) -> crate::Result<()> {
     for entry in fs::read_dir(directory).map_err(io_error)? {
         let path = entry.map_err(io_error)?.path();
@@ -109,24 +212,61 @@ fn visit(
             .map_err(io_error)?
             .to_string_lossy()
             .replace('\\', "/");
-        if excluded(&relative, excludes) {
+        if excluded(&relative, &options.excludes)
+            || (options.prune_runtime_artifacts && runtime_artifact(&relative))
+        {
             continue;
         }
         let metadata = fs::symlink_metadata(&path).map_err(io_error)?;
-        if metadata.is_dir() {
-            visit(root, &path, excludes, entries)?;
-        } else if metadata.is_file() {
-            let bytes = metadata.len();
+        if metadata.file_type().is_symlink() {
+            if !options.record_symlinks {
+                continue;
+            }
+            let target = fs::read_link(&path)
+                .map_err(io_error)?
+                .to_string_lossy()
+                .to_string();
             entries.insert(
                 relative,
-                Entry {
-                    digest: digest(&path)?,
-                    bytes,
+                TreeEntry {
+                    kind: TreeEntryKind::Symlink,
+                    mode: "0".to_string(),
+                    value: target,
+                    bytes: 0,
+                },
+            );
+        } else if metadata.is_dir() {
+            scan_directory(root, &path, options, entries)?;
+        } else if metadata.is_file() {
+            entries.insert(
+                relative,
+                TreeEntry {
+                    kind: TreeEntryKind::File,
+                    mode: entry_mode(&metadata, options),
+                    value: digest(&path)?,
+                    bytes: metadata.len(),
                 },
             );
         }
     }
     Ok(())
+}
+
+fn entry_mode(metadata: &fs::Metadata, options: &TreeScanOptions) -> String {
+    if !options.record_executable_mode {
+        return "0".to_string();
+    }
+    #[cfg(unix)]
+    {
+        executable_mode_tag(std::os::unix::fs::PermissionsExt::mode(
+            &metadata.permissions(),
+        ))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        "0".to_string()
+    }
 }
 
 pub fn excluded(path: &str, excludes: &[String]) -> bool {
@@ -211,5 +351,119 @@ mod tests {
         assert!(compare(&source, &destination, &["generated/".to_string()])
             .expect("compare")
             .is_empty());
+    }
+
+    /// #10290: deploy's manifest pruned this product's transport scratch files
+    /// and recovery's comparison did not, so the two disagreed about the same
+    /// directory pair. The scratch files belong to the tooling doing the
+    /// comparing; neither answer should ever have included them.
+    #[test]
+    fn recovery_comparison_prunes_this_products_transport_scratch_files() {
+        let temp = tempfile::tempdir().expect("temp");
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir_all(source.join("nested")).expect("source");
+        fs::create_dir_all(&destination).expect("destination");
+        let scratch = format!(
+            "{}upload.tmp",
+            crate::product_identity::PRODUCT_IDENTITY.artifact_prefix
+        );
+        fs::write(source.join(&scratch), "remote").expect("scratch");
+        fs::write(source.join("nested").join(&scratch), "remote").expect("nested scratch");
+        fs::write(destination.join(&scratch), "local").expect("scratch");
+
+        assert!(compare(&source, &destination, &[])
+            .expect("compare")
+            .is_empty());
+        assert!(runtime_artifact(&scratch));
+        assert!(runtime_artifact(&format!("nested/{scratch}")));
+        assert!(!runtime_artifact("nested/payload.txt"));
+    }
+
+    /// The recorded facts are options, not accidents: the same tree scanned
+    /// with recovery's options and with deploy's options must differ only in
+    /// the ways those options declare.
+    #[test]
+    fn scan_options_decide_which_facts_a_walk_records() {
+        let temp = tempfile::tempdir().expect("temp");
+        let root = temp.path().join("tree");
+        fs::create_dir_all(&root).expect("root");
+        fs::write(root.join("file"), "bytes").expect("file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(root.join("file"), fs::Permissions::from_mode(0o755))
+                .expect("mode");
+            std::os::unix::fs::symlink("file", root.join("link")).expect("link");
+        }
+
+        let recovery = scan_tree(
+            &root,
+            &TreeScanOptions {
+                prune_runtime_artifacts: true,
+                ..TreeScanOptions::default()
+            },
+        )
+        .expect("recovery scan");
+        let deployed = scan_tree(
+            &root,
+            &TreeScanOptions {
+                record_symlinks: true,
+                record_executable_mode: true,
+                prune_runtime_artifacts: true,
+                ..TreeScanOptions::default()
+            },
+        )
+        .expect("deploy scan");
+
+        assert_eq!(recovery["file"].kind, TreeEntryKind::File);
+        assert_eq!(recovery["file"].bytes, "bytes".len() as u64);
+        assert_eq!(recovery["file"].mode, "0");
+        assert_eq!(recovery["file"].value, deployed["file"].value);
+
+        #[cfg(unix)]
+        {
+            assert_eq!(deployed["file"].mode, executable_mode_tag(0o755));
+            assert!(!recovery.contains_key("link"));
+            assert_eq!(deployed["link"].kind, TreeEntryKind::Symlink);
+            assert_eq!(deployed["link"].value, "file");
+            assert_eq!(deployed["link"].mode, "0");
+        }
+    }
+
+    /// Byte length is provenance, not identity. A manifest parsed from a remote
+    /// probe or an archive has no stat size, so folding size into the match
+    /// predicate would report drift on byte-identical content.
+    #[test]
+    fn entry_identity_excludes_filesystem_byte_length() {
+        let walked = TreeEntry {
+            kind: TreeEntryKind::File,
+            mode: executable_mode_tag(0o755),
+            value: "a".repeat(64),
+            bytes: 42,
+        };
+        let parsed = TreeEntry {
+            bytes: 0,
+            ..walked.clone()
+        };
+        assert!(walked.matches(&parsed));
+        assert!(!walked.matches(&TreeEntry {
+            mode: "0".to_string(),
+            ..walked.clone()
+        }));
+        assert!(!walked.matches(&TreeEntry {
+            kind: TreeEntryKind::Symlink,
+            ..walked.clone()
+        }));
+    }
+
+    #[test]
+    fn executable_mode_tag_keeps_only_bits_that_survive_a_deploy() {
+        // Deploy normalizes ownership and group-write bits, so 0644 and 0664
+        // are the same deployed file while 0755 is not.
+        assert_eq!(executable_mode_tag(0o644), "0");
+        assert_eq!(executable_mode_tag(0o664), "0");
+        assert_eq!(executable_mode_tag(0o755), "111");
+        assert_eq!(executable_mode_tag(0o775), "111");
     }
 }

--- a/crates/homeboy-core/src/content_diff.rs
+++ b/crates/homeboy-core/src/content_diff.rs
@@ -253,20 +253,25 @@ fn scan_directory(
 }
 
 fn entry_mode(metadata: &fs::Metadata, options: &TreeScanOptions) -> String {
-    if !options.record_executable_mode {
-        return "0".to_string();
-    }
-    #[cfg(unix)]
-    {
-        executable_mode_tag(std::os::unix::fs::PermissionsExt::mode(
-            &metadata.permissions(),
-        ))
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = metadata;
+    if options.record_executable_mode {
+        platform_executable_mode(metadata)
+    } else {
         "0".to_string()
     }
+}
+
+/// Executable bits as the platform reports them.
+#[cfg(unix)]
+fn platform_executable_mode(metadata: &fs::Metadata) -> String {
+    use std::os::unix::fs::PermissionsExt;
+    executable_mode_tag(metadata.permissions().mode())
+}
+
+/// Targets without a mode concept compare every entry as non-executable, which
+/// is the same answer the previous deploy walker gave there.
+#[cfg(not(unix))]
+fn platform_executable_mode(_metadata: &fs::Metadata) -> String {
+    "0".to_string()
 }
 
 pub fn excluded(path: &str, excludes: &[String]) -> bool {

--- a/crates/homeboy-core/src/harvest.rs
+++ b/crates/homeboy-core/src/harvest.rs
@@ -297,7 +297,10 @@ fn materialize_remote(
                     Some("materialize harvest snapshot".to_string()),
                 )
             })?;
-        if content_diff::excluded(relative, excludes) {
+        // Runtime scratch files are created by deploy's own transport, so they
+        // are never remote content worth recovering. Skipping them here as well
+        // as in the comparison avoids downloading bytes only to discard them.
+        if content_diff::excluded(relative, excludes) || content_diff::runtime_artifact(relative) {
             continue;
         }
         let local = crate::resolve_contained_local_path(destination, relative, "remote path")?;

--- a/crates/homeboy-release/src/deploy/content_manifest.rs
+++ b/crates/homeboy-release/src/deploy/content_manifest.rs
@@ -1,4 +1,3 @@
-use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
@@ -6,6 +5,7 @@ use std::time::Duration;
 
 use sha2::{Digest, Sha256};
 
+use homeboy_core::content_diff::{self, TreeEntry, TreeEntryKind, TreeScanOptions};
 use homeboy_core::engine::shell;
 use homeboy_core::server::SshClient;
 
@@ -16,16 +16,28 @@ const SCOPE: &str = "deployed-tree-excluding-homeboy-runtime";
 const MAX_DIFFERENCES: usize = 20;
 const PROBE_TIMEOUT: Duration = Duration::from_secs(20);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct Entry {
-    kind: char,
-    mode: String,
-    value: String,
+/// How deploy scans a tree, stated once so the local walk cannot drift from the
+/// remote probe or from the archive reader.
+///
+/// `excludes` is deliberately empty. Deploy asks "does the installed tree still
+/// hold the bytes the package contract says it should", and every path in that
+/// contract is in scope by definition. Folding in a source checkout's ignore
+/// rules — the way recovery legitimately does, because recovery is comparing a
+/// checkout — would make drift inside shipped-but-gitignored directories
+/// (vendored dependencies, built assets) invisible, trading a false positive in
+/// a drift detector for a false negative. See #10290.
+fn deployed_tree_scan_options() -> TreeScanOptions {
+    TreeScanOptions {
+        excludes: Vec::new(),
+        record_symlinks: true,
+        record_executable_mode: true,
+        prune_runtime_artifacts: true,
+    }
 }
 
 #[derive(Default)]
 struct Manifest {
-    entries: BTreeMap<String, Entry>,
+    entries: BTreeMap<String, TreeEntry>,
 }
 
 impl Manifest {
@@ -34,7 +46,7 @@ impl Manifest {
         for (path, entry) in &self.entries {
             hash.update(path.as_bytes());
             hash.update([0]);
-            hash.update([entry.kind as u8]);
+            hash.update([entry.kind.tag() as u8]);
             hash.update([0]);
             hash.update(entry.mode.as_bytes());
             hash.update([0]);
@@ -125,9 +137,9 @@ fn local_manifest(root: &Path) -> Result<Manifest, String> {
     if !root.exists() {
         return Err(format!("{} does not exist", root.display()));
     }
-    let mut manifest = Manifest::default();
-    visit(root, root, &mut manifest)?;
-    Ok(manifest)
+    let entries = content_diff::scan_tree(root, &deployed_tree_scan_options())
+        .map_err(|error| error.to_string())?;
+    Ok(Manifest { entries })
 }
 
 fn archive_manifest(path: &Path) -> Result<Manifest, String> {
@@ -159,14 +171,16 @@ fn archive_manifest(path: &Path) -> Result<Manifest, String> {
             })
             .unwrap_or(name)
             .to_string();
+        let mode = content_diff::executable_mode_tag(entry.unix_mode().unwrap_or(0));
         let mut hash = Sha256::new();
         std::io::copy(&mut entry, &mut hash).map_err(|error| error.to_string())?;
         manifest.entries.insert(
             relative,
-            Entry {
-                kind: 'f',
-                mode: executable_mode(entry.unix_mode().unwrap_or(0)),
+            TreeEntry {
+                kind: TreeEntryKind::File,
+                mode,
                 value: format!("{:x}", hash.finalize()),
+                bytes: 0,
             },
         );
     }
@@ -181,58 +195,6 @@ fn archive_root(names: &[String]) -> Option<String> {
                 .is_some_and(|suffix| suffix.starts_with('/'))
         }))
     .then(|| first.to_string())
-}
-
-fn visit(root: &Path, path: &Path, manifest: &mut Manifest) -> Result<(), String> {
-    for entry in fs::read_dir(path).map_err(|e| e.to_string())? {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let child = entry.path();
-        let relative = child
-            .strip_prefix(root)
-            .map_err(|e| e.to_string())?
-            .to_string_lossy()
-            .replace('\\', "/");
-        if ignored(&relative) {
-            continue;
-        }
-        let metadata = fs::symlink_metadata(&child).map_err(|e| e.to_string())?;
-        #[cfg(unix)]
-        let mode = executable_mode(std::os::unix::fs::PermissionsExt::mode(
-            &metadata.permissions(),
-        ));
-        #[cfg(not(unix))]
-        let mode = "0".to_string();
-        if metadata.file_type().is_symlink() {
-            let target = fs::read_link(&child)
-                .map_err(|e| e.to_string())?
-                .to_string_lossy()
-                .to_string();
-            manifest.entries.insert(
-                relative,
-                Entry {
-                    kind: 'l',
-                    mode: "0".to_string(),
-                    value: target,
-                },
-            );
-        } else if metadata.is_dir() {
-            visit(root, &child, manifest)?;
-        } else if metadata.is_file() {
-            manifest.entries.insert(
-                relative,
-                Entry {
-                    kind: 'f',
-                    mode,
-                    value: sha256(&child)?,
-                },
-            );
-        }
-    }
-    Ok(())
-}
-
-fn sha256(path: &Path) -> Result<String, String> {
-    content_hash::sha256_file(path).map_err(|error| error.to_string())
 }
 
 fn remote_manifest(root: &str, client: &SshClient) -> Result<Option<Manifest>, String> {
@@ -267,43 +229,43 @@ fn parse_remote_manifest(output: &str) -> Result<Manifest, String> {
             continue;
         }
         let kind = match kind {
-            "f" => 'f',
-            "l" => 'l',
+            "f" => TreeEntryKind::File,
+            "l" => TreeEntryKind::Symlink,
             _ => return Err("unsupported remote manifest entry".to_string()),
         };
         let mode = u32::from_str_radix(mode, 8)
             .map_err(|_| "malformed remote manifest mode".to_string())?;
-        let mode = if kind == 'l' {
+        let mode = if kind == TreeEntryKind::Symlink {
             "0".to_string()
         } else {
-            executable_mode(mode)
+            content_diff::executable_mode_tag(mode)
         };
-        if kind == 'f' && (value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        if kind == TreeEntryKind::File
+            && (value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()))
         {
             return Err("malformed remote SHA-256 evidence".to_string());
         }
         manifest.entries.insert(
             path.to_string(),
-            Entry {
+            TreeEntry {
                 kind,
                 mode,
                 value: value.to_string(),
+                // A remote probe reports content identity, never a stat size.
+                bytes: 0,
             },
         );
     }
     Ok(manifest)
 }
 
-fn executable_mode(mode: u32) -> String {
-    // Deploy normalizes ownership and group-write/setgid bits. Executability is
-    // the mode semantic that survives those target-specific adjustments.
-    format!("{:o}", mode & 0o111)
-}
-
+/// Paths excluded from every deploy manifest, whatever produced it.
+///
+/// This is the whole exclusion policy: version-control metadata and this
+/// product's own transport scratch files. It is intentionally narrower than
+/// recovery's exclusion set — see [`deployed_tree_scan_options`].
 fn ignored(path: &str) -> bool {
-    path == ".git"
-        || path.starts_with(".git/")
-        || path.split('/').any(|part| part.starts_with(".homeboy-"))
+    content_diff::excluded(path, &[]) || content_diff::runtime_artifact(path)
 }
 
 fn differences(local: &Manifest, remote: &Manifest) -> Vec<String> {
@@ -312,10 +274,18 @@ fn differences(local: &Manifest, remote: &Manifest) -> Vec<String> {
     paths.extend(remote.entries.keys().map(|p| (p.as_str(), ())));
     paths
         .into_keys()
-        .filter(|path| local.entries.get(*path) != remote.entries.get(*path))
+        .filter(|path| !entries_match(local.entries.get(*path), remote.entries.get(*path)))
         .take(MAX_DIFFERENCES)
         .map(str::to_string)
         .collect()
+}
+
+fn entries_match(local: Option<&TreeEntry>, remote: Option<&TreeEntry>) -> bool {
+    match (local, remote) {
+        (Some(local), Some(remote)) => local.matches(remote),
+        (None, None) => true,
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -364,6 +334,53 @@ mod tests {
     fn remote_manifest_requires_well_formed_hash_evidence() {
         assert!(parse_remote_manifest("f\tpath\t644\n").is_err());
         assert!(parse_remote_manifest("f\tpath\t644\tnot-a-hash\n").is_err());
+    }
+
+    /// #10290: deploy and recovery now share one walker, and this pins the two
+    /// deliberate divergences so a future "just unify them" change has to argue
+    /// with a test instead of silently flipping a drift detector's answer.
+    ///
+    /// Deploy records symlinks and executability, recovery does not. Deploy
+    /// applies no caller excludes, so drift inside a shipped directory that the
+    /// source checkout happens to gitignore is still reported.
+    #[test]
+    fn deploy_scan_options_state_the_divergence_from_recovery() {
+        let options = deployed_tree_scan_options();
+        assert!(options.excludes.is_empty());
+        assert!(options.record_symlinks);
+        assert!(options.record_executable_mode);
+        assert!(options.prune_runtime_artifacts);
+
+        let temp = tempfile::tempdir().expect("temp");
+        let local = temp.path().join("local");
+        let remote = temp.path().join("plugin");
+        fs::create_dir_all(local.join("vendor")).expect("local vendor");
+        fs::create_dir_all(remote.join("vendor")).expect("remote vendor");
+        fs::write(local.join("vendor/library.php"), "shipped").expect("local vendor file");
+        fs::write(remote.join("vendor/library.php"), "tampered").expect("remote vendor file");
+        // A checkout-derived ignore rule would hide this; a deploy manifest
+        // must not, because the tampered bytes are live on the target.
+        assert_eq!(
+            differences(
+                &local_manifest(&local).expect("local manifest"),
+                &local_manifest(&remote).expect("remote manifest"),
+            ),
+            vec!["vendor/library.php"]
+        );
+    }
+
+    /// Version-control metadata and this product's transport scratch files are
+    /// the entire deploy exclusion policy, and it holds at any depth.
+    #[test]
+    fn deploy_exclusion_policy_is_vcs_metadata_and_transport_scratch_only() {
+        let scratch = homeboy_core::product_identity::PRODUCT_IDENTITY.artifact_prefix;
+        assert!(ignored(".git"));
+        assert!(ignored(".git/config"));
+        assert!(ignored(&format!("{scratch}upload.tmp")));
+        assert!(ignored(&format!("assets/{scratch}upload.tmp")));
+        assert!(!ignored(".gitignore"));
+        assert!(!ignored("vendor/library.php"));
+        assert!(!ignored("node_modules/pkg/index.js"));
     }
     #[test]
     #[cfg(unix)]

--- a/docs/commands/harvest.md
+++ b/docs/commands/harvest.md
@@ -9,7 +9,7 @@ homeboy harvest <project-id|component-id> [component-id...] [--check|--dry-run|-
 - `--check` reports additions, modifications, and deletions without writing local files. Drift exits with code 2.
 - `--dry-run` produces the same non-mutating content-change plan for review.
 - `--apply` materializes one component's remote changes, including remote deletions, and commits them. It refuses a dirty local Git worktree rather than choosing between local and remote content. Apply reviewed components separately so each recovery produces one provenance-bearing commit.
-- `--exclude` accepts repeatable relative globs. Existing component ignore and source-snapshot exclusion policy is also honored.
+- `--exclude` accepts repeatable relative globs. Existing component ignore and source-snapshot exclusion policy is also honored. Version-control metadata and Homeboy's own `.homeboy-*` transport scratch files are always excluded, on both sides.
 - `--author` sets the Git author for the recovery commit. The normal local Git identity remains the committer. The commit message records `Harvested-from: <project>:<remote-path>` provenance.
 
 Binary files are compared and copied as bytes. Remote-only files are additions; local-only files are deletions.
@@ -23,3 +23,14 @@ homeboy harvest production api --apply --author 'Remote agent <agent@example.inv
 ## Deploy drift protection
 
 Deploy already protects remote drift through the in-place content manifest added for [issue #10058](https://github.com/Extra-Chill/homeboy/issues/10058). Harvest uses the generic `content_diff` primitive after materializing the bounded remote component because recovery requires the actual bytes, while deploy checks need only compact remote hash evidence.
+
+Both answers are produced by the same directory walk (`content_diff::scan_tree`), so they can no longer disagree about what is in a tree ([issue #10290](https://github.com/Extra-Chill/homeboy/issues/10290)). The two call sites still differ, but only through named options:
+
+| | `harvest` | `deploy --check` |
+|---|---|---|
+| question | "what did the target change that my checkout does not have?" | "does the installed tree still hold the bytes the package contract says it should?" |
+| excludes | component ignore + source-snapshot policy (including `.gitignore`-derived entries) + `--exclude` | none |
+| symlinks | not recorded | recorded, compared by link target |
+| file mode | not recorded | executable bit only |
+
+`deploy --check` deliberately does **not** inherit the `.gitignore`-derived excludes. A deployed package routinely ships directories a source checkout ignores (vendored dependencies, built assets); silencing those would turn a false positive into a false negative in a drift detector.


### PR DESCRIPTION
## What this is

`deploy --check` and `harvest --check` each carried a privately written sha256 tree walker. This puts the walk in one place with the divergences as named options.

**It does not implement the fix #10290 prescribes.** See "Why not the prescribed fix" below.

## The two hashers, before

| | `crates/homeboy-core/src/content_diff.rs` (harvest) | `crates/homeboy-release/src/deploy/content_manifest.rs` (deploy) |
|---|---|---|
| walker | `visit()` `:99-130` | `visit()` `:186-232` (local), shell `find` `:243` (remote) |
| digest | `digest()` `:150` — sha256 of file bytes | `sha256()` `:234` + `Manifest::digest()` `:32-45` whole-tree digest |
| excludes | `excluded()` `:132` — `.git` + caller globs | `ignored()` `:303-307` — `.git` + `.homeboy-*`, hardcoded, no caller input |
| symlinks | **dropped** (`:116-118` handles only dir/file; a symlink is neither) | recorded, compared by link target `:205-217` |
| file mode | not recorded | executable bit only, `executable_mode()` `:297-301` |
| byte size | recorded `:119` | not recorded |
| exclude sources | `harvest.rs:111-122` — env policy + extension `sync_excludes` + `.gitignore`-derived (`source_snapshot.rs:34-38,181-213`) + `component.harvest_excludes` + `--exclude` | none |

Two of those differences (symlinks, file mode) were never mentioned in the issue and are the more consequential ones: harvest is structurally blind to symlink drift.

## What changed

- `content_diff::scan_tree(root, &TreeScanOptions)` is now the only directory walk. `TreeScanOptions` names every divergence: `excludes`, `record_symlinks`, `record_executable_mode`, `prune_runtime_artifacts`.
- `TreeEntry { kind, mode, value, bytes }` is the shared entry. `TreeEntry::matches` deliberately excludes `bytes`, because a manifest parsed from a remote probe or a zip has content identity but no stat size.
- `executable_mode_tag()` and `runtime_artifact()` moved into `content_diff`, so deploy's local walk, its remote probe parser, and its archive reader now render mode and kind identically by construction rather than by three copies agreeing.
- Deploy's `visit`, `sha256`, `executable_mode`, and private `Entry` are deleted. `local_manifest` is four lines.
- **Bug fixed:** harvest did not prune `.homeboy-*`, so deploy's own upload temporaries on the target could be reported as remote drift and even harvested into a recovery commit. `materialize_remote` no longer downloads them and the comparison no longer records them.

## Why not the prescribed fix

#10290 proposes giving `content_manifest::compare` an `excludes` parameter from `source_snapshot::policy_for_path` and replacing `ignored()` with `content_diff::excluded()`. That would be a regression.

Harvest compares a **checkout** against a target, so checkout ignore rules are the right scope. Deploy compares a **package contract** against an installed tree. A deployed package routinely ships directories a source checkout ignores — vendored dependencies, built assets, anything emitted into a `dist`/`build` path that is then packaged. `excluded()` is applied to *both* sides of the comparison, so inheriting `.gitignore` there does not just quiet the local side: it makes tampering inside those directories on the target invisible.

That trades a false positive for a false negative in a drift detector, which is the strictly worse failure. Deploy's exclusion set stays narrow — version-control metadata and Homeboy's own transport scratch — and the decision is pinned by `deploy_scan_options_state_the_divergence_from_recovery`, which asserts that byte drift under a `vendor/` path is still reported.

## #10489 is a different bug

I checked whether #10489 ("deploy check reports packaged plugins as remotely modified") is a symptom of this issue. It is not. Full evidence in a comment on that issue; short version:

#10489's differences are `.github/workflows/`, `.gitignore`, `CHANGELOG.md`, `artifacts/`. Three of those four are **tracked** files, so no `.gitignore`-derived exclude can suppress them. They appear because the *local comparison root* is the monorepo root (`component.local_path`), not the packaged subtree. `wp-codebox` already declares `release.package_coverage[0].source_roots = ["packages/wordpress-plugin"]`; the drift check never reads it. That is a comparison-root selection bug, not an exclusion-policy bug, and this PR does not fix it.

## Not in scope

This is one of the eight answers catalogued in #10309. Touched: `content_manifest` (deploy drift) and `content_diff` (harvest drift), and only their walk/entry mechanism — the *decision* logic (`calculate_component_status_with_git_cache`, version comparison, `source_snapshot` hashes, lab-runner's `workspace_content_manifest_for_policy`, git probes) is untouched. `crates/homeboy-lab-runner/src/workspace/snapshot.rs:193` is a third tree-manifest implementation and is deliberately left alone.

## Verification

Not run locally: this host cannot run `cargo build`/`test`/`clippy` (OOM). `cargo fmt` is clean. CI is the gate.

Tests added:
- `content_diff::recovery_comparison_prunes_this_products_transport_scratch_files`
- `content_diff::scan_options_decide_which_facts_a_walk_records`
- `content_diff::entry_identity_excludes_filesystem_byte_length`
- `content_diff::executable_mode_tag_keeps_only_bits_that_survive_a_deploy`
- `content_manifest::deploy_scan_options_state_the_divergence_from_recovery`
- `content_manifest::deploy_exclusion_policy_is_vcs_metadata_and_transport_scratch_only`

Existing deploy manifest tests (symlink/mode/add/delete, archive comparison, remote evidence validation) are unmodified and should still pass — the wire format and whole-tree digest are byte-identical, since `TreeEntryKind::tag()` emits the same `'f'`/`'l'` the old `char` field held.

## Known asymmetry left alone

`remote_manifest`'s `find` prunes `.git` at **any** depth (`-name .git -prune`); the local walk prunes only a root-level `.git`. A nested `.git` inside a deployed tree would compare asymmetrically. Pre-existing, vanishingly rare, and changing it would alter drift answers — flagging rather than fixing.

Refs #10290
