### PR TITLE
fix(release): never report a tag as delivered over an unpublished draft

### DIFF
--- a/.github/detect-stranded-release.sh
+++ b/.github/detect-stranded-release.sh
@@ -39,10 +39,15 @@
 #    release on top of it. Waiting one cycle is strictly better than either
 #    double-publishing a live release or burying a fresh one over a tag that
 #    turns out to be stranded.
-# 4. Scanning stops at the first *published* release. Recovery is confined to
+# 4. *Recovery* stops at the first published release. Recovery is confined to
 #    the contiguous run of unpublished tags at the head of the tag list.
 #    Resurrecting an ancient orphan sitting below a published release would
 #    ship stale artifacts and disturb `latest`; that is a human decision.
+#    *Reporting* does not stop there. Dropping those orphans silently is how
+#    v0.319.3 (no release) and v0.320.0 (Draft, 15 assets) became permanently
+#    invisible the moment v0.321.0 published above them. They are named in a
+#    warning and in the job summary, with the opt-in `workflow_dispatch`
+#    command to publish and the `git push origin :refs/tags/...` to drop.
 # 5. Oldest-first. When several tags are stranded the lowest version is chosen
 #    so releases publish in version order — later versions' notes and changelog
 #    ranges assume their predecessors shipped, and GitHub derives "latest" from
@@ -117,7 +122,10 @@ min_age_seconds=$(( MIN_AGE_MINUTES * 60 ))
 
 stranded_tags=()
 stranded_reasons=()
+buried_tags=()
+buried_reasons=()
 hold_reason=''
+past_published=0
 
 while IFS= read -r tag; do
   [ -n "${tag}" ] || continue
@@ -134,22 +142,46 @@ while IFS= read -r tag; do
   # Provenance: only tags whose commit is a Homeboy release commit are ours.
   subject="$(git log -1 --format=%s "${commit}")"
   if [ "${subject}" != "release: ${tag}" ]; then
-    echo "::notice::Ignoring tag ${tag} for recovery: commit subject is '${subject}', not 'release: ${tag}'"
+    if [ "${past_published}" -eq 0 ]; then
+      echo "::notice::Ignoring tag ${tag} for recovery: commit subject is '${subject}', not 'release: ${tag}'"
+    fi
     continue
   fi
 
   # Provenance: the tag must live on the branch this workflow releases from.
   if ! git merge-base --is-ancestor "${commit}" HEAD; then
-    echo "::notice::Ignoring tag ${tag} for recovery: not reachable from the release branch"
+    if [ "${past_published}" -eq 0 ]; then
+      echo "::notice::Ignoring tag ${tag} for recovery: not reachable from the release branch"
+    fi
     continue
   fi
 
   entry="$(jq -c --arg tag "${tag}" 'map(select(.tagName == $tag)) | first // empty' "${RELEASES_JSON}")"
 
   if [ -n "${entry}" ] && [ "$(jq -r '.isDraft' <<< "${entry}")" != "true" ]; then
-    # First published release found. Everything older is either published or a
-    # historical orphan that must not be resurrected automatically.
-    break
+    # First published release found. Automatic recovery stops here: a newer
+    # published release already owns `latest`, so resurrecting something below
+    # it would ship stale artifacts and reorder delivery. That rule is right.
+    #
+    # REPORTING deliberately does not stop here (issue #10441). Silently
+    # dropping everything below the boundary is how v0.319.3 (no release) and
+    # v0.320.0 (Draft, 15 assets) became permanently invisible the moment
+    # v0.321.0 published above them — no run will ever look at them again, and
+    # nothing tells an operator they exist. Keep scanning and name them.
+    past_published=1
+    continue
+  fi
+
+  if [ -z "${entry}" ]; then
+    reason='no GitHub Release'
+  else
+    reason='Draft GitHub Release'
+  fi
+
+  if [ "${past_published}" -eq 1 ]; then
+    buried_tags+=("${tag}")
+    buried_reasons+=("${reason}")
+    continue
   fi
 
   tag_epoch="$(git log -1 --format=%ct "${commit}")"
@@ -159,17 +191,37 @@ while IFS= read -r tag; do
     break
   fi
 
-  if [ -z "${entry}" ]; then
-    stranded_reasons+=('no GitHub Release')
-  else
-    stranded_reasons+=('Draft GitHub Release')
-  fi
+  stranded_reasons+=("${reason}")
   stranded_tags+=("${tag}")
 done < <(git tag --list --sort=-v:refname | head -n "${SCAN_LIMIT}")
 
 for index in "${!stranded_tags[@]}"; do
   echo "::warning::Stranded prepared release: ${stranded_tags[${index}]} (${stranded_reasons[${index}]})"
 done
+
+# Orphans below the published boundary are reported but never auto-recovered.
+# Republishing them is a human decision — it disturbs `latest` and ships
+# artifacts a newer release has already superseded — so the operator gets the
+# exact opt-in command instead of a silent drop.
+if [ "${#buried_tags[@]}" -gt 0 ]; then
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      printf '### Orphaned release tags (manual action required)\n\n'
+      printf 'These tags have no published GitHub Release and sit below a release that already published, so automatic recovery will never select them.\n\n'
+      printf '| Tag | State | Publish it | Or drop it |\n'
+      printf '| --- | --- | --- | --- |\n'
+    } >> "${GITHUB_STEP_SUMMARY}"
+  fi
+  for index in "${!buried_tags[@]}"; do
+    buried_tag="${buried_tags[${index}]}"
+    buried_reason="${buried_reasons[${index}]}"
+    echo "::warning::Orphaned release tag ${buried_tag} (${buried_reason}) sits below an already-published release, so it will NOT be recovered automatically. Publish it deliberately with: gh workflow run release.yml -f release_tag=${buried_tag} — or drop it with: git push origin :refs/tags/${buried_tag}"
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      printf '| `%s` | %s | `gh workflow run release.yml -f release_tag=%s` | `git push origin :refs/tags/%s` |\n' \
+        "${buried_tag}" "${buried_reason}" "${buried_tag}" "${buried_tag}" >> "${GITHUB_STEP_SUMMARY}"
+    fi
+  done
+fi
 
 if [ -n "${hold_reason}" ]; then
   # Holding beats both alternatives: recovering could double-publish a live

--- a/crates/homeboy-release/src/release/executor/github_release/delivery.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/delivery.rs
@@ -1,0 +1,61 @@
+//! Publication-state gating for a GitHub Release that already exists.
+//!
+//! Issue #10441: the release tag becomes durable on `origin` several jobs
+//! before the GitHub Release is published. That ordering is not accidental and
+//! it is not invertible: `release.yml`'s cargo-dist matrix checks the tag out
+//! (`actions/checkout` with `ref: <release-tag>`) and builds with
+//! `dist build --tag=<release-tag>`, so no publishable artifact can exist until
+//! the tag does. The window between "tag pushed" and "release published" spans
+//! the whole cross-platform build, and anything that dies inside it leaves the
+//! tag behind with either no release at all or an unpublished Draft.
+//!
+//! `github.release` is the last step in the pipeline that can close that gap.
+//! It therefore must never report success while the release for the tag it was
+//! handed is still unpublished — a Draft is a tag that ships nothing, which is
+//! precisely the state this issue is about.
+//!
+//! The decision is factored out as a pure function so the rules are testable
+//! without a live `gh`.
+
+/// What `github.release` must do before it may report success for a tag that
+/// already carries a GitHub Release object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExistingReleaseAction {
+    /// Published release and nothing to attach in this run: a genuine
+    /// idempotent no-op.
+    AlreadyPublished,
+    /// Unpublished Draft carrying assets, with nothing further to attach. The
+    /// artifacts were already uploaded (by this pipeline's earlier publish
+    /// stage or a previous attempt); publishing is the only remaining action
+    /// that makes the pushed tag deliverable.
+    PublishDraft,
+    /// Unpublished Draft with no assets, and nothing to attach. Publishing here
+    /// would mark an empty release `latest` and point every downloader at a
+    /// release with no binaries — strictly worse than the Draft. Fail loudly
+    /// instead and hand the operator the repair commands.
+    EmptyDraft,
+    /// This run carries artifacts. Reconcile and verify the assets first; the
+    /// publish decision is made only after verification succeeds.
+    ReconcileAssets,
+}
+
+/// Classify an already-existing GitHub Release.
+///
+/// `has_artifacts` is whether *this run* resolved release artifacts to attach;
+/// `existing_asset_count` is how many assets the release already carries.
+pub(crate) fn existing_release_action(
+    is_draft: bool,
+    has_artifacts: bool,
+    existing_asset_count: usize,
+) -> ExistingReleaseAction {
+    if has_artifacts {
+        return ExistingReleaseAction::ReconcileAssets;
+    }
+    if !is_draft {
+        return ExistingReleaseAction::AlreadyPublished;
+    }
+    if existing_asset_count == 0 {
+        return ExistingReleaseAction::EmptyDraft;
+    }
+    ExistingReleaseAction::PublishDraft
+}

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -424,19 +424,36 @@ pub(crate) fn gh_release_metadata(
     // tag made recovery impossible for the one case recovery exists to handle:
     // every retry 404'd, left the release a draft, and 404'd again forever.
     // Drafts are visible on the list endpoint, so fall back to resolving by id.
-    gh_draft_release_metadata(github, config, tag, repo_flag)
-        .ok_or_else(|| gh_failure_detail("gh api release metadata", &output))
+    //
+    // Report BOTH failures (issue #10441). The fallback is the path that
+    // matters for a stranded draft, so collapsing its failure into the
+    // primary call's generic "exited with status 1" makes the one failure
+    // that strands a release undiagnosable -- which is exactly what run
+    // 30313665269 left behind for v0.321.1: a step error naming only the
+    // expected 404, with no trace of why the draft lookup did not recover it.
+    gh_draft_release_metadata(github, config, tag, repo_flag).map_err(|draft_error| {
+        format!(
+            "{}; the draft fallback also failed: {}",
+            gh_failure_detail("gh api release metadata", &output),
+            draft_error
+        )
+    })
 }
 
 /// Resolve a draft release by scanning the list endpoint, which -- unlike
 /// `releases/tags/{tag}` -- includes drafts. Returns the REST shape, so the
 /// asset digests recovery depends on are preserved.
+///
+/// The error distinguishes the three ways this can fail -- the `gh` invocation
+/// itself failed, no release matched the tag, or the matched record was not
+/// parseable release metadata -- because they demand different responses and
+/// were previously indistinguishable (all collapsed into `None`).
 fn gh_draft_release_metadata(
     github: &GitHubRepo,
     config: &GithubConfig,
     tag: &str,
     repo_flag: &str,
-) -> Option<GitHubReleaseMetadata> {
+) -> Result<GitHubReleaseMetadata, String> {
     let endpoint = format!("repos/{repo_flag}/releases");
     let filter = format!(".[] | select(.tag_name == \"{tag}\")");
     let output = run_gh_command(
@@ -448,15 +465,29 @@ fn gh_draft_release_metadata(
         github_release_upload_timeout(),
     );
     if output.timed_out || output.exit_code != Some(0) {
-        return None;
+        let detail = gh_failure_detail("gh api releases list", &output);
+        let stderr = output.stderr.trim();
+        return Err(if stderr.is_empty() {
+            detail
+        } else {
+            format!("{detail}: {stderr}")
+        });
     }
-    parse_listed_release_metadata(&output.stdout)
+    parse_listed_release_metadata(&output.stdout).ok_or_else(|| {
+        if output.stdout.trim().is_empty() {
+            format!("no GitHub Release (published or draft) on {repo_flag} matched tag {tag}")
+        } else {
+            format!(
+                "the release list entry for {tag} on {repo_flag} was not valid release metadata"
+            )
+        }
+    })
 }
 
 /// `gh api --jq` streams one JSON object per match rather than an array, and
 /// `--paginate` concatenates pages. A tag resolves to at most one release, so
 /// take the first non-empty record.
-fn parse_listed_release_metadata(stdout: &str) -> Option<GitHubReleaseMetadata> {
+pub(crate) fn parse_listed_release_metadata(stdout: &str) -> Option<GitHubReleaseMetadata> {
     stdout
         .lines()
         .map(str::trim)

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! Split across focused submodules:
 //! - [`run`] — the `github.release` step entry point and lifecycle driver.
+//! - [`delivery`] — publication-state gating for an already-existing release.
 //! - [`notes`] — release-body construction, generated-notes probes, footers.
 //! - [`results`] — `ReleaseStepResult` builders for each outcome.
 //! - [`repair`] — manual-recovery command builders, hints, and logging.
 //! - [`gh_cli`] — `gh` CLI probes, environment, and command construction.
 
+mod delivery;
 mod gh_cli;
 mod notes;
 mod repair;
@@ -37,7 +39,11 @@ pub(crate) use gh_cli::{
 #[cfg(test)]
 pub(crate) use crate::release::types::ReleaseStepResult;
 #[cfg(test)]
-pub(crate) use gh_cli::{github_cli_env, github_release_artifact_paths};
+pub(crate) use delivery::{existing_release_action, ExistingReleaseAction};
+#[cfg(test)]
+pub(crate) use gh_cli::{
+    github_cli_env, github_release_artifact_paths, parse_listed_release_metadata,
+};
 #[cfg(test)]
 pub(crate) use notes::{
     build_github_release_body, fallback_release_notes, github_changelog_url,
@@ -51,6 +57,6 @@ pub(crate) use repair::{
 };
 #[cfg(test)]
 pub(crate) use results::{
-    create_failed_result, not_created_result, published_release_url, upload_failed_result,
-    upload_success_result,
+    create_failed_result, not_created_result, published_existing_draft_result,
+    published_release_url, unfinished_release_result, upload_failed_result, upload_success_result,
 };

--- a/crates/homeboy-release/src/release/executor/github_release/results.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/results.rs
@@ -51,6 +51,75 @@ pub(super) fn skipped_result(
     step_success("github.release", "github.release", Some(data), Vec::new())
 }
 
+/// An existing GitHub Release was still an unpublished Draft and this run
+/// published it (issue #10441).
+///
+/// The tag was already durable on `origin` — the cargo-dist build matrix checks
+/// the tag out, so it must exist before any artifact can be built — which means
+/// the Draft was a pushed tag that shipped nothing. Publishing it is the action
+/// that makes the tag deliverable, so this is a real `Success`, not a skip.
+pub(crate) fn published_existing_draft_result(
+    tag: &str,
+    github: &GitHubRepo,
+    asset_count: usize,
+    url: &str,
+) -> ReleaseStepResult {
+    step_success(
+        "github.release",
+        "github.release",
+        Some(serde_json::json!({
+            "action": "github.release.publish_existing_draft",
+            "skipped": false,
+            "reason": "draft-release-published",
+            "tag": tag,
+            "host": github.host,
+            "owner": github.owner,
+            "repo": github.repo,
+            "url": url,
+            "artifact_count": asset_count,
+            "published": true,
+        })),
+        Vec::new(),
+    )
+}
+
+/// A GitHub Release exists for the tag but this run could neither confirm nor
+/// make it published (issue #10441).
+///
+/// This must be `Failed`. The tag is already on `origin`, so reporting success
+/// here publishes nothing while telling every downstream consumer — and the
+/// `verify-published` release-workflow gate — that the version shipped. The
+/// three states that land here are: the release's publication state could not
+/// be read, `gh release edit --draft=false` failed, and an empty Draft that
+/// must not be published over.
+pub(crate) fn unfinished_release_result(
+    tag: &str,
+    github: &GitHubRepo,
+    reason: &str,
+    error: &str,
+    repair: GitHubReleaseRepairCommands,
+) -> ReleaseStepResult {
+    let data = serde_json::json!({
+        "skipped": false,
+        "release_created": true,
+        "published": false,
+        "reason": reason,
+        "tag": tag,
+        "host": github.host,
+        "owner": github.owner,
+        "repo": github.repo,
+        "repair": repair_data(&repair),
+    });
+
+    step_failed(
+        "github.release",
+        "github.release",
+        Some(data),
+        Some(error.to_string()),
+        existing_draft_repair_hints(&repair),
+    )
+}
+
 /// The GitHub Release object was NOT created and cannot be recovered in this
 /// run (no `gh` binary / not authenticated). This must be `Failed`, not a
 /// success-with-`skipped`, so the release pipeline halts before publish/upload

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -5,6 +5,7 @@ use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 
 use super::super::step_success;
+use super::delivery::{existing_release_action, ExistingReleaseAction};
 use super::gh_cli::{
     gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
     github_release_publications,
@@ -15,8 +16,9 @@ use super::notes::{
 };
 use super::repair::{gh_auth_failure_message, github_release_repair_commands, log_repair_commands};
 use super::results::{
-    create_failed_result, not_created_result, published_release_url, skipped_result,
-    upload_failed_result, upload_success_result_with_publications,
+    create_failed_result, not_created_result, published_existing_draft_result,
+    published_release_url, skipped_result, unfinished_release_result, upload_failed_result,
+    upload_success_result_with_publications,
 };
 use super::{
     gh_failure_detail, gh_release_metadata, github_release_upload_timeout,
@@ -146,25 +148,118 @@ pub(crate) fn run_github_release(
 
     let repo_flag = format!("{}/{}", github.owner, github.repo);
     if gh_release_exists(&github, &component.github, &tag, &repo_flag) {
-        // A pre-existing release is a retry boundary. Reconcile its assets by
-        // canonical name and digest before uploading anything.
-        if !has_artifacts {
-            homeboy_core::log_status!(
-                "release",
-                "GitHub Release {} already exists for {} — skipping (idempotent)",
-                tag,
-                repo_flag
-            );
-            return Ok(skipped_result(
-                &tag,
-                &github,
-                "release-already-exists",
-                None,
-            ));
+        // A pre-existing release is a retry boundary. Read its PUBLICATION
+        // state before deciding anything (issue #10441). By the time this step
+        // runs the tag is already durable on `origin` — `release.yml`'s
+        // cargo-dist matrix checks the tag out and builds with
+        // `dist build --tag=<tag>`, so the tag has to exist before any artifact
+        // can — which means an unpublished Draft here is a pushed tag that
+        // ships nothing. This step is the pipeline's last chance to close that
+        // window, so "a release object exists" is not sufficient to report
+        // success; it must also be published.
+        let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                let repair = repair_commands(None, None);
+                let detail = format!(
+                    "GitHub Release {} exists for {} but its publication state could not be read: {}",
+                    tag, repo_flag, error
+                );
+                homeboy_core::log_status!("release", "✗ {}", detail);
+                log_repair_commands(&repair);
+                return Ok(unfinished_release_result(
+                    &tag,
+                    &github,
+                    "release-state-unreadable",
+                    &detail,
+                    repair,
+                ));
+            }
+        };
+
+        match existing_release_action(metadata.is_draft, has_artifacts, metadata.assets.len()) {
+            ExistingReleaseAction::AlreadyPublished => {
+                homeboy_core::log_status!(
+                    "release",
+                    "GitHub Release {} is already published for {} — skipping (idempotent)",
+                    tag,
+                    repo_flag
+                );
+                return Ok(skipped_result(
+                    &tag,
+                    &github,
+                    "release-already-published",
+                    None,
+                ));
+            }
+            ExistingReleaseAction::EmptyDraft => {
+                // Publishing an assetless draft would make it `latest` and send
+                // every downloader (and the Homebrew formula) to a release with
+                // no binaries. That is worse than leaving the draft for the
+                // recovery path, which can still upload artifacts into it.
+                let repair = repair_commands(None, None);
+                let detail = format!(
+                    "GitHub Release {} for {} is an unpublished draft with no assets, and this run has no artifacts to attach. Refusing to publish an empty release over the pushed tag.",
+                    tag, repo_flag
+                );
+                homeboy_core::log_status!("release", "✗ {}", detail);
+                log_repair_commands(&repair);
+                return Ok(unfinished_release_result(
+                    &tag,
+                    &github,
+                    "draft-release-has-no-assets",
+                    &detail,
+                    repair,
+                ));
+            }
+            ExistingReleaseAction::PublishDraft => {
+                homeboy_core::log_status!(
+                    "release",
+                    "GitHub Release {} for {} is an unpublished draft with {} asset(s) — publishing it so the pushed tag delivers",
+                    tag,
+                    repo_flag,
+                    metadata.assets.len()
+                );
+                let publish_args = ["release", "edit", &tag, "--draft=false", "-R", &repo_flag];
+                let publish_output = run_gh_command(
+                    gh_command(&github, &component.github, &publish_args),
+                    github_release_upload_timeout(),
+                );
+                if publish_output.timed_out || publish_output.exit_code != Some(0) {
+                    let repair = repair_commands(None, None);
+                    let detail = format!(
+                        "{}: {}",
+                        gh_failure_detail("gh release edit --draft=false", &publish_output),
+                        publish_output.stderr.trim()
+                    );
+                    homeboy_core::log_status!("release", "✗ {}", detail);
+                    log_repair_commands(&repair);
+                    return Ok(unfinished_release_result(
+                        &tag,
+                        &github,
+                        "draft-publish-failed",
+                        &detail,
+                        repair,
+                    ));
+                }
+                let url = published_release_url(&github, &tag, "", &publish_output.stdout);
+                homeboy_core::log_status!(
+                    "release",
+                    "Published previously stranded GitHub Release: {}",
+                    url
+                );
+                return Ok(published_existing_draft_result(
+                    &tag,
+                    &github,
+                    metadata.assets.len(),
+                    &url,
+                ));
+            }
+            // This run carries artifacts: reconcile and verify the assets by
+            // canonical name and digest before any publish decision is made.
+            ExistingReleaseAction::ReconcileAssets => {}
         }
 
-        let metadata = gh_release_metadata(&github, &component.github, &tag, &repo_flag)
-            .map_err(|error| Error::internal_unexpected(error))?;
         let (uploads, existing) = reconcile_release_publications(
             &publications,
             &metadata.assets,

--- a/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
@@ -1,0 +1,95 @@
+//! Tests for the publication-state gating of an already-existing GitHub
+//! Release (issue #10441).
+//!
+//! Live evidence these encode, from `Extra-Chill/homeboy` on 2026-07-28:
+//!
+//! | tag       | git tag on origin | GitHub Release        |
+//! |-----------|-------------------|-----------------------|
+//! | `v0.321.1`| present           | Draft, 13 assets      |
+//! | `v0.321.0`| present           | published (Latest)    |
+//! | `v0.320.0`| present           | Draft, 15 assets      |
+//! | `v0.319.3`| present           | none                  |
+//!
+//! Every Draft row is a pushed tag that ships nothing. Before this change the
+//! `github.release` step returned `Success` with `skipped: true` for all of
+//! them whenever the run carried no artifacts of its own, so the pipeline
+//! reported a delivered release over an undeliverable tag.
+
+use super::super::{existing_release_action, ExistingReleaseAction};
+
+#[test]
+fn published_release_with_nothing_to_attach_is_an_idempotent_no_op() {
+    assert_eq!(
+        existing_release_action(false, false, 13),
+        ExistingReleaseAction::AlreadyPublished
+    );
+}
+
+#[test]
+fn published_release_with_no_assets_is_still_an_idempotent_no_op() {
+    // Asset count is only consulted for drafts: a published release with no
+    // assets is a delivery problem for `verify-published` to report, not a
+    // reason for this step to re-publish something already public.
+    assert_eq!(
+        existing_release_action(false, false, 0),
+        ExistingReleaseAction::AlreadyPublished
+    );
+}
+
+#[test]
+fn stranded_draft_carrying_assets_is_published_not_skipped() {
+    // The v0.320.0 / v0.321.1 state: the tag is durable on origin, cargo-dist
+    // already uploaded every asset, and only the un-draft edit is missing.
+    // Reporting `skipped` here is what let those tags sit undeliverable.
+    assert_eq!(
+        existing_release_action(true, false, 15),
+        ExistingReleaseAction::PublishDraft
+    );
+    assert_eq!(
+        existing_release_action(true, false, 1),
+        ExistingReleaseAction::PublishDraft
+    );
+}
+
+#[test]
+fn empty_draft_is_refused_rather_than_published() {
+    // Publishing an assetless draft marks it `latest` and points every
+    // downloader (and the Homebrew formula) at a release with no binaries.
+    // That is strictly worse than leaving the draft for the recovery path,
+    // which can still upload artifacts into it.
+    assert_eq!(
+        existing_release_action(true, false, 0),
+        ExistingReleaseAction::EmptyDraft
+    );
+}
+
+#[test]
+fn a_run_carrying_artifacts_always_reconciles_before_any_publish_decision() {
+    // Assets must be uploaded and verified by digest before the publish
+    // decision is made, so the artifact-carrying run never short-circuits into
+    // a publish — regardless of draft state or how many assets already exist.
+    for is_draft in [true, false] {
+        for existing in [0usize, 1, 15] {
+            assert_eq!(
+                existing_release_action(is_draft, true, existing),
+                ExistingReleaseAction::ReconcileAssets,
+                "is_draft={is_draft} existing_assets={existing}"
+            );
+        }
+    }
+}
+
+#[test]
+fn no_input_combination_reports_a_draft_as_already_published() {
+    // The core invariant of issue #10441: a durable tag must never be reported
+    // as delivered while its release is an unpublished draft.
+    for existing in [0usize, 1, 13, 15] {
+        for has_artifacts in [true, false] {
+            assert_ne!(
+                existing_release_action(true, has_artifacts, existing),
+                ExistingReleaseAction::AlreadyPublished,
+                "a draft must never classify as published (has_artifacts={has_artifacts}, existing_assets={existing})"
+            );
+        }
+    }
+}

--- a/crates/homeboy-release/src/release/executor/github_release/tests/draft_lookup_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/draft_lookup_tests.rs
@@ -1,0 +1,89 @@
+//! Tests for parsing the draft-release fallback lookup (issues #10480, #10441).
+//!
+//! `GET /repos/{owner}/{repo}/releases/tags/{tag}` returns 404 for a draft, so
+//! a release stranded by a failed publish can only be resolved through the list
+//! endpoint. Everything downstream of that fallback — asset digests, the
+//! draft/published decision, whether recovery can finish the release at all —
+//! depends on parsing its output correctly, and the failure is silent when it
+//! does not: the release simply stays a draft behind a pushed tag.
+//!
+//! The fixtures below are shaped exactly like the live output of
+//! `gh api --paginate repos/Extra-Chill/homeboy/releases \
+//!    --jq '.[] | select(.tag_name == "v0.321.1")'`
+//! captured while `v0.321.1` was stranded as a Draft with 13 assets: `gh`
+//! emits ONE compact JSON object per line, and `--paginate` concatenates
+//! pages, so a multi-page scan can put unrelated lines around the match.
+
+use super::super::parse_listed_release_metadata;
+
+/// One compact line, the real shape `gh api --jq` emits for a single match.
+const DRAFT_LINE: &str = r#"{"id":123,"tag_name":"v0.321.1","draft":true,"assets":[{"id":492086569,"name":"homeboy-aarch64-unknown-linux-gnu.tar.xz","size":23033568,"digest":"sha256:ed6b93c03f5638a8b70d4c077270145c88a8dc2fea987443bfbd0b82acd93710","state":"uploaded"}]}"#;
+
+#[test]
+fn a_stranded_draft_is_resolved_with_its_assets_and_digests() {
+    let metadata = parse_listed_release_metadata(DRAFT_LINE).expect("draft must resolve");
+
+    assert!(
+        metadata.is_draft,
+        "the whole point of the fallback is learning the release is still a draft"
+    );
+    assert_eq!(metadata.assets.len(), 1);
+    assert_eq!(
+        metadata.assets[0].name,
+        "homeboy-aarch64-unknown-linux-gnu.tar.xz"
+    );
+    assert_eq!(metadata.assets[0].size, 23_033_568);
+    // The REST digest is the reason the fallback reads the API rather than
+    // `gh release view --json`, whose GraphQL shape omits it.
+    assert_eq!(
+        metadata.assets[0].digest.as_deref(),
+        Some("sha256:ed6b93c03f5638a8b70d4c077270145c88a8dc2fea987443bfbd0b82acd93710")
+    );
+    assert_eq!(metadata.assets[0].id, Some(492_086_569));
+}
+
+#[test]
+fn a_published_release_is_resolved_as_not_draft() {
+    let published = r#"{"id":124,"tag_name":"v0.321.0","draft":false,"assets":[]}"#;
+    let metadata = parse_listed_release_metadata(published).expect("published must resolve");
+    assert!(!metadata.is_draft);
+    assert!(metadata.assets.is_empty());
+}
+
+#[test]
+fn leading_blank_lines_from_pagination_are_skipped() {
+    let stdout = format!("\n   \n{DRAFT_LINE}\n");
+    let metadata =
+        parse_listed_release_metadata(&stdout).expect("blank pages must not hide the match");
+    assert!(metadata.is_draft);
+    assert_eq!(metadata.assets.len(), 1);
+}
+
+#[test]
+fn no_match_yields_none_so_the_caller_can_report_it() {
+    // `--jq select(...)` prints nothing when no page contains the tag. The
+    // caller turns this into "no release matched", which is a different
+    // operator action than "the gh call failed".
+    assert!(parse_listed_release_metadata("").is_none());
+    assert!(parse_listed_release_metadata("\n\n   \n").is_none());
+}
+
+#[test]
+fn unparseable_output_yields_none_rather_than_a_wrong_draft_verdict() {
+    // Guessing here would be worse than failing: defaulting to "published"
+    // would let the step report a delivered release over a stranded draft,
+    // and defaulting to "draft" would republish a live release.
+    assert!(parse_listed_release_metadata("not json at all").is_none());
+    assert!(parse_listed_release_metadata("{").is_none());
+    assert!(parse_listed_release_metadata("[]").is_none());
+}
+
+#[test]
+fn the_graphql_is_draft_spelling_is_accepted_too() {
+    // `gh release list --json isDraft` uses camelCase; the metadata type
+    // aliases it so both shapes resolve to the same verdict.
+    let graphql = r#"{"tagName":"v0.321.1","isDraft":true}"#;
+    let metadata = parse_listed_release_metadata(graphql).expect("camelCase must resolve");
+    assert!(metadata.is_draft);
+    assert!(metadata.assets.is_empty());
+}

--- a/crates/homeboy-release/src/release/executor/github_release/tests/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/mod.rs
@@ -8,6 +8,8 @@ use homeboy_core::git::release_download::GitHubRepo;
 use super::{github_release_repair_commands, GitHubReleaseBody, GitHubReleaseRepairCommands};
 
 mod changelog_url_tests;
+mod delivery_tests;
+mod draft_lookup_tests;
 mod notes_tests;
 mod repair_tests;
 mod result_builders;

--- a/crates/homeboy-release/src/release/executor/github_release/tests/result_builders.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/result_builders.rs
@@ -3,8 +3,8 @@
 use crate::release::types::ReleaseStepStatus;
 
 use super::super::{
-    create_failed_result, not_created_result, published_release_url, upload_failed_result,
-    upload_success_result,
+    create_failed_result, not_created_result, published_existing_draft_result,
+    published_release_url, unfinished_release_result, upload_failed_result, upload_success_result,
 };
 use super::{data_bool, data_str, test_body, test_repair, test_repo};
 
@@ -158,6 +158,89 @@ fn verified_upload_result_is_successful_only_after_publication() {
             .and_then(|data| data.get("artifact_count"))
             .and_then(|value| value.as_u64()),
         Some(2)
+    );
+}
+
+#[test]
+fn publishing_a_stranded_draft_is_a_success_not_a_skip() {
+    // Issue #10441: finishing a draft that was left behind a pushed tag is a
+    // real delivery action. It must not be reported as an idempotent skip,
+    // because the release only became downloadable in this run.
+    let result = published_existing_draft_result(
+        "v0.320.0",
+        &test_repo(),
+        15,
+        "https://github.com/example-org/studio-web/releases/tag/v0.320.0",
+    );
+
+    assert_eq!(result.status, ReleaseStepStatus::Success);
+    assert_eq!(data_bool(&result, "skipped"), Some(false));
+    assert_eq!(data_bool(&result, "published"), Some(true));
+    assert_eq!(data_str(&result, "reason"), Some("draft-release-published"));
+    assert_eq!(
+        data_str(&result, "action"),
+        Some("github.release.publish_existing_draft")
+    );
+    assert_eq!(
+        result
+            .data
+            .as_ref()
+            .and_then(|data| data.get("artifact_count"))
+            .and_then(|value| value.as_u64()),
+        Some(15)
+    );
+}
+
+#[test]
+fn an_unfinished_release_is_failed_so_the_tag_is_never_reported_as_delivered() {
+    // Issue #10441: the tag is already durable on origin by the time this step
+    // runs. Reporting success over a release that is still a draft tells every
+    // downstream consumer the version shipped when nothing is downloadable.
+    let result = unfinished_release_result(
+        "v0.320.0",
+        &test_repo(),
+        "draft-publish-failed",
+        "`gh release edit --draft=false` failed for v0.320.0: HTTP 502",
+        test_repair(),
+    );
+
+    assert_eq!(result.status, ReleaseStepStatus::Failed);
+    assert_eq!(data_bool(&result, "skipped"), Some(false));
+    assert_eq!(data_bool(&result, "published"), Some(false));
+    // The release object does exist — recovery must resume it, not re-tag.
+    assert_eq!(data_bool(&result, "release_created"), Some(true));
+    assert_eq!(data_str(&result, "reason"), Some("draft-publish-failed"));
+    assert!(result.error.as_deref().unwrap().contains("HTTP 502"));
+    // Recovery guidance must point at the existing draft, never at a new tag.
+    assert!(result
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("Resume the existing draft")));
+    assert!(result
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("--draft=false")));
+    assert!(result
+        .hints
+        .iter()
+        .all(|hint| !hint.message.contains("release create")));
+}
+
+#[test]
+fn an_empty_draft_is_refused_with_the_same_failed_contract() {
+    let result = unfinished_release_result(
+        "v0.319.3",
+        &test_repo(),
+        "draft-release-has-no-assets",
+        "Refusing to publish an empty release over the pushed tag.",
+        test_repair(),
+    );
+
+    assert_eq!(result.status, ReleaseStepStatus::Failed);
+    assert_eq!(data_bool(&result, "published"), Some(false));
+    assert_eq!(
+        data_str(&result, "reason"),
+        Some("draft-release-has-no-assets")
     );
 }
 


### PR DESCRIPTION
Fixes #10441.

## The ordering, established in code

The tag is pushed by the **Rust** `git.push` step, invoked from the **workflow's** `prepare` job. The workflow then puts the entire cross-platform build between that push and the publish.

| what | where |
|---|---|
| plan order: `git.tag` → `git.push` → `github.release` | `crates/homeboy-release/src/release/plan_steps/release.rs:149-176` |
| `git.tag` creates the local annotated tag | `crates/homeboy-release/src/release/executor/tagging.rs:130-135` |
| `git.push` pushes it with `--follow-tags` | `crates/homeboy-release/src/release/advanced_remote.rs:121-136` → `crates/homeboy-core/src/git/operations_push.rs:74` |
| `prepare` runs the above with `release-skip-github-release: 'true'` — so the tag lands and **no** release is created in that job | `.github/workflows/release.yml:533-544` |
| `plan` creates the release as a **cargo-dist draft**, ~1 job later | `.github/workflows/release.yml:629` |
| ~20 min of cross-platform builds | `.github/workflows/release.yml:646-809` |
| `host` uploads, then the Rust `github.release` step finishes it | `.github/workflows/release.yml:860`, `:886-894` |

Live proof, run [`30313665269`](https://github.com/Extra-Chill/homeboy/actions/runs/30313665269): `Prepare Release` **success** (tag pushed) → `Plan Build Matrix` **success** (draft created) → all 4 build jobs **success** → `Create GitHub Release` **failure**. Result: `v0.321.1` tag on origin, release stuck as a Draft with 13 assets.

## Why the ordering is not inverted here

**Because cargo-dist is tag-driven and this is a legitimate blocker, not a shortcut.** Every matrix job does `actions/checkout` with `ref: <release-tag>` (`release.yml:605, 667, 737, 829`) and `dist build --tag=<tag>` (`:704, :796`). No publishable artifact can exist before the tag does, and the release cannot publish before the artifacts exist. Tag-before-publish is structurally required.

The one genuinely transactional alternative — never push a tag, create the draft with `--target <sha>`, and let `gh release edit --draft=false` create the tag ref and publish in a single server-side operation — is real, but it would (a) require rewriting the cargo-dist-generated matrix to build from a SHA, (b) downgrade Homeboy's annotated release tags to GitHub's lightweight ones, and (c) **regress the existing reconciler**, which is tag-driven: a stranded draft with no tag would be invisible to `detect-stranded-release.sh` entirely. So this PR makes the reconciliation reliable instead, per the issue's own second option.

## What changed

**1. `github.release` must not report success over an unpublished draft** — `github_release/run.rs:150-261`

The existing-release branch previously short-circuited *before reading publication state*:

```rust
if gh_release_exists(...) {
    if !has_artifacts {
        return Ok(skipped_result(&tag, &github, "release-already-exists", None));  // Success
    }
```

Since #10480 taught `gh_release_exists` to find drafts, that path now definitely hits them — a stranded draft reported as a delivered release, by the last step that could have fixed it. Metadata is now read first and routed through a pure classifier (`github_release/delivery.rs`):

| draft? | run has artifacts? | existing assets | action |
|---|---|---|---|
| no | no | any | `AlreadyPublished` → skip (genuine no-op) |
| **yes** | no | **> 0** | `PublishDraft` → `gh release edit --draft=false` → **Success** |
| yes | no | 0 | `EmptyDraft` → **Failed** (publishing would make an empty release `latest`) |
| any | **yes** | any | `ReconcileAssets` → unchanged path, still verifies by digest before publishing |

The artifact-carrying path — the hot path for Homeboy's own release — is behaviourally unchanged.

**2. The draft fallback no longer swallows its own failure** — `github_release/gh_cli.rs:427-490`

`gh_draft_release_metadata` returned `Option`, so any failure collapsed into the *primary* call's generic message. Run `30313665269` reports exactly `gh api release metadata exited with status 1` and nothing else — the failure that stranded `v0.321.1` is **not diagnosable from the logs at all**. It now returns `Result` and distinguishes: the `gh` call failed (with stderr), no release matched, or the record was unparseable.

**3. The reconciler reports orphans it will never recover** — `.github/detect-stranded-release.sh`

The scan `break`s at the first published release for both recovery *and* reporting. Refusing to auto-publish below that boundary is correct. Dropping them **silently** is not — it is exactly how `v0.319.3` and `v0.320.0` became permanently invisible the moment `v0.321.0` published above them.

Recovery selection is unchanged; reporting is added. Verified against a fixture reproducing the live state:

```
::warning::Stranded prepared release: v0.321.1 (Draft GitHub Release)          <- selected, as before
::warning::Orphaned release tag v0.320.0 (Draft GitHub Release) sits below an already-published
           release, so it will NOT be recovered automatically. Publish it deliberately with:
           gh workflow run release.yml -f release_tag=v0.320.0 — or drop it with:
           git push origin :refs/tags/v0.320.0
::warning::Orphaned release tag v0.319.3 (no GitHub Release) ...
```

`stranded-tag`/`stranded-version`/`stranded-attempts`/`hold-reason` are byte-identical to the pre-change script on the same fixture. Also emitted to `$GITHUB_STEP_SUMMARY` as a table. Nothing is destructive and nothing is automatic — the operator gets both the publish and the delete command.

## Recovering the live orphans

| tag | state | recovery |
|---|---|---|
| `v0.321.1` | Draft, 13 assets | already auto-recoverable (above the boundary) |
| `v0.320.0` | Draft, 15 assets | `gh workflow run release.yml -f release_tag=v0.320.0` — now reported every run |
| `v0.319.3` | no release | same, or `git push origin :refs/tags/v0.319.3` to drop it — now reported every run |

## Corrections to the issue

- **"`v0.320.0` — orphaned, no release, no assets" is wrong.** It is a **Draft with 15 assets**. `v0.321.1` is likewise a Draft with 13. Only `v0.319.3` is a true orphan with no release object. The distinction matters: a draft holds the artifacts, so it must be *finished*, never deleted.
- **"Nothing detects the orphaned state" is now only half true.** `6b64db503` already shipped `detect-stranded-release.sh`. Its gap is narrower than the issue describes: it detects fine, but *silently discards* anything below a published release.
- The `Test`-job red herring and the cancellation analysis were already retracted in the issue's correction comment; nothing here depends on them.

## Verification

Cannot run cargo on the authoring host (16 GB shared VPS; a workspace build OOM-kills the box), so per repo policy CI is the gate. Verified locally without cargo:

- `cargo fmt --check` clean.
- `bash -n` on the shell script, plus **executed** against a git fixture reproducing the exact live tag/release state — selection identical to the pre-change script, and the hold / all-published / `gh`-unavailable fail-safe paths all still behave.
- The draft-lookup test fixtures are the **real** output of `gh api --paginate repos/Extra-Chill/homeboy/releases --jq '.[] | select(.tag_name == "v0.321.1")'` captured against the live stranded draft (one compact line, `draft: true`, 13 assets).

**Not verified:** compilation and the Rust tests. Notably that `mod.rs`'s `#[cfg(test)]` re-exports resolve, and that the `metadata` shadowing in `run.rs` borrow-checks.

New tests: `github_release/tests/delivery_tests.rs` (classifier matrix, incl. an invariant that no input can ever classify a draft as published), `github_release/tests/draft_lookup_tests.rs` (fallback parsing), and three added to `tests/result_builders.rs`.