### PR TITLE
fix(release): adopt verified stranded drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          # Recovery checks out an older release tag downstream, but the
+          # finalizer must include the current recovery contract from main.
+          ref: ${{ github.sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -883,14 +885,46 @@ jobs:
         run: |
           rm -f artifacts/*-dist-manifest.json
 
+      - name: Create remote draft adoption manifest
+        if: needs.prepare.outputs.recovery-release == 'true'
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs['release-version'] }}
+          EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
+        run: |
+          set -euo pipefail
+          mkdir -p draft-adoption
+          COMMIT="$(git rev-parse "${RELEASE_TAG}^{}")"
+          jq -n \
+            --arg schema homeboy.draft-adoption \
+            --argjson schema_version 1 \
+            --arg component_id homeboy \
+            --arg tag "${RELEASE_TAG}" \
+            --arg version "${RELEASE_VERSION}" \
+            --arg commit "${COMMIT}" \
+            --argjson expected_assets "${EXPECTED_ASSETS}" \
+            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, expected_assets: $expected_assets}' > draft-adoption/manifest.json
+
+      - name: Download current Homeboy finalizer
+        if: needs.prepare.outputs.recovery-release == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
+
+      - name: Verify current Homeboy finalizer
+        if: needs.prepare.outputs.recovery-release == 'true'
+        run: chmod +x .homeboy-bin/homeboy
+
       - name: Finish Homeboy release pipeline at tag
         uses: Extra-Chill/homeboy-action@v2
         with:
           source: '.'
           component: homeboy
           commands: release
+          binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}
           release-head: 'true'
-          release-from-artifacts: artifacts
+          release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}
           release-skip-publish: 'true'
 
   # ── Step 5b: Fail loudly if a prepared release did not publish ──

--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -149,6 +149,7 @@ fn initial_release_state(
         artifacts: Vec::new(),
         package_owned_paths: Vec::new(),
         changelog_validation: None,
+        draft_adoption: None,
     })
 }
 

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -4,10 +4,13 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 use super::{step_success, ReleaseArtifact, ReleaseState, ReleaseStepResult};
+use crate::release::types::DraftAdoptionIntent;
 
 const PACKAGE_RECOVERY_MANIFEST: &str = "manifest.json";
 pub(crate) const PACKAGE_RECOVERY_MANIFEST_SCHEMA: &str = "homeboy.package-recovery";
 pub(crate) const PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION: u32 = 1;
+const DRAFT_ADOPTION_MANIFEST_SCHEMA: &str = "homeboy.draft-adoption";
+const DRAFT_ADOPTION_MANIFEST_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Deserialize)]
 struct PackageRecoveryManifest {
@@ -18,6 +21,17 @@ struct PackageRecoveryManifest {
     version: String,
     commit: String,
     artifacts: Vec<ReleaseArtifact>,
+}
+
+#[derive(Deserialize)]
+struct DraftAdoptionManifest {
+    schema: String,
+    schema_version: u32,
+    component_id: String,
+    tag: String,
+    version: String,
+    commit: String,
+    expected_assets: Vec<String>,
 }
 
 pub(crate) struct PackageRecoveryContext<'a> {
@@ -46,6 +60,19 @@ pub(crate) fn run_artifact_inventory(
     }
 
     let manifest_path = dir.join(PACKAGE_RECOVERY_MANIFEST);
+    if manifest_path.is_file() && is_draft_adoption_manifest(&manifest_path) {
+        let intent = inventory_draft_adoption_manifest(&manifest_path, recovery_context)?;
+        let count = intent.expected_assets.len();
+        state.draft_adoption = Some(intent);
+        return Ok(step_success(
+            "artifacts.inventory",
+            "artifacts.inventory",
+            Some(
+                serde_json::json!({ "dir": artifact_dir, "artifact_count": 0, "adoption_asset_count": count }),
+            ),
+            Vec::new(),
+        ));
+    }
     let mut artifacts = if manifest_path.is_file() && is_package_recovery_manifest(&manifest_path) {
         inventory_package_recovery_manifest(dir, &manifest_path, recovery_context)?
     } else {
@@ -85,6 +112,17 @@ pub(crate) fn run_artifact_inventory(
 /// explicit component `scripts.build` artifact; identical lower-precedence
 /// duplicates collapse, while differing bytes fail before commit/tag/push.
 pub(crate) fn establish_publication_authority(state: &mut ReleaseState) -> Result<Vec<String>> {
+    if state.draft_adoption.is_some() {
+        if !state.artifacts.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "release assets",
+                "draft adoption cannot include local artifacts",
+                None,
+                None,
+            ));
+        }
+        return Ok(Vec::new());
+    }
     let mut selected: BTreeMap<String, usize> = BTreeMap::new();
     let mut diagnostics = Vec::new();
     for artifact in &mut state.artifacts {
@@ -187,6 +225,97 @@ fn is_package_recovery_manifest(manifest_path: &std::path::Path) -> bool {
     };
     manifest.get("schema").and_then(serde_json::Value::as_str)
         == Some(PACKAGE_RECOVERY_MANIFEST_SCHEMA)
+}
+
+fn is_draft_adoption_manifest(manifest_path: &std::path::Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(manifest_path) else {
+        return false;
+    };
+    let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+    manifest.get("schema").and_then(serde_json::Value::as_str)
+        == Some(DRAFT_ADOPTION_MANIFEST_SCHEMA)
+}
+
+fn inventory_draft_adoption_manifest(
+    manifest_path: &std::path::Path,
+    context: &PackageRecoveryContext,
+) -> Result<DraftAdoptionIntent> {
+    let contents = std::fs::read_to_string(manifest_path).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to read draft adoption manifest '{}': {error}",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+        )
+    })?;
+    let manifest: DraftAdoptionManifest = serde_json::from_str(&contents).map_err(|error| {
+        Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Draft adoption manifest '{}' is invalid: {error}",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+            None,
+        )
+    })?;
+    if manifest.schema_version != DRAFT_ADOPTION_MANIFEST_SCHEMA_VERSION {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            "Draft adoption manifest has unsupported schema version",
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
+    let identity = PackageRecoveryManifest {
+        schema: manifest.schema,
+        schema_version: 1,
+        component_id: manifest.component_id,
+        tag: manifest.tag,
+        version: manifest.version,
+        commit: manifest.commit,
+        artifacts: Vec::new(),
+    };
+    validate_recovery_identity(&identity, manifest_path, context)?;
+    if manifest.expected_assets.is_empty()
+        || manifest
+            .expected_assets
+            .iter()
+            .any(|name| !valid_asset_name(name))
+    {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            "Draft adoption manifest must contain non-empty safe asset names",
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
+    let mut names = manifest.expected_assets;
+    names.sort();
+    if names.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            "Draft adoption manifest contains duplicate asset names",
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(DraftAdoptionIntent {
+        expected_assets: names,
+    })
+}
+
+fn valid_asset_name(name: &str) -> bool {
+    !name.is_empty()
+        && std::path::Path::new(name)
+            .file_name()
+            .and_then(|value| value.to_str())
+            == Some(name)
+        && name != "."
+        && name != ".."
 }
 
 fn inventory_directory_files(
@@ -607,6 +736,62 @@ mod tests {
             "commit": "abc123",
             "artifacts": [{ "path": artifact }]
         })
+    }
+
+    #[test]
+    fn draft_adoption_manifest_records_remote_only_intent_and_rejects_bad_identity_or_names() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let manifest = |component: &str, names: serde_json::Value| {
+            serde_json::json!({
+                "schema": "homeboy.draft-adoption", "schema_version": 1,
+                "component_id": component, "tag": "v1.2.3", "version": "1.2.3", "commit": "abc123",
+                "expected_assets": names
+            })
+        };
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            manifest(
+                "plugin",
+                serde_json::json!(["plugin.zip", "plugin.zip.sha256"]),
+            )
+            .to_string(),
+        )
+        .unwrap();
+        let mut state = ReleaseState::default();
+        run_artifact_inventory(
+            &mut state,
+            &temp.path().to_string_lossy(),
+            &recovery_context(),
+        )
+        .expect("adoption inventory");
+        assert!(state.artifacts.is_empty());
+        assert_eq!(
+            state.draft_adoption.unwrap().expected_assets,
+            ["plugin.zip", "plugin.zip.sha256"]
+        );
+
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            manifest("other", serde_json::json!(["plugin.zip"])).to_string(),
+        )
+        .unwrap();
+        assert!(run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &recovery_context()
+        )
+        .is_err());
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            manifest("plugin", serde_json::json!(["plugin.zip", "plugin.zip"])).to_string(),
+        )
+        .unwrap();
+        assert!(run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &recovery_context()
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -30,6 +30,8 @@ pub(crate) struct GhCommandOutput {
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct GitHubReleaseMetadata {
+    #[serde(default)]
+    pub tag_name: String,
     #[serde(rename = "draft", alias = "isDraft")]
     pub is_draft: bool,
     #[serde(default)]
@@ -42,6 +44,8 @@ pub(crate) struct GitHubReleaseAsset {
     pub id: Option<u64>,
     pub name: String,
     pub size: u64,
+    #[serde(default)]
+    pub state: String,
     #[serde(default)]
     pub digest: Option<String>,
 }
@@ -625,6 +629,44 @@ pub(crate) fn download_release_asset_identity(
     )
 }
 
+pub(crate) fn download_small_release_asset(
+    github: &GitHubRepo,
+    config: &GithubConfig,
+    repo_flag: &str,
+    asset: &GitHubReleaseAsset,
+) -> Result<String, String> {
+    const MAX_CHECKSUM_BYTES: u64 = 64 * 1024;
+    if asset.size == 0 || asset.size > MAX_CHECKSUM_BYTES {
+        return Err(format!(
+            "checksum asset '{}' exceeds the 64 KiB adoption limit",
+            asset.name
+        ));
+    }
+    let id = asset
+        .id
+        .ok_or_else(|| format!("checksum asset '{}' has no GitHub asset ID", asset.name))?;
+    let endpoint = format!("repos/{repo_flag}/releases/assets/{id}");
+    let output = run_gh_command(
+        gh_command(
+            github,
+            config,
+            &["api", &endpoint, "-H", "Accept: application/octet-stream"],
+        ),
+        github_release_upload_timeout(),
+    );
+    if output.timed_out
+        || output.exit_code != Some(0)
+        || output.stdout.len() as u64 != asset.size
+        || output.stdout.len() as u64 > MAX_CHECKSUM_BYTES
+    {
+        return Err(format!(
+            "could not download bounded checksum asset '{}'",
+            asset.name
+        ));
+    }
+    Ok(output.stdout)
+}
+
 fn run_bounded_asset_download(
     command: &mut Command,
     asset_name: &str,
@@ -953,6 +995,99 @@ fn canonical_remote_digest(asset: &GitHubReleaseAsset) -> Result<Option<String>,
     Ok(Some(format!("sha256:{}", hex.to_ascii_lowercase())))
 }
 
+pub(crate) fn validate_draft_adoption(
+    tag: &str,
+    expected_names: &[String],
+    metadata: &GitHubReleaseMetadata,
+    sidecars: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !metadata.is_draft || metadata.tag_name != tag {
+        return Err("draft adoption requires the matching unpublished GitHub Release".to_string());
+    }
+    let expected = expected_names
+        .iter()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let actual = metadata
+        .assets
+        .iter()
+        .map(|asset| asset.name.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    if expected != actual || actual.len() != metadata.assets.len() {
+        return Err(
+            "draft adoption asset inventory does not exactly match the manifest".to_string(),
+        );
+    }
+    for asset in &metadata.assets {
+        if asset.state != "uploaded" || asset.size == 0 || canonical_remote_digest(asset)?.is_none()
+        {
+            return Err(format!(
+                "draft adoption asset '{}' is not an uploaded non-empty SHA-256 GitHub asset",
+                asset.name
+            ));
+        }
+    }
+    let payloads = expected
+        .iter()
+        .filter(|name| !name.ends_with(".sha256") && *name != "sha256.sum")
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    if payloads.is_empty() || sidecars.is_empty() {
+        return Err(
+            "draft adoption requires at least one checksum contract and payload".to_string(),
+        );
+    }
+    let mut references = BTreeMap::new();
+    for (sidecar, contents) in sidecars {
+        if !expected.contains(sidecar) {
+            return Err("checksum sidecar is not an expected asset".to_string());
+        }
+        let mut sidecar_references = 0;
+        for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+            let mut fields = line.split_whitespace();
+            let digest = fields
+                .next()
+                .ok_or_else(|| format!("malformed checksum in {sidecar}"))?;
+            let name = fields
+                .next()
+                .ok_or_else(|| format!("malformed checksum in {sidecar}"))?
+                .trim_start_matches('*');
+            let digest = digest.to_ascii_lowercase();
+            if fields.next().is_some()
+                || digest.len() != 64
+                || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+                || !payloads.contains(name)
+                || (sidecar.ends_with(".sha256") && name != sidecar.trim_end_matches(".sha256"))
+            {
+                return Err(format!("invalid checksum contract in {sidecar}"));
+            }
+            if references
+                .insert(name.to_string(), digest.clone())
+                .is_some_and(|existing| existing != digest)
+            {
+                return Err(format!("inconsistent checksum contract in {sidecar}"));
+            }
+            sidecar_references += 1;
+        }
+        if sidecar_references == 0 || (sidecar.ends_with(".sha256") && sidecar_references != 1) {
+            return Err(format!("incomplete checksum contract in {sidecar}"));
+        }
+    }
+    for asset in &metadata.assets {
+        if let Some(expected_digest) = references.get(&asset.name) {
+            if canonical_remote_digest(asset)?.as_deref()
+                != Some(&format!("sha256:{expected_digest}"))
+            {
+                return Err(format!(
+                    "checksum contract does not match GitHub digest for '{}'",
+                    asset.name
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn gh_failure_detail(command: &str, output: &GhCommandOutput) -> String {
     if output.timed_out {
         return format!("{command} timed out");
@@ -1140,8 +1275,112 @@ mod tests {
             id: Some(123),
             name: name.to_string(),
             size,
+            state: "uploaded".to_string(),
             digest,
         }
+    }
+
+    #[test]
+    fn draft_adoption_requires_exact_uploaded_digest_checked_inventory_and_complete_checksums() {
+        let digest = "a".repeat(64);
+        let metadata = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: vec![
+                remote_asset("app.zip", 1, Some(format!("sha256:{digest}"))),
+                remote_asset(
+                    "app.zip.sha256",
+                    70,
+                    Some(format!("sha256:{}", "b".repeat(64))),
+                ),
+            ],
+        };
+        let expected = vec!["app.zip".to_string(), "app.zip.sha256".to_string()];
+        let mut sidecars = BTreeMap::new();
+        sidecars.insert("app.zip.sha256".to_string(), format!("{digest}  app.zip\n"));
+        validate_draft_adoption("v1.2.3", &expected, &metadata, &sidecars).expect("valid adoption");
+
+        let mut extra = metadata.clone();
+        extra
+            .assets
+            .push(remote_asset("extra", 1, Some(format!("sha256:{digest}"))));
+        assert!(validate_draft_adoption("v1.2.3", &expected, &extra, &sidecars).is_err());
+        let mut missing = metadata.clone();
+        missing.assets.pop();
+        assert!(validate_draft_adoption("v1.2.3", &expected, &missing, &sidecars).is_err());
+        let mut duplicate = metadata.clone();
+        duplicate
+            .assets
+            .push(remote_asset("app.zip", 1, Some(format!("sha256:{digest}"))));
+        assert!(validate_draft_adoption("v1.2.3", &expected, &duplicate, &sidecars).is_err());
+        assert!(validate_draft_adoption("v9.9.9", &expected, &metadata, &sidecars).is_err());
+        assert!(validate_draft_adoption("v1.2.3", &expected, &metadata, &BTreeMap::new()).is_err());
+        sidecars.insert(
+            "app.zip.sha256".to_string(),
+            format!("{}  unknown.zip\n", "c".repeat(64)),
+        );
+        assert!(validate_draft_adoption("v1.2.3", &expected, &metadata, &sidecars).is_err());
+    }
+
+    #[test]
+    fn draft_adoption_accepts_consistent_individual_and_aggregate_checksums() {
+        let app_digest = "a".repeat(64);
+        let source_digest = "b".repeat(64);
+        let metadata = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: vec![
+                remote_asset("app.zip", 1, Some(format!("sha256:{app_digest}"))),
+                remote_asset("source.tar.gz", 1, Some(format!("sha256:{source_digest}"))),
+                remote_asset(
+                    "dist-manifest.json",
+                    1,
+                    Some(format!("sha256:{}", "c".repeat(64))),
+                ),
+                remote_asset(
+                    "app.zip.sha256",
+                    1,
+                    Some(format!("sha256:{}", "d".repeat(64))),
+                ),
+                remote_asset(
+                    "source.tar.gz.sha256",
+                    1,
+                    Some(format!("sha256:{}", "e".repeat(64))),
+                ),
+                remote_asset("sha256.sum", 1, Some(format!("sha256:{}", "f".repeat(64)))),
+            ],
+        };
+        let expected = metadata
+            .assets
+            .iter()
+            .map(|asset| asset.name.clone())
+            .collect::<Vec<_>>();
+        let mut sidecars = BTreeMap::from([
+            (
+                "app.zip.sha256".to_string(),
+                format!("{app_digest}  app.zip\n"),
+            ),
+            (
+                "source.tar.gz.sha256".to_string(),
+                format!("{source_digest}  source.tar.gz\n"),
+            ),
+            (
+                "sha256.sum".to_string(),
+                format!("{app_digest}  app.zip\n{source_digest}  source.tar.gz\n"),
+            ),
+        ]);
+
+        validate_draft_adoption("v1.2.3", &expected, &metadata, &sidecars)
+            .expect("matching duplicate references are valid");
+
+        sidecars.insert(
+            "sha256.sum".to_string(),
+            format!(
+                "{}  app.zip\n{source_digest}  source.tar.gz\n",
+                "0".repeat(64)
+            ),
+        );
+        assert!(validate_draft_adoption("v1.2.3", &expected, &metadata, &sidecars).is_err());
     }
 
     fn unexpected_download(_: &GitHubReleaseAsset, _: u64) -> Result<(u64, String), String> {

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -27,9 +27,10 @@ pub(crate) use run::validate_declared_build_artifact;
 // step to gate tag-availability preflight, so they are part of the module's
 // non-test surface.
 pub(crate) use gh_cli::{
-    gh_failure_detail, gh_is_authenticated, gh_is_available, gh_release_exists,
-    gh_release_metadata, github_release_publications, github_release_upload_timeout,
-    reconcile_release_publications, run_gh_command, verify_release_publications,
+    download_small_release_asset, gh_failure_detail, gh_is_authenticated, gh_is_available,
+    gh_release_exists, gh_release_metadata, github_release_publications,
+    github_release_upload_timeout, reconcile_release_publications, run_gh_command,
+    validate_draft_adoption, verify_release_publications,
 };
 
 // Re-exports consumed by the in-crate test suites — both this module's own

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -21,8 +21,9 @@ use super::results::{
     upload_success_result_with_publications,
 };
 use super::{
-    gh_failure_detail, gh_release_metadata, github_release_upload_timeout,
-    reconcile_release_publications, run_gh_command, verify_release_publications,
+    download_small_release_asset, gh_failure_detail, gh_release_metadata,
+    github_release_upload_timeout, reconcile_release_publications, run_gh_command,
+    validate_draft_adoption, verify_release_publications,
 };
 
 /// Create a GitHub Release for the just-pushed tag.
@@ -176,6 +177,79 @@ pub(crate) fn run_github_release(
                 ));
             }
         };
+
+        if metadata.tag_name != tag {
+            return Err(Error::validation_invalid_argument(
+                "github.release",
+                format!(
+                    "GitHub Release tag '{}' does not match active tag '{}'",
+                    metadata.tag_name, tag
+                ),
+                None,
+                None,
+            ));
+        }
+        if let Some(adoption) = state.draft_adoption.as_ref() {
+            let sidecars = metadata
+                .assets
+                .iter()
+                .filter(|asset| asset.name.ends_with(".sha256") || asset.name == "sha256.sum")
+                .map(|asset| {
+                    download_small_release_asset(&github, &component.github, &repo_flag, asset)
+                        .map(|contents| (asset.name.clone(), contents))
+                })
+                .collect::<std::result::Result<std::collections::BTreeMap<_, _>, _>>()
+                .map_err(|error| {
+                    Error::validation_invalid_argument("release assets", error, None, None)
+                })?;
+            validate_draft_adoption(&tag, &adoption.expected_assets, &metadata, &sidecars)
+                .map_err(|error| {
+                    Error::validation_invalid_argument("release assets", error, None, None)
+                })?;
+            // Re-read immediately before un-drafting so a concurrent asset edit cannot race validation.
+            let current = gh_release_metadata(&github, &component.github, &tag, &repo_flag)
+                .map_err(|error| {
+                    Error::validation_invalid_argument("github.release", error, None, None)
+                })?;
+            let current_sidecars = current
+                .assets
+                .iter()
+                .filter(|asset| asset.name.ends_with(".sha256") || asset.name == "sha256.sum")
+                .map(|asset| {
+                    download_small_release_asset(&github, &component.github, &repo_flag, asset)
+                        .map(|contents| (asset.name.clone(), contents))
+                })
+                .collect::<std::result::Result<std::collections::BTreeMap<_, _>, _>>()
+                .map_err(|error| {
+                    Error::validation_invalid_argument("release assets", error, None, None)
+                })?;
+            validate_draft_adoption(&tag, &adoption.expected_assets, &current, &current_sidecars)
+                .map_err(|error| {
+                Error::validation_invalid_argument("release assets", error, None, None)
+            })?;
+            let output = run_gh_command(
+                gh_command(
+                    &github,
+                    &component.github,
+                    &["release", "edit", &tag, "--draft=false", "-R", &repo_flag],
+                ),
+                github_release_upload_timeout(),
+            );
+            if output.timed_out || output.exit_code != Some(0) {
+                return Err(Error::validation_invalid_argument(
+                    "github.release",
+                    gh_failure_detail("gh release edit --draft=false", &output),
+                    None,
+                    None,
+                ));
+            }
+            return Ok(published_existing_draft_result(
+                &tag,
+                &github,
+                current.assets.len(),
+                &published_release_url(&github, &tag, "", &output.stdout),
+            ));
+        }
 
         match existing_release_action(metadata.is_draft, has_artifacts, metadata.assets.len()) {
             ExistingReleaseAction::AlreadyPublished => {

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -324,6 +324,14 @@ pub struct ReleaseState {
     /// created by the current package invocation.
     pub package_owned_paths: Vec<String>,
     pub changelog_validation: Option<crate::release::version::ChangelogValidationResult>,
+    /// A remote-only draft may be published only when this manifest-bound
+    /// intent has been validated against the active release identity.
+    pub draft_adoption: Option<DraftAdoptionIntent>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DraftAdoptionIntent {
+    pub expected_assets: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -492,7 +492,12 @@ fn release_finish_head_pipeline_uses_homeboy_action_head_inputs() {
 
     assert!(host.contains("uses: Extra-Chill/homeboy-action@v2"));
     assert!(host.contains("release-head: 'true'"));
-    assert!(host.contains("release-from-artifacts: artifacts"));
+    assert!(host.contains("Create remote draft adoption manifest"));
+    assert!(host.contains("homeboy.draft-adoption"));
+    assert!(host.contains("expected_assets: $expected_assets"));
+    assert!(host.contains("Download current Homeboy finalizer"));
+    assert!(host.contains("binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}"));
+    assert!(host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add an explicit `homeboy.draft-adoption` recovery manifest bound to component, tag, version, commit, and exact remote asset names
- validate draft-only GitHub asset state, non-empty canonical SHA-256 digests, bounded checksum sidecars, and checksum consistency twice before publication
- route recovery finalization through the current-main Homeboy binary while preserving normal canonical-byte conflict behavior

## Safety

Draft adoption never uploads, replaces, or deletes assets. It fails closed for published releases, identity mismatches, inventory drift, missing digests, malformed checksums, or checksum mismatches, and revalidates immediately before removing draft status.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-release draft_adoption --lib`
- `cargo test -p homeboy-release github_release::gh_cli::tests --lib`
- `cargo test --test release_workflow_test`

Fixes #10547.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode drafted the implementation and tests, investigated the failed release evidence, and assisted with verification. Chris Huber reviewed and remains responsible for the change.