### PR TITLE
Align Windows release contract with current policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,11 @@ jobs:
       - name: Compile all workspace test targets
         run: cargo check --workspace --tests --locked
 
-  # Fail-fast mirror of the release `Windows Build` gate. Unix-only `libc`
-  # constants (`SIGKILL` has no Windows definition) and other cfg-gating misses
-  # compile fine on Linux, so they only surfaced after merge when the release
-  # workflow ran `cargo build --workspace` on windows-latest and turned `main`
-  # red (#10398). Same crate scope as that gate, but codegen-free so it stays
-  # cheap enough to run on every PR. Deliberately no `--tests`: the release gate
-  # does not build test targets, and some Unix-only test helpers rely on that.
+  # Unix-only `libc` constants (`SIGKILL` has no Windows definition) and other
+  # cfg-gating misses compile fine on Linux (#10398). The release has no Windows
+  # artifact consumer, so keep this codegen-free source check on every PR rather
+  # than paying for a native release build. Deliberately no `--tests`: some
+  # Unix-only test helpers rely on that boundary.
   windows-compile:
     name: homeboy / Windows Compile
     runs-on: windows-latest

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -2,6 +2,10 @@ fn release_workflow() -> &'static str {
     include_str!("../.github/workflows/release.yml")
 }
 
+fn ci_workflow() -> &'static str {
+    include_str!("../.github/workflows/ci.yml")
+}
+
 fn release_quality_policy_script() -> &'static str {
     include_str!("../.github/release-quality-policy.sh")
 }
@@ -266,29 +270,20 @@ fn release_preflight_validates_the_private_workspace_build_before_mutating_relea
 }
 
 #[test]
-fn release_blocks_preparation_and_publication_on_a_native_windows_workspace_build() {
-    let windows_build = job_section(release_workflow(), "gate-windows-build");
-    let quality_policy = job_section(release_workflow(), "release-quality-policy");
-    let prepare = job_section(release_workflow(), "prepare");
+fn release_omits_unused_windows_artifacts_while_ci_checks_windows_source() {
+    let release = release_workflow();
+    let windows_compile = job_section(ci_workflow(), "windows-compile");
 
-    assert!(windows_build.contains("runs-on: windows-latest"));
-    assert!(windows_build.contains("run: cargo build --workspace --locked"));
     assert!(
-        quality_policy.contains("- gate-windows-build"),
-        "the release quality policy must wait for the native Windows build"
+        !release.contains("gate-windows-build"),
+        "release must not restore the unused native Windows artifact gate"
     );
     assert!(
-        quality_policy.contains("needs.gate-windows-build.result == 'success'"),
-        "the release quality policy must fail closed when the native Windows build fails"
+        !dist_workspace_manifest().contains("x86_64-pc-windows-msvc"),
+        "release must not publish an unconsumed Windows artifact"
     );
-    assert!(
-        prepare.contains("- gate-windows-build"),
-        "release preparation must wait for the native Windows build"
-    );
-    assert!(
-        prepare.contains("needs.gate-windows-build.result == 'success'"),
-        "a failed native Windows build must prevent tag preparation and publication"
-    );
+    assert!(windows_compile.contains("runs-on: windows-latest"));
+    assert!(windows_compile.contains("run: cargo check --workspace --locked"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove the stale test requirement for the intentionally deleted Windows release artifact gate
- assert that release packaging stays Windows-free while PR CI retains native Windows source checks
- update CI documentation to describe the current ownership boundary

Closes #10543.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy --test release_workflow_test` (25 passed)

## AI Assistance
OpenAI `openai/gpt-5.6-sol` using OpenCode diagnosed the release-only contract drift, implemented the test and CI documentation alignment, and ran verification under Chris Huber's direction. Chris remains responsible for the submitted code.