### PR TITLE
fix(lab-runner): one currency verdict for materialization staleness, and two fail-open bugs it exposed

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod agent_task_config;
 pub mod agent_task_outcome;
 pub mod env_materialization_plan;
+pub mod materialization_currency;
 pub mod notification_payload;
 pub mod notification_route;
 pub mod path_materialization;

--- a/crates/contracts/homeboy-lab-contract/src/materialization_currency.rs
+++ b/crates/contracts/homeboy-lab-contract/src/materialization_currency.rs
@@ -1,0 +1,428 @@
+//! One verdict type for "is the copy over there still the copy we made?".
+//!
+//! # Why this exists
+//!
+//! Homeboy materializes a local thing onto a remote host in many shapes:
+//! workspaces, agent-runtime generations, extension overlays, rig package
+//! sources, command-argument files, built artifact directories. Each one grew
+//! its own answer to a currency question, and each one picked its own
+//! representation for the answer: a `bool`, a bare `Result`, a triple of
+//! free-form status strings, or an `Option<u64>` count. They disagree most
+//! sharply on the case that matters — what to report when the evidence needed
+//! for a verdict could not be gathered at all.
+//!
+//! This module owns three things and nothing else:
+//!
+//! 1. [`Currency`] — the verdict, with `Unknown` as a first-class outcome
+//!    rather than something that collapses into `Current`.
+//! 2. [`CurrencyEvidence`] — what a verdict rests on, and in particular
+//!    whether that evidence can prove byte equality
+//!    ([`CurrencyEvidence::proves_content_equality`]) or only provenance
+//!    equality.
+//! 3. Comparators ([`compare_content_digests`], [`compare_source_revisions`],
+//!    [`compare_identities`]) that all fail *closed* to `Unknown` when either
+//!    side of the comparison is missing.
+//!
+//! # What this deliberately does not do
+//!
+//! It does not make content digest the sole authority. Several call sites
+//! cannot obtain a digest of the remote side at all: they interrogate a remote
+//! installation over a control-plane probe that returns a revision string and
+//! nothing else. For those, revision comparison is not a weaker implementation
+//! of digest comparison — it is the only evidence that exists. Forcing them
+//! onto a digest contract would either require a full remote tree transfer per
+//! check or silently disable the check. [`CurrencyEvidence`] records the
+//! difference instead of erasing it.
+//!
+//! # Questions that look alike but are not
+//!
+//! Adopting this contract is only correct for *identity* questions — "does the
+//! copy equal the original". These neighbouring questions share the word
+//! "stale" and must not be folded in:
+//!
+//! - **Derivation currency.** "Is this built artifact behind the source it was
+//!   compiled from?" The artifact and its source are different bytes by
+//!   construction, so no digest comparison between them can answer it. It is
+//!   only answerable by evidence recorded *at build time* by the build step,
+//!   which Homeboy does not run.
+//! - **Process/build identity.** "Is the daemon serving this host the same
+//!   build as the controller?" A running process is not a copied tree; the
+//!   only evidence is what the process reports about itself.
+//! - **Upstream currency.** "Is this checkout behind its remote tracking
+//!   branch?" That compares one tree against a ref it has never held, not
+//!   against a copy that was made from it.
+//! - **Lifecycle eligibility.** "Has this materialization outlived its
+//!   retention policy?" Age, not equality.
+//! - **Work scope.** "Which subset of a component changed since a ref?" A
+//!   user-supplied scope filter that answers no currency question at all.
+//!
+//! # Content addressing dissolves rather than answers the question
+//!
+//! Several materializers name the remote path after the digest of what they
+//! put there. Those sites have no verdict to unify, because re-materializing
+//! changed content lands at a different path and the old path is still exactly
+//! what it always was. [`Currency`] is for sites that compare; it is not
+//! something a content-addressed materializer should be retrofitted with.
+
+use serde::{Deserialize, Serialize};
+
+/// What a [`Currency`] verdict rests on.
+///
+/// Recorded alongside a verdict so a consumer can tell a proof from an
+/// indication. Two verdicts of `Current` are not equally strong if one came
+/// from a digest and the other from a revision string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CurrencyEvidence {
+    /// A digest computed over the bytes of both sides. The only evidence that
+    /// proves the two copies are byte-identical.
+    ContentDigest,
+    /// A source-control revision reported by each side. Proves both sides were
+    /// materialized from the same commit; does not prove either side still
+    /// holds those bytes, because a revision can be reported by a tree that has
+    /// since been edited.
+    SourceRevision,
+    /// A version or build-identity string a running program reports about
+    /// itself. Applies to processes, not to copied trees.
+    BuildIdentity,
+    /// A filesystem timestamp compared against source-control history. A
+    /// heuristic: timestamps are set by transport and checkout, not only by
+    /// builds, so this evidence can be actively misleading and a verdict drawn
+    /// from it should prefer [`Currency::Unknown`] over a confident answer.
+    BuildTimestamp,
+}
+
+impl CurrencyEvidence {
+    /// Stable tag for records and diagnostics.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ContentDigest => "content_digest",
+            Self::SourceRevision => "source_revision",
+            Self::BuildIdentity => "build_identity",
+            Self::BuildTimestamp => "build_timestamp",
+        }
+    }
+
+    /// Whether a `Current` verdict drawn from this evidence proves the two
+    /// sides hold the same bytes.
+    ///
+    /// This is the distinction the codebase kept losing: a revision match and a
+    /// digest match were both stored as `true`, so a caller could not tell
+    /// "these are the same bytes" from "these claim the same provenance".
+    pub const fn proves_content_equality(self) -> bool {
+        matches!(self, Self::ContentDigest)
+    }
+}
+
+/// The verdict for one currency comparison.
+///
+/// `Unknown` exists so that "the evidence could not be gathered" has somewhere
+/// to go other than `Current`. Every fail-open bug this contract is meant to
+/// prevent has the same shape: a probe fails, the failure is discarded into an
+/// `Option`/`bool`, and the absence is then read as agreement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "verdict", rename_all = "snake_case")]
+pub enum Currency {
+    /// The two sides agree under the recorded evidence.
+    Current,
+    /// The two sides provably disagree.
+    Stale { reason: String },
+    /// The comparison could not be made. Not an assertion that the copy is
+    /// good, and not an assertion that it is bad.
+    Unknown { reason: String },
+}
+
+impl Currency {
+    /// Build a `Stale` verdict.
+    pub fn stale(reason: impl Into<String>) -> Self {
+        Self::Stale {
+            reason: reason.into(),
+        }
+    }
+
+    /// Build an `Unknown` verdict.
+    pub fn unknown(reason: impl Into<String>) -> Self {
+        Self::Unknown {
+            reason: reason.into(),
+        }
+    }
+
+    /// Stable tag for records and diagnostics.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::Stale { .. } => "stale",
+            Self::Unknown { .. } => "unknown",
+        }
+    }
+
+    /// Whether the comparison affirmatively succeeded.
+    ///
+    /// Deliberately false for `Unknown`, so `is_current()` can never be the
+    /// place a missing probe turns into a clean bill of health.
+    pub fn is_current(&self) -> bool {
+        matches!(self, Self::Current)
+    }
+
+    /// Whether the comparison affirmatively failed.
+    ///
+    /// Also false for `Unknown`: a caller that needs to distinguish "known bad"
+    /// from "unproven" gets two separate predicates rather than one negation.
+    pub fn is_stale(&self) -> bool {
+        matches!(self, Self::Stale { .. })
+    }
+
+    /// Whether the comparison could not be made.
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown { .. })
+    }
+
+    /// The explanation attached to a non-`Current` verdict.
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Current => None,
+            Self::Stale { reason } | Self::Unknown { reason } => Some(reason.as_str()),
+        }
+    }
+}
+
+/// The identity of one materialized thing, as recorded by whoever materialized
+/// it.
+///
+/// `source_revision` and `dirty` are provenance: they describe where the bytes
+/// came from. `algorithm` and `digest` are identity: they describe the bytes.
+/// [`compare_identities`] uses only the identity fields, so provenance can be
+/// carried in a record without silently becoming a comparison input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaterializedIdentity {
+    /// Names the digest construction, not just the hash function. Two digests
+    /// computed by different tree-walk rules are not comparable even when both
+    /// are SHA-256.
+    pub algorithm: String,
+    /// The digest itself.
+    pub digest: String,
+    /// Descriptive provenance. Never a comparison input for
+    /// [`compare_identities`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+    /// Whether the source had uncommitted modifications when this was
+    /// materialized. Descriptive provenance; it explains why a revision is not
+    /// sufficient identity, and is not itself a verdict.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub dirty: bool,
+}
+
+impl MaterializedIdentity {
+    /// A record carrying identity only.
+    pub fn new(algorithm: impl Into<String>, digest: impl Into<String>) -> Self {
+        Self {
+            algorithm: algorithm.into(),
+            digest: digest.into(),
+            source_revision: None,
+            dirty: false,
+        }
+    }
+
+    /// Attach descriptive provenance.
+    pub fn with_provenance(mut self, source_revision: Option<String>, dirty: bool) -> Self {
+        self.source_revision = source_revision;
+        self.dirty = dirty;
+        self
+    }
+}
+
+/// Compare two full identities.
+///
+/// `recorded` is the identity written down when the copy was made; `observed`
+/// is what a probe reports now. The two-name framing is deliberate: not every
+/// call site is a local/remote pair. A workspace verification compares a
+/// controller declaration against a runner rehash, and an installed-package
+/// check compares install-time metadata against the source as it stands today.
+///
+/// Returns `Unknown` when the two sides were computed under different
+/// algorithms: unequal digests from different constructions are not evidence of
+/// drift, and equal ones would be a coincidence rather than a proof.
+pub fn compare_identities(
+    subject: &str,
+    recorded: &MaterializedIdentity,
+    observed: &MaterializedIdentity,
+) -> Currency {
+    if recorded.algorithm != observed.algorithm {
+        return Currency::unknown(format!(
+            "{subject} identities are not comparable: recorded algorithm `{}` and observed algorithm `{}` differ",
+            recorded.algorithm, observed.algorithm
+        ));
+    }
+    compare_content_digests(subject, Some(&recorded.digest), Some(&observed.digest))
+}
+
+/// Compare a recorded and observed content digest.
+///
+/// Evidence: [`CurrencyEvidence::ContentDigest`]. Absent or blank on either
+/// side yields `Unknown`.
+pub fn compare_content_digests(
+    subject: &str,
+    recorded: Option<&str>,
+    observed: Option<&str>,
+) -> Currency {
+    compare_opaque(
+        subject,
+        CurrencyEvidence::ContentDigest,
+        "content digest",
+        recorded,
+        observed,
+    )
+}
+
+/// Compare a recorded and observed source revision.
+///
+/// Evidence: [`CurrencyEvidence::SourceRevision`]. A `Current` verdict here
+/// proves shared provenance, not byte equality — see
+/// [`CurrencyEvidence::proves_content_equality`].
+pub fn compare_source_revisions(
+    subject: &str,
+    recorded: Option<&str>,
+    observed: Option<&str>,
+) -> Currency {
+    compare_opaque(
+        subject,
+        CurrencyEvidence::SourceRevision,
+        "source revision",
+        recorded,
+        observed,
+    )
+}
+
+/// Shared comparison for two opaque identity strings.
+///
+/// Blank is treated as absent, because every call site that reached for this
+/// had already learned that a probe can return an empty string instead of
+/// failing, and each of them filtered for it separately.
+fn compare_opaque(
+    subject: &str,
+    evidence: CurrencyEvidence,
+    label: &str,
+    recorded: Option<&str>,
+    observed: Option<&str>,
+) -> Currency {
+    let recorded = recorded.map(str::trim).filter(|value| !value.is_empty());
+    let observed = observed.map(str::trim).filter(|value| !value.is_empty());
+    match (recorded, observed) {
+        (Some(recorded), Some(observed)) if recorded == observed => Currency::Current,
+        (Some(recorded), Some(observed)) => Currency::stale(format!(
+            "{subject}: recorded {label} {recorded} differs from observed {label} {observed} (evidence: {})",
+            evidence.as_str()
+        )),
+        (None, Some(_)) => Currency::unknown(format!(
+            "{subject}: currency could not be determined because the recorded {label} was unavailable"
+        )),
+        (Some(_), None) => Currency::unknown(format!(
+            "{subject}: currency could not be determined because the observed {label} was unavailable"
+        )),
+        (None, None) => Currency::unknown(format!(
+            "{subject}: currency could not be determined because no {label} was available on either side"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compare_content_digests, compare_identities, compare_source_revisions, Currency,
+        CurrencyEvidence, MaterializedIdentity,
+    };
+
+    #[test]
+    fn missing_evidence_is_unknown_rather_than_current() {
+        // The single behaviour this contract exists to force. Every mechanism
+        // it replaces had some path where a failed probe produced the same
+        // value as a successful match.
+        for verdict in [
+            compare_content_digests("workspace", None, Some("sha256:a")),
+            compare_content_digests("workspace", Some("sha256:a"), None),
+            compare_content_digests("workspace", None, None),
+            compare_source_revisions("extension", None, Some("abc1234")),
+            compare_source_revisions("extension", Some("abc1234"), None),
+            compare_source_revisions("extension", None, None),
+        ] {
+            assert!(verdict.is_unknown(), "expected unknown, got {verdict:?}");
+            assert!(!verdict.is_current());
+            assert!(!verdict.is_stale());
+        }
+    }
+
+    #[test]
+    fn blank_evidence_counts_as_absent_on_either_side() {
+        assert!(compare_source_revisions("rig", Some("   "), Some("abc1234")).is_unknown());
+        assert!(compare_source_revisions("rig", Some("abc1234"), Some("")).is_unknown());
+        assert!(compare_content_digests("workspace", Some(""), Some("")).is_unknown());
+    }
+
+    #[test]
+    fn matching_and_differing_evidence_produce_the_two_decided_verdicts() {
+        assert_eq!(
+            compare_content_digests("workspace", Some("sha256:a"), Some("sha256:a")),
+            Currency::Current
+        );
+        let stale = compare_content_digests("workspace", Some("sha256:a"), Some("sha256:b"));
+        assert!(stale.is_stale());
+        assert!(stale.reason().unwrap_or_default().contains("sha256:b"));
+        assert!(stale
+            .reason()
+            .unwrap_or_default()
+            .contains("content_digest"));
+    }
+
+    #[test]
+    fn digest_evidence_proves_byte_equality_and_revision_evidence_does_not() {
+        // A revision match and a digest match were both stored as `true` in the
+        // mechanisms this replaces, which is exactly why a dirty worktree could
+        // satisfy one check and fail another for the same subject.
+        assert!(CurrencyEvidence::ContentDigest.proves_content_equality());
+        assert!(!CurrencyEvidence::SourceRevision.proves_content_equality());
+        assert!(!CurrencyEvidence::BuildIdentity.proves_content_equality());
+        assert!(!CurrencyEvidence::BuildTimestamp.proves_content_equality());
+    }
+
+    #[test]
+    fn identities_computed_under_different_algorithms_are_not_comparable() {
+        let local = MaterializedIdentity::new("homeboy-workspace-content-v1", "sha256:a");
+        let remote = MaterializedIdentity::new("homeboy-workspace-content-v2+portable", "sha256:a");
+
+        let verdict = compare_identities("workspace", &local, &remote);
+
+        // Equal digest strings under unequal constructions are a coincidence,
+        // not a proof, so this must not report Current.
+        assert!(verdict.is_unknown());
+        assert!(verdict
+            .reason()
+            .unwrap_or_default()
+            .contains("not comparable"));
+    }
+
+    #[test]
+    fn provenance_fields_are_not_comparison_inputs() {
+        let local = MaterializedIdentity::new("alg", "sha256:a")
+            .with_provenance(Some("abc1234".to_string()), true);
+        let remote = MaterializedIdentity::new("alg", "sha256:a")
+            .with_provenance(Some("def5678".to_string()), false);
+
+        // Differing revision and dirty flag, identical bytes: the bytes decide.
+        assert_eq!(compare_identities("workspace", &local, &remote), Currency::Current);
+    }
+
+    #[test]
+    fn verdict_tags_are_stable_for_records() {
+        assert_eq!(Currency::Current.tag(), "current");
+        assert_eq!(Currency::stale("because").tag(), "stale");
+        assert_eq!(Currency::unknown("because").tag(), "unknown");
+        assert_eq!(
+            serde_json::to_value(Currency::Current).expect("serialize"),
+            serde_json::json!({ "verdict": "current" })
+        );
+        assert_eq!(
+            serde_json::to_value(Currency::stale("drifted")).expect("serialize"),
+            serde_json::json!({ "verdict": "stale", "reason": "drifted" })
+        );
+    }
+}

--- a/crates/contracts/homeboy-lab-contract/src/materialization_currency.rs
+++ b/crates/contracts/homeboy-lab-contract/src/materialization_currency.rs
@@ -412,7 +412,10 @@ mod tests {
             .with_provenance(Some("def5678".to_string()), false);
 
         // Differing revision and dirty flag, identical bytes: the bytes decide.
-        assert_eq!(compare_identities("workspace", &local, &remote), Currency::Current);
+        assert_eq!(
+            compare_identities("workspace", &local, &remote),
+            Currency::Current
+        );
     }
 
     #[test]

--- a/crates/contracts/homeboy-lab-contract/src/materialization_currency.rs
+++ b/crates/contracts/homeboy-lab-contract/src/materialization_currency.rs
@@ -253,7 +253,11 @@ pub fn compare_identities(
             recorded.algorithm, observed.algorithm
         ));
     }
-    compare_content_digests(subject, Some(&recorded.digest), Some(&observed.digest))
+    compare_content_digests(
+        subject,
+        Some(recorded.digest.as_str()),
+        Some(observed.digest.as_str()),
+    )
 }
 
 /// Compare a recorded and observed content digest.

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -127,6 +127,7 @@ pub mod local_permissions;
 pub use homeboy_lifecycle_contract::lifecycle;
 pub mod loop_lifecycle;
 pub mod markdown;
+pub use homeboy_lab_contract::materialization_currency;
 pub mod matrix_artifact_summary;
 pub use homeboy_lab_contract::notification_payload;
 pub use homeboy_lab_contract::notification_route;

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use homeboy_core::materialization_currency::{self, Currency};
 use homeboy_core::source_snapshot::SourceSnapshot;
 use homeboy_core::{Error, Result};
 use homeboy_rig;
@@ -197,10 +198,12 @@ pub(super) fn sync_lab_offload_rigs(
                     rig_path: Some(metadata.rig_path),
                     discovery_path: metadata.discovery_path,
                     source_revision: metadata.source_revision.clone(),
-                    current_source_revision: source_snapshot
-                        .git_sha
-                        .clone()
-                        .or_else(|| metadata.source_revision.clone()),
+                    // Only what the snapshot actually reports. Falling back to
+                    // the install-time revision here would make the freshness
+                    // comparison below compare that revision with itself and
+                    // report `verified` for a source whose current revision
+                    // could not be read at all.
+                    current_source_revision: source_snapshot.git_sha.clone(),
                     source_ref: source_snapshot
                         .git_branch
                         .clone()
@@ -298,42 +301,68 @@ pub(super) fn sync_lab_offload_rigs(
     Ok(synced_rigs)
 }
 
+/// Decide whether an installed rig package source still matches the source it
+/// was installed from.
+///
+/// The verdict comes from the shared currency contract rather than a private
+/// three-way match, because the rig subsystem answers this same question in
+/// `homeboy_rig::package_evidence_from_metadata` and the two used to disagree
+/// on the case that matters: with no revision readable, that one reports
+/// `unknown` while this one reported `verified`.
+///
+/// The `verified` answer came from copying the installed revision into the
+/// current-revision slot when the current one was missing, and then comparing
+/// the value with itself. Absence of evidence is now `unknown`, matching the
+/// rig subsystem and the contract's fail-closed rule. The wire tags
+/// (`verified` / `stale` / `unknown`) are unchanged so consumers of this
+/// evidence keep reading the same vocabulary.
 fn with_lab_package_freshness(
     rig_id: &str,
     mut package_source: LabOffloadRigPackageSource,
 ) -> LabOffloadRigPackageSource {
-    if package_source.current_source_revision.is_none() {
-        package_source.current_source_revision = package_source.source_revision.clone();
-    }
-
-    match (
+    let subject = format!("rig `{rig_id}` installed package source");
+    let currency = materialization_currency::compare_source_revisions(
+        &subject,
         package_source.source_revision.as_deref(),
         package_source.current_source_revision.as_deref(),
-    ) {
-        (Some(installed), Some(current)) if installed == current => {
+    );
+
+    let refresh_command = format!(
+        "homeboy rig install {} --id {} --reinstall",
+        package_source.install_source, rig_id
+    );
+
+    match currency {
+        Currency::Current => {
             package_source.freshness_verified = true;
             package_source.freshness_status = "verified".to_string();
+            package_source.freshness_message = None;
+            package_source.refresh_command = None;
         }
-        (Some(installed), Some(current)) => {
+        Currency::Stale { .. } => {
+            package_source.freshness_verified = false;
             package_source.freshness_status = "stale".to_string();
             package_source.freshness_message = Some(format!(
-                "installed source revision {installed} differs from current source revision {current}"
+                "installed source revision {} differs from current source revision {}",
+                package_source
+                    .source_revision
+                    .as_deref()
+                    .unwrap_or("<missing>"),
+                package_source
+                    .current_source_revision
+                    .as_deref()
+                    .unwrap_or("<missing>")
             ));
-            package_source.refresh_command = Some(format!(
-                "homeboy rig install {} --id {} --reinstall",
-                package_source.install_source, rig_id
-            ));
+            package_source.refresh_command = Some(refresh_command);
         }
-        _ => {
+        Currency::Unknown { .. } => {
+            package_source.freshness_verified = false;
             package_source.freshness_status = "unknown".to_string();
             package_source.freshness_message = Some(
                 "runner rig source freshness could not be verified because a git revision was unavailable"
                     .to_string(),
             );
-            package_source.refresh_command = Some(format!(
-                "homeboy rig install {} --id {} --reinstall",
-                package_source.install_source, rig_id
-            ));
+            package_source.refresh_command = Some(refresh_command);
         }
     }
     package_source
@@ -1901,8 +1930,17 @@ mod tests {
         );
     }
 
+    /// An unreadable current revision is unproven, not verified.
+    ///
+    /// This assertion is inverted from what it used to be. The previous
+    /// behaviour copied the install-time revision into the current-revision
+    /// slot and compared it with itself, so a source whose revision could not
+    /// be read at all was reported as `verified` with no refresh hint — a
+    /// missing probe rendered as a clean bill of health. The rig subsystem's
+    /// own check (`homeboy_rig::package_evidence_from_metadata`) already
+    /// reported `unknown` for the same input; this makes the two agree.
     #[test]
-    fn lab_package_source_freshness_uses_controller_metadata_when_snapshot_has_no_git() {
+    fn lab_package_source_freshness_is_unknown_when_no_current_revision_is_readable() {
         let package = with_lab_package_freshness(
             "ssi-matrix-run-latest",
             LabOffloadRigPackageSource {
@@ -1925,12 +1963,57 @@ mod tests {
             },
         );
 
-        assert!(package.freshness_verified);
-        assert_eq!(package.freshness_status, "verified");
+        assert!(!package.freshness_verified);
+        assert_eq!(package.freshness_status, "unknown");
         assert_eq!(package.source_ref.as_deref(), Some("main"));
         assert!(package.source_dirty);
+        assert!(package
+            .freshness_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("could not be verified"));
+        assert_eq!(
+            package.refresh_command.as_deref(),
+            Some("homeboy rig install /runner/_lab_workspaces/homeboy-rigs --id ssi-matrix-run-latest --reinstall")
+        );
+        // The unreadable slot stays unreadable: nothing fabricates a current
+        // revision from the installed one to satisfy the comparison.
+        assert!(package.current_source_revision.is_none());
+    }
+
+    /// A matching pair is still the only route to `verified`.
+    #[test]
+    fn lab_package_source_freshness_verifies_a_matching_revision_pair() {
+        let package = with_lab_package_freshness(
+            "ssi-matrix-run-latest",
+            LabOffloadRigPackageSource {
+                source: "/controller/homeboy-rigs".to_string(),
+                source_root: "/controller/homeboy-rigs".to_string(),
+                package_path: "/controller/homeboy-rigs".to_string(),
+                install_source: "/runner/_lab_workspaces/homeboy-rigs".to_string(),
+                rig_path: Some("/controller/homeboy-rigs/rigs/ssi/rig.json".to_string()),
+                discovery_path: Some("/controller/homeboy-rigs".to_string()),
+                source_revision: Some("abc1234".to_string()),
+                current_source_revision: Some("abc1234".to_string()),
+                source_ref: Some("main".to_string()),
+                source_dirty: true,
+                freshness_verified: false,
+                freshness_status: String::new(),
+                freshness_message: None,
+                refresh_command: None,
+                linked: true,
+                materialized: false,
+            },
+        );
+
+        assert!(package.freshness_verified);
+        assert_eq!(package.freshness_status, "verified");
         assert!(package.freshness_message.is_none());
         assert!(package.refresh_command.is_none());
+        // A dirty source still verifies here: revision evidence cannot see
+        // uncommitted edits, which is exactly why the currency contract records
+        // that a revision match does not prove content equality.
+        assert!(package.source_dirty);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
+++ b/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
@@ -17,17 +17,50 @@
 //! - `commits_behind` — `git rev-list --count built_from_sha..HEAD`.
 //!
 //! When `built_from_sha` differs from `source_sha` the build is stale: the
-//! source has commits the dist predates. The check is pure git + filesystem
-//! mtimes, assumes no package manager or language, and is computed on the
+//! source has commits the dist predates. The check is computed on the
 //! controller-local artifact directory (real mtimes) before it is snapshotted
 //! to the runner.
+//!
+//! # Why this is a heuristic and cannot become a content comparison
+//!
+//! This module answers a *derivation* question — "is this built output behind
+//! the source it was compiled from?" — not an *identity* question. An artifact
+//! and its source are different bytes by construction, so no digest computed
+//! over either one can be compared against the other. A derivation can only be
+//! bound by evidence recorded at build time by the build step, and the build
+//! step here is opaque and outside this product's control: there is nothing to
+//! ask for a source identity, and nowhere to have asked it.
+//!
+//! That leaves timestamps, whose weakness is inherent rather than incidental:
+//! transport and checkout both write mtimes, so a freshly created checkout
+//! makes every artifact in it look newly built. The shared currency contract
+//! records this evidence class as `CurrencyEvidence::BuildTimestamp`, one that
+//! should prefer an unknown verdict over a confident one.
+//!
+//! # Traversal caveat
+//!
+//! The mtime walk takes the *newest* file time under the artifact directory, so
+//! anything written into that directory after the build — a dependency tree
+//! installed in place, a cache, a scratch area — drags the apparent build time
+//! forward and can mask a stale build. The skip list below covers the common
+//! case by name only; it is not a general solution, and a directory it does not
+//! name will still hide staleness.
 
 use std::path::Path;
 use std::time::SystemTime;
 
+use homeboy_core::materialization_currency::{Currency, CurrencyEvidence};
 use serde::Serialize;
 
 use super::workspace::git_output;
+
+/// Directory names skipped by the mtime walk because they are written by
+/// something other than the build and would otherwise drag the apparent build
+/// time forward. Matched by exact name at any depth.
+///
+/// Named by convention, not derived from any declared project model, so this
+/// list is a mitigation rather than a rule. See the traversal caveat above.
+const MTIME_WALK_SKIPPED_DIRECTORY_NAMES: &[&str] = &[".git", "node_modules"];
 
 /// Env var that escalates a stale runtime-overlay build from a warning to a hard
 /// error for a single run. Accepts the usual truthy spellings (`1`, `true`,
@@ -42,6 +75,11 @@ pub(super) const REQUIRE_FRESH_RUNTIME_OVERLAY_ENV: &str =
 pub(super) struct RuntimeOverlayBuildProvenance {
     /// Coarse verdict for the artifact's freshness relative to its source.
     pub(super) status: RuntimeOverlayBuildStatus,
+    /// The same verdict in the shared currency vocabulary, so a reader of a run
+    /// record can compare this against every other materialization's verdict
+    /// without knowing this module's private status names. Derived from
+    /// `status`; see [`RuntimeOverlayBuildStatus::currency`].
+    pub(super) currency: Currency,
     /// `true` only when the build is provably behind its source checkout.
     pub(super) stale: bool,
     /// Path to the git checkout that contains the artifact directory.
@@ -83,6 +121,41 @@ pub(super) enum RuntimeOverlayBuildStatus {
     /// The artifact directory holds no files to date, so there is no build to
     /// compare.
     UnknownNoArtifacts,
+    /// The artifact directory is in a git checkout with files in it, but a git
+    /// probe needed for the comparison did not return a usable answer, so
+    /// neither `Fresh` nor `Stale` was established.
+    ///
+    /// This case previously reported `Fresh`: the probe results were carried in
+    /// `Option`s, every failure collapsed to `None`, and `None` fell through
+    /// the `commits_behind > 0` test to the fresh branch. A broken git
+    /// invocation therefore certified a stale build as current.
+    UnknownProbeFailed,
+}
+
+impl RuntimeOverlayBuildStatus {
+    /// This status as a shared currency verdict.
+    ///
+    /// The evidence is [`CurrencyEvidence::BuildTimestamp`], so a `Current`
+    /// verdict here is an indication and not a proof — see this module's header
+    /// for why no stronger evidence is obtainable.
+    pub(super) fn currency(self) -> Currency {
+        match self {
+            Self::Fresh => Currency::Current,
+            Self::Stale => Currency::stale(format!(
+                "built artifact predates the source checkout HEAD (evidence: {})",
+                CurrencyEvidence::BuildTimestamp.as_str()
+            )),
+            Self::UnknownNoGit => Currency::unknown(
+                "artifact directory is not inside a source checkout, so it has no build provenance to compare".to_string(),
+            ),
+            Self::UnknownNoArtifacts => Currency::unknown(
+                "artifact directory holds no files, so there is no build to compare".to_string(),
+            ),
+            Self::UnknownProbeFailed => Currency::unknown(
+                "a source-history probe did not return a usable answer, so build currency was not established".to_string(),
+            ),
+        }
+    }
 }
 
 impl RuntimeOverlayBuildProvenance {
@@ -91,6 +164,7 @@ impl RuntimeOverlayBuildProvenance {
     pub(super) fn unverifiable() -> Self {
         Self {
             status: RuntimeOverlayBuildStatus::UnknownNoGit,
+            currency: RuntimeOverlayBuildStatus::UnknownNoGit.currency(),
             stale: false,
             source_checkout: None,
             source_sha: None,
@@ -143,6 +217,7 @@ pub(super) fn assess_runtime_overlay_build_freshness(
     let Some(newest_mtime) = newest_mtime else {
         return RuntimeOverlayBuildProvenance {
             status: RuntimeOverlayBuildStatus::UnknownNoArtifacts,
+            currency: RuntimeOverlayBuildStatus::UnknownNoArtifacts.currency(),
             stale: false,
             source_checkout: Some(checkout.clone()),
             source_sha,
@@ -177,15 +252,23 @@ pub(super) fn assess_runtime_overlay_build_freshness(
         _ => None,
     };
 
-    let stale = matches!(commits_behind, Some(count) if count > 0);
-    let status = if stale {
-        RuntimeOverlayBuildStatus::Stale
-    } else {
-        RuntimeOverlayBuildStatus::Fresh
+    // Fail closed. `commits_behind` is `None` for every way the comparison can
+    // fail to produce an answer: HEAD unreadable, the `--before` walk empty or
+    // errored, the count unparseable. Treating that absence as "not behind"
+    // certified a stale build as fresh, which is the exact failure this module
+    // exists to prevent.
+    let (status, stale) = match commits_behind {
+        Some(0) => (RuntimeOverlayBuildStatus::Fresh, false),
+        Some(_) => (RuntimeOverlayBuildStatus::Stale, true),
+        // Unknown is reported, not escalated: `stale` stays false so this does
+        // not turn every unprobeable overlay into a warning or, under the
+        // require-fresh opt-in, a hard failure.
+        None => (RuntimeOverlayBuildStatus::UnknownProbeFailed, false),
     };
 
     RuntimeOverlayBuildProvenance {
         status,
+        currency: status.currency(),
         stale,
         source_checkout: Some(checkout),
         source_sha,
@@ -234,9 +317,9 @@ fn short_sha(sha: &str) -> String {
     sha.chars().take(12).collect()
 }
 
-/// Walk the artifact directory and return the newest file mtime, skipping
-/// `.git` and `node_modules` so dependency-install churn does not mask a stale
-/// build. Returns `None` when there are no files.
+/// Walk the artifact directory and return the newest file mtime, skipping the
+/// directory names in [`MTIME_WALK_SKIPPED_DIRECTORY_NAMES`] so their churn does
+/// not mask a stale build. Returns `None` when there are no files.
 fn newest_artifact_mtime(dir: &Path) -> Option<SystemTime> {
     let mut newest: Option<SystemTime> = None;
     let mut stack = vec![dir.to_path_buf()];
@@ -246,7 +329,10 @@ fn newest_artifact_mtime(dir: &Path) -> Option<SystemTime> {
         };
         for entry in entries.flatten() {
             let file_name = entry.file_name();
-            if matches!(file_name.to_str(), Some(".git" | "node_modules")) {
+            if file_name
+                .to_str()
+                .is_some_and(|name| MTIME_WALK_SKIPPED_DIRECTORY_NAMES.contains(&name))
+            {
                 continue;
             }
             let Ok(file_type) = entry.file_type() else {
@@ -274,6 +360,8 @@ mod tests {
     use std::process::Command;
 
     use chrono::{Duration, Utc};
+
+    use homeboy_core::materialization_currency::{Currency, CurrencyEvidence};
 
     use super::{
         assess_runtime_overlay_build_freshness, require_fresh_runtime_overlay,
@@ -401,6 +489,59 @@ mod tests {
         assert_eq!(provenance.status, RuntimeOverlayBuildStatus::UnknownNoGit);
         assert!(!provenance.stale);
         assert!(provenance.source_sha.is_none());
+    }
+
+    /// A checkout whose history cannot be read is unknown, not fresh.
+    ///
+    /// A repository with no commits reaches every probe this module makes:
+    /// `--show-toplevel` succeeds, artifacts exist, and both `rev-parse HEAD`
+    /// and the `--before` walk fail. Those failures used to collapse into
+    /// `commits_behind: None`, which fell through the `> 0` test onto the fresh
+    /// branch — so a build whose currency was entirely unestablished was
+    /// certified as reflecting the current source.
+    #[test]
+    fn unknown_when_a_history_probe_cannot_answer() {
+        let repo = tempfile::tempdir().expect("repo");
+        init_repo(repo.path());
+        let dist = write_dist(repo.path());
+
+        let provenance = assess_runtime_overlay_build_freshness(&dist);
+
+        assert_eq!(
+            provenance.status,
+            RuntimeOverlayBuildStatus::UnknownProbeFailed
+        );
+        assert!(provenance.currency.is_unknown());
+        assert!(!provenance.currency.is_current());
+        assert!(provenance.source_sha.is_none());
+        assert!(provenance.built_from_sha.is_none());
+        assert!(provenance.commits_behind.is_none());
+        // Unknown is reported, not escalated: no warning, so the require-fresh
+        // opt-in cannot turn an unprobeable overlay into a hard failure.
+        assert!(!provenance.stale);
+        assert!(stale_runtime_overlay_warning("cli", "/local/dist", &provenance).is_none());
+    }
+
+    #[test]
+    fn every_status_carries_the_shared_currency_verdict() {
+        assert_eq!(
+            RuntimeOverlayBuildStatus::Fresh.currency(),
+            Currency::Current
+        );
+        assert!(RuntimeOverlayBuildStatus::Stale.currency().is_stale());
+        for status in [
+            RuntimeOverlayBuildStatus::UnknownNoGit,
+            RuntimeOverlayBuildStatus::UnknownNoArtifacts,
+            RuntimeOverlayBuildStatus::UnknownProbeFailed,
+        ] {
+            assert!(
+                status.currency().is_unknown(),
+                "expected unknown currency for {status:?}"
+            );
+        }
+        // This module's verdict rests on filesystem timestamps, which the
+        // contract records as evidence that cannot prove content equality.
+        assert!(!CurrencyEvidence::BuildTimestamp.proves_content_equality());
     }
 
     #[test]


### PR DESCRIPTION
## The count is wrong, and the shape of the error matters

#10309 lists eight mechanisms. Four of the eight are not staleness decisions at all, the mechanism that *is* the extension staleness decision is not in the table, and there are at least four more real decisions the table misses. The corrected enumeration is below with `file:line` against `origin/main` at `7e3c664`.

I implemented the part that genuinely converges, fixed the two fail-open bugs the audit turned up, and did **not** implement the prescribed fix, which cannot work for the mechanism the issue spends the most words on. Details under "Why not the prescribed fix".

## The real enumeration

Grouped by the question each one answers, because that is the axis that decides what converges.

### Q-A — "Do these two copies hold the same bytes?" (digest evidence available on both sides)

| # | Site | Evidence | Returns | Called by |
|---|---|---|---|---|
| A1 | `homeboy-lab-runner/src/workspace/provenance.rs:626` `verify_snapshot_workspace_content` | v1/v2/v3 workspace content hash, rehashed runner-side | `Result<(), String>`, fails closed | `verify_lab_workspace_from_env` |
| A2 | `homeboy-lab-runner/src/runtime_materializer.rs:813` `generation_matches` | sha256 generation identity + resolved source identities + path existence | `Result<bool>` | `materialize_generation_with_operations:655` |
| A3 | `homeboy-lab-runner/src/execution/extension_parity.rs:944` `validate_dev_overlay_extension_revision` | `extension_source_content_hash` recomputed vs recorded | `Result<()>` | `validate_runner_extension_revision:875` |
| A4 | `homeboy-core/src/content_diff.rs` + `homeboy-release/src/deploy/content_manifest.rs` | sha256 tree scan | change list | harvest/deploy `--check`, unified by #10534 |

### Q-B — "Was the remote installation made from the same source revision?" (no remote digest obtainable)

| # | Site | Evidence | Returns | Called by |
|---|---|---|---|---|
| B1 | `execution/extension_parity.rs:875` `validate_runner_extension_revision` (non-overlay branch, `:889-940`) | local `read_source_revision` vs `source_revision` parsed from remote `extension show` JSON | `Result<()>` | `plan_runner_extension_parity:213`, `validate_runner_extension_ready_state:276` |
| B2 | `rig_materialization/mod.rs:317` `with_lab_package_freshness` | install-time revision vs current revision | three status strings | `sync_lab_offload_rigs:224` |
| B3 | `homeboy-rig/src/lib.rs:206` `package_evidence_from_metadata` | revision **and** package content hash | `RigPackageFreshness` enum | rig source listing |
| B4 | `rig_materialization/mod.rs:131` (inline) | `git_sha.is_some()` | status strings | primary-snapshot rig branch |

### Q-C — "Is the running program the same build as the controller?"

| # | Site | Evidence | Returns |
|---|---|---|---|
| C1 | `runtime_materialization_status.rs:65-67` / `:117` | version + build-identity strings a process reports about itself | `bool` |
| C2 | `connection.rs:2212` `stale_daemon_warning` | same | `Option<RunnerStaleDaemonWarning>` |

### Q-D — "Has the local source drifted since we snapshotted it?" (local vs local across time)

| # | Site | Evidence | Returns |
|---|---|---|---|
| D1 | `apply.rs:70` | `source_snapshot::collect_local` snapshot hash vs the one recorded in the artifact | hard error unless `--force` |

### Q-E — "Is this built output behind the source it was compiled from?" (derivation, not identity)

| # | Site | Evidence | Returns |
|---|---|---|---|
| E1 | `runtime_overlay_freshness.rs:196` | newest artifact mtime vs `git rev-list --before` | `RuntimeOverlayBuildProvenance` |

### Q-F — "Is this checkout behind its upstream ref?"

| # | Site | Evidence |
|---|---|---|
| F1 | `git_dependency_materialization.rs:580` `ensure_git_dependency_fresh` | `@{u}` fetch + compare |
| F2 | `homeboy-core/src/extension_update_check.rs:25` `check_update_available` | `git fetch` + `rev-list HEAD..@{u} --count` |

### Q-G / Q-H / Q-I — not currency questions

| # | Site | What it actually is |
|---|---|---|
| G1 | `offload_changed_since.rs` | **Work-scope selection.** Resolves a user-supplied `--changed-since` baseline so the remote command can narrow its scope. It never compares a local copy to a remote one. |
| H1 | `workspace/sync/mod.rs:2671` `is_stale_materialized_workspace_lifecycle` | **GC eligibility.** Ownership fields + TTL. Age, not equality. |
| I1 | `workload.rs:230` `required_extension_revisions` | **Provenance record with no consumer.** Produced, serialized into `LabRunnerWorkload`, and never read back for a comparison anywhere in the tree. |
| I2 | `extension_materialization.rs:44,46` `dirty` / `dirty_fingerprint` | Written at `:618-619`, never compared. `dirty_fingerprint` has exactly one non-test read: a test fixture literal. |
| I3 | `extension_materialization.rs:691` `dev_extension_path`, `:120-125`, `lab_args/at_files.rs:210` `remote_path_for_at_file` | **Content addressing.** The digest is the remote path. There is no verdict; re-materializing changed content lands somewhere else. |

## Where the issue's table is wrong

- **#5 (`at_files.rs:190-198`) is not a staleness test.** The sha256 becomes the remote *filename* (`remote_path_for_at_file:210`). Nothing is ever compared. It is I3, not a mechanism with a verdict to unify.
- **#1's cited lines are the same idiom.** `extension_materialization.rs:119-125` derives the overlay path from `&content_hash[..16]`. The extension staleness *decision* is `extension_parity.rs:875`, which the table does not list.
- **#6 (`offload_changed_since.rs`) answers no currency question.** It is a scope filter (G1).
- **#8 (`workload.rs:229-251`) renders no verdict.** `grep -rn required_extension_revisions crates/ --include=*.rs` returns the producer, the struct field, two metadata assertions, and two empty-vec initializers. Nothing consumes it as a comparison input.
- **"#1 and #8 can both be consulted for the same extension and reach different verdicts" is false as stated.** They are not both consulted, because #8 is never consulted at all. The arbitration between content hash and revision for extensions already exists and is already documented, at `extension_parity.rs:952-956`: a dev overlay is judged by content hash and its git revision is explicitly demoted to provenance; an installed extension is judged by revision. The branches are mutually exclusive (`if let Some(overlay) = dev_sync_extension_overlay(...) { return ... }` at `:882-889`).
- **`PathMaterializationEntry.validation_status` is not an enum.** It is `pub validation_status: String` (`contracts/homeboy-lab-contract/src/path_materialization.rs:76,154`), with `MATERIALIZED`/`VALIDATED` as `&str` consts. There is a closed list of accepted values at `homeboy-cli/src/command_contract/constants.rs:406`. Adding verdict values to it is therefore *not* automatically additive: it changes a documented closed vocabulary that a runner on an older build may be matching against. I did not touch it.

## Why not the prescribed fix

> Then #4: replace the mtime heuristic with the content hash the crate **already computes** (`extension_source_content_hash`, `workspace_content_hash`), recorded into a sidecar at build time.

This cannot work, for two independent reasons.

1. **Nothing to compare.** #4 asks a *derivation* question — is this built output behind the source it was compiled from? The artifact and its source are different bytes by construction. `extension_source_content_hash(dist)` and `workspace_content_hash(src)` are both computable, and comparing them is meaningless. No digest over either side answers the question.
2. **No build time to record at.** The module's own doc (`runtime_overlay_freshness.rs:5-8`) states the premise: the artifact is "produced outside Homeboy (an opaque build step)". Homeboy does not run that build, so there is no moment at which it can write the sidecar. The sidecar would have to be produced by the foreign build step, which is a build-tooling integration, not a refactor.

Deleting `newest_artifact_mtime` and the `--before` plumbing as the issue proposes would therefore delete the check, not replace it. Same for the three git fixtures: they pin the only behaviour that exists.

The related prescription — "content hash is the single authority; `source_revision` becomes descriptive provenance only, never a staleness input" — is also wrong for **B1**. There, the remote side is an installation interrogated over `homeboy extension show`, which returns a JSON document containing a revision string. There is no remote tree to hash without a full transfer per extension per dispatch. Making digest the sole authority there does not strengthen the check; it removes it. The contract in this PR records that difference as `CurrencyEvidence` instead of erasing it.

## What this PR does

### New contract

`crates/contracts/homeboy-lab-contract/src/materialization_currency.rs`, re-exported as `homeboy_core::materialization_currency` alongside `path_materialization`.

- `Currency { Current, Stale { reason }, Unknown { reason } }` — `Unknown` is first class so a failed probe has somewhere to go that is not `Current`. `is_current()` and `is_stale()` are both false for `Unknown`, so a caller cannot reach a clean bill of health by negation.
- `CurrencyEvidence { ContentDigest, SourceRevision, BuildIdentity, BuildTimestamp }` with `proves_content_equality()`. This is the distinction the codebase kept losing: a revision match and a digest match were both stored as `true`, so nothing downstream could tell "same bytes" from "same claimed provenance".
- `compare_content_digests` / `compare_source_revisions` / `compare_identities`, all failing closed to `Unknown` when either side is absent or blank. `compare_identities` returns `Unknown` — not `Current` — when the two sides were computed under different algorithms.
- `MaterializedIdentity { algorithm, digest, source_revision, dirty }`, where the provenance fields are documented and tested as **not** comparison inputs.
- The module doc carries the taxonomy above, including the list of neighbouring questions that must not be folded in, so the analysis lives next to the code rather than only in an issue.

Parameters are named `recorded` / `observed`, not `local` / `remote`: A1 compares a controller declaration against a runner rehash and B2 compares install-time metadata against today's source. Neither is a local/remote pair.

### Adopted at the two sites where the fail-open was real

**B2 — `rig_materialization::with_lab_package_freshness`.** This reported `verified` for a package source whose current revision could not be read at all. The old code copied the installed revision into the current-revision slot when the current one was missing (`:305-307`) and then compared that value with itself. The construction site did the same thing again upstream, at `:201-204`, via `.or_else(|| metadata.source_revision.clone())`, so the fabrication happened in production even before the function ran.

B3 — `homeboy_rig::package_evidence_from_metadata`, the rig subsystem's own answer to the identical question — already returned `Unknown` for the same input, and additionally consults the package content hash that B2 discards. Two implementations of one question, disagreeing precisely on the failure case, with the weaker one sitting in the dispatch path.

Both fabrications are removed; the verdict routes through `compare_source_revisions`. The wire tags (`verified` / `stale` / `unknown`) are unchanged. Nothing gates on `freshness_verified` — it is evidence folded into offload metadata — so this changes what is reported, not what is blocked.

The pinned test `lab_package_source_freshness_uses_controller_metadata_when_snapshot_has_no_git` asserted the fail-open. It is renamed to `..._is_unknown_when_no_current_revision_is_readable`, inverted, and carries a comment explaining why.

**E1 — `runtime_overlay_freshness`.** `stale` was `matches!(commits_behind, Some(count) if count > 0)` and the status was `Fresh` in every other case. `commits_behind` is `None` for every way the comparison can fail: HEAD unreadable, empty or errored `--before` walk, unparseable count. A broken git invocation therefore certified a stale build as current — the exact failure the module's header (`:7-8`) says it exists to prevent.

New `RuntimeOverlayBuildStatus::UnknownProbeFailed`, and every status now maps to a `Currency` carried in the record. `stale` deliberately stays `false` for the unknown case: escalating it would newly warn, and under `require_fresh_runtime_overlay()` newly hard-fail, on every overlay whose checkout cannot be probed. Reporting honestly and gating identically is the change I can defend without being able to run the suite.

The module doc lied in two places and now does not: it claimed the check "assumes no package manager or language" while hardcoding a package-directory name, and it did not state that the mtime walk's newest-file rule is maskable by anything written into the artifact directory after the build. The hardcoded skip list is now a named const whose doc says it is a mitigation, not a rule.

### Deliberately not converged

| Question | Why it stays separate |
|---|---|
| **C1/C2** binary and daemon drift | The subject is a running process, not a copied tree. The only evidence is what the process reports about itself; there is no tree to digest. `CurrencyEvidence::BuildIdentity` names it, but the comparison has nothing in common with a materialization check. |
| **F1/F2** upstream currency | Compares a checkout against a ref it has never held. There is no "copy" and no "original" — it is a reachability question over history. |
| **D1** apply-time drift | Local-vs-local across time. Its evidence is `snapshot_identity`, which mixes HEAD, porcelain status, and both diffs — deliberately *not* a portable content hash, because it is meant to detect any local change including staged ones. Converging it onto the portable digest would weaken it. |
| **H1** lifecycle GC | Age against a retention policy. |
| **G1** changed-since | Scope selection. |
| **I3** content-addressed materializers | Nothing to compare. Retrofitting a verdict onto a content-addressed path would add a check that is true by construction. |
| **B1** installed-extension parity | Same *question* as A3, but the remote side exposes only a revision over a control-plane probe. Routing it through `Currency` is correct and is the obvious next step; I left it alone in this PR because its error strings are matched by substring (`is_stale_runner_extension_parity_error:814` keys on `err.message.contains("stale extension parity")`) and asserted across `extension_parity.rs`, and I cannot run the suite to check I have not broken that coupling. |

## Traps found

1. **Deploy/harvest exclusion asymmetry** — already documented by #10534; confirmed still true and not touched here.
2. **The prescribed content-hash replacement for E1 would delete the check** rather than replace it. See above.
3. **"Content hash is the single authority" would silently disable B1**, whose remote side has no obtainable digest.
4. **B2's fail-open is load-bearing in a test.** A mechanical "make it use the shared comparator" refactor that kept the existing test green would have had to *preserve* the fabrication, i.e. would have converged the bug in.
5. **Escalating E1's `Unknown` to a warning would change gating**, because `require_fresh_runtime_overlay()` turns warnings into hard failures. `Unknown` is reported, not escalated.
6. **`validation_status` is a closed documented vocabulary, not an open enum.** Extending it as the issue proposes is a compatibility change, not an additive one.

## Follow-ups (not in this PR)

- **B1 onto `Currency`.** Mechanical, but coupled to substring-matched error text; wants a run of the suite.
- **B4** (`rig_materialization/mod.rs:131`) is a fourth inline answer to the rig question, still stringly typed. Folding it in is small and should ride with B1.
- **A1/A2/A3 onto `compare_identities`.** These are already correct and already fail closed, so this is vocabulary alignment rather than a bug fix — real value, zero urgency, and it touches the workspace verification path, which I would not change blind.
- **`dirty_fingerprint` and `required_extension_revisions` are dead as decision inputs.** Either wire them into a verdict or delete them; carrying four freshness-shaped fields where one is load-bearing is what made the record look like four competing answers.
- **E1's remaining weakness is unfixed.** A dependency tree or cache written into the artifact directory after the build still drags the apparent build time forward and masks a stale build, and the name-based skip list only covers the common case. A real fix needs build-step cooperation; there is no generic filesystem signal that distinguishes "artifact built now" from "checkout created now".
- **#10489** is unaffected. Its root cause is comparison-root selection (`modes.rs:48` passes `component.local_path` while `release.package_coverage[0].source_roots` goes unread), which is upstream of every mechanism here. Nothing in this PR makes the right root reachable.

## Verification

Not run locally — this host cannot run `cargo build`/`check`/`test`/`clippy` without OOM. `cargo fmt` is clean. CI is the gate.

Tests added:
- `materialization_currency::missing_evidence_is_unknown_rather_than_current`
- `materialization_currency::blank_evidence_counts_as_absent_on_either_side`
- `materialization_currency::matching_and_differing_evidence_produce_the_two_decided_verdicts`
- `materialization_currency::digest_evidence_proves_byte_equality_and_revision_evidence_does_not`
- `materialization_currency::identities_computed_under_different_algorithms_are_not_comparable`
- `materialization_currency::provenance_fields_are_not_comparison_inputs`
- `materialization_currency::verdict_tags_are_stable_for_records`
- `rig_materialization::lab_package_source_freshness_is_unknown_when_no_current_revision_is_readable` (inverted from the previous assertion)
- `rig_materialization::lab_package_source_freshness_verifies_a_matching_revision_pair`
- `runtime_overlay_freshness::unknown_when_a_history_probe_cannot_answer` (fixture: a repository with no commits, which reaches every probe and fails the two that matter)
- `runtime_overlay_freshness::every_status_carries_the_shared_currency_verdict`

What I could not verify without cargo: that the crate compiles, that the two adopted call sites' inference works out, that the unborn-repo fixture produces `UnknownProbeFailed` on CI's git version rather than some other status, and that no snapshot/contract test elsewhere asserts the old rig `verified` wire value or the `RuntimeOverlayBuildProvenance` field set. I grepped for all four; CI is the proof.

Refs #10309
