### PR TITLE
feat(daemon): drop the confirmation flags the lifecycle controller already proves

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -36,7 +36,8 @@ enum DaemonCommand {
         /// Exact lease ID reported by `homeboy daemon status`
         #[arg(long)]
         lease_id: String,
-        /// Confirm the recorded PID was inspected and is dead
+        /// Deprecated no-op retained for one release; adoption already proves the
+        /// recorded PID dead under the daemon lifecycle lock.
         #[arg(long)]
         confirm_pid_dead: bool,
         /// Accepted migration alias for legacy child recovery. It never mutates jobs.
@@ -52,10 +53,19 @@ enum DaemonCommand {
     ReconcileDeadLeaseOrphans {
         #[arg(long)]
         lease_id: String,
+        /// Exact, complete active durable-job set to terminalize. The store
+        /// recomputes the active set and refuses any mismatch, so this is a
+        /// compare-and-swap over the destructive scope, not a fact assertion.
         #[arg(long = "job-id", required = true)]
         job_ids: Vec<Uuid>,
+        /// Deprecated no-op retained for one release; recovery already requires
+        /// persisted unexpected-termination evidence and re-proves the PID dead.
         #[arg(long)]
         confirm_pid_dead: bool,
+        /// Required. Attests that the workload processes for --job-id were
+        /// inspected and are absent. Unverifiable by design: this command exists
+        /// because the daemon died before persisting any child identity, so the
+        /// store holds no PID to check. Persisted as durable job provenance.
         #[arg(long)]
         confirm_workload_processes_absent: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
@@ -78,6 +88,18 @@ enum DaemonCommand {
     },
     /// Explicitly reconcile active jobs after proving a missing-lease store has no daemon owner
     ReconcileLeaselessOrphans {
+        // Deprecated no-op retained for one release: recovery already fails
+        // closed on the daemon owner lock, daemon process candidates, and a
+        // reachable listener at --addr.
+        //
+        // This deliberately carries NO doc comment. Controllers negotiate the
+        // lease-less recovery contract by running this subcommand's `--help` on
+        // the remote and matching bare long options
+        // (`connection::declared_long_options` only accepts an option whose
+        // trailing tokens are value placeholders). Rendering help text after
+        // `--confirm-no-daemon-owner` removes it from the advertised contract
+        // and makes every controller refuse remote lease-less recovery. The
+        // deprecation is documented in `docs/commands/daemon.md` instead.
         #[arg(long)]
         confirm_no_daemon_owner: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
@@ -94,10 +116,13 @@ enum DaemonCommand {
         /// Recorded concrete loopback endpoint captured with the lease ID
         #[arg(long)]
         recorded_endpoint: String,
-        /// Confirm the recorded daemon PID was inspected and is dead
+        /// Deprecated no-op retained for one release; recovery already refuses a
+        /// running recorded PID.
         #[arg(long)]
         confirm_pid_dead: bool,
-        /// Confirm the daemon state record and endpoint are unavailable
+        /// Deprecated no-op retained for one release; recovery already requires an
+        /// absent state record, a `lease_missing` freshness code, an unreachable
+        /// daemon, and a failed probe of the recorded endpoint.
         #[arg(long)]
         confirm_control_plane_lost: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
@@ -208,7 +233,8 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         )),
         DaemonCommand::AdoptOrphan {
             lease_id,
-            confirm_pid_dead,
+            // Deprecated no-op: adoption proves PID death itself, under the lock.
+            confirm_pid_dead: _deprecated_confirm_pid_dead,
             recover_missing_child_identity,
             confirm_untracked_child_dead,
             addr,
@@ -220,16 +246,17 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             Ok((
                 DaemonOutput::AdoptOrphan(daemon::adopt_orphaned_lease(
                     &lease_id,
-                    confirm_pid_dead,
                     &confirm_untracked_child_dead,
                     &addr,
                 )?),
                 0,
             ))
         }
-        DaemonCommand::ReconcileDeadLeaseOrphans { lease_id, job_ids, confirm_pid_dead, confirm_workload_processes_absent, addr } => Ok((
+        // `confirm_workload_processes_absent` stays load-bearing: no PID exists
+        // for these jobs, so only the operator can attest workload absence.
+        DaemonCommand::ReconcileDeadLeaseOrphans { lease_id, job_ids, confirm_pid_dead: _deprecated_confirm_pid_dead, confirm_workload_processes_absent, addr } => Ok((
             DaemonOutput::ReconcileDeadLeaseOrphans(daemon::reconcile_dead_lease_orphans(
-                &lease_id, &job_ids, confirm_pid_dead, confirm_workload_processes_absent, &addr,
+                &lease_id, &job_ids, confirm_workload_processes_absent, &addr,
             )?),
             0,
         )),
@@ -237,12 +264,12 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
             DaemonOutput::RecoverMissingChildIdentity(daemon::recover_missing_child_identity(&lease_id, recorded_daemon_pid, &recorded_daemon_endpoint, job_id, child_pid, child_starttime_ticks)?),
             0,
         )),
-        DaemonCommand::ReconcileLeaselessOrphans { confirm_no_daemon_owner, addr } => Ok((
-            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(confirm_no_daemon_owner, &addr)?),
+        DaemonCommand::ReconcileLeaselessOrphans { confirm_no_daemon_owner: _deprecated_confirm_no_daemon_owner, addr } => Ok((
+            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(&addr)?),
             0,
         )),
-        DaemonCommand::RecoverMissingLeaseState { lease_id, recorded_pid, recorded_endpoint, confirm_pid_dead, confirm_control_plane_lost, addr } => Ok((
-            DaemonOutput::RecoverMissingLeaseState(daemon::recover_missing_lease_state(&lease_id, recorded_pid, &recorded_endpoint, confirm_pid_dead, confirm_control_plane_lost, &addr)?),
+        DaemonCommand::RecoverMissingLeaseState { lease_id, recorded_pid, recorded_endpoint, confirm_pid_dead: _deprecated_confirm_pid_dead, confirm_control_plane_lost: _deprecated_confirm_control_plane_lost, addr } => Ok((
+            DaemonOutput::RecoverMissingLeaseState(daemon::recover_missing_lease_state(&lease_id, recorded_pid, &recorded_endpoint, &addr)?),
             0,
         )),
         DaemonCommand::Serve { addr, startup_token } => {
@@ -379,7 +406,7 @@ impl AnalysisJobRunner for CommandAnalysisJobRunner {
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use std::io::{Read, Write};
     use std::net::TcpListener;
 
@@ -403,8 +430,14 @@ mod tests {
         ]).is_ok());
     }
 
+    /// `--confirm-workload-processes-absent` is the one confirmation on this
+    /// surface that is not ceremony. This command exists because the daemon died
+    /// before persisting any child identity, so the store holds no PID for the
+    /// named jobs and nothing in-process can observe whether their workloads are
+    /// still running. The attestation is the sole evidence, and it is persisted
+    /// as durable job provenance, so it must stay required.
     #[test]
-    fn exact_dead_lease_recovery_requires_both_operator_confirmations() {
+    fn exact_dead_lease_recovery_still_requires_the_workload_absence_attestation() {
         for args in [
             vec![
                 "homeboy",
@@ -431,12 +464,180 @@ mod tests {
                 panic!("expected daemon command");
             };
             let error = run(args, &crate::commands::GlobalArgs {})
-                .expect_err("missing operator confirmation is rejected before state access");
+                .expect_err("missing operator attestation is rejected before state access");
             assert!(
-                error.message.contains("confirm-pid-dead")
-                    || error.message.contains("confirm-workload-processes-absent")
+                error
+                    .message
+                    .contains("confirm-workload-processes-absent"),
+                "expected the workload attestation refusal, got {}",
+                error.message
+            );
+            assert!(
+                !error.message.contains("--confirm-pid-dead"),
+                "PID death is proven by the lifecycle controller, not asserted: {}",
+                error.message
             );
         }
+    }
+
+    /// PID death, control-plane loss, and daemon-owner absence are all proven by
+    /// the lifecycle controller before it mutates anything, so none of them may
+    /// be demanded as an operator assertion at the argument layer. Each command
+    /// below must get past argument validation without its former confirmation
+    /// and fail on real state instead.
+    #[test]
+    fn deprecated_confirmations_are_no_longer_demanded() {
+        with_isolated_home(|_| {
+            for (args, refused_flag) in [
+                (
+                    vec![
+                        "homeboy",
+                        "daemon",
+                        "adopt-orphan",
+                        "--lease-id",
+                        "lease-dead",
+                    ],
+                    "--confirm-pid-dead",
+                ),
+                (
+                    vec!["homeboy", "daemon", "reconcile-leaseless-orphans"],
+                    "--confirm-no-daemon-owner",
+                ),
+                (
+                    vec![
+                        "homeboy",
+                        "daemon",
+                        "recover-missing-lease-state",
+                        "--lease-id",
+                        "lease-dead",
+                        "--recorded-pid",
+                        "4242",
+                        "--recorded-endpoint",
+                        "127.0.0.1:4242",
+                    ],
+                    "--confirm-control-plane-lost",
+                ),
+            ] {
+                let cli = Cli::try_parse_from(args).expect("recovery command parses");
+                let Commands::Daemon(args) = cli.command else {
+                    panic!("expected daemon command");
+                };
+                let error = run(args, &crate::commands::GlobalArgs {})
+                    .expect_err("an isolated home has no recoverable daemon state");
+                assert!(
+                    !error.message.contains(refused_flag),
+                    "{refused_flag} must no longer gate recovery, got {}",
+                    error.message
+                );
+            }
+        });
+    }
+
+    /// The released spellings still appear in composed remote commands and in
+    /// operator runbooks. They must keep parsing for one release, and — because
+    /// controllers negotiate the lease-less recovery contract by reading
+    /// `--confirm-no-daemon-owner` out of the remote's `--help` output — they
+    /// must also stay visible in help rather than being hidden.
+    #[test]
+    fn deprecated_confirmations_remain_accepted_and_advertised() {
+        for args in [
+            vec![
+                "homeboy",
+                "daemon",
+                "adopt-orphan",
+                "--lease-id",
+                "lease-dead",
+                "--confirm-pid-dead",
+            ],
+            vec![
+                "homeboy",
+                "daemon",
+                "reconcile-leaseless-orphans",
+                "--confirm-no-daemon-owner",
+            ],
+            vec![
+                "homeboy",
+                "daemon",
+                "recover-missing-lease-state",
+                "--lease-id",
+                "lease-dead",
+                "--recorded-pid",
+                "4242",
+                "--recorded-endpoint",
+                "127.0.0.1:4242",
+                "--confirm-pid-dead",
+                "--confirm-control-plane-lost",
+            ],
+        ] {
+            assert!(
+                Cli::try_parse_from(args.clone()).is_ok(),
+                "released spelling must stay accepted: {args:?}"
+            );
+        }
+
+        let mut command = Cli::command();
+        let daemon = command
+            .find_subcommand_mut("daemon")
+            .expect("daemon subcommand");
+        let leaseless = daemon
+            .find_subcommand_mut("reconcile-leaseless-orphans")
+            .expect("reconcile-leaseless-orphans subcommand");
+        let help = leaseless.render_help().to_string();
+        assert!(
+            help.contains("--confirm-no-daemon-owner"),
+            "controllers negotiate this contract from remote help output: {help}"
+        );
+    }
+
+    /// Controllers negotiate the lease-less recovery contract by running this
+    /// subcommand's `--help` on the remote and matching *bare* long options:
+    /// `homeboy_lab_runner::connection::declared_long_options` only accepts an
+    /// option whose trailing tokens are value placeholders. Adding a doc comment
+    /// to `--confirm-no-daemon-owner` makes clap render help text after the flag
+    /// name, silently removing it from the advertised contract and making every
+    /// controller refuse remote lease-less recovery. This reproduces that
+    /// predicate against the real rendered help so the coupling cannot rot.
+    #[test]
+    fn leaseless_recovery_help_advertises_a_bare_confirmation_option() {
+        fn is_option_value_placeholder(token: &str) -> bool {
+            (token.starts_with('<') && token.ends_with('>'))
+                || (token.starts_with("[<") && token.ends_with(">]"))
+        }
+
+        let mut command = Cli::command();
+        let daemon = command
+            .find_subcommand_mut("daemon")
+            .expect("daemon subcommand");
+        let leaseless = daemon
+            .find_subcommand_mut("reconcile-leaseless-orphans")
+            .expect("reconcile-leaseless-orphans subcommand");
+        let help = leaseless.render_help().to_string();
+
+        let mut declared = Vec::new();
+        let mut in_options = false;
+        for line in help.lines() {
+            let trimmed = line.trim();
+            if line == trimmed && trimmed.ends_with(':') {
+                in_options = trimmed.eq_ignore_ascii_case("options:");
+                continue;
+            }
+            if !in_options || line == trimmed {
+                continue;
+            }
+            let mut tokens = trimmed.split_whitespace();
+            let Some(option) = tokens.next() else {
+                continue;
+            };
+            let option = option.trim_end_matches(',');
+            if option.starts_with("--") && tokens.all(is_option_value_placeholder) {
+                declared.push(option.to_string());
+            }
+        }
+
+        assert!(
+            declared.iter().any(|option| option == "--confirm-no-daemon-owner"),
+            "--confirm-no-daemon-owner must render as a bare long option or controllers refuse remote lease-less recovery; declared={declared:?} help={help}"
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -225,7 +225,7 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         adopt_orphan_lease: Option<String>,
 
-        /// Confirm the recorded PID for --adopt-orphan-lease is dead
+        /// Deprecated no-op retained for one release; the runner proves the recorded PID dead itself
         #[arg(long)]
         confirm_pid_dead: bool,
 
@@ -245,7 +245,7 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         reconcile_leaseless_orphans: bool,
 
-        /// Confirm the remote store has no daemon owner before lease-less reconciliation
+        /// Deprecated no-op retained for one release; the runner fails closed on owner-lock, process, and listener probes
         #[arg(long)]
         confirm_no_daemon_owner: bool,
 
@@ -261,7 +261,7 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         recorded_endpoint: Option<String>,
 
-        /// Confirm the remote daemon state record and endpoint are unavailable
+        /// Deprecated no-op retained for one release; the runner probes its own state record and endpoint
         #[arg(long)]
         confirm_control_plane_lost: bool,
     },

--- a/crates/homeboy-cli/src/commands/runner/registry.rs
+++ b/crates/homeboy-cli/src/commands/runner/registry.rs
@@ -215,11 +215,20 @@ pub(super) struct RunnerConnectInput {
     pub(super) confirm_control_plane_lost: bool,
 }
 
-pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOutput> {
+/// Argument-shape validation for `runner connect`, split out so it can be
+/// exercised without attempting an SSH connection.
+///
+/// The three `--confirm-*` inputs are deprecated no-ops: every fact they
+/// asserted is proven on the runner, under its own locks, before it mutates
+/// anything. They stay accepted for one release so composed repair commands and
+/// released operator muscle memory keep working. A confirmation supplied
+/// *without* its recovery mode still means the operator selected no recovery, so
+/// it is refused rather than silently ignored.
+pub(super) fn validate_connect_input(input: &RunnerConnectInput) -> homeboy::core::Result<()> {
     let RunnerConnectInput {
         reverse,
-        runner_id,
-        broker_url,
+        runner_id: _,
+        broker_url: _,
         adopt_orphan_lease,
         confirm_pid_dead,
         adopt_live_lease,
@@ -232,13 +241,38 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
         recorded_endpoint,
         confirm_control_plane_lost,
     } = input;
-    if adopt_orphan_lease.is_some() && !confirm_pid_dead {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "confirm_pid_dead",
-            "--adopt-orphan-lease requires --confirm-pid-dead",
-            None,
-            Some(vec!["Inspect `homeboy daemon status` on the runner before adopting its exact dead lease.".to_string()]),
-        ));
+    for (supplied, flag, selector, mode_selected) in [
+        (
+            *confirm_pid_dead,
+            "--confirm-pid-dead",
+            "--adopt-orphan-lease <lease> or --recover-missing-lease-state <lease>",
+            adopt_orphan_lease.is_some() || recover_missing_lease_state.is_some(),
+        ),
+        (
+            *confirm_no_daemon_owner,
+            "--confirm-no-daemon-owner",
+            "--reconcile-leaseless-orphans",
+            *reconcile_leaseless_orphans,
+        ),
+        (
+            *confirm_control_plane_lost,
+            "--confirm-control-plane-lost",
+            "--recover-missing-lease-state <lease>",
+            recover_missing_lease_state.is_some(),
+        ),
+    ] {
+        if supplied && !mode_selected {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "recovery_mode",
+                format!(
+                    "{flag} is a deprecated no-op and selects no recovery; pass {selector} to choose the recovery mode"
+                ),
+                None,
+                Some(vec![format!(
+                    "The runner proves this condition itself before mutating anything; {flag} can be dropped entirely."
+                )]),
+            ));
+        }
     }
     if adopt_live_lease.is_some() != expected_live_pid.is_some() {
         return Err(homeboy::core::Error::validation_invalid_argument(
@@ -248,7 +282,7 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
             None,
         ));
     }
-    if reverse && adopt_live_lease.is_some() {
+    if *reverse && adopt_live_lease.is_some() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "adopt_live_lease",
             "live daemon adoption only applies to direct SSH runner connections",
@@ -264,7 +298,7 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
             None,
         ));
     }
-    if reverse && adopt_orphan_lease.is_some() {
+    if *reverse && adopt_orphan_lease.is_some() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "adopt_orphan_lease",
             "orphan daemon adoption only applies to direct SSH runner connections",
@@ -272,15 +306,7 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
             None,
         ));
     }
-    if reconcile_leaseless_orphans != confirm_no_daemon_owner {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "reconcile_leaseless_orphans",
-            "--reconcile-leaseless-orphans requires --confirm-no-daemon-owner, and vice versa",
-            None,
-            None,
-        ));
-    }
-    if reverse && reconcile_leaseless_orphans {
+    if *reverse && *reconcile_leaseless_orphans {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "reconcile_leaseless_orphans",
             "lease-less recovery only applies to direct SSH runner connections",
@@ -289,7 +315,7 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
         ));
     }
     let recovery_mode_count = usize::from(adopt_orphan_lease.is_some())
-        + usize::from(reconcile_leaseless_orphans)
+        + usize::from(*reconcile_leaseless_orphans)
         + usize::from(recover_missing_lease_state.is_some())
         + usize::from(adopt_live_lease.is_some());
     if recovery_mode_count > 1 {
@@ -300,20 +326,20 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
             None,
         ));
     }
+    // `--recorded-pid` and `--recorded-endpoint` are evidence the runner cannot
+    // reconstruct once its state record is gone, so they remain required. The
+    // confirmations that used to be demanded alongside them are not.
     if recover_missing_lease_state.is_some()
-        && (!confirm_pid_dead
-            || !confirm_control_plane_lost
-            || recorded_pid.is_none()
-            || recorded_endpoint.is_none())
+        && (recorded_pid.is_none() || recorded_endpoint.is_none())
     {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "recover_missing_lease_state",
-            "--recover-missing-lease-state requires --recorded-pid, --recorded-endpoint, --confirm-pid-dead, and --confirm-control-plane-lost",
+            "--recover-missing-lease-state requires --recorded-pid and --recorded-endpoint",
             None,
             None,
         ));
     }
-    if reverse && recover_missing_lease_state.is_some() {
+    if *reverse && recover_missing_lease_state.is_some() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "recover_missing_lease_state",
             "state-loss recovery only applies to direct SSH runner connections",
@@ -321,6 +347,27 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
             None,
         ));
     }
+    Ok(())
+}
+
+pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOutput> {
+    validate_connect_input(&input)?;
+    let RunnerConnectInput {
+        reverse,
+        runner_id,
+        broker_url,
+        adopt_orphan_lease,
+        confirm_pid_dead: _deprecated_confirm_pid_dead,
+        adopt_live_lease,
+        expected_live_pid,
+        confirm_untracked_child_dead,
+        reconcile_leaseless_orphans,
+        confirm_no_daemon_owner: _deprecated_confirm_no_daemon_owner,
+        recover_missing_lease_state,
+        recorded_pid,
+        recorded_endpoint,
+        confirm_control_plane_lost: _deprecated_confirm_control_plane_lost,
+    } = input;
     let (report, exit_code) = if reverse {
         let runner_id = runner_id.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
@@ -392,7 +439,9 @@ pub(super) fn redact_runner_output_env(output: &mut RunnerOutput) {
 
 #[cfg(test)]
 mod tests {
-    use super::{connect, RunnerConnectInput};
+    // Argument validation is exercised through `validate_connect_input` rather
+    // than `connect` so no test can fall through to a real SSH attempt.
+    use super::{validate_connect_input, RunnerConnectInput};
 
     fn input() -> RunnerConnectInput {
         RunnerConnectInput {
@@ -414,78 +463,148 @@ mod tests {
     }
 
     #[test]
-    fn leaseless_recovery_requires_both_affirmative_flags() {
-        for (recover, confirm) in [(true, false), (false, true)] {
-            let error = connect(
-                "runner",
+    fn deprecated_confirmations_without_a_recovery_mode_are_refused() {
+        for (flag, input) in [
+            (
+                "--confirm-pid-dead",
                 RunnerConnectInput {
-                    reconcile_leaseless_orphans: recover,
-                    confirm_no_daemon_owner: confirm,
+                    confirm_pid_dead: true,
                     ..input()
                 },
-            )
-            .expect_err("partial confirmation must fail before connecting");
-            assert!(error
-                .message
-                .contains("--reconcile-leaseless-orphans requires"));
+            ),
+            (
+                "--confirm-no-daemon-owner",
+                RunnerConnectInput {
+                    confirm_no_daemon_owner: true,
+                    ..input()
+                },
+            ),
+            (
+                "--confirm-control-plane-lost",
+                RunnerConnectInput {
+                    confirm_control_plane_lost: true,
+                    ..input()
+                },
+            ),
+        ] {
+            let error = validate_connect_input(&input)
+                .expect_err("a confirmation that selects no recovery mode must fail");
+            assert!(
+                error.message.contains(flag),
+                "expected {flag} in {}",
+                error.message
+            );
+            assert!(
+                error.message.contains("deprecated no-op"),
+                "expected a deprecation notice in {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_modes_no_longer_demand_hand_confirmations() {
+        // The runner proves each of these facts itself, under its own locks,
+        // before it mutates anything: PID death for orphan adoption, owner
+        // absence for lease-less recovery, and state/endpoint loss for
+        // state-loss recovery. Selecting the mode alone must now validate.
+        for input in [
+            RunnerConnectInput {
+                adopt_orphan_lease: Some("lease-dead".to_string()),
+                ..input()
+            },
+            RunnerConnectInput {
+                reconcile_leaseless_orphans: true,
+                ..input()
+            },
+            RunnerConnectInput {
+                recover_missing_lease_state: Some("lease".to_string()),
+                recorded_pid: Some(42),
+                recorded_endpoint: Some("127.0.0.1:7421".to_string()),
+                ..input()
+            },
+        ] {
+            validate_connect_input(&input)
+                .expect("selecting a recovery mode must not require a confirmation flag");
+        }
+    }
+
+    #[test]
+    fn deprecated_confirmations_remain_accepted_alongside_their_mode() {
+        // The released spellings still appear in composed repair commands and in
+        // operator runbooks, so they must keep validating for one release.
+        for input in [
+            RunnerConnectInput {
+                adopt_orphan_lease: Some("lease-dead".to_string()),
+                confirm_pid_dead: true,
+                ..input()
+            },
+            RunnerConnectInput {
+                reconcile_leaseless_orphans: true,
+                confirm_no_daemon_owner: true,
+                ..input()
+            },
+            RunnerConnectInput {
+                recover_missing_lease_state: Some("lease".to_string()),
+                recorded_pid: Some(42),
+                recorded_endpoint: Some("127.0.0.1:7421".to_string()),
+                confirm_pid_dead: true,
+                confirm_control_plane_lost: true,
+                ..input()
+            },
+        ] {
+            validate_connect_input(&input)
+                .expect("released confirmation spellings stay accepted for one release");
         }
     }
 
     #[test]
     fn untracked_child_confirmation_requires_exact_orphan_lease_mode() {
-        let error = connect(
-            "runner",
-            RunnerConnectInput {
-                confirm_untracked_child_dead: vec![uuid::Uuid::new_v4()],
-                ..input()
-            },
-        )
+        let error = validate_connect_input(&RunnerConnectInput {
+            confirm_untracked_child_dead: vec![uuid::Uuid::new_v4()],
+            ..input()
+        })
         .expect_err("untracked child confirmation is only valid for exact adoption");
         assert!(error.message.contains("requires --adopt-orphan-lease"));
     }
 
     #[test]
     fn reverse_connections_cannot_reconcile_leaseless_jobs() {
-        let error = connect(
-            "runner",
-            RunnerConnectInput {
-                reverse: true,
-                reconcile_leaseless_orphans: true,
-                confirm_no_daemon_owner: true,
-                ..input()
-            },
-        )
+        let error = validate_connect_input(&RunnerConnectInput {
+            reverse: true,
+            reconcile_leaseless_orphans: true,
+            confirm_no_daemon_owner: true,
+            ..input()
+        })
         .expect_err("reverse recovery is unsupported");
         assert!(error.message.contains("direct SSH"));
     }
 
     #[test]
     fn reverse_connections_cannot_adopt_live_daemons() {
-        let error = connect(
-            "runner",
-            RunnerConnectInput {
-                reverse: true,
-                adopt_live_lease: Some("lease-live".to_string()),
-                expected_live_pid: Some(42),
-                ..input()
-            },
-        )
+        let error = validate_connect_input(&RunnerConnectInput {
+            reverse: true,
+            adopt_live_lease: Some("lease-live".to_string()),
+            expected_live_pid: Some(42),
+            ..input()
+        })
         .expect_err("reverse connections have no direct SSH daemon ownership");
         assert!(error.message.contains("direct SSH"));
     }
 
     #[test]
-    fn state_loss_recovery_requires_exact_evidence_and_confirmations() {
-        let error = connect(
-            "runner",
-            RunnerConnectInput {
-                recover_missing_lease_state: Some("lease".to_string()),
-                confirm_control_plane_lost: true,
-                ..input()
-            },
-        )
+    fn state_loss_recovery_still_requires_unreconstructable_evidence() {
+        // `--recorded-pid` and `--recorded-endpoint` are not confirmations: once
+        // the state record is gone the runner cannot recompute them, so they
+        // stay required while the confirmations alongside them do not.
+        let error = validate_connect_input(&RunnerConnectInput {
+            recover_missing_lease_state: Some("lease".to_string()),
+            confirm_control_plane_lost: true,
+            ..input()
+        })
         .expect_err("partial state-loss evidence must fail before connecting");
         assert!(error.message.contains("--recorded-pid"));
+        assert!(!error.message.contains("--confirm-control-plane-lost"));
     }
 
     #[test]
@@ -519,8 +638,8 @@ mod tests {
             },
         ];
         for input in conflicting_inputs {
-            let error =
-                connect("runner", input).expect_err("multiple recovery modes must fail before SSH");
+            let error = validate_connect_input(&input)
+                .expect_err("multiple recovery modes must fail before SSH");
             assert!(error.message.contains("mutually exclusive"));
         }
     }

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -199,22 +199,20 @@ pub struct ArtifactFetchOutcome {
 
 /// Recover active jobs from an absent daemon-state record only when an operator
 /// supplies the exact lease and dead PID recorded before control-plane loss.
+///
+/// PID death and control-plane loss are not operator assertions: both are
+/// established here. `validate_state_loss_preconditions` requires an absent
+/// state record, a `LeaseMissing` freshness code, an unreachable daemon, and a
+/// non-running recorded PID, and then `probe_recorded_daemon_endpoint` must
+/// fail to connect to the recorded endpoint. The former `--confirm-pid-dead`
+/// and `--confirm-control-plane-lost` gates ran *before* all of that and so
+/// could only reject correct operators.
 pub fn recover_missing_lease_state(
     lease_id: &str,
     recorded_pid: u32,
     recorded_endpoint: &str,
-    confirm_pid_dead: bool,
-    confirm_control_plane_lost: bool,
     addr: &str,
 ) -> Result<super::DaemonStateLossRecoveryResult> {
-    if !confirm_pid_dead || !confirm_control_plane_lost {
-        return Err(Error::validation_invalid_argument(
-            "recover_missing_lease_state",
-            "state-loss recovery requires --confirm-pid-dead and --confirm-control-plane-lost",
-            Some(lease_id.to_string()),
-            None,
-        ));
-    }
     parse_bind_addr(addr)?;
     let recorded_endpoint = parse_recorded_daemon_endpoint(recorded_endpoint)?;
     let _lock = acquire_daemon_operation_lock()?;
@@ -955,20 +953,17 @@ pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
 
 /// Replace one explicitly identified, provably dead daemon lease. The operation
 /// lock covers validation, durable-job reconciliation, and replacement startup.
+///
+/// The exact `lease_id` is the operator's destructive-action target; PID death
+/// is proven here rather than asserted. `adopt_orphaned_lease_with_operations`
+/// requires a `PidDead` freshness code, re-proves the recorded PID dead *under
+/// the owner lock* (so a reused PID cannot slip through), and refuses when any
+/// active child process survives.
 pub fn adopt_orphaned_lease(
     lease_id: &str,
-    confirm_pid_dead: bool,
     confirmed_no_pid_job_ids: &[uuid::Uuid],
     addr: &str,
 ) -> Result<DaemonOrphanAdoptionResult> {
-    if !confirm_pid_dead {
-        return Err(Error::validation_invalid_argument(
-            "confirm_pid_dead",
-            "orphan adoption requires explicit confirmation that the recorded daemon PID is dead",
-            None,
-            Some(vec!["Inspect `homeboy daemon status` and retry with --confirm-pid-dead only for the reported dead lease.".to_string()]),
-        ));
-    }
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     adopt_orphaned_lease_with_operations(
@@ -996,21 +991,26 @@ pub fn adopt_orphaned_lease(
 /// daemon lost jobs before it could persist a child identity. This never widens
 /// automatic adoption: the operator must name every active job and attest that
 /// workload processes were inspected and are absent.
+///
+/// `confirm_workload_processes_absent` is deliberately retained. This command
+/// exists precisely because the daemon died before persisting child identity,
+/// so the store holds no PID for the named jobs and nothing in this process can
+/// observe whether their workloads are still running. The store-side check only
+/// proves the *absence of recorded* child evidence — the very condition that
+/// makes the operator's inspection the sole source of truth — and it persists
+/// the attestation as durable provenance on every affected job.
+///
+/// PID death, by contrast, is proven here:
+/// `reconcile_dead_lease_orphans_with_operations` requires a `PidDead` freshness
+/// code, a non-running recorded PID, persisted unexpected-termination evidence
+/// bound to this exact lease and PID, and a second liveness proof taken under
+/// the owner lock. `--confirm-pid-dead` added nothing to that.
 pub fn reconcile_dead_lease_orphans(
     lease_id: &str,
     job_ids: &[uuid::Uuid],
-    confirm_pid_dead: bool,
     confirm_workload_processes_absent: bool,
     addr: &str,
 ) -> Result<DaemonExactOrphanRecoveryResult> {
-    if !confirm_pid_dead {
-        return Err(Error::validation_invalid_argument(
-            "confirm_pid_dead",
-            "exact dead-lease recovery requires --confirm-pid-dead",
-            None,
-            None,
-        ));
-    }
     if !confirm_workload_processes_absent {
         return Err(Error::validation_invalid_argument("confirm_workload_processes_absent", "exact dead-lease recovery requires --confirm-workload-processes-absent after inspecting workload processes", None, None));
     }
@@ -1296,18 +1296,13 @@ where
 /// typed `/jobs` view no longer accounts for their durable active jobs.
 /// Process and configured-listener probes are fail-closed because replacement
 /// is safe only after ownership has been ruled out.
-pub fn reconcile_leaseless_orphans(
-    confirm_no_daemon_owner: bool,
-    addr: &str,
-) -> Result<DaemonLeaselessRecoveryResult> {
-    if !confirm_no_daemon_owner {
-        return Err(Error::validation_invalid_argument(
-            "reconcile_leaseless_orphans",
-            "lease-less recovery requires --confirm-no-daemon-owner",
-            None,
-            None,
-        ));
-    }
+///
+/// Absence of a daemon owner is proven, not asserted: the daemon owner lock is
+/// refused while any daemon is live or starting, and `prove_no_daemon_owner`
+/// then fails closed on any related daemon process candidate or any reachable
+/// listener at `addr`. The former `--confirm-no-daemon-owner` gate ran ahead of
+/// both probes.
+pub fn reconcile_leaseless_orphans(addr: &str) -> Result<DaemonLeaselessRecoveryResult> {
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     let status = read_status()?;

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -67,20 +67,60 @@ all required evidence fields above, and never mutate jobs.
 
 For a proven unexpected daemon exit where exact active jobs have no persisted
 child identity, use the explicit all-active-job-set recovery command. It requires
-the dead lease, every active job ID, PID-death confirmation, and an operator
-attestation that workload processes were inspected and absent. It refuses a live
-or reused daemon PID, missing or mismatched unexpected-exit evidence, a held
-daemon owner lock, conflicting daemon-process evidence, child identities, or an
-omitted/extra/non-active job ID. Each named job receives durable typed
-daemon-loss failure evidence before the replacement daemon starts:
+the dead lease, every active job ID, and an operator attestation that workload
+processes were inspected and absent. It refuses a live or reused daemon PID,
+missing or mismatched unexpected-exit evidence, a held daemon owner lock,
+conflicting daemon-process evidence, child identities, or an omitted/extra/
+non-active job ID. Each named job receives durable typed daemon-loss failure
+evidence before the replacement daemon starts:
 
 ```sh
 homeboy daemon reconcile-dead-lease-orphans \
   --lease-id <exact-dead-lease> \
   --job-id <active-job-id> \
-  --confirm-pid-dead \
   --confirm-workload-processes-absent
 ```
+
+`--job-id` is not a transcription of `status` output. The store recomputes the
+active durable-job set and refuses any mismatch, so the repeated flag is a
+compare-and-swap over the exact destructive scope — omit a job, name an extra
+one, or race a change and the command aborts instead of terminalizing work you
+never saw. The named set is persisted with the reconciliation as
+`exact_active_job_set`.
+
+`--confirm-workload-processes-absent` stays required. This command exists
+precisely because the daemon died before persisting any child identity, so the
+store holds no PID for the named jobs and homeboy cannot observe whether their
+workloads are still running. The check that refuses jobs carrying recorded child
+evidence proves only that no such record exists — which is what makes the
+operator's inspection the sole source of truth. The attestation is written into
+every affected job's durable event data as
+`operator_confirmed_workload_processes_absent`.
+
+## Deprecated confirmation flags
+
+`--confirm-pid-dead`, `--confirm-no-daemon-owner`, and
+`--confirm-control-plane-lost` are deprecated no-ops, retained for one release
+and then removed. Every fact they asserted is established by the lifecycle
+controller *before* it mutates anything, and the old gates ran ahead of that
+verification, so they could only reject correct operators:
+
+| Deprecated flag | Commands | What proves it instead |
+| --- | --- | --- |
+| `--confirm-pid-dead` | `adopt-orphan`, `reconcile-dead-lease-orphans`, `recover-missing-lease-state` | A `pid_dead` freshness code, a non-running recorded PID, and — for adoption and dead-lease recovery — a second liveness proof taken under the daemon owner lock, so a reused PID cannot slip through. Dead-lease recovery additionally requires persisted unexpected-termination evidence bound to the exact lease and PID. |
+| `--confirm-no-daemon-owner` | `reconcile-leaseless-orphans` | The daemon owner lock (refused while any daemon is live or starting), a fail-closed daemon-process candidate probe, and a fail-closed listener probe at `--addr`. |
+| `--confirm-control-plane-lost` | `recover-missing-lease-state` | An absent daemon state record, a `lease_missing` freshness code, an unreachable daemon, active jobs, and a failed connect to the recorded endpoint. |
+
+Passing them still works and changes nothing. Drop them from scripts and
+runbooks. The same three flags are deprecated on `homeboy runner connect`, where
+supplying one *without* its recovery mode is still refused — a confirmation
+selects no recovery on its own.
+
+`--confirm-no-daemon-owner` intentionally remains visible, and with no help text,
+in `homeboy daemon reconcile-leaseless-orphans --help`: controllers negotiate the
+remote lease-less recovery contract by parsing bare long options out of that help
+output. Do not hide it or give it a doc comment before the flag is removed
+outright.
 
 ## VPS Reverse Runner Broker
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -346,14 +346,26 @@ plan is emitted; `--sync-mode` accepts `snapshot`, `snapshot-git`, or `git`.
 
 ```sh
 homeboy runner connect <runner-id>
-homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-pid-dead
-homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-pid-dead --confirm-untracked-child-dead <job-id>
-homeboy runner connect <runner-id> --reconcile-leaseless-orphans --confirm-no-daemon-owner
-homeboy daemon reconcile-leaseless-orphans --reconcile-leaseless-orphans --confirm-no-daemon-owner
-homeboy runner connect <runner-id> --recover-missing-lease-state <lease-id> --recorded-pid <pid> --recorded-endpoint <loopback-host:port> --confirm-pid-dead --confirm-control-plane-lost
-homeboy daemon recover-missing-lease-state --lease-id <lease-id> --recorded-pid <pid> --recorded-endpoint <loopback-host:port> --confirm-pid-dead --confirm-control-plane-lost
+homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id>
+homeboy runner connect <runner-id> --adopt-orphan-lease <lease-id> --confirm-untracked-child-dead <job-id>
+homeboy runner connect <runner-id> --reconcile-leaseless-orphans
+homeboy daemon reconcile-leaseless-orphans
+homeboy runner connect <runner-id> --recover-missing-lease-state <lease-id> --recorded-pid <pid> --recorded-endpoint <loopback-host:port>
+homeboy daemon recover-missing-lease-state --lease-id <lease-id> --recorded-pid <pid> --recorded-endpoint <loopback-host:port>
 homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>
 ```
+
+`--confirm-pid-dead`, `--confirm-no-daemon-owner`, and
+`--confirm-control-plane-lost` are deprecated no-ops on both surfaces; the runner
+proves each fact itself before mutating anything. See the deprecation table in
+[daemon.md](daemon.md). They remain accepted for one release, so released
+runbooks and composed repair commands keep working, but supplying one *without*
+its recovery mode is refused — a confirmation selects no recovery on its own.
+`--recorded-pid` and `--recorded-endpoint` are **not** confirmations: once a
+runner's state record is gone it cannot recompute them, so they stay required.
+`--confirm-untracked-child-dead <job-id>` also stays required where it applies —
+it names an exact job with no recorded child PID, which is evidence homeboy does
+not have.
 
 Starts a loopback-only Homeboy daemon on the runner and opens an SSH tunnel to
 it. This is the preferred Lab execution path because later `runner exec` calls
@@ -364,7 +376,8 @@ the runner ID, tunnel endpoint, daemon endpoint, and persisted session metadata.
 When a controller session was lost while a remote daemon lease is dead and its
 durable jobs remain, inspect the remote `homeboy daemon status` first. Recovery
 requires the explicit exact-lease form shown above. It verifies the recorded PID
-is dead. If a listed active job has neither a terminal result nor a recorded
+is dead itself — that is not an operator assertion. If a listed active job has
+neither a terminal result nor a recorded
 child PID, inspect its process identity independently and supply one repeated
 `--confirm-untracked-child-dead <job-id>` value for every such exact job. The
 confirmation is rejected for terminal, PID-backed, foreign-lease, or unknown

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -612,7 +612,7 @@ fn exact_lease_adoption_refuses_owner_lock_and_preserves_store() {
             .expect("owner lock")
             .expect("owner acquired");
 
-        let error = super::adopt_orphaned_lease("lease-dead", true, &[], "127.0.0.1:0")
+        let error = super::adopt_orphaned_lease("lease-dead", &[], "127.0.0.1:0")
             .expect_err("owner lock blocks adoption");
         assert!(error.message.contains("owner lock is held"));
         assert_eq!(std::fs::read(&jobs_path).expect("store bytes"), before);


### PR DESCRIPTION
## Verdict on the issue

Four of six are ceremony. **Two are load-bearing and I kept them.** The issue's row for `--confirm-workload-processes-absent` is **factually wrong** — details below.

| Flag | `file:line` | Fact already verified? | Decision |
|---|---|---|---|
| `--confirm-pid-dead` (`adopt-orphan`) | `commands/daemon.rs:39-41` → gate `control.rs:964-971` | **Yes.** `control.rs:1243-1250` requires a `PidDead` freshness code; `:1262-1269` re-proves the PID dead *under the owner lock* (reused-PID safe); `:1271-1282` aborts on any surviving child. | Deprecate |
| `--confirm-pid-dead` (`reconcile-dead-lease-orphans`) | `commands/daemon.rs:57-58` → gate `control.rs:1006-1013` | **Yes, strongest of the set.** `control.rs:1078-1087` (`PidDead` + `!pid_is_running`), `:1088-1107` (persisted `UnexpectedExit` evidence bound to this exact lease and PID, `!stop_requested`), `:1116-1123` (re-check under owner lock). | Deprecate |
| `--confirm-pid-dead` (`recover-missing-lease-state`) | `commands/daemon.rs:97-99` → gate `control.rs:210-217` | **Yes.** `control.rs:384-391` refuses a running recorded PID; re-checked on the replay path at `:230-237`. | Deprecate |
| `--confirm-no-daemon-owner` | `commands/daemon.rs:81-82` → gate `control.rs:1303-1310` | **Yes.** `control.rs:1334-1341` `try_acquire_daemon_owner_lock` (refused while any daemon is live *or starting*) + `:1342` `prove_no_daemon_owner` → `control.rs:1425-1462`: fail-closed process-candidate probe and fail-closed listener probe. | Deprecate |
| `--confirm-control-plane-lost` | `commands/daemon.rs:101-102` → gate `control.rs:210-217` | **Yes.** `validate_state_loss_preconditions` `control.rs:372-383` requires absent state record, `LeaseMissing`, unreachable daemon, active jobs; then `:392` `probe_recorded_daemon_endpoint` must fail to connect. | Deprecate |
| `--confirm-workload-processes-absent` | `commands/daemon.rs:59-60` → gate `control.rs:1014-1016` | **No — the issue is wrong.** See below. | **KEEP** |
| `--job-id` (repeated, required) | `commands/daemon.rs:55-56` → `reconciliation.rs:196-212` | **Not a fact assertion.** See below. | **KEEP** |

The decisive evidence for the four: **homeboy already ticks these boxes for itself.** `connection.rs:942-948` hardcodes `--confirm-pid-dead --confirm-control-plane-lost` into the remote state-loss command, `connection.rs:753-762` hardcodes `--confirm-no-daemon-owner`, and `remote_daemon.rs:1441` hardcodes `--confirm-pid-dead`. No operator is in the loop at any of those call sites. A confirmation a machine supplies unconditionally carries no operator intent.

## What I kept, and why

### `--confirm-workload-processes-absent` — the issue's premise is wrong

The issue says `reconciliation.rs:223-235` verifies it. It does not. That check **refuses jobs that *have* persisted `local_child.process` evidence** — it proves the store holds *no record of a child*. That is the exact condition under which homeboy cannot see the OS process at all.

This command exists *because* the daemon died before persisting child identity. The normal path (`reconcile_dead_daemon_lease_jobs` → `..._with_local_child_liveness`) can check liveness precisely because it has recorded PIDs, and it **blocks** identity-less jobs (`control_test.rs:1113`, `:1127`). `reconcile-dead-lease-orphans` is the escape hatch for those blocked jobs, and an unrecorded workload process can be alive with nothing in-process able to observe it. Both doc comments already said so (`control.rs:995-998`, `reconciliation.rs:172-176`).

It is also **recorded as provenance**: `reconciliation.rs:252` writes `"operator_confirmed_workload_processes_absent": true` into every affected job's durable event data, and `:243-246` sets the `stale_reason` accordingly. Auto-ticking it would make a persisted audit record false.

### `--job-id` — a compare-and-swap, not transcription

`reconciliation.rs:196-201` computes the active set and `:202-212` **aborts on any mismatch**. That is `--force-with-lease` semantics over a destructive scope: omit a job, name an extra one, or race a change and the command refuses rather than terminalizing work the operator never saw. It also scopes the workload attestation above — drop it and the attestation becomes unbounded — and it is persisted as `exact_active_job_set` (`:253`). It additionally enforces non-emptiness/uniqueness (`:187-194`) and per-job lease ownership (`:213-222`), which nothing else does.

## A contract hazard this nearly introduced

`connection.rs:784-813` `negotiate_leaseless_recovery_contract` runs `daemon reconcile-leaseless-orphans --help` **on the remote** and matches `--confirm-no-daemon-owner`. `declared_long_options` (`:815-837`) only accepts a long option whose trailing tokens are value placeholders — `recovery.rs:936-942` asserts that `--confirm-no-daemon-owner after inspection` does **not** count.

That flag currently has no doc comment. My first pass added one, which makes clap render help text on the same line — silently emptying the advertised contract and making **every controller refuse remote lease-less recovery between two current-version binaries.** It is reverted: the flag keeps a plain `//` comment, and `leaseless_recovery_help_advertises_a_bare_confirmation_option` reproduces the predicate against the real rendered help so the coupling cannot rot.

This is also why the flags are **deprecated rather than deleted**: deleting `--confirm-no-daemon-owner` breaks the same handshake from the other side.

## Deprecation convention

Followed `commands/worktree.rs:122` — flag retained, doc comment marks it deprecated for one release, behaviour becomes a no-op. I deliberately did **not** replicate the `deprecated_flag` output marker (`worktree.rs:170,278`): these payloads cross the SSH boundary and are deserialized field-for-field by the controller (`connection.rs:471,528`), so an output-shape change carries runtime risk I cannot validate on this host. Noted as a follow-up.

## Frame check (per #10511)

- The removed gates are **controller-local pre-flight checks** — they were never forwarded (`registry.rs` never passed them to `connect_with_orphan_adoption`). Nothing changes about which side verifies what.
- The **remote** command strings in `connection.rs:942-948`, `connection.rs:753-762`, `remote_daemon.rs:1441` still send the confirmations. Deliberate: a new controller must keep working against an older runner that still requires them. Deprecated-but-accepted makes the strings valid in both directions for the whole window.
- `daemon_repair.rs:45,54` composed `runner connect` strings are left alone for the same reason — they remain valid, and rewriting them would churn the assertions #10511 just landed. Follow-up once the flags are removed outright.

## Changes

- `control.rs`: `adopt_orphaned_lease`, `reconcile_dead_lease_orphans`, `reconcile_leaseless_orphans`, `recover_missing_lease_state` lose the confirmation parameters and their pre-verification gates; doc comments now state what proves each fact.
- `commands/daemon.rs`: flags stay parseable, no longer forwarded, marked deprecated.
- `commands/runner/{cli,registry}.rs`: same three flags deprecated. Argument validation extracted into `validate_connect_input` so tests cannot fall through to a real SSH attempt. A confirmation supplied *without* its recovery mode is still refused — it selects no recovery on its own. `--recorded-pid`/`--recorded-endpoint` stay required: a runner cannot recompute them once its state record is gone.
- `docs/commands/daemon.md`: deprecation table with the proving mechanism per flag, plus why the two survivors survive and why the bare-help-option coupling must not be broken. `docs/commands/runner.md` updated.

## Tests

- `exact_dead_lease_recovery_still_requires_the_workload_absence_attestation` — the attestation still gates; the PID confirmation no longer appears in the refusal.
- `deprecated_confirmations_are_no_longer_demanded` — each command clears argument validation without its former confirmation and fails on real state instead.
- `deprecated_confirmations_remain_accepted_and_advertised` — released spellings still parse; the contract flag stays visible in help.
- `leaseless_recovery_help_advertises_a_bare_confirmation_option` — the SSH contract-negotiation predicate, against real rendered help.
- `registry.rs`: `deprecated_confirmations_without_a_recovery_mode_are_refused`, `recovery_modes_no_longer_demand_hand_confirmations`, `deprecated_confirmations_remain_accepted_alongside_their_mode`, `state_loss_recovery_still_requires_unreconstructable_evidence`; existing tests repointed at the pure validator.

## Not verified locally

This host cannot run cargo (OOM risk), so **nothing here was compiled or executed** — only `cargo fmt`, which passes and confirms the tree parses. CI is the gate. Specifically unverified:

1. Compilation of all four changed crates' test targets.
2. That clap renders `--confirm-no-daemon-owner` bare in `--help` — the new test asserts it, but if clap's layout differs from my reading, **that test fails and is telling the truth**: treat a failure as a real contract break, not a bad assertion.
3. Runtime behaviour of `deprecated_confirmations_are_no_longer_demanded`, which calls `run()` under `with_isolated_home` and depends on each command's refusal message in an empty home.

Refs #10303
