### PR TITLE
feat(notify): give notifications a structured payload and make agent tasks emit

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod agent_task_config;
 pub mod agent_task_outcome;
 pub mod env_materialization_plan;
+pub mod notification_payload;
 pub mod notification_route;
 pub mod path_materialization;
 pub mod secret_env_plan;

--- a/crates/contracts/homeboy-lab-contract/src/notification_payload.rs
+++ b/crates/contracts/homeboy-lab-contract/src/notification_payload.rs
@@ -1,0 +1,603 @@
+//! Transport-neutral structured payload carried alongside notification prose.
+//!
+//! A notification used to be two fabricated sentences derived from the run id
+//! and status, so a transport could display an event but never act on one. This
+//! module adds the machine-readable half: what the event is about, the facts a
+//! reader needs, the exact commands that advance it, and the evidence a
+//! capable transport can attach.
+//!
+//! Two invariants keep this additive:
+//!
+//! 1. **Prose stays authoritative for rendering.** Every producer still emits
+//!    `title`/`body`. [`NotifyPayload::render_body`] derives that prose from the
+//!    payload, so a text-only transport gets the richer content with no change
+//!    at all, and the two halves cannot drift.
+//! 2. **The payload never reaches a transport through argv.** Installed
+//!    transports validate their argv and reject unknown flags, so appending new
+//!    flags would break every already-installed transport at its current
+//!    version. The payload travels as process environment instead, which an
+//!    unaware transport simply never reads.
+
+use serde::{Deserialize, Serialize};
+
+pub const NOTIFICATION_PAYLOAD_SCHEMA: &str = "homeboy/notification-payload/v1";
+
+/// Event kind. Read by transports that want to route or style by lifecycle
+/// position without parsing the payload.
+pub const NOTIFY_KIND_ENV: &str = "HOMEBOY_NOTIFY_KIND";
+/// The serialized [`NotifyPayload`].
+pub const NOTIFY_PAYLOAD_ENV: &str = "HOMEBOY_NOTIFY_PAYLOAD";
+/// The payload schema id, so a transport can version-gate before parsing.
+pub const NOTIFY_PAYLOAD_SCHEMA_ENV: &str = "HOMEBOY_NOTIFY_PAYLOAD_SCHEMA";
+/// Set to `1` only when bounding dropped payload members.
+pub const NOTIFY_PAYLOAD_TRUNCATED_ENV: &str = "HOMEBOY_NOTIFY_PAYLOAD_TRUNCATED";
+
+/// Serialized payload budget. `ARG_MAX` covers argv *and* environment on Linux,
+/// and a notification must never be the reason a transport fails to spawn.
+pub const NOTIFY_PAYLOAD_MAX_BYTES: usize = 48 * 1024;
+
+/// Rendered prose budget. Independent of any one transport's message limit;
+/// this only stops an unbounded body from reaching a child process at all.
+pub const NOTIFY_BODY_MAX_CHARS: usize = 3500;
+
+const BOUNDED_FACTS: usize = 12;
+const BOUNDED_ACTIONS: usize = 6;
+const BOUNDED_LINKS: usize = 6;
+const BOUNDED_ATTACHMENTS: usize = 20;
+const FIELD_MAX_CHARS: usize = 512;
+
+/// Where an event sits in its subject's lifecycle.
+///
+/// `Completed` is the default so a producer that only knows "this finished"
+/// keeps the historical meaning of a notification.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotifyEventKind {
+    /// Durable identity exists; execution has not begun.
+    Queued,
+    /// Execution has begun and the subject is addressable.
+    Started,
+    /// A bounded intermediate boundary (an attempt or retry), never a heartbeat.
+    Progress,
+    /// The subject reached a terminal state.
+    #[default]
+    Completed,
+    /// Terminal, but a human decision is required before anything advances.
+    NeedsAttention,
+}
+
+impl NotifyEventKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Started => "started",
+            Self::Progress => "progress",
+            Self::Completed => "completed",
+            Self::NeedsAttention => "needs_attention",
+        }
+    }
+
+    /// Whether the subject will not transition further on its own.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::NeedsAttention)
+    }
+}
+
+/// What the event is about. `kind` is a generic subject class (`run`,
+/// `agent_task_cook`, `schedule`, `activity`), never a transport concept.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotifySubject {
+    pub kind: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+    /// The batch, plan, or parent run this subject belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u32>,
+    /// The producer's own phase label at emission time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+}
+
+impl NotifySubject {
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            id: id.into(),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_component(mut self, component: impl Into<String>) -> Self {
+        self.component = Some(component.into());
+        self
+    }
+
+    pub fn with_parent(mut self, parent_id: impl Into<String>) -> Self {
+        self.parent_id = Some(parent_id.into());
+        self
+    }
+
+    pub fn with_attempt(mut self, attempt: u32) -> Self {
+        self.attempt = Some(attempt);
+        self
+    }
+
+    pub fn with_phase(mut self, phase: impl Into<String>) -> Self {
+        self.phase = Some(phase.into());
+        self
+    }
+}
+
+/// One ordered label/value fact. Producers put the facts an operator would
+/// otherwise have to re-gather by hand here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotifyFact {
+    pub label: String,
+    pub value: String,
+}
+
+impl NotifyFact {
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// An exact command that advances the subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotifyAction {
+    pub label: String,
+    pub command: String,
+    /// Generic intent hint (`show`, `watch`, `artifacts`, `repair`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+}
+
+impl NotifyAction {
+    pub fn new(label: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            command: command.into(),
+            kind: None,
+        }
+    }
+
+    pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = Some(kind.into());
+        self
+    }
+}
+
+/// An external reference (pull request, issue, CI run).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotifyLink {
+    pub label: String,
+    pub url: String,
+}
+
+impl NotifyLink {
+    pub fn new(label: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            url: url.into(),
+        }
+    }
+}
+
+/// Evidence an attachment-capable transport can deliver directly.
+///
+/// This is the declarative half of grouped-artifact delivery: a transport that
+/// cannot attach files ignores it and still renders `fetch_command`, while a
+/// transport that can attach resolves `uri`/`fetch_command` itself. `group_id`
+/// plus `role` carry the relationship (`source`/`candidate`/`diff`) explicitly,
+/// so no consumer has to parse filename conventions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotifyAttachment {
+    pub id: String,
+    /// Generic class: `artifact` or `evidence`.
+    pub kind: String,
+    pub uri: String,
+    /// The exact command that materializes the bytes locally.
+    pub fetch_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byte_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
+    /// Stable id shared by every attachment presented together.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_id: Option<String>,
+    /// Semantic role within `group_id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+}
+
+impl NotifyAttachment {
+    pub fn new(
+        id: impl Into<String>,
+        kind: impl Into<String>,
+        uri: impl Into<String>,
+        fetch_command: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            kind: kind.into(),
+            uri: uri.into(),
+            fetch_command: fetch_command.into(),
+            media_type: None,
+            display_name: None,
+            byte_size: None,
+            caption: None,
+            group_id: None,
+            role: None,
+        }
+    }
+
+    pub fn with_group(mut self, group_id: impl Into<String>, role: impl Into<String>) -> Self {
+        self.group_id = Some(group_id.into());
+        self.role = Some(role.into());
+        self
+    }
+
+    pub fn with_media_type(mut self, media_type: impl Into<String>) -> Self {
+        self.media_type = Some(media_type.into());
+        self
+    }
+}
+
+/// The structured half of a notification.
+///
+/// Deserializable so a transport written in Rust — and homeboy's own tests —
+/// can round-trip it. Deliberately *not* `deny_unknown_fields`: a payload
+/// produced by a newer homeboy must still parse in an older consumer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotifyPayload {
+    #[serde(default = "notification_payload_schema")]
+    pub schema: String,
+    #[serde(default)]
+    pub kind: NotifyEventKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<NotifySubject>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub facts: Vec<NotifyFact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub actions: Vec<NotifyAction>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<NotifyLink>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<NotifyAttachment>,
+}
+
+fn notification_payload_schema() -> String {
+    NOTIFICATION_PAYLOAD_SCHEMA.to_string()
+}
+
+impl Default for NotifyPayload {
+    fn default() -> Self {
+        Self {
+            schema: notification_payload_schema(),
+            kind: NotifyEventKind::default(),
+            subject: None,
+            facts: Vec::new(),
+            actions: Vec::new(),
+            links: Vec::new(),
+            attachments: Vec::new(),
+        }
+    }
+}
+
+impl NotifyPayload {
+    pub fn new(kind: NotifyEventKind, subject: NotifySubject) -> Self {
+        Self {
+            kind,
+            subject: Some(subject),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_fact(mut self, label: impl Into<String>, value: impl Into<String>) -> Self {
+        self.facts.push(NotifyFact::new(label, value));
+        self
+    }
+
+    /// Add a fact only when the value is present and non-empty, so an absent
+    /// field never renders as `Component: ` with nothing after it.
+    pub fn with_optional_fact(
+        self,
+        label: impl Into<String>,
+        value: Option<impl Into<String>>,
+    ) -> Self {
+        let value: Option<String> = value.map(Into::into);
+        match value.filter(|value| !value.trim().is_empty()) {
+            Some(value) => self.with_fact(label, value),
+            None => self,
+        }
+    }
+
+    pub fn with_action(mut self, action: NotifyAction) -> Self {
+        self.actions.push(action);
+        self
+    }
+
+    pub fn with_link(mut self, link: NotifyLink) -> Self {
+        self.links.push(link);
+        self
+    }
+
+    pub fn with_attachment(mut self, attachment: NotifyAttachment) -> Self {
+        self.attachments.push(attachment);
+        self
+    }
+
+    pub fn with_attachments(
+        mut self,
+        attachments: impl IntoIterator<Item = NotifyAttachment>,
+    ) -> Self {
+        self.attachments.extend(attachments);
+        self
+    }
+
+    /// Whether this payload carries anything a consumer could not already
+    /// derive from `run_id` and `status` alone.
+    pub fn is_empty(&self) -> bool {
+        self.subject.is_none()
+            && self.facts.is_empty()
+            && self.actions.is_empty()
+            && self.links.is_empty()
+            && self.attachments.is_empty()
+    }
+
+    /// Render the human-facing body for transports that only display text.
+    ///
+    /// This is the compatibility bridge: the same information a payload-aware
+    /// transport reads structurally is written here as bounded prose, so an
+    /// already-installed text transport gets the richer message without any
+    /// coordinated release.
+    pub fn render_body(&self) -> String {
+        let mut lines: Vec<String> = Vec::new();
+        if let Some(subject) = &self.subject {
+            if let Some(component) = subject.component.as_deref().filter(|it| !it.is_empty()) {
+                lines.push(format!("Component: {component}"));
+            }
+            if let Some(parent) = subject.parent_id.as_deref().filter(|it| !it.is_empty()) {
+                lines.push(format!("Batch: {parent}"));
+            }
+            if let Some(attempt) = subject.attempt {
+                lines.push(format!("Attempt: {attempt}"));
+            }
+            if let Some(phase) = subject.phase.as_deref().filter(|it| !it.is_empty()) {
+                lines.push(format!("Phase: {phase}"));
+            }
+        }
+        for fact in &self.facts {
+            lines.push(format!("{}: {}", fact.label, fact.value));
+        }
+        for link in &self.links {
+            lines.push(format!("{}: {}", link.label, link.url));
+        }
+        for action in &self.actions {
+            lines.push(format!("Next — {}: {}", action.label, action.command));
+        }
+        if !self.attachments.is_empty() {
+            lines.push(format!("Attachments: {}", self.attachments.len()));
+            for attachment in self.attachments.iter().take(3) {
+                let name = attachment
+                    .display_name
+                    .as_deref()
+                    .unwrap_or(attachment.id.as_str());
+                lines.push(format!("  {name}: {}", attachment.fetch_command));
+            }
+        }
+        bound_chars(&lines.join("\n"), NOTIFY_BODY_MAX_CHARS)
+    }
+
+    /// Serialize within [`NOTIFY_PAYLOAD_MAX_BYTES`].
+    ///
+    /// Returns the JSON plus whether members were dropped to fit. Bounding is
+    /// progressive rather than all-or-nothing: a payload with a thousand
+    /// artifacts still delivers its subject, facts, and repair actions.
+    pub fn serialize_bounded(&self) -> Option<(String, bool)> {
+        let json = serde_json::to_string(self).ok()?;
+        if json.len() <= NOTIFY_PAYLOAD_MAX_BYTES {
+            return Some((json, false));
+        }
+
+        let mut bounded = self.clone();
+        bounded.facts.truncate(BOUNDED_FACTS);
+        bounded.actions.truncate(BOUNDED_ACTIONS);
+        bounded.links.truncate(BOUNDED_LINKS);
+        bounded.attachments.truncate(BOUNDED_ATTACHMENTS);
+        for fact in &mut bounded.facts {
+            fact.value = bound_chars(&fact.value, FIELD_MAX_CHARS);
+        }
+        let json = serde_json::to_string(&bounded).ok()?;
+        if json.len() <= NOTIFY_PAYLOAD_MAX_BYTES {
+            return Some((json, true));
+        }
+
+        // Last resort: identity and actions only. A consumer that can still
+        // answer "what is this and what do I run next?" is strictly better
+        // than a dropped payload.
+        let minimal = Self {
+            schema: bounded.schema,
+            kind: bounded.kind,
+            subject: bounded.subject,
+            facts: Vec::new(),
+            actions: bounded.actions,
+            links: Vec::new(),
+            attachments: Vec::new(),
+        };
+        let json = serde_json::to_string(&minimal).ok()?;
+        (json.len() <= NOTIFY_PAYLOAD_MAX_BYTES).then_some((json, true))
+    }
+}
+
+fn bound_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(max.saturating_sub(3)).collect();
+    format!("{kept}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cook_payload() -> NotifyPayload {
+        NotifyPayload::new(
+            NotifyEventKind::NeedsAttention,
+            NotifySubject::new("agent_task_cook", "cook-abc")
+                .with_component("homeboy")
+                .with_attempt(2)
+                .with_phase("promotion"),
+        )
+        .with_fact("Status", "failed")
+        .with_optional_fact("Stop reason", Some("gate_failed"))
+        .with_optional_fact("Ignored", Option::<String>::None)
+        .with_optional_fact("Blank", Some("   "))
+        .with_action(
+            NotifyAction::new("diagnose", "homeboy agent-task diagnose cook-abc")
+                .with_kind("repair"),
+        )
+        .with_link(NotifyLink::new(
+            "pull request",
+            "https://example.test/pull/1",
+        ))
+    }
+
+    #[test]
+    fn rendered_body_carries_every_structured_member() {
+        let body = cook_payload().render_body();
+        assert!(body.contains("Component: homeboy"), "{body}");
+        assert!(body.contains("Attempt: 2"), "{body}");
+        assert!(body.contains("Phase: promotion"), "{body}");
+        assert!(body.contains("Status: failed"), "{body}");
+        assert!(body.contains("Stop reason: gate_failed"), "{body}");
+        assert!(
+            body.contains("Next — diagnose: homeboy agent-task diagnose cook-abc"),
+            "{body}"
+        );
+        assert!(body.contains("https://example.test/pull/1"), "{body}");
+    }
+
+    #[test]
+    fn optional_facts_skip_absent_and_blank_values() {
+        let body = cook_payload().render_body();
+        assert!(!body.contains("Ignored"), "{body}");
+        assert!(!body.contains("Blank"), "{body}");
+    }
+
+    #[test]
+    fn rendered_body_is_bounded() {
+        let payload = NotifyPayload::new(
+            NotifyEventKind::Completed,
+            NotifySubject::new("run", "run-1"),
+        )
+        .with_fact("Detail", "x".repeat(NOTIFY_BODY_MAX_CHARS * 2));
+        let body = payload.render_body();
+        assert!(body.chars().count() <= NOTIFY_BODY_MAX_CHARS);
+        assert!(body.ends_with("..."));
+    }
+
+    #[test]
+    fn payload_round_trips_through_json() {
+        let payload = cook_payload();
+        let json = serde_json::to_string(&payload).unwrap();
+        assert_eq!(
+            serde_json::from_str::<NotifyPayload>(&json).unwrap(),
+            payload
+        );
+    }
+
+    #[test]
+    fn payload_accepts_unknown_fields_from_a_newer_producer() {
+        // A newer homeboy must not break an older structured consumer.
+        let value = serde_json::json!({
+            "schema": NOTIFICATION_PAYLOAD_SCHEMA,
+            "kind": "started",
+            "subject": {"kind": "run", "id": "run-1", "unreleased_field": 7},
+            "unreleased_member": [1, 2, 3],
+        });
+        let payload: NotifyPayload = serde_json::from_value(value).unwrap();
+        assert_eq!(payload.kind, NotifyEventKind::Started);
+        assert_eq!(payload.subject.unwrap().id, "run-1");
+    }
+
+    #[test]
+    fn payload_defaults_to_completed_for_a_producer_that_omits_kind() {
+        let payload: NotifyPayload = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(payload.kind, NotifyEventKind::Completed);
+        assert_eq!(payload.schema, NOTIFICATION_PAYLOAD_SCHEMA);
+        assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn oversized_payload_is_bounded_but_keeps_identity_and_actions() {
+        let attachments = (0..5_000).map(|index| {
+            NotifyAttachment::new(
+                format!("artifact-{index}"),
+                "artifact",
+                format!("file:///tmp/artifact-{index}.png"),
+                format!("homeboy runs artifact get run-1 artifact-{index}"),
+            )
+            .with_group("visual_compare", "diff")
+        });
+        let payload = NotifyPayload::new(
+            NotifyEventKind::Completed,
+            NotifySubject::new("run", "run-1"),
+        )
+        .with_action(NotifyAction::new("show", "homeboy runs show run-1"))
+        .with_attachments(attachments);
+
+        let (json, truncated) = payload.serialize_bounded().expect("bounded payload");
+        assert!(truncated);
+        assert!(json.len() <= NOTIFY_PAYLOAD_MAX_BYTES);
+        let parsed: NotifyPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.subject.unwrap().id, "run-1");
+        assert_eq!(parsed.actions.len(), 1);
+        assert!(parsed.attachments.len() <= BOUNDED_ATTACHMENTS);
+    }
+
+    #[test]
+    fn small_payload_is_not_reported_as_truncated() {
+        let (json, truncated) = cook_payload().serialize_bounded().expect("payload");
+        assert!(!truncated);
+        assert!(json.contains("cook-abc"));
+    }
+
+    #[test]
+    fn event_kind_terminality_is_explicit() {
+        assert!(NotifyEventKind::Completed.is_terminal());
+        assert!(NotifyEventKind::NeedsAttention.is_terminal());
+        assert!(!NotifyEventKind::Queued.is_terminal());
+        assert!(!NotifyEventKind::Started.is_terminal());
+        assert!(!NotifyEventKind::Progress.is_terminal());
+        assert_eq!(NotifyEventKind::NeedsAttention.as_str(), "needs_attention");
+    }
+
+    #[test]
+    fn attachment_group_metadata_survives_serialization() {
+        let attachment = NotifyAttachment::new(
+            "visual_source",
+            "artifact",
+            "file:///tmp/source.png",
+            "homeboy runs artifact get run-1 visual_source",
+        )
+        .with_group("visual_compare_27", "source")
+        .with_media_type("image/png");
+        let json = serde_json::to_string(&attachment).unwrap();
+        let parsed: NotifyAttachment = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.group_id.as_deref(), Some("visual_compare_27"));
+        assert_eq!(parsed.role.as_deref(), Some("source"));
+        assert_eq!(parsed.media_type.as_deref(), Some("image/png"));
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -1,0 +1,413 @@
+//! Cook lifecycle notifications.
+//!
+//! Agent tasks used to emit nothing. A cook could run for twenty minutes and
+//! finish in total silence, so "fan out N tasks and report to my chat thread"
+//! produced N silences followed by N terminations the operator had to go
+//! looking for.
+//!
+//! Emission is deliberately sparse. Cook already reports eight internal phases
+//! (`durable_identity`, `provider_ready`, `provider_start`, `retry`,
+//! `heartbeat`, `promotion`, `finalization`, terminal) plus a heartbeat every
+//! fifteen seconds; forwarding that would make the destination useless. Only
+//! three boundaries change what a human would *do*:
+//!
+//! - `durable_identity` — the first point at which the cook is addressable, so
+//!   the operator can answer "what did I just start, and how do I watch it?"
+//! - `retry` — the attempt budget is being consumed. Someone who intends to
+//!   intervene has to know before it runs out, not after.
+//! - terminal — the outcome, with the pull request link on success and the
+//!   durable recovery commands on failure.
+//!
+//! `provider_ready`, `promotion`, `finalization`, and `heartbeat` are internal
+//! progress with no decision attached, and are intentionally not delivered.
+
+use homeboy_core::notification_payload::{
+    NotifyAction, NotifyEventKind, NotifyLink, NotifyPayload, NotifySubject,
+};
+use homeboy_core::notification_route;
+use homeboy_core::notify::{self, NotifyEvent};
+
+use crate::agent_task_service::AgentTaskCookReport;
+
+/// Generic subject class for every cook lifecycle notification.
+const COOK_SUBJECT_KIND: &str = "agent_task_cook";
+
+/// Whether a cook lifecycle event is delivered.
+///
+/// Non-terminal events require an explicitly bound route. A configured
+/// operations default transport is an ambient policy for "tell me when work
+/// finishes"; promoting it to per-attempt progress would be a noise regression
+/// for every operator who already set one. An operator who passed
+/// `--notification-route` named a destination for *this* work and gets the
+/// full arc.
+fn should_deliver(kind: NotifyEventKind, has_explicit_route: bool) -> bool {
+    kind.is_terminal() || has_explicit_route
+}
+
+fn deliver(event: NotifyEvent) {
+    let route = notification_route::current();
+    if !should_deliver(event.kind, route.is_some()) {
+        return;
+    }
+    // A notification is observability, never a cook failure mode.
+    let _ = notify::dispatch(&event.with_route(route.as_ref()));
+}
+
+fn cook_subject(cook_id: &str, run_id: &str, component: Option<&str>) -> NotifySubject {
+    let mut subject = NotifySubject::new(COOK_SUBJECT_KIND, cook_id);
+    if !run_id.is_empty() {
+        subject.parent_id = Some(run_id.to_string());
+    }
+    subject.component = component.map(str::to_string);
+    subject
+}
+
+/// Watch/diagnose commands legal at every point in a cook's life.
+fn cook_actions(payload: NotifyPayload, cook_id: &str) -> NotifyPayload {
+    payload
+        .with_action(
+            NotifyAction::new("status", format!("homeboy agent-task status {cook_id}"))
+                .with_kind("show"),
+        )
+        .with_action(
+            NotifyAction::new("watch", format!("homeboy activity watch {cook_id}"))
+                .with_kind("watch"),
+        )
+}
+
+/// Build the started payload. Separated from delivery so its content is
+/// assertable without spawning a transport.
+fn started_payload(
+    cook_id: &str,
+    run_id: &str,
+    title: &str,
+    component: Option<&str>,
+    base: &str,
+    max_attempts: u32,
+    provider: &str,
+) -> NotifyPayload {
+    cook_actions(
+        NotifyPayload::new(
+            NotifyEventKind::Started,
+            cook_subject(cook_id, run_id, component).with_phase("durable_identity"),
+        )
+        .with_fact("Task", title)
+        .with_fact("Base", base)
+        .with_fact("Provider", provider)
+        .with_fact("Attempt budget", max_attempts.to_string()),
+        cook_id,
+    )
+}
+
+/// The cook now has a durable identity and is addressable.
+pub(crate) fn cook_started(
+    cook_id: &str,
+    run_id: &str,
+    title: &str,
+    component: Option<&str>,
+    base: &str,
+    max_attempts: u32,
+    provider: &str,
+) {
+    let payload = started_payload(
+        cook_id,
+        run_id,
+        title,
+        component,
+        base,
+        max_attempts,
+        provider,
+    );
+    deliver(
+        NotifyEvent::lifecycle(NotifyEventKind::Started, cook_id, "started")
+            .with_title(format!("cook started — {title}"))
+            .with_payload(payload),
+    );
+}
+
+fn retry_payload(
+    cook_id: &str,
+    run_id: &str,
+    component: Option<&str>,
+    attempt: u32,
+    max_attempts: u32,
+) -> NotifyPayload {
+    cook_actions(
+        NotifyPayload::new(
+            NotifyEventKind::Progress,
+            cook_subject(cook_id, run_id, component)
+                .with_phase("retry")
+                .with_attempt(attempt),
+        )
+        .with_fact("Attempt", format!("{attempt} of {max_attempts}"))
+        .with_fact("Reason", "the previous attempt did not pass its gates"),
+        cook_id,
+    )
+}
+
+/// A gate-feedback retry is consuming the attempt budget.
+pub(crate) fn cook_retrying(
+    cook_id: &str,
+    run_id: &str,
+    component: Option<&str>,
+    attempt: u32,
+    max_attempts: u32,
+) {
+    let payload = retry_payload(cook_id, run_id, component, attempt, max_attempts);
+    deliver(
+        NotifyEvent::lifecycle(NotifyEventKind::Progress, cook_id, "retrying")
+            .with_title(format!("cook attempt {attempt} of {max_attempts}"))
+            .with_payload(payload),
+    );
+}
+
+/// Build the terminal payload from the report the cook already produced.
+///
+/// `exit_code` decides success, not the status string: the status vocabulary
+/// (`succeeded`, `durable_failure`, `attempts_exhausted`, `moving_base`, ...)
+/// is open, while the exit code is the contract every caller already branches
+/// on.
+fn terminal_payload(
+    report: &AgentTaskCookReport,
+    component: Option<&str>,
+    exit_code: i32,
+) -> NotifyPayload {
+    let kind = if exit_code == 0 {
+        NotifyEventKind::Completed
+    } else {
+        NotifyEventKind::NeedsAttention
+    };
+    let run_id = report.latest_run_id.clone().unwrap_or_default();
+    let attempts = u32::try_from(report.attempts.len()).unwrap_or(u32::MAX);
+
+    let mut subject = cook_subject(&report.cook_id, &run_id, component);
+    subject.phase = report
+        .terminal_phase
+        .clone()
+        .filter(|phase| !phase.is_empty());
+    if attempts > 0 {
+        subject.attempt = Some(attempts);
+    }
+
+    let mut payload = NotifyPayload::new(kind, subject)
+        .with_fact("Status", report.status.clone())
+        .with_fact("Attempts", attempts.to_string())
+        .with_optional_fact("Stop reason", report.stop_reason.clone())
+        .with_optional_fact(
+            "Failure classification",
+            report.terminal_failure_classification.clone(),
+        );
+
+    // The pull request link is the single most useful thing a completed cook
+    // can hand a reviewer, and it was previously discarded along with the rest
+    // of the finalization report.
+    if let Some(finalization) = &report.finalization {
+        if let Some(url) = finalization.get("pr_url").and_then(|url| url.as_str()) {
+            payload = payload.with_link(NotifyLink::new("pull request", url));
+        }
+        payload = payload.with_optional_fact(
+            "Pull request",
+            finalization
+                .get("pr_action")
+                .and_then(|action| action.as_str()),
+        );
+    }
+
+    // A failed cook already computed its own legal recovery commands. Forward
+    // them verbatim instead of restating the failure in English.
+    if let Some(context) = &report.failure_context {
+        payload = payload
+            .with_fact("Phase", context.phase.clone())
+            .with_fact("Reason code", context.reason_code.clone())
+            .with_fact("Recovery", context.recovery_reason.clone());
+        for action in context.next_actions.iter().chain(&context.legal_actions) {
+            payload = payload.with_action(
+                NotifyAction::new(action.action.clone(), action.command.clone())
+                    .with_kind("repair"),
+            );
+        }
+    }
+
+    cook_actions(payload, &report.cook_id)
+}
+
+/// The cook reached a terminal outcome.
+pub(crate) fn cook_terminal(report: &AgentTaskCookReport, component: Option<&str>, exit_code: i32) {
+    let succeeded = exit_code == 0;
+    let payload = terminal_payload(report, component, exit_code);
+    deliver(
+        NotifyEvent::lifecycle(payload.kind, &report.cook_id, &report.status)
+            .with_title(format!(
+                "cook {} — {}",
+                if succeeded {
+                    "succeeded"
+                } else {
+                    "needs attention"
+                },
+                report.cook_id
+            ))
+            .with_payload(payload),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_task_service::{AgentTaskCookFailureContext, AgentTaskCookRecoveryAction};
+
+    fn report(status: &str, finalization: Option<serde_json::Value>) -> AgentTaskCookReport {
+        AgentTaskCookReport {
+            schema: "homeboy/agent-task-cook/v1",
+            cook_id: "cook-abc".to_string(),
+            latest_run_id: Some("run-1".to_string()),
+            history_run_ids: Vec::new(),
+            invocation_run_ids: Vec::new(),
+            status: status.to_string(),
+            attempts: Vec::new(),
+            finalization,
+            stop_reason: None,
+            terminal_phase: None,
+            terminal_failure_classification: None,
+            moving_base_recovery: None,
+            failure_context: None,
+        }
+    }
+
+    fn failure_context() -> AgentTaskCookFailureContext {
+        AgentTaskCookFailureContext {
+            cook_id: "cook-abc".to_string(),
+            latest_run_id: "run-1".to_string(),
+            durable_recipe_ref: "recipe".to_string(),
+            lifecycle_state: "failed".to_string(),
+            phase: "controller".to_string(),
+            reason_code: "validation_invalid_argument".to_string(),
+            diagnostic: None,
+            blocking_claim: None,
+            provider_budget_consumed: true,
+            provider_executions_consumed: 1,
+            recovery_legal: true,
+            recovery_reason: "the durable recipe is intact".to_string(),
+            legal_actions: vec![AgentTaskCookRecoveryAction {
+                action: "continue".to_string(),
+                command: "homeboy agent-task cook --continue cook-abc".to_string(),
+            }],
+            next_actions: vec![AgentTaskCookRecoveryAction {
+                action: "diagnose".to_string(),
+                command: "homeboy agent-task diagnose cook-abc".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn successful_cook_carries_the_pull_request_link() {
+        let report = report(
+            "succeeded",
+            Some(serde_json::json!({
+                "pr_url": "https://example.test/pull/42",
+                "pr_action": "created",
+            })),
+        );
+        let payload = terminal_payload(&report, Some("homeboy"), 0);
+        assert_eq!(payload.kind, NotifyEventKind::Completed);
+        assert_eq!(payload.links.len(), 1);
+        assert_eq!(payload.links[0].url, "https://example.test/pull/42");
+        // The prose half must carry it too, for transports that only render text.
+        let body = payload.render_body();
+        assert!(body.contains("https://example.test/pull/42"), "{body}");
+        assert!(body.contains("Pull request: created"), "{body}");
+        assert!(body.contains("Component: homeboy"), "{body}");
+    }
+
+    #[test]
+    fn failed_cook_forwards_its_own_legal_recovery_commands() {
+        let mut failed = report("durable_failure", None);
+        failed.failure_context = Some(failure_context());
+        let payload = terminal_payload(&failed, None, 1);
+        assert_eq!(payload.kind, NotifyEventKind::NeedsAttention);
+        let commands: Vec<_> = payload
+            .actions
+            .iter()
+            .map(|action| action.command.as_str())
+            .collect();
+        assert!(
+            commands.contains(&"homeboy agent-task diagnose cook-abc"),
+            "{commands:?}"
+        );
+        assert!(
+            commands.contains(&"homeboy agent-task cook --continue cook-abc"),
+            "{commands:?}"
+        );
+        assert!(payload
+            .render_body()
+            .contains("Reason code: validation_invalid_argument"));
+    }
+
+    #[test]
+    fn terminal_kind_follows_the_exit_code_not_the_open_status_vocabulary() {
+        // An unrecognized status must not be mistaken for success.
+        let unknown = report("moving_base", None);
+        assert_eq!(
+            terminal_payload(&unknown, None, 1).kind,
+            NotifyEventKind::NeedsAttention
+        );
+        assert_eq!(
+            terminal_payload(&unknown, None, 0).kind,
+            NotifyEventKind::Completed
+        );
+    }
+
+    #[test]
+    fn started_payload_answers_what_did_i_just_start() {
+        let payload = started_payload(
+            "cook-abc",
+            "run-1",
+            "fix the notifier",
+            Some("homeboy"),
+            "main",
+            3,
+            "claude",
+        );
+        assert_eq!(payload.kind, NotifyEventKind::Started);
+        let subject = payload.subject.clone().expect("subject");
+        assert_eq!(subject.id, "cook-abc");
+        assert_eq!(subject.parent_id.as_deref(), Some("run-1"));
+        assert_eq!(subject.phase.as_deref(), Some("durable_identity"));
+        let body = payload.render_body();
+        assert!(body.contains("Task: fix the notifier"), "{body}");
+        assert!(body.contains("Attempt budget: 3"), "{body}");
+        assert!(body.contains("homeboy activity watch cook-abc"), "{body}");
+    }
+
+    #[test]
+    fn retry_payload_names_the_attempt_and_the_budget() {
+        let payload = retry_payload("cook-abc", "run-1", None, 2, 3);
+        assert_eq!(payload.kind, NotifyEventKind::Progress);
+        assert_eq!(payload.subject.clone().unwrap().attempt, Some(2));
+        assert!(payload.render_body().contains("Attempt: 2 of 3"));
+    }
+
+    #[test]
+    fn only_terminal_events_reach_an_ambient_default_transport() {
+        // The noise contract. A configured default transport keeps receiving
+        // outcomes and must not start receiving per-attempt progress.
+        assert!(should_deliver(NotifyEventKind::Completed, false));
+        assert!(should_deliver(NotifyEventKind::NeedsAttention, false));
+        assert!(!should_deliver(NotifyEventKind::Started, false));
+        assert!(!should_deliver(NotifyEventKind::Progress, false));
+        // An explicitly routed cook gets the full arc.
+        assert!(should_deliver(NotifyEventKind::Started, true));
+        assert!(should_deliver(NotifyEventKind::Progress, true));
+    }
+
+    #[test]
+    fn cook_lifecycle_emission_is_inert_without_a_configured_transport() {
+        // End-to-end guard that emission never panics or fails a cook when no
+        // transport is installed at all.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            cook_started("cook-abc", "run-1", "task", None, "main", 3, "claude");
+            cook_retrying("cook-abc", "run-1", None, 2, 3);
+            cook_terminal(&report("succeeded", None), None, 0);
+            cook_terminal(&report("durable_failure", None), None, 1);
+        });
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1514,7 +1514,63 @@ where
     run_cook_with_boundaries_observed(options, executor, side_effects, None)
 }
 
+/// The component a cook is working on, for notification attribution.
+///
+/// Read from the plan's own component contract rather than parsed out of the
+/// worktree handle, so a renamed or detached worktree cannot mislabel it.
+fn cook_component(options: &AgentTaskCookServiceOptions) -> Option<String> {
+    options
+        .initial_plan
+        .component_contracts
+        .iter()
+        .chain(
+            options
+                .initial_plan
+                .tasks
+                .iter()
+                .flat_map(|task| task.component_contracts.iter()),
+        )
+        .find_map(|contract| contract.slug.clone())
+}
+
+/// Whether a reported cook status means the cook will not advance on its own.
+///
+/// The single definition, shared by the durable progress phase label and the
+/// terminal notification, so a new in-flight status cannot make one of them
+/// silently disagree with the other.
+fn cook_status_is_terminal(status: &str) -> bool {
+    !matches!(status, "queued" | "running" | "in_flight")
+}
+
 fn run_cook_with_boundaries_observed<E, S>(
+    options: AgentTaskCookServiceOptions,
+    executor: E,
+    side_effects: S,
+    durable_observer: Option<&CookProgressObserver<'_>>,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
+where
+    E: AgentTaskExecutorAdapter + Clone,
+    S: CookSideEffectService,
+{
+    // Every exit from the observed boundary funnels through one notification
+    // point — including the durable-failure report built from a controller
+    // error — so the failure path is not the one that stays silent.
+    let notification_options = options.clone();
+    let result =
+        run_cook_with_boundaries_reported(options, executor, side_effects, durable_observer);
+    if let Ok(result) = &result {
+        if cook_status_is_terminal(&result.value.status) {
+            crate::agent_task_notify::cook_terminal(
+                &result.value,
+                cook_component(&notification_options).as_deref(),
+                result.exit_code,
+            );
+        }
+    }
+    result
+}
+
+fn run_cook_with_boundaries_reported<E, S>(
     options: AgentTaskCookServiceOptions,
     executor: E,
     side_effects: S,
@@ -1541,9 +1597,10 @@ where
             .last()
             .map(|attempt| attempt.attempt)
             .unwrap_or(1);
-        let phase = match result.value.status.as_str() {
-            "queued" | "running" | "in_flight" => "in_flight",
-            _ => "terminal",
+        let phase = if cook_status_is_terminal(&result.value.status) {
+            "terminal"
+        } else {
+            "in_flight"
         };
         if let Err(error) = report_cook_progress(
             durable_observer,
@@ -1718,6 +1775,18 @@ where
         1,
         None,
     )?;
+    // The same boundary, delivered to the operator's destination: this is the
+    // first moment the cook can be watched, diagnosed, or cancelled by id.
+    let notify_component = cook_component(&options);
+    crate::agent_task_notify::cook_started(
+        &options.cook_id,
+        &options.initial_run_id,
+        &options.title,
+        notify_component.as_deref(),
+        &options.base,
+        options.max_attempts,
+        &options.ai_tool,
+    );
     let required_toolchains = options.gates.required_toolchains();
     let preflight = required_toolchains
         .is_empty()
@@ -1877,6 +1946,18 @@ where
                 attempt,
                 None,
             )?;
+            // Attempt boundaries only. The first attempt is already covered by
+            // the started event, and the fifteen-second heartbeat is internal
+            // liveness with no decision attached to it.
+            if attempt > 1 {
+                crate::agent_task_notify::cook_retrying(
+                    &cook_id,
+                    &run_id,
+                    notify_component.as_deref(),
+                    attempt,
+                    max_attempts,
+                );
+            }
             validate_cook_workspace(&options)?;
             // Claim the durable attempt before candidate baseline staging. That
             // staging can take longer than the foreground controller's timeout;

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -26,6 +26,7 @@ pub mod agent_task_lifecycle;
 pub mod agent_task_loop_controller;
 pub mod agent_task_loop_definition;
 pub mod agent_task_loop_runner_policy;
+mod agent_task_notify;
 pub mod agent_task_promotion;
 pub mod agent_task_prompts;
 pub mod agent_task_provider;

--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -3,7 +3,12 @@ use std::time::{Duration, Instant};
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::core::activity::{self, ActivityItem, ActivityReport, ActivityScope, ActivityState};
+use homeboy::core::activity::{
+    self, ActivityEvidenceRef, ActivityItem, ActivityReport, ActivityScope, ActivityState,
+};
+use homeboy::core::notification_payload::{
+    NotifyAction, NotifyAttachment, NotifyEventKind, NotifyPayload, NotifySubject,
+};
 use homeboy::core::notify::{self, NotifyEvent, NotifyOutcome};
 use homeboy::core::{Error, Result};
 
@@ -413,14 +418,79 @@ fn maybe_notify(
     } else {
         format!("{:?}", item.state).to_lowercase()
     };
-    Some(notify::dispatch(&NotifyEvent {
-        title: format!("homeboy activity {status}"),
-        body: format!("{} {}", item.kind, item.id),
-        status,
-        run_id: item.id.clone(),
-        transport: None,
-        route: None,
-    }))
+    // The watched item already carries its command, runner placement, next
+    // actions, and artifact/evidence refs. Previously all of it was dropped and
+    // the notification said only "<kind> <id>".
+    let kind = if timed_out {
+        NotifyEventKind::NeedsAttention
+    } else {
+        NotifyEventKind::Completed
+    };
+    let payload = NotifyPayload::new(
+        kind,
+        NotifySubject::new(item.kind.clone(), item.id.clone()).with_phase(if timed_out {
+            "watch_timeout"
+        } else {
+            "terminal"
+        }),
+    )
+    .with_fact("Status", status.clone())
+    .with_optional_fact("Command", item.command.clone())
+    .with_optional_fact("Runner", item.runner.runner_id.clone())
+    .with_optional_fact("Finished", item.finished_at.clone())
+    .with_action(
+        NotifyAction::new("show", format!("homeboy activity show {}", item.id)).with_kind("show"),
+    );
+    let payload = item
+        .next_actions
+        .iter()
+        .fold(payload, |payload, action| {
+            payload.with_action(NotifyAction::new(
+                action.label.clone(),
+                action.command.clone(),
+            ))
+        })
+        .with_attachments(
+            item.artifacts
+                .iter()
+                .map(|artifact| notify_attachment(&item.id, "artifact", artifact))
+                .chain(
+                    item.evidence
+                        .iter()
+                        .map(|evidence| notify_attachment(&item.id, "evidence", evidence)),
+                ),
+        );
+
+    Some(notify::dispatch(
+        &NotifyEvent {
+            title: format!("homeboy activity {status}"),
+            body: format!("{} {}", item.kind, item.id),
+            status,
+            run_id: item.id.clone(),
+            kind,
+            transport: None,
+            route: None,
+            payload: None,
+        }
+        .with_payload(payload),
+    ))
+}
+
+/// Project an activity evidence ref into a deliverable attachment.
+///
+/// `fetch_command` is what makes this useful to a transport that cannot attach
+/// files: it renders the exact retrieval command instead of a bare path.
+fn notify_attachment(
+    owner_id: &str,
+    kind: &str,
+    reference: &ActivityEvidenceRef,
+) -> NotifyAttachment {
+    NotifyAttachment::new(
+        reference.id.clone(),
+        kind,
+        reference.uri.clone(),
+        format!("homeboy runs artifact get {owner_id} {}", reference.id),
+    )
 }
 
 fn parse_duration(raw: &str) -> Result<Duration> {

--- a/crates/homeboy-cli/src/commands/runs/watch.rs
+++ b/crates/homeboy-cli/src/commands/runs/watch.rs
@@ -248,7 +248,8 @@ fn maybe_notify(args: &RunsWatchArgs, result: &WatchResult) -> Option<NotifyOutc
         &result.run.metadata_json,
     );
     let event =
-        NotifyEvent::run_completed_with_route(&args.run_id, &result.run.status, route.as_ref());
+        NotifyEvent::run_completed_with_route(&args.run_id, &result.run.status, route.as_ref())
+            .with_payload(notify::run_completed_payload(&result.run));
     Some(notify::dispatch(&event))
 }
 

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1082,11 +1082,17 @@ fn completion_notify_loop(interval: std::time::Duration, shutdown: mpsc::Receive
                 if !won_race {
                     continue;
                 }
-                let event = crate::notify::NotifyEvent::run_completed_with_route(
+                let mut event = crate::notify::NotifyEvent::run_completed_with_route(
                     &completed_id,
                     status,
                     route.as_ref(),
                 );
+                // The completed record is already loaded above; carry its
+                // component, command, and evidence handles instead of
+                // re-deriving prose from the id and status alone.
+                if let Some(run) = run.as_ref() {
+                    event = event.with_payload(crate::notify::run_completed_payload(run));
+                }
                 let _ = crate::notify::dispatch(&event);
             }
         }

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -128,6 +128,7 @@ pub use homeboy_lifecycle_contract::lifecycle;
 pub mod loop_lifecycle;
 pub mod markdown;
 pub mod matrix_artifact_summary;
+pub use homeboy_lab_contract::notification_payload;
 pub use homeboy_lab_contract::notification_route;
 pub mod notify;
 pub mod observation;

--- a/crates/homeboy-core/src/notify.rs
+++ b/crates/homeboy-core/src/notify.rs
@@ -1,22 +1,44 @@
-//! Transport-neutral completion notifications delivered by installed extensions.
+//! Transport-neutral lifecycle notifications delivered by installed extensions.
+//!
+//! An event has two halves. The prose half (`title`/`body`) is the stable argv
+//! contract every installed transport already implements. The structured half
+//! ([`NotifyPayload`]) is what lets a consumer *act* on an event rather than
+//! only display it, and it is delivered out-of-band through the transport
+//! child's environment — see [`crate::notification_payload`] for why argv is
+//! not extended.
 
 use std::process::Command;
 
 use serde::Serialize;
 
+use crate::notification_payload::{
+    NotifyEventKind, NotifyPayload, NOTIFICATION_PAYLOAD_SCHEMA, NOTIFY_KIND_ENV,
+    NOTIFY_PAYLOAD_ENV, NOTIFY_PAYLOAD_SCHEMA_ENV, NOTIFY_PAYLOAD_TRUNCATED_ENV,
+};
 use crate::notification_route::NotificationRoute;
 
-/// A completion event passed to extension transports as typed argv values.
+/// Bound on transport output homeboy will hold in memory and inspect.
+const TRANSPORT_OUTPUT_INSPECTION_LIMIT: usize = 256 * 1024;
+/// Bound on the transport diagnostic text folded into `NotifyOutcome::error`.
+const TRANSPORT_ERROR_TAIL_CHARS: usize = 800;
+
+/// A lifecycle event passed to extension transports as typed argv values.
 #[derive(Debug, Clone, Serialize)]
 pub struct NotifyEvent {
     pub run_id: String,
     pub status: String,
     pub title: String,
     pub body: String,
+    /// Where this event sits in its subject's lifecycle. Terminal by default so
+    /// producers written before lifecycle events existed keep their meaning.
+    pub kind: NotifyEventKind,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transport: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub route: Option<String>,
+    /// The machine-readable half. Absent for producers that only have prose.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<NotifyPayload>,
 }
 
 impl NotifyEvent {
@@ -26,8 +48,10 @@ impl NotifyEvent {
             status: status.to_string(),
             title: format!("homeboy run {status}"),
             body: format!("Run {run_id} finished with status {status}"),
+            kind: NotifyEventKind::Completed,
             transport: None,
             route: None,
+            payload: None,
         }
     }
 
@@ -36,14 +60,67 @@ impl NotifyEvent {
         status: &str,
         route: Option<&NotificationRoute>,
     ) -> Self {
-        let mut event = Self::run_completed(run_id, status);
-        if let Some(route) = route {
-            event.transport = Some(route.transport.clone());
-            event.route = Some(route.route.clone());
-        }
-        event
+        Self::run_completed(run_id, status).with_route(route)
     }
 
+    /// A lifecycle event for a subject that is not an observation run.
+    ///
+    /// `run_id` remains the argv field name every installed transport already
+    /// reads, so a non-run subject identifies itself there rather than through
+    /// a new flag. Producers should attach a payload whose subject carries the
+    /// real class.
+    pub fn lifecycle(kind: NotifyEventKind, subject_id: &str, status: &str) -> Self {
+        Self {
+            run_id: subject_id.to_string(),
+            status: status.to_string(),
+            title: format!("homeboy {} {status}", kind.as_str()),
+            body: format!("{subject_id} is {status}"),
+            kind,
+            transport: None,
+            route: None,
+            payload: None,
+        }
+    }
+
+    /// Bind an explicit destination. A `None` route leaves the event route-less,
+    /// so it resolves through the configured operations default instead.
+    pub fn with_route(mut self, route: Option<&NotificationRoute>) -> Self {
+        if let Some(route) = route {
+            self.transport = Some(route.transport.clone());
+            self.route = Some(route.route.clone());
+        }
+        self
+    }
+
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Attach the structured half and derive the prose from it.
+    ///
+    /// Rendering the body from the payload is what keeps this change additive:
+    /// an already-installed text-only transport receives the component, phase,
+    /// facts, links, next actions, and attachment handles immediately, with no
+    /// coordinated extension release — and the prose can never drift from the
+    /// structure because there is only one source for both.
+    pub fn with_payload(mut self, payload: NotifyPayload) -> Self {
+        self.kind = payload.kind;
+        let rendered = payload.render_body();
+        if !rendered.trim().is_empty() {
+            self.body = rendered;
+        }
+        self.payload = Some(payload);
+        self
+    }
+
+    /// The frozen argv contract.
+    ///
+    /// Do not add flags here. An installed transport validates its own argv and
+    /// rejects unknown flags, so a new flag turns every notification into an
+    /// input error until every installed extension — in every repo, at every
+    /// pinned version — has shipped support for it. Structured additions travel
+    /// through `payload_env` instead, which an unaware transport ignores.
     fn argv(&self) -> Vec<String> {
         let mut argv = vec![
             "--run-id".to_string(),
@@ -63,6 +140,90 @@ impl NotifyEvent {
         }
         argv
     }
+
+    /// Environment handed to the transport child alongside the argv contract.
+    ///
+    /// Always carries the lifecycle kind, and the serialized payload when the
+    /// producer supplied one. A transport that knows nothing about these names
+    /// is unaffected: unread environment variables cost it nothing, where an
+    /// unknown flag would fail it outright.
+    fn payload_env(&self) -> Vec<(&'static str, String)> {
+        let mut env = vec![(NOTIFY_KIND_ENV, self.kind.as_str().to_string())];
+        let Some(payload) = &self.payload else {
+            return env;
+        };
+        let Some((json, truncated)) = payload.serialize_bounded() else {
+            return env;
+        };
+        env.push((
+            NOTIFY_PAYLOAD_SCHEMA_ENV,
+            NOTIFICATION_PAYLOAD_SCHEMA.to_string(),
+        ));
+        env.push((NOTIFY_PAYLOAD_ENV, json));
+        if truncated {
+            env.push((NOTIFY_PAYLOAD_TRUNCATED_ENV, "1".to_string()));
+        }
+        env
+    }
+}
+
+/// Whether a finished run still needs a human decision.
+///
+/// Resolved through the owned [`crate::observation::RunStatus`] vocabulary
+/// rather than a private string list, so a new status classifies itself here.
+/// An unowned label is conservatively treated as needing attention: silently
+/// reporting an unrecognized outcome as a clean completion is the worse error.
+fn run_status_needs_attention(status: &str) -> bool {
+    use crate::observation::RunStatus;
+    !matches!(
+        RunStatus::from_label(status),
+        Some(RunStatus::Pass | RunStatus::Skipped | RunStatus::Running)
+    )
+}
+
+/// The structured half of a run-completion notification, built from the run
+/// record every completion site already holds.
+///
+/// Shared by the controller's completion notifier, `runs watch --notify`, and
+/// the runner's direct delivery so all three describe a finished run the same
+/// way rather than each fabricating its own sentence.
+pub fn run_completed_payload(run: &crate::observation::RunRecord) -> NotifyPayload {
+    let kind = if run_status_needs_attention(&run.status) {
+        NotifyEventKind::NeedsAttention
+    } else {
+        NotifyEventKind::Completed
+    };
+    let mut subject =
+        crate::notification_payload::NotifySubject::new(run.kind.clone(), run.id.clone());
+    subject.component = run.component_id.clone();
+    NotifyPayload::new(kind, subject)
+        .with_fact("Status", run.status.clone())
+        .with_optional_fact("Command", run.command.clone())
+        .with_optional_fact("Component", run.component_id.clone())
+        .with_optional_fact("Finished", run.finished_at.clone())
+        .with_optional_fact("Version", run.homeboy_version.clone())
+        .with_optional_fact("Commit", run.git_sha.clone())
+        .with_action(
+            crate::notification_payload::NotifyAction::new(
+                "show run",
+                format!("homeboy runs show {}", run.id),
+            )
+            .with_kind("show"),
+        )
+        .with_action(
+            crate::notification_payload::NotifyAction::new(
+                "show evidence",
+                format!("homeboy runs evidence {}", run.id),
+            )
+            .with_kind("show"),
+        )
+        .with_action(
+            crate::notification_payload::NotifyAction::new(
+                "list artifacts",
+                format!("homeboy runs artifacts {}", run.id),
+            )
+            .with_kind("artifacts"),
+        )
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -73,6 +234,11 @@ pub enum NotifyDelivery {
         transport_id: String,
         command: Vec<String>,
         exit_code: Option<i32>,
+        /// Environment variable names carrying the structured payload. Recorded
+        /// so the delivery record stays a complete reproduction of the child
+        /// invocation now that not everything travels through argv.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        payload_env: Vec<String>,
     },
     NotConfigured,
 }
@@ -80,9 +246,18 @@ pub enum NotifyDelivery {
 #[derive(Debug, Clone, Serialize)]
 pub struct NotifyOutcome {
     pub delivered: bool,
+    /// The lifecycle position of the event this outcome describes.
+    pub event_kind: NotifyEventKind,
     pub delivery: NotifyDelivery,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// The transport's own structured result envelope, when it emitted one.
+    ///
+    /// Transports classify their failures, count their retries, and report
+    /// truncation on stdout. That work used to be discarded because homeboy
+    /// only read the exit code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
 }
 
 /// Deliver an event through the route's installed extension transport. Route-less
@@ -96,14 +271,16 @@ pub fn dispatch(event: &NotifyEvent) -> NotifyOutcome {
     let Some(transport_id) = transport_id else {
         return NotifyOutcome {
             delivered: false,
+            event_kind: event.kind,
             delivery: NotifyDelivery::NotConfigured,
             error: None,
+            result: None,
         };
     };
 
     let extensions = match crate::extension_store::load_all_extensions() {
         Ok(extensions) => extensions,
-        Err(err) => return missing_transport(&transport_id, err.message),
+        Err(err) => return missing_transport(event.kind, &transport_id, err.message),
     };
     let matches: Vec<_> = extensions
         .iter()
@@ -121,7 +298,7 @@ pub fn dispatch(event: &NotifyEvent) -> NotifyOutcome {
         } else {
             "is declared by more than one installed extension".to_string()
         };
-        return missing_transport(&transport_id, detail);
+        return missing_transport(event.kind, &transport_id, detail);
     };
 
     // Resolve `{extension_path}` in the transport's literal argv so a manifest
@@ -136,40 +313,110 @@ pub fn dispatch(event: &NotifyEvent) -> NotifyOutcome {
         .collect();
     argv.extend(event.argv());
     let program = argv.first().expect("validated transport command").clone();
-    match Command::new(&program).args(&argv[1..]).status() {
-        Ok(status) => NotifyOutcome {
-            delivered: status.success(),
-            delivery: NotifyDelivery::Transport {
-                extension_id: extension.id.clone(),
-                transport_id,
-                command: argv,
-                exit_code: status.code(),
-            },
-            error: (!status.success())
-                .then(|| format!("notification transport exited with {status}")),
-        },
+    let payload_env = event.payload_env();
+    let payload_env_names = payload_env
+        .iter()
+        .map(|(name, _)| (*name).to_string())
+        .collect();
+
+    let mut command = Command::new(&program);
+    command.args(&argv[1..]);
+    for (name, value) in payload_env {
+        command.env(name, value);
+    }
+
+    // `output()` rather than `status()`: a transport reports its delivery mode,
+    // route kind, truncation, attempt count, and a classified error kind on
+    // stdout. Reading only the exit code discarded all of it, so a failed
+    // notification could not be told apart from a rate-limited one.
+    match command.output() {
+        Ok(output) => {
+            let delivered = output.status.success();
+            let result = parse_transport_result(&output.stdout);
+            NotifyOutcome {
+                delivered,
+                event_kind: event.kind,
+                delivery: NotifyDelivery::Transport {
+                    extension_id: extension.id.clone(),
+                    transport_id,
+                    command: argv,
+                    exit_code: output.status.code(),
+                    payload_env: payload_env_names,
+                },
+                error: (!delivered).then(|| transport_failure_message(&output)),
+                result,
+            }
+        }
         Err(err) => NotifyOutcome {
             delivered: false,
+            event_kind: event.kind,
             delivery: NotifyDelivery::Transport {
                 extension_id: extension.id.clone(),
                 transport_id,
                 command: argv,
                 exit_code: None,
+                payload_env: payload_env_names,
             },
             error: Some(format!(
                 "failed to run notification transport `{program}`: {err}"
             )),
+            result: None,
         },
     }
 }
 
-fn missing_transport(transport_id: &str, detail: String) -> NotifyOutcome {
+/// Parse a transport's structured result envelope. A transport that prints
+/// nothing, prints prose, or prints oversized output is not an error — it just
+/// contributes no structured result.
+fn parse_transport_result(stdout: &[u8]) -> Option<serde_json::Value> {
+    if stdout.is_empty() || stdout.len() > TRANSPORT_OUTPUT_INSPECTION_LIMIT {
+        return None;
+    }
+    let text = std::str::from_utf8(stdout).ok()?.trim();
+    // Transports emit one JSON line; take the last so leading log lines from a
+    // chatty runtime do not defeat the parse.
+    let line = text.lines().rev().find(|line| !line.trim().is_empty())?;
+    serde_json::from_str::<serde_json::Value>(line.trim())
+        .ok()
+        .filter(serde_json::Value::is_object)
+}
+
+fn transport_failure_message(output: &std::process::Output) -> String {
+    let status = output.status;
+    let diagnostic = [&output.stderr, &output.stdout]
+        .into_iter()
+        .filter(|stream| stream.len() <= TRANSPORT_OUTPUT_INSPECTION_LIMIT)
+        .filter_map(|stream| std::str::from_utf8(stream).ok())
+        .map(str::trim)
+        .find(|text| !text.is_empty())
+        .map(|text| {
+            let tail: String = text
+                .chars()
+                .rev()
+                .take(TRANSPORT_ERROR_TAIL_CHARS)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            format!(": {tail}")
+        })
+        .unwrap_or_default();
+    format!("notification transport exited with {status}{diagnostic}")
+}
+
+fn missing_transport(
+    event_kind: NotifyEventKind,
+    transport_id: &str,
+    detail: String,
+) -> NotifyOutcome {
     NotifyOutcome {
         delivered: false,
+        event_kind,
         delivery: NotifyDelivery::NotConfigured,
         error: Some(format!(
             "notification transport `{transport_id}` {detail}; install or configure an extension that declares it"
         )),
+        result: None,
     }
 }
 
@@ -305,5 +552,211 @@ mod tests {
             .unwrap();
             assert!(dispatch(&NotifyEvent::run_completed("run-123", "pass")).delivered);
         });
+    }
+
+    fn cook_payload() -> NotifyPayload {
+        NotifyPayload::new(
+            NotifyEventKind::NeedsAttention,
+            crate::notification_payload::NotifySubject::new("agent_task_cook", "cook-abc")
+                .with_component("homeboy")
+                .with_attempt(2),
+        )
+        .with_fact("Stop reason", "gate_failed")
+        .with_action(
+            crate::notification_payload::NotifyAction::new(
+                "diagnose",
+                "homeboy agent-task diagnose cook-abc",
+            )
+            .with_kind("repair"),
+        )
+    }
+
+    #[test]
+    fn structured_payload_does_not_change_the_argv_contract() {
+        // The whole compatibility argument rests on this: an installed
+        // transport at its current version must see exactly the argv it
+        // already validates, with or without a payload.
+        let plain = NotifyEvent::run_completed("run-123", "pass");
+        let enriched = NotifyEvent::run_completed("run-123", "pass").with_payload(cook_payload());
+        let flags = |event: &NotifyEvent| {
+            event
+                .argv()
+                .into_iter()
+                .filter(|arg| arg.starts_with("--"))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(flags(&plain), flags(&enriched));
+    }
+
+    #[test]
+    fn payload_replaces_the_fabricated_body_so_text_transports_gain_detail() {
+        let event = NotifyEvent::run_completed("run-123", "pass").with_payload(cook_payload());
+        // The old body was derived entirely from run id and status.
+        assert_ne!(event.body, "Run run-123 finished with status pass");
+        assert!(event.body.contains("Component: homeboy"), "{}", event.body);
+        assert!(
+            event.body.contains("Stop reason: gate_failed"),
+            "{}",
+            event.body
+        );
+        assert!(
+            event.body.contains("homeboy agent-task diagnose cook-abc"),
+            "{}",
+            event.body
+        );
+        // Prose is still present and still delivered through argv.
+        assert!(event.argv().contains(&event.body));
+        assert_eq!(event.kind, NotifyEventKind::NeedsAttention);
+    }
+
+    #[test]
+    fn payload_free_event_keeps_its_historical_prose_and_kind() {
+        let event = NotifyEvent::run_completed("run-123", "pass");
+        assert_eq!(event.body, "Run run-123 finished with status pass");
+        assert_eq!(event.kind, NotifyEventKind::Completed);
+        assert!(event.payload.is_none());
+    }
+
+    #[test]
+    fn payload_env_carries_kind_without_a_payload() {
+        let env = NotifyEvent::run_completed("run-123", "pass").payload_env();
+        assert_eq!(env, vec![(NOTIFY_KIND_ENV, "completed".to_string())]);
+    }
+
+    #[test]
+    fn payload_env_carries_schema_and_serialized_payload() {
+        let event = NotifyEvent::run_completed("run-123", "fail").with_payload(cook_payload());
+        let env = event.payload_env();
+        let by_name = |name: &str| {
+            env.iter()
+                .find(|(key, _)| *key == name)
+                .map(|(_, value)| value.clone())
+        };
+        assert_eq!(by_name(NOTIFY_KIND_ENV).as_deref(), Some("needs_attention"));
+        assert_eq!(
+            by_name(NOTIFY_PAYLOAD_SCHEMA_ENV).as_deref(),
+            Some(NOTIFICATION_PAYLOAD_SCHEMA)
+        );
+        let payload: NotifyPayload =
+            serde_json::from_str(&by_name(NOTIFY_PAYLOAD_ENV).expect("payload env")).unwrap();
+        assert_eq!(payload.subject.unwrap().id, "cook-abc");
+        assert!(by_name(NOTIFY_PAYLOAD_TRUNCATED_ENV).is_none());
+    }
+
+    #[cfg(unix)]
+    fn install_recording_transport(
+        id: &str,
+        home: &std::path::Path,
+        stdout_line: &str,
+        exit_code: i32,
+    ) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let record = home.join("notify-observed.txt");
+        let script = home.join("notify-transport.sh");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\n\
+                 {{\n\
+                 echo \"kind=$HOMEBOY_NOTIFY_KIND\"\n\
+                 echo \"schema=$HOMEBOY_NOTIFY_PAYLOAD_SCHEMA\"\n\
+                 echo \"payload=$HOMEBOY_NOTIFY_PAYLOAD\"\n\
+                 }} > {record}\n\
+                 echo '{stdout_line}'\n\
+                 exit {exit_code}\n",
+                record = record.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        install_transport(id, vec![script.to_str().unwrap()]);
+        record
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transport_child_receives_the_structured_payload_through_its_environment() {
+        crate::test_support::with_isolated_home(|home| {
+            let record = install_recording_transport(
+                "test.run-completion",
+                home.path(),
+                "{\"schema\":\"test/notification-result/v1\",\"status\":\"delivered\",\"attempts\":2}",
+                0,
+            );
+            let route = NotificationRoute::new("test.run-completion", "route-42").unwrap();
+            let event = NotifyEvent::run_completed("run-123", "fail")
+                .with_route(Some(&route))
+                .with_payload(cook_payload());
+            let outcome = dispatch(&event);
+            assert!(outcome.delivered, "{:?}", outcome.error);
+
+            let observed = std::fs::read_to_string(&record).unwrap();
+            assert!(observed.contains("kind=needs_attention"), "{observed}");
+            assert!(
+                observed.contains(&format!("schema={NOTIFICATION_PAYLOAD_SCHEMA}")),
+                "{observed}"
+            );
+            assert!(observed.contains("cook-abc"), "{observed}");
+
+            let NotifyDelivery::Transport { payload_env, .. } = &outcome.delivery else {
+                panic!("expected transport delivery");
+            };
+            assert!(payload_env.iter().any(|name| name == NOTIFY_PAYLOAD_ENV));
+            assert_eq!(outcome.event_kind, NotifyEventKind::NeedsAttention);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transport_structured_result_is_retained_instead_of_discarded() {
+        crate::test_support::with_isolated_home(|home| {
+            install_recording_transport(
+                "test.run-completion",
+                home.path(),
+                "{\"schema\":\"test/notification-result/v1\",\"status\":\"delivered\",\"attempts\":3}",
+                0,
+            );
+            let route = NotificationRoute::new("test.run-completion", "route-42").unwrap();
+            let outcome = dispatch(&NotifyEvent::run_completed_with_route(
+                "run-123",
+                "pass",
+                Some(&route),
+            ));
+            let result = outcome.result.expect("transport result envelope");
+            assert_eq!(result["status"], "delivered");
+            assert_eq!(result["attempts"], 3);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_transport_reports_its_own_diagnostic_not_just_an_exit_code() {
+        crate::test_support::with_isolated_home(|home| {
+            install_recording_transport(
+                "test.run-completion",
+                home.path(),
+                "{\"schema\":\"test/notification-result/v1\",\"status\":\"failed\",\"error\":{\"kind\":\"auth_error\"}}",
+                1,
+            );
+            let route = NotificationRoute::new("test.run-completion", "route-42").unwrap();
+            let outcome = dispatch(&NotifyEvent::run_completed_with_route(
+                "run-123",
+                "fail",
+                Some(&route),
+            ));
+            assert!(!outcome.delivered);
+            let error = outcome.error.expect("failure diagnostic");
+            assert!(error.contains("auth_error"), "{error}");
+            assert_eq!(outcome.result.expect("result")["status"], "failed");
+        });
+    }
+
+    #[test]
+    fn non_json_transport_output_is_not_reported_as_a_structured_result() {
+        assert!(parse_transport_result(b"").is_none());
+        assert!(parse_transport_result(b"delivered\n").is_none());
+        // A bare JSON scalar is not a result envelope.
+        assert!(parse_transport_result(b"42\n").is_none());
+        assert!(parse_transport_result(b"warm-up log line\n{\"status\":\"ok\"}\n").is_some());
     }
 }

--- a/crates/homeboy-core/src/schedule/execution.rs
+++ b/crates/homeboy-core/src/schedule/execution.rs
@@ -4,6 +4,7 @@ use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
+use crate::notification_payload::{NotifyAction, NotifyEventKind, NotifyPayload, NotifySubject};
 
 use super::state::{load_state, save_state, ScheduleState};
 use super::types::{NotifyPolicy, Schedule, ScheduledCommand};
@@ -499,32 +500,52 @@ fn notify(schedule: &Schedule, outcome: &ScheduleRunOutcome) -> (bool, Option<St
         _ => None,
     };
 
-    let title = format!("schedule {} — {}", schedule.id, outcome.status);
-    let mut body = format!("Command: {}\n", schedule.command_display());
-    body.push_str(&format!(
-        "Status: {} (exit {})\n",
-        outcome.status, outcome.exit_code
-    ));
-    body.push_str(&format!(
-        "Result: {}\n",
+    // The facts a schedule notification used to hand-format into prose are now
+    // structured once. The prose is rendered from them, so a text-only
+    // transport keeps the same information and a payload-aware one can act on
+    // it (re-run the schedule, inspect the failure) without parsing English.
+    let run_id = format!("schedule-{}-{}", schedule.id, outcome.started_at);
+    let payload = NotifyPayload::new(
+        NotifyEventKind::Completed,
+        NotifySubject::new("schedule", schedule.id.clone()).with_phase("scheduled_run"),
+    )
+    .with_fact("Command", schedule.command_display())
+    .with_fact(
+        "Status",
+        format!("{} (exit {})", outcome.status, outcome.exit_code),
+    )
+    .with_fact(
+        "Result",
         if outcome.changed {
             "changed since the previous run"
         } else {
             "unchanged"
-        }
+        },
+    )
+    .with_optional_fact("Summary", outcome.summary.clone())
+    .with_action(NotifyAction::new(
+        "show schedule",
+        format!("homeboy schedule show {}", schedule.id),
+    ))
+    .with_action(NotifyAction::new(
+        "run now",
+        format!("homeboy schedule run {}", schedule.id),
     ));
-    if let Some(summary) = &outcome.summary {
-        body.push_str(&format!("Summary: {summary}\n"));
-    }
 
     let event = crate::notify::NotifyEvent {
-        run_id: format!("schedule-{}-{}", schedule.id, outcome.started_at),
+        run_id,
         status: outcome.status.clone(),
-        title,
-        body,
+        title: format!("schedule {} — {}", schedule.id, outcome.status),
+        body: format!(
+            "Schedule {} finished with status {}",
+            schedule.id, outcome.status
+        ),
+        kind: NotifyEventKind::Completed,
         transport: route.as_ref().map(|route| route.transport.clone()),
         route: route.as_ref().map(|route| route.route.clone()),
-    };
+        payload: None,
+    }
+    .with_payload(payload);
     let result = crate::notify::dispatch(&event);
     (result.delivered, result.error)
 }

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -1365,8 +1365,14 @@ pub(super) fn fire_runner_direct_notification(
     if already_delivered {
         return;
     }
-    let event =
+    let mut event =
         homeboy_core::notify::NotifyEvent::run_completed_with_route(run_id, status, Some(route));
+    // The store is already open for the delivery guard; reuse it so the
+    // runner's direct delivery carries the same structured detail the
+    // controller's notifier does.
+    if let Ok(Some(run)) = store.get_run(run_id) {
+        event = event.with_payload(homeboy_core::notify::run_completed_payload(&run));
+    }
     let outcome = homeboy_core::notify::dispatch(&event);
     if outcome.delivered {
         let _ = store.mark_notification_delivered(run_id, "runner-direct");

--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -219,6 +219,37 @@ non-secret transport-owned values. Transport IDs must be unique within an
 extension; an ID declared by multiple installed extensions is rejected at
 delivery time.
 
+**The argv contract is frozen.** Transports validate their own argv and reject
+unknown flags, so homeboy will not add flags to it. A transport that implements
+only the six values above keeps working at every future homeboy version.
+
+#### Structured payload (optional)
+
+Everything a transport needs to *act* on an event, rather than only display it,
+is delivered through the child process environment. A transport that ignores
+these variables is unaffected.
+
+| Variable | Meaning |
+| --- | --- |
+| `HOMEBOY_NOTIFY_KIND` | Lifecycle position: `queued`, `started`, `progress`, `completed`, `needs_attention`. Always set. |
+| `HOMEBOY_NOTIFY_PAYLOAD_SCHEMA` | Payload contract id, currently `homeboy/notification-payload/v1`. Version-gate on this before parsing. |
+| `HOMEBOY_NOTIFY_PAYLOAD` | The serialized payload. Set only when the producer supplied one. |
+| `HOMEBOY_NOTIFY_PAYLOAD_TRUNCATED` | `1` when members were dropped to keep the payload within its size budget. |
+
+The payload carries `subject` (generic class, id, component, parent, attempt,
+phase), ordered `facts`, executable `actions`, external `links`, and
+`attachments`. Attachments name a homeboy artifact by id, uri, and
+`fetch_command`, and may carry `media_type`, `display_name`, `byte_size`,
+`caption`, and a `group_id`/`role` pair for related evidence such as
+`source`/`candidate`/`diff`.
+
+Nothing is lost by ignoring the payload: `--body` is rendered *from* it, so a
+text-only transport receives the same information as bounded prose.
+
+Transports that print a JSON object on stdout have it retained verbatim in
+homeboy's `NotifyOutcome.result`, so delivery mode, attempt counts, truncation,
+and classified error kinds survive instead of collapsing to an exit code.
+
 Known sidecar names default to these run-directory paths when `path` is omitted:
 
 | Name | Default path |


### PR DESCRIPTION
Refs #10301.

## What the issue got right

Verified against `b937def60`-era code, all with current line numbers:

- `crates/homeboy-core/src/notify.rs:10-20` — `NotifyEvent { run_id, status, title, body, transport, route }`. Correct.
- `:23-32` `run_completed` derives **both** strings from `run_id` and `status`. Correct — zero additional information.
- Exactly **five** non-test `notify::dispatch` sites, all terminal-only:

| Site | Construction | Dispatch |
|---|---|---|
| `homeboy-cli/src/commands/activity.rs` | `:416` | `:416` |
| `homeboy-cli/src/commands/runs/watch.rs` | `:251` | `:252` |
| `homeboy-core/src/schedule/execution.rs` | `:520` | `:528` |
| `homeboy-core/src/daemon/mod.rs` | `:1085` | `:1090` |
| `homeboy-lab-runner/src/execution/mod.rs` | `:1369` | `:1370` |

- `grep -rn "NotifyEvent\|notify::dispatch" crates/homeboy-agents/` → **0 hits**. Correct.
- `homeboy-extensions/discord/scripts/notify.mjs:68` rejects unknown flags. Correct.
- The blocker (#10282) is resolved — `notification_route::capture()/bind()` landed in #10330 and is bound at all three spawn sites. Unblocked.

## Two things in the issue are wrong, and the fix does not follow them

### 1. `payload: Option<CommandActionableMetadata>` is not implementable

`CommandActionableMetadata` is defined at `crates/homeboy-cli/src/commands/utils/response.rs:70` — in **homeboy-cli**, which depends on homeboy-core. `NotifyEvent` is in homeboy-core. This would require `homeboy-core → homeboy-cli`, a dependency cycle.

It is also the wrong contract even if it compiled: it is the CLI's v3 *command-result envelope* type. Putting it on the wire would mean every third-party transport has to learn homeboy's CLI envelope schema in order to read a notification, in a subsystem whose entire virtue (correctly identified in the issue) is that it is transport- and consumer-agnostic.

**Instead:** a new `homeboy/notification-payload/v1` in `crates/contracts/homeboy-lab-contract/`, which already owns `notification_route.rs` and sits below both core and the CLI.

### 2. Extending `argv()` with `--kind` and `--payload` is a breaking change, not an additive one

> Existing transports are unaffected — **except** `notify.mjs:71` currently rejects unknown flags, so the two names must be added in the same change.

They cannot be added in the same change, and other transports are not unaffected:

- **homeboy and homeboy-extensions are separate repositories with independent release cadences and independent install state.** There is no atomic change spanning both. A user on new homeboy + `homeboy-extensions@v3.34.9` gets `input_error` on *every* notification — a silent total outage of the subsystem this issue exists to improve.
- **Third-party transports are unknowable.** Core cannot enumerate installed transports' argv validators.
- **Gating the flags behind a manifest capability does not rescue it.** `NotificationTransportConfig` has `#[serde(deny_unknown_fields)]` (`crates/contracts/homeboy-extension-contract/src/notification_transport_config.rs:17`). Declaring a new capability field would make the manifest fail to deserialize on any older homeboy — taking the *entire extension* down, not just its notifications.

**Instead:** the argv contract is frozen and documented as frozen. The payload travels through the transport child's **environment**. An unaware transport never reads it; there is no version to coordinate and nothing to break.

## Serde compatibility audit

Per the `ProvidesConfig` lesson:

```
grep -rn "deny_unknown_fields" crates/
```

- `NotifyEvent`, `NotifyOutcome`, `NotifyDelivery`, `NotificationRoute`: **none have it**. `NotifyEvent`/`NotifyOutcome`/`NotifyDelivery` are `Serialize`-only, so added fields cannot break a deserializer that does not exist.
- `NotifyPayload` is `Serialize + Deserialize` and **deliberately not** `deny_unknown_fields`, with `#[serde(default)]` on `schema` and `kind` — a payload from a newer homeboy must still parse in an older structured consumer. Tested (`payload_accepts_unknown_fields_from_a_newer_producer`, `payload_defaults_to_completed_for_a_producer_that_omits_kind`).
- `NotificationTransportConfig` **does** have `deny_unknown_fields`. **This PR does not touch it** — that is precisely why the design avoids manifest capability declaration.

## Payload design

`crates/contracts/homeboy-lab-contract/src/notification_payload.rs`

```rust
NotifyEventKind { Queued, Started, Progress, Completed (default), NeedsAttention }

NotifyPayload {
  schema, kind,
  subject:     Option<NotifySubject>,   // kind, id, component, parent_id, attempt, phase
  facts:       Vec<NotifyFact>,         // ordered label/value
  actions:     Vec<NotifyAction>,       // label + exact command + intent kind
  links:       Vec<NotifyLink>,         // PR / issue / CI
  attachments: Vec<NotifyAttachment>,
}
```

**Why prose stays and how it stays honest.** `NotifyEvent::with_payload` sets `body = payload.render_body()`. There is one source for both halves, so they cannot drift — and, more importantly, an **already-installed text-only transport gets the richer message with zero changes**. `homeboy-extensions@v3.34.9` goes from

```
[pass] homeboy run pass
Run: run-123
Run run-123 finished with status pass
```

to a body carrying component, command, commit, phase, attempt, PR URL, and the exact next commands — with no extension release at all. That is the compatibility argument, not a caveat to it.

**Why this does not corner #10260.** `NotifyAttachment` was shaped directly against #10260's acceptance criteria:

| #10260 requires | Field |
|---|---|
| attachment by homeboy artifact ref | `id`, `kind` |
| MIME type | `media_type` |
| bounded display name | `display_name` |
| size | `byte_size` |
| optional caption | `caption` |
| stable group ID | `group_id` |
| semantic roles `source`/`candidate`/`diff` | `role` |
| operator-local without public URL | `uri` (`file://`) + `fetch_command` |

#10260 becomes "populate attachments from the artifact store and teach a transport to upload them" rather than "design a payload contract first". A transport that cannot attach files still renders `fetch_command`, so the feature degrades instead of failing.

**Bounding.** `serialize_bounded()` keeps the payload under 48 KiB (`ARG_MAX` covers argv *and* env; a notification must never be why a transport fails to spawn). Bounding is progressive — a run with 5,000 artifacts still delivers its subject, facts, and repair actions — and sets `HOMEBOY_NOTIFY_PAYLOAD_TRUNCATED=1`.

## Environment contract

| Variable | Set when |
|---|---|
| `HOMEBOY_NOTIFY_KIND` | always |
| `HOMEBOY_NOTIFY_PAYLOAD_SCHEMA` | payload present |
| `HOMEBOY_NOTIFY_PAYLOAD` | payload present |
| `HOMEBOY_NOTIFY_PAYLOAD_TRUNCATED` | members dropped to fit |

Names are recorded in `NotifyDelivery::Transport { payload_env }` so the delivery record stays a complete reproduction of the child invocation. Documented in `docs/reference/schemas/extension-manifest-schema.md`.

## Agent-task lifecycle points

Cook reports eight internal phases plus a 15-second heartbeat. Three change what a human would *do*:

| Point | Kind | Why |
|---|---|---|
| `durable_identity` (`cook.rs:1778`) | `Started` | First moment the cook is addressable. Answers "what did I just start, how do I watch it?" — deliberately *before* gate preflight, transport prep, and Lab materialization, all of which can outlive a client timeout. |
| `retry`, `attempt > 1` (`cook.rs:1949`) | `Progress` | The attempt budget is being consumed. Anyone who will intervene must know before it runs out. First attempt is already covered by `Started`. |
| terminal (`cook.rs:1541`) | `Completed` / `NeedsAttention` | Outcome, with `pr_url` on success and the cook's own `failure_context.next_actions` / `legal_actions` on failure. |

`provider_ready`, `promotion`, `finalization`, and `heartbeat` are internal progress with no attached decision and are **not** delivered.

Placement notes:
- The terminal hook wraps `run_cook_with_boundaries_observed`, so it also covers the durable-failure report built from a controller error — the failure path is not the one that stays silent. Every cook variant (`run_cook`, `run_cook_with_durable_observer`, `run_cook_with_finalizer`), every `cook-batch` child, and every `fanout resume` child funnels through it.
- `NeedsAttention` follows the **exit code**, not the status string. The status vocabulary (`succeeded`, `durable_failure`, `attempts_exhausted`, `moving_base`, ...) is open; the exit code is the contract callers already branch on.
- **Noise contract:** non-terminal events require an explicitly bound route. A configured `notifications.default_transport` is ambient "tell me when work finishes" policy; promoting it to per-attempt progress would be a regression for everyone who already set one. Explicit `--notification-route` gets the full arc. Tested.
- Notifications are strictly best-effort — never a cook failure mode.

## Transport result no longer discarded

`.status()` → `.output()`. Transports emit a real result envelope (mode, route kind, destination, truncation, attempt count, classified error kind); homeboy read only the exit code. Now retained verbatim in `NotifyOutcome.result`, and a failing transport's own diagnostic is folded into `NotifyOutcome.error` instead of a bare exit status.

**Behavior change:** the transport's stdout/stderr are captured rather than inherited, so its JSON line no longer prints to the operator's terminal. It is now structured data in the command envelope instead, which is strictly more useful — but it is a visible difference.

## Other producers upgraded (no new dispatch sites)

- `notify::run_completed_payload(&RunRecord)` — one shared projection used by the daemon notifier, `runs watch --notify`, and the runner's direct delivery, so all three describe a finished run identically. Statuses classify through the owned `RunStatus` vocabulary; an unowned label is conservatively `NeedsAttention`.
- `schedule/execution.rs` — the hand-formatted prose block becomes structured facts plus `schedule show` / `schedule run` actions; prose is rendered from them.
- `activity watch --notify` — was `"<kind> <id>"` and nothing else; now carries command, runner, next actions, and artifact/evidence refs as attachments.

## Tests

25 new tests. Contract: rendering, optional-fact suppression, body bounding, JSON round-trip, forward compatibility with unknown fields, progressive truncation, attachment group metadata. Core: argv flag set is **identical** with and without a payload (the compatibility guarantee, asserted), payload-free events keep their historical prose and kind, env carries kind/schema/payload, a real child process observes them (`#[cfg(unix)]`), transport result retained, failure diagnostic surfaced, non-JSON output not misread. Agents: PR link on success, legal recovery commands on failure, exit-code-driven kind, started/retry content, and the noise contract.

## Not verified — cannot run cargo on this host

Repo policy forbids cargo builds here (OOM). Verified by `rustfmt --check` (a full parse) on every changed file; **type checking, borrow checking, clippy, and test execution are entirely on CI.** Highest-risk items if CI complains:

1. `payload_env_names` / `argv` moved into both match arms in `dispatch` (legal, but unexercised locally).
2. `&&Vec<u8>` → `&[u8]` deref coercion in `transport_failure_message`.
3. Iterator chain types in `cook_component` (plan-level and task-level `component_contracts`).
4. The generated `/bin/sh` fixture in the `#[cfg(unix)]` env tests.
5. Whether `cargo fmt` at the workspace root reaches `crates/contracts/*` at all — it did **not** here (`exclude = ["crates/contracts"]` in the root `Cargo.toml` appears to shadow member enumeration for fmt). I ran `rustfmt` on the new contract file directly. Worth a separate look: contract crates may be silently unformatted in CI too.

## One thing I found and deliberately did not fix

`activity watch --notify` constructs its event with `transport: None, route: None` and never consults `notification_route::current()`, so `--notification-route` is silently ignored on that path — the same shape as #10282, at a different site. Out of scope here; flagging rather than changing routing behavior in a payload PR.
