### PR TITLE
fix: preserve runner failure evidence

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -162,6 +162,19 @@ mod tests {
                         "scenario_metrics": [{"scenario_id":"cold","metrics":{"p95_ms":42.0}}],
                         "resource_policy": {"hot_command":"bench"},
                         "lab": {
+                            "failure": {
+                                "schema": "homeboy/runner-exec-failure-projection/v1",
+                                "failure_code": "validation.invalid_argument",
+                                "phase": "preflight",
+                                "exit_code": 1,
+                                "runner_id": "lab-default",
+                                "runner_job_id": "job-1",
+                                "stderr_tail": "invalid input",
+                                "stderr_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                                "runner_job_logs_command": "homeboy runner job logs lab-default job-1",
+                                "remote_command_result_command": "homeboy runner job logs lab-default job-1 --json",
+                                "artifact_refs": []
+                            },
                             "remote_events": [{
                                 "data": {
                                     "data": {
@@ -310,6 +323,17 @@ mod tests {
                 .contains("cleanup-persisted --run-id"));
             assert!(output.failure.failed);
             assert_eq!(output.failure.exit_code, Some(1));
+            let runner_failure = output.failure.runner_failure.expect("runner failure");
+            assert_eq!(
+                runner_failure.failure_code.as_deref(),
+                Some("validation.invalid_argument")
+            );
+            assert_eq!(runner_failure.phase.as_deref(), Some("preflight"));
+            assert_eq!(runner_failure.runner_job_id, "job-1");
+            assert_eq!(
+                runner_failure.runner_job_logs_command,
+                "homeboy runner job logs lab-default job-1"
+            );
             assert_eq!(output.failure.gate_failures, vec!["p95_ms exceeded"]);
             assert_eq!(output.failure.hints, vec!["inspect artifacts"]);
             assert_eq!(

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -18,7 +18,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::{run_owner_pid, running_status_note, ArtifactRecord, RunRecord};
@@ -249,6 +249,81 @@ pub struct EvidenceFailureSummary {
     pub hints: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub child_command_failures: Vec<Value>,
+    /// Runner-owned terminal diagnostics projected into controller evidence.
+    /// Missing for local and pre-projection records to preserve their schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_failure: Option<RunnerFailureEvidence>,
+}
+
+/// Versioned, controller-owned projection of a runner terminal failure.
+/// Unknown or malformed legacy metadata is omitted from evidence rather than
+/// making `runs evidence` unreadable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerFailureEvidence {
+    pub schema: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    pub exit_code: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+    pub stderr_tail: String,
+    /// Digest input is the original runner stderr bytes, before redaction.
+    pub stderr_sha256: String,
+    pub runner_id: String,
+    pub runner_job_id: String,
+    pub runner_job_logs_command: String,
+    pub remote_command_result_command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_snapshot: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_materialization_plan: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_job_projection: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_record: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestration_provenance: Option<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<RunnerFailureArtifactRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerFailureArtifactRef {
+    pub id: String,
+    pub kind: String,
+    pub path: String,
+    pub sha256: String,
+    pub size_bytes: i64,
+}
+
+impl RunnerFailureEvidence {
+    pub const SCHEMA: &'static str = "homeboy/runner-exec-failure-projection/v1";
+
+    pub fn from_metadata(value: &Value) -> Option<Self> {
+        let evidence: Self = serde_json::from_value(value.clone()).ok()?;
+        (evidence.schema == Self::SCHEMA
+            && !evidence.runner_id.is_empty()
+            && !evidence.runner_job_id.is_empty()
+            && evidence.stderr_sha256.len() == 64
+            && evidence
+                .stderr_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+            && evidence.artifact_refs.iter().all(|artifact| {
+                !artifact.id.is_empty()
+                    && !artifact.path.is_empty()
+                    && artifact.sha256.len() == 64
+                    && artifact.sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+                    && artifact.size_bytes >= 0
+            }))
+        .then_some(evidence)
+    }
 }
 
 #[derive(Serialize)]
@@ -643,6 +718,9 @@ pub fn evidence_failure_summary(run: &RunRecord) -> EvidenceFailureSummary {
         gate_failures: string_array(metadata.get("gate_failures")),
         hints: string_array(metadata.get("hints")),
         child_command_failures: child_command_failures(metadata),
+        runner_failure: metadata
+            .pointer("/lab/failure")
+            .and_then(RunnerFailureEvidence::from_metadata),
     }
 }
 

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1798,15 +1798,66 @@ fn parse_runner_jobs(
 
 pub fn reverse_broker_reconcile(runner_id: &str) -> Result<Value> {
     let broker_url = reverse_broker_url(runner_id)?;
+    reverse_broker_reconcile_at(runner_id, &broker_url)
+}
+
+/// Reconcile through a persisted reverse broker endpoint without consulting a
+/// live controller-side session.
+pub(crate) fn reverse_broker_reconcile_at(runner_id: &str, broker_url: &str) -> Result<Value> {
     let client = broker_client("build broker reconcile client")?;
     broker_http::post_json(
         &client,
-        &broker_url,
+        broker_url,
         "/runner/jobs/reconcile",
         serde_json::json!({ "runner_id": runner_id }),
         "reconcile reverse runner broker jobs",
         broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )
+}
+
+/// Read a reverse runner job from its persisted broker endpoint. This remains
+/// available after a controller restart because it does not require a live
+/// controller-side runner session.
+pub(crate) fn reverse_broker_job_snapshot_at(
+    broker_url: &str,
+    runner_id: &str,
+    job_id: &str,
+) -> Result<(Job, Vec<homeboy_core::api_jobs::JobEvent>)> {
+    let client = broker_client("build reverse broker job snapshot client")?;
+    let token = broker_auth::broker_submit_token_for_runner(runner_id)?;
+    let job_data = broker_http::get_json(
+        &client,
+        broker_url,
+        &format!("/runner/jobs/{job_id}"),
+        "fetch reverse runner broker job",
+        token.as_deref(),
+    )?;
+    let events_data = broker_http::get_json(
+        &client,
+        broker_url,
+        &format!("/runner/jobs/{job_id}/events"),
+        "fetch reverse runner broker job events",
+        token.as_deref(),
+    )?;
+    let job: Job = serde_json::from_value(job_data["job"].clone()).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse reverse broker job".to_string()),
+        )
+    })?;
+    if job.id.to_string() != job_id {
+        return Err(Error::internal_unexpected(format!(
+            "reverse broker returned job `{}` while polling requested job `{job_id}`",
+            job.id
+        )));
+    }
+    let events = serde_json::from_value(events_data["events"].clone()).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse reverse broker job events".to_string()),
+        )
+    })?;
+    Ok((job, events))
 }
 
 /// Submit a redacted, replayable request to a connected reverse broker. Secret

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 
 use base64::Engine;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::agent_task_lifecycle_event::{
@@ -193,15 +194,25 @@ pub fn mirror_daemon_evidence(
     let result = (|| {
         let remote_runs =
             mirror_remote_observation_runs(&store, runner, job, result, notification_route)?;
-        if remote_runs.is_empty() {
+        if remote_runs.is_empty() || job.status == JobStatus::Failed {
             mirror_terminal_job_artifacts(&store, runner, job, &local_job_run)?;
         }
         let patch = mirrored_patch_result(&store, runner, job, result.get("patch"))?;
-        let runs = if remote_runs.is_empty() {
+        let mut runs = if remote_runs.is_empty() {
             vec![local_job_run.run.clone()]
         } else {
             remote_runs
         };
+        if job.status == JobStatus::Failed && !runs.iter().any(|run| run.id == local_job_run.run.id)
+        {
+            // Remote observations describe workload output; retain the local
+            // runner-exec record that owns terminal command diagnostics.
+            runs.push(local_job_run.run.clone());
+        }
+        let runs = runs
+            .into_iter()
+            .map(|run| attach_controller_failure_artifact_refs(&store, run))
+            .collect::<Result<Vec<_>>>()?;
         let primary_run = primary_mirrored_run(&runs).unwrap_or_else(|| runs[0].clone());
         Ok(Some(MirroredDaemonEvidence {
             run: primary_run,
@@ -250,9 +261,25 @@ pub fn mirror_reverse_broker_evidence(
             )
             })?;
         let runs;
+        let local_artifacts = if job.status == JobStatus::Failed {
+            Some(mirror_reverse_terminal_artifacts(
+                &store,
+                runner,
+                broker_url,
+                job,
+                &local_job_run,
+            )?)
+        } else {
+            None
+        };
         if declared_run_ids.is_empty() {
-            let artifacts =
-                mirror_reverse_terminal_artifacts(&store, runner, broker_url, job, &local_job_run)?;
+            let artifacts = local_artifacts.unwrap_or(mirror_reverse_terminal_artifacts(
+                &store,
+                runner,
+                broker_url,
+                job,
+                &local_job_run,
+            )?);
             runs = vec![record_reverse_broker_metadata(
                 &store,
                 local_job_run.run.clone(),
@@ -269,8 +296,13 @@ pub fn mirror_reverse_broker_evidence(
             // typed details. Their job artifacts remain durable controller
             // evidence, while the declared identities are explicitly retained
             // as unresolved provenance rather than fabricated run records.
-            let artifacts =
-                mirror_reverse_terminal_artifacts(&store, runner, broker_url, job, &local_job_run)?;
+            let artifacts = local_artifacts.unwrap_or(mirror_reverse_terminal_artifacts(
+                &store,
+                runner,
+                broker_url,
+                job,
+                &local_job_run,
+            )?);
             runs = vec![record_reverse_broker_metadata(
                 &store,
                 local_job_run.run.clone(),
@@ -355,6 +387,10 @@ pub fn mirror_reverse_broker_evidence(
                 },
             )?;
         }
+        let mut runs = runs
+            .into_iter()
+            .map(|run| attach_controller_failure_artifact_refs(&store, run))
+            .collect::<Result<Vec<_>>>()?;
         let patch = mirrored_patch_result(
             &store,
             runner,
@@ -363,6 +399,29 @@ pub fn mirror_reverse_broker_evidence(
                 .get("patch")
                 .or_else(|| result.pointer("/data/patch")),
         )?;
+        if job.status == JobStatus::Failed && !runs.iter().any(|run| run.id == local_job_run.run.id)
+        {
+            runs.push(local_job_run.run.clone());
+        }
+        let runs = runs
+            .into_iter()
+            .map(|run| {
+                record_reverse_broker_metadata(
+                    &store,
+                    run,
+                    runner,
+                    broker_url,
+                    job,
+                    events,
+                    result,
+                    Vec::new(),
+                    None,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .map(|run| attach_controller_failure_artifact_refs(&store, run))
+            .collect::<Result<Vec<_>>>()?;
         let primary_run = primary_mirrored_run(&runs).unwrap_or_else(|| runs[0].clone());
         Ok(Some(MirroredDaemonEvidence {
             run: primary_run,
@@ -408,6 +467,18 @@ fn record_reverse_broker_metadata(
     unresolved_run_refs: Option<&[String]>,
 ) -> Result<RunRecord> {
     let mut metadata = run.metadata_json.clone();
+    let unresolved_run_refs = unresolved_run_refs.map(|refs| refs.to_vec()).or_else(|| {
+        metadata
+            .pointer("/lab/reverse_broker/unresolved_run_refs")
+            .and_then(Value::as_array)
+            .map(|refs| {
+                refs.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|refs| !refs.is_empty())
+    });
     metadata["lab"]["reverse_broker"] = json!({
         "runner_id": runner.id.clone(), "job_id": job.id.to_string(), "broker_url": broker_url,
         "status": job.status, "events": bounded_remote_events(events), "event_count": events.len(),
@@ -485,8 +556,19 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
         return Ok(None);
     };
     let runner = load(&runner_id)?;
-    let job = fetch_daemon_job(&runner_id, &job_id)?;
-    let events = fetch_daemon_events(&runner_id, &job_id)?;
+    let reverse_broker_url = run
+        .metadata_json
+        .pointer("/lab/reverse_broker/broker_url")
+        .and_then(Value::as_str);
+    let (job, events) = match reverse_broker_url {
+        Some(broker_url) => {
+            crate::connection::reverse_broker_job_snapshot_at(broker_url, &runner_id, &job_id)?
+        }
+        None => (
+            fetch_daemon_job(&runner_id, &job_id)?,
+            fetch_daemon_events(&runner_id, &job_id)?,
+        ),
+    };
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
     let cwd = run.cwd.as_deref().unwrap_or("");
     let command = run
@@ -494,6 +576,26 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
         .as_ref()
         .map(|command| vec![command.clone()])
         .unwrap_or_default();
+    if let Some(broker_url) = reverse_broker_url {
+        let mirrored = mirror_reverse_broker_evidence(
+            &runner,
+            broker_url,
+            cwd,
+            &command,
+            &job,
+            &events,
+            &result,
+            (run.kind == "runner-exec").then_some(run_id),
+            None,
+        )?;
+        if matches!(
+            job.status,
+            JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+        ) {
+            crate::connection::reverse_broker_reconcile_at(&runner_id, broker_url)?;
+        }
+        return Ok(mirrored.map(|evidence| evidence.runs));
+    }
     refresh_mirrored_daemon_evidence_with(
         &store,
         &runner,
@@ -536,16 +638,27 @@ where
     let result = (|| {
         reconcile()?;
         let remote_runs = mirror_remote_observation_runs(store, runner, job, result, None)?;
-        if remote_runs.is_empty()
-            && matches!(
-                job.status,
-                JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
-            )
-        {
+        let terminal = matches!(
+            job.status,
+            JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+        );
+        if terminal && (remote_runs.is_empty() || job.status == JobStatus::Failed) {
             mirror_terminal_job_artifacts(store, runner, job, &local_job_run)?;
-            return Ok(Some(vec![local_job_run.run.clone()]));
         }
-        Ok(Some(remote_runs))
+        let mut runs = if remote_runs.is_empty() {
+            vec![local_job_run.run.clone()]
+        } else {
+            remote_runs
+        };
+        if job.status == JobStatus::Failed && !runs.iter().any(|run| run.id == local_job_run.run.id)
+        {
+            runs.push(local_job_run.run.clone());
+        }
+        Ok(Some(
+            runs.into_iter()
+                .map(|run| attach_controller_failure_artifact_refs(store, run))
+                .collect::<Result<Vec<_>>>()?,
+        ))
     })();
     if result.is_err() {
         discard_owned_synthetic_run(store, &local_job_run);
@@ -741,10 +854,20 @@ pub(super) fn mirror_job_run(
         "run_label": inferred_label,
         "explicit_run_id": run_id,
     });
+    if let Some(failure) = runner_failure_projection(runner, job, result) {
+        lab["failure"] = failure;
+    }
     if let Some(event) = agent_task_lifecycle_event {
         lab["agent_task_lifecycle_event"] = event;
     }
     if run_id.is_none() {
+        lab["synthetic_publication_token"] = Value::String(synthetic_token.clone());
+    }
+    // Every runner-controlled value crosses this boundary through recursive
+    // redaction; numeric/status provenance remains typed and intact.
+    lab = homeboy_core::redaction::redact_json(&lab);
+    if run_id.is_none() {
+        // Controller-generated ownership capability, never runner input.
         lab["synthetic_publication_token"] = Value::String(synthetic_token.clone());
     }
     if let Some(run_id) = run_id {
@@ -792,22 +915,37 @@ pub(super) fn mirror_job_run(
         status: job_status_as_run_status(job.status).to_string(),
         command: Some(redact_argv_shell_display(command)),
         cwd: Some(cwd.to_string()),
-        homeboy_version: None,
+        homeboy_version: result
+            .pointer("/data/execution_record/orchestration_provenance/job_command_binary/version")
+            .or_else(|| {
+                result.pointer(
+                    "/data/execution_record/orchestration_provenance/configured_job_binary/version",
+                )
+            })
+            .and_then(Value::as_str)
+            .map(str::to_string),
         git_sha: None,
         rig_id: None,
-        metadata_json: json!({ "lab": lab }),
+        metadata_json: json!({
+            "exit_code": runner_terminal_exit_code(job, result),
+            "lab": lab,
+        }),
     };
     let mut run = run;
     if let Some(notification_route) = notification_route {
         notification_route.insert_into_metadata(&mut run.metadata_json);
     }
     let synthetic_ownership = if run_id.is_none() {
-        store
-            .import_synthetic_run(&run, &synthetic_token)?
-            .then(|| SyntheticRunOwnership {
-                run_id: run.id.clone(),
-                publication_token: synthetic_token,
-            })
+        let inserted = store.import_synthetic_run(&run, &synthetic_token)?;
+        if !inserted && job.status.is_terminal() {
+            // A progress mirror owns the same deterministic synthetic ID. Upsert
+            // its terminal result so restart/reconcile cannot leave it running.
+            store.upsert_imported_run_preserving_terminal(&run)?;
+        }
+        inserted.then(|| SyntheticRunOwnership {
+            run_id: run.id.clone(),
+            publication_token: synthetic_token,
+        })
     } else {
         import_run_if_absent(store, &run)?;
         None
@@ -847,6 +985,103 @@ pub(super) fn bounded_remote_events(events: &[JobEvent]) -> Vec<Value> {
             })
         })
         .collect()
+}
+
+/// Preserve the terminal diagnosis the runner already emitted without copying
+/// its unbounded event stream into the controller-owned observation row.
+fn runner_failure_projection(runner: &Runner, job: &Job, result: &Value) -> Option<Value> {
+    let exit_code = runner_terminal_exit_code(job, result)?;
+    if exit_code == 0 {
+        return None;
+    }
+    // Hash exactly the original terminal stream bytes; display only its
+    // recursively redacted bounded tail so the digest remains reproducible.
+    let stderr_original = result
+        .get("stderr")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let stderr = homeboy_core::redaction::redact_string(stderr_original);
+    let error = [
+        result.get("error"),
+        result.pointer("/data/error"),
+        result.pointer("/data/outcome/result/error"),
+        result.pointer("/outcome/result/error"),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|value| value.is_object())
+    .map(homeboy_core::redaction::redact_json);
+    let artifact_refs = [result.get("artifacts"), result.get("artifact_refs")]
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_array)
+        .flatten()
+        .filter_map(|artifact| {
+            let id = artifact.get("id").and_then(Value::as_str)?;
+            Some(json!({
+                "id": id,
+                "name": artifact.get("name"),
+                "path": artifact.get("path"),
+                "url": artifact.get("url"),
+            }))
+        })
+        .collect::<Vec<_>>();
+    Some(json!({
+        "schema": "homeboy/runner-exec-failure-projection/v1",
+        "failure_code": error.as_ref().and_then(|value| value.get("code")).cloned(),
+        "message": error.as_ref().and_then(|value| value.get("message")).cloned()
+            .or_else(|| result.get("error").filter(|value| value.is_string()).map(homeboy_core::redaction::redact_json)),
+        "details": error.as_ref().and_then(|value| value.get("details")).cloned(),
+        "phase": result.get("phase").cloned().or_else(|| result.pointer("/data/phase").cloned()),
+        "exit_code": exit_code,
+        "signal": result.get("signal").cloned(),
+        "stderr_tail": stderr.chars().rev().take(4_096).collect::<String>().chars().rev().collect::<String>(),
+        "stderr_sha256": format!("{:x}", Sha256::digest(stderr_original.as_bytes())),
+        "runner_id": runner.id.clone(),
+        "runner_job_id": job.id.to_string(),
+        "runner_job_logs_command": format!("homeboy runner job logs {} {}", runner.id, job.id),
+        "remote_command_result_command": format!("homeboy runner job logs {} {} --json", runner.id, job.id),
+        "source_snapshot": job.source_snapshot.clone(),
+        "path_materialization_plan": job.path_materialization_plan.clone(),
+        "runner_job_projection": job.runner_job_projection.clone(),
+        "execution_record": result.pointer("/data/execution_record").cloned(),
+        "orchestration_provenance": result.pointer("/data/orchestration_provenance").cloned(),
+        "artifact_refs": artifact_refs,
+    }))
+}
+
+fn runner_terminal_exit_code(job: &Job, result: &Value) -> Option<i64> {
+    result
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .or((job.status == JobStatus::Failed).then_some(1))
+}
+
+/// Failure evidence never exposes a runner artifact token. Only artifacts the
+/// controller already verified and persisted are made resolvable from evidence.
+fn attach_controller_failure_artifact_refs(
+    store: &ObservationStore,
+    mut run: RunRecord,
+) -> Result<RunRecord> {
+    let Some(failure) = run.metadata_json.pointer_mut("/lab/failure") else {
+        return Ok(run);
+    };
+    let artifacts = store.list_artifacts(&run.id)?;
+    let refs = artifacts
+        .into_iter()
+        .filter_map(|artifact| {
+            Some(json!({
+                "id": artifact.id,
+                "kind": artifact.kind,
+                "path": format!("homeboy://run/{}/artifact/{}", run.id, artifact.id),
+                "sha256": artifact.sha256?,
+                "size_bytes": artifact.size_bytes?,
+            }))
+        })
+        .collect::<Vec<_>>();
+    failure["artifact_refs"] = Value::Array(refs);
+    run = store.update_run_metadata(&run.id, run.metadata_json)?;
+    Ok(run)
 }
 
 fn mirror_remote_observation_runs(

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -1,4 +1,8 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
 
 use reqwest::header;
 use serde_json::json;
@@ -20,11 +24,11 @@ use super::detail::{
 use super::download::{content_disposition_filename, download_remote_artifact};
 use super::mirror::{
     bounded_remote_events, controller_artifact_metadata, import_mirrored_artifact_with_downloader,
-    mirror_job_run, mirror_remote_observation_runs_by_id_with,
+    mirror_daemon_evidence, mirror_job_run, mirror_remote_observation_runs_by_id_with,
     mirror_remote_observation_runs_by_id_with_downloader, mirror_reverse_broker_evidence,
     mirror_terminal_job_artifacts_with, mirrored_patch_result, primary_mirrored_run,
-    refresh_mirrored_daemon_evidence_with, MIRRORED_REMOTE_EVENT_LIMIT,
-    MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
+    refresh_mirrored_daemon_evidence, refresh_mirrored_daemon_evidence_with,
+    MIRRORED_REMOTE_EVENT_LIMIT, MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
 };
 use super::tokens::{
     is_reportable_artifact_evidence_path, is_retrievable_runner_artifact, runner_artifact_token,
@@ -72,6 +76,79 @@ fn terminal_runner_job() -> Job {
         artifacts: Vec::new(),
         runner_job_projection: None,
     }
+}
+
+fn reverse_broker_fixture(
+    job: Job,
+    events: Vec<JobEvent>,
+) -> (String, mpsc::Sender<()>, thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("broker listener");
+    let url = format!("http://{}", listener.local_addr().expect("broker address"));
+    let (shutdown, shutdown_signal) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let mut paths = Vec::new();
+        listener.set_nonblocking(true).expect("nonblocking broker");
+        loop {
+            let (mut stream, _) = match listener.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if shutdown_signal.try_recv().is_ok() {
+                        break;
+                    }
+                    thread::yield_now();
+                    continue;
+                }
+                Err(error) => panic!("broker request: {error}"),
+            };
+            stream
+                .set_nonblocking(false)
+                .expect("blocking request stream");
+            let mut request = Vec::new();
+            loop {
+                let mut byte = [0];
+                stream.read_exact(&mut byte).expect("request byte");
+                request.push(byte[0]);
+                if request.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request = String::from_utf8(request).expect("request text");
+            let content_length = request
+                .lines()
+                .find_map(|line| line.strip_prefix("content-length: "))
+                .and_then(|value| value.parse::<usize>().ok())
+                .unwrap_or_default();
+            if content_length > 0 {
+                let mut body = vec![0; content_length];
+                stream.read_exact(&mut body).expect("request body");
+            }
+            let path = request
+                .lines()
+                .next()
+                .expect("request line")
+                .split_whitespace()
+                .nth(1)
+                .expect("request path")
+                .to_string();
+            let body = if path.ends_with("/events") {
+                json!({ "events": events.clone() })
+            } else if path == "/runner/jobs/reconcile" {
+                json!({})
+            } else {
+                json!({ "job": job.clone() })
+            };
+            paths.push(path);
+            let body = json!({ "success": true, "data": { "body": body } }).to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(), body
+            )
+            .expect("broker response");
+        }
+        paths
+    });
+    (url, shutdown, handle)
 }
 
 #[test]
@@ -328,6 +405,80 @@ fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
 }
 
 #[test]
+fn direct_failure_mirror_projects_bounded_typed_diagnostics_without_artifacts() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut job = terminal_runner_job();
+        job.status = JobStatus::Failed;
+        let mirrored = mirror_daemon_evidence(
+            &ssh_runner(),
+            "/runner/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            &json!({
+                "exit_code": 2,
+                "stderr": "secret=redacted\nvalidation failed",
+                "phase": "path_materialization",
+                "signal": "SIGTERM",
+                "error": {
+                    "code": "validation.invalid_argument",
+                    "message": "required path is missing",
+                    "details": { "field": "path" }
+                },
+                "data": { "execution_record": { "orchestration_provenance": {
+                    "job_command_binary": { "version": "0.321.1" }
+                }}}
+            }),
+            None,
+            None,
+        )
+        .expect("direct failure mirror")
+        .expect("mirrored failure");
+
+        let failure = &mirrored.run.metadata_json["lab"]["failure"];
+        assert_eq!(failure["failure_code"], "validation.invalid_argument");
+        assert_eq!(failure["phase"], "path_materialization");
+        assert_eq!(failure["exit_code"], 2);
+        assert_eq!(mirrored.run.metadata_json["exit_code"], 2);
+        assert_eq!(mirrored.run.homeboy_version.as_deref(), Some("0.321.1"));
+        assert_eq!(failure["signal"], "SIGTERM");
+        assert_eq!(
+            failure["stderr_tail"],
+            "secret=[REDACTED]\nvalidation failed"
+        );
+        assert_eq!(failure["artifact_refs"], json!([]));
+        assert!(failure["stderr_sha256"].as_str().is_some());
+        assert_eq!(
+            failure["runner_job_logs_command"],
+            format!("homeboy runner job logs lab {}", job.id)
+        );
+    });
+}
+
+#[test]
+fn failed_job_without_terminal_exit_code_projects_root_failure_fallback() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut job = terminal_runner_job();
+        job.status = JobStatus::Failed;
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/runner/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            &json!({ "stderr": "failed before result" }),
+            None,
+            None,
+        )
+        .expect("mirror failed job");
+        assert_eq!(run.metadata_json["exit_code"], 1);
+        assert_eq!(run.metadata_json["lab"]["failure"]["exit_code"], 1);
+    });
+}
+
+#[test]
 fn synthetic_runner_run_identity_is_stable_across_repeated_progress_mirrors() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let store = ObservationStore::open_initialized().expect("store");
@@ -362,6 +513,54 @@ fn synthetic_runner_run_identity_is_stable_across_repeated_progress_mirrors() {
 
         assert_eq!(first.id, second.id);
         assert_eq!(store.list_artifacts(&first.id).expect("artifacts").len(), 0);
+    });
+}
+
+#[test]
+fn synthetic_progress_mirror_is_upserted_to_terminal_failure_after_restart() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let runner = ssh_runner();
+        let command = vec!["homeboy".to_string(), "bench".to_string()];
+        let mut progress = terminal_runner_job();
+        progress.status = JobStatus::Running;
+        progress.finished_at_ms = None;
+        let running = mirror_job_run(
+            &store,
+            &runner,
+            "/runner/project",
+            &command,
+            &progress,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("progress mirror");
+
+        let mut terminal = progress.clone();
+        terminal.status = JobStatus::Failed;
+        terminal.finished_at_ms = Some(terminal.updated_at_ms);
+        let failed = mirror_job_run(
+            &store,
+            &runner,
+            "/runner/project",
+            &command,
+            &terminal,
+            &[],
+            &json!({ "exit_code": 2, "stderr": "token=secret" }),
+            None,
+            None,
+        )
+        .expect("terminal mirror after restart");
+
+        assert_eq!(running.id, failed.id);
+        assert_eq!(failed.status, "fail");
+        assert_eq!(failed.metadata_json["lab"]["failure"]["exit_code"], 2);
+        assert_eq!(
+            failed.metadata_json["lab"]["failure"]["stderr_tail"],
+            "token=[REDACTED]"
+        );
     });
 }
 
@@ -1278,6 +1477,99 @@ fn reverse_broker_lookup_projects_only_embedded_typed_run_details() {
         assert_eq!(
             run.metadata_json["lab"]["reverse_broker"]["observation_run_details"],
             json!("unavailable_legacy")
+        );
+    });
+}
+
+#[test]
+fn reverse_failure_mirror_retains_terminal_failure_projection() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut job = terminal_runner_job();
+        job.status = JobStatus::Failed;
+        let mirrored = mirror_reverse_broker_evidence(
+            &ssh_runner(),
+            "http://127.0.0.1:1",
+            "/runner/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &[],
+            &json!({
+                "exit_code": 2,
+                "stderr": "invalid runner input",
+                "data": {
+                    "phase": "preflight",
+                    "error": { "code": "validation.invalid_argument", "message": "invalid input" },
+                    "execution_record": { "runner_id": "lab", "transport": "reverse_broker" },
+                    "orchestration_provenance": { "source": "reverse" }
+                },
+                "artifact_refs": [{ "id": "failure-log", "path": "runner-artifact://lab/job/failure-log" }]
+            }),
+            None,
+            None,
+        )
+        .expect("reverse failure mirror")
+        .expect("mirrored failure");
+
+        let failure = &mirrored.run.metadata_json["lab"]["failure"];
+        assert_eq!(failure["failure_code"], "validation.invalid_argument");
+        assert_eq!(failure["phase"], "preflight");
+        assert_eq!(failure["execution_record"]["transport"], "reverse_broker");
+        assert_eq!(failure["artifact_refs"], json!([]));
+    });
+}
+
+#[test]
+fn reverse_broker_refresh_uses_persisted_transport_after_store_reopen() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+            false,
+        )
+        .expect("persist runner");
+        let job = terminal_runner_job();
+        let events = vec![JobEvent {
+            sequence: 1,
+            job_id: job.id,
+            kind: JobEventKind::Result,
+            timestamp_ms: job.finished_at_ms.expect("terminal timestamp"),
+            message: None,
+            data: Some(json!({ "exit_code": 0 })),
+        }];
+        let (broker_url, shutdown, broker) = reverse_broker_fixture(job.clone(), events.clone());
+        let mirrored = mirror_reverse_broker_evidence(
+            &ssh_runner(),
+            &broker_url,
+            "/runner/project",
+            &["homeboy".to_string(), "bench".to_string()],
+            &job,
+            &events,
+            &json!({ "exit_code": 0 }),
+            None,
+            None,
+        )
+        .expect("persist reverse mirror")
+        .expect("reverse mirror");
+
+        // Refresh opens a new observation store and must recover its transport
+        // choice from persisted provenance, not a live daemon session.
+        let refreshed = refresh_mirrored_daemon_evidence(&mirrored.run.id)
+            .expect("refresh via persisted reverse broker")
+            .expect("refreshed evidence");
+        assert_eq!(refreshed[0].id, mirrored.run.id);
+        assert_eq!(
+            refreshed[0].metadata_json["lab"]["reverse_broker"]["broker_url"],
+            broker_url
+        );
+        assert_eq!(
+            {
+                shutdown.send(()).expect("stop broker");
+                broker.join().expect("broker requests")
+            },
+            vec![
+                format!("/runner/jobs/{}", job.id),
+                format!("/runner/jobs/{}/events", job.id),
+                "/runner/jobs/reconcile".to_string(),
+            ]
         );
     });
 }


### PR DESCRIPTION
## Summary
- project typed runner failure diagnostics into `runs evidence`
- retain controller-owned artifact links, exit codes, runtime identity, and reverse-broker refresh provenance
- reconcile progress mirrors to terminal failures across controller restarts

Closes #9624

## Verification
- `cargo test -p homeboy-lab-runner evidence::tests --lib -- --test-threads=1`
- `cargo test -p homeboy-cli commands::runs::evidence --lib -- --test-threads=1`
- `cargo check -p homeboy-lab-runner -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested the failure-evidence projection and restart reconciliation. Chris Huber reviewed and owns every line.