### PR TITLE
fix(observation): hoist retention store, reap artifact-root scratch (#10284, #10285)

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -11,7 +11,8 @@ use homeboy::core::defaults;
 use homeboy::core::engine;
 use homeboy::core::engine::shell::quote_arg;
 use homeboy::core::observation::runs_service::{
-    self, PersistedArtifactCleanupOptions, RunnerDownloadCleanupOptions,
+    self, OrphanedArtifactBytesCleanupOptions, PersistedArtifactCleanupOptions,
+    RunnerDownloadCleanupOptions,
 };
 use homeboy::core::resource_cleanup_intent::ResourceCleanupIntent;
 use homeboy::core::worktree::{self, WorktreeCleanupOptions, WorktreeCleanupOutput};
@@ -69,6 +70,7 @@ pub enum CleanupCategoryArg {
     WorktreeProviders,
     TerminalRuns,
     PersistedRunArtifacts,
+    OrphanedArtifactBytes,
     RunnerDownloads,
     RemoteLabWorkspaces,
     RuntimeTmp,
@@ -639,6 +641,19 @@ const TERMINAL_RUNS_METADATA: CleanupInventoryCategoryMetadata = CleanupInventor
     apply_command: "homeboy runs retention --apply",
 };
 
+/// Crash residue under the artifact root that no database row can describe.
+/// This is the only artifact-root cleanup that is not row-driven, so it is
+/// scoped to the two name families a single private constructor owns rather
+/// than to "anything without a row" — see
+/// `runs_service::orphaned_artifact_bytes` for why a row join is unsafe here.
+const ORPHANED_ARTIFACT_BYTES_METADATA: CleanupInventoryCategoryMetadata =
+    CleanupInventoryCategoryMetadata {
+        category: "orphaned_artifact_bytes",
+        include_arg: "orphaned-artifact-bytes",
+        dry_run_command: "homeboy cleanup --include orphaned-artifact-bytes",
+        apply_command: "homeboy cleanup --include orphaned-artifact-bytes --apply",
+    };
+
 pub(crate) const RUNNER_DOWNLOADS_METADATA: CleanupInventoryCategoryMetadata =
     CleanupInventoryCategoryMetadata {
         category: "runner_downloads",
@@ -793,6 +808,24 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             ));
         };
         categories.push(persisted_artifacts_category(persisted, resources, apply)?);
+    }
+
+    if selected.includes(CleanupCategoryArg::OrphanedArtifactBytes) {
+        let output =
+            runs_service::cleanup_orphaned_artifact_bytes(OrphanedArtifactBytesCleanupOptions {
+                apply,
+                limit: usize::try_from(limit).unwrap_or(usize::MAX),
+            })?;
+        categories.push(category_from_output(
+            ORPHANED_ARTIFACT_BYTES_METADATA,
+            apply,
+            output.planned_count,
+            output.removed_count,
+            output.skipped_count,
+            output.planned_size_bytes,
+            output.removed_size_bytes,
+            output,
+        )?);
     }
 
     if selected.includes(CleanupCategoryArg::RunnerDownloads) {
@@ -2040,6 +2073,13 @@ mod tests {
                 "persisted-run-artifacts",
                 "homeboy runs artifact cleanup-persisted",
                 "homeboy runs artifact cleanup-persisted --apply",
+            ),
+            (
+                ORPHANED_ARTIFACT_BYTES_METADATA,
+                "orphaned_artifact_bytes",
+                "orphaned-artifact-bytes",
+                "homeboy cleanup --include orphaned-artifact-bytes",
+                "homeboy cleanup --include orphaned-artifact-bytes --apply",
             ),
             (
                 RUNNER_DOWNLOADS_METADATA,

--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -173,6 +173,7 @@ pub enum ArtifactStorage {
 
 mod artifact_links;
 mod artifact_resolve;
+mod orphaned_artifact_bytes;
 mod persisted_cleanup;
 mod run_lookup;
 mod runner_downloads;
@@ -180,6 +181,7 @@ pub mod runner_evidence;
 
 pub use artifact_links::*;
 pub use artifact_resolve::*;
+pub use orphaned_artifact_bytes::*;
 pub use persisted_cleanup::*;
 pub use run_lookup::*;
 pub use runner_downloads::*;
@@ -204,24 +206,22 @@ pub fn retain_terminal_runs(
         ));
     }
     let finished_before = (Utc::now() - Duration::days(options.older_than_days)).to_rfc3339();
+    // The store and artifact root are resolved once for the whole sweep. Both
+    // used to be re-derived inside each per-run plan call, which meant one
+    // connection open plus a full migration ladder per candidate run.
     let mut store = ObservationStore::open_initialized()?;
+    let artifact_root = crate::artifacts::root()?;
     let candidate_run_ids = store.terminal_run_ids_before(&finished_before, options.limit)?;
     let mut artifact_cleanup = Vec::new();
     let mut lifecycle_directories = Vec::new();
     let mut removable_run_ids = Vec::new();
     let mut skipped_run_ids = Vec::new();
     for run_id in &candidate_run_ids {
-        let artifacts = cleanup_persisted_artifacts(PersistedArtifactCleanupOptions {
-            apply: false,
-            older_than_days: 0,
-            run_id: Some(run_id.clone()),
-            kind: None,
-            artifact_type: None,
-            run_kind: None,
-            component_id: None,
-            limit: 10_000,
-            terminal_only: true,
-        })?;
+        let artifacts = cleanup_persisted_artifacts_with_store(
+            &store,
+            &artifact_root,
+            terminal_run_artifact_plan_options(run_id),
+        )?;
         let lifecycle_directory = terminal_run_lifecycle_directory(&store, run_id)?;
         let blocked = artifacts
             .rows
@@ -237,21 +237,25 @@ pub fn retain_terminal_runs(
             }
         }
     }
+    let mut removed_run_count = 0;
     if options.apply {
         // Revalidate and remove artifact bytes before deleting any provenance.
         // A blocked resource leaves the terminal run record and lifecycle root intact.
+        //
+        // This second plan pass is *not* redundant with the loop above: that
+        // loop walks every candidate before any deletion happens, so the
+        // earliest plans are already stale by the time apply begins. Re-reading
+        // each run's classification immediately before deleting its bytes is
+        // the only thing that catches a run whose artifacts became unsafe (or
+        // whose owning run left a terminal state) during the planning window.
+        // What was redundant, and is now gone, is reopening the store and
+        // re-resolving the artifact root on every one of these calls.
         for run_id in &removable_run_ids {
-            let artifacts = cleanup_persisted_artifacts(PersistedArtifactCleanupOptions {
-                apply: false,
-                older_than_days: 0,
-                run_id: Some(run_id.clone()),
-                kind: None,
-                artifact_type: None,
-                run_kind: None,
-                component_id: None,
-                limit: 10_000,
-                terminal_only: true,
-            })?;
+            let artifacts = cleanup_persisted_artifacts_with_store(
+                &store,
+                &artifact_root,
+                terminal_run_artifact_plan_options(run_id),
+            )?;
             if artifacts
                 .rows
                 .iter()
@@ -262,7 +266,6 @@ pub fn retain_terminal_runs(
             }
             let records = store.list_artifacts(run_id)?;
             let run = store.get_run(run_id)?;
-            let artifact_root = crate::artifacts::root()?;
             for row in artifacts.rows.iter().filter(|row| row.action == "remove") {
                 let artifact = records
                     .iter()
@@ -310,22 +313,37 @@ pub fn retain_terminal_runs(
             }
         }
         store.delete_terminal_runs(&deleted)?;
+        // Count what was actually deleted. Subtracting `skipped_run_ids` from
+        // `removable_run_ids` under-reported by every run the planning loop had
+        // already blocked, because those runs are in `skipped_run_ids` but were
+        // never in `removable_run_ids` to begin with.
+        removed_run_count = deleted.len();
     }
     Ok(TerminalRunRetentionOutcome {
         dry_run: !options.apply,
         older_than_days: options.older_than_days,
-        removed_run_count: if options.apply {
-            removable_run_ids
-                .len()
-                .saturating_sub(skipped_run_ids.len())
-        } else {
-            0
-        },
+        removed_run_count,
         candidate_run_ids,
         artifact_cleanup,
         lifecycle_directories,
         skipped_run_ids,
     })
+}
+
+/// Per-run artifact plan used by terminal retention. Always a dry-run plan:
+/// retention removes bytes itself and releases the rows with the owning run.
+fn terminal_run_artifact_plan_options(run_id: &str) -> PersistedArtifactCleanupOptions {
+    PersistedArtifactCleanupOptions {
+        apply: false,
+        older_than_days: 0,
+        run_id: Some(run_id.to_string()),
+        kind: None,
+        artifact_type: None,
+        run_kind: None,
+        component_id: None,
+        limit: 10_000,
+        terminal_only: true,
+    }
 }
 
 fn terminal_run_lifecycle_directory(

--- a/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes.rs
+++ b/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes.rs
@@ -1,0 +1,483 @@
+//! Reap crash-orphaned scratch bytes under the artifact root.
+//!
+//! Every other artifact-root cleanup surface is database-row driven, so bytes
+//! that were written before their row existed are structurally invisible to
+//! them. Two artifact-root path families are created *outside* any durable
+//! journal and are only reclaimed by an in-process cleanup branch, which means
+//! SIGKILL/OOM leaks them permanently:
+//!
+//! * `<root>/<run_id>/.artifact-<uuid>.staging` — the staging sibling written
+//!   by `staged_artifact_path` before a file artifact is hard-linked into
+//!   place.
+//! * `<root>/_scratch/patch-<label>-<uuid>/` — the full working-tree baseline
+//!   copy taken by daemon patch capture, reclaimed only by `impl Drop`.
+//!
+//! # Why this is not a generic orphan walk
+//!
+//! Issue #10284 proposes walking the artifact root and removing anything with
+//! no matching `artifacts.path` row. That is not safe here, for two reasons
+//! that are both load-bearing:
+//!
+//! 1. **The artifact root is a shared namespace, not an artifact table
+//!    projection.** At least ten subsystems own top-level subtrees under it
+//!    that are never registered as artifact rows at those paths — `runner/`,
+//!    `runner-attach/`, `runner-exec-attach/`, `agent-task/`,
+//!    `agent-task-loop-controller/`, `controller-scratch-recovery/`,
+//!    `recovered-runner-artifacts/`, `executor-finalized/`,
+//!    `preview-consumer/`, and `_scratch/`. A row-join reaper would classify
+//!    all of them as orphans and delete live state.
+//! 2. **Artifact bytes are created before their row exists, by design.** The
+//!    window between `copy_artifact_file`/`copy_artifact_directory` and the
+//!    INSERT is exactly when a row-join reaper would see an "orphan". Deleting
+//!    there corrupts a publication that is actively succeeding.
+//!
+//! So the ownership proof used here is *name shape*, not row absence: both
+//! reaped families are produced by a single private constructor whose name
+//! format no other writer emits. Age is then required on top of that, to cover
+//! the in-flight window. A missing row proves nothing about these paths — they
+//! never get one — so the database is deliberately not consulted at all.
+//!
+//! # Size is advisory and never gates removal
+//!
+//! `bounded_directory_size` in the lab workspace pruner shells out to `du -sk`
+//! and feeds `size.is_some()` into the liveness verdict
+//! (`workspace/sync/mod.rs:2602-2604`, `:3457`). When `du` failed, size came
+//! back `None`, liveness degraded to `"unknown"`, and prune silently became a
+//! no-op. That couples an advisory measurement to a deletion decision, in the
+//! direction that quietly disables the feature.
+//!
+//! Here the removal decision is a pure function of (name shape, entry type,
+//! age, symlink-freedom, containment). Size is measured best-effort purely for
+//! reporting: a failed measurement reports `size_measured: false` and still
+//! removes, because it was never evidence of anything.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use serde::Serialize;
+use uuid::Uuid;
+
+use super::persisted_cleanup::{path_is_within_root, symlink_metadata_if_exists};
+use crate::{Error, Result};
+
+/// Minimum age before a name-owned scratch path is treated as crash residue.
+///
+/// This is the only liveness signal these paths have — nothing journals them,
+/// so there is no lease to consult and no owning process to probe. The floor is
+/// deliberately far larger than any plausible in-process window (a patch-capture
+/// baseline copy of a large working tree, or a staging copy of a multi-gigabyte
+/// artifact) and is intentionally not operator-overridable.
+pub const ORPHANED_ARTIFACT_BYTES_MIN_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Top-level artifact-root directory owned by daemon patch capture.
+const PATCH_CAPTURE_SCRATCH_DIR: &str = "_scratch";
+/// Name prefix emitted by `patch_capture::create_scratch_dir`.
+const PATCH_CAPTURE_SCRATCH_PREFIX: &str = "patch-";
+/// Name affixes emitted by `store::artifacts::staged_artifact_path`.
+const ARTIFACT_STAGING_PREFIX: &str = ".artifact-";
+const ARTIFACT_STAGING_SUFFIX: &str = ".staging";
+
+/// Owner of a reaped path, reported so operators can attribute the leak.
+const OWNER_ARTIFACT_STAGING: &str = "artifact-staging";
+const OWNER_PATCH_CAPTURE_SCRATCH: &str = "patch-capture-scratch";
+
+#[derive(Debug, Clone)]
+pub struct OrphanedArtifactBytesCleanupOptions {
+    pub apply: bool,
+    /// Maximum number of candidate paths inspected. Bounds a single sweep the
+    /// same way the persisted-artifact cleanup limit does.
+    pub limit: usize,
+}
+
+impl Default for OrphanedArtifactBytesCleanupOptions {
+    fn default() -> Self {
+        Self {
+            apply: false,
+            limit: 1000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanedArtifactBytesCleanupOutcome {
+    pub dry_run: bool,
+    pub artifact_root: PathBuf,
+    pub min_age_seconds: u64,
+    pub inspected_count: usize,
+    pub planned_count: usize,
+    pub removed_count: usize,
+    pub skipped_count: usize,
+    pub planned_size_bytes: u64,
+    pub removed_size_bytes: u64,
+    /// True when the sweep stopped at `limit` with candidates still unread.
+    pub truncated: bool,
+    pub rows: Vec<OrphanedArtifactBytesRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanedArtifactBytesRow {
+    pub path: String,
+    /// Which private constructor owns this name shape.
+    pub owner: &'static str,
+    #[serde(rename = "type")]
+    pub entry_type: &'static str,
+    pub age_seconds: u64,
+    pub size_bytes: u64,
+    /// Size is reported for operators, never used to decide removal. `false`
+    /// means the measurement failed and `size_bytes` is a floor, not a fact.
+    pub size_measured: bool,
+    pub action: String,
+    pub reason: String,
+}
+
+/// Reap crash-orphaned artifact-root scratch under the configured root.
+pub fn cleanup_orphaned_artifact_bytes(
+    options: OrphanedArtifactBytesCleanupOptions,
+) -> Result<OrphanedArtifactBytesCleanupOutcome> {
+    let artifact_root = crate::artifacts::root()?;
+    cleanup_orphaned_artifact_bytes_in(&artifact_root, options)
+}
+
+/// Reap crash-orphaned scratch under a caller-provided artifact root.
+pub fn cleanup_orphaned_artifact_bytes_in(
+    artifact_root: &Path,
+    options: OrphanedArtifactBytesCleanupOptions,
+) -> Result<OrphanedArtifactBytesCleanupOutcome> {
+    sweep(
+        artifact_root,
+        options,
+        ORPHANED_ARTIFACT_BYTES_MIN_AGE,
+        SystemTime::now(),
+    )
+}
+
+/// The sweep with its age floor and clock supplied explicitly. Both are fixed
+/// on every production path; tests move them so the age comparison, the
+/// future-mtime fail-closed branch, and the removal branch are all reachable
+/// without rewriting filesystem timestamps.
+fn sweep(
+    artifact_root: &Path,
+    options: OrphanedArtifactBytesCleanupOptions,
+    min_age: Duration,
+    now: SystemTime,
+) -> Result<OrphanedArtifactBytesCleanupOutcome> {
+    let mut outcome = OrphanedArtifactBytesCleanupOutcome {
+        dry_run: !options.apply,
+        artifact_root: artifact_root.to_path_buf(),
+        min_age_seconds: min_age.as_secs(),
+        inspected_count: 0,
+        planned_count: 0,
+        removed_count: 0,
+        skipped_count: 0,
+        planned_size_bytes: 0,
+        removed_size_bytes: 0,
+        truncated: false,
+        rows: Vec::new(),
+    };
+
+    for top_level in sorted_child_names(artifact_root)? {
+        let container = artifact_root.join(&top_level);
+        // Only descend one level. Deeper trees belong to subsystems that own
+        // their own lifecycle; this sweep must never walk into them.
+        let Some(container_metadata) = symlink_metadata_if_exists(&container)? else {
+            continue;
+        };
+        if !container_metadata.is_dir() || container_metadata.file_type().is_symlink() {
+            continue;
+        }
+        // An unreadable subtree is skipped, not fatal: one bad directory must
+        // not fail the whole cleanup inventory. Skipping can only under-reap.
+        let Ok(names) = sorted_child_names(&container) else {
+            continue;
+        };
+        for name in names {
+            let path = container.join(&name);
+            let Some(metadata) = symlink_metadata_if_exists(&path)? else {
+                continue;
+            };
+            let Some(candidate) = classify_candidate(&top_level, &name, &metadata) else {
+                continue;
+            };
+            // Bound only on real candidates, so `truncated` means "candidates
+            // remain", not "the root has many unrelated entries".
+            if outcome.inspected_count >= options.limit {
+                outcome.truncated = true;
+                return Ok(outcome);
+            }
+            outcome.inspected_count += 1;
+            sweep_candidate(
+                &mut outcome,
+                artifact_root,
+                &path,
+                candidate,
+                &metadata,
+                min_age,
+                now,
+            );
+        }
+    }
+
+    Ok(outcome)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Candidate {
+    owner: &'static str,
+    entry_type: &'static str,
+}
+
+/// Decide whether a depth-two artifact-root entry is one of the two name
+/// families this sweep owns. Everything else returns `None` and is never
+/// inspected, reported, or removed.
+fn classify_candidate(
+    container_name: &str,
+    entry_name: &str,
+    metadata: &fs::Metadata,
+) -> Option<Candidate> {
+    if metadata.file_type().is_symlink() {
+        return None;
+    }
+    if metadata.is_file() && is_artifact_staging_name(entry_name) {
+        return Some(Candidate {
+            owner: OWNER_ARTIFACT_STAGING,
+            entry_type: "file",
+        });
+    }
+    if metadata.is_dir()
+        && container_name == PATCH_CAPTURE_SCRATCH_DIR
+        && is_patch_capture_scratch_name(entry_name)
+    {
+        return Some(Candidate {
+            owner: OWNER_PATCH_CAPTURE_SCRATCH,
+            entry_type: "directory",
+        });
+    }
+    None
+}
+
+fn sweep_candidate(
+    outcome: &mut OrphanedArtifactBytesCleanupOutcome,
+    artifact_root: &Path,
+    path: &Path,
+    candidate: Candidate,
+    metadata: &fs::Metadata,
+    min_age: Duration,
+    now: SystemTime,
+) {
+    // Fail closed on every uncertainty below: an unreadable or future-dated
+    // mtime, or a path that does not resolve inside the artifact root, is
+    // reported and kept rather than guessed to be residue.
+    let Some(age) = entry_age(metadata, now) else {
+        outcome.skip(
+            path,
+            candidate,
+            0,
+            "modification time is unreadable or in the future",
+        );
+        return;
+    };
+    if age < min_age {
+        outcome.skip(
+            path,
+            candidate,
+            age.as_secs(),
+            "younger than the crash-residue age floor",
+        );
+        return;
+    }
+    if !path_is_within_root(path, artifact_root) {
+        outcome.skip(
+            path,
+            candidate,
+            age.as_secs(),
+            "path does not resolve inside the artifact root",
+        );
+        return;
+    }
+
+    // Advisory only. A `None` here changes the report, never the verdict.
+    let measured = best_effort_size(path, metadata);
+    let size_bytes = measured.unwrap_or(0);
+    outcome.planned_count += 1;
+    outcome.planned_size_bytes += size_bytes;
+
+    if outcome.dry_run {
+        outcome.rows.push(row(
+            path,
+            candidate,
+            age.as_secs(),
+            size_bytes,
+            measured.is_some(),
+            "remove",
+            "crash-orphaned scratch owned by a single private constructor",
+        ));
+        return;
+    }
+
+    match remove_candidate(path, candidate) {
+        Ok(()) => {
+            outcome.removed_count += 1;
+            outcome.removed_size_bytes += size_bytes;
+            outcome.rows.push(row(
+                path,
+                candidate,
+                age.as_secs(),
+                size_bytes,
+                measured.is_some(),
+                "removed",
+                "crash-orphaned scratch owned by a single private constructor",
+            ));
+        }
+        Err(error) => {
+            // One unremovable path must not abort the sweep or fail the
+            // command; it is reported so the leak stays visible.
+            outcome.planned_count -= 1;
+            outcome.planned_size_bytes -= size_bytes;
+            outcome.skipped_count += 1;
+            outcome.rows.push(row(
+                path,
+                candidate,
+                age.as_secs(),
+                size_bytes,
+                measured.is_some(),
+                "skip",
+                &format!("removal failed: {error}"),
+            ));
+        }
+    }
+}
+
+impl OrphanedArtifactBytesCleanupOutcome {
+    /// Record a retained candidate. Size is not measured for skipped paths:
+    /// it would report a number that no decision consumed.
+    fn skip(&mut self, path: &Path, candidate: Candidate, age_seconds: u64, reason: &str) {
+        self.skipped_count += 1;
+        self.rows
+            .push(row(path, candidate, age_seconds, 0, false, "skip", reason));
+    }
+}
+
+fn remove_candidate(path: &Path, candidate: Candidate) -> io::Result<()> {
+    if candidate.entry_type == "directory" {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
+fn row(
+    path: &Path,
+    candidate: Candidate,
+    age_seconds: u64,
+    size_bytes: u64,
+    size_measured: bool,
+    action: &str,
+    reason: &str,
+) -> OrphanedArtifactBytesRow {
+    OrphanedArtifactBytesRow {
+        path: path.display().to_string(),
+        owner: candidate.owner,
+        entry_type: candidate.entry_type,
+        age_seconds,
+        size_bytes,
+        size_measured,
+        action: action.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+/// `.artifact-<uuid>.staging`, the exact shape `staged_artifact_path` emits.
+/// The UUID must parse: a prefix match alone would also accept operator files.
+fn is_artifact_staging_name(name: &str) -> bool {
+    name.strip_prefix(ARTIFACT_STAGING_PREFIX)
+        .and_then(|rest| rest.strip_suffix(ARTIFACT_STAGING_SUFFIX))
+        .is_some_and(|id| Uuid::parse_str(id).is_ok())
+}
+
+/// `patch-<label>-<uuid>`, the exact shape `patch_capture::create_scratch_dir`
+/// emits. The label is not pinned to today's `baseline`/`after` values, but the
+/// trailing UUID is required, so a hand-made `_scratch/patch-notes` is ignored.
+fn is_patch_capture_scratch_name(name: &str) -> bool {
+    // A hyphenated UUID contains hyphens, so the label boundary is found by
+    // fixed width from the end, not by splitting on the last separator.
+    const HYPHENATED_UUID_LEN: usize = 36;
+    let Some(rest) = name.strip_prefix(PATCH_CAPTURE_SCRATCH_PREFIX) else {
+        return false;
+    };
+    if rest.len() <= HYPHENATED_UUID_LEN + 1 {
+        return false;
+    }
+    let id_start = rest.len() - HYPHENATED_UUID_LEN;
+    if !rest.is_char_boundary(id_start) || !rest.is_char_boundary(id_start - 1) {
+        return false;
+    }
+    if rest.as_bytes()[id_start - 1] != b'-' {
+        return false;
+    }
+    Uuid::parse_str(&rest[id_start..]).is_ok()
+}
+
+fn entry_age(metadata: &fs::Metadata, now: SystemTime) -> Option<Duration> {
+    // `duration_since` errors on a future mtime, which is exactly the clock-skew
+    // case that must not be rounded down to "old enough".
+    now.duration_since(metadata.modified().ok()?).ok()
+}
+
+/// Sorted child names, so a bounded sweep is deterministic across runs. A
+/// missing directory is an empty listing, not an error.
+fn sorted_child_names(path: &Path) -> Result<Vec<String>> {
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(format!("read artifact root {}", path.display())),
+            ))
+        }
+    };
+    let mut names = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read artifact root {}", path.display())),
+            )
+        })?;
+        names.push(entry.file_name().to_string_lossy().to_string());
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// Apparent size for reporting. Returns `None` on any read failure rather than
+/// a partial total, so the report can say the number is untrustworthy instead
+/// of quietly presenting a floor as a measurement. Never follows symlinks.
+fn best_effort_size(path: &Path, metadata: &fs::Metadata) -> Option<u64> {
+    const MAX_DEPTH: usize = 64;
+    fn walk(path: &Path, metadata: &fs::Metadata, depth: usize) -> Option<u64> {
+        if metadata.file_type().is_symlink() {
+            return Some(0);
+        }
+        if !metadata.is_dir() {
+            return Some(metadata.len());
+        }
+        if depth == 0 {
+            return None;
+        }
+        let mut total = metadata.len();
+        for entry in fs::read_dir(path).ok()? {
+            let entry = entry.ok()?;
+            let child = entry.path();
+            let child_metadata = fs::symlink_metadata(&child).ok()?;
+            total = total.checked_add(walk(&child, &child_metadata, depth - 1)?)?;
+        }
+        Some(total)
+    }
+    walk(path, metadata, MAX_DEPTH)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes/tests.rs
@@ -1,0 +1,318 @@
+use super::*;
+
+/// A clock far enough ahead that everything created during the test reads as
+/// crash residue against the real age floor.
+fn clock_past_the_floor() -> SystemTime {
+    SystemTime::now() + ORPHANED_ARTIFACT_BYTES_MIN_AGE + Duration::from_secs(3600)
+}
+
+fn staging_name() -> String {
+    format!(".artifact-{}.staging", Uuid::new_v4())
+}
+
+fn scratch_name(label: &str) -> String {
+    format!("patch-{label}-{}", Uuid::new_v4())
+}
+
+fn options(apply: bool) -> OrphanedArtifactBytesCleanupOptions {
+    OrphanedArtifactBytesCleanupOptions {
+        apply,
+        ..OrphanedArtifactBytesCleanupOptions::default()
+    }
+}
+
+/// Sweep with the production age floor and a clock that has moved past it.
+fn aged_sweep(root: &Path, apply: bool) -> OrphanedArtifactBytesCleanupOutcome {
+    sweep(
+        root,
+        options(apply),
+        ORPHANED_ARTIFACT_BYTES_MIN_AGE,
+        clock_past_the_floor(),
+    )
+    .expect("sweep")
+}
+
+#[test]
+fn missing_artifact_root_is_an_empty_sweep_not_an_error() {
+    let home = tempfile::tempdir().expect("home");
+    let outcome = aged_sweep(&home.path().join("absent"), true);
+    assert_eq!(outcome.inspected_count, 0);
+    assert_eq!(outcome.removed_count, 0);
+    assert!(outcome.rows.is_empty());
+}
+
+#[test]
+fn aged_staging_and_scratch_are_reaped_on_apply() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    let run_dir = root.join("run-1");
+    fs::create_dir_all(&run_dir).expect("run dir");
+    let staging = run_dir.join(staging_name());
+    fs::write(&staging, b"staged bytes").expect("staging bytes");
+
+    let scratch = root.join("_scratch").join(scratch_name("baseline"));
+    fs::create_dir_all(scratch.join("nested")).expect("scratch tree");
+    fs::write(scratch.join("nested/file"), b"baseline").expect("scratch bytes");
+
+    let dry = aged_sweep(root, false);
+    assert!(dry.dry_run);
+    assert_eq!(dry.inspected_count, 2);
+    assert_eq!(dry.planned_count, 2);
+    assert_eq!(dry.removed_count, 0);
+    assert!(dry.planned_size_bytes > 0);
+    assert!(staging.exists(), "dry run must not delete");
+    assert!(scratch.exists(), "dry run must not delete");
+    assert!(dry.rows.iter().all(|row| row.action == "remove"));
+
+    let applied = aged_sweep(root, true);
+    assert!(!applied.dry_run);
+    assert_eq!(applied.removed_count, 2);
+    assert_eq!(applied.skipped_count, 0);
+    assert!(!staging.exists());
+    assert!(!scratch.exists());
+    assert!(applied.rows.iter().all(|row| row.action == "removed"));
+    assert!(
+        applied.rows.iter().all(|row| row.size_measured),
+        "local fixtures are measurable"
+    );
+    // Both owners are attributed so an operator can see which constructor leaked.
+    let owners = applied
+        .rows
+        .iter()
+        .map(|row| row.owner)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        owners,
+        ["artifact-staging", "patch-capture-scratch"]
+            .into_iter()
+            .collect()
+    );
+}
+
+#[test]
+fn young_scratch_is_never_reaped() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    let run_dir = root.join("run-1");
+    fs::create_dir_all(&run_dir).expect("run dir");
+    let staging = run_dir.join(staging_name());
+    fs::write(&staging, b"in flight").expect("staging bytes");
+    let scratch = root.join("_scratch").join(scratch_name("after"));
+    fs::create_dir_all(&scratch).expect("scratch dir");
+
+    let outcome = sweep(
+        root,
+        options(true),
+        ORPHANED_ARTIFACT_BYTES_MIN_AGE,
+        SystemTime::now(),
+    )
+    .expect("sweep");
+    assert_eq!(outcome.inspected_count, 2);
+    assert_eq!(outcome.planned_count, 0);
+    assert_eq!(outcome.removed_count, 0);
+    assert_eq!(outcome.skipped_count, 2);
+    assert!(staging.exists());
+    assert!(scratch.exists());
+    assert!(outcome
+        .rows
+        .iter()
+        .all(|row| row.reason.contains("age floor")));
+}
+
+#[test]
+fn future_dated_scratch_fails_closed() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    let scratch = root.join("_scratch").join(scratch_name("baseline"));
+    fs::create_dir_all(&scratch).expect("scratch dir");
+
+    // A clock behind the entry's modification time is the clock-skew case. It
+    // must not round down to "old enough".
+    let outcome = sweep(
+        root,
+        options(true),
+        Duration::ZERO,
+        SystemTime::now() - Duration::from_secs(3600),
+    )
+    .expect("sweep");
+    assert_eq!(outcome.removed_count, 0);
+    assert_eq!(outcome.skipped_count, 1);
+    assert!(outcome.rows[0].reason.contains("future"));
+    assert!(scratch.exists());
+}
+
+#[test]
+fn subsystem_owned_artifact_root_subtrees_are_never_candidates() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    // Every one of these is a live top-level subtree owned by another
+    // subsystem and carrying no `artifacts.path` row at that path. The
+    // row-join orphan reaper proposed in #10284 would delete all of them.
+    for owned in [
+        "runner/runner-a",
+        "runner-attach/runner-a",
+        "runner-exec-attach/runner-a",
+        "agent-task/task-a",
+        "agent-task-loop-controller/loop-a",
+        "controller-scratch-recovery/run-a",
+        "recovered-runner-artifacts/run-a",
+        "executor-finalized/finalized-a",
+        "preview-consumer/preview-a",
+    ] {
+        let path = root.join(owned);
+        fs::create_dir_all(&path).expect("subsystem tree");
+        fs::write(path.join("evidence.json"), b"{}").expect("subsystem bytes");
+    }
+    // A published artifact that has not yet been inserted is the create-then-
+    // register window. It must survive too.
+    let run_dir = root.join("run-1");
+    fs::create_dir_all(&run_dir).expect("run dir");
+    let published = run_dir.join("artifact-1-report.json");
+    fs::write(&published, b"{}").expect("published bytes");
+
+    let outcome = aged_sweep(root, true);
+    assert_eq!(outcome.inspected_count, 0, "{:#?}", outcome.rows);
+    assert_eq!(outcome.removed_count, 0);
+    assert!(published.exists());
+    for owned in [
+        "runner",
+        "runner-attach",
+        "runner-exec-attach",
+        "agent-task",
+        "agent-task-loop-controller",
+        "controller-scratch-recovery",
+        "recovered-runner-artifacts",
+        "executor-finalized",
+        "preview-consumer",
+    ] {
+        assert!(root.join(owned).exists(), "{owned} was reaped");
+    }
+}
+
+#[test]
+fn lookalike_names_outside_the_owned_shapes_are_ignored() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    let run_dir = root.join("run-1");
+    fs::create_dir_all(&run_dir).expect("run dir");
+    let scratch_dir = root.join("_scratch");
+    fs::create_dir_all(&scratch_dir).expect("scratch dir");
+
+    // Prefix and suffix match, but the middle is not a UUID.
+    let bad_staging = run_dir.join(".artifact-not-a-uuid.staging");
+    fs::write(&bad_staging, b"operator file").expect("bytes");
+    // A staging-shaped *directory* is not what the constructor emits.
+    let staging_dir = run_dir.join(staging_name());
+    fs::create_dir_all(&staging_dir).expect("staging dir");
+    // Patch-prefixed but unstructured.
+    let bad_scratch = scratch_dir.join("patch-notes");
+    fs::create_dir_all(&bad_scratch).expect("bad scratch");
+    // Correct scratch shape, wrong container.
+    let misplaced = run_dir.join(scratch_name("baseline"));
+    fs::create_dir_all(&misplaced).expect("misplaced scratch");
+    // A scratch-shaped *file* is not what the constructor emits.
+    let scratch_file = scratch_dir.join(scratch_name("after"));
+    fs::write(&scratch_file, b"not a tree").expect("bytes");
+
+    let outcome = aged_sweep(root, true);
+    assert_eq!(outcome.inspected_count, 0, "{:#?}", outcome.rows);
+    assert!(bad_staging.exists());
+    assert!(staging_dir.exists());
+    assert!(bad_scratch.exists());
+    assert!(misplaced.exists());
+    assert!(scratch_file.exists());
+}
+
+#[test]
+fn nested_scratch_shaped_paths_are_not_reached() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    // Depth three. Only depth two is ever classified, so a runner-owned tree
+    // that happens to contain a staging-shaped name is untouched.
+    let nested = root.join("runner").join("runner-a");
+    fs::create_dir_all(&nested).expect("nested tree");
+    let decoy = nested.join(staging_name());
+    fs::write(&decoy, b"runner owned").expect("bytes");
+
+    let outcome = aged_sweep(root, true);
+    assert_eq!(outcome.inspected_count, 0);
+    assert!(decoy.exists());
+}
+
+#[test]
+fn limit_bounds_the_sweep_and_reports_truncation() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    let run_dir = root.join("run-1");
+    fs::create_dir_all(&run_dir).expect("run dir");
+    for _ in 0..5 {
+        fs::write(run_dir.join(staging_name()), b"staged").expect("staging bytes");
+    }
+
+    let outcome = sweep(
+        root,
+        OrphanedArtifactBytesCleanupOptions {
+            apply: true,
+            limit: 2,
+        },
+        ORPHANED_ARTIFACT_BYTES_MIN_AGE,
+        clock_past_the_floor(),
+    )
+    .expect("sweep");
+    assert!(outcome.truncated);
+    assert_eq!(outcome.inspected_count, 2);
+    assert_eq!(outcome.removed_count, 2);
+    assert_eq!(
+        fs::read_dir(&run_dir).expect("run dir").count(),
+        3,
+        "limit must leave the remainder for the next sweep"
+    );
+}
+
+#[test]
+fn owned_name_shapes_match_their_constructors() {
+    let id = Uuid::new_v4();
+    assert!(is_artifact_staging_name(&format!(".artifact-{id}.staging")));
+    assert!(!is_artifact_staging_name(".artifact-.staging"));
+    assert!(!is_artifact_staging_name(&format!(".artifact-{id}")));
+    assert!(!is_artifact_staging_name(&format!("artifact-{id}.staging")));
+
+    // Both labels `patch_capture::create_scratch_dir` uses today, plus an
+    // unknown one, so a future label needs no second code change. The trailing
+    // UUID is matched by fixed width because a hyphenated UUID contains
+    // hyphens — splitting on the last separator would never parse.
+    assert!(is_patch_capture_scratch_name(&format!(
+        "patch-baseline-{id}"
+    )));
+    assert!(is_patch_capture_scratch_name(&format!("patch-after-{id}")));
+    assert!(is_patch_capture_scratch_name(&format!("patch-future-{id}")));
+    assert!(!is_patch_capture_scratch_name(&format!("patch-{id}")));
+    assert!(!is_patch_capture_scratch_name("patch-baseline-not-a-uuid"));
+    assert!(!is_patch_capture_scratch_name(&format!(
+        "scratch-after-{id}"
+    )));
+    assert!(!is_patch_capture_scratch_name("patch-"));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_scratch_is_ignored_rather_than_followed() {
+    let home = tempfile::tempdir().expect("home");
+    let outside = home.path().join("outside");
+    fs::create_dir_all(outside.join("precious")).expect("outside tree");
+    fs::write(outside.join("precious/data"), b"keep").expect("outside bytes");
+
+    let root = home.path().join("artifacts");
+    let scratch_dir = root.join("_scratch");
+    fs::create_dir_all(&scratch_dir).expect("scratch dir");
+    let link = scratch_dir.join(scratch_name("baseline"));
+    std::os::unix::fs::symlink(outside.join("precious"), &link).expect("symlink");
+
+    let outcome = aged_sweep(&root, true);
+    assert_eq!(outcome.inspected_count, 0, "{:#?}", outcome.rows);
+    assert!(outside.join("precious/data").exists());
+    assert!(
+        fs::symlink_metadata(&link).is_ok(),
+        "the link itself is kept too"
+    );
+}

--- a/crates/homeboy-core/src/observation/runs_service/persisted_cleanup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/persisted_cleanup.rs
@@ -1,20 +1,34 @@
 use super::*;
 
+/// Plan (and optionally apply) persisted-artifact cleanup against a freshly
+/// opened store.
+///
+/// Callers that already hold an open store — notably terminal-run retention,
+/// which plans once per candidate run — must use
+/// [`cleanup_persisted_artifacts_with_store`] instead. Every
+/// `ObservationStore::open_initialized` is a `create_dir_all`, two
+/// `pragma_update` calls, the globally-locked migration ladder, and an
+/// unfinished-publication reconciliation pass, so opening per run turns a
+/// bounded retention sweep into thousands of redundant connection opens.
 pub fn cleanup_persisted_artifacts(
     options: PersistedArtifactCleanupOptions,
 ) -> Result<PersistedArtifactCleanupOutcome> {
-    if options.older_than_days < 0 {
-        return Err(Error::validation_invalid_argument(
-            "older_than_days",
-            "--older-than-days must be zero or greater",
-            Some(options.older_than_days.to_string()),
-            None,
-        ));
-    }
-
+    validate_persisted_cleanup_options(&options)?;
     let artifact_root = crate::artifacts::root()?;
-    let created_before = (Utc::now() - Duration::days(options.older_than_days)).to_rfc3339();
     let store = ObservationStore::open_initialized()?;
+    cleanup_persisted_artifacts_with_store(&store, &artifact_root, options)
+}
+
+/// Plan (and optionally apply) persisted-artifact cleanup against a store and
+/// artifact root the caller already resolved.
+pub fn cleanup_persisted_artifacts_with_store(
+    store: &ObservationStore,
+    artifact_root: &Path,
+    options: PersistedArtifactCleanupOptions,
+) -> Result<PersistedArtifactCleanupOutcome> {
+    validate_persisted_cleanup_options(&options)?;
+
+    let created_before = (Utc::now() - Duration::days(options.older_than_days)).to_rfc3339();
     let candidates = store.list_artifact_cleanup_candidates(ArtifactCleanupFilter {
         created_before: Some(created_before),
         run_id: options.run_id.clone(),
@@ -37,8 +51,7 @@ pub fn cleanup_persisted_artifacts(
     let mut skipped_count = 0;
 
     for candidate in candidates.iter() {
-        let mut row =
-            classify_persisted_artifact(candidate, &artifact_root, options.terminal_only)?;
+        let mut row = classify_persisted_artifact(candidate, artifact_root, options.terminal_only)?;
         if row.action == "remove" {
             planned_record_count += 1;
             planned_size_bytes += row.size_bytes;
@@ -47,7 +60,7 @@ pub fn cleanup_persisted_artifacts(
                 _ => planned_file_count += usize::from(row.exists),
             }
             if options.apply {
-                apply_persisted_artifact_cleanup(&store, &candidate.artifact, &artifact_root)?;
+                apply_persisted_artifact_cleanup(store, &candidate.artifact, artifact_root)?;
                 removed_record_count += 1;
                 removed_size_bytes += row.size_bytes;
                 match row.artifact_type.as_str() {
@@ -64,7 +77,7 @@ pub fn cleanup_persisted_artifacts(
 
     Ok(PersistedArtifactCleanupOutcome {
         dry_run: !options.apply,
-        artifact_root,
+        artifact_root: artifact_root.to_path_buf(),
         older_than_days: options.older_than_days,
         totals: CleanupSizeTotals {
             inspected_count: candidates.len(),
@@ -80,6 +93,18 @@ pub fn cleanup_persisted_artifacts(
         skipped_count,
         rows,
     })
+}
+
+fn validate_persisted_cleanup_options(options: &PersistedArtifactCleanupOptions) -> Result<()> {
+    if options.older_than_days < 0 {
+        return Err(Error::validation_invalid_argument(
+            "older_than_days",
+            "--older-than-days must be zero or greater",
+            Some(options.older_than_days.to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn classify_persisted_artifact(
@@ -185,7 +210,7 @@ fn persisted_artifact_path_from_record(artifact_root: &Path, raw: &str) -> PathB
     }
 }
 
-fn symlink_metadata_if_exists(path: &Path) -> Result<Option<fs::Metadata>> {
+pub(crate) fn symlink_metadata_if_exists(path: &Path) -> Result<Option<fs::Metadata>> {
     match fs::symlink_metadata(path) {
         Ok(metadata) => Ok(Some(metadata)),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
@@ -196,7 +221,7 @@ fn symlink_metadata_if_exists(path: &Path) -> Result<Option<fs::Metadata>> {
     }
 }
 
-fn path_is_within_root(path: &Path, artifact_root: &Path) -> bool {
+pub(crate) fn path_is_within_root(path: &Path, artifact_root: &Path) -> bool {
     if path
         .components()
         .any(|component| matches!(component, Component::ParentDir))

--- a/crates/homeboy-core/src/observation/runs_service/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/tests.rs
@@ -133,6 +133,78 @@ fn terminal_retention_is_dry_run_by_default_and_deletes_owned_lifecycle_on_apply
     });
 }
 
+/// Unix-only: blocking a candidate run requires an artifact path that exists
+/// but fails the safety revalidation, and a symlink is the portable-enough way
+/// to produce that state.
+#[cfg(unix)]
+#[test]
+fn terminal_retention_counts_only_the_runs_it_actually_deleted() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+
+        // Two aged terminal runs. One holds an artifact that cleanup must
+        // refuse (a symlink), so retention plans it as blocked and deletes
+        // only the other one.
+        let removable = store.start_run(sample_run("test")).expect("removable run");
+        let blocked = store.start_run(sample_run("test")).expect("blocked run");
+        for run in [&removable, &blocked] {
+            store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish run");
+        }
+
+        let source = home.path().join("source.json");
+        std::fs::write(&source, "{}").expect("source bytes");
+        let removable_artifact = store
+            .record_artifact(&removable.id, "report", &source)
+            .expect("removable artifact");
+        let blocked_artifact = store
+            .record_artifact(&blocked.id, "report", &source)
+            .expect("blocked artifact");
+
+        // Replace the recorded bytes with a symlink so classification returns
+        // `skip` with `exists = true`, which is what blocks a candidate run.
+        let blocked_path = std::path::PathBuf::from(&blocked_artifact.path);
+        std::fs::remove_file(&blocked_path).expect("drop blocked bytes");
+        std::os::unix::fs::symlink(&source, &blocked_path).expect("symlink blocked bytes");
+
+        let path = store.status().expect("status").path;
+        drop(store);
+        let db = rusqlite::Connection::open(path).expect("raw db");
+        for id in [&removable.id, &blocked.id] {
+            db.execute(
+                "UPDATE runs SET finished_at = '2000-01-01T00:00:00Z' WHERE id = ?1",
+                [id],
+            )
+            .expect("age terminal run");
+        }
+        drop(db);
+
+        let applied = retain_terminal_runs(TerminalRunRetentionOptions {
+            apply: true,
+            older_than_days: 1,
+            limit: 10,
+        })
+        .expect("apply");
+
+        assert_eq!(applied.candidate_run_ids.len(), 2);
+        assert_eq!(applied.skipped_run_ids, vec![blocked.id.clone()]);
+        // Before the accounting fix this reported `1 - 1 == 0` because the
+        // planning-loop skip was subtracted from a set it was never in.
+        assert_eq!(applied.removed_run_count, 1);
+
+        let store = ObservationStore::open_initialized().expect("reopen");
+        assert!(store
+            .get_run(&removable.id)
+            .expect("removable read")
+            .is_none());
+        assert!(store.get_run(&blocked.id).expect("blocked read").is_some());
+        assert!(!std::path::Path::new(&removable_artifact.path).exists());
+        assert!(std::fs::symlink_metadata(&blocked_path).is_ok());
+    });
+}
+
 #[test]
 fn missing_run_guidance_prints_runner_routed_retrieval_commands() {
     let hints = missing_run_guidance_for_runner_ids("run-123", vec!["homeboy-lab".to_string()]);

--- a/docs/cleanup-retention.md
+++ b/docs/cleanup-retention.md
@@ -10,6 +10,53 @@ Unsafe existing local artifact paths keep the run and its lifecycle directory.
 The existing cleanup inventory remains the only planner. This change does not
 add a second cleanup engine.
 
+Retention resolves the observation store and the artifact root once per sweep.
+Both used to be re-derived inside every per-run artifact plan, so a default
+`--limit 1000` sweep opened thousands of SQLite connections and re-ran the
+migration ladder for each one. The apply pass still re-plans each run
+immediately before deleting its bytes: the planning loop walks every candidate
+before any deletion happens, so the earliest plans are already stale by then.
+
+## Orphaned Artifact Bytes
+
+```bash
+homeboy cleanup --include orphaned-artifact-bytes
+homeboy cleanup --include orphaned-artifact-bytes --apply
+```
+
+Every other artifact-root cleanup surface is driven by `artifacts` rows, so
+bytes written before their row existed are structurally invisible to all of
+them. This category reclaims the two artifact-root path families that are
+created outside any durable journal and are otherwise only reclaimed by an
+in-process cleanup branch, which SIGKILL and OOM skip:
+
+- `<artifact_root>/<run_id>/.artifact-<uuid>.staging` — the staging sibling
+  written before a file artifact is hard-linked into place.
+- `<artifact_root>/_scratch/patch-<label>-<uuid>/` — the working-tree baseline
+  copy taken by daemon patch capture, reclaimed only by `impl Drop`.
+
+It is deliberately **not** a generic "filesystem path with no database row"
+reaper. The artifact root is a shared namespace: `runner/`, `runner-attach/`,
+`runner-exec-attach/`, `agent-task/`, `agent-task-loop-controller/`,
+`controller-scratch-recovery/`, `recovered-runner-artifacts/`,
+`executor-finalized/`, `preview-consumer/`, and `_scratch/` are all owned by
+other subsystems and carry no artifact row at those paths. Artifact bytes are
+also written *before* their row is inserted by design, so row absence is the
+normal state of a publication that is currently succeeding. Row absence
+therefore proves nothing, and the database is not consulted.
+
+Ownership is instead proven by name shape — both families come from a single
+private constructor whose format no other writer emits — plus a fixed 24-hour
+age floor covering the in-flight window. The floor is not operator-overridable.
+Anything else at those paths, including a lookalike name without a parseable
+UUID, a staging-shaped directory, a scratch-shaped file, or a symlink, is
+reported and kept.
+
+Reported sizes are advisory. Removal is a pure function of name shape, entry
+type, age, symlink-freedom, and root containment; a failed size measurement
+reports `size_measured: false` and does not change the verdict in either
+direction.
+
 ## Lab Failure Retention
 
 Lab offloads delete run-scoped workspaces on every known terminal outcome by
@@ -31,6 +78,9 @@ The following Issue #8648 portions remain independently owned and are not
 implemented by terminal-run retention:
 
 - Crash-orphaned `/tmp/hb-<uid>` invocation-root inventory and age-pruning.
+- Reverse reconciliation for the subsystem-owned artifact-root subtrees listed
+  above. Each needs its own lifecycle owner; none of them can be reclaimed by a
+  row join.
 - Controller-scratch index compaction for missing or deleted terminal tombstones.
 - Aging removed task-worktree records out of workspace registries.
 - Detecting collisions between task-worktree and adopted-workspace registry handles.

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -39,6 +39,21 @@ Configured worktree-provider previews run independently with a 30-second cancell
 
 Regular `homeboy cleanup` includes `repo-artifacts` inventory. After an agent-task provider exits, Homeboy also cleans declared rebuildable artifacts from that exact detached attempt worktree before applying its existing source-state and commit safety guard. Active sibling worktrees are not scanned by this lifecycle step.
 
+## Orphaned Artifact Bytes
+
+```bash
+homeboy cleanup --include orphaned-artifact-bytes
+homeboy cleanup --include orphaned-artifact-bytes --apply
+```
+
+Reclaims crash residue under the artifact root that no `artifacts` row can
+describe: staging siblings left behind when a publish is SIGKILLed, and
+patch-capture baseline copies whose `Drop` never ran. It is name-scoped rather
+than row-scoped on purpose — the artifact root is a shared namespace and
+artifact bytes are written before their row exists, so row absence is not
+evidence of an orphan. See `docs/cleanup-retention.md` for the full safety
+model.
+
 ## Shared Cargo Targets
 
 Homeboy-managed Cargo builds use shared stores below its local data directory. Inspect them through the normal cleanup inventory:


### PR DESCRIPTION
Addresses the still-valid parts of #10284 and #10285. Both issues also contain premises that are **factually wrong against current `main`** — corrections are posted on each issue and summarized below.

One PR because both land in `runs_service/` and #10284's new sweeper reuses safety primitives from the same file #10285's refactor rewrites. Splitting would guarantee a conflict.

---

## What was already fixed before this branch

Both issues lead with a "ship this alone first" fix. **Both had already landed**, roughly 90 minutes after the issues were filed:

| Issue | Claim | Reality |
|---|---|---|
| #10285 (1) | "Grep for `idx_artifacts`: zero hits." Append migration 9 with `idx_artifacts_run_created` + `idx_artifacts_created_at`. | Migration 9 at `schema.rs:176-186` creates **exactly those two indexes, with those exact names**. Landed in `b4c99b659` *"perf(observation): index artifact queries"*. |
| #10284 (1) | Directory artifacts have "**no `remove_dir_all` on the error path**". | `artifacts.rs:811-814` is `}) { fs::remove_dir_all(&stored_path).ok(); return Err(error); }`. Landed in `49128b28f` *"fix(artifacts): roll back failed directory inserts"*. |

Nothing in this PR re-does either. The schema is at migration 12, not 8, so every line number in both issues is stale.

---

## #10285 — store reopened per run (real)

`retain_terminal_runs` planned once per candidate run, and each plan call re-derived its own store and artifact root:

- `runs_service/mod.rs:214` — plan loop, one call per candidate run
- `runs_service/mod.rs:244` — apply loop, a second call per removable run
- `runs_service/persisted_cleanup.rs:17` — `ObservationStore::open_initialized()` inside the callee
- `runs_service/persisted_cleanup.rs:15` — `crate::artifacts::root()` inside the callee
- `runs_service/mod.rs:265` — a third `crate::artifacts::root()` inside the apply loop

Each `open_initialized` is `create_dir_all` + two `pragma_update` + the globally-mutexed migration ladder (**12** `SELECT COUNT(*) FROM schema_migrations` probes now, not 8) **plus** `reconcile_unfinished_artifact_publications()` (`store/runs.rs:32`) — a query the issue's cost model missed entirely. At the default `--limit 1000`: up to 2000 opens and 24,000 migration probes per `--apply`.

Fixed by `cleanup_persisted_artifacts_with_store(&store, &artifact_root, options)`. `cleanup_persisted_artifacts` stays as a thin wrapper, so every other caller is unchanged.

### Where I disagree with the proposed fix

The issue's fix (3) says to **delete** the second plan pass because "an in-loop revalidation already covers it". I kept it, deliberately.

The plan loop walks **every** candidate before **any** deletion happens. With `--limit 1000` the plan for run #1 is stale by the time apply reaches it. The in-loop revalidation (`remove_persisted_artifact_bytes`, `persisted_cleanup.rs:160-177`) only re-checks symlink and containment for a path already selected for removal — it does **not** re-check whether the owning run left a terminal state, which is what `terminal_only` classification decides and what `blocked` is derived from. Deleting the pass removes a real TOCTOU guard to save a query.

What was actually redundant — reopening the store and re-resolving the artifact root on each of those calls — is gone. The pass now costs one indexed query instead of a connection open, a migration ladder, and a reconciliation pass.

### Bonus defect found: `removed_run_count` under-reports

`mod.rs:317-323` computed `removable_run_ids.len() - skipped_run_ids.len()`. But `skipped_run_ids` contains runs blocked in the **planning** loop, which were never in `removable_run_ids`. With 10 candidates and 3 blocked at plan time, it reported `7 - 3 = 4` after deleting 7. Now counts `deleted.len()`. Covered by `terminal_retention_counts_only_the_runs_it_actually_deleted`.

---

## #10284 — artifact-root scratch has no reaper (real, but the proposed fix is dangerous)

Parts (2), (3) and (4) hold up:

- `artifacts.rs:1528-1532` `staged_artifact_path` writes `.artifact-<uuid>.staging`, cleaned on every in-process branch (`:557`, `:575`, `:587`, `:595`) and by nothing after SIGKILL. It is not journaled in `artifact_publication_intents`, so `reconcile_unfinished_artifact_publications` (`:243`) never sees it.
- `daemon/patch_capture.rs:156-167` creates `<artifact_root>/_scratch/patch-<label>-<uuid>` — a full working-tree copy — reclaimed only by `impl Drop for ScratchDir` (`:45-49`).
- The existing `controller-scratch` category is **not** this: it owns `homeboy_data()/controller-scratch/attempts` (`agents/controller_scratch.rs:91`), a different root.

### The proposed fix would delete live state

Fix (2) says to walk the root, join against `SELECT path FROM artifacts`, and remove ``<run_id>/*`` with no matching row. **Do not ship that.** Two independent reasons:

**1. The artifact root is a shared namespace, not a projection of the artifacts table.** At least nine other subsystems own top-level subtrees under it and register no row at those paths:

| Path | Owner |
|---|---|
| `runner/` | `lab-runner/evidence/download.rs:64` |
| `runner-attach/` | `lab-runner/artifact_attach.rs:171` |
| `runner-exec-attach/` | `lab-runner/execution/artifact_promotion.rs:671` |
| `agent-task/` | `agents/agent_task_scheduler/harvest.rs:387` |
| `agent-task-loop-controller/` | `agents/agent_task_controller_service/run_command.rs:307` |
| `controller-scratch-recovery/` | `agents/controller_scratch.rs:1217` |
| `recovered-runner-artifacts/` | `agents/agent_task_lifecycle/artifact_materialization.rs:215` |
| `executor-finalized/` | `agents/agent_task_provider/artifact_finalization.rs:55` |
| `preview-consumer/` | `tunnel/preview_consumer.rs:158` |

A row-join reaper classifies every one of these as an orphan.

**2. Artifact bytes are written before their row exists, by design.** The window between `copy_artifact_file`/`copy_artifact_directory` and the INSERT (`artifacts.rs:538` → `:625`, `:783` → `:788`) is exactly when a row-join reaper sees an "orphan". Row absence is the normal state of a publication that is currently *succeeding*. `patch_capture.rs:169-188` writes `<run_id>/<artifact_id>.diff` before `persist_patch_run` too.

So row absence proves nothing about these paths, and **the database is not consulted at all**.

### What shipped instead

`homeboy cleanup --include orphaned-artifact-bytes`, scoped by **name ownership** — both families come from a single private constructor whose format no other writer emits — plus a fixed 24h age floor for the in-flight window, which is not operator-overridable. Every removal requires all of: exact name shape (with a *parsed* UUID, not a prefix match), correct entry type, correct container, not a symlink, resolves inside the root, and past the floor. Anything uncertain is reported and kept. The walk is depth-2 only and never descends into subsystem-owned trees.

The hyphenated-UUID suffix is matched by fixed width, not `rsplit_once('-')` — a UUID contains hyphens, so splitting on the last separator never parses.

### Size is decoupled from the deletion decision

Prior art, per review guidance: `bounded_directory_size` (`lab-runner/workspace/sync/mod.rs:3457`) shells to `du -sk` and feeds `size.is_some()` into the liveness verdict at `:2602-2604`. A failed `du` returned `None`, liveness degraded to `"unknown"`, and prune became a silent no-op — an advisory measurement quietly disabling the feature.

Here removal is a pure function of (name shape, entry type, age, symlink-freedom, containment). Size is measured best-effort for reporting only; a failed measurement reports `size_measured: false` and changes the verdict in **neither** direction.

---

## Tests

`orphaned_artifact_bytes/tests.rs` (9 tests) and `runs_service/tests.rs` (1 test):

- staging + scratch reaped on apply, untouched on dry run, both owners attributed
- young scratch never reaped; a clock behind the entry's mtime fails closed
- **all nine subsystem-owned subtrees survive a full apply sweep**, as does an unregistered published artifact (the create-then-register window)
- lookalikes ignored: unparseable UUID, staging-shaped *directory*, scratch-shaped *file*, `patch-notes`, correct shape in the wrong container
- depth-3 staging-shaped decoy under `runner/` is not reached
- symlinked scratch is neither followed nor removed
- name-shape unit coverage incl. a future `patch-<label>-` value
- retention counts only what it deleted

Age and clock are injected into the private `sweep` rather than rewriting mtimes, because `filetime` is not a workspace dependency and adding one would have required a lockfile update I can't validate locally.

## Not verified locally

Per repo policy I ran only `cargo fmt` (clean); no `build`/`check`/`clippy`/`test` — this host OOMs on them. CI is the gate. Unverified: compilation, clippy, and every assertion above. Highest-risk spots if CI is red: the `pub(crate)` widening of `path_is_within_root`/`symlink_metadata_if_exists` under `pub use persisted_cleanup::*` (sibling `run_lookup.rs` and `artifact_links.rs` already do this, so the pattern is proven), and the new `CleanupCategoryArg` variant.

Refs #10284, #10285
