### PR TITLE
Keep raw agent tool dispatch controller-local

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -206,6 +206,9 @@ impl CliRuntime {
             && !normalized
                 .windows(2)
                 .any(|args| args == ["agent-task", "promotion-provider"])
+            && !normalized
+                .windows(3)
+                .any(|args| args == ["agent-task", "tool", "dispatch"])
         {
             let _ = crate::runner::reconcile_terminal_runner_exec_runs();
         }
@@ -503,11 +506,14 @@ impl CliRuntime {
             }
         }
 
-        // This internal provider's request is carried on process stdin. Execute
-        // it before generic routing or startup work can consume that stream.
+        // These internal adapters carry their requests on process stdin. Execute
+        // them before generic routing or startup work can consume that stream.
         if let Some(exit_code) =
             run_promotion_provider_dispatch(&cli.command, output_file.as_deref(), &command_identity)
         {
+            return std::process::ExitCode::from(exit_code_to_u8(exit_code));
+        }
+        if let Some(exit_code) = run_raw_agent_tool_dispatch(&cli.command) {
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
 
@@ -552,10 +558,6 @@ impl CliRuntime {
         crate::core::set_artifact_root_override(
             cli.artifact_root.clone().or(artifact_root_override),
         );
-
-        if let Some(exit_code) = run_raw_agent_tool_dispatch(&cli.command) {
-            return std::process::ExitCode::from(exit_code_to_u8(exit_code));
-        }
 
         run_startup_update_checks(&cli.command);
 


### PR DESCRIPTION
## Summary
- exempt stdin-owned agent tool dispatch from startup terminal-run reconciliation
- execute raw tool dispatch before resource preflight and Lab placement routing
- preserve normal routing for every other agent-task command

Closes #10540.

## Verification
- `cargo fmt --check`
- direct valid stdin dispatch under a configured default Lab runner
- `cargo test -p homeboy --test agent_tool_dispatch -- --test-threads=1` (6 passed; previously 4 deterministic exit-2 failures)

## AI Assistance
OpenAI `openai/gpt-5.6-sol` using OpenCode diagnosed the release-gate failure, implemented the controller stdin boundary fix, and ran verification under Chris Huber's direction. Chris remains responsible for the submitted code.