### PR TITLE
fix(rig): wire WorkloadSpec.lifecycle and report the lifecycle_snapshots drift class

### DIFF
--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -98,14 +98,14 @@ pub use spec::{
     DependencyMaterializationStepSpec, DiscoverSpec, ExecutableRequirementSpec,
     FilesystemAssertionKind, FilesystemAssertionSpec, LifecycleContract, LifecyclePhaseContract,
     LifecyclePhaseKind, LifecyclePhaseResult, LifecyclePhaseStatus, LifecycleResultMetadata,
-    LifecycleSnapshotRef, NewerThanSpec, NormalizedDependencyMaterializationStep, PatchOp,
-    PipelineStep, RigRequirementsSpec, RigResourceRetentionSpec, RigResourcesSpec, RigSpec,
-    RunnerToolRequirementSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp,
-    SymlinkSpec, TimeSource, TraceConfig, TraceDependencySpec, TraceExperimentArtifactSpec,
-    TraceExperimentCommandSpec, TraceExperimentSpec, TraceGuardrailSpec,
-    TraceNativePublicPreviewSpec, TracePhaseTemplateSpec, TracePreviewAssetFanoutSpec,
-    TraceProfileSpec, TracePublicPreviewMode, TracePublicPreviewSpec, TraceVariantSpec,
-    WorkloadSpec, RIG_RESOURCE_CLASSES, RIG_RESOURCE_CLASS_EXCLUSIVE,
+    LifecycleSnapshotRef, LifecycleWorkloadKind, LifecycleWorkloadRef, NewerThanSpec,
+    NormalizedDependencyMaterializationStep, PatchOp, PipelineStep, RigRequirementsSpec,
+    RigResourceRetentionSpec, RigResourcesSpec, RigSpec, RunnerToolRequirementSpec, ServiceKind,
+    ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource, TraceConfig,
+    TraceDependencySpec, TraceExperimentArtifactSpec, TraceExperimentCommandSpec,
+    TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec, TracePhaseTemplateSpec,
+    TracePreviewAssetFanoutSpec, TraceProfileSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
+    TraceVariantSpec, WorkloadSpec, RIG_RESOURCE_CLASSES, RIG_RESOURCE_CLASS_EXCLUSIVE,
     RIG_RESOURCE_CLASS_LIFECYCLE_SNAPSHOTS, RIG_RESOURCE_CLASS_PATHS, RIG_RESOURCE_CLASS_PORTS,
     RIG_RESOURCE_CLASS_PROCESS_PATTERNS,
 };
@@ -124,8 +124,8 @@ pub use workloads::{
     extension_workload_inputs, invocation_requirements_for_extension_workloads,
     required_component_id_for_workload, required_extension_ids_for_workload,
     runner_capabilities_for_extension, trace_dependencies_for_extension,
-    workload_path_expansions_for_extension, workloads_for_extension, RigExtensionWorkloadInputs,
-    RigWorkloadKind, RigWorkloadPathExpansion,
+    workload_lifecycle_contract, workload_path_expansions_for_extension, workloads_for_extension,
+    RigExtensionWorkloadInputs, RigWorkloadKind, RigWorkloadPathExpansion,
 };
 
 use discovery::discover_rigs_for_install;

--- a/crates/homeboy-rig/src/lint.rs
+++ b/crates/homeboy-rig/src/lint.rs
@@ -522,6 +522,7 @@ fn portability_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
         };
         failures.extend(shared_path_failures(root, file, &value));
         failures.extend(resource_retention_failures(root, file, &value));
+        failures.extend(lifecycle_step_source_failures(root, file, &value));
     }
 
     Ok(failures)
@@ -580,6 +581,87 @@ fn shared_path_failures(root: &Path, file: &Path, rig: &serde_json::Value) -> Ve
                 "{rel}: shared_paths[{index}] link and target must differ unless allow_self_target is true"
             ));
         }
+    }
+    failures
+}
+
+/// A `kind: "lifecycle"` step takes its contract from exactly one source:
+/// an inline `lifecycle` payload, or a `workload` reference.
+///
+/// Both fields are optional in the schema so either shape parses, which means
+/// serde no longer rejects a step that declares neither. The executor still
+/// fails closed at run time, but a rig author should not have to run `rig up`
+/// to find out — that is what this lint is for.
+fn lifecycle_step_source_failures(
+    root: &Path,
+    file: &Path,
+    rig: &serde_json::Value,
+) -> Vec<String> {
+    let rel = display_relative(root, file);
+    let Some(pipelines) = rig.get("pipeline").and_then(|value| value.as_object()) else {
+        return Vec::new();
+    };
+
+    let mut failures = Vec::new();
+    for (name, steps) in pipelines {
+        let Some(steps) = steps.as_array() else {
+            continue;
+        };
+        for (index, step) in steps.iter().enumerate() {
+            let Some(step) = step.as_object() else {
+                continue;
+            };
+            if step.get("kind").and_then(|value| value.as_str()) != Some("lifecycle") {
+                continue;
+            }
+            let inline = step.contains_key("lifecycle");
+            let reference = step.contains_key("workload");
+            let location = format!("{rel}: pipeline.{name}[{index}] lifecycle step");
+            match (inline, reference) {
+                (true, true) => failures.push(format!(
+                    "{location} declares both `lifecycle` and `workload`; use exactly one contract source"
+                )),
+                (false, false) => failures.push(format!(
+                    "{location} declares neither `lifecycle` nor `workload`; use exactly one contract source"
+                )),
+                _ => {}
+            }
+
+            if let Some(workload) = step.get("workload") {
+                failures.extend(lifecycle_workload_ref_failures(&location, workload));
+            }
+        }
+    }
+    failures
+}
+
+/// Shape checks for a `workload` reference. Resolution against the declared
+/// workload maps stays at run time — lint only rejects a reference that could
+/// never resolve for anyone.
+fn lifecycle_workload_ref_failures(location: &str, workload: &serde_json::Value) -> Vec<String> {
+    let Some(workload) = workload.as_object() else {
+        return vec![format!("{location} `workload` must be an object")];
+    };
+
+    let mut failures = Vec::new();
+    match workload.get("kind").and_then(|value| value.as_str()) {
+        Some("bench" | "fuzz" | "trace") => {}
+        Some(other) => failures.push(format!(
+            "{location} `workload.kind` must be one of bench, fuzz, trace (found '{other}')"
+        )),
+        None => failures.push(format!(
+            "{location} `workload.kind` is required and must be one of bench, fuzz, trace"
+        )),
+    }
+    let extension = workload
+        .get("extension")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .trim();
+    if extension.is_empty() {
+        failures.push(format!(
+            "{location} `workload.extension` is required and must be a non-empty extension id"
+        ));
     }
     failures
 }
@@ -1438,5 +1520,135 @@ mod tests {
         let error = reference_step.error.as_ref().expect("error");
         assert!(error.contains("fuzz_profile profile missing references write"));
         assert!(error.contains("bench_profile profile missing references slow"));
+    }
+
+    #[test]
+    fn package_lint_reports_lifecycle_step_without_a_contract_source() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("lifecycle");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "lifecycle",
+                "pipeline": {
+                    "up": [{ "kind": "lifecycle", "op": "prepare" }]
+                }
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let step = portability_step(&outcome);
+
+        assert_eq!(step.status, "fail");
+        let error = step.error.as_ref().expect("error");
+        assert!(
+            error.contains("declares neither `lifecycle` nor `workload`"),
+            "{error}"
+        );
+        assert!(error.contains("pipeline.up[0]"), "{error}");
+    }
+
+    #[test]
+    fn package_lint_reports_lifecycle_step_with_two_contract_sources() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("lifecycle");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "lifecycle",
+                "pipeline": {
+                    "up": [{
+                        "kind": "lifecycle",
+                        "lifecycle": { "phases": [] },
+                        "workload": { "kind": "fuzz", "extension": "generic" }
+                    }]
+                }
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let step = portability_step(&outcome);
+
+        assert_eq!(step.status, "fail");
+        let error = step.error.as_ref().expect("error");
+        assert!(
+            error.contains("declares both `lifecycle` and `workload`"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn package_lint_reports_malformed_lifecycle_workload_reference() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("lifecycle");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "lifecycle",
+                "pipeline": {
+                    "up": [{
+                        "kind": "lifecycle",
+                        "workload": { "kind": "sandbox", "extension": "  " }
+                    }]
+                }
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let step = portability_step(&outcome);
+
+        assert_eq!(step.status, "fail");
+        let error = step.error.as_ref().expect("error");
+        assert!(error.contains("`workload.kind` must be one of"), "{error}");
+        assert!(
+            error.contains("`workload.extension` is required"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn package_lint_accepts_both_lifecycle_contract_sources_used_alone() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        let rig_dir = temp.path().join("rigs").join("lifecycle");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("rig.json"),
+            r#"{
+                "id": "lifecycle",
+                "fuzz_workloads": {
+                    "generic": [{
+                        "path": "fuzz/a.workload.json",
+                        "lifecycle": {
+                            "phases": [{ "id": "make", "phase": "prepare", "command": "true" }]
+                        }
+                    }]
+                },
+                "pipeline": {
+                    "up": [{
+                        "kind": "lifecycle",
+                        "workload": { "kind": "fuzz", "extension": "generic" }
+                    }],
+                    "down": [{
+                        "kind": "lifecycle",
+                        "op": "teardown",
+                        "lifecycle": {
+                            "phases": [{ "id": "reap", "phase": "teardown", "command": "true" }]
+                        }
+                    }]
+                }
+            }"#,
+        )
+        .expect("write rig");
+
+        let outcome = run_package_lint_at(temp.path()).expect("lint package");
+        let step = portability_step(&outcome);
+
+        assert_eq!(step.status, "pass", "{:?}", step.error);
     }
 }

--- a/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
+++ b/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
@@ -16,7 +16,8 @@ use std::time::Duration;
 use super::super::expand::{expand_vars, settings_env};
 use super::super::spec::{
     LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,
-    LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef, RigSpec,
+    LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef, LifecycleWorkloadRef,
+    RigSpec,
 };
 use super::super::state::{now_rfc3339, LifecycleSnapshotState, RigState};
 use super::super::toolchain;
@@ -35,14 +36,17 @@ use homeboy_core::server::{
 /// names the thing it is holding a handle to.
 const DEFAULT_SNAPSHOT_KIND: &str = "lifecycle_snapshot";
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn run_lifecycle_step(
     rig: &RigSpec,
     step_id: Option<&str>,
     component: Option<&str>,
-    contract: &LifecycleContract,
+    contract: Option<&LifecycleContract>,
+    workload: Option<&LifecycleWorkloadRef>,
     op: LifecyclePhaseKind,
     settings: &[(String, String)],
 ) -> Result<()> {
+    let contract = resolve_contract(rig, contract, workload)?;
     let (result, failure) = execute_lifecycle_phases(rig, component, contract, op, settings)?;
 
     // Persist before propagating a phase failure: a handle captured before the
@@ -56,8 +60,36 @@ pub(super) fn run_lifecycle_step(
     }
 }
 
+/// Pick the contract this step executes: the inline payload, or the one a
+/// rig-owned workload declares.
+///
+/// Exactly one source is legal. Declaring both is a spec bug that would leave
+/// the reader guessing which contract governs, and declaring neither leaves
+/// nothing to run — both fail here, before any phase executes and before any
+/// state is touched.
+fn resolve_contract<'a>(
+    rig: &'a RigSpec,
+    contract: Option<&'a LifecycleContract>,
+    workload: Option<&LifecycleWorkloadRef>,
+) -> Result<&'a LifecycleContract> {
+    match (contract, workload) {
+        (Some(contract), None) => Ok(contract),
+        (None, Some(reference)) => {
+            super::super::workloads::workload_lifecycle_contract(rig, reference)
+        }
+        (Some(_), Some(_)) => Err(step_error(
+            rig,
+            "lifecycle step declares both `lifecycle` and `workload`; declare the contract inline or reference a workload, not both",
+        )),
+        (None, None) => Err(step_error(
+            rig,
+            "lifecycle step declares neither `lifecycle` nor `workload`; provide an inline `homeboy/lifecycle-contract/v1` payload or reference a workload that declares one",
+        )),
+    }
+}
+
 /// Stable ownership key for the handles a step captures.
-fn step_key(step_id: Option<&str>, component: Option<&str>) -> String {
+pub(crate) fn step_key(step_id: Option<&str>, component: Option<&str>) -> String {
     step_id
         .map(str::trim)
         .filter(|value| !value.is_empty())

--- a/crates/homeboy-rig/src/pipeline/mod.rs
+++ b/crates/homeboy-rig/src/pipeline/mod.rs
@@ -28,6 +28,10 @@ use homeboy_core::error::Result;
 pub use outcome::{PipelineOutcome, PipelineStepOutcome};
 
 pub(super) use command_step::run_command_step;
+/// Ownership key a `lifecycle` step's captured handles are recorded under.
+/// Exported so `repair` classifies live handles with the same key the executor
+/// writes, instead of a second copy that can drift.
+pub(super) use lifecycle_step::step_key as lifecycle_step_key;
 
 pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<PipelineOutcome> {
     run_pipeline_with_settings(rig, name, fail_fast, &[])
@@ -339,13 +343,15 @@ fn run_step(
             step_id,
             component,
             lifecycle,
+            workload,
             op,
             ..
         } => lifecycle_step::run_lifecycle_step(
             rig,
             step_id.as_deref(),
             component.as_deref(),
-            lifecycle,
+            lifecycle.as_ref(),
+            workload.as_ref(),
             *op,
             settings,
         ),

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -4,7 +4,7 @@
 //! JSON. Reports are the contract — they should be stable across minor
 //! homeboy versions.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -27,7 +27,10 @@ use super::resource_lifecycle::{
     rig_resource_lifecycle_index, RigResourceLifecycleOptions,
 };
 use super::service::{self, ServiceStatus};
-use super::spec::{DependencyMaterializationOutputKind, RigSpec, ServiceKind, SymlinkSpec};
+use super::spec::{
+    DependencyMaterializationOutputKind, PipelineStep, RigSpec, ServiceKind, SymlinkSpec,
+    RIG_RESOURCE_CLASS_LIFECYCLE_SNAPSHOTS,
+};
 use super::state::{
     now_rfc3339, ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot,
 };
@@ -726,6 +729,13 @@ pub fn run_down_with_settings(rig: &RigSpec, settings: &[(String, String)]) -> R
 /// `resources.ports`, `resources.process_patterns` — are inspected read-only
 /// and reported as `skipped` with the reason, so the coverage gap is visible in
 /// the report rather than silently absent.
+///
+/// Live `lifecycle_snapshots` handles are reported the same way. They are the
+/// one class repair deliberately refuses to touch even though it *could*
+/// delete the record: the handle is opaque, so dropping it does not reap the
+/// environment behind it — it only makes a live environment unreachable. A
+/// handle no declared step still owns is reported `blocked`, because that is
+/// drift needing manual attention, not something repair may silently discard.
 pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
     let _lease = acquire_active_run_lease(rig, "repair")?;
     let mut resources = Vec::new();
@@ -736,6 +746,7 @@ pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
     resources.extend(repair_rig_shared_paths(rig)?);
     resources.extend(repair_services(rig)?);
     resources.extend(report_declared_resources(rig));
+    resources.extend(report_lifecycle_snapshots(rig)?);
 
     let mut repaired = 0;
     let mut unchanged = 0;
@@ -913,6 +924,81 @@ fn report_declared_resources(rig: &RigSpec) -> Vec<RepairResourceReport> {
     }
 
     reports
+}
+
+/// Report every live lifecycle snapshot handle recorded in rig state.
+///
+/// Repair never reaps and never forgets a handle. Reaping means running a
+/// `teardown` phase, which is a pipeline op the spec author declares — repair
+/// does not execute pipeline steps. Forgetting means deleting the state record,
+/// which would strand a live environment with no way to address it again. So
+/// this class is report-only by construction, not by omission:
+///
+/// - a handle a declared `lifecycle` step still owns is `skipped`, with the
+///   command that reaps it
+/// - a handle no declared step owns any more is `blocked` — the rig captured an
+///   environment and then lost the step that could tear it down
+fn report_lifecycle_snapshots(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
+    let snapshots = RigState::load(&rig.id)?.lifecycle_snapshots;
+    if snapshots.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let owned = declared_lifecycle_step_keys(rig);
+
+    Ok(snapshots
+        .into_iter()
+        .map(|(id, entry)| {
+            let owns = owned.contains(&entry.step);
+            RepairResourceReport {
+                kind: RIG_RESOURCE_CLASS_LIFECYCLE_SNAPSHOTS.to_string(),
+                path: format!("{}:{}", entry.snapshot.kind, id),
+                expected_target: entry.snapshot.locator.clone(),
+                previous_target: Some(entry.captured_at.clone()),
+                status: if owns {
+                    REPAIR_STATUS_SKIPPED.to_string()
+                } else {
+                    REPAIR_STATUS_BLOCKED.to_string()
+                },
+                detail: Some(if owns {
+                    format!(
+                        "live handle captured by lifecycle step '{}'; repair does not run pipeline phases — run the declared `teardown` step (`homeboy rig down`) to reap it",
+                        entry.step
+                    )
+                } else {
+                    format!(
+                        "live handle captured by lifecycle step '{}', which the rig spec no longer declares; repair refuses to drop the record because that would strand the environment, not reap it",
+                        entry.step
+                    )
+                }),
+                error: (!owns).then(|| {
+                    format!(
+                        "orphaned lifecycle snapshot '{id}': no declared lifecycle step owns key '{}'",
+                        entry.step
+                    )
+                }),
+            }
+        })
+        .collect())
+}
+
+/// Ownership keys of every `lifecycle` step the rig declares, across all
+/// pipelines. Computed with the same key function the executor uses so the two
+/// cannot drift.
+fn declared_lifecycle_step_keys(rig: &RigSpec) -> BTreeSet<String> {
+    rig.pipeline
+        .values()
+        .flatten()
+        .filter_map(|step| match step {
+            PipelineStep::Lifecycle {
+                step_id, component, ..
+            } => Some(super::pipeline::lifecycle_step_key(
+                step_id.as_deref(),
+                component.as_deref(),
+            )),
+            _ => None,
+        })
+        .collect()
 }
 
 fn declared_resource(kind: &str, path: String, status: &str, detail: &str) -> RepairResourceReport {

--- a/crates/homeboy-rig/src/spec.rs
+++ b/crates/homeboy-rig/src/spec.rs
@@ -32,7 +32,8 @@ pub use dependencies::{
     NormalizedDependencyMaterializationStep,
 };
 pub use pipeline::{
-    GitOp, HostMutationOp, PatchOp, PipelineStep, ServiceOp, SharedPathOp, StackOp, SymlinkOp,
+    GitOp, HostMutationOp, LifecycleWorkloadKind, LifecycleWorkloadRef, PatchOp, PipelineStep,
+    ServiceOp, SharedPathOp, StackOp, SymlinkOp,
 };
 pub use toolchain::{PathDiscoverySort, PathDiscoverySpec, ToolchainSpec};
 pub use trace::{

--- a/crates/homeboy-rig/src/spec/pipeline.rs
+++ b/crates/homeboy-rig/src/spec/pipeline.rs
@@ -395,8 +395,22 @@ pub enum PipelineStep {
         /// shape for a runtime-owned throwaway environment.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         component: Option<String>,
-        /// Lifecycle contract payload (`homeboy/lifecycle-contract/v1`).
-        lifecycle: LifecycleContract,
+        /// Inline lifecycle contract payload (`homeboy/lifecycle-contract/v1`).
+        ///
+        /// Mutually exclusive with `workload`: a step declares its contract
+        /// inline *or* references one a workload already declares. Declaring
+        /// both, or neither, is a hard error raised before any phase runs.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lifecycle: Option<LifecycleContract>,
+        /// Reference to a contract declared by a rig-owned workload entry in
+        /// `bench_workloads` / `trace_workloads` / `fuzz_workloads`.
+        ///
+        /// This is what makes a workload-declared lifecycle load-bearing.
+        /// Without it the contract has to be duplicated once per op — an
+        /// `up` step and a `down` step drifting apart is exactly the trap a
+        /// single declaration site avoids.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workload: Option<LifecycleWorkloadRef>,
         /// Phase to execute. Every contract phase of this kind runs, in
         /// declared order. Defaults to `prepare`.
         #[serde(default = "default_lifecycle_op")]
@@ -438,6 +452,48 @@ fn default_host_mutation_op() -> HostMutationOp {
 
 fn default_lifecycle_op() -> LifecyclePhaseKind {
     LifecyclePhaseKind::Prepare
+}
+
+/// Which rig-owned workload map a [`LifecycleWorkloadRef`] selects from.
+///
+/// Deliberately a separate enum from `workloads::RigWorkloadKind`: the spec
+/// layer owns the on-disk vocabulary and must not inherit serde behaviour from
+/// a runtime type that has no serde contract today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleWorkloadKind {
+    Bench,
+    Fuzz,
+    Trace,
+}
+
+impl LifecycleWorkloadKind {
+    /// Spec-facing name, used verbatim in resolution error messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LifecycleWorkloadKind::Bench => "bench",
+            LifecycleWorkloadKind::Fuzz => "fuzz",
+            LifecycleWorkloadKind::Trace => "trace",
+        }
+    }
+}
+
+/// Pointer to the `lifecycle` contract a rig-owned workload entry declares.
+///
+/// Resolution is fail-closed in every direction: an unknown extension, a
+/// `path` that matches no declared workload, an ambiguous selection, or a
+/// workload that declares no `lifecycle` all fail before a phase executes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleWorkloadRef {
+    /// Workload map to search: `bench`, `fuzz`, or `trace`.
+    pub kind: LifecycleWorkloadKind,
+    /// Extension ID key within that map.
+    pub extension: String,
+    /// Declared workload `path`, matched verbatim against the spec (before
+    /// variable expansion). Required only when the extension declares more
+    /// than one workload carrying a lifecycle contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 /// Git operation supported by a rig `git` step.

--- a/crates/homeboy-rig/src/workloads.rs
+++ b/crates/homeboy-rig/src/workloads.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 use homeboy_core::engine::invocation::InvocationRequirements;
 use homeboy_core::{Error, Result};
 
-use super::spec::{RigSpec, TraceDependencySpec};
+use super::spec::{
+    LifecycleContract, LifecycleWorkloadKind, LifecycleWorkloadRef, RigSpec, TraceDependencySpec,
+    WorkloadSpec,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RigWorkloadKind {
@@ -19,6 +22,16 @@ pub enum RigWorkloadKind {
 pub struct RigWorkloadPathExpansion {
     pub declared_path: String,
     pub expanded_path: PathBuf,
+}
+
+impl From<LifecycleWorkloadKind> for RigWorkloadKind {
+    fn from(kind: LifecycleWorkloadKind) -> Self {
+        match kind {
+            LifecycleWorkloadKind::Bench => RigWorkloadKind::Bench,
+            LifecycleWorkloadKind::Fuzz => RigWorkloadKind::Fuzz,
+            LifecycleWorkloadKind::Trace => RigWorkloadKind::Trace,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,6 +91,122 @@ pub fn required_component_id_for_workload(
         None,
         None,
     ))
+}
+
+/// Resolve the `lifecycle` contract a rig-owned workload entry declares.
+///
+/// This is the reader that makes `WorkloadSpec.lifecycle` load-bearing: a
+/// `kind: "lifecycle"` pipeline step names a workload instead of restating the
+/// contract, so one declaration serves every op the rig runs against it.
+///
+/// Fail-closed by construction — every ambiguity is an error, never a guess:
+///
+/// - unknown extension key → error naming the keys that are declared
+/// - `path` matching no declared workload → error naming the declared paths
+/// - no `path` and zero or multiple workloads carrying a contract → error
+/// - selected workload declares no `lifecycle` → error
+pub fn workload_lifecycle_contract<'a>(
+    rig_spec: &'a RigSpec,
+    reference: &LifecycleWorkloadRef,
+) -> Result<&'a LifecycleContract> {
+    let kind_label = reference.kind.as_str();
+    let setting = format!("pipeline.lifecycle.workload.{kind_label}");
+    let extension = reference.extension.as_str();
+    let rig_id = rig_spec.id.as_str();
+    let workloads = workload_map(rig_spec, RigWorkloadKind::from(reference.kind));
+
+    let entries: &[WorkloadSpec] = match workloads.get(extension) {
+        Some(entries) => entries.as_slice(),
+        None => {
+            let mut declared = workloads.keys().cloned().collect::<Vec<String>>();
+            declared.sort();
+            return Err(workload_ref_error(
+                &setting,
+                format!(
+                    "rig '{rig_id}' declares no {kind_label}_workloads for extension '{extension}'{}",
+                    declared_suffix("declared extensions", &declared)
+                ),
+            ));
+        }
+    };
+
+    let selected: &WorkloadSpec = match reference.path.as_deref() {
+        Some(path) => match entries.iter().find(|entry| entry.path() == path) {
+            Some(entry) => entry,
+            None => {
+                let declared = entries
+                    .iter()
+                    .map(|entry| entry.path().to_string())
+                    .collect::<Vec<String>>();
+                return Err(workload_ref_error(
+                    &setting,
+                    format!(
+                        "rig '{rig_id}' declares no {kind_label} workload with path '{path}' for extension '{extension}'{}",
+                        declared_suffix("declared paths", &declared)
+                    ),
+                ));
+            }
+        },
+        None => {
+            let mut candidates = entries
+                .iter()
+                .filter(|entry| entry.lifecycle().is_some())
+                .collect::<Vec<&WorkloadSpec>>();
+            if candidates.len() != 1 {
+                let declared = candidates
+                    .iter()
+                    .map(|entry| entry.path().to_string())
+                    .collect::<Vec<String>>();
+                let problem = if candidates.is_empty() {
+                    format!(
+                        "no {kind_label} workload for extension '{extension}' in rig '{rig_id}' declares a lifecycle contract"
+                    )
+                } else {
+                    format!(
+                        "{} {kind_label} workloads for extension '{extension}' in rig '{rig_id}' declare a lifecycle contract; set `workload.path` to pick one{}",
+                        candidates.len(),
+                        declared_suffix("candidates", &declared)
+                    )
+                };
+                return Err(workload_ref_error(&setting, problem));
+            }
+            candidates.remove(0)
+        }
+    };
+
+    match selected.lifecycle() {
+        Some(contract) => Ok(contract),
+        None => Err(workload_ref_error(
+            &setting,
+            format!(
+                "{kind_label} workload '{}' for extension '{extension}' in rig '{rig_id}' declares no lifecycle contract",
+                selected.path()
+            ),
+        )),
+    }
+}
+
+fn workload_ref_error(setting: &str, problem: String) -> Error {
+    Error::validation_invalid_argument(setting, problem, None, None)
+}
+
+fn declared_suffix(label: &str, values: &[String]) -> String {
+    if values.is_empty() {
+        String::new()
+    } else {
+        format!(" ({label}: {})", values.join(", "))
+    }
+}
+
+fn workload_map(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+) -> &std::collections::HashMap<String, Vec<WorkloadSpec>> {
+    match kind {
+        RigWorkloadKind::Bench => &rig_spec.bench_workloads,
+        RigWorkloadKind::Fuzz => &rig_spec.fuzz_workloads,
+        RigWorkloadKind::Trace => &rig_spec.trace_workloads,
+    }
 }
 
 pub fn extension_ids_for_workloads(rig_spec: &RigSpec, kind: RigWorkloadKind) -> Vec<String> {

--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -55,14 +55,37 @@ touching component checkouts.
 ## Workload Lifecycle Contracts
 
 Workload entries in `bench_workloads`, `trace_workloads`, and `fuzz_workloads`
-can declare optional `lifecycle` metadata using
+can declare an optional `lifecycle` contract using
 `homeboy/lifecycle-contract/v1`. The shared lifecycle vocabulary is `prepare`,
 `seed`, `snapshot`, `reset`, `rollback`, and `teardown`; runtime implementations
 are extension hooks. See `docs/architecture/lifecycle-contracts.md`.
 
-The same contract is executable from a pipeline through the
-[`lifecycle`](#lifecycle) step, which is how a rig declares a disposable
-workload and gets back a reusable handle to it.
+A workload-declared contract is executed by a [`lifecycle`](#lifecycle) pipeline
+step that references it:
+
+```jsonc
+{
+  "fuzz_workloads": {
+    "generic": [{
+      "path": "fuzz/sandboxed.workload.json",
+      "lifecycle": {
+        "phases": [
+          { "id": "make", "phase": "prepare", "extension_hook": "sandbox-runtime.create" },
+          { "id": "reap", "phase": "teardown", "extension_hook": "sandbox-runtime.destroy" }
+        ]
+      }
+    }]
+  },
+  "pipeline": {
+    "up":   [{ "kind": "lifecycle", "op": "prepare",  "workload": { "kind": "fuzz", "extension": "generic" } }],
+    "down": [{ "kind": "lifecycle", "op": "teardown", "workload": { "kind": "fuzz", "extension": "generic" } }]
+  }
+}
+```
+
+One declaration on the workload, every op the rig runs against it. The step can
+also carry the contract inline — see [contract source](#lifecycle) — but two
+copies of the same contract in `up` and `down` is the drift a reference avoids.
 
 ## Templates And Variants
 
@@ -549,12 +572,43 @@ without any orchestrator-side code.
 
 | Field | Type | Description |
 |---|---|---|
-| `lifecycle` | object | The `homeboy/lifecycle-contract/v1` payload. Required. |
+| `lifecycle` | object | Inline `homeboy/lifecycle-contract/v1` payload. Required unless `workload` is set. |
+| `workload` | object | Reference to a contract a rig-owned workload already declares. Required unless `lifecycle` is set. |
 | `op` | string | Phase to execute. One of `prepare`, `seed`, `snapshot`, `reset`, `rollback`, `teardown`. Defaults to `prepare`. |
 | `component` | string | Optional component ID. Must exist in `components` when set; its resolved path becomes the phase working directory. |
 
 Every contract phase whose `phase` matches `op` runs, in declared order. A step
 whose contract declares no phase for its `op` fails before anything executes.
+
+**Contract source.** A step declares its contract inline *or* references a
+workload that declares one — exactly one of `lifecycle` / `workload`. Declaring
+both, or neither, fails before any phase runs.
+
+```jsonc
+{
+  "kind": "lifecycle",
+  "op": "teardown",
+  "workload": {
+    "kind": "fuzz",
+    "extension": "generic",
+    "path": "fuzz/sandboxed.workload.json"
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `kind` | string | Which workload map to search: `bench`, `fuzz`, or `trace`. Required. |
+| `extension` | string | Extension ID key within that map. Required. |
+| `path` | string | The workload's declared `path`, matched verbatim. Required only when more than one workload for that extension declares a `lifecycle`. |
+
+Reference resolution is fail-closed: an unknown `extension`, a `path` matching
+no declared workload, an ambiguous selection, or a selected workload that
+declares no `lifecycle` all fail before a phase runs. Nothing is guessed.
+
+This is what a workload-declared contract is *for*. Restating the same contract
+in an `up` step and a `down` step is two copies that drift; a reference means
+one declaration governs every op the rig runs against it.
 
 **Phase invocation.** Each phase declares exactly one of:
 

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -197,6 +197,7 @@ symlink this rig did not create, and never signals a process it did not start.
 | `resources.ports` | Reported `skipped`. Port ownership is declarative; repair does not bind, probe, or reclaim ports. |
 | `resources.process_patterns` | Reported `skipped`. Repair does not signal matched processes. |
 | `resources.exclusive` | Reported `skipped`. Exclusive tokens are lease-scoped; repair does not adjust rig leases. |
+| `lifecycle_snapshots` | Reported. A live handle a declared `lifecycle` step still owns is `skipped`; a handle no declared step owns any more is `blocked`. Repair never deletes a handle record — the handle is opaque, so dropping it would strand a live environment rather than reap it. Reaping is the declared `teardown` step's job (`homeboy rig down`), or `homeboy runs resources --cleanup-plan`. |
 
 Each entry in the report carries a status and a `detail` explaining what
 happened:

--- a/tests/core/rig/pipeline_test/lifecycle.rs
+++ b/tests/core/rig/pipeline_test/lifecycle.rs
@@ -475,3 +475,343 @@ fn test_pipeline_without_lifecycle_step_is_unchanged() {
     assert_eq!(out.steps[0].kind, "command");
     assert!(marker.exists());
 }
+
+// ------------------------------------------------------------------
+// Workload-referenced contracts (#10317)
+//
+// `WorkloadSpec.lifecycle` was parsed and serialized but had no reader: no
+// call site anywhere in the workspace read the field or the accessor. These
+// tests are that reader's contract. The point of the reference form is that
+// one declaration on the workload serves every op the rig runs against it —
+// an inline contract has to be restated per op, and two copies drift.
+// ------------------------------------------------------------------
+
+#[test]
+fn test_lifecycle_step_resolves_a_workload_declared_contract() {
+    with_isolated_home(|_home| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let log = tmp.path().join("workload.log");
+        let log_arg = log.to_string_lossy();
+
+        // One contract, two ops, zero duplication.
+        let rig = rig_from_json(&format!(
+            r#"{{
+                "id": "lifecycle-workload-ref",
+                "fuzz_workloads": {{
+                    "generic": [{{
+                        "path": "fuzz/read.workload.json",
+                        "lifecycle": {{
+                            "phases": [
+                                {{ "id": "make", "phase": "prepare", "command": "printf 'prepared\n' >> {log}" }},
+                                {{ "id": "reap", "phase": "teardown", "command": "printf 'torn\n' >> {log}" }}
+                            ]
+                        }}
+                    }}]
+                }},
+                "pipeline": {{
+                    "up": [{{
+                        "kind": "lifecycle",
+                        "op": "prepare",
+                        "workload": {{ "kind": "fuzz", "extension": "generic" }}
+                    }}],
+                    "down": [{{
+                        "kind": "lifecycle",
+                        "op": "teardown",
+                        "workload": {{ "kind": "fuzz", "extension": "generic" }}
+                    }}]
+                }}
+            }}"#,
+            log = log_arg
+        ));
+
+        let up = run_pipeline(&rig, "up", true).expect("up runs");
+        assert!(up.is_success(), "outcomes: {:?}", up.steps);
+        assert_eq!(up.steps[0].kind, "lifecycle");
+
+        let down = run_pipeline(&rig, "down", true).expect("down runs");
+        assert!(down.is_success(), "outcomes: {:?}", down.steps);
+
+        assert_eq!(
+            fs::read_to_string(&log).expect("log"),
+            "prepared\ntorn\n",
+            "the same workload contract governed both ops"
+        );
+    });
+}
+
+#[test]
+fn test_lifecycle_workload_ref_resolves_bench_and_trace_maps() {
+    for (kind, map) in [("bench", "bench_workloads"), ("trace", "trace_workloads")] {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let marker = tmp.path().join(format!("{kind}.txt"));
+        let marker_arg = marker.to_string_lossy();
+
+        let rig = rig_from_json(&format!(
+            r#"{{
+                "id": "lifecycle-workload-{kind}",
+                "{map}": {{
+                    "runner": [{{
+                        "path": "workloads/{kind}.json",
+                        "lifecycle": {{
+                            "phases": [{{ "id": "make", "phase": "prepare", "command": "printf {kind} > {marker}" }}]
+                        }}
+                    }}]
+                }},
+                "pipeline": {{
+                    "up": [{{
+                        "kind": "lifecycle",
+                        "workload": {{ "kind": "{kind}", "extension": "runner" }}
+                    }}]
+                }}
+            }}"#,
+            kind = kind,
+            map = map,
+            marker = marker_arg
+        ));
+
+        let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+        assert!(out.is_success(), "{kind} outcomes: {:?}", out.steps);
+        assert_eq!(fs::read_to_string(&marker).expect("marker"), kind);
+    }
+}
+
+#[test]
+fn test_lifecycle_workload_ref_disambiguates_by_path() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let marker = tmp.path().join("picked.txt");
+    let marker_arg = marker.to_string_lossy();
+
+    let rig = rig_from_json(&format!(
+        r#"{{
+            "id": "lifecycle-workload-path",
+            "fuzz_workloads": {{
+                "generic": [
+                    {{
+                        "path": "fuzz/a.workload.json",
+                        "lifecycle": {{
+                            "phases": [{{ "id": "make", "phase": "prepare", "command": "printf a > {marker}" }}]
+                        }}
+                    }},
+                    {{
+                        "path": "fuzz/b.workload.json",
+                        "lifecycle": {{
+                            "phases": [{{ "id": "make", "phase": "prepare", "command": "printf b > {marker}" }}]
+                        }}
+                    }}
+                ]
+            }},
+            "pipeline": {{
+                "up": [{{
+                    "kind": "lifecycle",
+                    "workload": {{
+                        "kind": "fuzz",
+                        "extension": "generic",
+                        "path": "fuzz/b.workload.json"
+                    }}
+                }}]
+            }}
+        }}"#,
+        marker = marker_arg
+    ));
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+    assert_eq!(fs::read_to_string(&marker).expect("marker"), "b");
+}
+
+/// Ambiguity is never resolved by guessing.
+#[test]
+fn test_lifecycle_workload_ref_rejects_ambiguous_selection() {
+    let rig = rig_from_json(
+        r#"{
+            "id": "lifecycle-workload-ambiguous",
+            "fuzz_workloads": {
+                "generic": [
+                    {
+                        "path": "fuzz/a.workload.json",
+                        "lifecycle": { "phases": [{ "id": "a", "phase": "prepare", "command": "true" }] }
+                    },
+                    {
+                        "path": "fuzz/b.workload.json",
+                        "lifecycle": { "phases": [{ "id": "b", "phase": "prepare", "command": "true" }] }
+                    }
+                ]
+            },
+            "pipeline": {
+                "up": [{
+                    "kind": "lifecycle",
+                    "workload": { "kind": "fuzz", "extension": "generic" }
+                }]
+            }
+        }"#,
+    );
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("workload.path"), "{error}");
+    assert!(error.contains("fuzz/a.workload.json"), "{error}");
+    assert!(error.contains("fuzz/b.workload.json"), "{error}");
+}
+
+#[test]
+fn test_lifecycle_workload_ref_rejects_unknown_extension() {
+    let rig = rig_from_json(
+        r#"{
+            "id": "lifecycle-workload-unknown-extension",
+            "fuzz_workloads": {
+                "generic": [{
+                    "path": "fuzz/a.workload.json",
+                    "lifecycle": { "phases": [{ "id": "a", "phase": "prepare", "command": "true" }] }
+                }]
+            },
+            "pipeline": {
+                "up": [{
+                    "kind": "lifecycle",
+                    "workload": { "kind": "fuzz", "extension": "missing" }
+                }]
+            }
+        }"#,
+    );
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("fuzz_workloads"), "{error}");
+    assert!(error.contains("generic"), "{error}");
+}
+
+#[test]
+fn test_lifecycle_workload_ref_rejects_unknown_path() {
+    let rig = rig_from_json(
+        r#"{
+            "id": "lifecycle-workload-unknown-path",
+            "fuzz_workloads": {
+                "generic": [{
+                    "path": "fuzz/a.workload.json",
+                    "lifecycle": { "phases": [{ "id": "a", "phase": "prepare", "command": "true" }] }
+                }]
+            },
+            "pipeline": {
+                "up": [{
+                    "kind": "lifecycle",
+                    "workload": {
+                        "kind": "fuzz",
+                        "extension": "generic",
+                        "path": "fuzz/typo.workload.json"
+                    }
+                }]
+            }
+        }"#,
+    );
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("fuzz/typo.workload.json"), "{error}");
+    assert!(error.contains("fuzz/a.workload.json"), "{error}");
+}
+
+/// A workload that exists but declares nothing is not silently a no-op.
+#[test]
+fn test_lifecycle_workload_ref_rejects_workload_without_contract() {
+    let rig = rig_from_json(
+        r#"{
+            "id": "lifecycle-workload-no-contract",
+            "fuzz_workloads": {
+                "generic": [{ "path": "fuzz/a.workload.json" }]
+            },
+            "pipeline": {
+                "up": [{
+                    "kind": "lifecycle",
+                    "workload": { "kind": "fuzz", "extension": "generic" }
+                }]
+            }
+        }"#,
+    );
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("declares a lifecycle contract"), "{error}");
+}
+
+#[test]
+fn test_lifecycle_step_rejects_both_inline_and_workload_sources() {
+    let rig = rig_from_json(
+        r#"{
+            "id": "lifecycle-both-sources",
+            "fuzz_workloads": {
+                "generic": [{
+                    "path": "fuzz/a.workload.json",
+                    "lifecycle": { "phases": [{ "id": "a", "phase": "prepare", "command": "true" }] }
+                }]
+            },
+            "pipeline": {
+                "up": [{
+                    "kind": "lifecycle",
+                    "lifecycle": { "phases": [{ "id": "inline", "phase": "prepare", "command": "true" }] },
+                    "workload": { "kind": "fuzz", "extension": "generic" }
+                }]
+            }
+        }"#,
+    );
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("not both"), "{error}");
+}
+
+#[test]
+fn test_lifecycle_step_rejects_neither_inline_nor_workload_source() {
+    let rig = rig_from_json(
+        r#"{
+            "id": "lifecycle-no-source",
+            "pipeline": {
+                "up": [{ "kind": "lifecycle", "op": "prepare" }]
+            }
+        }"#,
+    );
+
+    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(
+        error.contains("declares neither `lifecycle` nor `workload`"),
+        "{error}"
+    );
+}
+
+/// Pre-existing inline-contract specs keep parsing and running untouched:
+/// making `lifecycle` optional is additive, and `PipelineStep` does not use
+/// `deny_unknown_fields`, so no already-authored rig file changes meaning.
+#[test]
+fn test_inline_lifecycle_specs_round_trip_unchanged() {
+    let json = r#"{
+        "id": "lifecycle-roundtrip",
+        "pipeline": {
+            "up": [{
+                "kind": "lifecycle",
+                "op": "seed",
+                "lifecycle": { "phases": [{ "id": "seed", "phase": "seed", "command": "true" }] }
+            }]
+        }
+    }"#;
+
+    let rig = rig_from_json(json);
+    let reserialized = serde_json::to_value(&rig).expect("serialize");
+    let step = &reserialized["pipeline"]["up"][0];
+
+    assert_eq!(step["kind"], "lifecycle");
+    assert_eq!(step["op"], "seed");
+    assert_eq!(step["lifecycle"]["phases"][0]["id"], "seed");
+    // An absent workload reference stays absent on the way out.
+    assert!(step.get("workload").is_none());
+}

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -28,11 +28,11 @@ use crate::runner::{
 use crate::spec::{
     ComponentSpec, DependencyMaterializationOutputKind, DependencyMaterializationOutputSpec,
     DependencyMaterializationSafety, DependencyMaterializationStepSpec, DiscoverSpec,
-    ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec, PipelineStep,
-    RigRequirementsSpec, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp,
-    SharedPathSpec, SymlinkSpec,
+    ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec, LifecycleContract,
+    LifecyclePhaseKind, LifecycleSnapshotRef, PipelineStep, RigRequirementsSpec, RigResourcesSpec,
+    RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, SymlinkSpec,
 };
-use crate::state::{RigState, ServiceState};
+use crate::state::{LifecycleSnapshotState, RigState, ServiceState};
 use homeboy_core::test_support::with_isolated_home;
 
 fn empty_pipeline(name: &str) -> PipelineOutcome {
@@ -1849,6 +1849,155 @@ fn dependency_materialization_cache_rejects_output_symlink_escapes() {
         assert!(
             !outside.join("value").exists(),
             "the materializer must not run through an output symlink"
+        );
+    });
+}
+
+// ------------------------------------------------------------------
+// repair: live lifecycle snapshot handles (#10319)
+//
+// Handles are captured at run time, not declared, so `repair` reads them back
+// from state. This class is deliberately report-only: the handle is opaque, so
+// deleting the record does not reap the environment behind it — it only makes
+// a live environment unaddressable. Repair reports, and never discards.
+// ------------------------------------------------------------------
+
+fn lifecycle_snapshot_rig(id: &str, step_id: Option<&str>) -> RigSpec {
+    let mut rig = minimal_spec(id);
+    if let Some(step_id) = step_id {
+        rig.pipeline.insert(
+            "up".to_string(),
+            vec![PipelineStep::Lifecycle {
+                step_id: Some(step_id.to_string()),
+                depends_on: Vec::new(),
+                component: None,
+                lifecycle: Some(LifecycleContract {
+                    schema: "homeboy/lifecycle-contract/v1".to_string(),
+                    version: 1,
+                    phases: Vec::new(),
+                    metadata: Default::default(),
+                }),
+                workload: None,
+                op: LifecyclePhaseKind::Snapshot,
+                label: None,
+            }],
+        );
+    }
+    rig
+}
+
+fn record_snapshot(rig_id: &str, snapshot_id: &str, step: &str) {
+    let mut state = RigState::load(rig_id).expect("state");
+    state.lifecycle_snapshots.insert(
+        snapshot_id.to_string(),
+        LifecycleSnapshotState {
+            step: step.to_string(),
+            component: None,
+            captured_at: "2026-01-01T00:00:00Z".to_string(),
+            snapshot: LifecycleSnapshotRef {
+                schema: "homeboy/lifecycle-snapshot-ref/v1".to_string(),
+                id: snapshot_id.to_string(),
+                kind: "sandbox".to_string(),
+                phase_id: Some("capture".to_string()),
+                artifact_id: None,
+                artifact: None,
+                locator: Some("opaque://sandbox/7f3".to_string()),
+                created_at: Some("2026-01-01T00:00:00Z".to_string()),
+                metadata: Default::default(),
+            },
+        },
+    );
+    state.save(rig_id).expect("save state");
+}
+
+#[test]
+fn test_run_repair_reports_owned_lifecycle_snapshot_as_skipped() {
+    with_isolated_home(|_dir| {
+        let rig = lifecycle_snapshot_rig("repair-owned-snapshot-fixture", Some("provision"));
+        record_snapshot(&rig.id, "sandbox-1", "provision");
+
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success, "an owned live handle is not a failure");
+        assert_eq!(report.skipped, 1);
+        assert_eq!(report.blocked, 0);
+        let handle = resource(&report, "lifecycle_snapshots");
+        assert_eq!(handle.status, "skipped");
+        assert_eq!(handle.path, "sandbox:sandbox-1");
+        assert_eq!(
+            handle.expected_target.as_deref(),
+            Some("opaque://sandbox/7f3")
+        );
+        assert!(handle.error.is_none());
+        assert!(
+            handle
+                .detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains("teardown"),
+            "detail names the op that actually reaps: {:?}",
+            handle.detail
+        );
+
+        // Report-only: the record survives.
+        assert_eq!(
+            RigState::load(&rig.id)
+                .expect("state")
+                .lifecycle_snapshots
+                .len(),
+            1,
+            "repair must never drop a handle it cannot reap"
+        );
+    });
+}
+
+#[test]
+fn test_run_repair_blocks_on_orphaned_lifecycle_snapshot() {
+    with_isolated_home(|_dir| {
+        // The rig declares a lifecycle step, but under a different key than
+        // the one that captured the live handle — the owning step was renamed
+        // or removed, so nothing declared can tear this environment down.
+        let rig = lifecycle_snapshot_rig("repair-orphan-snapshot-fixture", Some("provision"));
+        record_snapshot(&rig.id, "sandbox-9", "retired-step");
+
+        let report = run_repair(&rig).expect("repair reports blocked resource");
+
+        assert!(!report.success);
+        assert_eq!(report.blocked, 1);
+        let handle = resource(&report, "lifecycle_snapshots");
+        assert_eq!(handle.status, "blocked");
+        assert!(handle
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("orphaned lifecycle snapshot"));
+
+        assert_eq!(
+            RigState::load(&rig.id)
+                .expect("state")
+                .lifecycle_snapshots
+                .len(),
+            1,
+            "a blocked handle is reported, never discarded"
+        );
+    });
+}
+
+#[test]
+fn test_run_repair_reports_no_lifecycle_snapshot_resource_when_state_is_clean() {
+    with_isolated_home(|_dir| {
+        let rig = lifecycle_snapshot_rig("repair-no-snapshot-fixture", Some("provision"));
+
+        let report = run_repair(&rig).expect("repair succeeds");
+
+        assert!(report.success);
+        assert!(
+            !report
+                .resources
+                .iter()
+                .any(|resource| resource.kind == "lifecycle_snapshots"),
+            "no handles means no rows: {:?}",
+            report.resources
         );
     });
 }

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -829,6 +829,7 @@ fn test_spec_lifecycle_step_round_trips_the_shipped_contract() {
             depends_on,
             component,
             lifecycle,
+            workload,
             op,
             label,
         } => {
@@ -837,6 +838,9 @@ fn test_spec_lifecycle_step_round_trips_the_shipped_contract() {
             assert_eq!(component.as_deref(), Some("app"));
             assert_eq!(*op, LifecyclePhaseKind::Snapshot);
             assert_eq!(label.as_deref(), Some("capture sandbox handle"));
+            // An inline contract leaves the workload reference absent.
+            assert!(workload.is_none());
+            let lifecycle = lifecycle.as_ref().expect("inline contract");
             assert_eq!(lifecycle.schema, "homeboy/lifecycle-contract/v1");
             assert_eq!(lifecycle.phases.len(), 3);
             assert_eq!(lifecycle.phases[1].phase, LifecyclePhaseKind::Snapshot);
@@ -859,10 +863,82 @@ fn test_spec_lifecycle_step_round_trips_the_shipped_contract() {
     match &re_parsed.pipeline.get("up").unwrap()[0] {
         PipelineStep::Lifecycle { lifecycle, op, .. } => {
             assert_eq!(*op, LifecyclePhaseKind::Snapshot);
-            assert_eq!(lifecycle.phases.len(), 3);
+            assert_eq!(lifecycle.as_ref().expect("inline contract").phases.len(), 3);
         }
         other => panic!("expected Lifecycle, got {:?}", other),
     }
+}
+
+/// A `lifecycle` step can name a contract a workload already declares instead
+/// of restating it. `lifecycle` and `workload` are mutually exclusive contract
+/// sources; the executor rejects zero or two of them, and `rig lint` catches
+/// it before `rig up`.
+#[test]
+fn test_spec_lifecycle_step_round_trips_a_workload_reference() {
+    use crate::spec::{LifecyclePhaseKind, LifecycleWorkloadKind};
+    let json = r#"{
+        "id": "sandbox-rig",
+        "fuzz_workloads": {
+            "generic": [
+                {
+                    "path": "fuzz/sandboxed.workload.json",
+                    "lifecycle": {
+                        "phases": [
+                            { "id": "make", "phase": "prepare", "extension_hook": "runtime.prepare" },
+                            { "id": "reap", "phase": "teardown", "extension_hook": "runtime.teardown" }
+                        ]
+                    }
+                }
+            ]
+        },
+        "pipeline": {
+            "down": [
+                {
+                    "kind": "lifecycle",
+                    "op": "teardown",
+                    "workload": {
+                        "kind": "fuzz",
+                        "extension": "generic",
+                        "path": "fuzz/sandboxed.workload.json"
+                    }
+                }
+            ]
+        }
+    }"#;
+
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+
+    // The workload still carries the contract it declared.
+    let declared = spec.fuzz_workloads["generic"][0]
+        .lifecycle()
+        .expect("workload contract");
+    assert_eq!(declared.phases.len(), 2);
+
+    match &spec.pipeline.get("down").unwrap()[0] {
+        PipelineStep::Lifecycle {
+            lifecycle,
+            workload,
+            op,
+            ..
+        } => {
+            assert!(lifecycle.is_none(), "reference form carries no inline body");
+            assert_eq!(*op, LifecyclePhaseKind::Teardown);
+            let workload = workload.as_ref().expect("workload reference");
+            assert_eq!(workload.kind, LifecycleWorkloadKind::Fuzz);
+            assert_eq!(workload.extension, "generic");
+            assert_eq!(
+                workload.path.as_deref(),
+                Some("fuzz/sandboxed.workload.json")
+            );
+        }
+        other => panic!("expected Lifecycle, got {:?}", other),
+    }
+
+    // Round-trips without growing an empty inline contract.
+    let re_serialized = serde_json::to_value(&spec).expect("serialize");
+    let step = &re_serialized["pipeline"]["down"][0];
+    assert_eq!(step["workload"]["kind"], "fuzz");
+    assert!(step.get("lifecycle").is_none());
 }
 
 #[test]
@@ -893,6 +969,7 @@ fn test_spec_lifecycle_step_defaults_op_and_component() {
             assert_eq!(*op, LifecyclePhaseKind::Prepare);
             assert!(component.is_none());
             // Contract schema/version default without being declared.
+            let lifecycle = lifecycle.as_ref().expect("inline contract");
             assert_eq!(lifecycle.schema, "homeboy/lifecycle-contract/v1");
             assert_eq!(lifecycle.version, 1);
         }

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
-use crate::spec::RigSpec;
+use crate::spec::{LifecycleWorkloadKind, LifecycleWorkloadRef, RigSpec};
 use crate::{
     check_groups_for_extension_workloads, env_provider_extensions_for_extension_workloads,
     extension_ids_for_workloads, extension_workload_inputs, required_component_id_for_workload,
     required_extension_ids_for_workload, runner_capabilities_for_extension,
-    trace_dependencies_for_extension, workload_path_expansions_for_extension,
-    workloads_for_extension, RigWorkloadKind,
+    trace_dependencies_for_extension, workload_lifecycle_contract,
+    workload_path_expansions_for_extension, workloads_for_extension, RigWorkloadKind,
 };
 
 #[test]
@@ -560,4 +560,170 @@ fn test_trace_workload_dependencies_expand_paths_and_capabilities_dedupe() {
             "sample-runtime.recipe-run".to_string()
         ]
     );
+}
+
+// ------------------------------------------------------------------
+// `WorkloadSpec.lifecycle` resolution (#10317)
+//
+// Before this reader existed the field was parsed, defaulted in four test
+// constructors, serialized — and never read by anything. These tests pin the
+// resolution contract, which is fail-closed in every direction.
+// ------------------------------------------------------------------
+
+fn workload_ref(
+    kind: LifecycleWorkloadKind,
+    extension: &str,
+    path: Option<&str>,
+) -> LifecycleWorkloadRef {
+    LifecycleWorkloadRef {
+        kind,
+        extension: extension.to_string(),
+        path: path.map(str::to_string),
+    }
+}
+
+fn lifecycle_rig() -> RigSpec {
+    serde_json::from_str(
+        r#"{
+            "id": "workload-lifecycle",
+            "fuzz_workloads": {
+                "generic": [
+                    { "path": "fuzz/plain.workload.json" },
+                    {
+                        "path": "fuzz/sandboxed.workload.json",
+                        "lifecycle": {
+                            "phases": [
+                                { "id": "make", "phase": "prepare", "extension_hook": "sandbox-runtime.create" },
+                                { "id": "reap", "phase": "teardown", "extension_hook": "sandbox-runtime.destroy" }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "bench_workloads": {
+                "runner": [
+                    {
+                        "path": "bench/a.mjs",
+                        "lifecycle": { "phases": [{ "id": "a", "phase": "prepare", "command": "true" }] }
+                    },
+                    {
+                        "path": "bench/b.mjs",
+                        "lifecycle": { "phases": [{ "id": "b", "phase": "prepare", "command": "true" }] }
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse rig spec")
+}
+
+#[test]
+fn workload_lifecycle_contract_resolves_the_only_declaring_workload() {
+    let rig_spec = lifecycle_rig();
+
+    let contract = workload_lifecycle_contract(
+        &rig_spec,
+        &workload_ref(LifecycleWorkloadKind::Fuzz, "generic", None),
+    )
+    .expect("resolves the single workload carrying a contract");
+
+    assert_eq!(contract.schema, "homeboy/lifecycle-contract/v1");
+    assert_eq!(contract.phases.len(), 2);
+    assert_eq!(
+        contract.phases[0].extension_hook.as_deref(),
+        Some("sandbox-runtime.create")
+    );
+}
+
+#[test]
+fn workload_lifecycle_contract_selects_by_declared_path() {
+    let rig_spec = lifecycle_rig();
+
+    let contract = workload_lifecycle_contract(
+        &rig_spec,
+        &workload_ref(LifecycleWorkloadKind::Bench, "runner", Some("bench/b.mjs")),
+    )
+    .expect("resolves by path");
+
+    assert_eq!(contract.phases[0].id, "b");
+}
+
+#[test]
+fn workload_lifecycle_contract_refuses_to_guess_between_candidates() {
+    let rig_spec = lifecycle_rig();
+
+    let error = workload_lifecycle_contract(
+        &rig_spec,
+        &workload_ref(LifecycleWorkloadKind::Bench, "runner", None),
+    )
+    .expect_err("two candidates is ambiguous");
+
+    let message = error.to_string();
+    assert!(message.contains("workload.path"), "{message}");
+    assert!(message.contains("bench/a.mjs"), "{message}");
+    assert!(message.contains("bench/b.mjs"), "{message}");
+}
+
+#[test]
+fn workload_lifecycle_contract_rejects_a_workload_without_a_contract() {
+    let rig_spec = lifecycle_rig();
+
+    let error = workload_lifecycle_contract(
+        &rig_spec,
+        &workload_ref(
+            LifecycleWorkloadKind::Fuzz,
+            "generic",
+            Some("fuzz/plain.workload.json"),
+        ),
+    )
+    .expect_err("an explicitly selected workload with no contract is an error, not a no-op");
+
+    assert!(
+        error.to_string().contains("declares no lifecycle contract"),
+        "{error}"
+    );
+}
+
+#[test]
+fn workload_lifecycle_contract_rejects_unknown_extension_and_path() {
+    let rig_spec = lifecycle_rig();
+
+    let unknown_extension = workload_lifecycle_contract(
+        &rig_spec,
+        &workload_ref(LifecycleWorkloadKind::Fuzz, "nope", None),
+    )
+    .expect_err("unknown extension");
+    assert!(
+        unknown_extension
+            .to_string()
+            .contains("declared extensions"),
+        "{unknown_extension}"
+    );
+
+    let unknown_path = workload_lifecycle_contract(
+        &rig_spec,
+        &workload_ref(
+            LifecycleWorkloadKind::Fuzz,
+            "generic",
+            Some("fuzz/nope.json"),
+        ),
+    )
+    .expect_err("unknown path");
+    assert!(
+        unknown_path.to_string().contains("declared paths"),
+        "{unknown_path}"
+    );
+}
+
+#[test]
+fn workload_lifecycle_contract_reports_an_empty_map_without_panicking() {
+    let rig_spec: RigSpec = serde_json::from_str(r#"{ "id": "empty" }"#).expect("parse rig spec");
+
+    let error = workload_lifecycle_contract(
+        &rig_spec,
+        &workload_ref(LifecycleWorkloadKind::Trace, "runner", None),
+    )
+    .expect_err("no trace_workloads at all");
+
+    assert!(error.to_string().contains("trace_workloads"), "{error}");
 }


### PR DESCRIPTION
Closes #10317. Closes #10319.

One PR, not two: the residual work in both issues is the same seam. #10317's dead field needed a reader, and the reader (`PipelineStep::Lifecycle` referencing a workload) is exactly what creates the new drift class #10319 has to report. Splitting them would mean landing a repair path for a class the other PR introduces.

---

## First: both issues are substantially stale

Most of what both issues ask for landed on `main` on 2026-07-27, after the issues were written:

| Issue asks for | Status on `main` | Commit |
|---|---|---|
| #10317 (1) `PipelineStep::Lifecycle` variant | **done** | `e179f0dd7` |
| #10317 (2) execution + snapshot handles | **done** | `a846f9f12`, `526226e42` |
| #10317 (3) `ResourceLifecycleRecord { kind: "lifecycle_snapshot" }` | **done** | `4b7e2e8ba` |
| #10319 (1) per-class `ttl` / `cleanup_policy` instead of hardcoded `Manual` | **done** — `resources.lifecycle` / `lifecycle_by_class` | `4b7e2e8ba` and predecessors |
| #10319 (2) repair `shared_paths` + `services` | **done** | `d8874ac80` |

Corrections have been posted on both issues. Two specific factual claims in #10317 are wrong even against the code as it stood:

- *"has **no** `lifecycle()` accessor"* — there is one, `crates/homeboy-rig/src/spec/workload.rs:20`. It was added with the same wave and is itself unread, which is a *narrower* and more interesting bug than the one described.
- *"`homeboy-fuzz/src/types.rs:188` — the only real reader"* — that line is a **field declaration** (`pub lifecycle: Option<LifecycleContract>` on `FuzzWorkload`), not a reader. It has no readers either. Same for `FuzzWorkloadConfig.lifecycle` (`extension-contract/fuzz_config.rs:42`). There are **three** declared-and-unread `Option<LifecycleContract>` fields, not one dead one and one live one.

The genuine residual is exactly the issue titles: `WorkloadSpec.lifecycle` is dead, and `repair` has no row for the newest drift class.

## #10317 — dead-code proof

`WorkloadSpec.lifecycle` is declared at `crates/homeboy-rig/src/spec.rs:813`. Every place checked, across all 25 workspace crates (`grep -rn`, not `rg` — ripgrep is not installed here and fails silently):

| Check | Result |
|---|---|
| `\.lifecycle()` — accessor call sites, whole workspace | **0** |
| `\.lifecycle\b` — field reads, whole workspace (~180 hits) | every hit is a *different* type's `lifecycle` (`RigSpec.lifecycle`, `RunLifecycleRecord`, `FuzzCampaign.lifecycle`, `Component.lifecycle`, …). The only `WorkloadSpec` hit is `spec/workload.rs:21`, the accessor's own body |
| Serde round-trip | serialized/deserialized, but `WorkloadSpec` has **no** `deny_unknown_fields`, and no consumer reads the key back out of emitted JSON |
| `#[path]`-included test modules | checked — `workloads.rs`, `runner.rs`, `pipeline/mod.rs` includes all traced |
| Cross-crate | `homeboy-cli` reads `.artifact_postprocess()`, `.check_groups()`, `.port_range_size()`, `.named_leases()`, `.path()`, `.trace_*()` off `WorkloadSpec` — never `.lifecycle()` |
| Macro expansion | no macro generates `WorkloadSpec` field access; the type is a plain `#[derive(Serialize, Deserialize)]` struct |
| Control grep | `grep -rn "fn main" crates/` → 40 hits, so the invocation pattern works |

Confirmed dead.

## Wire, not delete — and why

Deleting would remove a surface `docs/commands/rig-spec.md` §"Workload Lifecycle Contracts" already advertises, and would leave the duplication problem it exists to solve: with only an inline contract, a spec author restates the same contract in the `up` step and the `down` step. Two copies drift; that is a worse correctness trap than the one being fixed.

So `PipelineStep::Lifecycle` now takes its contract from **exactly one** of:

```jsonc
{ "kind": "lifecycle", "op": "prepare", "lifecycle": { /* inline */ } }
{ "kind": "lifecycle", "op": "teardown", "workload": { "kind": "fuzz", "extension": "generic" } }
```

Resolution is fail-closed in every direction — unknown `extension`, `path` matching no declared workload, ambiguous selection with no `path`, and a selected workload declaring no `lifecycle` are all errors raised **before any phase executes and before any state is touched**. Nothing is guessed.

**What this deliberately does not do:** it does not make a workload's lifecycle run implicitly around a `bench`/`trace`/`fuzz` invocation. `docs/commands/rig-spec.md:875` establishes the opposite rule — *"Lifecycle phases are explicit too: a `kind: lifecycle` step runs only the phase it declares. `rig down` does not tear down a captured environment unless the spec author adds a `teardown` step."* Implicit wrapping would contradict that and would mutate host state from commands users do not expect to mutate. This is wiring by reference, on purpose.

### Serde safety

Checked before touching the type, per the `ProvidesConfig` lesson:

- `WorkloadSpec` — **no** `deny_unknown_fields`. Untouched anyway.
- `PipelineStep` — **no** `deny_unknown_fields`; `#[serde(tag = "kind")]`. Adding `workload` cannot break an existing spec.
- `LifecycleContract` and friends — **do** have `deny_unknown_fields` (`crates/contracts/homeboy-lifecycle-contract/src/lifecycle.rs:18,31,59,74,98`). No field added or removed there.
- `lifecycle` on the step goes `LifecycleContract` → `Option<LifecycleContract>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Every already-authored spec parses identically and re-serializes byte-identically (pinned by `test_inline_lifecycle_specs_round_trip_unchanged`).
- No in-repo rig JSON declares a `lifecycle` step, so nothing shipped changes meaning.

### The one real regression, and its mitigation

Making `lifecycle` optional means a step declaring *neither* source no longer fails at spec-load time with serde's "missing field `lifecycle`" — it now fails at execution. That is a genuine loss of early detection. Mitigated by a new `rig lint` check that rejects zero-or-two contract sources and validates the reference's shape, so `rig lint` / `rig package` catch it without running `rig up`.

## #10319 — what repair handles now vs. advertises

| Class | Before this PR | After |
|---|---|---|
| `symlinks` | repaired | repaired |
| `shared_paths` | repaired | repaired |
| `services` (stale PID) | repaired | repaired |
| `resources.paths` | reported | reported |
| `resources.ports` | reported `skipped` | reported `skipped` |
| `resources.process_patterns` | reported `skipped` | reported `skipped` |
| `resources.exclusive` | reported `skipped` | reported `skipped` |
| **`lifecycle_snapshots`** | **absent entirely** | **reported** |

`lifecycle_snapshots` is report-only **by construction, not by omission**, and this is the conservative call the issue's framing would have gotten wrong:

- **Reaping** means running a `teardown` phase. Repair does not execute pipeline steps — `test_run_repair_does_not_run_pipeline_commands` is an existing invariant.
- **Forgetting** — deleting the state record — is the tempting "repair" and is a **resource-leak bug**. The handle is opaque by design; Homeboy cannot tell whether the environment behind it still exists. Dropping the record does not reap the environment, it makes a live environment permanently unaddressable. So repair never deletes a handle, and both tests assert the record survives.

A handle a declared `lifecycle` step still owns → `skipped`, with the op that actually reaps it. A handle **no** declared step owns → `blocked`, which fails the command: a rig that captured an environment and then lost the step that could tear it down is precisely "drift that needs manual attention". Ownership is computed with the *same* `step_key` function the executor writes with, re-exported rather than reimplemented, so the two cannot drift.

## Tests

19 new tests. All written blind — see below.

- `tests/core/rig/workloads_test.rs` — 6 resolver tests (single candidate, path selection, ambiguity refusal, workload without contract, unknown extension/path, empty map).
- `tests/core/rig/pipeline_test/lifecycle.rs` — 10 end-to-end dispatch tests, including one proving a single workload contract governs both `up` prepare and `down` teardown, and a serde round-trip test pinning backward compatibility.
- `tests/core/rig/runner_test.rs` — 3 repair tests, each asserting the handle record survives.
- `crates/homeboy-rig/src/lint.rs` — 4 lint tests.

## What I could not verify

Per this host's constraints I cannot run `cargo build`, `cargo test`, `cargo check`, or `cargo clippy`. `cargo fmt --check` is clean, which proves syntax only. Everything below is reasoned, not executed, and CI is the gate:

- **Type/borrow checking.** Reviewed by hand — notably the `'a` threading in `workload_lifecycle_contract`, and the `Vec<&WorkloadSpec>` candidate selection, which was deliberately rewritten away from a slice pattern (`[only] => only` binds `&&WorkloadSpec`, not `&WorkloadSpec`) to `len() != 1` + `remove(0)`.
- **Clippy.** `#[allow(clippy::too_many_arguments)]` added defensively on the now-7-arg `run_lifecycle_step`. `uninlined_format_args` avoided by inlining only simple local bindings.
- **Test assertions.** Error-string assertions depend on `Error::validation_invalid_argument` rendering as `Invalid argument '<field>': <problem>` (`crates/homeboy-error/src/lib.rs:594`) and on `PipelineStepOutcome.error` being `error.to_string()` (`pipeline/mod.rs:194`). Both read, neither run.
- **Audit baseline.** New code was grepped against the `core-agnostic-source` forbidden-term list in `homeboy.json` — zero hits. Test fixtures use `sandbox-runtime.*` hooks rather than a product name, both to stay clear of the `codebox` term and because a generic example is the honest one for a primitive whose whole point is not knowing what it is holding.
