### PR TITLE
fix: include crates/contracts/* in the workspace (#10550)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,19 @@
 # incremental compilation and lower peak build memory. They are path-only
 # dependencies of the `homeboy` crate. The entire workspace is private; the
 # shipped CLI artifact remains the single `homeboy` binary.
-members = ["crates/*", "crates/contracts/*"]
-# `crates/*` also globs the `crates/contracts` grouping directory, which is not
-# itself a crate; exclude it so only the contract crates under it are members.
-exclude = ["crates/contracts"]
+#
+# Both globs are prefix-qualified (`homeboy-*`) rather than a bare `crates/*`.
+# A bare `crates/*` also matches the `crates/contracts` grouping directory,
+# which is not itself a crate, so cargo fails to load its (nonexistent)
+# manifest. The previous workaround was `exclude = ["crates/contracts"]`, but
+# cargo's `exclude` matches by path PREFIX and outranks the members globs, so it
+# silently dropped all 18 `crates/contracts/*` crates from the workspace too
+# (#10550). Keeping the grouping directory out of the glob in the first place is
+# what makes the membership honest. Every crate under `crates/` and
+# `crates/contracts/` is named `homeboy-*`; `workspace_membership_is_complete`
+# in `crates/homeboy-paths` fails closed if a crate is ever added that these
+# globs would miss.
+members = ["crates/homeboy-*", "crates/contracts/homeboy-*"]
 
 [package]
 name = "homeboy"

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -447,3 +447,88 @@ pub fn authorize_remote_artifact_path(
         Err(RemotePathAuthorizationError::OutsideAllowedRoots)
     }
 }
+
+/// Fails closed when a crate on disk is not enumerated as a workspace member.
+///
+/// The root manifest globs members as `crates/homeboy-*` and
+/// `crates/contracts/homeboy-*` rather than a bare `crates/*`, because a bare
+/// glob also matches the `crates/contracts` grouping directory (not itself a
+/// crate) and cargo then fails to load its manifest. The historical workaround
+/// was `exclude = ["crates/contracts"]`, but cargo's `exclude` matches by path
+/// PREFIX and outranks the members globs -- it silently dropped all 18
+/// `crates/contracts/*` crates out of the workspace. Nothing warned: they still
+/// compiled as path dependencies, so `cargo build` was green while
+/// `--workspace` selection (test, clippy, `check --tests`) never saw them and
+/// their unit tests never ran (#10550).
+///
+/// The prefix globs remove the need for `exclude`, but they trade one silent
+/// failure for another: a crate added under `crates/` without the `homeboy-`
+/// prefix would be just as invisible. This test closes that hole by comparing
+/// the manifests on disk against the members cargo actually resolved.
+#[cfg(test)]
+mod workspace_membership {
+    use std::collections::BTreeSet;
+    use std::path::{Path, PathBuf};
+
+    fn workspace_root() -> PathBuf {
+        // crates/homeboy-paths -> crates -> <root>
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("homeboy-paths should live at <root>/crates/homeboy-paths")
+            .to_path_buf()
+    }
+
+    /// Every directory under `dir` that contains a `Cargo.toml`.
+    fn crate_dirs(dir: &Path) -> BTreeSet<String> {
+        let mut found = BTreeSet::new();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return found;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.join("Cargo.toml").is_file() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    found.insert(name.to_string());
+                }
+            }
+        }
+        found
+    }
+
+    #[test]
+    fn workspace_membership_is_complete() {
+        let root = workspace_root();
+        let manifest = std::fs::read_to_string(root.join("Cargo.toml")).expect("root manifest");
+
+        // Guard the mechanism itself: `exclude` outranks the members globs, so
+        // reintroducing it silently re-orphans crates.
+        assert!(
+            !manifest.contains("\nexclude = [\"crates/contracts\"]"),
+            "root manifest must not exclude `crates/contracts`: cargo's exclude \
+             matches by path prefix and would drop every crates/contracts/* \
+             member from the workspace (#10550)"
+        );
+
+        for (dir, glob) in [
+            (root.join("crates"), "crates/homeboy-*"),
+            (
+                root.join("crates").join("contracts"),
+                "crates/contracts/homeboy-*",
+            ),
+        ] {
+            for name in crate_dirs(&dir) {
+                assert!(
+                    name.starts_with("homeboy-"),
+                    "crate `{}` in {} is not matched by the `{}` members glob, so it \
+                     is invisible to every `--workspace` gate (test, clippy, \
+                     `check --tests`). Rename it with the `homeboy-` prefix or widen \
+                     the glob in the root Cargo.toml.",
+                    name,
+                    dir.display(),
+                    glob
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10550.

## What

`exclude = ["crates/contracts"]` in the root `Cargo.toml` was silently dropping all **18 `crates/contracts/*` crates out of the workspace**. Cargo's `exclude` matches by path **prefix** and outranks the `members` globs, so the `"crates/contracts/*"` entry on the `members` line never had any effect.

```
before:  cargo metadata --no-deps | jq '.workspace_members | length'  ->  25
after:                                                               ->  43   (1 root + 24 + 18)
```

## Why it was invisible

Every contract crate is a path dependency of a workspace member, so they all still compiled and `cargo build` stayed green. Only `--workspace` **package selection** was wrong — and package selection is what drives the test, clippy, and `check --tests` gates.

Net effect: **199 `#[test]` functions across 12 contract crates have never been compiled or run in CI.** Contract crates were only ever built as plain library dependencies, so their `#[cfg(test)]` code was never codegen'd at all.

## About the original report

This started from a report on #10538 that "`cargo fmt` does not reach `crates/contracts/*`, so the Rustfmt CI gate is blind to 18 crates."

**The Rustfmt gate was not blind.** `.github/workflows/ci.yml` runs `cargo fmt --all --check`, and cargo-fmt's `--all` recurses into *path dependencies*, not just workspace members. I probed all 18 contract crates individually (append a deliberately misformatted fn to `lib.rs`, check exit code) and `cargo fmt --all --check` catches every one. Consistent with that, direct `rustfmt --check` across all 110 `.rs` files under `crates/contracts/` reports **0 diffs** — they are already clean. **There is no formatting commit in this PR because there was nothing to format.**

What the reporter actually hit is a real but different bug — the fmt *fixer* is narrower than the fmt *checker*:

```
exit=0  :: cargo fmt --check                                  # misses contracts
exit=1  :: cargo fmt --all --check                            # catches  <-- ci.yml
exit=0  :: cargo fmt --manifest-path ./Cargo.toml --check     # misses   <-- lint-runner.sh
exit=1  :: cargo fmt --all --manifest-path ./Cargo.toml --check
```

So `cargo fmt` / `homeboy lint --fix` does nothing to a contract file, then CI's `--all` check fails with no local reproduction. That is a `homeboy-extensions` fix (`lint-runner.sh` needs `--all` on fmt and `--workspace` on clippy, mirroring what `test-runner.sh` already does for `cargo test`) and is tracked in #10550 as follow-up — it is not fixable from this repo.

The reporter's *hypothesis* — that the line in the root `Cargo.toml` shadows member enumeration — was correct, and the consequences are considerably worse than the fmt symptom that prompted it.

## The fix

The `exclude` was **not** gratuitous. Removing it outright breaks the workspace: a bare `crates/*` glob also matches the `crates/contracts` grouping directory, which has no manifest, and cargo hard errors. The original comment was accurate about the cause; `exclude` was just the wrong instrument.

Prefix-qualifying both globs keeps the grouping directory out of the match set, so no exclude is needed:

```toml
members = ["crates/homeboy-*", "crates/contracts/homeboy-*"]
```

All 42 crates already carry the `homeboy-` prefix; `crates/contracts` is the only non-`homeboy-*` entry under `crates/`. Chosen over the alternatives (explicitly listing 24 paths — high maintenance; moving `crates/contracts` to a top-level `contracts/` — 18 crate moves and churns every path dep) because it is a one-line change with no file moves.

`Cargo.lock` is **unchanged** and `cargo metadata --locked` still resolves, so `--locked` CI steps are unaffected.

Second commit adds `workspace_membership_is_complete` in `homeboy-paths`, because the prefix globs trade one silent-drop mode for another: a future crate under `crates/` without the `homeboy-` prefix would be equally invisible. It compares crate dirs on disk against what the globs can match and asserts the `exclude` workaround is not reintroduced.

Commits are kept separate (gate fix / guard test) for review.

## Verification

Done locally (this host cannot run cargo build/test — 16GB shared VPS, per repo policy CI is the gate):

- `cargo metadata --no-deps` — 25 -> 43 members, split 1/24/18 as expected
- `cargo metadata --no-deps --locked` — exits 0, `Cargo.lock` untouched
- `cargo fmt --all --check` — clean
- probe matrix above, run against both `origin/main` and this branch
- all 18 contract manifests are `publish = false`, identical to the existing 24 members, so no release/publish surface change

**Not verified locally, deliberately left to CI:** whether the 199 newly-enabled tests compile and pass, and whether clippy is clean across the 18 newly-selected crates. If `Workspace Tests Compile` or `review test` goes red here, that is almost certainly latent breakage this PR is exposing rather than causing — it is the first time this code has ever been built as a test target.
