### PR TITLE
feat(evidence): produce the evidence manifest instead of only reading it

### DIFF
--- a/crates/homeboy-cli/src/command_contract/registry.rs
+++ b/crates/homeboy-cli/src/command_contract/registry.rs
@@ -187,6 +187,14 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         rust_type: "homeboy::agents::agent_task_provider::ResolvedAgentRuntimeExecutionContract",
     },
     ContractRegistryEntry {
+        schema_id: crate::core::evidence_manifest::EVIDENCE_MANIFEST_SCHEMA,
+        name: "evidence-manifest",
+        title: "Evidence manifest",
+        owner: "homeboy-core",
+        summary: "Portable interpretation of a body of evidence: state, summary, confidence, blocking conditions, and tracker/pull-request/run/artifact references.",
+        rust_type: "homeboy::core::evidence_manifest::EvidenceManifest",
+    },
+    ContractRegistryEntry {
         schema_id: crate::core::artifact_ref::ARTIFACT_REF_SCHEMA,
         name: "reviewer-facing-artifact-ref",
         title: "Reviewer-facing artifact reference",

--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -21,6 +21,7 @@ use crate::command_contract::{
 use crate::commands::{adapter, CmdResult};
 use crate::core::artifact_ref::{validate_reviewer_facing_artifact_ref, ArtifactReference};
 use crate::core::artifacts::{validate_artifact_postprocess_plan, ArtifactManifest};
+use crate::core::evidence_manifest::{EvidenceManifest, EVIDENCE_MANIFEST_SCHEMA};
 use crate::core::host_mutation_lifecycle::{
     HostMutationLifecycle, HostMutationRevertStrategy, HostMutationStatus,
     HOST_MUTATION_LIFECYCLE_SCHEMA,
@@ -1291,6 +1292,7 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
     contract_schema!(RUNNER_EXECUTION_RECORD_SCHEMA, RunnerExecutionRecord),
     contract_schema!(PATH_MATERIALIZATION_PLAN_SCHEMA, PathMaterializationPlan),
     contract_schema!(RUN_OUTCOME_ENVELOPE_SCHEMA, RunOutcomeEnvelope),
+    contract_schema!(EVIDENCE_MANIFEST_SCHEMA, EvidenceManifest),
 ];
 
 trait ContractValidation: DeserializeOwned {
@@ -1333,6 +1335,7 @@ impl_contract_validation! {
     ResourceCleanupIntentContract => RESOURCE_CLEANUP_INTENT_SCHEMA, |value| value.validate();
     ResourceLifecycleIndex => RESOURCE_LIFECYCLE_INDEX_SCHEMA, |value| value.validate();
     HostMutationLifecycle => HOST_MUTATION_LIFECYCLE_SCHEMA, |value| value.validate();
+    EvidenceManifest => EVIDENCE_MANIFEST_SCHEMA, |value| validate_evidence_manifest(&value);
     Value => FUZZ_WORKLOAD_SCHEMA, |value| {
         FuzzWorkload::from_value(value).map_err(|message| {
             homeboy::core::Error::new(
@@ -1347,6 +1350,24 @@ impl_contract_validation! {
         })?;
         Ok(())
     };
+}
+
+/// Bridge the evidence manifest's own structural validation into the shared
+/// contract-validation error envelope, so a producer can check a manifest with
+/// `homeboy contract validate` before attaching it to a run instead of finding
+/// out from `evidence_manifest_errors` after the fact.
+fn validate_evidence_manifest(manifest: &EvidenceManifest) -> homeboy::core::Result<()> {
+    manifest.validate().map_err(|message| {
+        homeboy::core::Error::new(
+            homeboy::core::ErrorCode::ValidationInvalidArgument,
+            "Contract validation failed",
+            serde_json::json!({
+                "schema": EVIDENCE_MANIFEST_SCHEMA,
+                "valid": false,
+                "error": message,
+            }),
+        )
+    })
 }
 
 fn deserialize_contract<T: DeserializeOwned>(
@@ -1463,6 +1484,63 @@ mod tests {
             schema_id: schema_id.to_string(),
             file,
         })
+    }
+
+    /// The evidence manifest is an inbound contract: a producer outside this
+    /// repository attaches one to a run. That is only usable if the producer can
+    /// discover the schema and check a candidate before attaching it.
+    #[test]
+    fn evidence_manifest_is_discoverable_and_validatable() {
+        let contract =
+            registered_contract("evidence-manifest").expect("evidence manifest registry entry");
+        assert_eq!(contract.schema_id, EVIDENCE_MANIFEST_SCHEMA);
+
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "manifest.json",
+            json!({
+                "schema": EVIDENCE_MANIFEST_SCHEMA,
+                "status": { "state": "blocked" },
+                "interpretation": {
+                    "summary": "One scenario regressed.",
+                    "confidence": "medium"
+                },
+                "blocking_conditions": [{
+                    "kind": "coverage_gap",
+                    "summary": "Missing scenario.",
+                    "severity": "warning"
+                }]
+            }),
+        );
+
+        let output = validate_file(EVIDENCE_MANIFEST_SCHEMA, file).expect("valid manifest");
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn evidence_manifest_validation_rejects_an_empty_interpretation() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "manifest.json",
+            json!({
+                "schema": EVIDENCE_MANIFEST_SCHEMA,
+                "status": { "state": "passed" },
+                "interpretation": { "summary": "" }
+            }),
+        );
+
+        let err = validate_file(EVIDENCE_MANIFEST_SCHEMA, file).expect_err("invalid manifest");
+        assert_eq!(err.details["valid"], json!(false));
+        assert!(
+            err.details["error"]
+                .as_str()
+                .expect("error detail")
+                .contains("interpretation.summary"),
+            "{:?}",
+            err.details
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -356,6 +356,16 @@ mod tests {
             assert_eq!(manifest.schema, "homeboy/evidence-manifest/v1");
             assert_eq!(manifest.tracker_refs[0].id, "Extra-Chill/homeboy#123");
             assert_eq!(manifest.blocking_conditions[0].kind, "review_needed");
+            // An attached manifest is surfaced verbatim, stamped with where it
+            // was found rather than replaced by a derived reading.
+            assert_eq!(
+                manifest.source,
+                Some(homeboy::core::evidence_manifest::EvidenceManifestSource::RunMetadata)
+            );
+            assert_eq!(
+                manifest.interpretation.summary,
+                "Evidence is blocked on reviewer confirmation."
+            );
             assert!(output.evidence_manifest_errors.is_empty());
             let lifecycle_event = output
                 .agent_task_lifecycle_event
@@ -368,6 +378,65 @@ mod tests {
                 output.disk_budget.available_bytes.is_some()
                     || output.disk_budget.warning.is_some()
             );
+            homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    /// Before this wiring the manifest member was structurally always absent:
+    /// nothing in the repository produced one, so `runs evidence` advertised an
+    /// interpretation layer it never populated. A run nobody attached a manifest
+    /// to must still carry one, marked as Homeboy's own reading.
+    #[test]
+    fn evidence_command_derives_a_manifest_when_no_producer_attached_one() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let _public_artifact_base = EnvGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            homeboy::core::set_artifact_root_override(Some(artifact_root));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "bench",
+                    "homeboy",
+                    "studio",
+                    serde_json::json!({ "gate_failures": ["p95_ms exceeded"] }),
+                ))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Fail, None)
+                .expect("finish run");
+
+            let (output, _) = evidence(&run.id).expect("evidence");
+            let RunsOutput::Evidence(output) = output else {
+                panic!("expected evidence output");
+            };
+
+            let manifest = output.evidence_manifest.expect("derived evidence manifest");
+            manifest
+                .validate()
+                .expect("derived manifest is contract-valid");
+            assert_eq!(
+                manifest.source,
+                Some(homeboy::core::evidence_manifest::EvidenceManifestSource::Derived)
+            );
+            assert_eq!(
+                manifest.status.state,
+                homeboy::core::evidence_manifest::EvidenceManifestState::Failed
+            );
+            assert_eq!(manifest.id.as_deref(), Some(run.id.as_str()));
+            assert_eq!(manifest.run_refs[0].id, run.id);
+            assert_eq!(manifest.run_refs[0].kind.as_deref(), Some("bench"));
+            assert_eq!(
+                manifest.run_refs[0].component_id.as_deref(),
+                Some("homeboy")
+            );
+            let gate = manifest
+                .blocking_conditions
+                .iter()
+                .find(|condition| condition.kind == "gate_failure")
+                .expect("gate failure blocker");
+            assert_eq!(gate.summary, "p95_ms exceeded");
+            assert!(output.evidence_manifest_errors.is_empty());
             homeboy::core::set_artifact_root_override(None);
         });
     }

--- a/crates/homeboy-core/src/evidence_manifest.rs
+++ b/crates/homeboy-core/src/evidence_manifest.rs
@@ -1,9 +1,64 @@
+//! Portable interpretation contract for a body of evidence.
+//!
+//! An evidence manifest answers the two questions a raw run record cannot:
+//! *what does this evidence mean*, and *what is blocking*. It is deliberately
+//! separate from the run record itself so a producer that knows more than the
+//! exit code — an extension, an agent, an external orchestrator — can attach a
+//! judgement, and so that judgement stays portable when it is lifted out of the
+//! report it arrived in.
+//!
+//! ## Provenance is part of the contract
+//!
+//! A manifest is either **authored** (a producer attached it to a run, in
+//! `metadata.evidence_manifest` or as an artifact of kind `evidence_manifest`)
+//! or **derived** (Homeboy composed it from the run record because no producer
+//! attached one). Those two are not interchangeable: an authored manifest is an
+//! assertion, a derived one is a mechanical reading of status, gate failures,
+//! and artifact reviewability. [`EvidenceManifest::source`] records which, and
+//! the reader stamps it from the resolution path rather than trusting the
+//! serialized value, so a producer cannot claim provenance it does not have.
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::artifact_ref::ArtifactRef;
 
 pub const EVIDENCE_MANIFEST_SCHEMA: &str = "homeboy/evidence-manifest/v1";
+
+/// Where a resolved manifest came from.
+///
+/// Optional on the wire so the field is additive: a manifest written by an
+/// older producer simply carries no source, and an older reader ignores it.
+/// Readers overwrite it with the truth of the resolution path.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceManifestSource {
+    /// A producer attached it to the run's metadata.
+    RunMetadata,
+    /// A producer attached it as an artifact.
+    Artifact,
+    /// No producer attached one; Homeboy composed it from the run record.
+    Derived,
+}
+
+impl EvidenceManifestSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RunMetadata => "run_metadata",
+            Self::Artifact => "artifact",
+            Self::Derived => "derived",
+        }
+    }
+
+    /// Whether a producer asserted this interpretation.
+    ///
+    /// Consumers that will act on a manifest without a human in the loop should
+    /// gate on this: a derived manifest is Homeboy reading its own run record,
+    /// not an independent judgement.
+    pub fn is_authored(self) -> bool {
+        matches!(self, Self::RunMetadata | Self::Artifact)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EvidenceManifest {
@@ -12,6 +67,10 @@ pub struct EvidenceManifest {
     pub id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Resolution provenance. Absent on a manifest that has not been resolved
+    /// through a reader yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<EvidenceManifestSource>,
     pub status: EvidenceManifestStatus,
     pub interpretation: EvidenceManifestInterpretation,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -27,14 +86,94 @@ pub struct EvidenceManifest {
 }
 
 impl EvidenceManifest {
+    /// Start a manifest with the two members the contract requires.
+    ///
+    /// Every other member is optional, so this is the only constructor a
+    /// producer needs; fill the rest by assignment.
+    pub fn new(state: EvidenceManifestState, summary: impl Into<String>) -> Self {
+        Self {
+            schema: EVIDENCE_MANIFEST_SCHEMA.to_string(),
+            id: None,
+            title: None,
+            source: None,
+            status: EvidenceManifestStatus {
+                state,
+                label: None,
+                updated_at: None,
+            },
+            interpretation: EvidenceManifestInterpretation {
+                summary: summary.into(),
+                confidence: None,
+                notes: Vec::new(),
+            },
+            tracker_refs: Vec::new(),
+            pr_refs: Vec::new(),
+            run_refs: Vec::new(),
+            artifact_refs: Vec::new(),
+            blocking_conditions: Vec::new(),
+        }
+    }
+
     pub fn parse_value(value: Value) -> Result<Self, String> {
         let manifest: Self = serde_json::from_value(value).map_err(|err| err.to_string())?;
-        if manifest.schema != EVIDENCE_MANIFEST_SCHEMA {
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Reject a manifest that parses but says nothing.
+    ///
+    /// The point of this contract is that a consumer can act on it without
+    /// re-deriving anything. A blank summary, an identifier-less tracker or run
+    /// reference, or a blocking condition with no kind are all shapes that
+    /// satisfy serde and then force the consumer back to the raw run — which is
+    /// worse than no manifest, because the field's presence claims otherwise.
+    /// Failing closed here surfaces the producer bug in
+    /// `evidence_manifest_errors` instead of publishing an empty judgement.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema != EVIDENCE_MANIFEST_SCHEMA {
             return Err(format!(
                 "evidence manifest schema must be {EVIDENCE_MANIFEST_SCHEMA}"
             ));
         }
-        Ok(manifest)
+        if self.interpretation.summary.trim().is_empty() {
+            return Err("evidence manifest interpretation.summary must not be empty".to_string());
+        }
+        for (index, tracker) in self.tracker_refs.iter().enumerate() {
+            if tracker.kind.trim().is_empty() || tracker.id.trim().is_empty() {
+                return Err(format!(
+                    "evidence manifest tracker_refs[{index}] requires a non-empty kind and id"
+                ));
+            }
+        }
+        for (index, pr) in self.pr_refs.iter().enumerate() {
+            if pr.repo.trim().is_empty() || pr.number == 0 {
+                return Err(format!(
+                    "evidence manifest pr_refs[{index}] requires a non-empty repo and a nonzero number"
+                ));
+            }
+        }
+        for (index, run) in self.run_refs.iter().enumerate() {
+            if run.id.trim().is_empty() {
+                return Err(format!(
+                    "evidence manifest run_refs[{index}] requires a non-empty id"
+                ));
+            }
+        }
+        for (index, condition) in self.blocking_conditions.iter().enumerate() {
+            if condition.kind.trim().is_empty() || condition.summary.trim().is_empty() {
+                return Err(format!(
+                    "evidence manifest blocking_conditions[{index}] requires a non-empty kind and summary"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether the manifest reports at least one blocker of the given severity.
+    pub fn has_blocking_condition(&self, severity: BlockingSeverity) -> bool {
+        self.blocking_conditions
+            .iter()
+            .any(|condition| condition.severity == Some(severity))
     }
 }
 
@@ -47,7 +186,7 @@ pub struct EvidenceManifestStatus {
     pub updated_at: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceManifestState {
     Pending,
@@ -66,7 +205,7 @@ pub struct EvidenceManifestInterpretation {
     pub notes: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceConfidence {
     Low,
@@ -125,7 +264,7 @@ pub struct BlockingCondition {
     pub refs: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockingSeverity {
     Info,
@@ -209,26 +348,11 @@ mod tests {
 
     #[test]
     fn evidence_manifest_serializes_without_empty_optional_collections() {
-        let manifest = EvidenceManifest {
-            schema: EVIDENCE_MANIFEST_SCHEMA.to_string(),
-            id: None,
-            title: None,
-            status: EvidenceManifestStatus {
-                state: EvidenceManifestState::Passed,
-                label: None,
-                updated_at: None,
-            },
-            interpretation: EvidenceManifestInterpretation {
-                summary: "Evidence supports merge.".to_string(),
-                confidence: Some(EvidenceConfidence::High),
-                notes: Vec::new(),
-            },
-            tracker_refs: Vec::new(),
-            pr_refs: Vec::new(),
-            run_refs: Vec::new(),
-            artifact_refs: Vec::new(),
-            blocking_conditions: Vec::new(),
-        };
+        let mut manifest = EvidenceManifest::new(
+            EvidenceManifestState::Passed,
+            "Evidence supports merge.".to_string(),
+        );
+        manifest.interpretation.confidence = Some(EvidenceConfidence::High);
 
         assert_eq!(
             serde_json::to_value(&manifest).expect("manifest json"),
@@ -243,6 +367,57 @@ mod tests {
         );
     }
 
+    /// The provenance member is additive: a manifest that never went through a
+    /// reader serializes exactly as it did before the member existed, so an
+    /// already-published manifest stays byte-identical.
+    #[test]
+    fn evidence_manifest_source_is_absent_until_a_reader_stamps_it() {
+        let manifest = EvidenceManifest::new(EvidenceManifestState::Passed, "Fine.");
+
+        assert!(manifest.source.is_none());
+        let value = serde_json::to_value(&manifest).expect("manifest json");
+        assert!(value.get("source").is_none());
+    }
+
+    #[test]
+    fn evidence_manifest_round_trips_every_source_value() {
+        for (source, label) in [
+            (EvidenceManifestSource::RunMetadata, "run_metadata"),
+            (EvidenceManifestSource::Artifact, "artifact"),
+            (EvidenceManifestSource::Derived, "derived"),
+        ] {
+            let mut manifest = EvidenceManifest::new(EvidenceManifestState::Passed, "Fine.");
+            manifest.source = Some(source);
+
+            let value = serde_json::to_value(&manifest).expect("manifest json");
+            assert_eq!(value["source"], json!(label));
+            assert_eq!(source.as_str(), label);
+
+            let parsed = EvidenceManifest::parse_value(value).expect("manifest");
+            assert_eq!(parsed.source, Some(source));
+        }
+
+        assert!(EvidenceManifestSource::RunMetadata.is_authored());
+        assert!(EvidenceManifestSource::Artifact.is_authored());
+        assert!(!EvidenceManifestSource::Derived.is_authored());
+    }
+
+    /// An unknown member must stay ignorable: evidence manifests are written by
+    /// producers that ship on their own cadence, so a manifest from a newer
+    /// producer has to remain readable by an older reader.
+    #[test]
+    fn evidence_manifest_ignores_unknown_members() {
+        let manifest = EvidenceManifest::parse_value(json!({
+            "schema": "homeboy/evidence-manifest/v1",
+            "status": { "state": "passed" },
+            "interpretation": { "summary": "Fine." },
+            "member_from_a_newer_producer": { "anything": true }
+        }))
+        .expect("manifest");
+
+        assert_eq!(manifest.status.state, EvidenceManifestState::Passed);
+    }
+
     #[test]
     fn evidence_manifest_rejects_unknown_schema() {
         let err = EvidenceManifest::parse_value(json!({
@@ -253,5 +428,90 @@ mod tests {
         .expect_err("schema error");
 
         assert!(err.contains(EVIDENCE_MANIFEST_SCHEMA));
+    }
+
+    #[test]
+    fn evidence_manifest_rejects_a_blank_interpretation() {
+        let err = EvidenceManifest::parse_value(json!({
+            "schema": "homeboy/evidence-manifest/v1",
+            "status": { "state": "passed" },
+            "interpretation": { "summary": "   " }
+        }))
+        .expect_err("summary error");
+
+        assert!(err.contains("interpretation.summary"), "{err}");
+    }
+
+    #[test]
+    fn evidence_manifest_rejects_references_without_identifiers() {
+        let cases = [
+            ("tracker_refs", json!([{ "kind": "", "id": "HB-1" }])),
+            ("tracker_refs", json!([{ "kind": "issue", "id": " " }])),
+            ("run_refs", json!([{ "id": "" }])),
+        ];
+
+        for (member, refs) in cases {
+            let mut value = json!({
+                "schema": "homeboy/evidence-manifest/v1",
+                "status": { "state": "passed" },
+                "interpretation": { "summary": "Fine." }
+            });
+            value
+                .as_object_mut()
+                .expect("object")
+                .insert(member.to_string(), refs);
+
+            let err = EvidenceManifest::parse_value(value).expect_err("reference error");
+
+            assert!(err.contains(member), "{err}");
+        }
+    }
+
+    #[test]
+    fn evidence_manifest_rejects_a_pull_request_reference_without_a_repo_or_number() {
+        let err = EvidenceManifest::parse_value(json!({
+            "schema": "homeboy/evidence-manifest/v1",
+            "status": { "state": "passed" },
+            "interpretation": { "summary": "Fine." },
+            "pr_refs": [{ "repo": "", "number": 1 }]
+        }))
+        .expect_err("pr error");
+        assert!(err.contains("pr_refs[0]"), "{err}");
+
+        let err = EvidenceManifest::parse_value(json!({
+            "schema": "homeboy/evidence-manifest/v1",
+            "status": { "state": "passed" },
+            "interpretation": { "summary": "Fine." },
+            "pr_refs": [{ "repo": "owner/repo", "number": 0 }]
+        }))
+        .expect_err("pr error");
+        assert!(err.contains("pr_refs[0]"), "{err}");
+    }
+
+    #[test]
+    fn evidence_manifest_rejects_a_blocking_condition_without_a_kind_or_summary() {
+        let err = EvidenceManifest::parse_value(json!({
+            "schema": "homeboy/evidence-manifest/v1",
+            "status": { "state": "failed" },
+            "interpretation": { "summary": "Failed." },
+            "blocking_conditions": [{ "kind": "gate_failure", "summary": "" }]
+        }))
+        .expect_err("blocking condition error");
+
+        assert!(err.contains("blocking_conditions[0]"), "{err}");
+    }
+
+    #[test]
+    fn evidence_manifest_reports_blocking_condition_severity() {
+        let mut manifest = EvidenceManifest::new(EvidenceManifestState::Failed, "Failed.");
+        manifest.blocking_conditions.push(BlockingCondition {
+            kind: "gate_failure".to_string(),
+            summary: "p95_ms exceeded".to_string(),
+            severity: Some(BlockingSeverity::Critical),
+            refs: Vec::new(),
+        });
+
+        assert!(manifest.has_blocking_condition(BlockingSeverity::Critical));
+        assert!(!manifest.has_blocking_condition(BlockingSeverity::Warning));
     }
 }

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -21,12 +21,15 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{run_owner_pid, running_status_note, ArtifactRecord, RunRecord};
+use super::{run_owner_pid, running_status_note, ArtifactRecord, RunRecord, RunStatus};
 use crate::artifact_address::{ArtifactAddress, ArtifactAddressKind};
 use crate::artifact_preview::{html_preview_entrypoints, ArtifactPreviewEntrypoint};
 use crate::artifact_ref::{artifact_ref_from_record, ArtifactRef, EvidenceRef};
 use crate::artifacts::{generic_matrix_summary_from_artifacts, GenericMatrixSummary};
-use crate::evidence_manifest::{EvidenceManifest, TrackerRef, EVIDENCE_MANIFEST_SCHEMA};
+use crate::evidence_manifest::{
+    BlockingCondition, BlockingSeverity, EvidenceConfidence, EvidenceManifest,
+    EvidenceManifestSource, EvidenceManifestState, RunRef, TrackerRef, EVIDENCE_MANIFEST_SCHEMA,
+};
 use crate::observation::disk_budget::DiskBudget;
 
 /// Default retention window (days) surfaced in evidence retention guidance.
@@ -57,6 +60,10 @@ pub struct RunEvidenceReport<S: Serialize> {
     pub agent_task_lifecycle_event: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix_summary: Option<GenericMatrixSummary>,
+    /// The run's interpretation contract: what the evidence means and what is
+    /// blocking. Resolved from a producer-authored manifest when one is
+    /// attached, otherwise derived from this run record. Always present — check
+    /// `evidence_manifest.source` to tell an assertion from a derivation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence_manifest: Option<EvidenceManifest>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -110,9 +117,21 @@ pub fn build_run_evidence_report<S: Serialize>(
     let homeboy_provenance = evidence_homeboy_provenance(&run);
     let agent_task_lifecycle_event = evidence_agent_task_lifecycle_event(&run.metadata_json);
     let matrix_summary = evidence_matrix_summary(&run, &artifacts);
-    let (evidence_manifest, evidence_manifest_errors) = evidence_manifest(&run, &artifacts);
-    let tracker_refs = evidence_tracker_refs(&run.metadata_json, evidence_manifest.as_ref());
+    let (authored_manifest, evidence_manifest_errors) = evidence_manifest(&run, &artifacts);
+    // Tracker refs stay derived from the *authored* manifest only. A derived
+    // manifest copies this list, so folding it back in would double every ref.
+    let tracker_refs = evidence_tracker_refs(&run.metadata_json, authored_manifest.as_ref());
     let stale_reason = running_status_note(&run);
+    let evidence_manifest = Some(authored_manifest.unwrap_or_else(|| {
+        derive_evidence_manifest(EvidenceManifestDerivation {
+            run: &run,
+            artifacts: artifacts.as_slice(),
+            failure: &failure,
+            evidence_links: evidence_links.as_slice(),
+            tracker_refs: tracker_refs.as_slice(),
+            stale_reason: stale_reason.as_deref(),
+        })
+    }));
     let heartbeat = EvidenceHeartbeat {
         status: run.status.clone(),
         stale: stale_reason.is_some(),
@@ -782,11 +801,17 @@ pub fn evidence_matrix_summary(
     generic_matrix_summary_from_artifacts(&run.id, artifacts)
 }
 
-/// Resolve an embedded evidence manifest from run metadata or artifacts.
+/// Resolve a **producer-authored** evidence manifest from run metadata or
+/// artifacts.
 ///
 /// Returns the parsed manifest (if any) plus any non-fatal parse errors
 /// encountered while resolving candidates, preserving the original error
-/// message format.
+/// message format. `None` means no producer attached one — not that the run has
+/// no interpretation; see [`derive_evidence_manifest`].
+///
+/// The resolved manifest's `source` is stamped from the path it was found on,
+/// overwriting whatever the producer serialized. Provenance is the reader's to
+/// state, not the producer's to claim.
 pub fn evidence_manifest(
     run: &RunRecord,
     artifacts: &[ArtifactRecord],
@@ -794,7 +819,10 @@ pub fn evidence_manifest(
     let mut errors = Vec::new();
     if let Some(value) = run.metadata_json.get("evidence_manifest") {
         match EvidenceManifest::parse_value(value.clone()) {
-            Ok(manifest) => return (Some(manifest), errors),
+            Ok(mut manifest) => {
+                manifest.source = Some(EvidenceManifestSource::RunMetadata);
+                return (Some(manifest), errors);
+            }
             Err(err) => errors.push(format!("metadata.evidence_manifest: {err}")),
         }
     }
@@ -814,12 +842,261 @@ pub fn evidence_manifest(
             }
         };
         match EvidenceManifest::parse_value(value) {
-            Ok(manifest) => return (Some(manifest), errors),
+            Ok(mut manifest) => {
+                manifest.source = Some(EvidenceManifestSource::Artifact);
+                return (Some(manifest), errors);
+            }
             Err(err) => errors.push(format!("artifact.{}: {err}", artifact.id)),
         }
     }
 
     (None, errors)
+}
+
+/// Inputs [`derive_evidence_manifest`] reads. Grouped rather than passed
+/// positionally so adding a signal later is not a signature break for callers.
+pub struct EvidenceManifestDerivation<'a> {
+    pub run: &'a RunRecord,
+    pub artifacts: &'a [ArtifactRecord],
+    pub failure: &'a EvidenceFailureSummary,
+    /// Reviewer-visible evidence targets. Emptiness is the signal that a run
+    /// recorded artifacts nobody outside this machine can look at.
+    pub evidence_links: &'a [EvidenceLink],
+    pub tracker_refs: &'a [TrackerRef],
+    /// Set when the run holds a `running` record whose owner is gone.
+    pub stale_reason: Option<&'a str>,
+}
+
+/// Upper bound on derived blockers.
+///
+/// A manifest is meant to be lifted out of the report and carried around; a run
+/// with a thousand gate failures must not turn it into an unbounded payload.
+/// Truncation is announced in `interpretation.notes` rather than silent, and the
+/// full lists stay available on the report's `failure` block.
+const DERIVED_BLOCKING_CONDITION_LIMIT: usize = 20;
+
+/// Compose an interpretation contract from a run record when no producer
+/// attached one.
+///
+/// This is a mechanical reading, not a judgement, and it says so: the result
+/// carries `source: derived`, and a consumer that must not act on Homeboy's own
+/// reading of its own run can gate on
+/// [`EvidenceManifestSource::is_authored`](crate::evidence_manifest::EvidenceManifestSource::is_authored).
+///
+/// The mapping is conservative in both directions. An unrecognized status label
+/// becomes `unknown` rather than being guessed at, and a run recorded as passing
+/// that nonetheless carries a critical blocker is reported as `blocked`: a
+/// manifest that claims a pass while listing what stopped it is worse than no
+/// manifest, because a consumer reads `status.state` and stops there.
+pub fn derive_evidence_manifest(inputs: EvidenceManifestDerivation<'_>) -> EvidenceManifest {
+    let EvidenceManifestDerivation {
+        run,
+        artifacts,
+        failure,
+        evidence_links,
+        tracker_refs,
+        stale_reason,
+    } = inputs;
+
+    let status = RunStatus::from_label(&run.status);
+    let mut state = match status {
+        Some(RunStatus::Running) => EvidenceManifestState::Pending,
+        Some(RunStatus::Pass) => EvidenceManifestState::Passed,
+        Some(RunStatus::Fail) | Some(RunStatus::Error) => EvidenceManifestState::Failed,
+        Some(RunStatus::Stale) => EvidenceManifestState::Blocked,
+        Some(RunStatus::Skipped) | None => EvidenceManifestState::Unknown,
+    };
+    let terminal = matches!(
+        status,
+        Some(RunStatus::Pass) | Some(RunStatus::Fail) | Some(RunStatus::Error)
+    );
+
+    let mut notes = Vec::new();
+    let mut blocking_conditions = derived_blocking_conditions(
+        run,
+        failure,
+        status,
+        stale_reason,
+        terminal,
+        evidence_links.is_empty(),
+    );
+    if blocking_conditions.len() > DERIVED_BLOCKING_CONDITION_LIMIT {
+        notes.push(format!(
+            "{} more blocking conditions were omitted; read the run's failure block for the full list.",
+            blocking_conditions.len() - DERIVED_BLOCKING_CONDITION_LIMIT
+        ));
+        blocking_conditions.truncate(DERIVED_BLOCKING_CONDITION_LIMIT);
+    }
+
+    if state == EvidenceManifestState::Passed
+        && blocking_conditions
+            .iter()
+            .any(|condition| condition.severity == Some(BlockingSeverity::Critical))
+    {
+        state = EvidenceManifestState::Blocked;
+        notes.push(
+            "The run record reports a pass while also recording a critical blocker; the blocker wins."
+                .to_string(),
+        );
+    }
+
+    let confidence = if !terminal || artifacts.is_empty() {
+        EvidenceConfidence::Low
+    } else if evidence_links.is_empty() {
+        EvidenceConfidence::Medium
+    } else {
+        EvidenceConfidence::High
+    };
+
+    notes.push(
+        "Derived by Homeboy from the run record; no producer attached an evidence manifest."
+            .to_string(),
+    );
+    if let Some(reason) = stale_reason {
+        notes.push(reason.to_string());
+    }
+    if terminal && artifacts.is_empty() {
+        notes.push("The run recorded no artifacts, so it produced nothing reviewable.".to_string());
+    } else if terminal && evidence_links.is_empty() {
+        notes.push(
+            "Every recorded artifact is operator-local; fetch it with `homeboy runs artifact get` before citing it as evidence."
+                .to_string(),
+        );
+    }
+    notes.extend(failure.hints.iter().cloned());
+
+    let mut manifest = EvidenceManifest::new(
+        state,
+        derived_summary(run, failure, artifacts.len(), evidence_links.len()),
+    );
+    manifest.id = Some(run.id.clone());
+    manifest.title = run
+        .command
+        .clone()
+        .or_else(|| Some(format!("{} run {}", run.kind, run.id)));
+    manifest.source = Some(EvidenceManifestSource::Derived);
+    manifest.status.label = stale_reason.map(str::to_string);
+    manifest.status.updated_at = Some(
+        run.finished_at
+            .clone()
+            .unwrap_or_else(|| run.started_at.clone()),
+    );
+    manifest.interpretation.confidence = Some(confidence);
+    manifest.interpretation.notes = notes;
+    manifest.tracker_refs = tracker_refs.to_vec();
+    manifest.run_refs = vec![RunRef {
+        id: run.id.clone(),
+        kind: Some(run.kind.clone()),
+        component_id: run.component_id.clone(),
+        rig_id: run.rig_id.clone(),
+        url: None,
+    }];
+    manifest.artifact_refs = artifacts.iter().map(artifact_ref_from_record).collect();
+    manifest.blocking_conditions = blocking_conditions;
+    manifest
+}
+
+fn derived_summary(
+    run: &RunRecord,
+    failure: &EvidenceFailureSummary,
+    artifact_count: usize,
+    evidence_link_count: usize,
+) -> String {
+    let mut summary = format!(
+        "{} run {} recorded status `{}` with {artifact_count} artifact(s) and {evidence_link_count} reviewer-visible evidence link(s).",
+        run.kind, run.id, run.status
+    );
+    if let Some(error) = failure.error.as_deref() {
+        summary.push_str(&format!(" Recorded error: {error}"));
+    }
+    summary
+}
+
+fn derived_blocking_conditions(
+    run: &RunRecord,
+    failure: &EvidenceFailureSummary,
+    status: Option<RunStatus>,
+    stale_reason: Option<&str>,
+    terminal: bool,
+    no_reviewable_evidence: bool,
+) -> Vec<BlockingCondition> {
+    let refs = vec![run.id.clone()];
+    let mut conditions = Vec::new();
+
+    for gate in &failure.gate_failures {
+        conditions.push(BlockingCondition {
+            kind: "gate_failure".to_string(),
+            summary: gate.clone(),
+            severity: Some(BlockingSeverity::Critical),
+            refs: refs.clone(),
+        });
+    }
+    if let Some(error) = failure.error.as_deref() {
+        conditions.push(BlockingCondition {
+            kind: "run_error".to_string(),
+            summary: error.to_string(),
+            severity: Some(BlockingSeverity::Critical),
+            refs: refs.clone(),
+        });
+    }
+    if let Some(runner_failure) = failure.runner_failure.as_ref() {
+        let detail = runner_failure
+            .message
+            .clone()
+            .or_else(|| runner_failure.failure_code.clone())
+            .unwrap_or_else(|| runner_failure.stderr_tail.clone());
+        conditions.push(BlockingCondition {
+            kind: "runner_failure".to_string(),
+            summary: format!(
+                "Runner job {} failed: {detail}",
+                runner_failure.runner_job_id
+            ),
+            severity: Some(BlockingSeverity::Critical),
+            refs: refs.clone(),
+        });
+    }
+    match status {
+        Some(RunStatus::Stale) => conditions.push(BlockingCondition {
+            kind: "stale_run".to_string(),
+            summary: stale_reason
+                .map(str::to_string)
+                .unwrap_or_else(|| "The run record is stale.".to_string()),
+            severity: Some(BlockingSeverity::Critical),
+            refs: refs.clone(),
+        }),
+        Some(RunStatus::Running) => conditions.push(BlockingCondition {
+            kind: "run_in_progress".to_string(),
+            summary: "The run has not reached a terminal state.".to_string(),
+            severity: Some(BlockingSeverity::Info),
+            refs: refs.clone(),
+        }),
+        Some(RunStatus::Skipped) => conditions.push(BlockingCondition {
+            kind: "run_skipped".to_string(),
+            summary: "The run was skipped, so it proved nothing.".to_string(),
+            severity: Some(BlockingSeverity::Warning),
+            refs: refs.clone(),
+        }),
+        None => conditions.push(BlockingCondition {
+            kind: "unknown_run_status".to_string(),
+            summary: format!(
+                "Status `{}` is not a status Homeboy owns, so terminality cannot be assumed.",
+                run.status
+            ),
+            severity: Some(BlockingSeverity::Warning),
+            refs: refs.clone(),
+        }),
+        Some(RunStatus::Pass) | Some(RunStatus::Fail) | Some(RunStatus::Error) => {}
+    }
+    if terminal && no_reviewable_evidence {
+        conditions.push(BlockingCondition {
+            kind: "no_reviewable_evidence".to_string(),
+            summary: "The run recorded no reviewer-visible evidence target.".to_string(),
+            severity: Some(BlockingSeverity::Warning),
+            refs,
+        });
+    }
+
+    conditions
 }
 
 fn is_evidence_manifest_artifact(artifact: &ArtifactRecord) -> bool {
@@ -910,8 +1187,251 @@ mod tests {
         // A passing run is not a failure.
         assert!(!report.failure.failed);
         assert_eq!(report.failure.status, "pass");
-        // No manifest in metadata or artifacts means a clean (None, empty) result.
-        assert!(report.evidence_manifest.is_none());
+        // No producer attached a manifest, so the report carries a derived one.
+        let manifest = report.evidence_manifest.expect("derived manifest");
+        assert_eq!(manifest.source, Some(EvidenceManifestSource::Derived));
+        assert_eq!(manifest.status.state, EvidenceManifestState::Passed);
         assert!(report.evidence_manifest_errors.is_empty());
+    }
+
+    fn local_file_artifact() -> ArtifactRecord {
+        ArtifactRecord {
+            id: "summary".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "summary".to_string(),
+            artifact_type: "file".to_string(),
+            path: "/tmp/does-not-need-to-exist/summary.json".to_string(),
+            created_at: "2026-06-12T00:00:30Z".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn derived_manifest(run: &RunRecord, artifacts: &[ArtifactRecord]) -> EvidenceManifest {
+        let failure = evidence_failure_summary(run);
+        let links = evidence_links(artifacts);
+        let stale_reason = running_status_note(run);
+        derive_evidence_manifest(EvidenceManifestDerivation {
+            run,
+            artifacts,
+            failure: &failure,
+            evidence_links: links.as_slice(),
+            tracker_refs: &[],
+            stale_reason: stale_reason.as_deref(),
+        })
+    }
+
+    /// A derived manifest must be self-describing: it always validates against
+    /// its own contract, so it can be lifted out of the report and handed to any
+    /// consumer of `homeboy/evidence-manifest/v1`.
+    #[test]
+    fn derived_manifest_satisfies_the_contract_for_every_status_label() {
+        for status in ["running", "pass", "fail", "error", "skipped", "stale", "?"] {
+            let mut run = sample_run();
+            run.status = status.to_string();
+            let manifest = derived_manifest(&run, &[url_artifact()]);
+
+            manifest
+                .validate()
+                .unwrap_or_else(|err| panic!("{status}: {err}"));
+            assert_eq!(manifest.source, Some(EvidenceManifestSource::Derived));
+            assert_eq!(manifest.id.as_deref(), Some("run-1"));
+            assert_eq!(manifest.run_refs[0].id, "run-1");
+        }
+    }
+
+    #[test]
+    fn derived_manifest_maps_each_owned_status_to_a_state() {
+        let cases = [
+            ("running", EvidenceManifestState::Pending),
+            ("pass", EvidenceManifestState::Passed),
+            ("fail", EvidenceManifestState::Failed),
+            ("error", EvidenceManifestState::Failed),
+            ("stale", EvidenceManifestState::Blocked),
+            ("skipped", EvidenceManifestState::Unknown),
+        ];
+
+        for (status, expected) in cases {
+            let mut run = sample_run();
+            run.status = status.to_string();
+            assert_eq!(
+                derived_manifest(&run, &[url_artifact()]).status.state,
+                expected,
+                "{status}"
+            );
+        }
+    }
+
+    /// Fail closed: a label Homeboy does not own is `unknown`, never guessed
+    /// into a pass, and it says why.
+    #[test]
+    fn derived_manifest_refuses_to_interpret_a_status_it_does_not_own() {
+        let mut run = sample_run();
+        run.status = "mostly_fine".to_string();
+        let manifest = derived_manifest(&run, &[url_artifact()]);
+
+        assert_eq!(manifest.status.state, EvidenceManifestState::Unknown);
+        assert_eq!(
+            manifest.interpretation.confidence,
+            Some(EvidenceConfidence::Low)
+        );
+        assert!(manifest
+            .blocking_conditions
+            .iter()
+            .any(|condition| condition.kind == "unknown_run_status"));
+    }
+
+    /// A pass that also recorded a gate failure is contradictory metadata. The
+    /// manifest is what a consumer acts on, so the blocker wins.
+    #[test]
+    fn derived_manifest_downgrades_a_pass_that_carries_a_critical_blocker() {
+        let mut run = sample_run();
+        run.metadata_json = serde_json::json!({ "gate_failures": ["p95_ms exceeded"] });
+        let manifest = derived_manifest(&run, &[url_artifact()]);
+
+        assert_eq!(run.status, "pass");
+        assert_eq!(manifest.status.state, EvidenceManifestState::Blocked);
+        assert!(manifest.has_blocking_condition(BlockingSeverity::Critical));
+        assert!(manifest
+            .interpretation
+            .notes
+            .iter()
+            .any(|note| note.contains("the blocker wins")));
+    }
+
+    #[test]
+    fn derived_manifest_grades_confidence_by_reviewability() {
+        let run = sample_run();
+
+        let none = derived_manifest(&run, &[]);
+        assert_eq!(
+            none.interpretation.confidence,
+            Some(EvidenceConfidence::Low)
+        );
+        assert!(none
+            .blocking_conditions
+            .iter()
+            .any(|condition| condition.kind == "no_reviewable_evidence"));
+
+        let local = derived_manifest(&run, &[local_file_artifact()]);
+        assert_eq!(
+            local.interpretation.confidence,
+            Some(EvidenceConfidence::Medium)
+        );
+        assert_eq!(local.artifact_refs.len(), 1);
+
+        let reviewable = derived_manifest(&run, &[url_artifact()]);
+        assert_eq!(
+            reviewable.interpretation.confidence,
+            Some(EvidenceConfidence::High)
+        );
+        assert!(!reviewable
+            .blocking_conditions
+            .iter()
+            .any(|condition| condition.kind == "no_reviewable_evidence"));
+    }
+
+    #[test]
+    fn derived_manifest_bounds_its_blocking_conditions() {
+        let mut run = sample_run();
+        run.status = "fail".to_string();
+        let gates: Vec<String> = (0..50).map(|index| format!("gate {index}")).collect();
+        run.metadata_json = serde_json::json!({ "gate_failures": gates });
+
+        let manifest = derived_manifest(&run, &[url_artifact()]);
+
+        assert_eq!(
+            manifest.blocking_conditions.len(),
+            DERIVED_BLOCKING_CONDITION_LIMIT
+        );
+        assert!(manifest
+            .interpretation
+            .notes
+            .iter()
+            .any(|note| note.contains("omitted")));
+    }
+
+    /// An authored manifest is never overwritten, and the reader stamps where it
+    /// came from instead of trusting what the producer serialized.
+    #[test]
+    fn an_authored_manifest_wins_and_is_stamped_with_its_real_provenance() {
+        let mut run = sample_run();
+        run.metadata_json = serde_json::json!({
+            "evidence_manifest": {
+                "schema": "homeboy/evidence-manifest/v1",
+                "source": "artifact",
+                "status": { "state": "blocked" },
+                "interpretation": { "summary": "Reviewer confirmation is required." }
+            }
+        });
+
+        let report = build_run_evidence_report(RunEvidenceReportInputs {
+            command: "runs.evidence",
+            run: run.clone(),
+            run_summary: serde_json::json!({ "id": run.id }),
+            artifacts: vec![url_artifact()],
+            artifact_root: PathBuf::from("/tmp/artifacts"),
+            disk_budget: sample_disk_budget(),
+        });
+
+        let manifest = report.evidence_manifest.expect("authored manifest");
+        assert_eq!(manifest.status.state, EvidenceManifestState::Blocked);
+        assert_eq!(
+            manifest.interpretation.summary,
+            "Reviewer confirmation is required."
+        );
+        // Claimed `artifact`, resolved from run metadata. The reader decides.
+        assert_eq!(manifest.source, Some(EvidenceManifestSource::RunMetadata));
+    }
+
+    /// A derived manifest copies the report's tracker refs, so the report must
+    /// not fold them back in — that would double every ref.
+    #[test]
+    fn a_derived_manifest_does_not_double_the_reports_tracker_refs() {
+        let mut run = sample_run();
+        run.metadata_json = serde_json::json!({
+            "tracker_refs": [{ "kind": "issue", "id": "HB-42" }]
+        });
+
+        let report = build_run_evidence_report(RunEvidenceReportInputs {
+            command: "runs.evidence",
+            run: run.clone(),
+            run_summary: serde_json::json!({ "id": run.id }),
+            artifacts: vec![url_artifact()],
+            artifact_root: PathBuf::from("/tmp/artifacts"),
+            disk_budget: sample_disk_budget(),
+        });
+
+        assert_eq!(report.tracker_refs.len(), 1);
+        let manifest = report.evidence_manifest.expect("derived manifest");
+        assert_eq!(manifest.tracker_refs.len(), 1);
+        assert_eq!(manifest.tracker_refs[0].id, "HB-42");
+    }
+
+    /// A malformed authored manifest must not be silently replaced by a derived
+    /// one that hides the producer's bug: the error is still reported.
+    #[test]
+    fn a_malformed_authored_manifest_still_reports_its_error() {
+        let mut run = sample_run();
+        run.metadata_json = serde_json::json!({
+            "evidence_manifest": {
+                "schema": "homeboy/evidence-manifest/v1",
+                "status": { "state": "passed" },
+                "interpretation": { "summary": "" }
+            }
+        });
+
+        let report = build_run_evidence_report(RunEvidenceReportInputs {
+            command: "runs.evidence",
+            run: run.clone(),
+            run_summary: serde_json::json!({ "id": run.id }),
+            artifacts: vec![url_artifact()],
+            artifact_root: PathBuf::from("/tmp/artifacts"),
+            disk_budget: sample_disk_budget(),
+        });
+
+        assert_eq!(report.evidence_manifest_errors.len(), 1);
+        assert!(report.evidence_manifest_errors[0].contains("metadata.evidence_manifest"));
+        let manifest = report.evidence_manifest.expect("derived manifest");
+        assert_eq!(manifest.source, Some(EvidenceManifestSource::Derived));
     }
 }

--- a/docs/commands/contract.md
+++ b/docs/commands/contract.md
@@ -38,10 +38,18 @@ Accepted contract IDs include `all`, `artifact-manifest`, `loop`,
 ```sh
 homeboy contract list
 homeboy contract show secret-env-plan
+homeboy contract show evidence-manifest
 ```
 
 The registry is the central source for contract names, schema IDs, titles,
 owners, summaries, and Rust type anchors.
+
+Inbound contracts — ones a producer outside this repository attaches to a run,
+such as `evidence-manifest` — can be checked before they are attached:
+
+```sh
+homeboy contract validate homeboy/evidence-manifest/v1 --file manifest.json
+```
 
 ## Export
 

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -65,6 +65,44 @@ homeboy --output json runs refs --kind trace --component gutenberg --aggregate-a
 
 `homeboy runs evidence <run-id>` emits reviewer-facing evidence using generic artifact addresses. Local operator files are represented as non-reviewer-visible `homeboy://run/<run-id>/artifact/<artifact-id>` handles with a fetch command instead of absolute machine paths. Remote runner artifacts use `runner-artifact://...` refs, validated public HTTP(S) URLs are emitted as public evidence links, and metadata-only evidence remains non-public. Lab-specific publication or mirroring policy belongs in runner/extension enrichment, not in the generic evidence serializer.
 
+### Evidence manifest
+
+Every `runs evidence` report carries an `evidence_manifest`: the run's
+interpretation contract (`homeboy/evidence-manifest/v1`). It answers *what does
+this evidence mean* and *what is blocking* in one place, so an orchestrator does
+not have to re-derive that from status strings, gate failures, and artifact
+addresses.
+
+`evidence_manifest.source` says where the interpretation came from and is stamped
+by Homeboy, not by the producer:
+
+| `source` | Meaning |
+| --- | --- |
+| `run_metadata` | A producer attached a manifest at `metadata.evidence_manifest`. |
+| `artifact` | A producer attached a manifest as an artifact of kind `evidence_manifest`. |
+| `derived` | No producer attached one; Homeboy composed it from the run record. |
+
+An attached manifest always wins and is surfaced verbatim — Homeboy never
+overwrites a producer's judgement. A manifest that fails to parse or fails
+contract validation is reported in `evidence_manifest_errors` and a derived
+manifest is used instead, so a producer bug is visible rather than silent.
+
+A derived manifest is a mechanical reading, not a judgement. Treat it as such:
+gate it on `source == "derived"` if a decision needs an independent assertion.
+It maps run status to `status.state` conservatively — a status label Homeboy does
+not own becomes `unknown` rather than a guess, and a run recorded as passing that
+also recorded a critical blocker is reported as `blocked`. `interpretation.confidence`
+grades reviewability: `low` for a non-terminal run or one with no artifacts,
+`medium` when every artifact is operator-local, `high` when at least one
+reviewer-visible evidence link exists.
+
+Producers can validate a candidate manifest before attaching it:
+
+```bash
+homeboy contract show evidence-manifest
+homeboy contract validate homeboy/evidence-manifest/v1 --file manifest.json
+```
+
 When a run passed but `runs evidence` has zero artifacts, the command completed
 but did not produce reviewable evidence. Preserve the run id and output directory,
 then promote or attach artifacts through the command-specific surface when it is

--- a/docs/concepts/structured-evidence.md
+++ b/docs/concepts/structured-evidence.md
@@ -27,6 +27,24 @@ homeboy runs artifacts <run-id>
 homeboy runs evidence <run-id>
 ```
 
+## Interpretation
+
+Artifacts are facts; they do not say what the facts mean. The evidence manifest
+(`homeboy/evidence-manifest/v1`) is the interpretation layer: a state, a summary,
+a confidence grade, blocking conditions, and portable references to the trackers,
+pull requests, runs, and artifacts the judgement rests on.
+
+`homeboy runs evidence <run-id>` always emits one. A producer that knows more
+than the exit code can attach its own — at `metadata.evidence_manifest`, or as an
+artifact of kind `evidence_manifest` — and Homeboy surfaces it verbatim.
+Otherwise Homeboy derives one from the run record and marks it `source: derived`,
+so an authored assertion is never confused with a mechanical reading.
+
+```bash
+homeboy contract show evidence-manifest
+homeboy contract validate homeboy/evidence-manifest/v1 --file manifest.json
+```
+
 ## Reviewer-Safe Evidence
 
 Reviewer-facing evidence should point to a reachable artifact, PR comment, issue, release asset, or exported run bundle. Local paths and localhost URLs are operator notes, not durable review evidence.


### PR DESCRIPTION
Closes #10306.

## The issue's central claim holds

`EvidenceManifest` really is a complete interpretation contract with a reader, a consumer, and **no producer**. Everything below is `grep -rn` over all 43 workspace crates (`rg` is not installed on this host and fails silently; control grep `grep -rn "fn main" crates/` → 40 hits, so the invocation works).

### Dead-code proof — every place checked

| Check | Result |
|---|---|
| `grep -rn "EvidenceManifest\|EVIDENCE_MANIFEST_SCHEMA\|evidence_manifest"` over `.rs`/`.md`/`.json`/`.toml`, whole tree | 53 hits. Definition (`crates/homeboy-core/src/evidence_manifest.rs`), the reader/consumer (`observation/evidence_report.rs`), `lib.rs:96`, four `TrackerRef`-only imports under `cli/commands/fuzz/`, and test fixtures. **Zero non-test constructions of `EvidenceManifest`.** |
| Root `tests/` tree (integration + `#[path]`-included modules) | `grep -rn "EvidenceManifest\|evidence_manifest" tests/` → **0 hits** |
| `#[path]`-included modules under `observation/` | two: `observation/store/mod.rs:63` → `tests/core/observation/store_test.rs`, and `records.rs:6` → `finding_records.rs`. Neither touches the manifest. |
| The one JSON that sets `metadata.evidence_manifest` | `cli/commands/runs/evidence.rs:145`, inside `#[cfg(test)] mod tests` — confirmed, the module opens at `:41` |
| Contract registry | absent from `cli/command_contract/registry.rs`; also absent from the `CONTRACT_SCHEMAS` validate table (`commands/contract/mod.rs:1272`) |
| `docs/**` | no mention anywhere except a changelog line, `docs/changelog.md:4639` "add portable evidence manifest schema" |
| Serde round-trip | the type is `Serialize + Deserialize` and is genuinely read back off storage — this is an *inbound* contract, not a dead struct. See below. |
| Cross-crate | only `homeboy-cli` reaches into the module, and only for `TrackerRef` |
| Macro expansion | plain `#[derive]` structs; nothing generates constructions |
| `git log` on both files since the issue was written (2026-07-27 01:28Z) | `evidence_manifest.rs` last touched by `9ff96feb4` (the core extraction, #8389). `evidence_report.rs` last touched by `6a2fcff26`. **Nothing landed after the issue.** Unlike the last two waves, this issue is not stale. |

### Corrections to the issue

Two, both small, neither changes the conclusion:

1. **"1 of 9 types" — there are 10.** The list omits `EvidenceManifestState` (`evidence_manifest.rs:52`). Per-type non-test hits outside the defining file:

   | Type | Hits outside `evidence_manifest.rs` | Live? |
   |---|---|---|
   | `TrackerRef` | 16 | **yes** — `fuzz/types.rs:427` constructs, `fuzz/execution.rs:877` writes `metadata.tracker_refs`, `evidence_report.rs:453` reads it back. Real closed loop. |
   | `EvidenceManifest` | 12, all reader/consumer/test | no producer |
   | `PullRequestRef` | **0** | dead |
   | `BlockingCondition` | **0** | dead |
   | `BlockingSeverity` / `EvidenceConfidence` / `EvidenceManifestState` / `EvidenceManifestStatus` / `EvidenceManifestInterpretation` | 0 outside the file's own tests | dead |
   | `RunRef` | 4 — **and all four are a different type** | dead |

2. **`RunRef` is exactly the trap warned about.** `grep -rn "\bRunRef\b"` returns four hits in `cli/commands/runs/refs.rs` (`:47`, `:72`, `:180`, `:181`) — that is a *separate* `RunRef` struct declared in that file for `runs refs`. The manifest's `RunRef` has zero readers. Anyone grepping the name and stopping there would conclude it was live.

Sibling dead contracts the issue did not name: **`PullRequestRef` and `BlockingCondition` have literally zero references anywhere outside the type they are a member of** — not even a Rust-level test construction (the existing tests only exercise them through JSON).

## Producer / consumer / what breaks today

**Consumer (exists, works).** `evidence_report.rs:790` looks in `run.metadata_json["evidence_manifest"]`, then at any artifact with `kind == "evidence_manifest"` or `metadata.schema == EVIDENCE_MANIFEST_SCHEMA`. What it finds lands on `RunEvidenceReport.evidence_manifest` (`:61`) and its `tracker_refs` are merged into the report's (`:444`).

So this is an **inbound** contract by design: the intended producer is an extension, an agent, or an external orchestrator that knows more than the exit code.

**Producer (missing, twice over).**
1. Homeboy never derives one for the runs it owns itself — so for ~100% of real runs the member is absent.
2. The schema is not in the contract registry and has no `contract validate` entry, so an external producer cannot *discover* the contract or check a candidate before attaching it. `homeboy contract` is the documented discovery surface; the manifest was invisible to it.

**What breaks today.** An orchestrator asking "what does this run mean, and what is blocking?" gets a member that is structurally always `null`, and has to re-derive the answer from `run.status` strings, `failure.gate_failures`, `failure.runner_failure`, `heartbeat.stale`, and artifact reviewability — separately, in every consumer, with no shared vocabulary. The docs already carry that reasoning as prose (`docs/commands/runs.md:68`, "a run passed but `runs evidence` has zero artifacts … did not produce reviewable evidence") with nothing machine-readable behind it.

## Decision: wire, not delete

Deleting would remove the only structure that expresses interpretation, and would delete the *inbound* seam an extension needs — the reader is real, load-bearing, and already covered by a passing CLI test. The debt is not the contract; it is that the contract had no producer and no discoverability. Both are addable without touching the shape.

### What this does

**1. Derive a manifest when no producer attached one** — `derive_evidence_manifest`, called from `build_run_evidence_report`, which the issue correctly identified as already holding every input.

Conservative in both directions:

| Run status | `status.state` |
|---|---|
| `running` | `pending` |
| `pass` | `passed` |
| `fail` / `error` | `failed` |
| `stale` | `blocked` |
| `skipped` | `unknown` |
| anything else | `unknown` + an `unknown_run_status` blocker |

A label Homeboy does not own is never guessed into a pass. And a run recorded as `pass` that *also* recorded a critical blocker is downgraded to `blocked`: a manifest that claims a pass while listing what stopped it is worse than no manifest, because a consumer reads `status.state` and stops there.

`interpretation.confidence` grades reviewability, which is what the docs prose was already about: `low` for non-terminal or zero-artifact runs, `medium` when every artifact is operator-local, `high` when at least one reviewer-visible evidence link exists. Blocking conditions come from `gate_failures`, `metadata.error`, `lab.failure` (the runner failure projection), staleness, non-terminality, and absence of reviewable evidence — bounded at 20 with the truncation announced in `interpretation.notes`, never silently.

**2. Provenance, stamped by the reader.** New optional `EvidenceManifest.source`: `run_metadata` / `artifact` / `derived`. An authored manifest is an assertion; a derived one is Homeboy reading its own run record. Conflating those is the correctness trap of naive derivation. The reader **overwrites** whatever the producer serialized — a test pins that a manifest claiming `"source": "artifact"` in run metadata comes back stamped `run_metadata`. `EvidenceManifestSource::is_authored()` is the gate for a consumer that must not act on a derived reading.

An authored manifest always wins and is surfaced verbatim. Homeboy never overwrites a producer's judgement.

**3. Fail closed on empty judgements.** `EvidenceManifest::validate()` rejects a blank `interpretation.summary`, identifier-less tracker/PR/run refs, and blocking conditions with no kind or summary. `parse_value` calls it, so a malformed authored manifest surfaces in `evidence_manifest_errors` *and* the report falls back to a derived manifest — the producer bug is visible, not silent.

**4. Discoverability.** Registered as `evidence-manifest` in `CONTRACT_REGISTRY`, and added to `CONTRACT_SCHEMAS` so `homeboy contract validate homeboy/evidence-manifest/v1 --file manifest.json` works. That is what makes it usable as an inbound contract at all.

### What this deliberately does not do

- **No `write_to_run_metadata`.** The issue proposed `EvidenceManifest::write_to_run_metadata(&ObservationStore, run_id)`. I did not add it. Deriving inside `runs evidence` is a read-only projection — no storage mutation, no host effects, computed in the one command whose entire job is emitting the evidence report. Persisting a derived interpretation into every run's metadata would mutate stored state from a reader, and would freeze a derivation that improves as the deriver improves. If a *producer* later wants to persist an authored manifest, `metadata.evidence_manifest` is already the documented slot.
- **No new manifest emission from `bench`/`trace`/`fuzz`/`rig`.** Same rule the rig lifecycle wiring (#10553) established: do not make a contract run implicitly in commands users do not expect.

## Serde and cross-repo safety

Checked before touching the type, per the `ProvidesConfig` / `NotificationTransportConfig` lesson:

- `grep -rn "deny_unknown_fields" crates/homeboy-core/src/evidence_manifest.rs crates/homeboy-core/src/artifact_ref.rs crates/homeboy-core/src/observation/evidence_report.rs` → **0 hits** (control: 32 files elsewhere in `crates/` do have it). Neither `EvidenceManifest` nor any member type nor its parent `RunEvidenceReport` is strict.
- `source` is the only added member: `Option`, `#[serde(default, skip_serializing_if = "Option::is_none")]`. **Additive-only in both directions.** New binary reading an old producer's manifest → `default` → `None`. Old binary reading a new manifest → unknown member ignored. A manifest that never passes through a reader serializes byte-identically to before (pinned by `evidence_manifest_source_is_absent_until_a_reader_stamps_it`), and `evidence_manifest_ignores_unknown_members` pins the forward direction.
- **Cross-repo:** `EvidenceManifest` lives in `homeboy-core`, not a `crates/contracts/` crate, so no extension links the Rust type — it crosses the boundary only as JSON, through run metadata or an artifact file. Nothing about the argv or manifest surface of an installed extension changes, so the new-binary/old-extension failure mode from #10538 does not apply here.
- The one behavior change on stored data: `parse_value` now also enforces `validate()`. Since **nothing has ever produced a manifest**, there is no stored corpus to break; and a manifest that fails now reports its reason in `evidence_manifest_errors` rather than being surfaced as an empty judgement.

`runs evidence` JSON gains a member that was previously always omitted. There are no golden JSON fixtures (`grep -rln "evidence_manifest" --include=*.json .` → 0) and `runs.evidence` is not in `PUBLIC_OUTPUT_VARIANT_CONTRACTS`.

## Adjacent work — checked, no collision

- **#10538** (`NotifyPayload` / `NotifyAttachment` in `homeboy-lab-contract`) — no overlap. That contract carries *prose plus actionable facts* to a transport through the process environment; this one carries *interpretation of persisted evidence* through run storage. I considered moving the manifest into `homeboy-lab-contract` alongside it and did not: the manifest's `artifact_refs` are `ArtifactRef`, and the derivation reads `RunRecord`/`ArtifactRecord`, which are core types — the same upward-dependency reason `artifact_ref_from_record` lives in core rather than in the leaf contract crate. Nothing in `notification_payload.rs` is touched.
- **#10537** (retention hoist + artifact-root sweeper) — lands entirely in `runs_service/`; this branch touches `observation/evidence_report.rs` and `evidence_manifest.rs`. No shared file.
- **#10553** — the lifecycle wiring. Same shape, and I followed its rules: wire fail-closed, do not run implicitly, additive serde only.

## Tests

23 new, all written blind.

- `evidence_manifest.rs` (9): source round-trip for all three values, additive absence, unknown-member tolerance, and one per `validate()` rejection (blank summary, identifier-less tracker/run refs, PR ref without repo or with number 0, blocking condition without kind/summary), plus `has_blocking_condition`.
- `observation/evidence_report.rs` (9): contract-validity of the derived manifest across all seven status labels, the full status→state map, refusal to interpret an unowned label, the pass-with-critical-blocker downgrade, confidence grading across none/local-only/reviewer-visible artifacts, the blocking-condition bound, authored-wins-and-is-restamped, tracker refs not doubled, and a malformed authored manifest still reporting its error.
- `commands/runs/evidence.rs` (2): end-to-end through the real command and observation store — a run with no attached manifest gets a contract-valid derived one carrying its gate failure; the existing authored-manifest test now also pins `source` and verbatim passthrough.
- `commands/contract/mod.rs` (2): registry lookup by name plus `contract validate` accepting a good manifest and rejecting an empty interpretation.

## What I could not verify

Per this host's constraints I cannot run `cargo build`, `cargo test`, `cargo check`, or `cargo clippy`. `cargo fmt --check` is clean, which proves syntax only. CI is the gate. Specifically unverified:

- **Type/borrow checking.** Hand-reviewed: the `'a` threading in `EvidenceManifestDerivation`; the closure passed to `unwrap_or_else` borrowing `run`/`artifacts`/`failure`/`evidence_links`/`tracker_refs`/`stale_reason` and releasing before `stale_reason` moves into the heartbeat. I used explicit `.as_slice()` rather than relying on `&Vec<T>` → `&[T]` coercion at struct-literal field positions, and bound `running_status_note(run)` to a local in the test helper rather than `.as_deref()`-ing a temporary.
- **Copy on three fieldless enums.** `EvidenceManifestState`, `EvidenceConfidence`, and `BlockingSeverity` gained `Copy` so `has_blocking_condition(severity)` can compare by value. Additive, and none of them is captured by a closure elsewhere.
- **Clippy.** `derived_blocking_conditions` takes 6 arguments, under the 7 threshold. No `uninlined_format_args` candidates: every non-inlined argument is a field access or an expression.
- **Test assertions.** `evidence_manifest_validation_rejects_an_empty_interpretation` reads `err.details["error"]` rather than `err.to_string()`, because `Display for Error` (`crates/homeboy-error/src/lib.rs:280-284`) renders only `self.message`.
