### PR TITLE
Reconcile runner jobs across transports

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/jobs.rs
+++ b/crates/homeboy-cli/src/commands/runner/jobs.rs
@@ -53,7 +53,7 @@ fn job_reconcile(runner_id: &str) -> CmdResult<RunnerJobCommandOutput> {
             runner_id: runner_id.to_string(),
             job_id: None,
             artifact_id: None,
-            response: runner::reverse_broker_reconcile(runner_id)?,
+            response: runner::reconcile_terminal_jobs(runner_id)?,
         }),
         0,
     ))

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1809,6 +1809,54 @@ pub fn reverse_broker_reconcile(runner_id: &str) -> Result<Value> {
     )
 }
 
+/// Reconcile terminal runner jobs through the session's authoritative transport.
+/// The returned body is transport-neutral so callers retain one command contract.
+pub fn reconcile_terminal_jobs(runner_id: &str) -> Result<Value> {
+    let report = status(runner_id)?;
+    let Some(session) = report.session.filter(|_| report.connected) else {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            format!("runner `{runner_id}` is not connected"),
+            Some(runner_id.to_string()),
+            None,
+        ));
+    };
+    reconcile_terminal_jobs_for_session(
+        &session,
+        |_| {
+            let data = crate::execution::daemon_api_post_for_session(
+                &session,
+                "/jobs/reconcile-terminal",
+            )?;
+            crate::execution::canonical_daemon_body(&data, "direct daemon reconcile response")
+                .cloned()
+        },
+        || reverse_broker_reconcile(runner_id),
+    )
+}
+
+fn reconcile_terminal_jobs_for_session<T>(
+    session: &RunnerSession,
+    direct: impl FnOnce(&str) -> Result<T>,
+    reverse: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    if let Some(local_url) = session.local_url.as_deref() {
+        return direct(local_url);
+    }
+    if session.mode == RunnerTunnelMode::Reverse {
+        return reverse();
+    }
+    Err(Error::validation_invalid_argument(
+        "runner_id",
+        format!(
+            "runner `{}` has no authoritative job reconciliation endpoint",
+            session.runner_id
+        ),
+        Some(session.runner_id.clone()),
+        None,
+    ))
+}
+
 /// Submit a redacted, replayable request to a connected reverse broker. Secret
 /// values are intentionally absent: the worker resolves named references when
 /// it prepares the claimed process.

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -875,6 +875,32 @@ fn terminal_phantom_reconciliation_is_fail_soft_for_an_unreachable_stale_session
 }
 
 #[test]
+fn terminal_reconciliation_routes_direct_sessions_to_the_daemon() {
+    let session = direct_ssh_session("lease-live");
+    let result = reconcile_terminal_jobs_for_session(
+        &session,
+        |url| Ok(format!("direct:{url}")),
+        || Ok("reverse".to_string()),
+    )
+    .expect("direct reconciliation route");
+
+    assert!(result.starts_with("direct:http://"));
+}
+
+#[test]
+fn terminal_reconciliation_routes_reverse_sessions_to_the_broker() {
+    let session = reverse_controller_session();
+    let result = reconcile_terminal_jobs_for_session(
+        &session,
+        |_| Ok("direct".to_string()),
+        || Ok("reverse".to_string()),
+    )
+    .expect("reverse reconciliation route");
+
+    assert_eq!(result, "reverse");
+}
+
+#[test]
 fn terminal_phantom_reconciliation_ignores_non_success_responses() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
     let address = listener.local_addr().expect("address");

--- a/crates/homeboy-lab-runner/src/execution/daemon_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon_api.rs
@@ -114,6 +114,18 @@ pub(crate) fn daemon_api_get_for_session(session: &RunnerSession, path: &str) ->
     daemon_get(&client, local_url, path)
 }
 
+pub(crate) fn daemon_api_post_for_session(session: &RunnerSession, path: &str) -> Result<Value> {
+    let local_url = session.local_url.as_deref().ok_or_else(|| {
+        Error::internal_unexpected("known daemon generation has no direct local endpoint")
+    })?;
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
+    daemon_post(&client, local_url, path)
+}
+
 pub fn daemon_api_post(runner_id: &str, path: &str) -> Result<Value> {
     daemon_api_request(runner_id, path, "POST")
 }

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -120,6 +120,7 @@ pub use artifact_promotion::{
     promote_runner_exec_summaries, promoted_output, runner_exec_structured_summary,
 };
 pub use daemon_api::daemon_api_post;
+pub(crate) use daemon_api::daemon_api_post_for_session;
 pub use failure::runner_exec_failure_error;
 pub use handoff::{runner_job_cancel, runner_job_cancel_projection};
 pub use recovery::reconcile_terminal_runner_exec_runs;

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -138,9 +138,9 @@ pub(crate) use connection::disconnect_with_force;
 pub use connection::{
     close_reconnected_job_log_owner, connect, connect_reverse, connect_with_live_lease_adoption,
     connect_with_orphan_adoption, disconnect, persisted_status, persisted_statuses,
-    reconnect_job_log_owner, reverse_broker_artifact, reverse_broker_artifact_content,
-    reverse_broker_reconcile, runner_artifact_content, status, statuses, statuses_indexed,
-    submit_reverse_broker_job,
+    reconcile_terminal_jobs, reconnect_job_log_owner, reverse_broker_artifact,
+    reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
+    statuses, statuses_indexed, submit_reverse_broker_job,
 };
 pub(crate) use connection::{
     configured_runner_homeboy_build_identity, local_live_session, status_for_admission,

--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -19,9 +19,10 @@ pub use crate::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, close_reconnected_job_log_owner,
     connect, connect_with_live_lease_adoption, connect_with_orphan_adoption,
-    reconnect_job_log_owner, reverse_broker_artifact, reverse_broker_artifact_content,
-    reverse_broker_reconcile, runner_artifact_content, BrokerAuthGrant, BrokerAuthStore,
-    BrokerCredential, BrokerScope, MintedCredential, BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
+    reconcile_terminal_jobs, reconnect_job_log_owner, reverse_broker_artifact,
+    reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content,
+    BrokerAuthGrant, BrokerAuthStore, BrokerCredential, BrokerScope, MintedCredential,
+    BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use crate::{
     connect_reverse, disconnect, download_remote_artifact,

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant, SystemTime};
 use base64::Engine;
 use homeboy_core::source_snapshot::SourceSnapshot;
 
+use homeboy_core::api_jobs::JobStatus;
 use homeboy_core::engine::temp;
 use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::resource_lifecycle_index::{
@@ -1236,7 +1237,7 @@ pub fn prune_workspaces(
             }
             // The scan is only a snapshot. Recheck ownership at the destructive boundary.
             match revalidate_candidate_liveness(&runner, &candidate) {
-                Ok(liveness) if liveness.state == "inactive" => {
+                Ok(liveness) if revalidated_candidate_is_deletable(&liveness) => {
                     match remove_prune_candidate(&runner, &lab_workspaces_root, &candidate) {
                         Ok(None) => removed.push(candidate),
                         Ok(Some(liveness)) => skipped.push(RunnerWorkspacePruneSkippedEntry {
@@ -2716,40 +2717,31 @@ fn workspace_liveness(
     metadata: &serde_json::Value,
     path: &Path,
 ) -> RunnerWorkspaceLivenessEvidence {
-    let terminal_lifecycle_owner = match active_resource_lifecycle_liveness(metadata, |run_id| {
+    let job_id = metadata
+        .get("job_id")
+        .and_then(|value| value.as_str())
+        .filter(|id| !id.trim().is_empty());
+    match active_resource_lifecycle_liveness(metadata, |run_id| {
         match homeboy_agents::agent_task_lifecycle::exact_record(run_id) {
             Ok(record) if record.state.is_terminal() => RunAuthority::Terminal,
             Ok(_) => RunAuthority::Active,
             Err(_) => RunAuthority::Unavailable,
         }
     }) {
-        ActiveResourceLifecycleLiveness::Terminal(owner) => Some(owner),
+        ActiveResourceLifecycleLiveness::Terminal(_)
+        | ActiveResourceLifecycleLiveness::NotActive => {}
         ActiveResourceLifecycleLiveness::Live => {
             return liveness("live", vec!["active_resource_lifecycle_lease".to_string()]);
         }
         ActiveResourceLifecycleLiveness::Unknown(observation) => {
             return liveness("unknown", vec![observation.to_string()]);
         }
-        ActiveResourceLifecycleLiveness::NotActive => None,
-    };
-
-    if terminal_lifecycle_owner.is_none() {
-        if let Some(job_id) = metadata.get("job_id").and_then(|value| value.as_str()) {
-            match super::super::status(&runner.id) {
-                Ok(report)
-                    if report.active_job_state == super::super::RunnerActiveJobState::Available =>
-                {
-                    if report.active_jobs.iter().any(|job| job.job_id == job_id) {
-                        return liveness("live", vec![format!("active_runner_job:{job_id}")]);
-                    }
-                }
-                Ok(_) => {
-                    return liveness("unknown", vec!["runner_job_probe_unavailable".to_string()]);
-                }
-                Err(_) => {
-                    return liveness("unknown", vec!["runner_job_probe_failed".to_string()]);
-                }
-            }
+    }
+    if let Some(job_id) = job_id {
+        let job_liveness = runner_job_liveness(runner, Some(job_id))
+            .unwrap_or_else(|_| liveness("unknown", vec!["runner_job_probe_failed".to_string()]));
+        if job_liveness.state != "inactive" {
+            return job_liveness;
         }
     }
 
@@ -2799,13 +2791,6 @@ pub(crate) fn active_resource_lifecycle_liveness(
     if resource.get("status").and_then(|value| value.as_str()) != Some("active") {
         return ActiveResourceLifecycleLiveness::NotActive;
     }
-    if metadata
-        .get("job_id")
-        .and_then(|value| value.as_str())
-        .is_some_and(|id| !id.trim().is_empty())
-    {
-        return ActiveResourceLifecycleLiveness::Live;
-    }
     let Some(run_id) = metadata
         .get("run_id")
         .and_then(|value| value.as_str())
@@ -2854,6 +2839,12 @@ fn revalidate_candidate_liveness(
     ))
 }
 
+pub(crate) fn revalidated_candidate_is_deletable(
+    liveness: &RunnerWorkspaceLivenessEvidence,
+) -> bool {
+    liveness.state == "inactive"
+}
+
 fn runner_job_liveness(
     runner: &super::super::Runner,
     job_id: Option<&str>,
@@ -2861,26 +2852,71 @@ fn runner_job_liveness(
     let Some(job_id) = job_id else {
         return Ok(liveness("inactive", Vec::new()));
     };
-    match super::super::status(&runner.id) {
-        Ok(report) if report.active_job_state == super::super::RunnerActiveJobState::Available => {
-            if report.active_jobs.iter().any(|job| job.job_id == job_id) {
-                Ok(liveness(
-                    "live",
-                    vec![format!("active_runner_job:{job_id}")],
-                ))
-            } else {
-                Ok(liveness("inactive", Vec::new()))
-            }
+    let active_jobs = super::super::status(&runner.id).ok().and_then(|report| {
+        (report.active_job_state == super::super::RunnerActiveJobState::Available
+            && report.active_job_error.is_none())
+        .then(|| {
+            report
+                .active_jobs
+                .into_iter()
+                .map(|job| job.job_id)
+                .collect::<Vec<_>>()
+        })
+    });
+    let exact = super::super::runner_job_log_snapshot(&runner.id, job_id)
+        .map(|snapshot| snapshot.job.status);
+    Ok(runner_job_liveness_with(
+        job_id,
+        exact,
+        active_jobs.as_deref(),
+    ))
+}
+
+pub(crate) fn runner_job_liveness_with(
+    job_id: &str,
+    exact: Result<JobStatus>,
+    active_jobs: Option<&[String]>,
+) -> RunnerWorkspaceLivenessEvidence {
+    let listed_active = active_jobs.is_some_and(|jobs| jobs.iter().any(|id| id == job_id));
+    let complete_snapshot = active_jobs.is_some();
+    match exact {
+        Ok(JobStatus::Queued | JobStatus::Running) if complete_snapshot && !listed_active => {
+            liveness(
+                "unknown",
+                vec!["runner_job_authority_contradictory".to_string()],
+            )
         }
-        Ok(_) => Ok(liveness(
+        Ok(JobStatus::Queued | JobStatus::Running) => {
+            liveness("live", vec![format!("active_runner_job:{job_id}")])
+        }
+        Ok(status) if status.is_terminal() && listed_active => liveness(
             "unknown",
-            vec!["runner_job_probe_unavailable".to_string()],
-        )),
-        Err(_) => Ok(liveness(
+            vec!["runner_job_authority_contradictory".to_string()],
+        ),
+        Ok(status) if status.is_terminal() => liveness("inactive", Vec::new()),
+        Err(error) if runner_job_is_authoritatively_absent(&error) && listed_active => liveness(
             "unknown",
-            vec!["runner_job_probe_failed".to_string()],
-        )),
+            vec!["runner_job_authority_contradictory".to_string()],
+        ),
+        Err(error) if runner_job_is_authoritatively_absent(&error) => {
+            liveness("inactive", Vec::new())
+        }
+        Err(_) => liveness("unknown", vec!["runner_job_probe_failed".to_string()]),
+        Ok(_) => liveness("unknown", vec!["runner_job_probe_failed".to_string()]),
     }
+}
+
+fn runner_job_is_authoritatively_absent(error: &Error) -> bool {
+    error
+        .details
+        .get("http_status")
+        .and_then(serde_json::Value::as_u64)
+        == Some(404)
+        || error
+            .details
+            .pointer("/daemon_transport_error/http_status")
+            .and_then(serde_json::Value::as_u64)
+            == Some(404)
 }
 
 fn liveness(state: &str, observations: Vec<String>) -> RunnerWorkspaceLivenessEvidence {
@@ -3296,10 +3332,11 @@ fn remove_ssh_prune_candidate(
             homeboy_agents::agent_task_lifecycle::exact_record(run_id)
                 .is_ok_and(|record| record.state.is_terminal())
         });
-        ssh_prune_delete_command_with_terminal_owner(
+        ssh_prune_delete_command_with_terminal_authority(
             root,
             &candidate.remote_path,
             terminal_owner_run_id,
+            candidate.job_id.as_deref(),
         )
     };
     let output = client.execute_with_timeout(&command, WORKSPACE_PRUNE_TIMEOUT);
@@ -3345,9 +3382,19 @@ pub(crate) fn ssh_prune_delete_command_with_terminal_owner(
     remote_path: &str,
     terminal_owner_run_id: Option<&str>,
 ) -> String {
+    ssh_prune_delete_command_with_terminal_authority(root, remote_path, terminal_owner_run_id, None)
+}
+
+fn ssh_prune_delete_command_with_terminal_authority(
+    root: &str,
+    remote_path: &str,
+    terminal_owner_run_id: Option<&str>,
+    terminal_job_id: Option<&str>,
+) -> String {
     let owner = shell::quote_arg(terminal_owner_run_id.unwrap_or(""));
+    let job = shell::quote_arg(terminal_job_id.unwrap_or(""));
     format!(
-        "root={root}; p={path}; meta_rel={meta}; owner={owner}; case \"$p\" in \"$root\"/*) ;; *) printf unknown:workspace_path; exit 0 ;; esac; meta=\"$p/$meta_rel\"; [ -f \"$meta\" ] && grep -Eq '\"schema\"[[:space:]]*:[[:space:]]*\"homeboy/runner-workspace/v1\"' \"$meta\" || {{ printf unknown:metadata; exit 0; }}; if grep -Eq '\"status\"[[:space:]]*:[[:space:]]*\"active\"' \"$meta\"; then compact=$(tr -d '[:space:]' < \"$meta\") || {{ printf unknown:metadata; exit 0; }}; [ -n \"$owner\" ] && [ \"$(printf '%s' \"$compact\" | grep -Fo -- \"\\\"run_id\\\":\\\"$owner\\\"\" | wc -l | tr -d ' ')\" -ge 2 ] || {{ printf live:active_resource_lifecycle_lease; exit 0; }}; fi; command -v ps >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1 || {{ printf unknown:process_probe_unavailable; exit 0; }}; ps_output=$(ps -eo pid=,ppid=,args=) || {{ printf unknown:process_probe_failed; exit 0; }}; printf '%s\\n' \"$ps_output\" | awk -v p=\"$p\" -v self=\"$$\" -v parent=\"$PPID\" '$1 != self && $1 != parent && $2 != self && index($0, p) {{ found=1 }} END {{ exit !found }}'; state=$?; [ \"$state\" -eq 0 ] && {{ printf live:remote_process_ownership; exit 0; }}; [ \"$state\" -eq 1 ] || {{ printf unknown:process_probe_failed; exit 0; }}; cwd=$(lsof -w -Fn -a -d cwd +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$cwd\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$cwd\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; open=$(lsof -w -Fn +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$open\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$open\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; rm -rf -- \"$p\" && printf removed || printf unknown:delete_failed",
+        "root={root}; p={path}; meta_rel={meta}; owner={owner}; job={job}; case \"$p\" in \"$root\"/*) ;; *) printf unknown:workspace_path; exit 0 ;; esac; meta=\"$p/$meta_rel\"; [ -f \"$meta\" ] && grep -Eq '\"schema\"[[:space:]]*:[[:space:]]*\"homeboy/runner-workspace/v1\"' \"$meta\" || {{ printf unknown:metadata; exit 0; }}; if grep -Eq '\"status\"[[:space:]]*:[[:space:]]*\"active\"' \"$meta\"; then compact=$(tr -d '[:space:]' < \"$meta\") || {{ printf unknown:metadata; exit 0; }}; {{ [ -n \"$owner\" ] && [ \"$(printf '%s' \"$compact\" | grep -Fo -- \"\\\"run_id\\\":\\\"$owner\\\"\" | wc -l | tr -d ' ')\" -ge 2 ]; }} || {{ [ -n \"$job\" ] && printf '%s' \"$compact\" | grep -Fq -- \"\\\"job_id\\\":\\\"$job\\\"\"; }} || {{ printf live:active_resource_lifecycle_lease; exit 0; }}; fi; command -v ps >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1 || {{ printf unknown:process_probe_unavailable; exit 0; }}; ps_output=$(ps -eo pid=,ppid=,args=) || {{ printf unknown:process_probe_failed; exit 0; }}; printf '%s\\n' \"$ps_output\" | awk -v p=\"$p\" -v self=\"$$\" -v parent=\"$PPID\" '$1 != self && $1 != parent && $2 != self && index($0, p) {{ found=1 }} END {{ exit !found }}'; state=$?; [ \"$state\" -eq 0 ] && {{ printf live:remote_process_ownership; exit 0; }}; [ \"$state\" -eq 1 ] || {{ printf unknown:process_probe_failed; exit 0; }}; cwd=$(lsof -w -Fn -a -d cwd +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$cwd\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$cwd\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; open=$(lsof -w -Fn +D \"$p\" 2>&1); state=$?; [ \"$state\" -eq 0 ] && [ -n \"$open\" ] && {{ printf live:remote_process_ownership; exit 0; }}; {{ [ \"$state\" -eq 1 ] && [ -z \"$open\" ]; }} || {{ printf unknown:process_probe_failed; exit 0; }}; rm -rf -- \"$p\" && printf removed || printf unknown:delete_failed",
         root = shell::quote_arg(root),
         path = shell::quote_arg(remote_path),
         meta = shell::quote_arg(WORKSPACE_METADATA_FILE),

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -8,7 +8,8 @@ use base64::Engine;
 
 use crate::workspace::sync::{
     active_resource_lifecycle_liveness, encoded_materialized_workspace_metadata_is_valid,
-    prune_scan_command, prune_workspaces, ssh_process_liveness_command, ssh_prune_delete_command,
+    prune_scan_command, prune_workspaces, revalidated_candidate_is_deletable,
+    runner_job_liveness_with, ssh_process_liveness_command, ssh_prune_delete_command,
     ssh_prune_delete_command_with_terminal_owner, ssh_prune_delete_materialized_workspace_command,
     sync_workspace, update_workspace_resource_lifecycle, workspace_liveness_with_size_observation,
     ActiveResourceLifecycleLiveness, RunAuthority, WORKSPACE_METADATA_FILE,
@@ -17,6 +18,7 @@ use crate::workspace::types::{
     RunnerWorkspacePruneOptions, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 use crate::{MaterializedWorkspace, WorkspaceCleanupPolicy, WorkspaceTerminalOutcome};
+use homeboy_core::api_jobs::JobStatus;
 
 #[test]
 fn prune_workspaces_previews_orphans_without_deleting_by_default() {
@@ -180,7 +182,7 @@ fn prune_preserves_process_owned_workspace_in_preview_and_apply() {
 }
 
 #[test]
-fn prune_preserves_active_job_lifecycle_lease() {
+fn prune_preserves_job_lifecycle_lease_when_authority_is_unavailable() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root tempdir");
         let workspace = runner_root.path().join("_lab_workspaces/active-lease");
@@ -228,7 +230,7 @@ fn prune_preserves_active_job_lifecycle_lease() {
 
         assert_eq!(exit_code, 0);
         assert!(output.removed.is_empty());
-        assert_eq!(output.skipped_live_count, 1);
+        assert_eq!(output.skipped_unknown_count, 1);
         assert!(workspace.exists());
     });
 }
@@ -261,7 +263,7 @@ fn active_lifecycle_lease_requires_unambiguous_terminal_run_authority() {
     });
     assert!(matches!(
         active_resource_lifecycle_liveness(&job_owned, |_| RunAuthority::Terminal),
-        ActiveResourceLifecycleLiveness::Live
+        ActiveResourceLifecycleLiveness::NotActive
     ));
 
     let ambiguous = active_lifecycle_metadata("run-terminal", "other-run");
@@ -269,6 +271,83 @@ fn active_lifecycle_lease_requires_unambiguous_terminal_run_authority() {
         active_resource_lifecycle_liveness(&ambiguous, |_| RunAuthority::Terminal),
         ActiveResourceLifecycleLiveness::Unknown("active_resource_lifecycle_owner_ambiguous")
     ));
+}
+
+#[test]
+fn runner_job_authority_requires_exact_transport_state_and_consistent_snapshot() {
+    let active = vec!["job-1".to_string()];
+    for (name, exact, snapshot, state) in [
+        (
+            "direct-live",
+            Ok(JobStatus::Running),
+            Some(&active[..]),
+            "live",
+        ),
+        (
+            "reverse-live",
+            Ok(JobStatus::Queued),
+            Some(&active[..]),
+            "live",
+        ),
+        (
+            "terminal",
+            Ok(JobStatus::Succeeded),
+            Some(&[][..]),
+            "inactive",
+        ),
+        ("absent", Err(absent_job_error()), Some(&[][..]), "inactive"),
+        (
+            "unavailable",
+            Err(homeboy_core::Error::internal_unexpected(
+                "transport unavailable",
+            )),
+            None,
+            "unknown",
+        ),
+        (
+            "terminal-listed",
+            Ok(JobStatus::Failed),
+            Some(&active[..]),
+            "unknown",
+        ),
+        (
+            "live-omitted",
+            Ok(JobStatus::Running),
+            Some(&[][..]),
+            "unknown",
+        ),
+        (
+            "absent-listed",
+            Err(absent_job_error()),
+            Some(&active[..]),
+            "unknown",
+        ),
+    ] {
+        assert_eq!(
+            runner_job_liveness_with("job-1", exact, snapshot).state,
+            state,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn prune_revalidates_job_authority_before_deletion() {
+    let scanned = runner_job_liveness_with("job-1", Ok(JobStatus::Succeeded), Some(&[]));
+    let revalidated = runner_job_liveness_with(
+        "job-1",
+        Ok(JobStatus::Running),
+        Some(&["job-1".to_string()]),
+    );
+
+    assert!(revalidated_candidate_is_deletable(&scanned));
+    assert!(!revalidated_candidate_is_deletable(&revalidated));
+}
+
+fn absent_job_error() -> homeboy_core::Error {
+    let mut error = homeboy_core::Error::internal_unexpected("daemon request returned HTTP 404");
+    error.details["daemon_transport_error"] = serde_json::json!({ "http_status": 404 });
+    error
 }
 
 #[test]
@@ -895,7 +974,7 @@ fn ssh_prune_scan_command_advances_past_a_timed_out_size_measurement() {
 }
 
 #[test]
-fn unavailable_size_does_not_override_inactive_ownership_evidence() {
+fn unavailable_job_authority_fails_closed_despite_inactive_process_evidence() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let root = tempfile::tempdir().expect("workspace root");
         let workspace = root.path().join("_lab_workspaces/orphan");
@@ -924,14 +1003,14 @@ fn unavailable_size_does_not_override_inactive_ownership_evidence() {
         );
 
         metadata["job_id"] = serde_json::json!("active-job");
-        metadata["resource_lifecycle"] = serde_json::json!({ "status": "active" });
+        metadata["resource_lifecycle"] = serde_json::json!({ "status": "terminal" });
         let evidence =
             workspace_liveness_with_size_observation(&runner, &metadata, &workspace, false);
-        assert_eq!(evidence.state, "live");
+        assert_eq!(evidence.state, "unknown");
         assert_eq!(
             evidence.observations,
             vec![
-                "active_resource_lifecycle_lease",
+                "runner_job_probe_failed",
                 "workspace_size_measurement_unavailable"
             ]
         );


### PR DESCRIPTION
## Summary
- route runner job reconciliation through direct-daemon or reverse-broker authority
- resolve workspace job leases from exact typed job state with active-list contradiction checks
- revalidate run, job, metadata, and process authority immediately before workspace removal

## Evidence
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner connection::tests::session::terminal_reconciliation --no-fail-fast` (2 passed)
- `cargo test -p homeboy-lab-runner workspace::tests::prune --no-fail-fast` (23 passed)
- `cargo test -p homeboy-cli commands::runner::jobs --lib` (7 passed)

Closes #10504.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode implemented and reviewed the transport routing, liveness authority hierarchy, race revalidation, and focused tests. Chris Huber reviewed and remains responsible for the change.