### PR TITLE
Generate the CLI reference from clap (#10324)

### DIFF
--- a/.github/workflows/cli-reference-docs.yml
+++ b/.github/workflows/cli-reference-docs.yml
@@ -1,0 +1,64 @@
+# Keeps `docs/reference/cli/commands/` byte-identical to the clap command tree.
+#
+# The same assertion runs as a plain unit test
+# (`cli_surface::reference_docs_tests::cli_reference_docs_are_current`), but the
+# `review test` gate in ci.yml is differentially scoped. This job is the
+# non-differential guard, and — more usefully — it always uploads the
+# regenerated tree, so a contributor whose PR moved the command surface can
+# download the correct docs instead of needing a local toolchain.
+#
+# Path-filtered on purpose: every `#[derive(Subcommand)]` and `#[derive(Args)]`
+# in the workspace lives in `crates/homeboy-cli`, so a PR that does not touch
+# that crate cannot move the command surface, and pays nothing here.
+
+name: CLI Reference Docs
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/homeboy-cli/**'
+      - 'docs/reference/cli/commands/**'
+      - '.github/workflows/cli-reference-docs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: cli-reference-docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cli-reference-docs:
+    name: homeboy / CLI Reference Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Write mode rewrites the tree and returns without asserting; the git
+      # check below is the gate. Running it this way means a failure ships the
+      # fix as an artifact instead of only a diagnostic.
+      - name: Regenerate the CLI reference from clap
+        env:
+          HOMEBOY_WRITE_CLI_REFERENCE: '1'
+        run: cargo test -p homeboy-cli --lib --locked cli_surface::reference_docs
+
+      - name: Upload the regenerated CLI reference
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-reference-docs
+          path: docs/reference/cli/commands
+          if-no-files-found: warn
+
+      # `git diff` alone ignores files the generator newly created, so stage
+      # intents first.
+      - name: Fail if the checked-in CLI reference is stale
+        run: |
+          git add --intent-to-add -- docs/reference/cli/commands
+          git diff --exit-code -- docs/reference/cli/commands

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1491,3 +1491,8 @@ mod tests {
 
 #[cfg(test)]
 mod global_flag_surface_tests;
+
+#[cfg(test)]
+mod reference_docs;
+#[cfg(test)]
+mod reference_docs_tests;

--- a/crates/homeboy-cli/src/cli_surface/reference_docs.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs.rs
@@ -1,0 +1,411 @@
+//! Generates the CLI reference under `docs/reference/cli/commands/` from the
+//! clap command tree.
+//!
+//! # Why reflective, and not `--help` scraping
+//!
+//! Rendered `--help` is a *wire protocol* in this repository:
+//! `homeboy-lab-runner`'s `negotiate_leaseless_recovery_contract` parses a
+//! remote binary's rendered `Options:` block to negotiate a capability
+//! handshake. Generating docs by shelling out to `--help` would couple doc
+//! generation to that rendering, and would also require a built binary. Walking
+//! `clap::Command` reflectively reads the same source of truth without touching
+//! the rendered surface at all: this module only *reads* `Command`/`Arg`
+//! accessors, so it can never change what `--help` prints.
+//!
+//! # Why checked in, and not generated at build time
+//!
+//! `crates/homeboy-cli/build.rs` already embeds every `docs/**/*.md` file into
+//! the binary and emits a `rerun-if-changed` for each one. Generating this tree
+//! during the build would add a second pass over the whole command surface to
+//! every single compile of an already-slow workspace. Instead the tree is
+//! checked in and [`super::reference_docs_tests::cli_reference_docs_are_current`]
+//! fails when it drifts, so generation cost is paid only when someone
+//! deliberately regenerates:
+//!
+//! ```sh
+//! HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+//! ```
+//!
+//! # Why it does not overwrite `docs/commands/`
+//!
+//! `docs/commands/*.md` is hand-written narrative: concepts, recipes, contracts,
+//! and migration tables that clap cannot derive. This module writes to a
+//! disjoint directory and links back to the narrative page; nothing hand-written
+//! is read, rewritten, or deleted.
+
+use super::Cli;
+use clap::{Arg, ArgAction, Command, CommandFactory};
+use std::collections::BTreeMap;
+
+/// Repo-root-relative directory owned entirely by this generator.
+pub(super) const GENERATED_DIR: &str = "docs/reference/cli/commands";
+
+/// Set to any value to rewrite [`GENERATED_DIR`] instead of asserting currency.
+pub(super) const WRITE_ENV: &str = "HOMEBOY_WRITE_CLI_REFERENCE";
+
+const BANNER: &str = "<!-- GENERATED FILE. DO NOT EDIT BY HAND.\n\
+     Source of truth: the clap command tree in `crates/homeboy-cli`.\n\
+     Regenerate with:\n\
+     HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs\n\
+     Hand-written narrative for these commands lives in `docs/commands/`. -->\n\n";
+
+const MISSING_DESCRIPTION: &str =
+    "_This command declares no clap help text, so no description can be generated for it._\n\n";
+
+const NO_HELP_CELL: &str = "_no help text_";
+
+/// Renders the full generated tree as `file name -> markdown body`.
+pub(super) fn generated_reference_docs() -> BTreeMap<String, String> {
+    let mut root = Cli::command();
+    // Populates clap-managed state (value names, `help` args, propagated
+    // globals) so introspection sees the same shapes `--help` would.
+    root.build();
+
+    let mut files = BTreeMap::new();
+    let mut summaries = Vec::new();
+    let mut undocumented = Vec::new();
+    let mut node_count = 0usize;
+
+    for command in documented_subcommands(&root) {
+        let name = command.get_name().to_string();
+        node_count += count_nodes(command);
+        commands_without_description(&[name.clone()], command, &mut undocumented);
+        summaries.push((
+            name.clone(),
+            styled(command.get_about())
+                .map(|about| cell(&about))
+                .unwrap_or_else(|| NO_HELP_CELL.to_string()),
+        ));
+        files.insert(format!("{name}.md"), render_command_page(&name, command));
+    }
+
+    files.insert(
+        "index.md".to_string(),
+        render_index(&summaries, node_count, &undocumented),
+    );
+    files
+}
+
+fn render_command_page(name: &str, command: &Command) -> String {
+    let mut out = String::from(BANNER);
+    out.push_str(&format!("# `homeboy {name}` command reference\n\n"));
+    out.push_str(
+        "Generated from the clap command tree. This page is the complete synopsis, \
+         argument, flag, and subcommand surface for this command family.\n\n",
+    );
+
+    if let Some(slug) = narrative_slug(name) {
+        out.push_str(&format!(
+            "Concepts, recipes, and contracts are hand-written in \
+             [docs/commands/{slug}.md](../../../commands/{slug}.md).\n\n"
+        ));
+    }
+
+    out.push_str(
+        "Global flags apply to every command and are documented once in \
+         [the root command reference](../homeboy-root-command.md).\n\n",
+    );
+
+    render_node(&mut out, &[name.to_string()], command);
+    out
+}
+
+fn render_node(out: &mut String, path: &[String], command: &Command) {
+    let display = path.join(" ");
+    out.push_str(&format!("## `homeboy {display}`\n\n"));
+
+    let aliases = command
+        .get_visible_aliases()
+        .map(|alias| format!("`{alias}`"))
+        .collect::<Vec<_>>();
+    if !aliases.is_empty() {
+        out.push_str(&format!("Aliases: {}\n\n", aliases.join(", ")));
+    }
+
+    out.push_str("```sh\n");
+    out.push_str(&synopsis(path, command));
+    out.push_str("\n```\n\n");
+
+    match description(command) {
+        Some(text) => {
+            out.push_str(&text);
+            out.push_str("\n\n");
+        }
+        None => out.push_str(MISSING_DESCRIPTION),
+    }
+
+    let positionals = documented_positionals(command);
+    if !positionals.is_empty() {
+        out.push_str("| Argument | Required | Description |\n| --- | --- | --- |\n");
+        for arg in positionals {
+            let placeholder = positional_synopsis(arg);
+            let required = if arg.is_required_set() { "yes" } else { "no" };
+            let help = help_cell(arg);
+            out.push_str(&format!("| `{placeholder}` | {required} | {help} |\n"));
+        }
+        out.push('\n');
+    }
+
+    let options = documented_options(command);
+    if !options.is_empty() {
+        out.push_str("| Option | Value | Description |\n| --- | --- | --- |\n");
+        for arg in options {
+            let label = option_label(arg);
+            let value = match value_placeholder(arg) {
+                Some(placeholder) => format!("`{placeholder}`"),
+                None => "flag".to_string(),
+            };
+            let help = help_cell(arg);
+            out.push_str(&format!("| {label} | {value} | {help} |\n"));
+        }
+        out.push('\n');
+    }
+
+    let subcommands = documented_subcommands(command);
+    if !subcommands.is_empty() {
+        out.push_str("| Subcommand | Summary |\n| --- | --- |\n");
+        for subcommand in subcommands.iter().copied() {
+            let name = subcommand.get_name();
+            let summary = styled(subcommand.get_about())
+                .map(|about| cell(&about))
+                .unwrap_or_else(|| NO_HELP_CELL.to_string());
+            out.push_str(&format!("| `homeboy {display} {name}` | {summary} |\n"));
+        }
+        out.push('\n');
+    }
+
+    for subcommand in subcommands {
+        let mut child = path.to_vec();
+        child.push(subcommand.get_name().to_string());
+        render_node(out, &child, subcommand);
+    }
+}
+
+fn render_index(
+    summaries: &[(String, String)],
+    node_count: usize,
+    undocumented: &[String],
+) -> String {
+    let mut out = String::from(BANNER);
+    out.push_str("# Homeboy CLI reference (generated)\n\n");
+    out.push_str(&format!(
+        "`homeboy` exposes {node_count} visible commands across {} top-level command \
+         families. Every page below is generated from the clap command tree in \
+         `crates/homeboy-cli`, so it cannot drift from the binary.\n\n",
+        summaries.len()
+    ));
+    out.push_str(
+        "Hand-written narrative lives in the \
+         [commands index](../../../commands/commands-index.md). Global flags are \
+         documented in [the root command reference](../homeboy-root-command.md). \
+         Machine-readable safety, docs, output, and Lab metadata come from \
+         `homeboy contract manifest`.\n\n",
+    );
+
+    out.push_str("| Command | Reference | Summary |\n| --- | --- | --- |\n");
+    for (name, summary) in summaries {
+        out.push_str(&format!(
+            "| `homeboy {name}` | [{name}.md]({name}.md) | {summary} |\n"
+        ));
+    }
+    out.push('\n');
+
+    out.push_str("## Commands shipping without help text\n\n");
+    if undocumented.is_empty() {
+        out.push_str("None. Every visible command declares a clap `about` string.\n");
+        return out;
+    }
+
+    out.push_str(&format!(
+        "{} visible commands declare no clap `about`/`long_about`, so no description \
+         can be generated for them. The fix is a doc comment on the clap variant, not \
+         prose in this file.\n\n",
+        undocumented.len()
+    ));
+    for path in undocumented {
+        out.push_str(&format!("- `homeboy {path}`\n"));
+    }
+    out
+}
+
+fn synopsis(path: &[String], command: &Command) -> String {
+    let mut parts = vec!["homeboy".to_string()];
+    parts.extend(path.iter().cloned());
+
+    if !documented_options(command).is_empty() {
+        parts.push("[OPTIONS]".to_string());
+    }
+    for arg in documented_positionals(command) {
+        parts.push(positional_synopsis(arg));
+    }
+    if !documented_subcommands(command).is_empty() {
+        parts.push(if command.is_subcommand_required_set() {
+            "<COMMAND>".to_string()
+        } else {
+            "[COMMAND]".to_string()
+        });
+    }
+
+    parts.join(" ")
+}
+
+/// Visible child commands, minus clap's generated `help` subcommand.
+pub(super) fn documented_subcommands(command: &Command) -> Vec<&Command> {
+    command
+        .get_subcommands()
+        .filter(|subcommand| !subcommand.is_hide_set())
+        .filter(|subcommand| subcommand.get_name() != "help")
+        .collect()
+}
+
+fn documented_positionals(command: &Command) -> Vec<&Arg> {
+    command
+        .get_positionals()
+        .filter(|arg| !arg.is_hide_set())
+        .collect()
+}
+
+/// Non-positional, non-hidden, non-global arguments.
+///
+/// Globals are deliberately excluded: they are identical on every node and are
+/// pinned as a wire protocol by `root_global_flag_surface_is_pinned`. Repeating
+/// them on ~500 pages would bury the per-command surface and would make an
+/// unrelated global-flag change rewrite the entire generated tree.
+fn documented_options(command: &Command) -> Vec<&Arg> {
+    command
+        .get_arguments()
+        .filter(|arg| !arg.is_positional())
+        .filter(|arg| !arg.is_hide_set())
+        .filter(|arg| !arg.is_global_set())
+        .filter(|arg| !matches!(arg.get_id().as_str(), "help" | "version"))
+        .collect()
+}
+
+/// Records every visible command node under `path` that has no help text.
+pub(super) fn commands_without_description(
+    path: &[String],
+    command: &Command,
+    out: &mut Vec<String>,
+) {
+    if description(command).is_none() {
+        out.push(path.join(" "));
+    }
+
+    for subcommand in documented_subcommands(command) {
+        let mut child = path.to_vec();
+        child.push(subcommand.get_name().to_string());
+        commands_without_description(&child, subcommand, out);
+    }
+}
+
+fn count_nodes(command: &Command) -> usize {
+    1 + documented_subcommands(command)
+        .into_iter()
+        .map(count_nodes)
+        .sum::<usize>()
+}
+
+fn narrative_slug(name: &str) -> Option<&'static str> {
+    crate::command_contract::registered_command(name).and_then(|spec| spec.docs_slug)
+}
+
+fn description(command: &Command) -> Option<String> {
+    styled(command.get_long_about())
+        .or_else(|| styled(command.get_about()))
+        .map(|text| paragraphs(&text))
+}
+
+fn positional_synopsis(arg: &Arg) -> String {
+    let name = arg
+        .get_value_names()
+        .and_then(|names| names.first())
+        .map(|name| name.to_string())
+        .unwrap_or_else(|| default_value_name(arg));
+    let repeated = if matches!(arg.get_action(), ArgAction::Append) {
+        "..."
+    } else {
+        ""
+    };
+
+    if arg.is_required_set() {
+        format!("<{name}>{repeated}")
+    } else {
+        format!("[{name}]{repeated}")
+    }
+}
+
+fn option_label(arg: &Arg) -> String {
+    let mut label = String::new();
+    if let Some(short) = arg.get_short() {
+        label.push_str(&format!("`-{short}`, "));
+    }
+    match arg.get_long() {
+        Some(long) => label.push_str(&format!("`--{long}`")),
+        None => label.push_str(&format!("`{}`", arg.get_id().as_str())),
+    }
+    label
+}
+
+fn value_placeholder(arg: &Arg) -> Option<String> {
+    if !matches!(arg.get_action(), ArgAction::Set | ArgAction::Append) {
+        return None;
+    }
+
+    match arg.get_value_names() {
+        Some(names) if !names.is_empty() => Some(
+            names
+                .iter()
+                .map(|name| format!("<{name}>"))
+                .collect::<Vec<_>>()
+                .join(" "),
+        ),
+        _ => Some(format!("<{}>", default_value_name(arg))),
+    }
+}
+
+fn default_value_name(arg: &Arg) -> String {
+    arg.get_id().as_str().to_uppercase().replace('_', "-")
+}
+
+fn help_cell(arg: &Arg) -> String {
+    let mut text = styled(arg.get_help())
+        .or_else(|| styled(arg.get_long_help()))
+        .map(|help| cell(&help))
+        .unwrap_or_else(|| NO_HELP_CELL.to_string());
+
+    let values = arg
+        .get_possible_values()
+        .into_iter()
+        .filter(|value| !value.is_hide_set())
+        .map(|value| format!("`{}`", value.get_name()))
+        .collect::<Vec<_>>();
+    if !values.is_empty() {
+        text.push_str(&format!(" Values: {}.", values.join(", ")));
+    }
+
+    text
+}
+
+fn styled(text: Option<&clap::builder::StyledStr>) -> Option<String> {
+    text.map(|value| value.to_string())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Collapses hard-wrapped doc comments into markdown paragraphs so the rendered
+/// prose reflows instead of inheriting Rust's 80-column source wrapping.
+fn paragraphs(text: &str) -> String {
+    text.split("\n\n")
+        .map(|paragraph| paragraph.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|paragraph| !paragraph.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Flattens text into a single markdown table cell.
+fn cell(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace('|', "\\|")
+}

--- a/crates/homeboy-cli/src/cli_surface/reference_docs.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs.rs
@@ -26,6 +26,21 @@
 //! HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
 //! ```
 //!
+//! # Why it does not call `Command::build`
+//!
+//! Everything here reads the tree exactly as `clap_derive` produced it.
+//! `clap_derive` already emits an explicit `ArgAction` and `value_name` for
+//! every field, so building buys nothing this module needs — and it costs two
+//! things it does not want. It propagates every `global = true` argument into
+//! all ~500 nodes, which this module strips again anyway; and it runs clap's
+//! `debug_assert` suite over the whole tree, which turns any pre-existing
+//! definition defect anywhere in the CLI into a *docs* test failure. That is not
+//! hypothetical: `runner refresh-plan` declares a local `--output` that collides
+//! with the propagated global `--output`, and building trips
+//! `Long option names must be unique for each argument`. Once that is fixed, a
+//! deliberate `build()`-based assertion canary would be a good separate guard;
+//! it should not be smuggled in as a side effect of generating docs.
+//!
 //! # Why it does not overwrite `docs/commands/`
 //!
 //! `docs/commands/*.md` is hand-written narrative: concepts, recipes, contracts,
@@ -56,10 +71,7 @@ const NO_HELP_CELL: &str = "_no help text_";
 
 /// Renders the full generated tree as `file name -> markdown body`.
 pub(super) fn generated_reference_docs() -> BTreeMap<String, String> {
-    let mut root = Cli::command();
-    // Populates clap-managed state (value names, `help` args, propagated
-    // globals) so introspection sees the same shapes `--help` would.
-    root.build();
+    let root = Cli::command();
 
     let mut files = BTreeMap::new();
     let mut summaries = Vec::new();

--- a/crates/homeboy-cli/src/cli_surface/reference_docs.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs.rs
@@ -385,14 +385,18 @@ fn help_cell(arg: &Arg) -> String {
         .map(|help| cell(&help))
         .unwrap_or_else(|| NO_HELP_CELL.to_string());
 
-    let values = arg
-        .get_possible_values()
-        .into_iter()
-        .filter(|value| !value.is_hide_set())
-        .map(|value| format!("`{}`", value.get_name()))
-        .collect::<Vec<_>>();
-    if !values.is_empty() {
-        text.push_str(&format!(" Values: {}.", values.join(", ")));
+    // Only value-taking arguments have a meaningful enum. A `SetTrue` flag
+    // reports `true`/`false` from its bool value parser, which is noise.
+    if value_placeholder(arg).is_some() {
+        let values = arg
+            .get_possible_values()
+            .into_iter()
+            .filter(|value| !value.is_hide_set())
+            .map(|value| format!("`{}`", value.get_name()))
+            .collect::<Vec<_>>();
+        if !values.is_empty() {
+            text.push_str(&format!(" Values: {}.", values.join(", ")));
+        }
     }
 
     text

--- a/crates/homeboy-cli/src/cli_surface/reference_docs_tests.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs_tests.rs
@@ -108,8 +108,7 @@ fn cli_reference_docs_are_current() {
 /// One generated page per visible top-level command, plus the index.
 #[test]
 fn generated_reference_covers_every_visible_top_level_command() {
-    let mut root = Cli::command();
-    root.build();
+    let root = Cli::command();
 
     let expected = documented_subcommands(&root)
         .into_iter()
@@ -136,8 +135,7 @@ fn generated_reference_covers_every_visible_top_level_command() {
 /// shows up as a reviewed docs diff.
 #[test]
 fn commands_without_help_text_are_confined_to_agent_task() {
-    let mut root = Cli::command();
-    root.build();
+    let root = Cli::command();
 
     let mut undocumented = Vec::new();
     for command in documented_subcommands(&root) {

--- a/crates/homeboy-cli/src/cli_surface/reference_docs_tests.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs_tests.rs
@@ -1,0 +1,196 @@
+//! Currency and coverage guards for the generated CLI reference.
+//!
+//! Lives beside `cli_surface/mod.rs` rather than inside its `mod tests` block
+//! for the same reason as `global_flag_surface_tests`: that file sits a handful
+//! of lines under the audit's 1500-line `god_file` threshold.
+//!
+//! Every `#[derive(Subcommand)]` and `#[derive(Args)]` in the workspace lives in
+//! `crates/homeboy-cli`, so any change that can move the command surface must
+//! touch this crate. That makes the differential `review test` gate a real
+//! guard for these tests, and `.github/workflows/cli-reference-docs.yml` runs
+//! the same generation non-differentially (and uploads the regenerated tree) on
+//! every PR that touches the CLI crate.
+
+use super::reference_docs::{
+    commands_without_description, documented_subcommands, generated_reference_docs, GENERATED_DIR,
+    WRITE_ENV,
+};
+use super::Cli;
+use clap::CommandFactory;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+/// Repo-root-relative paths resolve from the workspace root, not this crate's
+/// manifest dir.
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn checked_in_reference_docs() -> BTreeMap<String, String> {
+    let directory = workspace_root().join(GENERATED_DIR);
+    let mut docs = BTreeMap::new();
+
+    let Ok(entries) = std::fs::read_dir(&directory) else {
+        return docs;
+    };
+
+    for entry in entries {
+        let path = entry
+            .expect("failed to read a generated CLI reference entry")
+            .path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("md") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("generated CLI reference filenames should be valid UTF-8")
+            .to_string();
+        let body = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {GENERATED_DIR}/{name}: {error}"));
+        docs.insert(name, body);
+    }
+
+    docs
+}
+
+/// The generated reference must byte-match the live clap command tree.
+///
+/// With `HOMEBOY_WRITE_CLI_REFERENCE` set, this rewrites the tree instead of
+/// asserting, which is how the tree is regenerated and how CI produces the
+/// downloadable artifact for a stale PR.
+#[test]
+fn cli_reference_docs_are_current() {
+    let expected = generated_reference_docs();
+    let directory = workspace_root().join(GENERATED_DIR);
+
+    if std::env::var_os(WRITE_ENV).is_some() {
+        if directory.exists() {
+            std::fs::remove_dir_all(&directory)
+                .expect("failed to clear the generated CLI reference");
+        }
+        std::fs::create_dir_all(&directory)
+            .expect("failed to create the generated CLI reference directory");
+        for (name, body) in &expected {
+            std::fs::write(directory.join(name), body)
+                .unwrap_or_else(|error| panic!("failed to write {GENERATED_DIR}/{name}: {error}"));
+        }
+        return;
+    }
+
+    let actual = checked_in_reference_docs();
+    let regenerate = format!(
+        "regenerate with `{WRITE_ENV}=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs`"
+    );
+
+    assert_eq!(
+        actual.keys().collect::<Vec<_>>(),
+        expected.keys().collect::<Vec<_>>(),
+        "{GENERATED_DIR} does not contain exactly one page per visible top-level command; {regenerate}"
+    );
+
+    for (name, body) in &expected {
+        let current = actual
+            .get(name)
+            .map(String::as_str)
+            .expect("file set already asserted equal");
+        assert!(
+            current == body,
+            "{GENERATED_DIR}/{name} is stale ({} checked-in lines vs {} generated lines); {regenerate}",
+            current.lines().count(),
+            body.lines().count(),
+        );
+    }
+}
+
+/// One generated page per visible top-level command, plus the index.
+#[test]
+fn generated_reference_covers_every_visible_top_level_command() {
+    let mut root = Cli::command();
+    root.build();
+
+    let expected = documented_subcommands(&root)
+        .into_iter()
+        .map(|command| format!("{}.md", command.get_name()))
+        .chain(std::iter::once("index.md".to_string()))
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        generated_reference_docs()
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        expected
+    );
+}
+
+/// A command with no clap `about` is invisible in `--help`, in the generated
+/// reference, and to any agent reading the command surface.
+///
+/// `agent-task` is the one family that still ships subcommands without help
+/// text (#10324). Pinning the *shape* of that debt rather than a count keeps
+/// the guard honest: no other family may acquire the same gap, and the exact
+/// remaining paths are listed in the generated index, so shrinking the set
+/// shows up as a reviewed docs diff.
+#[test]
+fn commands_without_help_text_are_confined_to_agent_task() {
+    let mut root = Cli::command();
+    root.build();
+
+    let mut undocumented = Vec::new();
+    for command in documented_subcommands(&root) {
+        commands_without_description(
+            &[command.get_name().to_string()],
+            command,
+            &mut undocumented,
+        );
+    }
+
+    let stray = undocumented
+        .iter()
+        .filter(|path| !path.starts_with("agent-task"))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    assert!(
+        stray.is_empty(),
+        "these commands ship without clap help text: {stray:?}. Add a doc comment to \
+         the clap variant instead of widening this guard."
+    );
+}
+
+/// `documented_command_index_entries` collects into a `BTreeSet` and the
+/// registry guard uses `index.contains(..)`, so a duplicated index line is
+/// invisible to both `self doctor` and
+/// `command_registry_docs_paths_exist_and_are_indexed`. It shipped: `api` was
+/// listed twice (#10324).
+#[test]
+fn commands_index_lists_each_command_once() {
+    let index = std::fs::read_to_string(workspace_root().join("docs/commands/commands-index.md"))
+        .expect("failed to read docs/commands/commands-index.md");
+
+    // Mirror `documented_command_index_entries`: only the command section above
+    // `Related:` is the command list.
+    let command_section = index.split("Related:").next().unwrap_or(index.as_str());
+
+    let mut seen = BTreeSet::new();
+    let mut duplicates = Vec::new();
+    for line in command_section.lines() {
+        let Some(rest) = line.strip_prefix("- [") else {
+            continue;
+        };
+        let Some(slug) = rest.split(']').next() else {
+            continue;
+        };
+        if !seen.insert(slug.to_string()) {
+            duplicates.push(slug.to_string());
+        }
+    }
+
+    assert!(
+        duplicates.is_empty(),
+        "docs/commands/commands-index.md lists these commands more than once: {duplicates:?}"
+    );
+}

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -96,13 +96,13 @@ always authoritative across both retry paths.
 
 ```bash
 # Exactly one provider process: no retry and no rotation.
-homeboy agent-task dispatch --prompt @task.md --max-provider-executions 1
+homeboy agent-task cook --prompt @task.md --max-provider-executions 1
 
 # One retry on the same provider, with at most two executions total.
-homeboy agent-task dispatch --prompt @task.md --max-provider-executions 2 --max-same-provider-retries 1
+homeboy agent-task cook --prompt @task.md --max-provider-executions 2 --max-same-provider-retries 1
 
 # Rotate once after a provider failure, with no same-provider retry.
-homeboy agent-task dispatch --prompt @task.md --max-provider-executions 2 --max-provider-rotations 1
+homeboy agent-task cook --prompt @task.md --max-provider-executions 2 --max-provider-rotations 1
 ```
 
 `--attempts N` remains accepted as a legacy alias for `--max-provider-executions N`.

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -1,6 +1,5 @@
 # Commands index
 
-- [api](api.md)
 - [activity](activity.md) — unified active and recently finished Homeboy work
 - [agent-task](agent-task.md)
 - [api](api.md)
@@ -51,6 +50,10 @@ when installed. Extension command docs describe possible runtime-provided
 commands rather than guaranteed core subcommands.
 
 Agents and automation that need command safety metadata should read the recursive manifest with `homeboy contract manifest`.
+
+Every page above is hand-written narrative. The exhaustive, always-current
+synopsis/flag/subcommand surface for each command is generated from clap into
+[the CLI reference](../reference/cli/commands/index.md).
 
 Related:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ Mental models and vocabulary:
 Exact CLI, configuration, schema, and output details:
 
 - [Reference index](reference/index.md)
+- [Generated CLI reference](reference/cli/commands/index.md)
 - [Root command and global flags](reference/cli/homeboy-root-command.md)
 - [Command index](commands/commands-index.md)
 - [Configuration reference](reference/configuration.md)

--- a/docs/reference/cli/commands/activity.md
+++ b/docs/reference/cli/commands/activity.md
@@ -1,0 +1,71 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy activity` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/activity.md](../../../commands/activity.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy activity`
+
+```sh
+homeboy activity [COMMAND]
+```
+
+Unified view of active and recently finished Homeboy work
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy activity list` | List active and recent Homeboy work |
+| `homeboy activity show` | Resolve and show one activity item by run/task/job id |
+| `homeboy activity watch` | Poll any activity item until it reaches a terminal state |
+
+## `homeboy activity list`
+
+```sh
+homeboy activity list [OPTIONS]
+```
+
+List active and recent Homeboy work
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--limit` | `<LIMIT>` | Maximum activity items to return |
+| `--all` | flag | Include older completed records instead of active + recent |
+
+## `homeboy activity show`
+
+```sh
+homeboy activity show <ID>
+```
+
+Resolve and show one activity item by run/task/job id
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | _no help text_ |
+
+## `homeboy activity watch`
+
+```sh
+homeboy activity watch [OPTIONS] <ID>
+```
+
+Poll any activity item until it reaches a terminal state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Activity id, observation run id, agent-task run id, or runner job id |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--timeout` | `<TIMEOUT>` | Maximum time to wait before giving up (e.g. `30m`, `2h`, `7d`) |
+| `--interval` | `<INTERVAL>` | Delay between status polls (e.g. `2s`, `1m`) |
+| `--notify` | flag | Emit a local completion notification when the item reaches a terminal state |
+

--- a/docs/reference/cli/commands/agent-task.md
+++ b/docs/reference/cli/commands/agent-task.md
@@ -1,0 +1,1424 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy agent-task` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/agent-task.md](../../../commands/agent-task.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy agent-task`
+
+```sh
+homeboy agent-task <COMMAND>
+```
+
+Run generic agent task plans
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy agent-task doctor` | _no help text_ |
+| `homeboy agent-task cook` | Run an agent task end to end and open a pull request |
+| `homeboy agent-task cook-continue` | Continue a detached Cook from its durable Cook ID or provider attempt ID. The persisted recipe supplies the original prompt, transport, gates, worktree, and disclosure policy |
+| `homeboy agent-task loop` | _no help text_ |
+| `homeboy agent-task run-plan` | _no help text_ |
+| `homeboy agent-task run` | _no help text_ |
+| `homeboy agent-task run-next` | _no help text_ |
+| `homeboy agent-task submit` | _no help text_ |
+| `homeboy agent-task status` | _no help text_ |
+| `homeboy agent-task list` | _no help text_ |
+| `homeboy agent-task active` | _no help text_ |
+| `homeboy agent-task reconcile` | Preview or apply reconciliation for one durable run |
+| `homeboy agent-task reconcile-records` | _no help text_ |
+| `homeboy agent-task latest` | _no help text_ |
+| `homeboy agent-task logs` | _no help text_ |
+| `homeboy agent-task artifacts` | _no help text_ |
+| `homeboy agent-task evidence` | _no help text_ |
+| `homeboy agent-task diagnose` | _no help text_ |
+| `homeboy agent-task runtime-recover` | Recover a missing or corrupted immutable controller runtime pin |
+| `homeboy agent-task runtime-validate` | Validate controller runtime eligibility without executing provider work |
+| `homeboy agent-task replay-provider-boundary` | _no help text_ |
+| `homeboy agent-task cancel` | _no help text_ |
+| `homeboy agent-task resume` | _no help text_ |
+| `homeboy agent-task retry` | _no help text_ |
+| `homeboy agent-task fanout` | _no help text_ |
+| `homeboy agent-task review` | _no help text_ |
+| `homeboy agent-task promote` | _no help text_ |
+| `homeboy agent-task adopt` | Adopt an immutable commit candidate through a tracked cook's normal gates and finalization |
+| `homeboy agent-task finalize-pr` | _no help text_ |
+| `homeboy agent-task gate-feedback` | _no help text_ |
+| `homeboy agent-task providers` | _no help text_ |
+| `homeboy agent-task prompts` | _no help text_ |
+| `homeboy agent-task contract` | _no help text_ |
+| `homeboy agent-task compile-loop` | _no help text_ |
+| `homeboy agent-task auth` | _no help text_ |
+| `homeboy agent-task controller` | _no help text_ |
+
+## `homeboy agent-task doctor`
+
+```sh
+homeboy agent-task doctor [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner` | `<RUNNER>` | _no help text_ |
+| `--backend` | `<BACKEND>` | _no help text_ |
+| `--selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--path` | `<PATH>` | _no help text_ |
+| `--extension` | `<EXTENSION>` | _no help text_ |
+| `--require-tool` | `<TOOL>` | _no help text_ |
+| `--secret-env` | `<ENV>` | _no help text_ |
+| `--repair` | flag | _no help text_ |
+
+## `homeboy agent-task cook`
+
+```sh
+homeboy agent-task cook [OPTIONS]
+```
+
+Run an agent task end to end and open a pull request.
+
+Provide the work with one `--prompt` and optional `--goal` framing, point `--to-worktree` at the existing worktree to edit (that checkout is authoritative — the agent's changes, the `--verify` gates, and the PR all operate on it), and give one or more `--verify` commands that must pass in that worktree before promotion. Cook then commits, runs the deterministic gates, and finalizes a `--base`-targeted PR (use `--no-finalize` to stop before opening the PR). Repeatable `--verify` gates all run; the run retries up to `--max-attempts` times. Use `agent-task fanout cook-batch` for independent task waves.
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--prompt` | `<PROMPT>` | Inline prompt, @file, or - for stdin |
+| `--cwd` | `<PATH>` | Existing local repo checkout or worktree path to cook in |
+| `--workspace` | `<ID_OR_PATH>` | Homeboy workspace ID or existing local workspace path to cook in |
+| `--repo` | `<REPO>` | Repo/component slug for metadata and task grouping, e.g. sample-plugin |
+| `--task-url` | `<URL>` | Issue, PR, or tracker URL the task is cooking |
+| `--backend` | `<BACKEND>` | Executor backend to request. Defaults to the configured coding backend |
+| `--selector` | `<PROVIDER_ID>` | Optional provider id when more than one provider exists for the backend |
+| `--model` | `<MODEL>` | Optional model override passed through to the provider |
+| `--secret-env` | `<ENV>` | Secret environment variable name to hydrate for the provider. Repeatable |
+| `--concurrency` | `<N>` | Maximum number of task cells to run at once |
+| `--run-id` | `<ID>` | Optional durable run id. Generated when omitted |
+| `--provider-config` | `<JSON>` | Provider config JSON object, @file, or - for stdin. Merged with workspace metadata |
+| `--client-context` | `<JSON>` | Opaque client context JSON object, @file, or - for stdin |
+| `--max-provider-executions` | `<N>` | Maximum total provider executions per task, including same-provider retries and provider rotations. `--attempts 1` runs exactly once |
+| `--max-same-provider-retries` | `<N>` | Same-provider retries allowed after the first provider execution |
+| `--max-provider-rotations` | `<N>` | Cross-provider rotations allowed after the first provider execution |
+| `--queue-only` | flag | Persist the run for a daemon/runner but do not execute immediately |
+| `--timeout-ms` | `<MS>` | Provider wall-clock timeout in milliseconds. Defaults to Homeboy's provider timeout |
+| `--candidate-completion` | `<POLICY>` | Completion rule for isolated candidates: wait for all results (default) or promote the first successful candidate |
+| `--goal` | `<TEXT>` | One-line statement of what a successful cook must achieve. Recorded as framing metadata for the provider task and used for review. Without --prompt, it supplies the one provider task |
+| `--to-worktree` | `<HANDLE>` | Workspace handle the cook edits, verifies, and finalizes into (e.g. `repo@branch-slug`). Existing destinations are reused. A missing managed destination is created through its configured provider when --repo, --base, --head, and --task-url declare explicit intent |
+| `--provider-command` | `<COMMAND>` | Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`. |
+| `--provider-argv` | `<ARG>` | Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`. |
+| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
+| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Use for gates whose logs may contain secrets. Repeatable |
+| `--private-gate-reveal` | `<POLICY>` | How much of a `--private-verify` gate's output to reveal: `summary-only` (default) shows just pass/fail; other policies expose more detail Values: `full-evidence`, `summary-only`, `redacted`, `no-detail`. |
+| `--gate-execution-policy` | `<POLICY>` | Gate scheduling policy: `ordered-fail-fast` (default) skips downstream gates after the first failure; `continue-all` runs every declared gate Values: `ordered-fail-fast`, `continue-all`. |
+| `--gate-timeout-seconds` | `<SECONDS>` | Wall-clock timeout, in seconds, for each verification gate command (default 1800 = 30 min). A gate exceeding this fails |
+| `--gate-heartbeat-interval-seconds` | `<SECONDS>` | How often, in seconds, to emit a heartbeat while a gate runs so long gates are not mistaken for a stalled cook (default 5) |
+| `--rerun-completed-gates` | flag | Re-run gates that already recorded a passing result on a previous attempt instead of reusing the recorded pass. Off by default |
+| `--gate-environment-mode` | `<MODE>` | Environment for gate commands: `inherit` (default) extends the current environment; `replace` starts from an empty environment plus `--gate-env` Values: `inherit`, `replace`. |
+| `--gate-env` | `<NAME=VALUE>` | Extra environment variable for gate commands, as `NAME=VALUE`. Repeatable |
+| `--gate-env-from` | `<NAME=SOURCE[/PATH]>` | Preserve a required toolchain setting from the host as `NAME=SOURCE` or `NAME=SOURCE/relative/path`. The mapping is retained in gate evidence |
+| `--gate-toolchain` | `<COMMAND>` | Required executable to initialize before provider execution. Its probe is `COMMAND --version` in the final isolated gate environment. Repeatable |
+| `--isolate-gate-home` | `<ISOLATE_GATE_HOME>` | Run gates with an isolated `$HOME` so gate side effects do not touch the operator's home directory (default true) Values: `true`, `false`. |
+| `--isolate-gate-xdg` | `<ISOLATE_GATE_XDG>` | Run gates with isolated XDG base directories so gate side effects do not touch the operator's config/cache/data dirs (default true) Values: `true`, `false`. |
+| `--max-attempts` | `<N>` | Maximum cook attempts before giving up. Each attempt re-runs the agent and gates; a later attempt can recover from a transient failure (default 3) |
+| `--no-finalize` | flag | Stop after the work is verified but before opening the pull request, leaving the committed change on the worktree branch for manual review or a later `agent-task review`/finalize |
+| `--full` | flag | Return the complete cook report, including nested promotion and gate evidence |
+| `--base` | `<BRANCH>` | Base branch the finalized pull request targets and the branch changes are diffed against (default `main`) |
+| `--head` | `<BRANCH>` | Head branch to push and open the PR from. Defaults to the branch the destination worktree is already on |
+| `--title` | `<TEXT>` | Title for the finalized pull request. Defaults to a title derived from the goal / commit |
+| `--commit-message` | `<TEXT>` | Commit message for the cook's committed change. Defaults to a message derived from the goal |
+| `--protected-branch` | `<BRANCH>` | Branch names the cook refuses to push to or target directly, as a safety guard. Repeatable; defaults to the standard protected set |
+| `--ai-tool` | `<TEXT>` | AI tool disclosure recorded in the PR's assistance attribution (default `AI-assisted`) |
+| `--ai-used-for` | `<TEXT>` | Legacy AI-usage disclosure. The reviewer-facing "Used for" text is now authored by the agent's `review_form.used_for` (a self-reflective process description) and validated by the cook loop's review-form gate; this flag no longer feeds the PR body. Retained only for recipe back-compatibility and defaults empty (no canned platitude) |
+
+## `homeboy agent-task cook-continue`
+
+```sh
+homeboy agent-task cook-continue [OPTIONS] <COOK_OR_ATTEMPT_ID>
+```
+
+Continue a detached Cook from its durable Cook ID or provider attempt ID. The persisted recipe supplies the original prompt, transport, gates, worktree, and disclosure policy
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COOK_OR_ATTEMPT_ID>` | yes | Durable Cook ID or one of its provider attempt IDs |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--full` | flag | Include the complete Cook report rather than the compact lifecycle view |
+
+## `homeboy agent-task loop`
+
+```sh
+homeboy agent-task loop <COMMAND>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy agent-task loop define` | _no help text_ |
+| `homeboy agent-task loop status` | _no help text_ |
+| `homeboy agent-task loop resume` | _no help text_ |
+| `homeboy agent-task loop stop` | _no help text_ |
+
+## `homeboy agent-task loop define`
+
+```sh
+homeboy agent-task loop define [OPTIONS] <SPEC>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SPEC>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--on` | flag | _no help text_ |
+| `--off` | flag | _no help text_ |
+| `--revolution-limit` | `<N>` | _no help text_ |
+| `--resume` | flag | _no help text_ |
+| `--dispatch-backend` | `<BACKEND>` | _no help text_ |
+| `--dispatch-selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--dispatch-model` | `<MODEL>` | _no help text_ |
+| `--dispatch-provider-config` | `<JSON>` | _no help text_ |
+
+## `homeboy agent-task loop status`
+
+```sh
+homeboy agent-task loop status <LOOP_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | _no help text_ |
+
+## `homeboy agent-task loop resume`
+
+```sh
+homeboy agent-task loop resume [OPTIONS] <LOOP_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--revolution-limit` | `<N>` | _no help text_ |
+| `--dispatch-backend` | `<BACKEND>` | _no help text_ |
+| `--dispatch-selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--dispatch-model` | `<MODEL>` | _no help text_ |
+| `--dispatch-provider-config` | `<JSON>` | _no help text_ |
+
+## `homeboy agent-task loop stop`
+
+```sh
+homeboy agent-task loop stop <LOOP_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | _no help text_ |
+
+## `homeboy agent-task run-plan`
+
+```sh
+homeboy agent-task run-plan [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--plan` | `<JSON|@FILE|->` | Agent-task plan as a JSON spec: inline JSON, `@FILE` to read a file, or `-` to read stdin. A bare path is NOT accepted — use `@/path/plan.json` |
+| `--record-run-id` | `<ID>` | _no help text_ |
+| `--timeout-ms` | `<MS>` | _no help text_ |
+
+## `homeboy agent-task run`
+
+```sh
+homeboy agent-task run [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--timeout-ms` | `<MS>` | _no help text_ |
+
+## `homeboy agent-task run-next`
+
+```sh
+homeboy agent-task run-next
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+## `homeboy agent-task submit`
+
+```sh
+homeboy agent-task submit [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--plan` | `<JSON|@FILE|->` | Agent-task plan as a JSON spec: inline JSON, `@FILE` to read a file, or `-` to read stdin. A bare path is NOT accepted — use `@/path/plan.json` |
+| `--run-id` | `<ID>` | _no help text_ |
+
+## `homeboy agent-task status`
+
+```sh
+homeboy agent-task status [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bridge` | flag | _no help text_ |
+| `--since-cursor` | `<CURSOR>` | _no help text_ |
+| `--full` | flag | _no help text_ |
+| `--no-runner-probe` | flag | Answer from durable controller state only, without reaching the runner |
+
+## `homeboy agent-task list`
+
+```sh
+homeboy agent-task list [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--limit` | `<N>` | _no help text_ |
+| `--full` | flag | Return every matching record. This is intentionally explicit because discovery defaults to a finite agent-facing page |
+
+## `homeboy agent-task active`
+
+```sh
+homeboy agent-task active [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--limit` | `<N>` | _no help text_ |
+| `--full` | flag | Return every matching record. This is intentionally explicit because discovery defaults to a finite agent-facing page |
+| `--reconcile` | flag | _no help text_ |
+| `--dry-run` | flag | _no help text_ |
+| `--apply` | flag | _no help text_ |
+
+## `homeboy agent-task reconcile`
+
+```sh
+homeboy agent-task reconcile [OPTIONS] <RUN_ID>
+```
+
+Preview or apply reconciliation for one durable run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | _no help text_ |
+| `--apply` | flag | _no help text_ |
+
+## `homeboy agent-task reconcile-records`
+
+```sh
+homeboy agent-task reconcile-records [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | _no help text_ |
+
+## `homeboy agent-task latest`
+
+```sh
+homeboy agent-task latest [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--limit` | `<N>` | _no help text_ |
+
+## `homeboy agent-task logs`
+
+```sh
+homeboy agent-task logs [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--raw` | flag | Include unprojected runner transport frames under `raw_events` for diagnostics |
+
+## `homeboy agent-task artifacts`
+
+```sh
+homeboy agent-task artifacts [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bridge` | flag | _no help text_ |
+| `--since-cursor` | `<CURSOR>` | _no help text_ |
+| `--full` | flag | _no help text_ |
+| `--no-runner-probe` | flag | Answer from durable controller state only, without reaching the runner |
+
+## `homeboy agent-task evidence`
+
+```sh
+homeboy agent-task evidence [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--kind` | `<KIND>` | _no help text_ |
+| `--task` | `<TASK_ID>` | _no help text_ |
+| `--failure-only` | flag | _no help text_ |
+| `--full` | flag | Return every matching evidence record rather than the bounded preview |
+
+## `homeboy agent-task diagnose`
+
+```sh
+homeboy agent-task diagnose [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--full` | flag | Hydrate every available evidence summary rather than the bounded preview |
+
+## `homeboy agent-task runtime-recover`
+
+```sh
+homeboy agent-task runtime-recover [OPTIONS] <RUN_ID>
+```
+
+Recover a missing or corrupted immutable controller runtime pin
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Durable run whose exact controller executable should be rematerialized |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--source` | `<PATH>` | Trusted source checkout used to rebuild the recorded runtime revision |
+| `--artifact` | `<PATH>` | Exact prebuilt controller executable. Its hash and self identity must match the durable pin |
+
+## `homeboy agent-task runtime-validate`
+
+```sh
+homeboy agent-task runtime-validate <RUN_ID>
+```
+
+Validate controller runtime eligibility without executing provider work
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Durable run to validate without executing its provider lifecycle |
+
+## `homeboy agent-task replay-provider-boundary`
+
+```sh
+homeboy agent-task replay-provider-boundary [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--task` | `<TASK_ID>` | _no help text_ |
+
+## `homeboy agent-task cancel`
+
+```sh
+homeboy agent-task cancel [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--reason` | `<TEXT>` | _no help text_ |
+
+## `homeboy agent-task resume`
+
+```sh
+homeboy agent-task resume [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bridge` | flag | _no help text_ |
+| `--since-cursor` | `<CURSOR>` | _no help text_ |
+| `--full` | flag | _no help text_ |
+| `--no-runner-probe` | flag | Answer from durable controller state only, without reaching the runner |
+
+## `homeboy agent-task retry`
+
+```sh
+homeboy agent-task retry [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--new-run-id` | `<ID>` | _no help text_ |
+| `--run` | flag | _no help text_ |
+
+## `homeboy agent-task fanout`
+
+```sh
+homeboy agent-task fanout <COMMAND>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy agent-task fanout cook-batch` | _no help text_ |
+| `homeboy agent-task fanout plan` | _no help text_ |
+| `homeboy agent-task fanout submit` | _no help text_ |
+| `homeboy agent-task fanout submit-batch` | _no help text_ |
+| `homeboy agent-task fanout status` | _no help text_ |
+| `homeboy agent-task fanout resume` | Resume a durable fanout batch after coordinator loss: idempotently harvest terminal children through gates, commit, push, and PR finalization |
+| `homeboy agent-task fanout artifacts` | _no help text_ |
+| `homeboy agent-task fanout run-plan` | _no help text_ |
+
+## `homeboy agent-task fanout cook-batch`
+
+```sh
+homeboy agent-task fanout cook-batch [OPTIONS] <ISSUE_URL>...
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ISSUE_URL>...` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--repo` | `<REPO>` | _no help text_ |
+| `--from` | `<REF>` | _no help text_ |
+| `--base` | `<BRANCH>` | _no help text_ |
+| `--branch-prefix` | `<PREFIX>` | _no help text_ |
+| `--fanout-id` | `<ID>` | _no help text_ |
+| `--prompt-template` | `<TEXT>` | _no help text_ |
+| `--backend` | `<BACKEND>` | _no help text_ |
+| `--selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--model` | `<MODEL>` | _no help text_ |
+| `--provider-profile` | `<PROFILE>` | _no help text_ |
+| `--secret-env` | `<ENV>` | _no help text_ |
+| `--provider-config` | `<JSON>` | _no help text_ |
+| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
+| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Use for gates whose logs may contain secrets. Repeatable |
+| `--private-gate-reveal` | `<POLICY>` | How much of a `--private-verify` gate's output to reveal: `summary-only` (default) shows just pass/fail; other policies expose more detail Values: `full-evidence`, `summary-only`, `redacted`, `no-detail`. |
+| `--gate-execution-policy` | `<POLICY>` | Gate scheduling policy: `ordered-fail-fast` (default) skips downstream gates after the first failure; `continue-all` runs every declared gate Values: `ordered-fail-fast`, `continue-all`. |
+| `--gate-timeout-seconds` | `<SECONDS>` | Wall-clock timeout, in seconds, for each verification gate command (default 1800 = 30 min). A gate exceeding this fails |
+| `--gate-heartbeat-interval-seconds` | `<SECONDS>` | How often, in seconds, to emit a heartbeat while a gate runs so long gates are not mistaken for a stalled cook (default 5) |
+| `--rerun-completed-gates` | flag | Re-run gates that already recorded a passing result on a previous attempt instead of reusing the recorded pass. Off by default |
+| `--gate-environment-mode` | `<MODE>` | Environment for gate commands: `inherit` (default) extends the current environment; `replace` starts from an empty environment plus `--gate-env` Values: `inherit`, `replace`. |
+| `--gate-env` | `<NAME=VALUE>` | Extra environment variable for gate commands, as `NAME=VALUE`. Repeatable |
+| `--gate-env-from` | `<NAME=SOURCE[/PATH]>` | Preserve a required toolchain setting from the host as `NAME=SOURCE` or `NAME=SOURCE/relative/path`. The mapping is retained in gate evidence |
+| `--gate-toolchain` | `<COMMAND>` | Required executable to initialize before provider execution. Its probe is `COMMAND --version` in the final isolated gate environment. Repeatable |
+| `--isolate-gate-home` | `<ISOLATE_GATE_HOME>` | Run gates with an isolated `$HOME` so gate side effects do not touch the operator's home directory (default true) Values: `true`, `false`. |
+| `--isolate-gate-xdg` | `<ISOLATE_GATE_XDG>` | Run gates with isolated XDG base directories so gate side effects do not touch the operator's config/cache/data dirs (default true) Values: `true`, `false`. |
+| `--dry-run` | flag | _no help text_ |
+| `--run-plan` | flag | _no help text_ |
+
+## `homeboy agent-task fanout plan`
+
+```sh
+homeboy agent-task fanout plan [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<SPEC>` | _no help text_ |
+| `--fanout-id` | `<ID>` | _no help text_ |
+| `--backend` | `<BACKEND>` | _no help text_ |
+| `--selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--model` | `<MODEL>` | _no help text_ |
+
+## `homeboy agent-task fanout submit`
+
+```sh
+homeboy agent-task fanout submit [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<SPEC>` | _no help text_ |
+| `--fanout-id` | `<ID>` | _no help text_ |
+| `--backend` | `<BACKEND>` | _no help text_ |
+| `--selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--model` | `<MODEL>` | _no help text_ |
+| `--run-id` | `<ID>` | _no help text_ |
+
+## `homeboy agent-task fanout submit-batch`
+
+```sh
+homeboy agent-task fanout submit-batch [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<SPEC>` | _no help text_ |
+| `--fanout-id` | `<ID>` | _no help text_ |
+| `--backend` | `<BACKEND>` | _no help text_ |
+| `--selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--model` | `<MODEL>` | _no help text_ |
+| `--batch-id` | `<ID>` | _no help text_ |
+
+## `homeboy agent-task fanout status`
+
+```sh
+homeboy agent-task fanout status <BATCH_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<BATCH_ID>` | yes | _no help text_ |
+
+## `homeboy agent-task fanout resume`
+
+```sh
+homeboy agent-task fanout resume <BATCH_ID>
+```
+
+Resume a durable fanout batch after coordinator loss: idempotently harvest terminal children through gates, commit, push, and PR finalization
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<BATCH_ID>` | yes | _no help text_ |
+
+## `homeboy agent-task fanout artifacts`
+
+```sh
+homeboy agent-task fanout artifacts <BATCH_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<BATCH_ID>` | yes | _no help text_ |
+
+## `homeboy agent-task fanout run-plan`
+
+```sh
+homeboy agent-task fanout run-plan [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<SPEC>` | _no help text_ |
+| `--fanout-id` | `<ID>` | _no help text_ |
+| `--backend` | `<BACKEND>` | _no help text_ |
+| `--selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--model` | `<MODEL>` | _no help text_ |
+| `--record-run-id` | `<ID>` | _no help text_ |
+
+## `homeboy agent-task review`
+
+```sh
+homeboy agent-task review [OPTIONS] <RUN_ID>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--to-worktree` | `<HANDLE>` | _no help text_ |
+| `--provider-command` | `<COMMAND>` | Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`. |
+| `--provider-argv` | `<ARG>` | Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`. |
+
+## `homeboy agent-task promote`
+
+```sh
+homeboy agent-task promote [OPTIONS] <SOURCE>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SOURCE>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--to-worktree` | `<HANDLE>` | _no help text_ |
+| `--base` | `<BRANCH>` | Declared base branch resolved immediately before promotion gates run |
+| `--provider-command` | `<COMMAND>` | Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`. |
+| `--provider-argv` | `<ARG>` | Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`. |
+| `--task-id` | `<TASK_ID>` | _no help text_ |
+| `--artifact-id` | `<ARTIFACT_ID>` | _no help text_ |
+| `--dry-run` | flag | _no help text_ |
+| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
+| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Use for gates whose logs may contain secrets. Repeatable |
+| `--private-gate-reveal` | `<POLICY>` | How much of a `--private-verify` gate's output to reveal: `summary-only` (default) shows just pass/fail; other policies expose more detail Values: `full-evidence`, `summary-only`, `redacted`, `no-detail`. |
+| `--gate-execution-policy` | `<POLICY>` | Gate scheduling policy: `ordered-fail-fast` (default) skips downstream gates after the first failure; `continue-all` runs every declared gate Values: `ordered-fail-fast`, `continue-all`. |
+| `--gate-timeout-seconds` | `<SECONDS>` | Wall-clock timeout, in seconds, for each verification gate command (default 1800 = 30 min). A gate exceeding this fails |
+| `--gate-heartbeat-interval-seconds` | `<SECONDS>` | How often, in seconds, to emit a heartbeat while a gate runs so long gates are not mistaken for a stalled cook (default 5) |
+| `--rerun-completed-gates` | flag | Re-run gates that already recorded a passing result on a previous attempt instead of reusing the recorded pass. Off by default |
+| `--gate-environment-mode` | `<MODE>` | Environment for gate commands: `inherit` (default) extends the current environment; `replace` starts from an empty environment plus `--gate-env` Values: `inherit`, `replace`. |
+| `--gate-env` | `<NAME=VALUE>` | Extra environment variable for gate commands, as `NAME=VALUE`. Repeatable |
+| `--gate-env-from` | `<NAME=SOURCE[/PATH]>` | Preserve a required toolchain setting from the host as `NAME=SOURCE` or `NAME=SOURCE/relative/path`. The mapping is retained in gate evidence |
+| `--gate-toolchain` | `<COMMAND>` | Required executable to initialize before provider execution. Its probe is `COMMAND --version` in the final isolated gate environment. Repeatable |
+| `--isolate-gate-home` | `<ISOLATE_GATE_HOME>` | Run gates with an isolated `$HOME` so gate side effects do not touch the operator's home directory (default true) Values: `true`, `false`. |
+| `--isolate-gate-xdg` | `<ISOLATE_GATE_XDG>` | Run gates with isolated XDG base directories so gate side effects do not touch the operator's config/cache/data dirs (default true) Values: `true`, `false`. |
+
+## `homeboy agent-task adopt`
+
+```sh
+homeboy agent-task adopt [OPTIONS] <RUN_OR_COOK_ID>
+```
+
+Adopt an immutable commit candidate through a tracked cook's normal gates and finalization
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_OR_COOK_ID>` | yes | Existing durable run id or cook id whose recipe owns the candidate lifecycle |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--attempt` | `<N>` | Select an exact durable attempt from the Cook recipe. Required when attempts use different policies |
+| `--candidate-ref` | `<SHA>` | Immutable commit revision in the recorded source worktree |
+| `--ai-model` | `<MODEL>` | Concrete model that prepared the externally supplied candidate |
+| `--replace-interrupted` | flag | Replace a stale interrupted adoption while retaining its lifecycle evidence |
+| `--full` | flag | Return the complete cook adoption report, including nested gate evidence |
+
+## `homeboy agent-task finalize-pr`
+
+```sh
+homeboy agent-task finalize-pr [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--recover` | `<RUN_OR_COOK_ID>` | Hydrate finalization from a durable Cook recipe and its applied promotion |
+| `--run-id` | `<ID>` | _no help text_ |
+| `--path` | `<PATH>` | _no help text_ |
+| `--base` | `<BRANCH>` | _no help text_ |
+| `--verified-base-sha` | `<SHA>` | Immutable base commit SHA recorded before the declared verification gates ran |
+| `--head` | `<BRANCH>` | _no help text_ |
+| `--title` | `<TEXT>` | _no help text_ |
+| `--commit-message` | `<TEXT>` | _no help text_ |
+| `--attempt-summary` | `<TEXT>` | Attempt summary to include in the PR body |
+| `--source-ref` | `<REF>` | Source tracker/reference URL or identifier. Repeatable |
+| `--artifact-ref` | `<REF>` | Artifact/evidence URL, path, or identifier. Repeatable |
+| `--ai-tool` | `<TEXT>` | AI tool disclosure line for the PR body |
+| `--ai-model` | `<MODEL>` | Actual model identifier for AI disclosure. Finalization requires a recorded model |
+| `--related-finding-id` | `<ID>` | Source finding id shared by sibling generated PRs |
+| `--source-packet-id` | `<ID>` | Source validation packet id shared by sibling generated PRs |
+| `--change-kind` | `<KIND>` | Generated change kind, e.g. evidence-only, runtime-fix, or test-only |
+| `--supersedes` | `<REF>` | Generated PR or artifact this PR supersedes. Repeatable |
+| `--depends-on` | `<REF>` | Generated PR or artifact this PR depends on. Repeatable |
+| `--targeted-check-run` | `<COMMAND>` | Targeted verification command that ran before finalization. Repeatable |
+| `--targeted-checks-unavailable` | `<TEXT>` | Exact backend limitation when targeted checks could not be run |
+| `--ci-expected` | `<CHECK>` | CI check expected to run after push. Repeatable |
+| `--manual-reviewer-check` | `<TEXT>` | Manual reviewer verification requested when targeted checks/CI do not cover behavior |
+| `--why-not-broader-than-packet` | `<TEXT>` | Runtime-fix evidence bound for generated predicates/semantics |
+| `--evidence-discriminator` | `<TEXT>` | Evidence-specific discriminator preserved by the runtime fix. Repeatable |
+| `--nearby-contract-preserved` | `<TEXT>` | Nearby predicate/contract preserved by the runtime fix. Repeatable |
+| `--changed-public-contract` | `<ID=>SUMMARY>` | Declared changed public contract as ID=>SUMMARY. Requires the complete compatibility/external-usage evidence bundle below |
+| `--compatibility-impact` | `<TEXT>` | Compatibility impact for declared public contracts |
+| `--external-consumer-impact` | `<TEXT>` | External-consumer impact for declared public contracts |
+| `--external-usage-status` | `<STATUS>` | External usage evidence status: completed or unavailable_manual_review |
+| `--external-usage-source` | `<TEXT>` | Source used for external usage evidence |
+| `--external-usage-limitations` | `<TEXT>` | Limitations of the external usage evidence or manual review |
+| `--external-usage-url` | `<URL>` | Reviewer-resolvable HTTPS URL for external usage evidence |
+| `--gate-result` | `<NAME=STATUS[:DETAIL]>` | _no help text_ |
+| `--changed-file` | `<PATH>` | _no help text_ |
+| `--protected-branch` | `<BRANCH>` | _no help text_ |
+| `--ai-used-for` | `<TEXT>` | _no help text_ |
+| `--summary` | `<TEXT>` | _no help text_ |
+| `--what-changed` | `<TEXT>` | _no help text_ |
+| `--test-step` | `<COMMAND=>EXPECTED>` | Reviewer test step. Strict shape: COMMAND=>EXPECTED |
+| `--compatibility` | `<TEXT>` | _no help text_ |
+| `--closes` | `<ISSUE_REF>` | Closing issue reference: #NUMBER, OWNER/REPO#NUMBER, or a github.com issue URL |
+| `--relates-to` | `<ISSUE_REF>` | Related issue reference: #NUMBER, OWNER/REPO#NUMBER, or a github.com issue URL |
+| `--review-override` | `<TARGET=VALUE@PROVENANCE>` | _no help text_ |
+| `--preflight` | flag | Validate the complete hydrated dossier and candidate without publishing |
+| `--manual-finalization` | flag | _no help text_ |
+
+## `homeboy agent-task gate-feedback`
+
+```sh
+homeboy agent-task gate-feedback [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--promotion` | `<JSON|@FILE|->` | Promotion report as a JSON spec: inline JSON, `@FILE` to read a file, or `-` to read stdin. A bare path is NOT accepted — use `@/path/promotion.json` |
+| `--source-task` | `<JSON|@FILE|->` | Source task as a JSON spec: inline JSON, `@FILE` to read a file, or `-` to read stdin. A bare path is NOT accepted — use `@/path/task.json` |
+| `--attempt` | `<N>` | _no help text_ |
+| `--max-attempts` | `<N>` | _no help text_ |
+| `--source-run-id` | `<ID>` | _no help text_ |
+| `--current-diff` | `<SPEC>` | _no help text_ |
+
+## `homeboy agent-task providers`
+
+```sh
+homeboy agent-task providers [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--backend` | `<BACKEND>` | _no help text_ |
+| `--selector` | `<PROVIDER_ID>` | _no help text_ |
+| `--runtime` | `<RUNTIME>` | Restrict results to the runtime that owns the provider |
+| `--status` | `<STATUS>` | Restrict results to `default` or `available` providers |
+| `--secret-env` | `<ENV>` | _no help text_ |
+| `--validate-readiness` | flag | _no help text_ |
+| `--refresh` | flag | _no help text_ |
+| `--catalog` | flag | Return the full multi-backend catalog even when `--backend` is set. Without this, `--backend X` filters the presentation to X so the output stays within caller display limits (#9654) |
+| `--full` | flag | Return the complete provider declarations and discovery diagnostics |
+
+## `homeboy agent-task prompts`
+
+```sh
+homeboy agent-task prompts <COMMAND>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy agent-task prompts save` | Save a markdown prompt in Homeboy's agent-task prompt store |
+| `homeboy agent-task prompts list` | List stored agent-task prompts |
+| `homeboy agent-task prompts show` | Show a stored agent-task prompt |
+| `homeboy agent-task prompts remove` | Remove a stored agent-task prompt |
+
+## `homeboy agent-task prompts save`
+
+```sh
+homeboy agent-task prompts save [OPTIONS] <NAME>
+```
+
+Save a markdown prompt in Homeboy's agent-task prompt store
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<NAME>` | yes | Stable prompt name. Unsafe path characters are normalized for storage |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<PROMPT>` | Prompt markdown content, @file, or - for stdin |
+
+## `homeboy agent-task prompts list`
+
+```sh
+homeboy agent-task prompts list
+```
+
+List stored agent-task prompts
+
+## `homeboy agent-task prompts show`
+
+```sh
+homeboy agent-task prompts show <NAME>
+```
+
+Show a stored agent-task prompt
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<NAME>` | yes | Stored prompt name or id |
+
+## `homeboy agent-task prompts remove`
+
+```sh
+homeboy agent-task prompts remove <NAME>
+```
+
+Remove a stored agent-task prompt
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<NAME>` | yes | Stored prompt name or id |
+
+## `homeboy agent-task contract`
+
+```sh
+homeboy agent-task contract [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--format` | `<FORMAT>` | _no help text_ Values: `json`. |
+
+## `homeboy agent-task compile-loop`
+
+```sh
+homeboy agent-task compile-loop [OPTIONS]
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--definition` | `<SPEC>` | _no help text_ |
+
+## `homeboy agent-task auth`
+
+```sh
+homeboy agent-task auth <COMMAND>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy agent-task auth status` | Show redacted readiness for provider secret environment variables |
+| `homeboy agent-task auth set-keychain` | Store a provider secret in the OS keychain and map it to a required env name |
+| `homeboy agent-task auth set-config` | Store a provider secret in Homeboy global config and map it to a required env name |
+| `homeboy agent-task auth set-keychain-bundle` | Store a JSON secret bundle in one OS keychain item |
+| `homeboy agent-task auth map-env` | Map a required provider env name to another process env var |
+| `homeboy agent-task auth map-keychain-bundle` | Map a required provider env name to a field in a JSON keychain bundle |
+| `homeboy agent-task auth remove` | Remove a provider secret source mapping |
+
+## `homeboy agent-task auth status`
+
+```sh
+homeboy agent-task auth status [OPTIONS]
+```
+
+Show redacted readiness for provider secret environment variables
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--backend` | `<BACKEND>` | Executor backend whose required secrets to report. Defaults to the same backend cook/dispatch would use when omitted |
+| `--selector` | `<PROVIDER_ID>` | Provider id to disambiguate when more than one provider exists for the backend |
+| `--secret-env` | `<ENV>` | Secret environment variable name to check without exposing its value. Repeatable. When omitted, the selected backend's required secrets are used |
+
+## `homeboy agent-task auth set-keychain`
+
+```sh
+homeboy agent-task auth set-keychain [OPTIONS] <ENV> [VALUE]
+```
+
+Store a provider secret in the OS keychain and map it to a required env name
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ENV>` | yes | Required provider environment variable name to satisfy |
+| `[VALUE]` | no | Secret value. Omit to prompt securely |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--value-stdin` | flag | Read the secret value from stdin |
+| `--scope` | `<SCOPE>` | Keychain scope. Defaults to agent-task |
+| `--name` | `<NAME>` | Keychain entry name. Defaults to ENV |
+
+## `homeboy agent-task auth set-config`
+
+```sh
+homeboy agent-task auth set-config [OPTIONS] <ENV> [VALUE]
+```
+
+Store a provider secret in Homeboy global config and map it to a required env name
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ENV>` | yes | Required provider environment variable name to satisfy |
+| `[VALUE]` | no | Secret value. Omit to prompt securely |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--value-stdin` | flag | Read the secret value from stdin |
+
+## `homeboy agent-task auth set-keychain-bundle`
+
+```sh
+homeboy agent-task auth set-keychain-bundle [OPTIONS] <BUNDLE> [JSON]
+```
+
+Store a JSON secret bundle in one OS keychain item
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<BUNDLE>` | yes | Logical bundle id to store |
+| `[JSON]` | no | JSON bundle value. Omit to prompt securely |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--value-stdin` | flag | Read the JSON bundle value from stdin |
+| `--scope` | `<SCOPE>` | Keychain scope. Defaults to agent-task |
+| `--name` | `<NAME>` | Keychain entry name. Defaults to BUNDLE |
+
+## `homeboy agent-task auth map-env`
+
+```sh
+homeboy agent-task auth map-env [OPTIONS] <ENV>
+```
+
+Map a required provider env name to another process env var
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ENV>` | yes | Required provider environment variable name to satisfy |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--from` | `<ENV>` | Source process environment variable. Defaults to ENV |
+
+## `homeboy agent-task auth map-keychain-bundle`
+
+```sh
+homeboy agent-task auth map-keychain-bundle [OPTIONS] <ENV>
+```
+
+Map a required provider env name to a field in a JSON keychain bundle
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ENV>` | yes | Required provider environment variable name to satisfy |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bundle` | `<BUNDLE>` | Logical bundle id to read |
+| `--field` | `<FIELD>` | Field path inside the JSON bundle, using dots for nested objects |
+| `--scope` | `<SCOPE>` | Keychain scope. Defaults to agent-task |
+| `--name` | `<NAME>` | Keychain entry name. Defaults to BUNDLE |
+
+## `homeboy agent-task auth remove`
+
+```sh
+homeboy agent-task auth remove [OPTIONS] <ENV>
+```
+
+Remove a provider secret source mapping
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ENV>` | yes | Required provider environment variable name whose mapping should be removed |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--keychain` | flag | Also remove the mapped keychain entry when the mapping points at keychain |
+
+## `homeboy agent-task controller`
+
+```sh
+homeboy agent-task controller <COMMAND>
+```
+
+_This command declares no clap help text, so no description can be generated for it._
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy agent-task controller init` | Create a durable loop controller record |
+| `homeboy agent-task controller from-spec` | Initialize or resume a durable loop controller from a repo-authored JSON spec |
+| `homeboy agent-task controller run-from-spec` | Materialize, initialize, and run a bounded controller loop from a repo-authored JSON spec |
+| `homeboy agent-task controller materialize` | Materialize a repo-authored loop spec with explicit run inputs |
+| `homeboy agent-task controller validate-proof` | Validate a proof, materialized spec, or controller record for deterministic handoff |
+| `homeboy agent-task controller plan` | Compile a controller spec into a dry Homeboy plan without writing state |
+| `homeboy agent-task controller status` | Read a durable loop controller record |
+| `homeboy agent-task controller diagnose` | Render the controller failure tree for failed child actions |
+| `homeboy agent-task controller list` | List durable loop controller records |
+| `homeboy agent-task controller events` | Apply a generic external controller event |
+| `homeboy agent-task controller apply-event` | Apply an external event and resume matching waits |
+| `homeboy agent-task controller run-next` | Claim and execute the next pending controller action |
+| `homeboy agent-task controller run` | Claim and execute one pending controller action |
+| `homeboy agent-task controller resume` | Execute pending controller actions until no executable action remains |
+| `homeboy agent-task controller mark-human-ready` | Mark a tracked entity as human-ready work |
+| `homeboy agent-task controller proof` | Run a one-command end-to-end controller proof from a named profile + runner |
+
+## `homeboy agent-task controller init`
+
+```sh
+homeboy agent-task controller init [OPTIONS] <LOOP_ID>
+```
+
+Create a durable loop controller record
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id. Unsafe path characters are normalized for storage |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--phase` | `<PHASE>` | Initial controller phase |
+| `--config-version` | `<VERSION>` | Declared graph/config version for resume compatibility |
+
+## `homeboy agent-task controller from-spec`
+
+```sh
+homeboy agent-task controller from-spec [OPTIONS] <SPEC>
+```
+
+Initialize or resume a durable loop controller from a repo-authored JSON spec.
+
+With a configured default Lab runner, --resume uses automatic Lab offload unless local execution is explicitly forced.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SPEC>` | yes | Repo loop spec JSON, @file, or - for stdin |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--resume` | flag | Execute pending actions after applying the spec |
+| `--inputs` | `<JSON>` | Explicit controller run inputs JSON, @file, or - for stdin. Supports `inputs` and `metadata` objects |
+| `--policy-result` | `<JSON>` | Declarative policy result JSON, @file, or - for stdin. Repeatable |
+| `--max-actions` | `<N>` | Maximum controller actions to execute when --resume is supplied |
+| `--reconcile-stale` | flag | On --resume, automatically reset stale persisted controller state and re-create it from this spec |
+| `--replace` | flag | On --resume, discard stale persisted controller state and re-create it from this spec |
+| `--fork` | flag | On --resume, apply this spec under a derived fork loop id, leaving the original untouched |
+| `--resume-existing` | flag | On --resume, accept stale/mismatched persisted state and resume the existing controller as-is |
+| `--doctor` | flag | Compile and preflight generic controller prerequisites without writing state |
+| `--dispatch-backend` | `<BACKEND>` | Executor backend to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-selector` | `<PROVIDER_ID>` | Extension-provider selector: the Homeboy executor provider id (e.g. `sample.executor-provider`) that runs controller-spawned dispatch actions when the action omits one. This is not model/runtime provider configuration; pass runtime-specific values in --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids |
+| `--dispatch-model` | `<MODEL>` | Model override to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-provider-config` | `<JSON>` | Agent/model provider config (JSON, @file, or -): the nested AI runtime/provider/model the selected executor uses for controller-spawned dispatch actions when the action omits one. Put runtime-specific provider selection here, not in --dispatch-selector |
+
+## `homeboy agent-task controller run-from-spec`
+
+```sh
+homeboy agent-task controller run-from-spec [OPTIONS] <SPEC>
+```
+
+Materialize, initialize, and run a bounded controller loop from a repo-authored JSON spec.
+
+With a configured default Lab runner, this uses automatic Lab offload unless local execution is explicitly forced.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SPEC>` | yes | Repo loop spec JSON, @file, -, or a generator manifest that writes a spec file |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--inputs` | `<JSON>` | Explicit run inputs JSON, @file, or - for stdin. Supports `inputs` and `metadata` objects |
+| `--policy-result` | `<JSON>` | Declarative policy result JSON, @file, or - for stdin. Repeatable |
+| `--max-actions` | `<N>` | Maximum controller actions to execute before returning a bounded partial result |
+| `--reconcile-stale` | flag | One-flag safe proof-run mode: automatically reset stale persisted controller state and re-derive isolated run-scoped state from this spec, with no manual state cleanup. Use this for proof/rerun workflows when the persisted spec fingerprint conflicts with the requested spec |
+| `--replace` | flag | Discard stale persisted controller state and re-create it from this spec before running |
+| `--fork` | flag | Apply this spec under a derived fork loop id, leaving the original controller untouched |
+| `--resume-existing` | flag | Accept stale/mismatched persisted state and resume the existing controller as-is |
+| `--dispatch-backend` | `<BACKEND>` | Executor backend to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-selector` | `<PROVIDER_ID>` | Extension-provider selector: the Homeboy executor provider id (e.g. `sample.executor-provider`) that runs controller-spawned dispatch actions when the action omits one. This is not model/runtime provider configuration; pass runtime-specific values in --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids |
+| `--dispatch-model` | `<MODEL>` | Model override to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-provider-config` | `<JSON>` | Agent/model provider config (JSON, @file, or -): the nested AI runtime/provider/model the selected executor uses for controller-spawned dispatch actions when the action omits one. Put runtime-specific provider selection here, not in --dispatch-selector |
+
+## `homeboy agent-task controller materialize`
+
+```sh
+homeboy agent-task controller materialize [OPTIONS] <SPEC>
+```
+
+Materialize a repo-authored loop spec with explicit run inputs.
+
+With a configured default Lab runner, this uses automatic Lab offload unless local execution is explicitly forced.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SPEC>` | yes | Repo loop spec JSON, @file, -, or a generator manifest that writes a spec file |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--inputs` | `<JSON>` | Explicit run inputs JSON, @file, or - for stdin. Supports `inputs` and `metadata` objects |
+| `--policy-result` | `<JSON>` | Declarative policy result JSON, @file, or - for stdin. Repeatable |
+
+## `homeboy agent-task controller validate-proof`
+
+```sh
+homeboy agent-task controller validate-proof <JSON>
+```
+
+Validate a proof, materialized spec, or controller record for deterministic handoff
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<JSON>` | yes | Proof JSON, materialize output JSON, controller record JSON, @file, or - for stdin |
+
+## `homeboy agent-task controller plan`
+
+```sh
+homeboy agent-task controller plan <SPEC>
+```
+
+Compile a controller spec into a dry Homeboy plan without writing state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SPEC>` | yes | Controller spec JSON, @file, or - for stdin |
+
+## `homeboy agent-task controller status`
+
+```sh
+homeboy agent-task controller status [OPTIONS] <LOOP_ID>
+```
+
+Read a durable loop controller record
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--spec` | `<SPEC>` | Optional repo loop spec JSON, @file, or - to compare against persisted controller state |
+| `--dispatch-backend` | `<BACKEND>` | Executor backend to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-selector` | `<PROVIDER_ID>` | Extension-provider selector: the Homeboy executor provider id (e.g. `sample.executor-provider`) that runs controller-spawned dispatch actions when the action omits one. This is not model/runtime provider configuration; pass runtime-specific values in --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids |
+| `--dispatch-model` | `<MODEL>` | Model override to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-provider-config` | `<JSON>` | Agent/model provider config (JSON, @file, or -): the nested AI runtime/provider/model the selected executor uses for controller-spawned dispatch actions when the action omits one. Put runtime-specific provider selection here, not in --dispatch-selector |
+
+## `homeboy agent-task controller diagnose`
+
+```sh
+homeboy agent-task controller diagnose [OPTIONS] <LOOP_ID>
+```
+
+Render the controller failure tree for failed child actions
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--spec` | `<SPEC>` | Optional repo loop spec JSON, @file, or - to compare against persisted controller state |
+| `--dispatch-backend` | `<BACKEND>` | Executor backend to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-selector` | `<PROVIDER_ID>` | Extension-provider selector: the Homeboy executor provider id (e.g. `sample.executor-provider`) that runs controller-spawned dispatch actions when the action omits one. This is not model/runtime provider configuration; pass runtime-specific values in --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids |
+| `--dispatch-model` | `<MODEL>` | Model override to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-provider-config` | `<JSON>` | Agent/model provider config (JSON, @file, or -): the nested AI runtime/provider/model the selected executor uses for controller-spawned dispatch actions when the action omits one. Put runtime-specific provider selection here, not in --dispatch-selector |
+
+## `homeboy agent-task controller list`
+
+```sh
+homeboy agent-task controller list
+```
+
+List durable loop controller records
+
+## `homeboy agent-task controller events`
+
+```sh
+homeboy agent-task controller events [OPTIONS] <LOOP_ID>
+```
+
+Apply a generic external controller event
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--event-type` | `<TYPE>` | External event type, for example github.pr.merged or task.completed |
+| `--event-id` | `<ID>` | Stable event id. Generated from the loop history length when omitted |
+| `--event-key` | `<KEY>` | Optional deterministic event key, such as repo#pr or a check-suite id |
+| `--entity-id` | `<ID>` | Optional target entity id for wait matching and lineage |
+| `--payload` | `<JSON>` | Event payload JSON, @file, or - for stdin. May contain a `policy` object to evaluate |
+
+## `homeboy agent-task controller apply-event`
+
+```sh
+homeboy agent-task controller apply-event [OPTIONS] <LOOP_ID>
+```
+
+Apply an external event and resume matching waits
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--event-type` | `<TYPE>` | External event type, for example github.pr.merged or task.completed |
+| `--event-id` | `<ID>` | Stable event id. Generated from the loop history length when omitted |
+| `--event-key` | `<KEY>` | Optional deterministic event key, such as repo#pr or a check-suite id |
+| `--entity-id` | `<ID>` | Optional target entity id for wait matching and lineage |
+| `--payload` | `<JSON>` | Event payload JSON, @file, or - for stdin. May contain a `policy` object to evaluate |
+
+## `homeboy agent-task controller run-next`
+
+```sh
+homeboy agent-task controller run-next [OPTIONS] <LOOP_ID>
+```
+
+Claim and execute the next pending controller action
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dispatch-backend` | `<BACKEND>` | Executor backend to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-selector` | `<PROVIDER_ID>` | Extension-provider selector: the Homeboy executor provider id (e.g. `sample.executor-provider`) that runs controller-spawned dispatch actions when the action omits one. This is not model/runtime provider configuration; pass runtime-specific values in --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids |
+| `--dispatch-model` | `<MODEL>` | Model override to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-provider-config` | `<JSON>` | Agent/model provider config (JSON, @file, or -): the nested AI runtime/provider/model the selected executor uses for controller-spawned dispatch actions when the action omits one. Put runtime-specific provider selection here, not in --dispatch-selector |
+
+## `homeboy agent-task controller run`
+
+```sh
+homeboy agent-task controller run [OPTIONS] <LOOP_ID>
+```
+
+Claim and execute one pending controller action
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--action-id` | `<ID>` | Pending controller action id to execute |
+| `--dispatch-backend` | `<BACKEND>` | Executor backend to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-selector` | `<PROVIDER_ID>` | Extension-provider selector: the Homeboy executor provider id (e.g. `sample.executor-provider`) that runs controller-spawned dispatch actions when the action omits one. This is not model/runtime provider configuration; pass runtime-specific values in --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids |
+| `--dispatch-model` | `<MODEL>` | Model override to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-provider-config` | `<JSON>` | Agent/model provider config (JSON, @file, or -): the nested AI runtime/provider/model the selected executor uses for controller-spawned dispatch actions when the action omits one. Put runtime-specific provider selection here, not in --dispatch-selector |
+
+## `homeboy agent-task controller resume`
+
+```sh
+homeboy agent-task controller resume [OPTIONS] <LOOP_ID>
+```
+
+Execute pending controller actions until no executable action remains
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dispatch-backend` | `<BACKEND>` | Executor backend to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-selector` | `<PROVIDER_ID>` | Extension-provider selector: the Homeboy executor provider id (e.g. `sample.executor-provider`) that runs controller-spawned dispatch actions when the action omits one. This is not model/runtime provider configuration; pass runtime-specific values in --dispatch-provider-config. Run `homeboy agent-task providers` for valid ids |
+| `--dispatch-model` | `<MODEL>` | Model override to use for controller-spawned dispatch actions when the action omits one |
+| `--dispatch-provider-config` | `<JSON>` | Agent/model provider config (JSON, @file, or -): the nested AI runtime/provider/model the selected executor uses for controller-spawned dispatch actions when the action omits one. Put runtime-specific provider selection here, not in --dispatch-selector |
+
+## `homeboy agent-task controller mark-human-ready`
+
+```sh
+homeboy agent-task controller mark-human-ready [OPTIONS] <LOOP_ID>
+```
+
+Mark a tracked entity as human-ready work
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<LOOP_ID>` | yes | Durable loop id returned by `agent-task controller init` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--entity-id` | `<ID>` | Entity id to mark human-ready |
+| `--reason` | `<TEXT>` | Operator-visible reason stored in loop history |
+
+## `homeboy agent-task controller proof`
+
+```sh
+homeboy agent-task controller proof [OPTIONS]
+```
+
+Run a one-command end-to-end controller proof from a named profile + runner
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--profile` | `<NAME>` | Named proof profile (intent + policy). Resolved from the registry passed via --profiles; the orchestration never branches on the profile name |
+| `--runner` | `<RUNNER>` | Runner to dispatch the proof through (for example a Lab runner id) |
+| `--profiles` | `<JSON>` | Proof profile registry JSON, @file, or - for stdin: a generic object mapping profile names to profile definitions. Keeps profile data out of core so adding a profile is pure data |
+| `--seed` | `<SEED>` | Optional explicit seed material for run-scoped identity. Defaults to a fresh timestamp so each invocation derives an isolated run/loop id |
+| `--max-actions` | `<N>` | Maximum controller actions to execute once preflight passes |
+| `--preflight-only` | flag | Run preflight reconciliation only; do not dispatch even when it passes |
+

--- a/docs/reference/cli/commands/api.md
+++ b/docs/reference/cli/commands/api.md
@@ -1,0 +1,352 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy api` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/api.md](../../../commands/api.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy api`
+
+```sh
+homeboy api <COMMAND>
+```
+
+Make API requests to a project
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy api auth` | Manage API credentials and auth profiles |
+| `homeboy api http` | Make generic HTTP requests to full URLs |
+| `homeboy api get` | Make a GET request |
+| `homeboy api post` | Make a POST request |
+| `homeboy api put` | Make a PUT request |
+| `homeboy api patch` | Make a PATCH request |
+| `homeboy api delete` | Make a DELETE request |
+
+## `homeboy api auth`
+
+```sh
+homeboy api auth <COMMAND>
+```
+
+Manage API credentials and auth profiles
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy api auth login` | Authenticate with a project's API |
+| `homeboy api auth set` | Store a project API variable in the OS keychain |
+| `homeboy api auth get` | Read a project API variable from the OS keychain |
+| `homeboy api auth remove` | Remove a project API variable from the OS keychain |
+| `homeboy api auth logout` | Clear stored authentication for a project |
+| `homeboy api auth status` | Show authentication status for a project |
+| `homeboy api auth profile` | Manage reusable auth profiles for generic HTTP requests |
+
+## `homeboy api auth login`
+
+```sh
+homeboy api auth login [OPTIONS]
+```
+
+Authenticate with a project's API
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECT>` | Project ID |
+| `--identifier` | `<IDENTIFIER>` | Username or email |
+| `--password` | `<PASSWORD>` | Password (or read from stdin) |
+
+## `homeboy api auth set`
+
+```sh
+homeboy api auth set [OPTIONS] <VARIABLE> [VALUE]
+```
+
+Store a project API variable in the OS keychain
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<VARIABLE>` | yes | Variable name |
+| `[VALUE]` | no | Secret value (or read from stdin) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECT>` | Project ID |
+
+## `homeboy api auth get`
+
+```sh
+homeboy api auth get [OPTIONS] <VARIABLE>
+```
+
+Read a project API variable from the OS keychain
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<VARIABLE>` | yes | Variable name |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECT>` | Project ID |
+| `--redacted` | flag | Return a redacted marker instead of the secret value |
+
+## `homeboy api auth remove`
+
+```sh
+homeboy api auth remove [OPTIONS] <VARIABLE>
+```
+
+Remove a project API variable from the OS keychain
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<VARIABLE>` | yes | Variable name |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECT>` | Project ID |
+
+## `homeboy api auth logout`
+
+```sh
+homeboy api auth logout [OPTIONS]
+```
+
+Clear stored authentication for a project
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECT>` | Project ID |
+
+## `homeboy api auth status`
+
+```sh
+homeboy api auth status [OPTIONS]
+```
+
+Show authentication status for a project
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECT>` | Project ID |
+
+## `homeboy api auth profile`
+
+```sh
+homeboy api auth profile <COMMAND>
+```
+
+Manage reusable auth profiles for generic HTTP requests
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy api auth profile set-basic` | Store a Basic auth profile in the OS keychain |
+| `homeboy api auth profile set-bearer` | Store a Bearer token auth profile in the OS keychain |
+| `homeboy api auth profile status` | Show whether an auth profile is available |
+| `homeboy api auth profile remove` | Remove an auth profile from the OS keychain |
+
+## `homeboy api auth profile set-basic`
+
+```sh
+homeboy api auth profile set-basic [OPTIONS] <PROFILE>
+```
+
+Store a Basic auth profile in the OS keychain
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROFILE>` | yes | Profile name |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--username` | `<USERNAME>` | Username |
+| `--password` | `<PASSWORD>` | Password; omit to prompt securely |
+
+## `homeboy api auth profile set-bearer`
+
+```sh
+homeboy api auth profile set-bearer [OPTIONS] <PROFILE>
+```
+
+Store a Bearer token auth profile in the OS keychain
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROFILE>` | yes | Profile name |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--token` | `<TOKEN>` | Token; omit to prompt securely |
+
+## `homeboy api auth profile status`
+
+```sh
+homeboy api auth profile status <PROFILE>
+```
+
+Show whether an auth profile is available
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROFILE>` | yes | Profile name |
+
+## `homeboy api auth profile remove`
+
+```sh
+homeboy api auth profile remove <PROFILE>
+```
+
+Remove an auth profile from the OS keychain
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROFILE>` | yes | Profile name |
+
+## `homeboy api http`
+
+```sh
+homeboy api http <COMMAND>
+```
+
+Make generic HTTP requests to full URLs
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy api http get` | Make a GET request to a full URL |
+| `homeboy api http request` | Make an arbitrary HTTP request to a full URL |
+
+## `homeboy api http get`
+
+```sh
+homeboy api http get [OPTIONS] <URL>
+```
+
+Make a GET request to a full URL
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<URL>` | yes | Full URL to request |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--proxy` | `<PROXY>` | Optional proxy URL, e.g. socks5://127.0.0.1:8080 |
+| `--auth-profile` | `<AUTH_PROFILE>` | Auth profile from `homeboy api auth profile ...` |
+| `--header` | `<HEADERS>` | Header in `Name: value` format; repeatable |
+| `--json` | `<JSON>` | JSON request body |
+| `--form` | `<FORM>` | Form field as key=value; repeatable |
+
+## `homeboy api http request`
+
+```sh
+homeboy api http request [OPTIONS] <METHOD> <URL>
+```
+
+Make an arbitrary HTTP request to a full URL
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<METHOD>` | yes | HTTP method |
+| `<URL>` | yes | Full URL to request |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Confirm the mutating request should be sent |
+| `--proxy` | `<PROXY>` | Optional proxy URL, e.g. socks5://127.0.0.1:8080 |
+| `--auth-profile` | `<AUTH_PROFILE>` | Auth profile from `homeboy api auth profile ...` |
+| `--header` | `<HEADERS>` | Header in `Name: value` format; repeatable |
+| `--json` | `<JSON>` | JSON request body |
+| `--form` | `<FORM>` | Form field as key=value; repeatable |
+
+## `homeboy api get`
+
+```sh
+homeboy api get <PROJECT_ID> <ENDPOINT>
+```
+
+Make a GET request
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<ENDPOINT>` | yes | API endpoint (e.g., /wp/v2/posts) |
+
+## `homeboy api post`
+
+```sh
+homeboy api post [OPTIONS] <PROJECT_ID> <ENDPOINT>
+```
+
+Make a POST request
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<ENDPOINT>` | yes | API endpoint |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Confirm the mutating request should be sent |
+| `--body` | `<BODY>` | JSON body |
+| `--form` | `<FORM>` | Form field as key=value. May be repeated |
+
+## `homeboy api put`
+
+```sh
+homeboy api put [OPTIONS] <PROJECT_ID> <ENDPOINT>
+```
+
+Make a PUT request
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<ENDPOINT>` | yes | API endpoint |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Confirm the mutating request should be sent |
+| `--body` | `<BODY>` | JSON body |
+| `--form` | `<FORM>` | Form field as key=value. May be repeated |
+
+## `homeboy api patch`
+
+```sh
+homeboy api patch [OPTIONS] <PROJECT_ID> <ENDPOINT>
+```
+
+Make a PATCH request
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<ENDPOINT>` | yes | API endpoint |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Confirm the mutating request should be sent |
+| `--body` | `<BODY>` | JSON body |
+| `--form` | `<FORM>` | Form field as key=value. May be repeated |
+
+## `homeboy api delete`
+
+```sh
+homeboy api delete [OPTIONS] <PROJECT_ID> <ENDPOINT>
+```
+
+Make a DELETE request
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<ENDPOINT>` | yes | API endpoint |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Confirm the mutating request should be sent |
+

--- a/docs/reference/cli/commands/bench.md
+++ b/docs/reference/cli/commands/bench.md
@@ -1,0 +1,136 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy bench` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/bench.md](../../../commands/bench.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy bench`
+
+```sh
+homeboy bench [OPTIONS] [COMPONENT] [ARGS]... [COMMAND]
+```
+
+Run performance benchmarks for a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional arguments to pass to the bench runner (must follow --) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | flag | Print the full JSON output instead of the compact human summary. The compact summary is the default for terminals; the full structured payload is always written to `--output <file>` and is printed to stdout with this flag. No data differs between the two — only the default presentation is compact |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--iterations` | `<ITERATIONS>` | Iterations per scenario (default 10). Forwarded to the runner via HOMEBOY_BENCH_ITERATIONS. Individual extensions may clamp |
+| `--warmup` | `<N>` | Warmup iterations to run before measured iterations. Forwarded to the runner via HOMEBOY_BENCH_WARMUP_ITERATIONS. When omitted, rig bench.warmup_iterations may provide the value; otherwise the runner keeps its own default |
+| `--runs` | `<COUNT>` | Number of repetitions (independent substrate spawns). Default 1 preserves today's exact behaviour. This is a numeric COUNT, not a proof label — use --run-id to tag a run with a stable identifier. When > 1, the bench dispatcher is invoked N times in sequence and per-scenario metrics carry both the cross-run p50 (top-level, unchanged shape) and a runs array with each run's raw metrics, plus a runs_summary object with n/min/max/mean/stdev/cv_pct/p50/p95 |
+| `--run-id` | `<ID>` | Caller-supplied stable proof label for this run. Forwarded to component bench scripts via HOMEBOY_BENCH_RUN_ID so a run can be correlated across systems (CI logs, dashboards, proof archives). This is NOT a repetition count — use --runs for that. Components whose bench runner does not consume HOMEBOY_BENCH_RUN_ID simply ignore it; homeboy emits a notice rather than a hard error |
+| `--shared-state` | `<DIR>` | Directory shared across bench runner instances |
+| `--concurrency` | `<CONCURRENCY>` | Number of concurrent bench runner instances. When `--matrix` is used, this controls scheduler task concurrency |
+| `--matrix` | `<NAME=VALUE[,VALUE...]>` | Matrix axis in NAME=value,value form. Repeat for multiple axes |
+| `--runner-pool` | `<BACKEND>` | Generic agent-task executor backend/runner pool for matrix fan-out |
+| `--max-tasks` | `<N>` | Cap the number of matrix cells accepted by the scheduler |
+| `--max-queue-depth` | `<N>` | Cap the scheduler queue depth for matrix cells |
+| `--expect-artifact` | `<NAME>` | Artifact name expected from each matrix cell |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+| `--regression-threshold` | `<PERCENT>` | p95 regression tolerance as a percentage. A scenario regresses when its current p95_ms exceeds baseline.p95_ms * (1 + threshold/100) |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--json-summary` | flag | Print compact machine-readable summary (for CI wrappers) |
+| `--status-file` | `<PATH>` | Write machine-readable long-loop heartbeat/status JSON to this path. The file is updated when the observation starts and again when it finishes or errors |
+| `--report` | `<REPORT>` | Include a combined comparison report artifact. Currently supports `side-by-side` for multi-rig bench comparisons Values: `side-by-side`. |
+| `--rig` | `<RIG_ID[,RIG_ID...]>` | Run bench against one or more homeboy rigs |
+| `--rig-order` | `<RIG_ORDER>` | Order to use when running a multi-rig comparison. `input` preserves the --rig list order and keeps the first rig as the comparison reference. `reverse` flips the order so users can repeat the same comparison with the opposite cold/warm position when rigs share external daemon or cache state Values: `input`, `reverse`. |
+| `--rig-concurrency` | `<RIG_CONCURRENCY>` | Number of rigs to run concurrently during a multi-rig comparison. Default 1 preserves stable sequential CI behavior. Values greater than 1 opt into bounded parallel rig execution |
+| `--scenario` | `<SCENARIO_ID>` | Only run matching benchmark scenario ids. Repeat to select multiple |
+| `--profile` | `<PROFILE>` | Run the named rig-defined bench profile |
+| `--ci-profile` | `<ID>` | Run using env and passthrough args from a single extension-declared CI bench profile |
+| `--ignore-default-baseline` | flag | Skip auto-upgrading single-rig runs into a comparison even when the rig spec declares `bench.default_baseline_rig`. Use with `--baseline` / `--ratchet` against a rig that normally auto-pairs, or to bench the candidate alone |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy bench matrix` | Run a local settings matrix and aggregate child bench runs |
+| `homeboy bench list` | List declared benchmark scenarios without executing them |
+
+## `homeboy bench matrix`
+
+```sh
+homeboy bench matrix [OPTIONS] [COMPONENT] [ARGS]...
+```
+
+Run a local settings matrix and aggregate child bench runs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional arguments to pass to the bench runner (must follow --) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--iterations` | `<ITERATIONS>` | Iterations per scenario (default 10). Forwarded to the runner via HOMEBOY_BENCH_ITERATIONS. Individual extensions may clamp |
+| `--warmup` | `<N>` | Warmup iterations to run before measured iterations. Forwarded to the runner via HOMEBOY_BENCH_WARMUP_ITERATIONS. When omitted, rig bench.warmup_iterations may provide the value; otherwise the runner keeps its own default |
+| `--runs` | `<COUNT>` | Number of repetitions (independent substrate spawns). Default 1 preserves today's exact behaviour. This is a numeric COUNT, not a proof label — use --run-id to tag a run with a stable identifier. When > 1, the bench dispatcher is invoked N times in sequence and per-scenario metrics carry both the cross-run p50 (top-level, unchanged shape) and a runs array with each run's raw metrics, plus a runs_summary object with n/min/max/mean/stdev/cv_pct/p50/p95 |
+| `--run-id` | `<ID>` | Caller-supplied stable proof label for this run. Forwarded to component bench scripts via HOMEBOY_BENCH_RUN_ID so a run can be correlated across systems (CI logs, dashboards, proof archives). This is NOT a repetition count — use --runs for that. Components whose bench runner does not consume HOMEBOY_BENCH_RUN_ID simply ignore it; homeboy emits a notice rather than a hard error |
+| `--shared-state` | `<DIR>` | Directory shared across bench runner instances |
+| `--concurrency` | `<CONCURRENCY>` | Number of concurrent bench runner instances. When `--matrix` is used, this controls scheduler task concurrency |
+| `--matrix` | `<NAME=VALUE[,VALUE...]>` | Matrix axis in NAME=value,value form. Repeat for multiple axes |
+| `--runner-pool` | `<BACKEND>` | Generic agent-task executor backend/runner pool for matrix fan-out |
+| `--max-tasks` | `<N>` | Cap the number of matrix cells accepted by the scheduler |
+| `--max-queue-depth` | `<N>` | Cap the scheduler queue depth for matrix cells |
+| `--expect-artifact` | `<NAME>` | Artifact name expected from each matrix cell |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+| `--regression-threshold` | `<PERCENT>` | p95 regression tolerance as a percentage. A scenario regresses when its current p95_ms exceeds baseline.p95_ms * (1 + threshold/100) |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--json-summary` | flag | Print compact machine-readable summary (for CI wrappers) |
+| `--status-file` | `<PATH>` | Write machine-readable long-loop heartbeat/status JSON to this path. The file is updated when the observation starts and again when it finishes or errors |
+| `--report` | `<REPORT>` | Include a combined comparison report artifact. Currently supports `side-by-side` for multi-rig bench comparisons Values: `side-by-side`. |
+| `--rig` | `<RIG_ID[,RIG_ID...]>` | Run bench against one or more homeboy rigs |
+| `--rig-order` | `<RIG_ORDER>` | Order to use when running a multi-rig comparison. `input` preserves the --rig list order and keeps the first rig as the comparison reference. `reverse` flips the order so users can repeat the same comparison with the opposite cold/warm position when rigs share external daemon or cache state Values: `input`, `reverse`. |
+| `--rig-concurrency` | `<RIG_CONCURRENCY>` | Number of rigs to run concurrently during a multi-rig comparison. Default 1 preserves stable sequential CI behavior. Values greater than 1 opt into bounded parallel rig execution |
+| `--scenario` | `<SCENARIO_ID>` | Only run matching benchmark scenario ids. Repeat to select multiple |
+| `--profile` | `<PROFILE>` | Run the named rig-defined bench profile |
+| `--ci-profile` | `<ID>` | Run using env and passthrough args from a single extension-declared CI bench profile |
+| `--ignore-default-baseline` | flag | Skip auto-upgrading single-rig runs into a comparison even when the rig spec declares `bench.default_baseline_rig`. Use with `--baseline` / `--ratchet` against a rig that normally auto-pairs, or to bench the candidate alone |
+| `--setting-matrix` | `<NAME=VALUE[,VALUE...]>` | Settings matrix axis in NAME=value,value form. Repeat the flag or pass multiple axes after it, e.g. --setting-matrix clients=10,100 rounds=3 |
+
+## `homeboy bench list`
+
+```sh
+homeboy bench list [OPTIONS] [COMPONENT] [ARGS]...
+```
+
+List declared benchmark scenarios without executing them
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional arguments to pass to the bench runner (must follow --) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--rig` | `<RIG_ID>` | Discover scenarios using a rig's component path, extension config, and rig-declared bench workloads |
+| `--scenario` | `<SCENARIO_ID>` | Only list matching benchmark scenario ids. Repeat to select multiple |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+

--- a/docs/reference/cli/commands/cleanup.md
+++ b/docs/reference/cli/commands/cleanup.md
@@ -1,0 +1,85 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy cleanup` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/cleanup.md](../../../commands/cleanup.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy cleanup`
+
+```sh
+homeboy cleanup [OPTIONS] [COMMAND]
+```
+
+Remove declared reconstructable artifacts from managed worktrees
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply cleanup across the selected categories. Omit for inventory dry-run output |
+| `--include` | `<INCLUDE>` | Include only these cleanup categories. Comma-separated or repeatable Values: `repo-artifacts`, `task-worktrees`, `worktree-providers`, `terminal-runs`, `persisted-run-artifacts`, `orphaned-artifact-bytes`, `runner-downloads`, `runner-binary-caches`, `remote-lab-workspaces`, `runtime-tmp`, `controller-scratch`, `shared-cargo-targets`, `controller-runtimes`. |
+| `--exclude` | `<EXCLUDE>` | Exclude these cleanup categories. Comma-separated or repeatable Values: `repo-artifacts`, `task-worktrees`, `worktree-providers`, `terminal-runs`, `persisted-run-artifacts`, `orphaned-artifact-bytes`, `runner-downloads`, `runner-binary-caches`, `remote-lab-workspaces`, `runtime-tmp`, `controller-scratch`, `shared-cargo-targets`, `controller-runtimes`. |
+| `--older-than-days` | `<DAYS>` | Override the configured terminal-run retention window for this invocation |
+| `--limit` | `<N>` | Override the configured maximum number of persisted artifacts inspected |
+| `--full` | flag | Include every controller-scratch candidate and retained-resource detail. Default output keeps representative detail within the shared response budget |
+| `--cursor` | `<CURSOR>` | Continue a bounded shared-store cleanup inventory from this cursor |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy cleanup artifacts` | Inspect or remove declared reconstructable artifacts across repo worktrees |
+| `homeboy cleanup worktrees` | Aggregate cleanup across configured external worktree providers |
+| `homeboy cleanup retained-storage` | Explain retained Homeboy storage without deleting or reconciling resources |
+
+## `homeboy cleanup artifacts`
+
+```sh
+homeboy cleanup artifacts [OPTIONS]
+```
+
+Inspect or remove declared reconstructable artifacts across repo worktrees
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply cleanup. Omit for dry-run output |
+| `--self` | flag | Clean artifacts from the Homeboy source checkout that built this binary |
+| `--path` | `<PATH>` | Resolve managed worktrees from this checkout instead of the current directory |
+| `--temp-root` | `<PATH>` | Also scan this temp root for detached Homeboy build artifacts. Repeatable |
+| `--sort` | `<SORT>` | Sort artifact candidates before reporting or applying cleanup Values: `discovery`, `size`. |
+| `--limit` | `<N>` | Limit artifact candidates reported or removed after sorting |
+| `--merged-only` | flag | Only reclaim artifacts from worktrees whose branch is already merged into its upstream. Preserves in-progress cooks' build dirs |
+| `--min-age-days` | `<DAYS>` | Only reclaim artifacts untouched for at least this many days. Composes with any age floor a declaration owner sets; the stricter one wins |
+| `--include-active-worktrees` | flag | Also reclaim extension-declared artifacts from checkouts registered as active task worktrees. Those are protected by default because removing an install tree leaves a live checkout unusable until it is rehydrated |
+
+## `homeboy cleanup worktrees`
+
+```sh
+homeboy cleanup worktrees [OPTIONS]
+```
+
+Aggregate cleanup across configured external worktree providers
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--provider` | `<ID>` | Cleanup a specific configured provider. Repeatable |
+| `--all-providers` | flag | Cleanup every enabled configured provider |
+| `--apply` | flag | Apply cleanup. Omit for provider preview/dry-run output |
+
+## `homeboy cleanup retained-storage`
+
+```sh
+homeboy cleanup retained-storage [OPTIONS]
+```
+
+Explain retained Homeboy storage without deleting or reconciling resources
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--limit` | `<LIMIT>` | Maximum largest-byte examples to return. The report always aggregates all inspected sources |
+| `--cursor` | `<CURSOR>` | Continue largest-byte examples after this deterministic reference token |
+

--- a/docs/reference/cli/commands/component.md
+++ b/docs/reference/cli/commands/component.md
@@ -1,0 +1,228 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy component` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/component.md](../../../commands/component.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy component`
+
+```sh
+homeboy component <COMMAND>
+```
+
+Manage standalone component configurations
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy component create` | Initialize portable component config for a repo |
+| `homeboy component show` | Display component configuration |
+| `homeboy component set` | Update component configuration fields |
+| `homeboy component delete` | Delete a component configuration |
+| `homeboy component rename` | Rename a component (changes ID directly) |
+| `homeboy component list` | List all available components |
+| `homeboy component projects` | List projects using this component |
+| `homeboy component shared` | Show which components are shared across projects |
+| `homeboy component env` | Detect runtime environment requirements from the component's source files |
+| `homeboy component setup` | Prepare a component for build/test: install its declared extensions and install its dependencies through detected providers |
+| `homeboy component reconcile` | Inspect and optionally repair stale standalone registry local_path data |
+| `homeboy component artifacts` | Report or remove declared reconstructable artifacts for a component |
+
+## `homeboy component create`
+
+```sh
+homeboy component create [OPTIONS]
+```
+
+Initialize portable component config for a repo
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--local-path` | `<LOCAL_PATH>` | Absolute path to local source directory (writes homeboy.json there) |
+| `--remote-path` | `<REMOTE_PATH>` | Remote path relative to project basePath |
+| `--build-artifact` | `<BUILD_ARTIFACT>` | Build artifact path relative to localPath |
+| `--version-target` | `<TARGET>` | Version targets in the form "file" or "file::pattern" (repeatable). For complex patterns, use --version-targets @file.json to avoid shell escaping |
+| `--version-targets` | `<JSON>` | Version targets as JSON array (supports @file.json and - for stdin) |
+| `--extract-command` | `<EXTRACT_COMMAND>` | Extract command to run after upload (e.g., "unzip -o {{artifact}} && rm {{artifact}}") |
+| `--changelog-target` | `<CHANGELOG_TARGET>` | Path to changelog file relative to localPath |
+| `--extension` | `<EXTENSION>` | Extension(s) this component uses (e.g., a runtime/framework extension id). Repeatable |
+| `--project` | `<PROJECT>` | Attach component to a project after creation |
+
+## `homeboy component show`
+
+```sh
+homeboy component show [OPTIONS] [ID]
+```
+
+Display component configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Component ID (optional when --path is provided) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Discover component from a directory's homeboy.json instead of the registry |
+
+## `homeboy component set`
+
+```sh
+homeboy component set [OPTIONS] [ID]
+```
+
+Update component configuration fields
+
+Supports dedicated flags for common fields (e.g., --local-path, --changelog-target) as well as --json/--base64 for arbitrary object updates.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Entity ID (optional if provided in JSON body) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON object to merge into the entity (supports @file and - for stdin) |
+| `--base64` | `<BASE64>` | Base64-encoded JSON object (bypasses shell escaping issues) |
+| `--replace` | `<FIELD>` | Replace these fields instead of merging arrays |
+| `--local-path` | `<LOCAL_PATH>` | Absolute path to local source directory |
+| `--remote-path` | `<REMOTE_PATH>` | Remote path relative to project basePath |
+| `--build-artifact` | `<BUILD_ARTIFACT>` | Build artifact path relative to localPath |
+| `--extract-command` | `<EXTRACT_COMMAND>` | Extract command to run after upload (e.g., "unzip -o {{artifact}} && rm {{artifact}}") |
+| `--changelog-target` | `<CHANGELOG_TARGET>` | Path to changelog file relative to localPath |
+| `--version-target` | `<TARGET>` | Version targets in the form "file" or "file::pattern" (repeatable). Same format as `component create --version-target` |
+| `--extension` | `<EXTENSION>` | Extension(s) this component uses (e.g., a runtime/framework extension id). Repeatable |
+
+## `homeboy component delete`
+
+```sh
+homeboy component delete <ID>
+```
+
+Delete a component configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Component ID |
+
+## `homeboy component rename`
+
+```sh
+homeboy component rename <ID> <NEW_ID>
+```
+
+Rename a component (changes ID directly)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Current component ID |
+| `<NEW_ID>` | yes | New component ID (should match repository directory name) |
+
+## `homeboy component list`
+
+```sh
+homeboy component list
+```
+
+List all available components
+
+## `homeboy component projects`
+
+```sh
+homeboy component projects <ID>
+```
+
+List projects using this component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Component ID |
+
+## `homeboy component shared`
+
+```sh
+homeboy component shared [ID]
+```
+
+Show which components are shared across projects
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Specific component ID to check (optional, shows all if omitted) |
+
+## `homeboy component env`
+
+```sh
+homeboy component env [OPTIONS] [ID]
+```
+
+Detect runtime environment requirements from the component's source files.
+
+Reads extension-specific metadata to determine what runtime versions the component needs. Outputs generic runtime requirement JSON suitable for CI environment setup.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Component ID (optional when --path is provided) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Discover component from a directory's homeboy.json |
+
+## `homeboy component setup`
+
+```sh
+homeboy component setup [OPTIONS] [ID]
+```
+
+Prepare a component for build/test: install its declared extensions and install its dependencies through detected providers.
+
+Core-owned replacement for hardcoded CI install/refresh + per-ecosystem dependency setup. The package manager is chosen by detection and manifest config, never by shell literals. CI calls this instead of orchestrating the sequence itself.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Component ID (optional when --path is provided) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Discover component from a directory's homeboy.json |
+| `--source` | `<SOURCE>` | Source (git URL or local path) to install the component's configured extensions from. Omit to skip extension install (deps only) |
+| `--skip-dependencies` | flag | Skip the dependency install step (extensions only) |
+
+## `homeboy component reconcile`
+
+```sh
+homeboy component reconcile [OPTIONS] <ID>
+```
+
+Inspect and optionally repair stale standalone registry local_path data
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply a safe discovered repair instead of reporting only |
+
+## `homeboy component artifacts`
+
+```sh
+homeboy component artifacts [OPTIONS] [ID]
+```
+
+Report or remove declared reconstructable artifacts for a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Component ID (optional when --path is provided or run from a component checkout) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Discover component from a directory's homeboy.json instead of the registry |
+| `--apply` | flag | Remove reported artifact paths instead of dry-run reporting only |
+

--- a/docs/reference/cli/commands/config.md
+++ b/docs/reference/cli/commands/config.md
@@ -1,0 +1,87 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy config` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/config.md](../../../commands/config.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy config`
+
+```sh
+homeboy config <COMMAND>
+```
+
+Manage global Homeboy configuration
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy config show` | Display configuration (merged defaults + file) |
+| `homeboy config set` | Set a configuration value at a JSON pointer path |
+| `homeboy config remove` | Remove a configuration value at a JSON pointer path |
+| `homeboy config reset` | Reset configuration to built-in defaults (deletes homeboy.json) |
+| `homeboy config path` | Show the path to homeboy.json |
+
+## `homeboy config show`
+
+```sh
+homeboy config show [OPTIONS]
+```
+
+Display configuration (merged defaults + file)
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--builtin` | flag | Show only built-in defaults (ignore homeboy.json) |
+
+## `homeboy config set`
+
+```sh
+homeboy config set [OPTIONS] <POINTER> <VALUE>
+```
+
+Set a configuration value at a JSON pointer path
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<POINTER>` | yes | JSON pointer path (e.g., /defaults/deploy/scp_flags) |
+| `<VALUE>` | yes | Value to set (JSON) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--string` | flag | Treat value as a literal string instead of parsing it as JSON |
+
+## `homeboy config remove`
+
+```sh
+homeboy config remove <POINTER>
+```
+
+Remove a configuration value at a JSON pointer path
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<POINTER>` | yes | JSON pointer path (e.g., /defaults/deploy/scp_flags) |
+
+## `homeboy config reset`
+
+```sh
+homeboy config reset
+```
+
+Reset configuration to built-in defaults (deletes homeboy.json)
+
+## `homeboy config path`
+
+```sh
+homeboy config path
+```
+
+Show the path to homeboy.json
+

--- a/docs/reference/cli/commands/contract.md
+++ b/docs/reference/cli/commands/contract.md
@@ -1,0 +1,135 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy contract` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/contract.md](../../../commands/contract.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy contract`
+
+```sh
+homeboy contract <COMMAND>
+```
+
+Inspect, export, validate, and normalize Homeboy contract metadata
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy contract list` | List core-owned data contracts |
+| `homeboy contract show` | Show one core-owned data contract by schema id or registry name |
+| `homeboy contract export` | Export machine-consumable Homeboy contract JSON files |
+| `homeboy contract validate` | Validate a JSON file against a registered generic Homeboy contract |
+| `homeboy contract constants` | Export Homeboy-owned constants for a generic contract surface |
+| `homeboy contract normalize` | Validate and normalize generic contract values |
+| `homeboy contract materialize` | Materialize generic contract envelopes from declarative inputs |
+| `homeboy contract manifest` | Print the recursive command safety, docs, and output manifest |
+
+## `homeboy contract list`
+
+```sh
+homeboy contract list
+```
+
+List core-owned data contracts
+
+## `homeboy contract show`
+
+```sh
+homeboy contract show <SCHEMA_ID_OR_NAME>
+```
+
+Show one core-owned data contract by schema id or registry name
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SCHEMA_ID_OR_NAME>` | yes | Schema id or short registry name |
+
+## `homeboy contract export`
+
+```sh
+homeboy contract export [OPTIONS]
+```
+
+Export machine-consumable Homeboy contract JSON files
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dir` | `<DIR>` | Directory to receive exported JSON contract files |
+
+## `homeboy contract validate`
+
+```sh
+homeboy contract validate [OPTIONS] <SCHEMA_ID>
+```
+
+Validate a JSON file against a registered generic Homeboy contract
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SCHEMA_ID>` | yes | Contract schema id to validate against |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--file` | `<PATH>` | JSON file to validate |
+
+## `homeboy contract constants`
+
+```sh
+homeboy contract constants <CONTRACT_ID>
+```
+
+Export Homeboy-owned constants for a generic contract surface
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<CONTRACT_ID>` | yes | Contract ID: all, artifact-manifest, artifact-paths, loop, secret-env-plan, resource-lifecycle-index, host-mutation-lifecycle, run-location-index, runner-execution-record, path-materialization-plan, run-outcome-envelope, run-artifact-files, runtime-artifacts, runner-artifact-manifest-ref, reviewer-facing-ref |
+
+## `homeboy contract normalize`
+
+```sh
+homeboy contract normalize [OPTIONS] <KIND>
+```
+
+Validate and normalize generic contract values
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<KIND>` | yes | Contract value kind to normalize Values: `artifact-ref`, `path-materialization-plan`, `run-lifecycle-status`, `runner-execution-record`, `run-outcome-envelope`. |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<JSON>` | JSON value to normalize. If omitted, stdin is read |
+| `--input-file` | `<PATH>` | Read JSON value to normalize from a file |
+
+## `homeboy contract materialize`
+
+```sh
+homeboy contract materialize [OPTIONS] <KIND>
+```
+
+Materialize generic contract envelopes from declarative inputs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<KIND>` | yes | Contract value kind to materialize Values: `secret-env-handoff`, `secret-env-plan`. |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<JSON>` | JSON request to materialize. If omitted, stdin is read |
+| `--input-file` | `<PATH>` | Read JSON request to materialize from a file |
+
+## `homeboy contract manifest`
+
+```sh
+homeboy contract manifest
+```
+
+Print the recursive command safety, docs, and output manifest
+

--- a/docs/reference/cli/commands/daemon.md
+++ b/docs/reference/cli/commands/daemon.md
@@ -1,0 +1,207 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy daemon` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/daemon.md](../../../commands/daemon.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy daemon`
+
+```sh
+homeboy daemon <COMMAND>
+```
+
+Run the local-only HTTP API daemon
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy daemon start` | Start the local daemon in the background |
+| `homeboy daemon ensure-running` | Return the current live daemon or start one when no live daemon exists |
+| `homeboy daemon adopt-orphan` | Explicitly replace one proven-dead daemon lease and reconcile its durable jobs |
+| `homeboy daemon reconcile-dead-lease-orphans` | Reconcile an exact PID-less job set after one proven unexpected daemon exit |
+| `homeboy daemon recover-missing-child-identity` | Recover one legacy job with exact PID and Linux start-tick evidence |
+| `homeboy daemon reconcile-leaseless-orphans` | Explicitly reconcile active jobs after proving a missing-lease store has no daemon owner |
+| `homeboy daemon recover-missing-lease-state` | Recover one exact lease after its daemon state record was lost |
+| `homeboy daemon serve` | Run the local daemon in the foreground |
+| `homeboy daemon stop` | Stop the background daemon recorded in the state file |
+| `homeboy daemon status` | Show daemon state and selected local address |
+| `homeboy daemon broker-config` | Render deployable reverse-runner broker service configuration |
+| `homeboy daemon artifact-get` | Fetch artifact bytes through the local daemon byte endpoint |
+
+## `homeboy daemon start`
+
+```sh
+homeboy daemon start [OPTIONS]
+```
+
+Start the local daemon in the background
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--addr` | `<ADDR>` | Local bind address. Defaults to an OS-selected loopback port |
+
+## `homeboy daemon ensure-running`
+
+```sh
+homeboy daemon ensure-running [OPTIONS]
+```
+
+Return the current live daemon or start one when no live daemon exists
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--addr` | `<ADDR>` | _no help text_ |
+
+## `homeboy daemon adopt-orphan`
+
+```sh
+homeboy daemon adopt-orphan [OPTIONS]
+```
+
+Explicitly replace one proven-dead daemon lease and reconcile its durable jobs
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--lease-id` | `<LEASE_ID>` | Exact lease ID reported by `homeboy daemon status` |
+| `--confirm-pid-dead` | flag | Deprecated no-op retained for one release; adoption already proves the recorded PID dead under the daemon lifecycle lock |
+| `--recover-missing-child-identity` | flag | Accepted migration alias for legacy child recovery. It never mutates jobs |
+| `--confirm-untracked-child-dead` | `<CONFIRM_UNTRACKED_CHILD_DEAD>` | Confirm the one expired PID-less reservation to terminalize before replacement |
+| `--addr` | `<ADDR>` | _no help text_ |
+
+## `homeboy daemon reconcile-dead-lease-orphans`
+
+```sh
+homeboy daemon reconcile-dead-lease-orphans [OPTIONS]
+```
+
+Reconcile an exact PID-less job set after one proven unexpected daemon exit
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--lease-id` | `<LEASE_ID>` | _no help text_ |
+| `--job-id` | `<JOB_IDS>` | Exact, complete active durable-job set to terminalize. The store recomputes the active set and refuses any mismatch, so this is a compare-and-swap over the destructive scope, not a fact assertion |
+| `--confirm-pid-dead` | flag | Deprecated no-op retained for one release; recovery already requires persisted unexpected-termination evidence and re-proves the PID dead |
+| `--confirm-workload-processes-absent` | flag | Required. Attests that the workload processes for --job-id were inspected and are absent. Unverifiable by design: this command exists because the daemon died before persisting any child identity, so the store holds no PID to check. Persisted as durable job provenance |
+| `--addr` | `<ADDR>` | _no help text_ |
+
+## `homeboy daemon recover-missing-child-identity`
+
+```sh
+homeboy daemon recover-missing-child-identity [OPTIONS]
+```
+
+Recover one legacy job with exact PID and Linux start-tick evidence
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--lease-id` | `<LEASE_ID>` | _no help text_ |
+| `--recorded-daemon-pid` | `<RECORDED_DAEMON_PID>` | _no help text_ |
+| `--recorded-daemon-endpoint` | `<RECORDED_DAEMON_ENDPOINT>` | _no help text_ |
+| `--job-id` | `<JOB_ID>` | _no help text_ |
+| `--child-pid` | `<CHILD_PID>` | _no help text_ |
+| `--child-starttime-ticks` | `<CHILD_STARTTIME_TICKS>` | _no help text_ |
+
+## `homeboy daemon reconcile-leaseless-orphans`
+
+```sh
+homeboy daemon reconcile-leaseless-orphans [OPTIONS]
+```
+
+Explicitly reconcile active jobs after proving a missing-lease store has no daemon owner
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--confirm-no-daemon-owner` | flag | _no help text_ |
+| `--addr` | `<ADDR>` | _no help text_ |
+
+## `homeboy daemon recover-missing-lease-state`
+
+```sh
+homeboy daemon recover-missing-lease-state [OPTIONS]
+```
+
+Recover one exact lease after its daemon state record was lost
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--lease-id` | `<LEASE_ID>` | Exact lease ID captured before the daemon state record was lost |
+| `--recorded-pid` | `<RECORDED_PID>` | Recorded daemon PID captured with the lease ID |
+| `--recorded-endpoint` | `<RECORDED_ENDPOINT>` | Recorded concrete loopback endpoint captured with the lease ID |
+| `--confirm-pid-dead` | flag | Deprecated no-op retained for one release; recovery already refuses a running recorded PID |
+| `--confirm-control-plane-lost` | flag | Deprecated no-op retained for one release; recovery already requires an absent state record, a `lease_missing` freshness code, an unreachable daemon, and a failed probe of the recorded endpoint |
+| `--addr` | `<ADDR>` | _no help text_ |
+
+## `homeboy daemon serve`
+
+```sh
+homeboy daemon serve [OPTIONS]
+```
+
+Run the local daemon in the foreground
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--addr` | `<ADDR>` | Local bind address. Defaults to an OS-selected loopback port |
+
+## `homeboy daemon stop`
+
+```sh
+homeboy daemon stop [OPTIONS]
+```
+
+Stop the background daemon recorded in the state file
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--lease-id` | `<LEASE_ID>` | Require this exact live daemon lease before stopping |
+| `--force` | flag | Directly SIGTERM a matching stale or unreachable daemon lease. Requires --lease-id |
+
+## `homeboy daemon status`
+
+```sh
+homeboy daemon status
+```
+
+Show daemon state and selected local address
+
+## `homeboy daemon broker-config`
+
+```sh
+homeboy daemon broker-config [OPTIONS]
+```
+
+Render deployable reverse-runner broker service configuration
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--listen-addr` | `<LISTEN_ADDR>` | Stable loopback address for the VPS service |
+| `--binary-path` | `<BINARY_PATH>` | Homeboy binary path used by the service unit |
+| `--user` | `<USER>` | System user that runs the broker service |
+| `--group` | `<GROUP>` | System group that runs the broker service |
+| `--domain` | `<DOMAIN>` | Optional public hostname to render disabled Nginx/Caddy examples |
+
+## `homeboy daemon artifact-get`
+
+```sh
+homeboy daemon artifact-get [OPTIONS] <RUN_ID> <ARTIFACT_ID>
+```
+
+Fetch artifact bytes through the local daemon byte endpoint
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run id that owns the artifact |
+| `<ARTIFACT_ID>` | yes | Artifact id/path token from daemon artifact metadata |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-o`, `--output` | `<OUTPUT>` | Destination file path. Defaults to the artifact id basename |
+| `--daemon-url` | `<DAEMON_URL>` | Daemon base URL. Defaults to the address from `homeboy daemon status` |
+

--- a/docs/reference/cli/commands/db.md
+++ b/docs/reference/cli/commands/db.md
@@ -1,0 +1,151 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy db` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/db.md](../../../commands/db.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy db`
+
+```sh
+homeboy db <COMMAND>
+```
+
+Database operations
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy db status` | Show local Homeboy observation-store status |
+| `homeboy db tables` | List database tables |
+| `homeboy db describe` | Show table structure |
+| `homeboy db query` | Execute SELECT query |
+| `homeboy db search` | Search table by column value |
+| `homeboy db delete-row` | Delete a row from a table |
+| `homeboy db drop-table` | Drop a database table |
+| `homeboy db tunnel` | Open SSH tunnel to database |
+
+## `homeboy db status`
+
+```sh
+homeboy db status
+```
+
+Show local Homeboy observation-store status
+
+## `homeboy db tables`
+
+```sh
+homeboy db tables <PROJECT_ID> [ARGS]...
+```
+
+List database tables
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[ARGS]...` | no | Optional subtarget |
+
+## `homeboy db describe`
+
+```sh
+homeboy db describe <PROJECT_ID> [ARGS]...
+```
+
+Show table structure
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[ARGS]...` | no | Optional subtarget and table name |
+
+## `homeboy db query`
+
+```sh
+homeboy db query <PROJECT_ID> [ARGS]...
+```
+
+Execute SELECT query
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[ARGS]...` | no | Optional subtarget and SQL query |
+
+## `homeboy db search`
+
+```sh
+homeboy db search [OPTIONS] <PROJECT_ID> <TABLE>
+```
+
+Search table by column value
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<TABLE>` | yes | Table name |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--column` | `<COLUMN>` | Column to search |
+| `--pattern` | `<PATTERN>` | Search pattern |
+| `--exact` | flag | Use exact match instead of LIKE |
+| `--limit` | `<LIMIT>` | Maximum rows to return |
+| `--subtarget` | `<SUBTARGET>` | Optional subtarget |
+
+## `homeboy db delete-row`
+
+```sh
+homeboy db delete-row [OPTIONS] <PROJECT_ID> [ARGS]...
+```
+
+Delete a row from a table
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[ARGS]...` | no | Table name and row ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply the destructive mutation. Without this flag, prints a plan only |
+
+## `homeboy db drop-table`
+
+```sh
+homeboy db drop-table [OPTIONS] <PROJECT_ID> [ARGS]...
+```
+
+Drop a database table
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[ARGS]...` | no | Table name |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply the destructive mutation. Without this flag, prints a plan only |
+
+## `homeboy db tunnel`
+
+```sh
+homeboy db tunnel [OPTIONS] <PROJECT_ID>
+```
+
+Open SSH tunnel to database
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--local-port` | `<LOCAL_PORT>` | Local port to bind |
+

--- a/docs/reference/cli/commands/deploy.md
+++ b/docs/reference/cli/commands/deploy.md
@@ -1,0 +1,52 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy deploy` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/deploy.md](../../../commands/deploy.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy deploy`
+
+```sh
+homeboy deploy [OPTIONS] [TARGET_ID] [COMPONENT_IDS]...
+```
+
+Deploy components to remote server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[TARGET_ID]` | no | Target ID: project ID or component ID (order is auto-detected) |
+| `[COMPONENT_IDS]...` | no | Additional component IDs (enables project/component order detection) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--project` | `<PROJECT>` | Explicit project ID (takes precedence over positional detection) |
+| `-c`, `--component` | `<COMPONENT>` | Explicit component IDs (takes precedence over positional) |
+| `--json` | `<JSON>` | JSON input spec for bulk operations (array or {"component_ids": [...]}) |
+| `--all` | flag | Deploy all configured components |
+| `--outdated` | flag | Deploy only components whose local version differs from deployed remote |
+| `--behind-upstream` | flag | Deploy only components whose local checkout is behind upstream |
+| `--dry-run` | flag | Preview what would be deployed without executing |
+| `--apply` | flag | Confirm dangerous deploy modes like --head, --ref, or --force |
+| `--check` | flag | Check component status without building or deploying |
+| `--force` | flag | Deploy even with uncommitted changes |
+| `--projects` | `<PROJECTS>` | Deploy to multiple projects (comma-separated or repeated) |
+| `-f`, `--fleet` | `<FLEET>` | Deploy to all projects in a fleet |
+| `-s`, `--shared` | flag | Deploy to all projects using the specified component(s) |
+| `--keep-deps` | flag | Keep build dependencies (skip post-deploy cleanup) |
+| `--no-pull` | flag | Skip auto-pulling latest changes before deploy |
+| `--allow-stale-source` | flag | Deploy a local build even when its source checkout is behind its upstream |
+| `--allow-downgrade` | flag | Deploy a local build even when its semantic version is older than the remote |
+| `--head` | flag | Deploy from current branch HEAD instead of the latest tag |
+| `--release-set` | `<PATH>` | Validate this versioned release-set manifest before any deploy action |
+| `--ref` | `<GIT_REF_OR_SHA>` | Deploy an exact Git ref resolved from the declared component repository |
+| `--tagged` | flag | Force local tag-based build/deploy, ignoring reusable release assets |
+| `--resume` | `<RUN_ID>` | Resume a prior multi-project deploy run after exact identity validation |
+

--- a/docs/reference/cli/commands/deps.md
+++ b/docs/reference/cli/commands/deps.md
@@ -1,0 +1,135 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy deps` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/deps.md](../../../commands/deps.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy deps`
+
+```sh
+homeboy deps <COMMAND>
+```
+
+Manage component dependencies
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy deps status` | Inspect dependency constraints and locked package versions |
+| `homeboy deps install` | Install a component's dependencies through its detected providers |
+| `homeboy deps update` | Update one package through its dependency provider |
+| `homeboy deps stack` | Work with declared downstream dependency stacks |
+
+## `homeboy deps status`
+
+```sh
+homeboy deps status [OPTIONS] [COMPONENT]
+```
+
+Inspect dependency constraints and locked package versions
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID. When omitted, auto-detected from CWD |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--package` | `<PACKAGE>` | Limit output to one package |
+| `--path` | `<PATH>` | Workspace path to operate on directly |
+
+## `homeboy deps install`
+
+```sh
+homeboy deps install [OPTIONS] [COMPONENT]
+```
+
+Install a component's dependencies through its detected providers
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID. When omitted, auto-detected from CWD |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Workspace path to operate on directly |
+
+## `homeboy deps update`
+
+```sh
+homeboy deps update [OPTIONS] <PACKAGE> [COMPONENT]
+```
+
+Update one package through its dependency provider
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PACKAGE>` | yes | Package name, e.g. example-org/block-format-bridge |
+| `[COMPONENT]` | no | Component ID. When omitted, auto-detected from CWD |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--to` | `<CONSTRAINT>` | New manifest constraint, e.g. ^0.4 |
+| `--path` | `<PATH>` | Workspace path to operate on directly |
+| `--no-install` | flag | Skip provider-owned install/lockfile refresh after the manifest update |
+| `--rebuild` | flag | Rebuild the component through its generic build capability after updating |
+
+## `homeboy deps stack`
+
+```sh
+homeboy deps stack <COMMAND>
+```
+
+Work with declared downstream dependency stacks
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy deps stack status` | List declared dependency stack edges |
+| `homeboy deps stack plan` | Plan downstream updates for an upstream component/repo |
+| `homeboy deps stack apply` | Run downstream update commands for an upstream component/repo |
+
+## `homeboy deps stack status`
+
+```sh
+homeboy deps stack status
+```
+
+List declared dependency stack edges
+
+## `homeboy deps stack plan`
+
+```sh
+homeboy deps stack plan <UPSTREAM>
+```
+
+Plan downstream updates for an upstream component/repo
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<UPSTREAM>` | yes | Upstream component or repository identifier from dependency_stack[].upstream |
+
+## `homeboy deps stack apply`
+
+```sh
+homeboy deps stack apply [OPTIONS] <UPSTREAM>
+```
+
+Run downstream update commands for an upstream component/repo
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<UPSTREAM>` | yes | Upstream component or repository identifier from dependency_stack[].upstream |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--to` | `<CONSTRAINT>` | New manifest constraint to pass to provider-backed default update steps |
+| `--dry-run` | flag | Print the command plan without running commands |
+| `--no-install` | flag | Skip provider-owned install/lockfile refresh after each manifest update |
+| `--rebuild` | flag | Rebuild each downstream component through its generic build capability |
+

--- a/docs/reference/cli/commands/extension.md
+++ b/docs/reference/cli/commands/extension.md
@@ -1,0 +1,277 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy extension` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/extension.md](../../../commands/extension.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy extension`
+
+```sh
+homeboy extension <COMMAND>
+```
+
+Execute CLI-compatible extensions
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy extension list` | Show available extensions with compatibility status |
+| `homeboy extension diff-installed` | Compare installed extension revisions with their current checkout HEADs |
+| `homeboy extension show` | Show detailed information about a extension |
+| `homeboy extension run` | Execute a extension |
+| `homeboy extension setup` | Run the extension's setup command (if defined) |
+| `homeboy extension install` | Install a extension from a git URL or local path |
+| `homeboy extension refresh` | Refresh an extension: uninstall any existing install, then reinstall |
+| `homeboy extension relink` | Relink an installed symlinked extension to a new local source path |
+| `homeboy extension dev-run` | Sync local extension source to a runner, refresh it there, then run a command |
+| `homeboy extension install-for-component` | Install every extension configured by a component |
+| `homeboy extension update` | Update an installed extension (git pull) |
+| `homeboy extension uninstall` | Uninstall a extension |
+| `homeboy extension action` | Execute a extension action (API call or builtin) |
+| `homeboy extension exec` | Run a tool from a extension's vendor directory |
+| `homeboy extension set` | Update extension manifest fields |
+
+## `homeboy extension list`
+
+```sh
+homeboy extension list [OPTIONS]
+```
+
+Show available extensions with compatibility status
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--project` | `<PROJECT>` | Project ID to filter compatible extensions |
+
+## `homeboy extension diff-installed`
+
+```sh
+homeboy extension diff-installed [OPTIONS] [EXTENSION_ID]
+```
+
+Compare installed extension revisions with their current checkout HEADs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[EXTENSION_ID]` | no | Optional extension ID to inspect |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner` | `<RUNNER>` | Inspect the extension install visible to a configured runner |
+
+## `homeboy extension show`
+
+```sh
+homeboy extension show <EXTENSION_ID>
+```
+
+Show detailed information about a extension
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+
+## `homeboy extension run`
+
+```sh
+homeboy extension run [OPTIONS] <EXTENSION_ID> [ARGS]...
+```
+
+Execute a extension
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+| `[ARGS]...` | no | Arguments to pass to the extension (for CLI extensions) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--project` | `<PROJECT>` | Project ID (defaults to active project) |
+| `-c`, `--component` | `<COMPONENT>` | Component ID (required when ambiguous) |
+| `-i`, `--input` | `<INPUT>` | Input values as key=value pairs |
+| `--step` | `<STEP>` | Run only specific steps (comma-separated, e.g. --step test,lint) |
+| `--skip` | `<SKIP>` | Skip specific steps (comma-separated, e.g. --skip analyze,lint) |
+| `--stream` | flag | Stream output directly to terminal (default: auto-detect based on TTY) |
+| `--no-stream` | flag | Disable streaming and capture output (default: auto-detect based on TTY) |
+
+## `homeboy extension setup`
+
+```sh
+homeboy extension setup <EXTENSION_ID>
+```
+
+Run the extension's setup command (if defined)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+
+## `homeboy extension install`
+
+```sh
+homeboy extension install [OPTIONS] <SOURCE>
+```
+
+Install a extension from a git URL or local path
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SOURCE>` | yes | Git URL or local path to extension directory |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--id` | `<ID>` | Override extension id |
+| `--ref` | `<REVISION>` | Git ref to check out for URL installs (branch, tag, or commit) |
+| `--replace` | flag | Replace an existing extension install/link |
+
+## `homeboy extension refresh`
+
+```sh
+homeboy extension refresh [OPTIONS] <SOURCE>
+```
+
+Refresh an extension: uninstall any existing install, then reinstall
+
+Idempotent core-owned replacement for CI's hardcoded uninstall/install sequence. Safe to re-run; a missing prior install is not an error.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SOURCE>` | yes | Git URL or local path to extension directory |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--id` | `<ID>` | Override extension id |
+| `--ref` | `<REVISION>` | Git ref to check out for URL installs (branch, tag, or commit) |
+
+## `homeboy extension relink`
+
+```sh
+homeboy extension relink <EXTENSION_ID> <SOURCE>
+```
+
+Relink an installed symlinked extension to a new local source path
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+| `<SOURCE>` | yes | Local path to extension directory |
+
+## `homeboy extension dev-run`
+
+```sh
+homeboy extension dev-run [OPTIONS] <EXTENSION_ID> <COMMAND>...
+```
+
+Sync local extension source to a runner, refresh it there, then run a command
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+| `<COMMAND>...` | yes | Command and arguments to execute on the runner after refresh |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--source` | `<SOURCE>` | Local extension source directory to sync to the runner |
+| `--runner` | `<RUNNER>` | Runner ID |
+
+## `homeboy extension install-for-component`
+
+```sh
+homeboy extension install-for-component [OPTIONS]
+```
+
+Install every extension configured by a component
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--source` | `<SOURCE>` | Git URL or local path to extension repository/directory |
+| `--path` | `<PATH>` | Component path containing homeboy.json (defaults to current directory) |
+
+## `homeboy extension update`
+
+```sh
+homeboy extension update [OPTIONS] [EXTENSION_ID]
+```
+
+Update an installed extension (git pull)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[EXTENSION_ID]` | no | Extension ID (omit with --all to update everything) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--all` | flag | Update all installed extensions |
+| `--force` | flag | Force update even with uncommitted changes |
+
+## `homeboy extension uninstall`
+
+```sh
+homeboy extension uninstall <EXTENSION_ID>
+```
+
+Uninstall a extension
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+
+## `homeboy extension action`
+
+```sh
+homeboy extension action [OPTIONS] <EXTENSION_ID> <ACTION_ID>
+```
+
+Execute a extension action (API call or builtin)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+| `<ACTION_ID>` | yes | Action ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--project` | `<PROJECT>` | Project ID (required for API actions) |
+| `--data` | `<DATA>` | JSON array of selected data rows |
+
+## `homeboy extension exec`
+
+```sh
+homeboy extension exec [OPTIONS] <EXTENSION_ID> <ARGS>...
+```
+
+Run a tool from a extension's vendor directory
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<EXTENSION_ID>` | yes | Extension ID |
+| `<ARGS>...` | yes | Command and arguments to run |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-c`, `--component` | `<COMPONENT>` | Component ID (sets working directory to component path) |
+
+## `homeboy extension set`
+
+```sh
+homeboy extension set [OPTIONS] [EXTENSION_ID]
+```
+
+Update extension manifest fields
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[EXTENSION_ID]` | no | Extension ID (optional if provided in JSON body) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON object to merge into manifest (supports @file and - for stdin) |
+| `--replace` | `<FIELD>` | Replace these fields instead of merging arrays |
+

--- a/docs/reference/cli/commands/file.md
+++ b/docs/reference/cli/commands/file.md
@@ -1,0 +1,266 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy file` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/file.md](../../../commands/file.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy file`
+
+```sh
+homeboy file <COMMAND>
+```
+
+Remote file operations
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy file list` | List directory contents |
+| `homeboy file read` | Read file content |
+| `homeboy file write` | Write content to file (from stdin) |
+| `homeboy file mkdir` | Create a directory |
+| `homeboy file delete` | Delete a file or directory |
+| `homeboy file rename` | Rename or move a file |
+| `homeboy file find` | Find files by name pattern |
+| `homeboy file grep` | Search file contents |
+| `homeboy file download` | Download a file or directory from remote server |
+| `homeboy file copy` | Copy a file or path between local and remote targets |
+| `homeboy file sync` | Sync a directory between local and remote targets without deleting extras |
+| `homeboy file edit` | Edit file with line-based or pattern-based operations |
+
+## `homeboy file list`
+
+```sh
+homeboy file list <PROJECT_ID> <PATH>
+```
+
+List directory contents
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Remote directory path |
+
+## `homeboy file read`
+
+```sh
+homeboy file read [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Read file content
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Remote file path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--raw` | flag | Output raw content only (no JSON wrapper) |
+
+## `homeboy file write`
+
+```sh
+homeboy file write [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Write content to file (from stdin)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Remote file path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply the destructive write. Without this flag, prints a plan only |
+
+## `homeboy file mkdir`
+
+```sh
+homeboy file mkdir [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Create a directory
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Remote directory path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply the directory creation. Without this flag, prints a plan only |
+
+## `homeboy file delete`
+
+```sh
+homeboy file delete [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Delete a file or directory
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Remote path to delete |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-r`, `--recursive` | flag | Delete directories recursively |
+| `--apply` | flag | Apply the destructive delete. Without this flag, prints a plan only |
+
+## `homeboy file rename`
+
+```sh
+homeboy file rename [OPTIONS] <PROJECT_ID> <OLD_PATH> <NEW_PATH>
+```
+
+Rename or move a file
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<OLD_PATH>` | yes | Current path |
+| `<NEW_PATH>` | yes | New path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Apply the rename/move. Without this flag, prints a plan only |
+
+## `homeboy file find`
+
+```sh
+homeboy file find [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Find files by name pattern
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Directory path to search |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--name` | `<NAME>` | Filename pattern (glob, e.g., "*.php") |
+| `--file-type` | `<type>` | File type: f (file), d (directory), l (symlink) |
+| `--max-depth` | `<MAX_DEPTH>` | Maximum directory depth |
+
+## `homeboy file grep`
+
+```sh
+homeboy file grep [OPTIONS] <PROJECT_ID> <PATH> <PATTERN>
+```
+
+Search file contents
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Directory path to search |
+| `<PATTERN>` | yes | Search pattern |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--name` | `<NAME>` | Filter files by name pattern (e.g., "*.php") |
+| `--max-depth` | `<MAX_DEPTH>` | Maximum directory depth |
+| `-i`, `--ignore-case` | flag | Case insensitive search |
+
+## `homeboy file download`
+
+```sh
+homeboy file download [OPTIONS] <PROJECT_ID> <PATH> [LOCAL_PATH]
+```
+
+Download a file or directory from remote server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Remote file path |
+| `[LOCAL_PATH]` | no | Local destination path (defaults to current directory) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-r`, `--recursive` | flag | Download directories recursively |
+
+## `homeboy file copy`
+
+```sh
+homeboy file copy [OPTIONS] <SOURCE> <DESTINATION>
+```
+
+Copy a file or path between local and remote targets
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SOURCE>` | yes | Source: local path or server_id:/path |
+| `<DESTINATION>` | yes | Destination: local path or server_id:/path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-r`, `--recursive` | flag | Copy directories recursively |
+| `-c`, `--compress` | flag | Compress data during transfer |
+| `--dry-run` | flag | Show what would be copied without doing it |
+| `--exclude` | `<EXCLUDE>` | Exclude patterns for recursive server-to-server copies |
+
+## `homeboy file sync`
+
+```sh
+homeboy file sync [OPTIONS] <SOURCE> <DESTINATION>
+```
+
+Sync a directory between local and remote targets without deleting extras
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SOURCE>` | yes | Source: local path or server_id:/path |
+| `<DESTINATION>` | yes | Destination: local path or server_id:/path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-c`, `--compress` | flag | Compress data during transfer |
+| `--dry-run` | flag | Show what would be copied without doing it |
+| `--exclude` | `<EXCLUDE>` | Exclude patterns for recursive server-to-server copies |
+
+## `homeboy file edit`
+
+```sh
+homeboy file edit [OPTIONS] <PROJECT_ID> <FILE_PATH>
+```
+
+Edit file with line-based or pattern-based operations
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<FILE_PATH>` | yes | Remote file path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--dry-run` | flag | Show changes without applying |
+| `-f`, `--force` | flag | Apply even if multiple pattern matches (warns by default) |
+| `--replace-line` | `<REPLACE_LINE>` | _no help text_ |
+| `--replace-line-content` | `<CONTENT>` | _no help text_ |
+| `--insert-after` | `<INSERT_AFTER>` | _no help text_ |
+| `--insert-after-content` | `<CONTENT>` | _no help text_ |
+| `--insert-before` | `<INSERT_BEFORE>` | _no help text_ |
+| `--insert-before-content` | `<CONTENT>` | _no help text_ |
+| `--delete-line` | `<DELETE_LINE>` | _no help text_ |
+| `--delete-lines` | `<START> <END>` | _no help text_ |
+| `--replace-pattern` | `<PATTERN>` | _no help text_ |
+| `--replace-pattern-content` | `<CONTENT>` | _no help text_ |
+| `--replace-all-pattern` | `<REPLACE_ALL_PATTERN>` | _no help text_ |
+| `--replace-all-content` | `<CONTENT>` | _no help text_ |
+| `--delete-pattern` | `<PATTERN>` | _no help text_ |
+| `--append` | `<CONTENT>` | _no help text_ |
+| `--prepend` | `<CONTENT>` | _no help text_ |
+

--- a/docs/reference/cli/commands/fleet.md
+++ b/docs/reference/cli/commands/fleet.md
@@ -1,0 +1,212 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy fleet` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/fleet.md](../../../commands/fleet.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy fleet`
+
+```sh
+homeboy fleet <COMMAND>
+```
+
+Manage fleets (groups of projects)
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy fleet create` | Create a new fleet |
+| `homeboy fleet show` | Display fleet configuration |
+| `homeboy fleet set` | Update fleet configuration |
+| `homeboy fleet delete` | Delete a fleet |
+| `homeboy fleet list` | List all fleets |
+| `homeboy fleet add` | Add a project to a fleet |
+| `homeboy fleet remove` | Remove a project from a fleet |
+| `homeboy fleet projects` | Show projects in a fleet |
+| `homeboy fleet components` | Show component usage across a fleet |
+| `homeboy fleet status` | Show live component versions and server health across a fleet (via SSH) |
+| `homeboy fleet check` | Check component drift across a fleet (compares local vs remote) |
+| `homeboy fleet exec` | Run a command across all projects in a fleet via SSH |
+
+## `homeboy fleet create`
+
+```sh
+homeboy fleet create [OPTIONS] <ID>
+```
+
+Create a new fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--projects` | `<PROJECTS>` | Project IDs to include (comma-separated or repeated) |
+| `-d`, `--description` | `<DESCRIPTION>` | Description of the fleet |
+
+## `homeboy fleet show`
+
+```sh
+homeboy fleet show <ID>
+```
+
+Display fleet configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+## `homeboy fleet set`
+
+```sh
+homeboy fleet set [OPTIONS] [ID]
+```
+
+Update fleet configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Entity ID (optional if provided in JSON body) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON object to merge into the entity (supports @file and - for stdin) |
+| `--base64` | `<BASE64>` | Base64-encoded JSON object (bypasses shell escaping issues) |
+| `--replace` | `<FIELD>` | Replace these fields instead of merging arrays |
+
+## `homeboy fleet delete`
+
+```sh
+homeboy fleet delete <ID>
+```
+
+Delete a fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+## `homeboy fleet list`
+
+```sh
+homeboy fleet list
+```
+
+List all fleets
+
+## `homeboy fleet add`
+
+```sh
+homeboy fleet add [OPTIONS] <ID>
+```
+
+Add a project to a fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--project` | `<PROJECT>` | Project ID to add |
+
+## `homeboy fleet remove`
+
+```sh
+homeboy fleet remove [OPTIONS] <ID>
+```
+
+Remove a project from a fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--project` | `<PROJECT>` | Project ID to remove |
+
+## `homeboy fleet projects`
+
+```sh
+homeboy fleet projects <ID>
+```
+
+Show projects in a fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+## `homeboy fleet components`
+
+```sh
+homeboy fleet components <ID>
+```
+
+Show component usage across a fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+## `homeboy fleet status`
+
+```sh
+homeboy fleet status [OPTIONS] <ID>
+```
+
+Show live component versions and server health across a fleet (via SSH)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--cached` | flag | Use locally cached versions instead of live SSH check |
+| `--health-only` | flag | Show only server health metrics, skip component versions |
+
+## `homeboy fleet check`
+
+```sh
+homeboy fleet check [OPTIONS] <ID>
+```
+
+Check component drift across a fleet (compares local vs remote)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--outdated` | flag | Only show components that need updates |
+
+## `homeboy fleet exec`
+
+```sh
+homeboy fleet exec [OPTIONS] <ID> [COMMAND]...
+```
+
+Run a command across all projects in a fleet via SSH
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Fleet ID |
+| `[COMMAND]...` | no | Command to execute on each project's server |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--check` | flag | Show what would execute without running anything |
+| `--apply` | flag | Confirm the command should execute over SSH on every project in the fleet |
+| `--user` | `<USER>` | Override the SSH user for this execution (instead of each server's configured user) |
+

--- a/docs/reference/cli/commands/fuzz.md
+++ b/docs/reference/cli/commands/fuzz.md
@@ -1,0 +1,465 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy fuzz` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/fuzz.md](../../../commands/fuzz.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy fuzz`
+
+```sh
+homeboy fuzz [OPTIONS] [COMPONENT] [ARGS]... [COMMAND]
+```
+
+Run generic fuzz workloads for a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional runner arguments reserved for the fuzz extension script |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--rig` | `<RIG_ID>` | Run against a rig's component path, extension config, and rig-declared fuzz workloads |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--workload` | `<ID>` | Extension-declared workload id to select |
+| `--profile` | `<ID>` | Rig-defined fuzz profile to select. Without --rig, `lab` expands the generic safe Lab evidence-run defaults |
+| `--shared-state` | `<DIR>` | Shared state directory handed to the fuzz runner. Homeboy forwards the path as HOMEBOY_FUZZ_SHARED_STATE; the runner owns any mutation policy |
+| `--run-id` | `<ID>` | Stable caller-supplied proof label for downstream fuzz runners |
+| `--tracker-ref` | `<KIND:ID>` | Product-agnostic tracker anchor for this fuzz run. Repeatable. Format: KIND:ID |
+| `--seed` | `<SEED>` | Deterministic seed forwarded by future fuzz runners |
+| `--inventory` | `<PATH>` | Product-neutral fuzz target inventory JSON discovered before execution |
+| `--sequence-plan` | `<PATH>` | Exact generated generic sequence plan JSON (`homeboy/fuzz-sequence-plan/v1`) to hand to the runner |
+| `--require-case-log` | flag | Fail the run unless the campaign links case-level execution evidence |
+| `--require-coverage-summary` | flag | Fail the run unless the campaign includes or links a coverage summary |
+| `--require-result-envelope` | flag | Fail the run unless the campaign links a result-envelope artifact |
+| `--max-duration` | `<DURATION>` | Maximum runtime budget forwarded by future fuzz runners, e.g. 60s or 5m |
+| `--gate-profile` | `<GATE_PROFILE>` | Required artifact and gate profile to request from the fuzz runner Values: `measurement`, `evidence`, `coverage-complete`, `strict`. |
+| `--allow-destructive` | flag | Permit destructive fuzz operations when verified generic isolation proof is present |
+| `--isolation` | `<ISOLATION>` | Requested generic runner isolation contract for the fuzz run. This flag is advisory; destructive fuzz also requires verified isolation proof from the run context Values: `shared`, `isolated`. |
+| `--isolation-proof` | `<PATH>` | Explicit homeboy/isolation-proof/v1 JSON proving destructive fuzz can run safely |
+| `--allow-local-destructive-fuzz` | flag | Permit destructive fuzz to execute on the local controller instead of Lab |
+| `--expect-metric` | `<METRIC=VALUE>` | Require a numeric metric emitted by the fuzz campaign to equal this value. Repeatable. Format: `--expect-metric metric_name=2` |
+| `--action-model` | `<PATH>` | Generic action model contract JSON (`homeboy/fuzz-action-model/v1`) to include in the execution request |
+| `--exploration-policy` | `<PATH>` | Generic exploration policy contract JSON (`homeboy/fuzz-exploration-policy/v1`) to include in the execution request |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy fuzz contract` | Print the product-neutral fuzz schema contract |
+| `homeboy fuzz doctor` | Diagnose active fuzz runtime provenance and installed extension revision |
+| `homeboy fuzz discover` | Normalize and merge discovered fuzz target inventory artifacts |
+| `homeboy fuzz list` | List declared fuzz workloads without executing them |
+| `homeboy fuzz plan` | Build a fuzz execution request without executing it |
+| `homeboy fuzz stable` | Plan stable workload Lab commands from a manifest without executing them |
+| `homeboy fuzz run-campaign` | Execute or dry-run a generated fuzz campaign plan |
+| `homeboy fuzz run` | Execute the selected fuzz workload, persist fuzz evidence, and surface its campaign contract |
+| `homeboy fuzz validate` | Validate a fuzz result campaign file |
+| `homeboy fuzz report` | Persist a result envelope from a fuzz campaign file |
+| `homeboy fuzz compare` | Compare two persisted fuzz result envelopes |
+| `homeboy fuzz replay` | Resolve replay metadata for persisted fuzz cases |
+| `homeboy fuzz minimize` | Resolve minimization metadata for persisted fuzz cases |
+| `homeboy fuzz inspect` | Print a compact fuzz failure diagnosis or the complete runner result |
+
+## `homeboy fuzz contract`
+
+```sh
+homeboy fuzz contract
+```
+
+Print the product-neutral fuzz schema contract
+
+## `homeboy fuzz doctor`
+
+```sh
+homeboy fuzz doctor [OPTIONS]
+```
+
+Diagnose active fuzz runtime provenance and installed extension revision
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--extension` | `<ID>` | Extension whose active install should be diagnosed |
+
+## `homeboy fuzz discover`
+
+```sh
+homeboy fuzz discover [OPTIONS]
+```
+
+Normalize and merge discovered fuzz target inventory artifacts
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--inventory` | `<PATH>` | Existing fuzz target inventory artifact to ingest |
+| `--inventory-id` | `<ID>` | Stable id for the merged inventory artifact |
+| `--source-label` | `<LABEL>` | Human-readable source label recorded in merged provenance |
+
+## `homeboy fuzz list`
+
+```sh
+homeboy fuzz list [OPTIONS] [COMPONENT]
+```
+
+List declared fuzz workloads without executing them
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--rig` | `<RIG_ID>` | Discover workloads using a rig's component path, extension config, and rig-declared fuzz workloads |
+| `--remote-discovery` | flag | Query the selected runner for runner-specific availability. Without this flag list reads only local installed rig metadata |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+
+## `homeboy fuzz plan`
+
+```sh
+homeboy fuzz plan [OPTIONS] [COMPONENT] [ARGS]...
+```
+
+Build a fuzz execution request without executing it
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional runner arguments reserved for the fuzz extension script |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--rig` | `<RIG_ID>` | Run against a rig's component path, extension config, and rig-declared fuzz workloads |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--workload` | `<ID>` | Extension-declared workload id to select |
+| `--profile` | `<ID>` | Rig-defined fuzz profile to select. Without --rig, `lab` expands the generic safe Lab evidence-run defaults |
+| `--shared-state` | `<DIR>` | Shared state directory handed to the fuzz runner. Homeboy forwards the path as HOMEBOY_FUZZ_SHARED_STATE; the runner owns any mutation policy |
+| `--run-id` | `<ID>` | Stable caller-supplied proof label for downstream fuzz runners |
+| `--tracker-ref` | `<KIND:ID>` | Product-agnostic tracker anchor for this fuzz run. Repeatable. Format: KIND:ID |
+| `--seed` | `<SEED>` | Deterministic seed forwarded by future fuzz runners |
+| `--inventory` | `<PATH>` | Product-neutral fuzz target inventory JSON discovered before execution |
+| `--sequence-plan` | `<PATH>` | Exact generated generic sequence plan JSON (`homeboy/fuzz-sequence-plan/v1`) to hand to the runner |
+| `--require-case-log` | flag | Fail the run unless the campaign links case-level execution evidence |
+| `--require-coverage-summary` | flag | Fail the run unless the campaign includes or links a coverage summary |
+| `--require-result-envelope` | flag | Fail the run unless the campaign links a result-envelope artifact |
+| `--max-duration` | `<DURATION>` | Maximum runtime budget forwarded by future fuzz runners, e.g. 60s or 5m |
+| `--gate-profile` | `<GATE_PROFILE>` | Required artifact and gate profile to request from the fuzz runner Values: `measurement`, `evidence`, `coverage-complete`, `strict`. |
+| `--allow-destructive` | flag | Permit destructive fuzz operations when verified generic isolation proof is present |
+| `--isolation` | `<ISOLATION>` | Requested generic runner isolation contract for the fuzz run. This flag is advisory; destructive fuzz also requires verified isolation proof from the run context Values: `shared`, `isolated`. |
+| `--isolation-proof` | `<PATH>` | Explicit homeboy/isolation-proof/v1 JSON proving destructive fuzz can run safely |
+| `--allow-local-destructive-fuzz` | flag | Permit destructive fuzz to execute on the local controller instead of Lab |
+| `--expect-metric` | `<METRIC=VALUE>` | Require a numeric metric emitted by the fuzz campaign to equal this value. Repeatable. Format: `--expect-metric metric_name=2` |
+| `--action-model` | `<PATH>` | Generic action model contract JSON (`homeboy/fuzz-action-model/v1`) to include in the execution request |
+| `--exploration-policy` | `<PATH>` | Generic exploration policy contract JSON (`homeboy/fuzz-exploration-policy/v1`) to include in the execution request |
+| `--request-id` | `<ID>` | Stable request id. Defaults to --run-id, then the selected workload id |
+| `--strategy` | `<STRATEGY>` | Inventory selection strategy Values: `all`, `read-only`, `crud`, `coverage-gaps`. |
+| `--operation` | `<FILTER>` | Select operations by canonical family, operation kind, or operation id |
+| `--operation-family` | `<FAMILY>` | Select operations by canonical family |
+| `--case-budget` | `<COUNT>` | Maximum number of cases the downstream runner should generate |
+| `--duration-budget-seconds` | `<SECONDS>` | Maximum execution budget in seconds for downstream runners |
+| `--campaign-manifest` | `<PATH>` | Product-neutral campaign manifest containing workload ids and optional planning metadata |
+| `--campaign-workload` | `<ID>` | Add a workload id to the generated campaign plan. Repeatable |
+| `--lab-runner` | `<ID>` | Preferred Lab runner id to record in campaign plan entries without executing them. Prefer the global `--runner` spelling; this alias remains compatible with existing manifests and automation |
+| `--required-artifact` | `<ID>` | Additional required artifact id/kind expected from every campaign entry. Repeatable |
+| `--execute` | flag | Execute generated campaign entries through the existing `fuzz run` primitive |
+| `--dry-run` | flag | Emit structured dispatch records without executing campaign entries |
+| `--resume` | flag | Skip campaign entries whose run id already exists in the persisted run store |
+
+## `homeboy fuzz stable`
+
+```sh
+homeboy fuzz stable <COMMAND>
+```
+
+Plan stable workload Lab commands from a manifest without executing them
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy fuzz stable plan` | Emit stable workload Lab command JSON from a stable workload manifest |
+
+## `homeboy fuzz stable plan`
+
+```sh
+homeboy fuzz stable plan [OPTIONS]
+```
+
+Emit stable workload Lab command JSON from a stable workload manifest
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--manifest` | `<PATH>` | Stable workload manifest JSON path |
+| `--stable-id` | `<ID[,ID]>` | Limit to one or more stable workload ids. Repeatable and comma-separated |
+| `--runner` | `<ID>` | Preferred Lab runner id to include in every command |
+| `--artifact-root` | `<DIR>` | Persisted artifact root to include in every command |
+| `--run-id-prefix` | `<ID>` | Stable run id prefix. Defaults to stable-YYYYMMDD |
+| `--tracker-ref` | `<KIND:ID>` | Extra tracker ref added to every run command. Repeatable. Format: KIND:ID |
+| `--detach-after-handoff` | flag | Return after the Lab daemon accepts each run |
+| `--component` | `<ID>` | Optional component id for comparison commands |
+| `--since` | `<SINCE>` | Lookback for refs compare command |
+| `--limit` | `<LIMIT>` | Run-history limit for refs/compare commands |
+| `--hotspot-limit` | `<HOTSPOT_LIMIT>` | Hotspot compare row limit |
+
+## `homeboy fuzz run-campaign`
+
+```sh
+homeboy fuzz run-campaign [OPTIONS] [COMPONENT] [ARGS]...
+```
+
+Execute or dry-run a generated fuzz campaign plan
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional runner arguments reserved for the fuzz extension script |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--rig` | `<RIG_ID>` | Run against a rig's component path, extension config, and rig-declared fuzz workloads |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--workload` | `<ID>` | Extension-declared workload id to select |
+| `--profile` | `<ID>` | Rig-defined fuzz profile to select. Without --rig, `lab` expands the generic safe Lab evidence-run defaults |
+| `--shared-state` | `<DIR>` | Shared state directory handed to the fuzz runner. Homeboy forwards the path as HOMEBOY_FUZZ_SHARED_STATE; the runner owns any mutation policy |
+| `--run-id` | `<ID>` | Stable caller-supplied proof label for downstream fuzz runners |
+| `--tracker-ref` | `<KIND:ID>` | Product-agnostic tracker anchor for this fuzz run. Repeatable. Format: KIND:ID |
+| `--seed` | `<SEED>` | Deterministic seed forwarded by future fuzz runners |
+| `--inventory` | `<PATH>` | Product-neutral fuzz target inventory JSON discovered before execution |
+| `--sequence-plan` | `<PATH>` | Exact generated generic sequence plan JSON (`homeboy/fuzz-sequence-plan/v1`) to hand to the runner |
+| `--require-case-log` | flag | Fail the run unless the campaign links case-level execution evidence |
+| `--require-coverage-summary` | flag | Fail the run unless the campaign includes or links a coverage summary |
+| `--require-result-envelope` | flag | Fail the run unless the campaign links a result-envelope artifact |
+| `--max-duration` | `<DURATION>` | Maximum runtime budget forwarded by future fuzz runners, e.g. 60s or 5m |
+| `--gate-profile` | `<GATE_PROFILE>` | Required artifact and gate profile to request from the fuzz runner Values: `measurement`, `evidence`, `coverage-complete`, `strict`. |
+| `--allow-destructive` | flag | Permit destructive fuzz operations when verified generic isolation proof is present |
+| `--isolation` | `<ISOLATION>` | Requested generic runner isolation contract for the fuzz run. This flag is advisory; destructive fuzz also requires verified isolation proof from the run context Values: `shared`, `isolated`. |
+| `--isolation-proof` | `<PATH>` | Explicit homeboy/isolation-proof/v1 JSON proving destructive fuzz can run safely |
+| `--allow-local-destructive-fuzz` | flag | Permit destructive fuzz to execute on the local controller instead of Lab |
+| `--expect-metric` | `<METRIC=VALUE>` | Require a numeric metric emitted by the fuzz campaign to equal this value. Repeatable. Format: `--expect-metric metric_name=2` |
+| `--action-model` | `<PATH>` | Generic action model contract JSON (`homeboy/fuzz-action-model/v1`) to include in the execution request |
+| `--exploration-policy` | `<PATH>` | Generic exploration policy contract JSON (`homeboy/fuzz-exploration-policy/v1`) to include in the execution request |
+| `--request-id` | `<ID>` | Stable request id. Defaults to --run-id, then the selected workload id |
+| `--strategy` | `<STRATEGY>` | Inventory selection strategy Values: `all`, `read-only`, `crud`, `coverage-gaps`. |
+| `--operation` | `<FILTER>` | Select operations by canonical family, operation kind, or operation id |
+| `--operation-family` | `<FAMILY>` | Select operations by canonical family |
+| `--case-budget` | `<COUNT>` | Maximum number of cases the downstream runner should generate |
+| `--duration-budget-seconds` | `<SECONDS>` | Maximum execution budget in seconds for downstream runners |
+| `--campaign-manifest` | `<PATH>` | Product-neutral campaign manifest containing workload ids and optional planning metadata |
+| `--campaign-workload` | `<ID>` | Add a workload id to the generated campaign plan. Repeatable |
+| `--lab-runner` | `<ID>` | Preferred Lab runner id to record in campaign plan entries without executing them. Prefer the global `--runner` spelling; this alias remains compatible with existing manifests and automation |
+| `--required-artifact` | `<ID>` | Additional required artifact id/kind expected from every campaign entry. Repeatable |
+| `--execute` | flag | Execute generated campaign entries through the existing `fuzz run` primitive |
+| `--dry-run` | flag | Emit structured dispatch records without executing campaign entries |
+| `--resume` | flag | Skip campaign entries whose run id already exists in the persisted run store |
+
+## `homeboy fuzz run`
+
+```sh
+homeboy fuzz run [OPTIONS] [COMPONENT] [ARGS]...
+```
+
+Execute the selected fuzz workload, persist fuzz evidence, and surface its campaign contract
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional runner arguments reserved for the fuzz extension script |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--rig` | `<RIG_ID>` | Run against a rig's component path, extension config, and rig-declared fuzz workloads |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--workload` | `<ID>` | Extension-declared workload id to select |
+| `--profile` | `<ID>` | Rig-defined fuzz profile to select. Without --rig, `lab` expands the generic safe Lab evidence-run defaults |
+| `--shared-state` | `<DIR>` | Shared state directory handed to the fuzz runner. Homeboy forwards the path as HOMEBOY_FUZZ_SHARED_STATE; the runner owns any mutation policy |
+| `--run-id` | `<ID>` | Stable caller-supplied proof label for downstream fuzz runners |
+| `--tracker-ref` | `<KIND:ID>` | Product-agnostic tracker anchor for this fuzz run. Repeatable. Format: KIND:ID |
+| `--seed` | `<SEED>` | Deterministic seed forwarded by future fuzz runners |
+| `--inventory` | `<PATH>` | Product-neutral fuzz target inventory JSON discovered before execution |
+| `--sequence-plan` | `<PATH>` | Exact generated generic sequence plan JSON (`homeboy/fuzz-sequence-plan/v1`) to hand to the runner |
+| `--require-case-log` | flag | Fail the run unless the campaign links case-level execution evidence |
+| `--require-coverage-summary` | flag | Fail the run unless the campaign includes or links a coverage summary |
+| `--require-result-envelope` | flag | Fail the run unless the campaign links a result-envelope artifact |
+| `--max-duration` | `<DURATION>` | Maximum runtime budget forwarded by future fuzz runners, e.g. 60s or 5m |
+| `--gate-profile` | `<GATE_PROFILE>` | Required artifact and gate profile to request from the fuzz runner Values: `measurement`, `evidence`, `coverage-complete`, `strict`. |
+| `--allow-destructive` | flag | Permit destructive fuzz operations when verified generic isolation proof is present |
+| `--isolation` | `<ISOLATION>` | Requested generic runner isolation contract for the fuzz run. This flag is advisory; destructive fuzz also requires verified isolation proof from the run context Values: `shared`, `isolated`. |
+| `--isolation-proof` | `<PATH>` | Explicit homeboy/isolation-proof/v1 JSON proving destructive fuzz can run safely |
+| `--allow-local-destructive-fuzz` | flag | Permit destructive fuzz to execute on the local controller instead of Lab |
+| `--expect-metric` | `<METRIC=VALUE>` | Require a numeric metric emitted by the fuzz campaign to equal this value. Repeatable. Format: `--expect-metric metric_name=2` |
+| `--action-model` | `<PATH>` | Generic action model contract JSON (`homeboy/fuzz-action-model/v1`) to include in the execution request |
+| `--exploration-policy` | `<PATH>` | Generic exploration policy contract JSON (`homeboy/fuzz-exploration-policy/v1`) to include in the execution request |
+
+## `homeboy fuzz validate`
+
+```sh
+homeboy fuzz validate [OPTIONS] <RESULTS_FILE>
+```
+
+Validate a fuzz result campaign file
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RESULTS_FILE>` | yes | Fuzz campaign JSON file emitted by a runner |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--gate-profile` | `<GATE_PROFILE>` | Gate profile to evaluate while validating the campaign Values: `measurement`, `evidence`, `coverage-complete`, `strict`. |
+| `--case-log` | `<PATH>` | Canonical fuzz case log JSONL/JSON artifact to validate |
+
+## `homeboy fuzz report`
+
+```sh
+homeboy fuzz report [OPTIONS] <RESULTS_FILE> [COMPONENT] [ARGS]...
+```
+
+Persist a result envelope from a fuzz campaign file
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RESULTS_FILE>` | yes | Fuzz campaign JSON file emitted by a runner |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional runner arguments reserved for the fuzz extension script |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--rig` | `<RIG_ID>` | Run against a rig's component path, extension config, and rig-declared fuzz workloads |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--workload` | `<ID>` | Extension-declared workload id to select |
+| `--profile` | `<ID>` | Rig-defined fuzz profile to select. Without --rig, `lab` expands the generic safe Lab evidence-run defaults |
+| `--shared-state` | `<DIR>` | Shared state directory handed to the fuzz runner. Homeboy forwards the path as HOMEBOY_FUZZ_SHARED_STATE; the runner owns any mutation policy |
+| `--run-id` | `<ID>` | Stable caller-supplied proof label for downstream fuzz runners |
+| `--tracker-ref` | `<KIND:ID>` | Product-agnostic tracker anchor for this fuzz run. Repeatable. Format: KIND:ID |
+| `--seed` | `<SEED>` | Deterministic seed forwarded by future fuzz runners |
+| `--inventory` | `<PATH>` | Product-neutral fuzz target inventory JSON discovered before execution |
+| `--sequence-plan` | `<PATH>` | Exact generated generic sequence plan JSON (`homeboy/fuzz-sequence-plan/v1`) to hand to the runner |
+| `--require-case-log` | flag | Fail the run unless the campaign links case-level execution evidence |
+| `--require-coverage-summary` | flag | Fail the run unless the campaign includes or links a coverage summary |
+| `--require-result-envelope` | flag | Fail the run unless the campaign links a result-envelope artifact |
+| `--max-duration` | `<DURATION>` | Maximum runtime budget forwarded by future fuzz runners, e.g. 60s or 5m |
+| `--gate-profile` | `<GATE_PROFILE>` | Required artifact and gate profile to request from the fuzz runner Values: `measurement`, `evidence`, `coverage-complete`, `strict`. |
+| `--allow-destructive` | flag | Permit destructive fuzz operations when verified generic isolation proof is present |
+| `--isolation` | `<ISOLATION>` | Requested generic runner isolation contract for the fuzz run. This flag is advisory; destructive fuzz also requires verified isolation proof from the run context Values: `shared`, `isolated`. |
+| `--isolation-proof` | `<PATH>` | Explicit homeboy/isolation-proof/v1 JSON proving destructive fuzz can run safely |
+| `--allow-local-destructive-fuzz` | flag | Permit destructive fuzz to execute on the local controller instead of Lab |
+| `--expect-metric` | `<METRIC=VALUE>` | Require a numeric metric emitted by the fuzz campaign to equal this value. Repeatable. Format: `--expect-metric metric_name=2` |
+| `--action-model` | `<PATH>` | Generic action model contract JSON (`homeboy/fuzz-action-model/v1`) to include in the execution request |
+| `--exploration-policy` | `<PATH>` | Generic exploration policy contract JSON (`homeboy/fuzz-exploration-policy/v1`) to include in the execution request |
+| `--output-envelope` | `<PATH>` | Persist the result envelope JSON to this path |
+| `--envelope-id` | `<ID>` | Stable envelope id. Defaults to --run-id, then the campaign id |
+
+## `homeboy fuzz compare`
+
+```sh
+homeboy fuzz compare [OPTIONS] <BASELINE_ENVELOPE> <CANDIDATE_ENVELOPE>
+```
+
+Compare two persisted fuzz result envelopes
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<BASELINE_ENVELOPE>` | yes | Baseline fuzz result envelope JSON file |
+| `<CANDIDATE_ENVELOPE>` | yes | Candidate fuzz result envelope JSON file |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--hotspot-policy` | `<HOTSPOT_POLICY>` | How relative hotspot regressions affect the blocking compare status Values: `advisory`, `blocking`, `off`. |
+
+## `homeboy fuzz replay`
+
+```sh
+homeboy fuzz replay [OPTIONS] [ARTIFACT_OR_CASE] [ARGS]...
+```
+
+Resolve replay metadata for persisted fuzz cases
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ARTIFACT_OR_CASE]` | no | Fuzz campaign/result envelope path, or a case id when --artifact is used |
+| `[ARGS]...` | no | Additional arguments passed to the extension replay command |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--component` | `<ID>` | Component ID used to resolve the extension replay_command |
+| `--path` | `<PATH>` | Override the component checkout path for replay command execution |
+| `--rig` | `<RIG_ID>` | Resolve replay through a rig's component path and extension config |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--artifact` | `<PATH>` | Fuzz campaign or result envelope artifact to inspect for replay metadata |
+| `--case-id` | `<ID>` | Case id to replay from the campaign/envelope artifact |
+| `--run-id` | `<ID>` | Stable Homeboy run id associated with the persisted fuzz evidence |
+| `--dry-run` | flag | Resolve replay metadata and command environment without executing replay_command |
+
+## `homeboy fuzz minimize`
+
+```sh
+homeboy fuzz minimize [OPTIONS] [ARTIFACT_OR_CASE] [ARGS]...
+```
+
+Resolve minimization metadata for persisted fuzz cases
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ARTIFACT_OR_CASE]` | no | Fuzz campaign/result envelope path, or a case id when --artifact is used |
+| `[ARGS]...` | no | Additional arguments passed to the extension minimize command |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--component` | `<ID>` | Component ID used to resolve the extension minimize_command |
+| `--path` | `<PATH>` | Override the component checkout path for minimize command execution |
+| `--rig` | `<RIG_ID>` | Resolve minimization through a rig's component path and extension config |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--artifact` | `<PATH>` | Fuzz campaign or result envelope artifact to inspect for minimization metadata |
+| `--case-id` | `<ID>` | Case id to minimize from the campaign/envelope artifact |
+| `--run-id` | `<ID>` | Stable Homeboy run id associated with the persisted fuzz evidence |
+| `--dry-run` | flag | Resolve minimization metadata and command environment without executing minimize_command |
+
+## `homeboy fuzz inspect`
+
+```sh
+homeboy fuzz inspect [OPTIONS] <RUN_ID>
+```
+
+Print a compact fuzz failure diagnosis or the complete runner result
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Homeboy run id whose raw fuzz result should be inspected. Accepts the fuzz run id or the Lab runner-exec run id that offloaded it |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--raw` | flag | Print the complete result body as raw bytes/text |
+| `--full` | flag | Print the complete parsed result body instead of the bounded diagnosis |
+

--- a/docs/reference/cli/commands/git.md
+++ b/docs/reference/cli/commands/git.md
@@ -1,0 +1,568 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy git` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/git.md](../../../commands/git.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy git`
+
+```sh
+homeboy git <COMMAND>
+```
+
+Git operations for components
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy git status` | Show git status for a component |
+| `homeboy git commit` | Commit changes (by default stages all, use flags for granular control) |
+| `homeboy git push` | Push local commits to remote |
+| `homeboy git rebase` | Rebase the current branch onto another ref |
+| `homeboy git cherry-pick` | Cherry-pick one or more commits onto the current branch |
+| `homeboy git pull` | Pull remote changes |
+| `homeboy git tag` | Create a git tag |
+| `homeboy git issue` | Manage GitHub issues for a component |
+| `homeboy git pr` | Manage GitHub pull requests for a component |
+
+## `homeboy git status`
+
+```sh
+homeboy git status [OPTIONS] [COMPONENT_ID]
+```
+
+Show git status for a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID (non-JSON mode). When omitted, the component is auto-detected from CWD via the registry or a portable `homeboy.json` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON input spec for bulk operations. Use "-" for stdin, "@file.json" for file, or inline JSON string |
+| `--path` | `<PATH>` | Workspace path to operate on directly. Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees) |
+
+## `homeboy git commit`
+
+```sh
+homeboy git commit [OPTIONS] [COMPONENT_ID] [SPEC]
+```
+
+Commit changes (by default stages all, use flags for granular control)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID (optional if provided in JSON body or auto-detected from CWD) |
+| `[SPEC]` | no | Commit message or JSON spec (auto-detected). Plain text: treated as commit message. JSON (starts with { or [): parsed as commit spec. @file.json: reads JSON from file. "-": reads JSON from stdin |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | Explicit JSON spec (takes precedence over positional) |
+| `-m`, `--message` | `<MESSAGE>` | Commit message (CLI mode) |
+| `--staged-only` | flag | Commit only staged changes (skip automatic git add) |
+| `--files` | `<FILES>` | Stage and commit only these specific files |
+| `--exclude` | `<EXCLUDE>` | Stage all files except these (mutually exclusive with --files) |
+| `--include` | `<INCLUDE>` | Explicit include list (repeatable) |
+| `--path` | `<PATH>` | Workspace path to operate on directly. Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees) |
+
+## `homeboy git push`
+
+```sh
+homeboy git push [OPTIONS] [COMPONENT_ID]
+```
+
+Push local commits to remote
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID (non-JSON mode). When omitted, the component is auto-detected from CWD via the registry or a portable `homeboy.json` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON input spec for bulk operations. Use "-" for stdin, "@file.json" for file, or inline JSON string |
+| `--tags` | flag | Push tags as well |
+| `--force-with-lease` | flag | Use `--force-with-lease` for safe force-pushes (e.g. after a rebase). Refuses to overwrite the remote if it has commits the local ref hasn't seen. Plain `--force` is intentionally not exposed |
+| `--remote-url` | `<URL>` | Push to this remote URL directly instead of the configured upstream. Prefer this without credentials plus --token; embedding tokens in the URL can expose them in process listings |
+| `--token` | `<TOKEN>` | GitHub token to inject into --remote-url for this invocation. Requires a https://github.com/... remote URL |
+| `--refspec` | `<REFSPEC>` | Explicit push refspec, e.g. HEAD:refs/heads/my-branch |
+| `--strip-extraheader` | flag | Clear GitHub Actions checkout's auth extraheader so URL auth wins |
+| `--path` | `<PATH>` | Workspace path to operate on directly. Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees) |
+
+## `homeboy git rebase`
+
+```sh
+homeboy git rebase [OPTIONS] [COMPONENT_ID]
+```
+
+Rebase the current branch onto another ref.
+
+Default (no `--onto`) rebases onto the current branch's tracked upstream (`@{upstream}`), same semantics as `git pull --rebase`. Git's default rebase drops commits whose patch-id matches a commit already in upstream — squash-merged PRs are NOT dropped (different patch-id); that case will land in a follow-up.
+
+On conflict, the operation returns a failed result with git's stderr. Resolve manually, then re-run with `--continue` or `--abort`.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID. When omitted, auto-detected from CWD |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--onto` | `<REF>` | Target ref to rebase onto. Defaults to the current branch's tracked upstream (`@{upstream}`) |
+| `--continue` | flag | Continue an in-progress rebase after manual conflict resolution. Mutually exclusive with `--abort` |
+| `--abort` | flag | Abort an in-progress rebase and return to the pre-rebase state |
+| `--path` | `<PATH>` | Workspace path to operate on directly |
+
+## `homeboy git cherry-pick`
+
+```sh
+homeboy git cherry-pick [OPTIONS] [REF]...
+```
+
+Cherry-pick one or more commits onto the current branch.
+
+Accepts SHAs, branch names, and ranges (`<a>..<b>`) as positional args. Use `--pr <n>` to pick all commits from a GitHub PR via `gh`. Both can be combined.
+
+On conflict, returns a failed result. Resolve manually, then re-run with `--continue` or `--abort`.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[REF]...` | no | Commit refs to pick: SHAs, branches, ranges (`<a>..<b>`). Multiple positional args allowed |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-c`, `--component-id` | `<COMPONENT_ID>` | Component ID. When omitted, auto-detected from CWD |
+| `--pr` | `<NUMBER>` | Cherry-pick all commits from a GitHub PR (repeatable). Resolved via `gh pr view <n> --json commits` |
+| `--continue` | flag | Continue an in-progress cherry-pick after manual conflict resolution. Mutually exclusive with `--abort` |
+| `--abort` | flag | Abort an in-progress cherry-pick |
+| `--path` | `<PATH>` | Workspace path to operate on directly |
+
+## `homeboy git pull`
+
+```sh
+homeboy git pull [OPTIONS] [COMPONENT_ID]
+```
+
+Pull remote changes
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID (non-JSON mode). When omitted, the component is auto-detected from CWD via the registry or a portable `homeboy.json` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON input spec for bulk operations. Use "-" for stdin, "@file.json" for file, or inline JSON string |
+| `--path` | `<PATH>` | Workspace path to operate on directly. Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees) |
+
+## `homeboy git tag`
+
+```sh
+homeboy git tag [OPTIONS] [COMPONENT_ID] [TAG_NAME]
+```
+
+Create a git tag
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID. When omitted, the component is auto-detected from CWD via the registry or a portable `homeboy.json` |
+| `[TAG_NAME]` | no | Tag name (e.g., v0.1.2) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-m`, `--message` | `<MESSAGE>` | Tag message (creates annotated tag) |
+| `--path` | `<PATH>` | Workspace path to operate on directly. Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees) |
+
+## `homeboy git issue`
+
+```sh
+homeboy git issue <COMMAND>
+```
+
+Manage GitHub issues for a component
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy git issue create` | Create a new issue |
+| `homeboy git issue comment` | Comment on an existing issue |
+| `homeboy git issue find` | Find issues matching filters (dedup primitive) |
+| `homeboy git issue close` | Close an existing issue with a typed reason |
+| `homeboy git issue edit` | Edit an existing issue's title, body, or labels |
+
+## `homeboy git issue create`
+
+```sh
+homeboy git issue create [OPTIONS] <COMPONENT_ID>
+```
+
+Create a new issue
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-t`, `--title` | `<TITLE>` | Issue title |
+| `-b`, `--body` | `<BODY>` | Issue body (markdown). Prefer --body-file for long content |
+| `--body-file` | `<PATH>` | Read body from a file ("-" for stdin) |
+| `-l`, `--label` | `<LABEL>` | Issue label (repeatable) |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json (for unregistered checkouts — CI runners, ad-hoc clones) |
+
+## `homeboy git issue comment`
+
+```sh
+homeboy git issue comment [OPTIONS] <COMPONENT_ID>
+```
+
+Comment on an existing issue
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--number` | `<NUMBER>` | Issue number |
+| `-b`, `--body` | `<BODY>` | Comment body (markdown). Prefer --body-file for long content |
+| `--body-file` | `<PATH>` | Read body from a file ("-" for stdin) |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git issue find`
+
+```sh
+homeboy git issue find [OPTIONS] <COMPONENT_ID>
+```
+
+Find issues matching filters (dedup primitive)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-t`, `--title` | `<TITLE>` | Exact title match |
+| `-l`, `--label` | `<LABEL>` | Required label (repeatable — all labels must be present) |
+| `-s`, `--state` | `<STATE>` | State filter: open (default), closed, all |
+| `--limit` | `<LIMIT>` | Max results (default 30) |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git issue close`
+
+```sh
+homeboy git issue close [OPTIONS] <COMPONENT_ID>
+```
+
+Close an existing issue with a typed reason
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--number` | `<NUMBER>` | Issue number |
+| `-r`, `--reason` | `<REASON>` | Close reason: completed (default) or not-planned. Use `not-planned` to suppress re-filing by `homeboy runs findings reconcile` — the GitHub-native signal for "we have decided not to fix this." |
+| `-c`, `--comment` | `<COMMENT>` | Optional closing comment (markdown). Posted before the state transition. Prefer --comment-file for long content |
+| `--comment-file` | `<PATH>` | Read closing comment from a file ("-" for stdin) |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git issue edit`
+
+```sh
+homeboy git issue edit [OPTIONS] <COMPONENT_ID>
+```
+
+Edit an existing issue's title, body, or labels
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--number` | `<NUMBER>` | Issue number |
+| `-t`, `--title` | `<TITLE>` | New title (optional) |
+| `-b`, `--body` | `<BODY>` | New body (markdown). Prefer --body-file for long content |
+| `--body-file` | `<PATH>` | Read body from a file ("-" for stdin) |
+| `--add-label` | `<LABEL>` | Add labels (repeatable) |
+| `--remove-label` | `<LABEL>` | Remove labels (repeatable) |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr`
+
+```sh
+homeboy git pr <COMMAND>
+```
+
+Manage GitHub pull requests for a component
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy git pr create` | Create a new pull request |
+| `homeboy git pr edit` | Edit an existing PR's title or body |
+| `homeboy git pr find` | Find PRs matching filters |
+| `homeboy git pr readiness` | Explain PR merge readiness without attempting a merge |
+| `homeboy git pr comment` | Post a comment on a PR. Three modes: |
+| `homeboy git pr fleet` | Report and optionally land a fleet of pull requests |
+| `homeboy git pr reconcile-mergeability` | Compare GitHub mergeability with local git merge-tree evidence |
+| `homeboy git pr policy` | Evaluate PR open/merge policy |
+| `homeboy git pr refresh` | Refresh a PR branch from its current base and report conflicts/checks |
+| `homeboy git pr land` | Land a train of ready PRs sequentially, pausing on the first blocker |
+
+## `homeboy git pr create`
+
+```sh
+homeboy git pr create [OPTIONS] <COMPONENT_ID>
+```
+
+Create a new pull request
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-b`, `--base` | `<BASE>` | Base branch (target of the PR) |
+| `-H`, `--head` | `<HEAD>` | Head branch (source of the PR) |
+| `-t`, `--title` | `<TITLE>` | PR title |
+| `-B`, `--body` | `<BODY>` | PR body (markdown). Prefer --body-file for long content |
+| `--body-file` | `<PATH>` | Read body from a file ("-" for stdin) |
+| `--draft` | flag | Open as draft |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr edit`
+
+```sh
+homeboy git pr edit [OPTIONS] <COMPONENT_ID>
+```
+
+Edit an existing PR's title or body
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--number` | `<NUMBER>` | PR number |
+| `-t`, `--title` | `<TITLE>` | New title |
+| `-B`, `--body` | `<BODY>` | New body (markdown) |
+| `--body-file` | `<PATH>` | Read body from a file ("-" for stdin) |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr find`
+
+```sh
+homeboy git pr find [OPTIONS] <COMPONENT_ID>
+```
+
+Find PRs matching filters
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-b`, `--base` | `<BASE>` | Base branch filter |
+| `-H`, `--head` | `<HEAD>` | Head branch filter |
+| `-s`, `--state` | `<STATE>` | State filter: open (default), closed, merged, all |
+| `--limit` | `<LIMIT>` | Max results (default 30) |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr readiness`
+
+```sh
+homeboy git pr readiness [OPTIONS] <COMPONENT_ID>
+```
+
+Explain PR merge readiness without attempting a merge
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--number` | `<NUMBER>` | PR number |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr comment`
+
+```sh
+homeboy git pr comment [OPTIONS] <COMPONENT_ID>
+```
+
+Post a comment on a PR. Three modes:
+
+1. Plain: no marker flags — a fresh comment is appended. 2. Sticky single-section (#1334): `--key <k>` finds-or-updates the one comment tagged `<!-- homeboy:key=<k> -->`. The whole `--body` becomes the comment body. 3. Sectioned (#1348): `--comment-key <outer> --section-key <inner>` merges `--body` into section `<inner>` of the shared comment tagged `<!-- homeboy:comment-key=<outer> -->`. Other sections are preserved. `--header` sets the line printed after the outer marker on new comments; `--footer` / `--footer-file` sets a block printed after the last section (e.g. a tooling-versions <details> block). Both are preserved from existing comments on merge when omitted. `--section-order` pins section ordering (CSV of keys); default is alphabetical.
+
+Modes 2 and 3 are mutually exclusive. `--key` with `--comment-key` or `--section-key` is an error.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--number` | `<NUMBER>` | PR number |
+| `-B`, `--body` | `<BODY>` | Comment body (markdown). Prefer --body-file for long content |
+| `--body-file` | `<PATH>` | Read body from a file ("-" for stdin) |
+| `-k`, `--key` | `<KEY>` | Sticky whole-body key (mode 2, PR #1334). Mutually exclusive with --comment-key / --section-key |
+| `--comment-key` | `<COMMENT_KEY>` | Sectioned mode: outer shared-comment key (mode 3, #1348). Must be combined with --section-key |
+| `--section-key` | `<SECTION_KEY>` | Sectioned mode: inner per-section key (mode 3, #1348). Must be combined with --comment-key |
+| `--header` | `<HEADER>` | Sectioned mode: optional header line written after the outer marker on freshly-created shared comments (e.g. "## Homeboy Results — `<component>`"). Existing comment headers are preserved on merge |
+| `--footer` | `<FOOTER>` | Sectioned mode: optional footer block written after the last section (e.g. a tooling-versions <details> block). Existing footers are preserved on merge when this is omitted; passing --footer or --footer-file overwrites the preserved footer. Mutually exclusive with --footer-file |
+| `--footer-file` | `<PATH>` | Sectioned mode: read footer content from a file ("-" for stdin). Mutually exclusive with --footer |
+| `--section-order` | `<SECTION_ORDER>` | Sectioned mode: CSV of section keys in desired order. Sections listed here come first in the given order; others are appended alphabetically. Example: `--section-order lint,test,audit` |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr fleet`
+
+```sh
+homeboy git pr fleet [OPTIONS] <COMPONENT_ID> [PR]...
+```
+
+Report and optionally land a fleet of pull requests
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+| `[PR]...` | no | PR numbers or URLs |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--update-branches` | flag | Update stale PR branches where GitHub can do so safely |
+| `--apply` | flag | Merge green, clean PRs. Without this flag the command is read-only |
+| `--merge-method` | `<MERGE_METHOD>` | Merge method: merge, squash, or rebase |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr reconcile-mergeability`
+
+```sh
+homeboy git pr reconcile-mergeability [OPTIONS] <COMPONENT_ID>
+```
+
+Compare GitHub mergeability with local git merge-tree evidence
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--number` | `<NUMBER>` | PR number |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr policy`
+
+```sh
+homeboy git pr policy <COMMAND>
+```
+
+Evaluate PR open/merge policy
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy git pr policy open` | Evaluate whether Homeboy may create or update a proposed PR |
+| `homeboy git pr policy merge` | Evaluate whether an existing PR is safe to merge; optionally merge it |
+
+## `homeboy git pr policy open`
+
+```sh
+homeboy git pr policy open [OPTIONS] <COMPONENT_ID>
+```
+
+Evaluate whether Homeboy may create or update a proposed PR
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--policy` | `<PATH>` | Policy file path (YAML or JSON) |
+| `--source` | `<SOURCE>` | Change source, e.g. autofix, deps, generated, release-prep, agent |
+| `--base` | `<BASE>` | Base branch |
+| `--head` | `<HEAD>` | Head branch |
+| `--head-repo` | `<HEAD_REPOSITORY>` | Head repository owner/name |
+| `--repository` | `<REPOSITORY>` | Base repository owner/name |
+| `--file` | `<PATH>` | Changed file path. Repeatable |
+| `--files-file` | `<PATH>` | Read changed file paths from a newline-delimited file |
+| `--files-from-git` | flag | Read changed files from the current git working tree |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr policy merge`
+
+```sh
+homeboy git pr policy merge [OPTIONS] <COMPONENT_ID>
+```
+
+Evaluate whether an existing PR is safe to merge; optionally merge it
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--policy` | `<PATH>` | Policy file path (YAML or JSON) |
+| `-n`, `--number` | `<NUMBER>` | PR number |
+| `--author` | `<AUTHOR>` | Author login override. Defaults to GitHub PR metadata |
+| `--base` | `<BASE>` | Base branch override. Defaults to GitHub PR metadata |
+| `--head` | `<HEAD>` | Head branch override. Defaults to GitHub PR metadata |
+| `--head-repo` | `<HEAD_REPOSITORY>` | Head repository owner/name override. Defaults to GitHub PR metadata |
+| `--repository` | `<REPOSITORY>` | Base repository owner/name override. Defaults to component remote |
+| `--merge` | flag | Merge the PR when policy allows it |
+| `--merge-method` | `<MERGE_METHOD>` | Merge method: merge, squash, or rebase |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr refresh`
+
+```sh
+homeboy git pr refresh [OPTIONS] <COMPONENT_ID> <PR>
+```
+
+Refresh a PR branch from its current base and report conflicts/checks
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID |
+| `<PR>` | yes | PR number or GitHub pull request URL |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--strategy` | `<STRATEGY>` | Update strategy. `auto` uses branch/pull rebase git config, falling back to rebase Values: `auto`, `rebase`, `merge`, `ff-only`. |
+| `--push` | flag | Push the refreshed PR branch when the worktree is clean and checks pass. Uses --force-with-lease for rebase safety; plain force is not exposed |
+| `--check` | `<COMMAND>` | Lightweight check command to run after a clean refresh. Repeatable. Defaults to `git diff --check` when omitted |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json |
+
+## `homeboy git pr land`
+
+```sh
+homeboy git pr land [OPTIONS] <REPO> [PR]...
+```
+
+Land a train of ready PRs sequentially, pausing on the first blocker
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<REPO>` | yes | Repository as owner/repo or host/owner/repo |
+| `[PR]...` | no | PR numbers or URLs. URLs must point at the selected repo |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--merge-method` | `<MERGE_METHOD>` | Merge method: merge, squash, or rebase Values: `merge`, `squash`, `rebase`. |
+| `--delete-branch` | flag | Delete the PR branch after merge |
+| `--dry-run` | flag | Inspect and report what would land without merging or refreshing |
+| `--refresh-helper` | `<PROGRAM>` | Safe helper program used to refresh a dirty dependent PR. Not run through a shell. Combine with --refresh-helper-arg |
+| `--refresh-helper-arg` | `<ARG>` | Argument for --refresh-helper. Supports {repo}, {number}, {url}, {head_sha} |
+| `--max-base-retries` | `<MAX_BASE_RETRIES>` | Retry merge after this many base-branch-modified races |
+

--- a/docs/reference/cli/commands/harvest.md
+++ b/docs/reference/cli/commands/harvest.md
@@ -1,0 +1,35 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy harvest` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/harvest.md](../../../commands/harvest.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy harvest`
+
+```sh
+homeboy harvest [OPTIONS] <TARGET_ID> [COMPONENT_IDS]...
+```
+
+Recover remote component content into local Git history
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<TARGET_ID>` | yes | Project ID or component ID (order is auto-detected) |
+| `[COMPONENT_IDS]...` | no | Additional component IDs or the project ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--check` | flag | Report remote content drift without writing local files |
+| `--dry-run` | flag | Print the remote content delta without writing or committing |
+| `--apply` | flag | Materialize the reviewed remote delta and commit it |
+| `--exclude` | `<EXCLUDE>` | Relative glob to exclude. Repeat for multiple patterns |
+| `--author` | `<AUTHOR>` | Git author for the recovery commit, for example 'Remote agent <agent@example.invalid>' |
+

--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -1,0 +1,100 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# Homeboy CLI reference (generated)
+
+`homeboy` exposes 524 visible commands across 40 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
+
+Hand-written narrative lives in the [commands index](../../../commands/commands-index.md). Global flags are documented in [the root command reference](../homeboy-root-command.md). Machine-readable safety, docs, output, and Lab metadata come from `homeboy contract manifest`.
+
+| Command | Reference | Summary |
+| --- | --- | --- |
+| `homeboy activity` | [activity.md](activity.md) | Unified view of active and recently finished Homeboy work |
+| `homeboy agent-task` | [agent-task.md](agent-task.md) | Run generic agent task plans |
+| `homeboy project` | [project.md](project.md) | Manage project configuration |
+| `homeboy ssh` | [ssh.md](ssh.md) | SSH into a project server or configured server |
+| `homeboy server` | [server.md](server.md) | Manage SSH server configurations |
+| `homeboy bench` | [bench.md](bench.md) | Run performance benchmarks for a component |
+| `homeboy fuzz` | [fuzz.md](fuzz.md) | Run generic fuzz workloads for a component |
+| `homeboy trace` | [trace.md](trace.md) | Capture black-box behavioral traces for a component |
+| `homeboy observe` | [observe.md](observe.md) | Passively observe a running system and persist timeline evidence |
+| `homeboy db` | [db.md](db.md) | Database operations |
+| `homeboy deps` | [deps.md](deps.md) | Manage component dependencies |
+| `homeboy file` | [file.md](file.md) | Remote file operations |
+| `homeboy fleet` | [fleet.md](fleet.md) | Manage fleets (groups of projects) |
+| `homeboy logs` | [logs.md](logs.md) | Remote log viewing |
+| `homeboy triage` | [triage.md](triage.md) | Attention reports and watch utilities for components, projects, fleets, and rigs |
+| `homeboy deploy` | [deploy.md](deploy.md) | Deploy components to remote server |
+| `homeboy harvest` | [harvest.md](harvest.md) | Recover remote component content into local Git history |
+| `homeboy component` | [component.md](component.md) | Manage standalone component configurations |
+| `homeboy config` | [config.md](config.md) | Manage global Homeboy configuration |
+| `homeboy contract` | [contract.md](contract.md) | Inspect, export, validate, and normalize Homeboy contract metadata |
+| `homeboy daemon` | [daemon.md](daemon.md) | Run the local-only HTTP API daemon |
+| `homeboy extension` | [extension.md](extension.md) | Execute CLI-compatible extensions |
+| `homeboy schedule` | [schedule.md](schedule.md) | Declare homeboy commands that run on a cadence |
+| `homeboy status` | [status.md](status.md) | Actionable component status overview |
+| `homeboy cleanup` | [cleanup.md](cleanup.md) | Remove declared reconstructable artifacts from managed worktrees |
+| `homeboy git` | [git.md](git.md) | Git operations for components |
+| `homeboy release` | [release.md](release.md) | Plan release workflows |
+| `homeboy report` | [report.md](report.md) | Render reports from Homeboy structured output artifacts |
+| `homeboy review` | [review.md](review.md) | Run scoped audit + lint + test umbrella against PR-style changes |
+| `homeboy refactor` | [refactor.md](refactor.md) | Structural refactoring (rename terms across codebase) |
+| `homeboy rig` | [rig.md](rig.md) | Manage local dev rigs (reproducible multi-component environments) |
+| `homeboy runner` | [runner.md](runner.md) | Manage local and SSH execution runners |
+| `homeboy runtime` | [runtime.md](runtime.md) | Inspect core-owned runtime helper assets |
+| `homeboy worktree` | [worktree.md](worktree.md) | Manage component-backed task worktrees |
+| `homeboy tunnel` | [tunnel.md](tunnel.md) | Manage private service tunnel declarations |
+| `homeboy runs` | [runs.md](runs.md) | Inspect persisted observation runs and artifacts |
+| `homeboy self` | [self.md](self.md) | Inspect the active Homeboy binary and install signals |
+| `homeboy stack` | [stack.md](stack.md) | Manage stacks (combined-fixes branches built from base + cherry-picked PRs) |
+| `homeboy api` | [api.md](api.md) | Make API requests to a project |
+| `homeboy upgrade` | [upgrade.md](upgrade.md) | Upgrade Homeboy to the latest version |
+
+## Commands shipping without help text
+
+41 visible commands declare no clap `about`/`long_about`, so no description can be generated for them. The fix is a doc comment on the clap variant, not prose in this file.
+
+- `homeboy agent-task doctor`
+- `homeboy agent-task loop`
+- `homeboy agent-task loop define`
+- `homeboy agent-task loop status`
+- `homeboy agent-task loop resume`
+- `homeboy agent-task loop stop`
+- `homeboy agent-task run-plan`
+- `homeboy agent-task run`
+- `homeboy agent-task run-next`
+- `homeboy agent-task submit`
+- `homeboy agent-task status`
+- `homeboy agent-task list`
+- `homeboy agent-task active`
+- `homeboy agent-task reconcile-records`
+- `homeboy agent-task latest`
+- `homeboy agent-task logs`
+- `homeboy agent-task artifacts`
+- `homeboy agent-task evidence`
+- `homeboy agent-task diagnose`
+- `homeboy agent-task replay-provider-boundary`
+- `homeboy agent-task cancel`
+- `homeboy agent-task resume`
+- `homeboy agent-task retry`
+- `homeboy agent-task fanout`
+- `homeboy agent-task fanout cook-batch`
+- `homeboy agent-task fanout plan`
+- `homeboy agent-task fanout submit`
+- `homeboy agent-task fanout submit-batch`
+- `homeboy agent-task fanout status`
+- `homeboy agent-task fanout artifacts`
+- `homeboy agent-task fanout run-plan`
+- `homeboy agent-task review`
+- `homeboy agent-task promote`
+- `homeboy agent-task finalize-pr`
+- `homeboy agent-task gate-feedback`
+- `homeboy agent-task providers`
+- `homeboy agent-task prompts`
+- `homeboy agent-task contract`
+- `homeboy agent-task compile-loop`
+- `homeboy agent-task auth`
+- `homeboy agent-task controller`

--- a/docs/reference/cli/commands/logs.md
+++ b/docs/reference/cli/commands/logs.md
@@ -1,0 +1,98 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy logs` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/logs.md](../../../commands/logs.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy logs`
+
+```sh
+homeboy logs <COMMAND>
+```
+
+Remote log viewing
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy logs list` | List pinned log files |
+| `homeboy logs show` | Show log file content (shows all pinned logs if path omitted) |
+| `homeboy logs clear` | Clear log file contents |
+| `homeboy logs search` | Search log file for pattern |
+
+## `homeboy logs list`
+
+```sh
+homeboy logs list <PROJECT_ID>
+```
+
+List pinned log files
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+## `homeboy logs show`
+
+```sh
+homeboy logs show [OPTIONS] <PROJECT_ID> [PATH]
+```
+
+Show log file content (shows all pinned logs if path omitted)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[PATH]` | no | Log file path (optional - shows all pinned logs if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-n`, `--lines` | `<LINES>` | Number of lines to show |
+| `-f`, `--follow` | flag | Follow log output (like tail -f) |
+| `--local` | flag | Execute locally instead of via SSH (for when running on the target server) |
+
+## `homeboy logs clear`
+
+```sh
+homeboy logs clear [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Clear log file contents
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Log file path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--local` | flag | Execute locally instead of via SSH |
+
+## `homeboy logs search`
+
+```sh
+homeboy logs search [OPTIONS] <PROJECT_ID> <PATH> <PATTERN>
+```
+
+Search log file for pattern
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Log file path |
+| `<PATTERN>` | yes | Search pattern |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-i`, `--ignore-case` | flag | Case insensitive search |
+| `-n`, `--lines` | `<LINES>` | Limit to last N lines before searching |
+| `-C`, `--context` | `<CONTEXT>` | Lines of context around matches |
+| `--local` | flag | Execute locally instead of via SSH |
+

--- a/docs/reference/cli/commands/observe.md
+++ b/docs/reference/cli/commands/observe.md
@@ -1,0 +1,36 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy observe` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/observe.md](../../../commands/observe.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy observe`
+
+```sh
+homeboy observe [OPTIONS] [COMPONENT]
+```
+
+Passively observe a running system and persist timeline evidence
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--duration` | `<DURATION>` | _no help text_ |
+| `--tail-log` | `<PATH>` | _no help text_ |
+| `--grep` | `<REGEX>` | _no help text_ |
+| `--watch-process` | `<REGEX>` | _no help text_ |
+| `--watch-process-interval` | `<WATCH_PROCESS_INTERVAL>` | _no help text_ |
+| `--probe` | `<JSON>` | _no help text_ |
+

--- a/docs/reference/cli/commands/project.md
+++ b/docs/reference/cli/commands/project.md
@@ -1,0 +1,365 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy project` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/project.md](../../../commands/project.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy project`
+
+```sh
+homeboy project <COMMAND>
+```
+
+Manage project configuration
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy project list` | List all configured projects |
+| `homeboy project show` | Show project configuration |
+| `homeboy project resolve-path` | Resolve a filesystem path to its configured Homeboy project |
+| `homeboy project create` | Create a new project |
+| `homeboy project set` | Update project configuration fields |
+| `homeboy project remove` | Remove items from project configuration arrays |
+| `homeboy project rename` | Rename a project (changes ID) |
+| `homeboy project components` | Manage project components |
+| `homeboy project pin` | Manage pinned files and logs |
+| `homeboy project delete` | Delete a project configuration |
+| `homeboy project init` | Initialize a project directory |
+| `homeboy project status` | Show live server health and component versions for a project |
+
+## `homeboy project list`
+
+```sh
+homeboy project list
+```
+
+List all configured projects
+
+## `homeboy project show`
+
+```sh
+homeboy project show <PROJECT_ID>
+```
+
+Show project configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+## `homeboy project resolve-path`
+
+```sh
+homeboy project resolve-path <PATH>
+```
+
+Resolve a filesystem path to its configured Homeboy project
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PATH>` | yes | Filesystem path inside a project base_path |
+
+## `homeboy project create`
+
+```sh
+homeboy project create [OPTIONS] [ID] [DOMAIN]
+```
+
+Create a new project
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Project ID (CLI mode) |
+| `[DOMAIN]` | no | Public site domain (CLI mode) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON input spec for create/update (supports single or bulk) |
+| `--skip-existing` | flag | Skip items that already exist (JSON mode only) |
+| `--server-id` | `<SERVER_ID>` | Optional server ID |
+| `--base-path` | `<BASE_PATH>` | Optional remote base path |
+| `--table-prefix` | `<TABLE_PREFIX>` | Optional table prefix |
+
+## `homeboy project set`
+
+```sh
+homeboy project set [OPTIONS] [ID]
+```
+
+Update project configuration fields
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Entity ID (optional if provided in JSON body) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON object to merge into the entity (supports @file and - for stdin) |
+| `--base64` | `<BASE64>` | Base64-encoded JSON object (bypasses shell escaping issues) |
+| `--replace` | `<FIELD>` | Replace these fields instead of merging arrays |
+
+## `homeboy project remove`
+
+```sh
+homeboy project remove [OPTIONS] [PROJECT_ID] [SPEC]
+```
+
+Remove items from project configuration arrays
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[PROJECT_ID]` | no | Project ID (optional if provided in JSON body) |
+| `[SPEC]` | no | JSON spec (positional, supports @file and - for stdin) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | Explicit JSON spec (takes precedence over positional) |
+
+## `homeboy project rename`
+
+```sh
+homeboy project rename <PROJECT_ID> <NEW_ID>
+```
+
+Rename a project (changes ID)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Current project ID |
+| `<NEW_ID>` | yes | New project ID |
+
+## `homeboy project components`
+
+```sh
+homeboy project components <COMMAND>
+```
+
+Manage project components
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy project components list` | List associated components |
+| `homeboy project components set` | Replace project components with the provided list |
+| `homeboy project components attach-path` | Attach a repo path for a project component discovered via homeboy.json |
+| `homeboy project components remove` | Remove one or more components |
+| `homeboy project components clear` | Remove all components |
+
+## `homeboy project components list`
+
+```sh
+homeboy project components list <PROJECT_ID>
+```
+
+List associated components
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+## `homeboy project components set`
+
+```sh
+homeboy project components set [OPTIONS] <PROJECT_ID>
+```
+
+Replace project components with the provided list
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON array of attachments: [{"id":"foo","local_path":"/repo","remote_path":"wp-content/plugins/foo"}] |
+
+## `homeboy project components attach-path`
+
+```sh
+homeboy project components attach-path <PROJECT_ID> <LOCAL_PATH>
+```
+
+Attach a repo path for a project component discovered via homeboy.json
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<LOCAL_PATH>` | yes | Local repo path containing homeboy.json |
+
+## `homeboy project components remove`
+
+```sh
+homeboy project components remove <PROJECT_ID> [COMPONENT_IDS]...
+```
+
+Remove one or more components
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[COMPONENT_IDS]...` | no | Component IDs |
+
+## `homeboy project components clear`
+
+```sh
+homeboy project components clear <PROJECT_ID>
+```
+
+Remove all components
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+## `homeboy project pin`
+
+```sh
+homeboy project pin <COMMAND>
+```
+
+Manage pinned files and logs
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy project pin list` | List pinned items |
+| `homeboy project pin add` | Pin a file or log |
+| `homeboy project pin remove` | Unpin a file or log |
+| `homeboy project pin update` | Update an existing pinned file or log |
+| `homeboy project pin rename` | Rename the path for an existing pinned file or log |
+
+## `homeboy project pin list`
+
+```sh
+homeboy project pin list [OPTIONS] <PROJECT_ID>
+```
+
+List pinned items
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--type` | `<TYPE>` | Item type: file or log Values: `file`, `log`. |
+
+## `homeboy project pin add`
+
+```sh
+homeboy project pin add [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Pin a file or log
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Path to pin (relative to basePath or absolute) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--type` | `<TYPE>` | Item type: file or log Values: `file`, `log`. |
+| `--label` | `<LABEL>` | Optional display label |
+| `--tail` | `<TAIL>` | Number of lines to tail (logs only) |
+
+## `homeboy project pin remove`
+
+```sh
+homeboy project pin remove [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Unpin a file or log
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Path to unpin |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--type` | `<TYPE>` | Item type: file or log Values: `file`, `log`. |
+
+## `homeboy project pin update`
+
+```sh
+homeboy project pin update [OPTIONS] <PROJECT_ID> <PATH>
+```
+
+Update an existing pinned file or log
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<PATH>` | yes | Path to update |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--type` | `<TYPE>` | Item type: file or log Values: `file`, `log`. |
+| `--label` | `<LABEL>` | Optional display label |
+| `--tail` | `<TAIL>` | Number of lines to tail (logs only) |
+
+## `homeboy project pin rename`
+
+```sh
+homeboy project pin rename [OPTIONS] <PROJECT_ID> <OLD_PATH> <NEW_PATH>
+```
+
+Rename the path for an existing pinned file or log
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `<OLD_PATH>` | yes | Current pinned path |
+| `<NEW_PATH>` | yes | New pinned path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--type` | `<TYPE>` | Item type: file or log Values: `file`, `log`. |
+
+## `homeboy project delete`
+
+```sh
+homeboy project delete <PROJECT_ID>
+```
+
+Delete a project configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+## `homeboy project init`
+
+```sh
+homeboy project init <PROJECT_ID>
+```
+
+Initialize a project directory
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+## `homeboy project status`
+
+```sh
+homeboy project status [OPTIONS] <PROJECT_ID>
+```
+
+Show live server health and component versions for a project
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--health-only` | flag | Show only server health metrics, skip component versions |
+

--- a/docs/reference/cli/commands/refactor.md
+++ b/docs/reference/cli/commands/refactor.md
@@ -1,0 +1,272 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy refactor` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/refactor.md](../../../commands/refactor.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy refactor`
+
+```sh
+homeboy refactor [OPTIONS] [COMPONENT] [COMMAND]
+```
+
+Structural refactoring (rename terms across codebase)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--from` | `<SOURCE>` | Include a specific proposal source (repeatable): audit, lint, test, all |
+| `--all` | flag | Compatibility alias for `--from all` |
+| `--changed-since` | `<CHANGED_SINCE>` | Only include files changed since a git ref (branch, tag, or SHA) |
+| `--only` | `<kind>` | Restrict audit-generated fixes to these fix kinds (repeatable) |
+| `--exclude` | `<kind>` | Exclude audit-generated fixes for these fix kinds (repeatable) |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+| `--force` | flag | Skip the clean working tree check (for CI or when you know what you're doing) |
+| `--write` | flag | _no help text_ |
+| `--commit` | flag | After applying fixes, stage all changes and commit. Only effective with --write. The commit message is built from fix results |
+| `--git-identity` | `<GIT_IDENTITY>` | Git identity for the commit (used with --commit). Use "bot" for the default CI bot identity, or "Name <email>" for custom |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy refactor rename` | Rename a term across the codebase with case-variant awareness |
+| `homeboy refactor add` | Add imports, stubs, or fixes to source files |
+| `homeboy refactor move` | Move items or entire files between modules |
+| `homeboy refactor propagate` | Add missing fields to struct instantiations after a struct definition changes |
+| `homeboy refactor collapse-defaults` | Collapse default-valued fields in struct instantiations into `..Default::default()` (the inverse of `propagate`) |
+| `homeboy refactor transform` | Apply an ad-hoc pattern-based find/replace transform across a codebase |
+| `homeboy refactor decompose` | Decompose a large source file into a directory of smaller modules |
+| `homeboy refactor refs` | Read-only reference discovery for a symbol or term |
+| `homeboy refactor undo` | Undo the last write operation snapshot |
+
+## `homeboy refactor rename`
+
+```sh
+homeboy refactor rename [OPTIONS]
+```
+
+Rename a term across the codebase with case-variant awareness
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--from` | `<FROM>` | Term to rename from |
+| `--to` | `<TO>` | Term to rename to |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--scope` | `<SCOPE>` | Scope: code, config, all (default: all) |
+| `--literal` | flag | Exact string matching (no boundary detection, no case variants) |
+| `--files` | `<GLOB>` | Include only files matching this glob (repeatable) |
+| `--exclude` | `<GLOB>` | Exclude files matching this glob (repeatable) |
+| `--variant` | `<FROM=TO>` | Add an explicit variant mapping as FROM=TO (repeatable) |
+| `--no-file-renames` | flag | Disable file/directory path renames (content edits only) |
+| `--context` | `<CONTEXT>` | Syntactic context filter: key (strings/property access), variable/var, parameter/param, all (default — match everything) |
+| `--write` | flag | _no help text_ |
+
+## `homeboy refactor add`
+
+```sh
+homeboy refactor add [OPTIONS]
+```
+
+Add imports, stubs, or fixes to source files
+
+Two modes: From audit: `refactor add --from-audit @audit.json [--write]` Explicit: `refactor add --import "use serde::Serialize;" --to "src/**/*.rs" [--write]`
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--from-audit` | `<AUDIT_JSON>` | Apply fixes from saved audit JSON (supports @file, -, or inline JSON) |
+| `--import` | `<IMPORT>` | Import/use statement to add (explicit mode) |
+| `--to` | `<PATTERN>` | Target file or glob pattern for explicit additions |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--write` | flag | _no help text_ |
+
+## `homeboy refactor move`
+
+```sh
+homeboy refactor move [OPTIONS]
+```
+
+Move items or entire files between modules
+
+Item mode: `refactor move --item has_import --from src/conventions.rs --to src/import_matching.rs` File mode: `refactor move --file src/core/hooks.rs --to src/core/engine/hooks.rs`
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--item` | `<NAME>` | Name(s) of items to move (functions, structs, enums, consts). When omitted with --file, moves the entire file |
+| `--file` | `<FILE>` | Move an entire module file to a new location. Rewrites all imports and updates mod.rs declarations |
+| `--from` | `<FILE>` | Source file (for item mode — relative to component/path root) |
+| `--to` | `<FILE>` | Destination file (relative to component/path root, created if needed) |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--write` | flag | _no help text_ |
+
+## `homeboy refactor propagate`
+
+```sh
+homeboy refactor propagate [OPTIONS]
+```
+
+Add missing fields to struct instantiations after a struct definition changes
+
+Scans the codebase for instantiations of the named struct, detects which fields are missing, and inserts them with sensible defaults (None, vec![], false, etc.).
+
+Example: `refactor propagate --struct-name FileFingerprint --component homeboy`
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--struct-name` | `<NAME>` | Name of the struct to propagate fields for |
+| `--definition` | `<FILE>` | File containing the struct definition (auto-detected if omitted) |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--write` | flag | _no help text_ |
+
+## `homeboy refactor collapse-defaults`
+
+```sh
+homeboy refactor collapse-defaults [OPTIONS]
+```
+
+Collapse default-valued fields in struct instantiations into `..Default::default()` (the inverse of `propagate`).
+
+Scans the codebase for instantiations of the named struct and, for each, removes fields whose value equals the type's default (None, Vec::new(), Value::Null, String::new(), false, 0, etc.), replacing them with a single trailing `..Default::default()`. Conservative: skips literals that already spread, contain an interspersed comment, or set an unknown-type field. The struct must have a `Default` impl for the result to compile.
+
+Dry-run by default — pass `--write` to apply.
+
+Example: `refactor collapse-defaults --struct-name AgentTaskOutcome --component homeboy`
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--struct-name` | `<NAME>` | Name of the struct to collapse defaults for |
+| `--definition` | `<FILE>` | File containing the struct definition (auto-detected if omitted) |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--write` | flag | _no help text_ |
+
+## `homeboy refactor transform`
+
+```sh
+homeboy refactor transform [OPTIONS]
+```
+
+Apply an ad-hoc pattern-based find/replace transform across a codebase
+
+Example: `refactor transform --find "old" --replace "new" --files "**/*.php" --component C`
+
+Replacement templates support capture group refs ($1, $2, ${name}), case transforms ($1:lower, $1:upper, $1:kebab, $1:snake, $1:pascal, $1:camel), and literal $ via $$ (important for PHP code where every variable starts with $).
+
+Backslash escapes collapse before regex replacement: `\\` → one literal backslash, `\n` → newline, `\t` → tab, `\r` → CR, `\"` / `\'` → the quote. Write `\\WP_Foo` to emit `\WP_Foo` on disk (useful for PHP fully-qualified class names). Unknown `\X` sequences pass through as-is.
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--find` | `<REGEX>` | Regex pattern to find |
+| `--replace` | `<TEMPLATE>` | Replacement template. Supports $1, $2 capture group refs, ${name} named groups, $1:lower/:upper/:kebab/:snake/:pascal/:camel case transforms, and $$ for a literal dollar sign. Backslash escapes are collapsed: \\ → one literal backslash, \n/\t/\r/\0 → the control character, \" / \' → the quote |
+| `--files` | `<GLOB>` | Glob pattern for files to apply to (default: **/*) |
+| `--context` | `<CONTEXT>` | Match context: "line" (default, per-line matching) or "file" (whole-file, enables multi-line regex with (?s) dotall flag for patterns spanning newlines) |
+| `--full-match-details` | flag | Include every match detail in JSON output instead of the default bounded sample |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--write` | flag | _no help text_ |
+
+## `homeboy refactor decompose`
+
+```sh
+homeboy refactor decompose [OPTIONS]
+```
+
+Decompose a large source file into a directory of smaller modules
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--file` | `<FILE>` | Source file to decompose (relative to component/path root) |
+| `--strategy` | `<STRATEGY>` | Planning strategy (currently: grouped) |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--write` | flag | _no help text_ |
+
+## `homeboy refactor refs`
+
+```sh
+homeboy refactor refs [OPTIONS] <SYMBOL>
+```
+
+Read-only reference discovery for a symbol or term
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SYMBOL>` | yes | Symbol or term to find |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-c`, `--component` | `<ID>` | Target a component by ID (repeatable) |
+| `--components` | `<ID[,ID...]>` | Target multiple components with a comma-separated list |
+| `--path` | `<PATH>` | Override the source root for a single target |
+| `--scope` | `<SCOPE>` | Scope: code, config, all |
+| `--literal` | flag | Exact string matching (no boundary detection, no case variants) |
+| `--files` | `<GLOB>` | Include only files matching this glob (repeatable) |
+| `--exclude` | `<GLOB>` | Exclude files matching this glob (repeatable) |
+| `--context` | `<CONTEXT>` | Syntactic context filter: key, variable/var, parameter/param, all |
+
+## `homeboy refactor undo`
+
+```sh
+homeboy refactor undo [OPTIONS] [COMMAND]
+```
+
+Undo the last write operation snapshot
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--id` | `<ID>` | Restore a specific snapshot by ID (default: latest) |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy refactor undo list` | List available undo snapshots |
+| `homeboy refactor undo delete` | Delete a snapshot without restoring |
+
+## `homeboy refactor undo list`
+
+```sh
+homeboy refactor undo list
+```
+
+List available undo snapshots
+
+## `homeboy refactor undo delete`
+
+```sh
+homeboy refactor undo delete <ID>
+```
+
+Delete a snapshot without restoring
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Snapshot ID to delete |
+

--- a/docs/reference/cli/commands/release.md
+++ b/docs/reference/cli/commands/release.md
@@ -1,0 +1,130 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy release` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/release.md](../../../commands/release.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy release`
+
+```sh
+homeboy release [OPTIONS] [COMPONENTS]... [COMMAND]
+```
+
+Plan release workflows
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENTS]...` | no | Component ID(s) to release |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `-p`, `--project` | `<PROJECT>` | Release all components in a project that need a release |
+| `--outdated` | flag | Only release components with unreleased code commits (use with --project) |
+| `--path` | `<PATH>` | Override local_path for version file lookup (single component only) |
+| `--dry-run` | flag | _no help text_ |
+| `--apply` | flag | Confirm risky release execution modes |
+| `--deploy` | flag | Deploy to all projects using this component after release |
+| `--recover` | flag | Recover from an interrupted release (tag + push current version) |
+| `--retag` | flag | With --recover: if the release tag exists but points at a commit behind HEAD (e.g. config-only commits landed after tagging), move the tag to HEAD instead of refusing. Guarded — the tagged commit must be an ancestor of HEAD, HEAD must satisfy the version targets, and no GitHub Release may exist for the tag |
+| `--head` | flag | Finish the release pipeline for an already-versioned, already-tagged HEAD. Skips changelog/version/git mutation steps and runs package, GitHub Release, publish, cleanup, and post-release hooks against the tag pointing at HEAD |
+| `--from-artifacts` | `<DIR>` | Use existing release artifacts from this directory instead of running release.package. Requires --head |
+| `--package-only` | flag | Regenerate only the release package for an existing tag at HEAD. Combine with --head --tag <tag> --apply to write a durable artifact inventory for later --head --from-artifacts finalization |
+| `--tag` | `<TAG>` | Existing release tag to package with --package-only |
+| `--skip-checks` | `<CHECK>` | Skip pre-release quality checks |
+| `--skip-build-validation` | flag | Bypass the package/build-structure validation while still running the build |
+| `--bump` | `<BUMP>` | Force a specific version bump: major, minor, patch, or an explicit version (e.g. 2.0.0). Overrides auto-detection from commit history |
+| `--force-lower-bump` | flag | Allow an explicit bump lower than Homeboy's commit-derived recommendation |
+| `--skip-publish` | flag | Skip registry/package publishing only (version bump + tag + push). This does NOT skip GitHub Release creation — a GitHub Release is still created unless you ALSO pass --no-github-release. Use when CI handles registry/package publishing after the tag is pushed |
+| `--no-github-release` | flag | Skip the GitHub Release creation step (the reviewer-facing release page with notes + assets on github.com). The tag is still created and pushed |
+| `--i-know-ci-creates-the-github-release` | flag | Confirm that --no-github-release is intentional on a manual/local release because CI (or another pipeline) creates the GitHub Release. Required whenever --no-github-release is used on a component that would otherwise get a reviewer-facing GitHub Release |
+| `--i-know-this-is-a-manual-tag-only-release` | flag | Confirm an intentional manual tag-only release. Use only when no CI-owned GitHub Release automation should create the reviewer-facing release page |
+| `--git-identity` | `<GIT_IDENTITY>` | Git identity for release commits and tags. Use "bot" for the default CI bot identity, or "Name <email>" for custom. When set, configures git user.name and user.email before committing |
+| `--cascade` | flag | After releasing the component, release every dependent that declares a dependency on it: update the dependent's declared dependency pin and release it with an automatic patch bump, transitively. Single-component releases only |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy release changes` | Show changes since the last version tag |
+| `homeboy release changelog` | Show generated changelog content |
+| `homeboy release version` | Version inspection helpers |
+
+## `homeboy release changes`
+
+```sh
+homeboy release changes [OPTIONS] [TARGET_ID] [COMPONENT_IDS]...
+```
+
+Show changes since the last version tag
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[TARGET_ID]` | no | Target ID: component ID (single mode) or project ID (if followed by component IDs) |
+| `[COMPONENT_IDS]...` | no | Component IDs to filter (when target_id is a project) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECT>` | Show changes for all components in a project (alternative to positional project mode) |
+| `--path` | `<PATH>` | Workspace path to operate on directly. Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees) |
+| `--json` | `<JSON>` | JSON input spec for bulk operations: {"componentIds": ["id1", "id2"]} |
+| `--since` | `<SINCE>` | Compare against specific tag instead of latest |
+| `--git-diffs` | flag | Include commit range diff in output (uncommitted diff is always included) |
+
+## `homeboy release changelog`
+
+```sh
+homeboy release changelog [COMMAND]
+```
+
+Show generated changelog content
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy release changelog show` | Show Homeboy's changelog, or a component changelog when an ID is provided |
+
+## `homeboy release changelog show`
+
+```sh
+homeboy release changelog show [COMPONENT_ID]
+```
+
+Show Homeboy's changelog, or a component changelog when an ID is provided
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID to show changelog for |
+
+## `homeboy release version`
+
+```sh
+homeboy release version <COMMAND>
+```
+
+Version inspection helpers
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy release version show` | Show current version (default: discovered component, fallback: homeboy binary) |
+
+## `homeboy release version show`
+
+```sh
+homeboy release version show [OPTIONS] [COMPONENT_ID]
+```
+
+Show current version (default: discovered component, fallback: homeboy binary)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID (optional - shows discovered component version, or homeboy binary version) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override local_path for version file lookup |
+

--- a/docs/reference/cli/commands/report.md
+++ b/docs/reference/cli/commands/report.md
@@ -1,0 +1,142 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy report` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/report.md](../../../commands/report.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy report`
+
+```sh
+homeboy report <COMMAND>
+```
+
+Render reports from Homeboy structured output artifacts
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy report failure-digest` | Render a markdown failure digest from Homeboy command output JSON files |
+| `homeboy report performance-digest` | Render a generic performance digest from Homeboy run artifacts |
+| `homeboy report bench-coverage` | Report list-only benchmark coverage for hot command paths |
+| `homeboy report browser-evidence-compare` | Compare before/after browser evidence artifact sets |
+| `homeboy report matrix-artifacts` | Summarize matrix-style run artifacts and finding packets |
+| `homeboy report compare` | Compare structured matrix/report artifacts |
+
+## `homeboy report failure-digest`
+
+```sh
+homeboy report failure-digest [OPTIONS]
+```
+
+Render a markdown failure digest from Homeboy command output JSON files
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--output-dir` | `<DIR>` | Directory containing audit.json, lint.json, test.json, etc |
+| `--results` | `<JSON>` | Results JSON, e.g. '{"audit":"fail","lint":"pass"}' (supports @file) |
+| `--run-url` | `<URL>` | Workflow run URL used as the fallback full-log link |
+| `--tooling-json` | `<JSON_OR_FILE>` | Optional tooling metadata JSON file (supports @file) |
+| `--commands` | `<CSV>` | Commands in this run, used to derive default autofix candidates |
+| `--autofix-commands` | `<CSV>` | Commands with autofix support. Defaults to failed audit/lint/test commands |
+| `--autofix-enabled` | flag | Whether automated fixes are enabled for this run |
+| `--autofix-attempted` | flag | Whether automated fixes were already attempted in this run |
+| `--format` | `<FORMAT>` | Output format. Markdown is the only supported report format for now Values: `markdown`. |
+
+## `homeboy report performance-digest`
+
+```sh
+homeboy report performance-digest [OPTIONS]
+```
+
+Render a generic performance digest from Homeboy run artifacts
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--output-dir` | `<DIR>` | Directory containing Homeboy run artifacts such as resource-summary.json and bench.json |
+| `--metadata-json` | `<JSON_OR_FILE>` | Optional run metadata JSON, e.g. observation metadata or a status file (supports @file) |
+| `--run-url` | `<URL>` | Workflow run URL used as the fallback full-log link |
+| `--min-samples` | `<MIN_SAMPLES>` | Minimum run count for baseline health checks |
+| `--max-cv-pct` | `<MAX_CV_PCT>` | Maximum coefficient of variation percentage before a baseline is considered noisy |
+| `--format` | `<FORMAT>` | Output format. Markdown is the only direct-render report format for now Values: `markdown`. |
+
+## `homeboy report bench-coverage`
+
+```sh
+homeboy report bench-coverage [OPTIONS] [COMPONENT]
+```
+
+Report list-only benchmark coverage for hot command paths
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--all` | flag | Inspect every registered component instead of the selected component |
+| `--format` | `<FORMAT>` | Output format Values: `markdown`, `json`. |
+
+## `homeboy report browser-evidence-compare`
+
+```sh
+homeboy report browser-evidence-compare [OPTIONS]
+```
+
+Compare before/after browser evidence artifact sets
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--baseline-dir` | `<DIR>` | Directory containing baseline browser evidence JSON artifacts |
+| `--candidate-dir` | `<DIR>` | Directory containing candidate browser evidence JSON artifacts |
+| `--baseline-label` | `<BASELINE_LABEL>` | Label for the baseline artifact set |
+| `--candidate-label` | `<CANDIDATE_LABEL>` | Label for the candidate artifact set |
+| `--include-local-paths` | flag | Include local filesystem paths in Markdown output. By default Markdown only uses relative artifact names and URLs |
+| `--format` | `<FORMAT>` | Output format. Markdown is direct-rendered; JSON uses the normal command envelope Values: `markdown`, `json`. |
+| `--visual-compare` | flag | Run visual screenshot comparisons through a declared visual compare provider |
+| `--visual-artifacts-dir` | `<DIR>` | Directory where visual compare artifacts should be written |
+| `--visual-compare-provider` | `<COMMAND>` | Executable implementing the generic Homeboy visual compare provider contract |
+| `--visual-provider-arg` | `<ARG>` | Extra argument forwarded to the visual compare provider before the input JSON path |
+| `--visual-threshold` | `<RATIO>` | Visual mismatch threshold forwarded to the visual compare provider |
+
+## `homeboy report matrix-artifacts`
+
+```sh
+homeboy report matrix-artifacts [OPTIONS] <RUN_ID>
+```
+
+Summarize matrix-style run artifacts and finding packets
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run ID or the human `--run-id` launch label to summarize |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--format` | `<FORMAT>` | Output format: json or markdown |
+
+## `homeboy report compare`
+
+```sh
+homeboy report compare [OPTIONS]
+```
+
+Compare structured matrix/report artifacts
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--old` | `<RUN_OR_ARTIFACT>` | Baseline artifact input: local JSON path, run id, or run:artifact / run/artifact ref |
+| `--new` | `<RUN_OR_ARTIFACT>` | Candidate artifact input: local JSON path, run id, or run:artifact / run/artifact ref |
+| `--format` | `<FORMAT>` | Output format Values: `markdown`, `json`. |
+

--- a/docs/reference/cli/commands/review.md
+++ b/docs/reference/cli/commands/review.md
@@ -1,0 +1,323 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy review` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/review.md](../../../commands/review.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy review`
+
+```sh
+homeboy review [OPTIONS] [COMPONENT] [COMMAND]
+```
+
+Run scoped audit + lint + test umbrella against PR-style changes
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--run-id` | `<RUN_ID>` | Attach to an already-persisted review run instead of starting another audit/lint/test execution |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--changed-since` | `<REF>` | Run audit + lint + test only against files changed since this git ref (branch, tag, or SHA). CI-friendly — mirrors the per-stage flag |
+| `--changed-only` | flag | Run only against files modified in the working tree (staged, unstaged, untracked). Only the lint stage scopes natively; audit and test run on the full component with a hint noting the limitation. Use `--changed-since` for full umbrella scoping |
+| `--summary` | flag | Show compact summary instead of full per-stage output |
+| `--ci-profile` | `<ID>` | Run an extension-declared CI profile as an additional review gate |
+| `--audit-profile` | `<PROFILE>` | Audit detector profile for the audit stage. Defaults to `pr` for changed-file review and `full` for full review Values: `full`, `pr`, `architecture`. |
+| `--report` | `<FORMAT>` | Output format. Default JSON envelope; `--report=pr-comment` emits a markdown PR-comment section instead, suitable for piping to `homeboy git pr comment --body-file` Values: `pr-comment`. |
+| `--banner` | `<KEY=VALUE>` | Action-level banner rendered above the PR-comment scope line. Repeatable as `--banner key=value` |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy review audit` | Audit code conventions and detect architectural drift |
+| `homeboy review lint` | Lint a component |
+| `homeboy review test` | Run tests for a component |
+| `homeboy review build` | Run a local build quality gate for a component |
+| `homeboy review ci` | Inspect CI reproduction profiles and discovered CI surfaces |
+
+## `homeboy review audit`
+
+```sh
+homeboy review audit [OPTIONS] [COMPONENT]
+```
+
+Audit code conventions and detect architectural drift
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--conventions` | flag | Only show discovered conventions (skip findings) |
+| `--only` | `<kind>` | Restrict findings to these kinds (repeatable) |
+| `--exclude` | `<kind>` | Exclude findings of these kinds (repeatable) |
+| `--profile` | `<PROFILE>` | Detector profile to run. `full` preserves the default full audit; `pr` runs cheap root-level blockers for changed-file review Values: `full`, `pr`, `architecture`. |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+| `--changed-since` | `<CHANGED_SINCE>` | Only audit files changed since a git ref (branch, tag, or SHA) |
+| `--json-summary` | flag | Include compact machine-readable summary for CI wrappers |
+| `--fixability` | flag | Include automated-fixability metadata. This can be expensive because it runs the refactor planner after audit completes |
+
+## `homeboy review lint`
+
+```sh
+homeboy review lint [OPTIONS] [COMPONENT]
+```
+
+Lint a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--summary` | flag | Show compact summary instead of full output |
+| `--file` | `<FILE>` | Lint only a single file (path relative to component root) |
+| `--glob` | `<GLOB>` | Lint only files matching a repo-relative glob pattern |
+| `--changed-only` | flag | Lint modified files in the working tree (file-scoped, not hunk-scoped) |
+| `--changed-since` | `<CHANGED_SINCE>` | Lint only files changed since a git ref (branch, tag, or SHA) — CI-friendly |
+| `--ci-job` | `<ID>` | Run using env from a single extension-declared CI lint job |
+| `--errors-only` | flag | Show only errors, suppress warnings |
+| `--sniffs` | `<SNIFFS>` | Only check specific sniffs (comma-separated codes) |
+| `--exclude-sniffs` | `<EXCLUDE_SNIFFS>` | Exclude sniffs from checking (comma-separated codes) |
+| `--category` | `<CATEGORY>` | Filter by category: security, i18n, yoda, whitespace |
+| `--fix` | flag | Apply auto-fixable lint findings in place using the lint fixer pipeline |
+| `--force` | flag | Allow --fix to edit the current dirty working tree for unbounded runs |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+| `--json-summary` | flag | Print compact machine-readable summary (for CI wrappers) |
+
+## `homeboy review test`
+
+```sh
+homeboy review test [OPTIONS] [COMPONENT] [ARGS]...
+```
+
+Run tests for a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[ARGS]...` | no | Additional arguments to pass to the test runner (must follow --) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--skip-lint` | flag | Skip linting before running tests |
+| `--coverage` | flag | Collect code coverage when the selected extension supports it |
+| `--coverage-min` | `<PERCENT>` | Minimum coverage percentage — fail if below this threshold (implies --coverage) |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+| `--analyze` | flag | Analyze test failures — cluster by root cause and suggest fixes |
+| `--drift` | flag | Detect test drift — cross-reference production changes with test files |
+| `--write` | flag | Write fixes to disk for workflows that support it |
+| `--since` | `<REF>` | Git ref to compare against for drift detection (tag, commit, branch) |
+| `--changed-since` | `<REF>` | Limit test execution to files changed since this git ref (PR impact scope) |
+| `--ci-job` | `<ID>` | Run using env and passthrough args from a single extension-declared CI test job |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--json-summary` | flag | Print compact machine-readable summary (for CI wrappers) |
+
+## `homeboy review build`
+
+```sh
+homeboy review build [OPTIONS] [TARGET_ID] [COMPONENT_IDS]...
+```
+
+Run a local build quality gate for a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[TARGET_ID]` | no | Target ID: component ID or project ID (when using --all) |
+| `[COMPONENT_IDS]...` | no | Additional component IDs (enables project/component order detection) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON input spec for bulk operations: {"componentIds": ["id1", "id2"]} |
+| `--all` | flag | Build all components in the project |
+| `--project` | `<ID>` | Scope: project id |
+| `--fleet` | `<ID>` | Scope: fleet id |
+| `--component` | `<ID>` | Scope: registered component id |
+| `--rig` | `<ID>` | Scope: local rig id |
+| `--path` | `<PATH>` | Scope: checkout path, bypassing the registry |
+| `--workspace` | flag | Scope: every configured workspace repo |
+| `--changed-since` | `<CHANGED_SINCE>` | Ask the build provider to resolve the build scope from files changed since this git ref |
+
+## `homeboy review ci`
+
+```sh
+homeboy review ci <COMMAND>
+```
+
+Inspect CI reproduction profiles and discovered CI surfaces
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy review ci list` | List declared CI profiles and shallow discovered CI surfaces |
+| `homeboy review ci plan` | Resolve a CI command request into a structured execution plan |
+| `homeboy review ci run` | Run an extension-declared CI job or profile locally |
+| `homeboy review ci autofix` | Run the end-to-end CI autofix transaction (branch prep, drift-only filtering, push-target resolution, commit, and push) |
+| `homeboy review ci scope` | Resolve a CI event context into the Homeboy scope (changed vs full) and the per-command `--changed-since` flags |
+| `homeboy review ci differential-gate` | Classify differential CI results without blaming a PR for a red baseline |
+| `homeboy review ci triage` | Summarize failed GitHub Actions runs for a pull request without dumping raw logs |
+
+## `homeboy review ci list`
+
+```sh
+homeboy review ci list [OPTIONS] [COMPONENT]
+```
+
+List declared CI profiles and shallow discovered CI surfaces
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+
+## `homeboy review ci plan`
+
+```sh
+homeboy review ci plan [OPTIONS]
+```
+
+Resolve a CI command request into a structured execution plan.
+
+This is the core-owned orchestration the action calls instead of inferring commands, splitting quality vs operations, enforcing canonical order, and deriving output filenames in shell. It is pure and emits JSON; it does not execute anything.
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--commands` | `<COMMANDS>` | Raw, comma-separated command request (e.g. `audit,lint,test` or `refactor --from all`). When empty, commands are inferred from `--context` |
+| `--context` | `<CONTEXT>` | Event context driving inference: `pr`, `push`, `cron`, or `manual`. Unknown values fall back to `manual`. Defaults to `manual` |
+
+## `homeboy review ci run`
+
+```sh
+homeboy review ci run [OPTIONS] [COMPONENT]
+```
+
+Run an extension-declared CI job or profile locally
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--job` | `<JOB>` | Run a single extension-declared CI job |
+| `--profile` | `<PROFILE>` | Run all jobs in an extension-declared CI profile |
+
+## `homeboy review ci autofix`
+
+```sh
+homeboy review ci autofix [OPTIONS] [COMPONENT]
+```
+
+Run the end-to-end CI autofix transaction (branch prep, drift-only filtering, push-target resolution, commit, and push).
+
+This is the core-owned transaction the action calls instead of re-implementing branch/commit/push orchestration in shell. It assumes the working tree already contains the autofix changes to commit.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--extension` | `<ID>` | One-shot extension override for the current invocation |
+| `--target-repo` | `<TARGET_REPO>` | Target repository to push to (`owner/repo`). Defaults to `origin` |
+| `--origin-repo` | `<ORIGIN_REPO>` | Repository backing the current `origin` remote (`owner/repo`) |
+| `--target-branch` | `<TARGET_BRANCH>` | Branch to push to (PR head branch or autofix branch) |
+| `--token` | `<TOKEN>` | GitHub App / access token for the push (enables workflow re-runs and cross-repo pushes). Falls back to the `APP_TOKEN` env var |
+| `--git-identity` | `<GIT_IDENTITY>` | Git identity to commit as. Defaults to the CI bot identity |
+| `--message` | `<MESSAGE>` | Commit message for authored (non-drift) fixes. Defaults to a generic autofix subject |
+| `--dry-run` | flag | Classify and resolve the push target without committing or pushing |
+
+## `homeboy review ci scope`
+
+```sh
+homeboy review ci scope [OPTIONS]
+```
+
+Resolve a CI event context into the Homeboy scope (changed vs full) and the per-command `--changed-since` flags.
+
+This is the core-owned translation the action calls instead of deriving event-context → scope in shell (`scripts/scope/*.sh`). With `--github-actions` the context is read from the standard GitHub Actions environment; explicit flags override individual fields.
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--github-actions` | flag | Read the event context from the GitHub Actions environment (`GITHUB_EVENT_NAME`, `BASE_SHA`, `PR_HEAD_REPO`, `GITHUB_REPOSITORY`) |
+| `--event-name` | `<EVENT_NAME>` | Override the event name (e.g. `pull_request`, `push`, `schedule`) |
+| `--base-sha` | `<BASE_SHA>` | Override the PR base SHA used for changed-file diffs |
+| `--head-repo` | `<HEAD_REPO>` | Override the PR head repository (`owner/repo`) for fork detection |
+| `--base-repo` | `<BASE_REPO>` | Override the base repository (`owner/repo`) |
+| `--repo-path` | `<REPO_PATH>` | Checkout to resolve the merge base against (deepens shallow clones). When omitted, the supplied base ref is trusted verbatim |
+| `--for` | `<FOR_COMMANDS>` | Emit `--changed-since` flags for this command in addition to the resolved scope. May be repeated |
+
+## `homeboy review ci differential-gate`
+
+```sh
+homeboy review ci differential-gate [OPTIONS]
+```
+
+Classify differential CI results without blaming a PR for a red baseline
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--baseline-command` | `<BASELINE_COMMAND>` | Exact command run against the baseline checkout |
+| `--baseline-exit-code` | `<BASELINE_EXIT_CODE>` | Exit code from the baseline command |
+| `--baseline-evidence` | `<BASELINE_EVIDENCE>` | Evidence for baseline failures, such as log excerpts or artifact refs |
+| `--head-command` | `<HEAD_COMMAND>` | Exact command run against the candidate/PR-head checkout |
+| `--head-exit-code` | `<HEAD_EXIT_CODE>` | Exit code from the candidate/PR-head command |
+| `--head-evidence` | `<HEAD_EVIDENCE>` | Evidence for candidate failures, such as log excerpts or artifact refs |
+
+## `homeboy review ci triage`
+
+```sh
+homeboy review ci triage [OPTIONS] <REFERENCE>
+```
+
+Summarize failed GitHub Actions runs for a pull request without dumping raw logs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<REFERENCE>` | yes | Pull request number, owner/repo#number, or GitHub PR URL |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--repo` | `<REPO>` | GitHub repository in owner/repo form. Required when `reference` is only a number |
+| `--max-runs` | `<MAX_RUNS>` | Maximum failed workflow runs to inspect. Use 0 for the default |
+| `--max-snippets-per-job` | `<MAX_SNIPPETS_PER_JOB>` | Maximum relevant log snippet lines to retain per failed job. Use 0 for the default |
+| `--context-lines` | `<CONTEXT_LINES>` | Context lines around relevant log matches. Use 0 for the default |
+

--- a/docs/reference/cli/commands/rig.md
+++ b/docs/reference/cli/commands/rig.md
@@ -1,0 +1,428 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy rig` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/rig.md](../../../commands/rig.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy rig`
+
+```sh
+homeboy rig <COMMAND>
+```
+
+Manage local dev rigs (reproducible multi-component environments)
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy rig list` | List all declared rigs |
+| `homeboy rig show` | Show a rig spec |
+| `homeboy rig materialize` | Read and normalize a rig spec, resolving its local inheritance chain |
+| `homeboy rig up` | Materialize a rig: run its `up` pipeline |
+| `homeboy rig check` | Run a rig's `check` pipeline and report health |
+| `homeboy rig lint` | Lint a rig package without touching the environment |
+| `homeboy rig package` | Validate rig package artifacts without touching the environment |
+| `homeboy rig down` | Tear down a rig: stop services and run its `down` pipeline |
+| `homeboy rig repair` | Repair safe declared drift without running the full `up` pipeline |
+| `homeboy rig sync` | Sync every stack declared by this rig's components |
+| `homeboy rig run` | Refresh, sync, check, and benchmark a rig profile end-to-end |
+| `homeboy rig status` | Show current state of a rig: running services, last up/check |
+| `homeboy rig release-lock` | Release a stuck active-run lock (rig lease) so a new run can proceed |
+| `homeboy rig install` | Install rigs from a local package path or git URL |
+| `homeboy rig update` | Update rigs installed from git-backed rig packages |
+| `homeboy rig sources` | Inspect or remove installed rig sources |
+| `homeboy rig app` | Install, update, or remove this rig's desktop app launcher |
+| `homeboy rig artifact` | Register local command-step evidence with the enclosing rig run |
+
+## `homeboy rig list`
+
+```sh
+homeboy rig list
+```
+
+List all declared rigs
+
+## `homeboy rig show`
+
+```sh
+homeboy rig show <RIG_ID>
+```
+
+Show a rig spec
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+## `homeboy rig materialize`
+
+```sh
+homeboy rig materialize [OPTIONS] <RIG_PATH>
+```
+
+Read and normalize a rig spec, resolving its local inheritance chain
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_PATH>` | yes | Path to a rig.json file |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--source-root` | `<SOURCE_ROOT>` | Directory that inherited templates must remain within. Defaults to the package root for rigs/<id>/rig.json, otherwise the rig directory |
+
+## `homeboy rig up`
+
+```sh
+homeboy rig up [OPTIONS] <RIG_ID>
+```
+
+Materialize a rig: run its `up` pipeline
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Build an execution plan without running the rig |
+
+## `homeboy rig check`
+
+```sh
+homeboy rig check [OPTIONS] <TARGET>
+```
+
+Run a rig's `check` pipeline and report health
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<TARGET>` | yes | Rig ID, local package path, or direct rig.json path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--id` | `<ID>` | Select a rig from a local package path containing multiple rigs |
+| `--path` | `<CHECKOUT>` | Override the rig's primary component checkout path for this check. Uses bench.default_component when present, otherwise the rig's only component |
+
+## `homeboy rig lint`
+
+```sh
+homeboy rig lint [OPTIONS] <TARGET>
+```
+
+Lint a rig package without touching the environment.
+
+Runs ONLY the env-independent package lint (conflict markers, JSON validity, and `extends` template materialization) — no requirements and no live `check` probes. This is the entry point CI uses to validate a rig package where no component checkouts exist.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<TARGET>` | yes | Rig ID, local package path, or direct rig.json path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--id` | `<ID>` | Select a rig from a local package path containing multiple rigs |
+| `--all` | flag | Lint every rig discovered in a local package path |
+| `--format` | `<FORMAT>` | Output format. `json` uses Homeboy's standard command-result envelope Values: `json`. |
+
+## `homeboy rig package`
+
+```sh
+homeboy rig package <COMMAND>
+```
+
+Validate rig package artifacts without touching the environment
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy rig package lint` | Lint every rig and package-level manifest under a local package path |
+
+## `homeboy rig package lint`
+
+```sh
+homeboy rig package lint <MANIFEST_PATH>
+```
+
+Lint every rig and package-level manifest under a local package path
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<MANIFEST_PATH>` | yes | Local package directory containing rig.json or rigs/<id>/rig.json |
+
+## `homeboy rig down`
+
+```sh
+homeboy rig down [OPTIONS] <RIG_ID>
+```
+
+Tear down a rig: stop services and run its `down` pipeline
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+
+## `homeboy rig repair`
+
+```sh
+homeboy rig repair <RIG_ID>
+```
+
+Repair safe declared drift without running the full `up` pipeline
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+## `homeboy rig sync`
+
+```sh
+homeboy rig sync [OPTIONS] <RIG_ID>
+```
+
+Sync every stack declared by this rig's components
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Print what WOULD happen without mutating stack specs or target branches |
+
+## `homeboy rig run`
+
+```sh
+homeboy rig run [OPTIONS] <RIG_ID> [ARGS]...
+```
+
+Refresh, sync, check, and benchmark a rig profile end-to-end
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+| `[ARGS]...` | no | Additional arguments to pass to the bench runner (must follow --) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--profile` | `<PROFILE>` | Rig-defined bench profile to run |
+| `--component` | `<COMPONENT>` | Optional component ID override for rigs with multiple bench components |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--iterations` | `<ITERATIONS>` | Iterations per scenario. Forwarded to the bench runner |
+| `--warmup` | `<N>` | Warmup iterations to run before measured iterations |
+| `--runs` | `<COUNT>` | Number of repetitions (independent substrate spawns) |
+| `--run-id` | `<ID>` | Caller-supplied stable proof label for this run |
+| `--shared-state` | `<DIR>` | Directory shared across bench runner instances |
+| `--concurrency` | `<CONCURRENCY>` | Number of concurrent bench runner instances |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--json-summary` | flag | Print compact machine-readable bench summary |
+
+## `homeboy rig status`
+
+```sh
+homeboy rig status <RIG_ID>
+```
+
+Show current state of a rig: running services, last up/check
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+## `homeboy rig release-lock`
+
+```sh
+homeboy rig release-lock [OPTIONS] <RIG_ID>
+```
+
+Release a stuck active-run lock (rig lease) so a new run can proceed.
+
+By default the lock is only released when its holder is provably gone or past its TTL. Pass `--force` to reclaim a lock whose holder is still alive but wedged. Releasing the lock frees the local guardrail; it does not terminate the holder process.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--force` | flag | Reclaim the lock even if its holder process is still alive |
+
+## `homeboy rig install`
+
+```sh
+homeboy rig install [OPTIONS] <SOURCE>
+```
+
+Install rigs from a local package path or git URL
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SOURCE>` | yes | Git URL or local path containing rig.json or rigs/<id>/rig.json |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--id` | `<ID>` | Install a specific rig from a multi-rig package |
+| `--all` | flag | Install every rig in the package |
+| `--reinstall` | flag | Explicitly refresh an existing matching rig install. Refuses user-owned conflicts |
+
+## `homeboy rig update`
+
+```sh
+homeboy rig update [OPTIONS] [RIG_ID]
+```
+
+Update rigs installed from git-backed rig packages
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[RIG_ID]` | no | Rig ID to update. Updates the source package that owns this rig |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--all` | flag | Update every installed git-backed rig source package |
+
+## `homeboy rig sources`
+
+```sh
+homeboy rig sources [COMMAND]
+```
+
+Inspect or remove installed rig sources
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy rig sources list` | List installed rig source packages |
+| `homeboy rig sources remove` | Remove rigs installed from a source package |
+| `homeboy rig sources refresh` | Refresh rigs installed from recorded source package paths |
+
+## `homeboy rig sources list`
+
+```sh
+homeboy rig sources list
+```
+
+List installed rig source packages
+
+## `homeboy rig sources remove`
+
+```sh
+homeboy rig sources remove <SOURCE>
+```
+
+Remove rigs installed from a source package
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SOURCE>` | yes | Source URL/path, package path, or package ID from `rig sources list` |
+
+## `homeboy rig sources refresh`
+
+```sh
+homeboy rig sources refresh [SOURCE]
+```
+
+Refresh rigs installed from recorded source package paths
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[SOURCE]` | no | Source URL/path, package path, or package ID from `rig sources list`. Omit to refresh every installed git-backed source package |
+
+## `homeboy rig app`
+
+```sh
+homeboy rig app <COMMAND>
+```
+
+Install, update, or remove this rig's desktop app launcher
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy rig app install` | Generate and install this rig's configured launcher |
+| `homeboy rig app update` | Regenerate this rig's configured launcher |
+| `homeboy rig app uninstall` | Remove this rig's configured launcher |
+
+## `homeboy rig app install`
+
+```sh
+homeboy rig app install [OPTIONS] <RIG_ID>
+```
+
+Generate and install this rig's configured launcher
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Print generated paths without writing files |
+
+## `homeboy rig app update`
+
+```sh
+homeboy rig app update [OPTIONS] <RIG_ID>
+```
+
+Regenerate this rig's configured launcher
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Print generated paths without writing files |
+
+## `homeboy rig app uninstall`
+
+```sh
+homeboy rig app uninstall [OPTIONS] <RIG_ID>
+```
+
+Remove this rig's configured launcher
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | Rig ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Print generated paths without deleting files |
+
+## `homeboy rig artifact`
+
+```sh
+homeboy rig artifact <COMMAND>
+```
+
+Register local command-step evidence with the enclosing rig run
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy rig artifact register` | Register an existing local file or directory with the current rig run |
+
+## `homeboy rig artifact register`
+
+```sh
+homeboy rig artifact register [OPTIONS]
+```
+
+Register an existing local file or directory with the current rig run
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--kind` | `<KIND>` | Stable artifact kind used by run artifact readers |
+| `--path` | `<PATH>` | Existing local file or directory to retain |
+

--- a/docs/reference/cli/commands/runner.md
+++ b/docs/reference/cli/commands/runner.md
@@ -1,0 +1,712 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy runner` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/runner.md](../../../commands/runner.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy runner`
+
+```sh
+homeboy runner <COMMAND>
+```
+
+Manage local and SSH execution runners
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runner add` | Register a local or SSH execution runner |
+| `homeboy runner enable` | Enable runner capability on an existing SSH server |
+| `homeboy runner list` | List all configured runners |
+| `homeboy runner show` | Display runner configuration |
+| `homeboy runner set` | Modify runner settings |
+| `homeboy runner trust` | Trust a runner for constrained controller-side project execution |
+| `homeboy runner pair` | Pair a runner with a trusted peer/controller policy from the runner side |
+| `homeboy runner remove` | Remove a runner configuration |
+| `homeboy runner doctor` | Diagnose a local or configured SSH runner without mutating it |
+| `homeboy runner connect` | Connect to a runner by starting a loopback-only remote daemon and SSH tunnel |
+| `homeboy runner status` | Show persisted runner tunnel status |
+| `homeboy runner disconnect` | Close a runner tunnel and remove its persisted session state |
+| `homeboy runner refresh-homeboy` | Build or select the Homeboy binary used for runner/Lab jobs |
+| `homeboy runner dev-sync` | Sync a controller-local Homeboy dev binary to the runner and select it for Lab jobs |
+| `homeboy runner cache-prune` | Inventory or remove stale managed Homeboy binary slots on a runner |
+| `homeboy runner exec` | Execute a command on a configured runner. Use `homeboy runner exec [HOMEBOY_OPTIONS] <RUNNER> -- <COMMAND>...` |
+| `homeboy runner env` | Show the effective environment injected into runner jobs |
+| `homeboy runner lifecycle` | Evaluate runner workspace lifecycle and finalization readiness without mutating state |
+| `homeboy runner job` | Inspect or follow a runner daemon job stream |
+| `homeboy runner work` | Claim and execute one brokered reverse-runner job from this machine |
+| `homeboy runner workspace` | Materialize local workspaces on a configured runner |
+| `homeboy runner refresh-plan` | Plan a runner-backed refresh loop before dispatching matrix-style work |
+| `homeboy runner broker` | Manage reverse runner broker authentication and pairing |
+
+## `homeboy runner add`
+
+```sh
+homeboy runner add [OPTIONS] [ID]
+```
+
+Register a local or SSH execution runner
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON input spec for add/update (supports single or bulk) |
+| `--skip-existing` | flag | Skip items that already exist (JSON mode only) |
+| `--kind` | `<KIND>` | Runner kind. Defaults to ssh when --server is set, otherwise local Values: `local`, `ssh`. |
+| `--server` | `<SERVER>` | Existing server ID for SSH runners |
+| `--workspace-root` | `<WORKSPACE_ROOT>` | Root directory where this runner checks out or owns workspaces |
+| `--homeboy-path` | `<HOMEBOY_PATH>` | Homeboy binary path on the runner machine |
+| `--daemon` | flag | Prefer daemon-backed execution for future runner commands |
+| `--concurrency-limit` | `<CONCURRENCY_LIMIT>` | Maximum concurrent workflows this runner should accept |
+| `--artifact-policy` | `<ARTIFACT_POLICY>` | Artifact retention/copying policy label for future execution commands |
+
+## `homeboy runner enable`
+
+```sh
+homeboy runner enable [OPTIONS] <SERVER_ID>
+```
+
+Enable runner capability on an existing SSH server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID to make runner-capable |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--workspace-root` | `<WORKSPACE_ROOT>` | Root directory where this server checks out or owns workspaces |
+| `--homeboy-path` | `<HOMEBOY_PATH>` | Homeboy binary path on the server machine |
+| `--daemon` | flag | Prefer daemon-backed execution for future runner commands |
+| `--concurrency-limit` | `<CONCURRENCY_LIMIT>` | Maximum concurrent workflows this server should accept |
+| `--artifact-policy` | `<ARTIFACT_POLICY>` | Artifact retention/copying policy label for future execution commands |
+
+## `homeboy runner list`
+
+```sh
+homeboy runner list
+```
+
+List all configured runners
+
+## `homeboy runner show`
+
+```sh
+homeboy runner show <ID>
+```
+
+Display runner configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Runner ID |
+
+## `homeboy runner set`
+
+```sh
+homeboy runner set [OPTIONS] [ID]
+```
+
+Modify runner settings
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Entity ID (optional if provided in JSON body) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON object to merge into the entity (supports @file and - for stdin) |
+| `--base64` | `<BASE64>` | Base64-encoded JSON object (bypasses shell escaping issues) |
+| `--replace` | `<FIELD>` | Replace these fields instead of merging arrays |
+
+## `homeboy runner trust`
+
+```sh
+homeboy runner trust [OPTIONS] <RUNNER_ID>
+```
+
+Trust a runner for constrained controller-side project execution
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<PROJECTS>` | Project ID allowed to use this runner. Repeat for multiple projects |
+| `--command` | `<COMMANDS>` | Allowed command family, for example test, bench, lint, audit, trace, cargo, or runner.exec. Repeat or pass comma-separated values |
+| `--allow-raw-exec` | `<ALLOW_RAW_EXEC>` | Explicitly allow or deny raw runner exec shell commands Values: `true`, `false`. |
+| `--allow-homeboy-convergence` | `<ALLOW_HOMEBOY_CONVERGENCE>` | Explicitly allow controller-driven Homeboy binary convergence Values: `true`, `false`. |
+| `--workspace-root` | `<WORKSPACE_ROOTS>` | Workspace root allowed by policy. Repeat for multiple roots |
+| `--artifact-policy` | `<ARTIFACT_POLICY>` | Artifact behavior for runner jobs, for example copy, metadata, none, or deny |
+| `--peer` | `<PEERS>` | Expected peer/controller server ID. Repeat for multiple peers |
+| `--fingerprint` | `<FINGERPRINTS>` | Expected peer host key/fingerprint. Repeat for multiple fingerprints |
+
+## `homeboy runner pair`
+
+```sh
+homeboy runner pair [OPTIONS] <RUNNER_ID>
+```
+
+Pair a runner with a trusted peer/controller policy from the runner side
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--peer` | `<PEERS>` | Peer/controller server ID accepted by this runner. Repeat for multiple peers |
+| `--fingerprint` | `<FINGERPRINTS>` | Peer/controller host key/fingerprint. Repeat for multiple fingerprints |
+| `--accept-project` | `<PROJECTS>` | Project ID accepted from the peer. Repeat for multiple projects |
+| `--workspace-root` | `<WORKSPACE_ROOTS>` | Workspace root this runner accepts jobs under. Repeat for multiple roots |
+| `--allow-raw-exec` | `<ALLOW_RAW_EXEC>` | Explicitly allow or deny raw runner exec shell commands Values: `true`, `false`. |
+| `--allow-homeboy-convergence` | `<ALLOW_HOMEBOY_CONVERGENCE>` | Explicitly allow controller-driven Homeboy binary convergence Values: `true`, `false`. |
+
+## `homeboy runner remove`
+
+```sh
+homeboy runner remove <ID>
+```
+
+Remove a runner configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Runner ID |
+
+## `homeboy runner doctor`
+
+```sh
+homeboy runner doctor [OPTIONS] <RUNNER_ID>
+```
+
+Diagnose a local or configured SSH runner without mutating it
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID. Use `local`, `localhost`, or `self` for this machine; other values resolve through `homeboy runner` configuration |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Component/workspace path to use as the extension parity probe cwd |
+| `--extension` | `<REQUIRED_EXTENSIONS>` | Required extension ID to resolve on the runner. Repeat for multiple extensions |
+| `--require-tool` | `<REQUIRED_TOOLS>` | Required command to resolve on the runner PATH. Repeat for provider/job-specific tools |
+| `--scope` | `<SCOPE>` | Readiness scope. `lab-offload` adds Lab-specific binary, daemon, and provider readiness checks Values: `general`, `lab-offload`, `secret-env`. |
+| `--repair` | flag | Safely repair issues in the selected scope, such as reconnecting a stale Lab daemon |
+
+## `homeboy runner connect`
+
+```sh
+homeboy runner connect [OPTIONS] <ID>
+```
+
+Connect to a runner by starting a loopback-only remote daemon and SSH tunnel
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Runner ID for direct SSH connect, or controller/broker ID when --reverse is set |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--reverse` | flag | Record a runner-initiated reverse tunnel session substrate |
+| `--reverse-runner` | `<REVERSE_RUNNER>` | Runner ID initiating the reverse connection |
+| `--broker-url` | `<BROKER_URL>` | Broker/controller URL observed by the reverse runner |
+| `--adopt-orphan-lease` | `<ADOPT_ORPHAN_LEASE>` | Explicitly adopt this exact remote daemon lease after confirming its PID is dead |
+| `--confirm-pid-dead` | flag | Deprecated no-op retained for one release; the runner proves the recorded PID dead itself |
+| `--adopt-live-lease` | `<ADOPT_LIVE_LEASE>` | Operator-confirm a live lease/PID/build adoption within the trusted remote SSH UID boundary; never stops or replaces a daemon |
+| `--expected-live-pid` | `<EXPECTED_LIVE_PID>` | Current remote daemon PID paired with --adopt-live-lease |
+| `--confirm-untracked-child-dead` | `<CONFIRM_UNTRACKED_CHILD_DEAD>` | Confirm one exact unresolved job has no live untracked child; repeat for each job |
+| `--reconcile-leaseless-orphans` | flag | Explicitly reconcile active jobs after proving the missing-lease remote store has no daemon owner |
+| `--confirm-no-daemon-owner` | flag | Deprecated no-op retained for one release; the runner fails closed on owner-lock, process, and listener probes |
+| `--recover-missing-lease-state` | `<RECOVER_MISSING_LEASE_STATE>` | Recover this exact lease after the remote daemon state record was lost |
+| `--recorded-pid` | `<RECORDED_PID>` | Recorded remote daemon PID paired with --recover-missing-lease-state |
+| `--recorded-endpoint` | `<RECORDED_ENDPOINT>` | Recorded concrete remote daemon endpoint paired with --recover-missing-lease-state |
+| `--confirm-control-plane-lost` | flag | Deprecated no-op retained for one release; the runner probes its own state record and endpoint |
+
+## `homeboy runner status`
+
+```sh
+homeboy runner status [OPTIONS] [ID]
+```
+
+Show persisted runner tunnel status
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Runner ID. Omit to show all runner session states |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--generations` | flag | Include the full historical draining-generation inventory. By default status leads with the compact authoritative admission summary and omits the expanded per-generation ledger, which can run to thousands of lines on a long-lived runner |
+| `--full` | flag | Return complete status, runtime diagnostics, followups, and generation detail |
+
+## `homeboy runner disconnect`
+
+```sh
+homeboy runner disconnect <ID>
+```
+
+Close a runner tunnel and remove its persisted session state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Runner ID |
+
+## `homeboy runner refresh-homeboy`
+
+```sh
+homeboy runner refresh-homeboy [OPTIONS] <RUNNER_ID>
+```
+
+Build or select the Homeboy binary used for runner/Lab jobs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--select` | `<SELECT>` | Existing runner-side Homeboy binary to select instead of building one |
+| `--source` | `<SOURCE>` | Git remote URL to clone/fetch when materializing a managed Homeboy binary |
+| `--ref` | `<GIT_REF>` | Git ref to materialize from the source remote |
+| `--target-dir` | `<TARGET_DIR>` | Runner-side checkout directory for the managed Homeboy source |
+| `--reconnect` | flag | Disconnect and reconnect the runner daemon after updating homeboy_path |
+| `--force` | flag | Interrupt active daemon jobs when reconnecting |
+| `--allow-downgrade` | flag | Permit replacing a newer managed runner build with an older Git revision |
+| `--dry-run` | flag | Print the plan without executing it or changing runner config |
+
+## `homeboy runner dev-sync`
+
+```sh
+homeboy runner dev-sync [OPTIONS] <RUNNER_ID>
+```
+
+Sync a controller-local Homeboy dev binary to the runner and select it for Lab jobs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--homeboy-source` | `<HOMEBOY_SOURCE>` | Controller-local Homeboy source checkout to build before upload. Defaults to current directory |
+| `--homeboy-binary` | `<HOMEBOY_BINARY>` | Controller-local prebuilt Homeboy binary to upload instead of building from source |
+| `--extensions` | `<EXTENSIONS>` | Dev extension source to sync later, in id=path form. Accepted and recorded; extension relink is deferred |
+| `--reconnect` | flag | Disconnect and reconnect the runner daemon after selecting the dev binary |
+| `--dry-run` | flag | Print the plan without executing it or changing runner config |
+
+## `homeboy runner cache-prune`
+
+```sh
+homeboy runner cache-prune [OPTIONS] <RUNNER_ID>
+```
+
+Inventory or remove stale managed Homeboy binary slots on a runner
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Delete eligible slots. Omit for inventory only |
+| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum slot age before an unselected slot is eligible |
+
+## `homeboy runner exec`
+
+```sh
+homeboy runner exec [OPTIONS] <ID> [COMMAND]...
+```
+
+Execute a command on a configured runner. Use `homeboy runner exec [HOMEBOY_OPTIONS] <RUNNER> -- <COMMAND>...`
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Runner ID |
+| `[COMMAND]...` | no | Command and arguments to execute on the runner |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--cwd` | `<CWD>` | Remote/current working directory. SSH runners require this to be inside the runner workspace root unless the runner has a default workspace_root |
+| `--sync-workspace` | `<SYNC_WORKSPACE>` | Snapshot a local worktree to the runner first and execute from the materialized remote path |
+| `--project` | `<PROJECT>` | Project ID used for runner trust policy checks |
+| `--ssh` | flag | Allow diagnostic-only SSH command execution when no daemon session is connected |
+| `--capture-patch` | flag | Capture the file delta produced by the remote command as a patch artifact |
+| `--require-path` | `<REQUIRE_PATHS>` | Runner-side path that must exist before executing the command. Repeat for multiple paths |
+| `--script-file` | `<SCRIPT_FILE>` | Read a shell script from this path and execute it on the runner with bash. Use `-` to read the script from stdin |
+| `--env` | `<ENV>` | Environment variable to inject into the runner process as KEY=VALUE. Repeat for multiple values |
+| `--secret-env` | `<NAME>` | Secret environment variable name to resolve through the runner secret-env contract. Repeat for multiple names |
+| `--secret-env-plan` | `<JSON>` | Secret-env plan JSON to apply to the runner process |
+| `--secret-env-plan-file` | `<PATH>` | Path to a secret-env plan JSON file to apply to the runner process |
+| `--extension-env` | `<ID>` | Installed extension that contributes runtime environment on the selected runner. Repeat in contribution order |
+| `--dry-run` | flag | Build the runner exec plan without executing it |
+| `--run-id` | `<RUN_ID>` | Explicit persisted run id for ad hoc runner exec evidence |
+| `--artifact` | `<PATH>` | File or directory path produced by the runner command to persist as a run artifact. Relative paths are resolved from the runner exec cwd. Repeat for multiple artifacts |
+| `--artifact-dir` | `<PATH>` | Directory whose immediate produced files/directories should each be persisted as run artifacts. Relative paths are resolved from the runner exec cwd. Repeat for multiple directories |
+| `--summary` | `<PATH>` | Summary file or directory produced by the runner command to persist as typed run evidence. Relative paths are resolved from the runner exec cwd. Repeat for multiple summaries |
+| `--json` | flag | Print the full structured runner execution envelope to stdout |
+| `--raw` | flag | Print remote stdout/stderr directly instead of the structured JSON envelope. Use global --output to still write the full structured envelope to a file |
+| `--read-only-artifact` | flag | Treat this exec as a read-only retrieval of evidence the runner already retains (for example, hydrating a completed run's artifact). Routes to the generation that owns the retained run/artifact and never rotates the shared tunnel, so a stale admission daemon does not block the read |
+
+## `homeboy runner env`
+
+```sh
+homeboy runner env <ID>
+```
+
+Show the effective environment injected into runner jobs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Runner ID |
+
+## `homeboy runner lifecycle`
+
+```sh
+homeboy runner lifecycle [OPTIONS] <RUNNER_ID>
+```
+
+Evaluate runner workspace lifecycle and finalization readiness without mutating state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID that owns the workspace |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--workspace` | `<WORKSPACE>` | Absolute runner-side workspace path |
+| `--job-id` | `<JOB_ID>` | Runner daemon or broker job ID associated with this workspace |
+| `--run-id` | `<RUN_ID>` | Durable run ID associated with this workspace |
+| `--status` | `<STATUS>` | Canonical lifecycle status. When omitted, --exit-code maps 0 to succeeded and non-zero to failed Values: `unknown`, `queued`, `running`, `succeeded`, `partial-failure`, `failed`, `cancelled`, `timed-out`, `stale`. |
+| `--exit-code` | `<EXIT_CODE>` | Process exit code to project into lifecycle status and RunOutcomeEnvelope fields |
+
+## `homeboy runner job`
+
+```sh
+homeboy runner job <COMMAND>
+```
+
+Inspect or follow a runner daemon job stream
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runner job logs` | Show or follow durable runner daemon job events |
+| `homeboy runner job cancel` | Cancel a queued or running durable runner daemon job |
+| `homeboy runner job reconcile` | Reconcile expired reverse-runner broker claims |
+| `homeboy runner job artifacts` | Inspect broker-held reverse-runner artifact metadata |
+
+## `homeboy runner job logs`
+
+```sh
+homeboy runner job logs [OPTIONS] <RUNNER_ID> <JOB_ID>
+```
+
+Show or follow durable runner daemon job events
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID with an active daemon connection |
+| `<JOB_ID>` | yes | Runner daemon job ID from runner exec/Lab output or error details |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--follow` | flag | Poll until the remote job reaches a terminal state, printing new events to stderr |
+| `--poll-ms` | `<POLL_MS>` | Poll interval in milliseconds when --follow is set |
+| `--cursor` | `<CURSOR>` | Resume after this previously displayed event sequence |
+| `--compact` | flag | Return only lifecycle events, exit code, and a bounded stdout/stderr tail |
+| `--tail` | `<KB>` | Bound embedded stdout/stderr to the last N kilobytes, surfaced as a tail |
+
+## `homeboy runner job cancel`
+
+```sh
+homeboy runner job cancel <RUNNER_ID> <JOB_ID>
+```
+
+Cancel a queued or running durable runner daemon job
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID with an active daemon connection |
+| `<JOB_ID>` | yes | Runner daemon job ID from runner exec/Lab output or error details |
+
+## `homeboy runner job reconcile`
+
+```sh
+homeboy runner job reconcile <RUNNER_ID>
+```
+
+Reconcile expired reverse-runner broker claims
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Reverse-connected runner ID |
+
+## `homeboy runner job artifacts`
+
+```sh
+homeboy runner job artifacts <RUNNER_ID> <JOB_ID> <ARTIFACT_ID>
+```
+
+Inspect broker-held reverse-runner artifact metadata
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Reverse-connected runner ID |
+| `<JOB_ID>` | yes | Reverse broker job ID |
+| `<ARTIFACT_ID>` | yes | Artifact ID reported by the finished broker job |
+
+## `homeboy runner work`
+
+```sh
+homeboy runner work [OPTIONS] <RUNNER_ID>
+```
+
+Claim and execute one brokered reverse-runner job from this machine
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID on this machine |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--broker-url` | `<BROKER_URL>` | Controller/broker daemon URL |
+| `--broker-token` | `<BROKER_TOKEN>` | Paired broker bearer token. Falls back to the HOMEBOY_BROKER_TOKEN environment variable when omitted. Required when the broker enforces auth; omit only for loopback-open smoke setups |
+| `--project` | `<PROJECT>` | Optional project filter for claimed jobs |
+| `--lease-ms` | `<LEASE_MS>` | Claim lease duration in milliseconds |
+| `--loop` | flag | Keep claiming jobs until SIGINT/SIGTERM instead of exiting after one claim |
+| `--idle-backoff-ms` | `<IDLE_BACKOFF_MS>` | Initial sleep after an empty claim in loop mode |
+| `--max-idle-backoff-ms` | `<MAX_IDLE_BACKOFF_MS>` | Maximum sleep after repeated empty claims in loop mode |
+| `--broker-failure-backoff-ms` | `<BROKER_FAILURE_BACKOFF_MS>` | Sleep after transient broker failures in loop mode |
+| `--broker-retry-limit` | `<BROKER_RETRY_LIMIT>` | Consecutive broker failures allowed before the worker exits non-zero |
+
+## `homeboy runner workspace`
+
+```sh
+homeboy runner workspace <COMMAND>
+```
+
+Materialize local workspaces on a configured runner
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runner workspace list` | List recent runner-side Lab workspaces and reusable exec commands |
+| `homeboy runner workspace snapshots` | Discover metadata-backed runner workspace snapshots by repo, ref, commit, or run |
+| `homeboy runner workspace sync` | Materialize a controller-side worktree into the runner workspace root |
+| `homeboy runner workspace update` | Apply a source delta to a prepared workspace selected by its snapshot lease |
+| `homeboy runner workspace pull` | Copy selected files from a runner workspace back to the controller |
+| `homeboy runner workspace apply` | Apply a Lab-generated patch/delta back to its local source worktree |
+| `homeboy runner workspace prune` | Preview or remove orphaned runner-side Lab workspaces |
+
+## `homeboy runner workspace list`
+
+```sh
+homeboy runner workspace list [OPTIONS] <RUNNER_ID>
+```
+
+List recent runner-side Lab workspaces and reusable exec commands
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--limit` | `<LIMIT>` | Maximum number of workspaces to return |
+
+## `homeboy runner workspace snapshots`
+
+```sh
+homeboy runner workspace snapshots [OPTIONS] <RUNNER_ID>
+```
+
+Discover metadata-backed runner workspace snapshots by repo, ref, commit, or run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--repo` | `<REPO>` | Source repository name, normally the local workspace basename before any @slug suffix |
+| `--source-ref` | `<SOURCE_REF>` | Source git ref captured when the snapshot was synced |
+| `--source-commit` | `<SOURCE_COMMIT>` | Source git commit captured when the snapshot was synced |
+| `--run` | `<RUN_ID>` | Agent-task or Lab run id captured in snapshot metadata when available |
+| `--limit` | `<LIMIT>` | Maximum number of snapshots to return |
+
+## `homeboy runner workspace sync`
+
+```sh
+homeboy runner workspace sync [OPTIONS] <RUNNER_ID>
+```
+
+Materialize a controller-side worktree into the runner workspace root
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Local worktree path to materialize for Lab execution |
+| `--mode` | `<MODE>` | Sync mode. snapshot streams source from the controller; snapshot-git also initializes a synthetic git checkout; git is only for clean public/runner-accessible remotes Values: `snapshot`, `snapshot-git`, `git`. |
+| `--allow-dirty-lab-workspace` | flag | Permit git sync to overwrite a dirty runner-side workspace |
+
+## `homeboy runner workspace update`
+
+```sh
+homeboy runner workspace update [OPTIONS] <RUNNER_ID>
+```
+
+Apply a source delta to a prepared workspace selected by its snapshot lease
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Local worktree containing the updated source |
+| `--lease` | `<LEASE>` | Opaque prepared-workspace lease returned by workspace sync or a previous update |
+
+## `homeboy runner workspace pull`
+
+```sh
+homeboy runner workspace pull [OPTIONS] <RUNNER_ID>
+```
+
+Copy selected files from a runner workspace back to the controller
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--remote-path` | `<REMOTE_PATH>` | Absolute runner-side workspace or snapshot path to pull from |
+| `--include` | `<INCLUDES>` | Relative glob to copy from the remote path. Repeat for multiple globs |
+| `--to` | `<TO>` | Local destination directory on the controller |
+| `--dry-run` | flag | Validate and print the copy plan without transferring files |
+
+## `homeboy runner workspace apply`
+
+```sh
+homeboy runner workspace apply [OPTIONS] <INPUT>
+```
+
+Apply a Lab-generated patch/delta back to its local source worktree
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<INPUT>` | yes | Lab apply JSON artifact path |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--force` | flag | Apply even when the local worktree snapshot no longer matches the Lab source snapshot |
+
+## `homeboy runner workspace prune`
+
+```sh
+homeboy runner workspace prune [OPTIONS] <RUNNER_ID>
+```
+
+Preview or remove orphaned runner-side Lab workspaces
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNNER_ID>` | yes | Runner ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Delete the previewed orphaned workspaces. Without this flag, the command is a dry run |
+| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum workspace age before it can be considered orphaned |
+| `--limit` | `<LIMIT>` | Maximum number of orphan candidates to report or remove |
+| `--passes` | `<PASSES>` | Maximum apply passes to run. Each pass re-scans and removes at most --limit candidates |
+| `--cursor` | `<CURSOR>` | Opaque continuation cursor returned by an incomplete workspace-prune scan |
+
+## `homeboy runner refresh-plan`
+
+```sh
+homeboy runner refresh-plan [OPTIONS] [COMMAND]...
+```
+
+Plan a runner-backed refresh loop before dispatching matrix-style work
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMMAND]...` | no | Command and arguments to run after the plan checks pass |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner` | `<RUNNER>` | Runner ID that will execute the workload |
+| `--workspace` | `<WORKSPACE>` | Controller-side workspace or worktree to sync to the runner |
+| `--runner-cwd` | `<RUNNER_CWD>` | Runner-side cwd for the eventual runner exec command |
+| `--run-id` | `<RUN_ID>` | Stable run id to use for the produced evidence |
+| `--output` | `<PATH>` | Produced output directory or file. Relative paths are resolved from --runner-cwd |
+| `--summary` | `<PATH>` | Produced summary directory or file. Relative paths are resolved from --runner-cwd |
+| `--source` | `<PATH>` | Source path that must exist before the refresh is dispatched. Repeat for multiple paths |
+| `--fixture` | `<PATH>` | Fixture path that must exist before the refresh is dispatched. Repeat for multiple paths |
+| `--sync-mode` | `<SYNC_MODE>` | Runner workspace sync mode to use in the planned sync command |
+
+## `homeboy runner broker`
+
+```sh
+homeboy runner broker <COMMAND>
+```
+
+Manage reverse runner broker authentication and pairing
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runner broker pair` | Pair a runner with the broker, minting a one-time scoped bearer token |
+| `homeboy runner broker revoke` | Revoke a paired credential by id |
+| `homeboy runner broker list` | List paired broker credentials (never prints tokens) |
+
+## `homeboy runner broker pair`
+
+```sh
+homeboy runner broker pair [OPTIONS] <ID>
+```
+
+Pair a runner with the broker, minting a one-time scoped bearer token
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Stable credential id used for later revocation |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner-id` | `<RUNNER_ID>` | Runner id this credential authorizes (worker routes must match it) |
+| `--submit` | flag | Grant the controller submit scope (POST /runner/jobs) |
+| `--work` | flag | Grant the worker scope (register/claim/event/finish/heartbeat) |
+| `--no-install` | flag | Store only on this controller; skip installing broker_auth.json on an SSH runner host |
+
+## `homeboy runner broker revoke`
+
+```sh
+homeboy runner broker revoke <ID>
+```
+
+Revoke a paired credential by id
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Credential id to revoke |
+
+## `homeboy runner broker list`
+
+```sh
+homeboy runner broker list
+```
+
+List paired broker credentials (never prints tokens)
+

--- a/docs/reference/cli/commands/runs.md
+++ b/docs/reference/cli/commands/runs.md
@@ -1,0 +1,740 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy runs` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/runs.md](../../../commands/runs.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy runs`
+
+```sh
+homeboy runs <COMMAND>
+```
+
+Inspect persisted observation runs and artifacts
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runs list` | List persisted observation runs |
+| `homeboy runs distribution` | Aggregate persisted run metadata |
+| `homeboy runs latest-run` | Show the latest persisted observation run matching filters |
+| `homeboy runs compare` | Compare selected metrics across persisted run history |
+| `homeboy runs bench-compare` | Compare two persisted benchmark runs by exact run id |
+| `homeboy runs fuzz-compare` | Compare two persisted fuzz runs by exact run id |
+| `homeboy runs hotspots` | Aggregate hotspot rankings across persisted fuzz run artifacts |
+| `homeboy runs reconcile` | Mark orphaned running observation records stale |
+| `homeboy runs retention` | Plan or apply bounded retention of terminal observation rows and dependent records |
+| `homeboy runs watch` | Block and stream a run's status until it reaches a terminal state, exiting with a code that reflects pass/fail. Works for attached and detached/offloaded runs |
+| `homeboy runs cancel` | Cooperatively cancel a persisted foreground run before its next stage |
+| `homeboy runs show` | Show one persisted observation run |
+| `homeboy runs proof` | Show only the compact proof signals for one run: verdict, gate failures, and declared proof/scorecard signal fields. Full evidence stays behind `runs show --json` / `runs evidence` |
+| `homeboy runs dossier` | Aggregate the actionable read-only dossier for one persisted run |
+| `homeboy runs resume-plan` | Show a generic resume plan for a validation-progress run |
+| `homeboy runs evidence` | Show stable evidence registry data for one run; start here for reviewer-facing evidence |
+| `homeboy runs env` | Explain redacted Lab environment provenance for one run |
+| `homeboy runs artifacts` | List artifacts recorded for one run |
+| `homeboy runs artifact` | Retrieve or sync recorded run artifacts |
+| `homeboy runs findings` | List findings recorded for one run |
+| `homeboy runs finding` | Show one recorded finding |
+| `homeboy runs latest-finding` | Show the latest finding from the latest run matching filters |
+| `homeboy runs export` | Export observation records as an inspectable directory bundle |
+| `homeboy runs import` | Import an observation bundle (default) or ingest GitHub Actions artifacts (`--from-gh-actions`) |
+| `homeboy runs query` | Project JSONPath expressions over imported run artifact rows |
+| `homeboy runs refs` | Emit stable run/artifact refs for matching runs |
+| `homeboy runs resources` | Inspect resource lifecycle records from resource index files |
+| `homeboy runs drift` | Window-based distribution drift over a JSONPath metric |
+| `homeboy runs loop-sync` | Sync continuous-loop archive directories into observation artifacts |
+
+## `homeboy runs list`
+
+```sh
+homeboy runs list [OPTIONS]
+```
+
+List persisted observation runs
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner` | `<RUNNER>` | Query runs from a connected execution runner daemon |
+| `--kind` | `<KIND>` | Run kind: bench, rig, trace, etc |
+| `--component` | `<COMPONENT_ID>` | Component ID |
+| `--rig` | `<RIG>` | Rig ID |
+| `--scenario` | `<SCENARIO_ID>` | Benchmark scenario ID. Only applies to bench metadata |
+| `--status` | `<STATUS>` | Run status |
+| `--running` | flag | Show only in-flight runs. Shorthand for `--status running`; surfaces runs that could otherwise become ghosts |
+| `--since` | `<SINCE>` | Only include runs started at or after this RFC-3339 timestamp (e.g. `2026-07-22T00:00:00Z`) or a relative age (`2d`, `6h`, `30m`) |
+| `--until` | `<UNTIL>` | Only include runs started at or before this RFC-3339 timestamp or a relative age (`2d`, `6h`, `30m`) |
+| `--id` | `<ID>` | Match runs whose persisted id or run-label contains this fragment |
+| `--command-contains` | `<COMMAND_CONTAINS>` | Match runs whose command string contains this substring |
+| `--correlation` | `<CORRELATION>` | Resolve controller run, runner job, and mirrored observation records that share this correlation/lineage fragment (matches persisted id, run-label, runner id, or job id) |
+| `--include-mirrors` | flag | Show every underlying observation row, including runner-execution mirrors that are collapsed into one canonical row by default |
+| `--limit` | `<LIMIT>` | Maximum runs to return |
+| `--include-active-runner-jobs` | flag | Include active runner jobs from connected runner daemons |
+
+## `homeboy runs distribution`
+
+```sh
+homeboy runs distribution [OPTIONS]
+```
+
+Aggregate persisted run metadata
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--kind` | `<KIND>` | Run kind: bench, rig, trace, etc |
+| `--component` | `<COMPONENT_ID>` | Component ID |
+| `--rig` | `<RIG>` | Rig ID |
+| `--scenario` | `<SCENARIO_ID>` | Benchmark scenario ID. Only applies to bench metadata |
+| `--status` | `<STATUS>` | Run status |
+| `--field` | `<FIELDS>` | Dot-separated metadata path to aggregate |
+| `--limit` | `<LIMIT>` | Maximum runs to inspect before scenario filtering |
+
+## `homeboy runs latest-run`
+
+```sh
+homeboy runs latest-run [OPTIONS]
+```
+
+Show the latest persisted observation run matching filters
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--kind` | `<KIND>` | Run kind: bench, rig, trace, etc |
+| `--component` | `<COMPONENT_ID>` | Component ID |
+| `--rig` | `<RIG>` | Rig ID |
+| `--status` | `<STATUS>` | Run status |
+
+## `homeboy runs compare`
+
+```sh
+homeboy runs compare [OPTIONS]
+```
+
+Compare selected metrics across persisted run history
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--kind` | `<KIND>` | Run kind: bench, rig, trace, etc |
+| `--component` | `<COMPONENT_ID>` | Component ID |
+| `--rig` | `<RIG>` | Rig ID |
+| `--scenario` | `<SCENARIO_ID>` | Scenario ID for scenario-scoped metrics |
+| `--status` | `<STATUS>` | Run status |
+| `--metric` | `<METRICS>` | Metric to include. Repeat to compare multiple metrics |
+| `--limit` | `<LIMIT>` | Maximum runs to inspect |
+| `--format` | `<FORMAT>` | Output format Values: `table`, `json`. |
+
+## `homeboy runs bench-compare`
+
+```sh
+homeboy runs bench-compare [OPTIONS]
+```
+
+Compare two persisted benchmark runs by exact run id
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--from-run` | `<FROM_RUN>` | Earlier benchmark run ID |
+| `--to-run` | `<TO_RUN>` | Later benchmark run ID |
+| `--metric` | `<METRICS>` | Metric to include. Repeat to compare multiple metrics. Defaults to all shared numeric metrics |
+
+## `homeboy runs fuzz-compare`
+
+```sh
+homeboy runs fuzz-compare [OPTIONS]
+```
+
+Compare two persisted fuzz runs by exact run id
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--from-run` | `<RUN_ID>` | Baseline fuzz run id |
+| `--to-run` | `<RUN_ID>` | Candidate fuzz run id |
+| `--hotspot-policy` | `<HOTSPOT_POLICY>` | How relative hotspot regressions affect the blocking compare status Values: `advisory`, `blocking`, `off`. |
+
+## `homeboy runs hotspots`
+
+```sh
+homeboy runs hotspots [OPTIONS] [RUN_ID]...
+```
+
+Aggregate hotspot rankings across persisted fuzz run artifacts
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[RUN_ID]...` | no | One or more persisted Homeboy run ids to inspect |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--baseline-run` | `<RUN_ID>` | Baseline run id for threshold-free cohort comparison |
+| `--candidate-run` | `<RUN_ID>` | Candidate run id for threshold-free cohort comparison |
+| `--limit` | `<LIMIT>` | Maximum ranked hotspots to return |
+
+## `homeboy runs reconcile`
+
+```sh
+homeboy runs reconcile [OPTIONS]
+```
+
+Mark orphaned running observation records stale
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Preview orphaned running records without mutating them |
+| `--limit` | `<LIMIT>` | Maximum running records to inspect |
+
+## `homeboy runs retention`
+
+```sh
+homeboy runs retention [OPTIONS]
+```
+
+Plan or apply bounded retention of terminal observation rows and dependent records
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Delete the planned terminal rows. Without this flag, only reports the plan |
+| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include terminal runs finished more than this many days ago |
+| `--limit` | `<LIMIT>` | Maximum terminal run rows to inspect and remove in one invocation |
+
+## `homeboy runs watch`
+
+Aliases: `follow`, `tail`
+
+```sh
+homeboy runs watch [OPTIONS] <RUN_ID>
+```
+
+Block and stream a run's status until it reaches a terminal state, exiting with a code that reflects pass/fail. Works for attached and detached/offloaded runs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run id to watch until it reaches a terminal state |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--timeout` | `<TIMEOUT>` | Maximum time to wait before giving up (e.g. `30m`, `2h`, `7d`). Defaults to five minutes; use `--forever` for an intentional indefinite watch |
+| `--forever` | flag | Keep watching without a time bound. This is explicit because streams are otherwise finite by default |
+| `--interval` | `<INTERVAL>` | Delay between status polls (e.g. `2s`, `1m`) |
+| `--notify` | flag | Emit a local completion notification when the run reaches a terminal state. Delivery resolves the run's installed extension transport, or an explicitly configured operations transport for route-less runs |
+
+## `homeboy runs cancel`
+
+```sh
+homeboy runs cancel <RUN_ID>
+```
+
+Cooperatively cancel a persisted foreground run before its next stage
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+## `homeboy runs show`
+
+```sh
+homeboy runs show [OPTIONS] <RUN_ID>
+```
+
+Show one persisted observation run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | flag | Print the full JSON output instead of the compact human summary. The compact summary surfaces status, key metadata, and artifact pointers with inspect commands; the full payload is unchanged and always available with this flag or via `--output <file>` |
+| `-q`, `--field` | `<FIELD>` | JSONPath selector(s) projected over the run detail so callers extract only specific fields instead of the whole structure. Repeat or comma-separate. Rooted at the run detail, e.g. `-q '$.status'`, `-q '$.metadata.run_dir'` |
+
+## `homeboy runs proof`
+
+```sh
+homeboy runs proof [OPTIONS] <RUN_ID>
+```
+
+Show only the compact proof signals for one run: verdict, gate failures, and declared proof/scorecard signal fields. Full evidence stays behind `runs show --json` / `runs evidence`
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | flag | Print the full JSON output instead of the compact human summary |
+
+## `homeboy runs dossier`
+
+```sh
+homeboy runs dossier [OPTIONS] <RUN_ID>
+```
+
+Aggregate the actionable read-only dossier for one persisted run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | flag | Print the full JSON output instead of the compact human dossier |
+
+## `homeboy runs resume-plan`
+
+```sh
+homeboy runs resume-plan <RUN_ID>
+```
+
+Show a generic resume plan for a validation-progress run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+## `homeboy runs evidence`
+
+```sh
+homeboy runs evidence <RUN_ID>
+```
+
+Show stable evidence registry data for one run; start here for reviewer-facing evidence
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+## `homeboy runs env`
+
+```sh
+homeboy runs env <RUN_ID>
+```
+
+Explain redacted Lab environment provenance for one run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | _no help text_ |
+
+## `homeboy runs artifacts`
+
+```sh
+homeboy runs artifacts [OPTIONS] <RUN_ID>
+```
+
+List artifacts recorded for one run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run id that owns the artifacts |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner` | `<RUNNER>` | Query artifacts from a connected execution runner daemon |
+| `--pull` | flag | Pull runner/remote artifact bytes to the operator-local artifact root so the completed run is self-contained. Best-effort and per-artifact: the listing still prints, and each artifact reports a pull status |
+| `--pull-dir` | `<PULL_DIR>` | Optional directory to write pulled artifact bytes into. Defaults to a run-scoped path under the operator-local artifact root |
+
+## `homeboy runs artifact`
+
+```sh
+homeboy runs artifact <COMMAND>
+```
+
+Retrieve or sync recorded run artifacts
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runs artifact attach` | Attach an existing runner-side output file to a persisted run |
+| `homeboy runs artifact get` | Copy a recorded file artifact to a local path |
+| `homeboy runs artifact preview` | Serve a recorded directory artifact with a local static preview URL |
+| `homeboy runs artifact capture` | Capture generated HTML entrypoint screenshots from a recorded directory artifact |
+| `homeboy runs artifact cleanup-downloads` | Plan or delete locally cached runner artifact downloads |
+| `homeboy runs artifact cleanup-persisted` | Plan or delete persisted local run artifacts and their database records |
+| `homeboy runs artifact postprocess` | Run a generic artifact postprocess plan over persisted artifact roots |
+
+## `homeboy runs artifact attach`
+
+```sh
+homeboy runs artifact attach [OPTIONS] <RUN_ID>
+```
+
+Attach an existing runner-side output file to a persisted run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run id that should own the attached artifact |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner` | `<RUNNER>` | Runner ID that can read the path |
+| `--path` | `<PATH>` | Absolute runner-side file path under an allowed workspace/output root |
+| `--name` | `<NAME>` | Artifact kind/name to record in the observation store |
+
+## `homeboy runs artifact get`
+
+```sh
+homeboy runs artifact get [OPTIONS] <RUN_ID> <ARTIFACT_ID>
+```
+
+Copy a recorded file artifact to a local path
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run id that owns the artifact |
+| `<ARTIFACT_ID>` | yes | Artifact id/path token from `homeboy runs artifacts <run-id>` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--runner` | `<RUNNER>` | Pull the artifact from a connected execution runner daemon |
+| `-o`, `--output` | `<OUTPUT>` | Destination file path. Defaults to the recorded artifact filename |
+| `-q`, `--field` | `<FIELD>` | JSONPath selector(s) projected over the artifact-get result so callers extract only specific fields (e.g. `sha256`, `output_path`) instead of the whole structure. Repeat or comma-separate. Field selection still writes the artifact bytes when `--output` is set. Example: `-q '$.sha256'`, `-q '$.output_path'` |
+
+## `homeboy runs artifact preview`
+
+```sh
+homeboy runs artifact preview [OPTIONS] <RUN_ID> <ARTIFACT_ID>
+```
+
+Serve a recorded directory artifact with a local static preview URL
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run id that owns the artifact |
+| `<ARTIFACT_ID>` | yes | Directory artifact id/path token from `homeboy runs artifacts <run-id>` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--port` | `<PORT>` | Local loopback port. Defaults to an available ephemeral port |
+
+## `homeboy runs artifact capture`
+
+```sh
+homeboy runs artifact capture [OPTIONS] <RUN_ID> <ARTIFACT_ID>
+```
+
+Capture generated HTML entrypoint screenshots from a recorded directory artifact
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUN_ID>` | yes | Observation run id that owns the artifact |
+| `<ARTIFACT_ID>` | yes | Directory artifact id/path token from `homeboy runs artifacts <run-id>` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--entrypoint` | `<ENTRYPOINTS>` | HTML path inside the directory artifact. Repeat for multiple pages |
+| `--output-dir` | `<OUTPUT_DIR>` | Directory where screenshots and capture-manifest.json should be written |
+| `--port` | `<PORT>` | Local loopback port. Defaults to an available ephemeral port |
+| `--viewport-width` | `<VIEWPORT_WIDTH>` | Browser viewport width in CSS pixels |
+| `--viewport-height` | `<VIEWPORT_HEIGHT>` | Browser viewport height in CSS pixels |
+
+## `homeboy runs artifact cleanup-downloads`
+
+```sh
+homeboy runs artifact cleanup-downloads [OPTIONS]
+```
+
+Plan or delete locally cached runner artifact downloads
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Delete the planned cached downloads. Without this flag, only reports the plan |
+| `--runner` | `<RUNNER>` | Limit cleanup to one runner id under the local runner artifact cache |
+| `--run-id` | `<RUN_ID>` | Limit cleanup to one run id. Requires --runner |
+
+## `homeboy runs artifact cleanup-persisted`
+
+```sh
+homeboy runs artifact cleanup-persisted [OPTIONS]
+```
+
+Plan or delete persisted local run artifacts and their database records
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Delete planned artifact files/directories and their DB rows. Without this flag, only reports the plan |
+| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include artifacts older than this many days |
+| `--run-id` | `<RUN_ID>` | Limit cleanup to one run id |
+| `--kind` | `<KIND>` | Limit cleanup to one artifact kind |
+| `--type` | `<ARTIFACT_TYPE>` | Limit cleanup to one artifact type (`file` or `directory`) |
+| `--run-kind` | `<RUN_KIND>` | Limit cleanup to one run kind (`bench`, `trace`, etc.) |
+| `--component` | `<COMPONENT_ID>` | Limit cleanup to one component id |
+| `--limit` | `<LIMIT>` | Maximum artifact rows to inspect in one invocation |
+
+## `homeboy runs artifact postprocess`
+
+```sh
+homeboy runs artifact postprocess [OPTIONS] <PLAN>
+```
+
+Run a generic artifact postprocess plan over persisted artifact roots
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PLAN>` | yes | Artifact postprocess plan JSON file, @file spec, or - for stdin |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--artifact-root-id` | `<ID>` | Artifact root id from the plan to use as HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT |
+| `--input-root-id` | `<ID>` | Optional artifact root id from the plan to expose as ${run.input} |
+| `--result` | `<PATH>` | Write the bare artifact-postprocess result contract to this path |
+
+## `homeboy runs findings`
+
+```sh
+homeboy runs findings [OPTIONS] [RUN_ID] [COMMAND]
+```
+
+List findings recorded for one run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[RUN_ID]` | no | Observation run ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--tool` | `<TOOL>` | Finding tool, for example lint |
+| `--file` | `<FILE>` | Finding file path |
+| `--fingerprint` | `<FINGERPRINT>` | Finding fingerprint |
+| `--limit` | `<LIMIT>` | Maximum findings to return |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runs findings reconcile` | Reconcile a finding stream against an issue tracker |
+| `homeboy runs findings reconcile-run` | Reconcile all structured command outputs in one CI run |
+| `homeboy runs findings build` | Convert native command output into the canonical reconcile input shape |
+
+## `homeboy runs findings reconcile`
+
+```sh
+homeboy runs findings reconcile [OPTIONS] <COMPONENT_ID>
+```
+
+Reconcile a finding stream against an issue tracker.
+
+Reads structured findings (from `homeboy review audit --json-summary` or `homeboy review lint --json` or any equivalent), inspects open and closed issues on the tracker, and produces a deterministic plan: file new, update, close, dedupe, or skip per category.
+
+Defaults to dry-run; pass `--apply` to actually call the tracker.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID. Tracker repo is resolved from this component's `remote_url` (or git remote, when --path is set) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--tracker` | `<URI>` | Tracker URI. Currently only `github://owner/repo` is supported. When omitted, defaults to the component's GitHub remote — the common case |
+| `--findings` | `<PATH>` | Path to a JSON findings file. Use `-` to read from stdin. The file's shape: |
+| `--from-output` | `<COMMAND=PATH>` | Native Homeboy command output to normalize before reconcile. Repeatable as `--from-output audit=/tmp/audit.json` |
+| `--run-url` | `<URL>` | Optional run URL appended to generated issue bodies when using `--from-output` |
+| `--no-refresh-closed` | flag | Don't refresh the body of closed-not_planned issues with the latest finding count. Default is to refresh (so the closed issue stays useful as a "current state" reference) |
+| `--list-limit` | `<LIST_LIMIT>` | Cap the number of issues fetched from the tracker for dedup analysis. Defaults to 200 — high enough for normal repos, but avoids paginating the entire tracker |
+| `--apply` | flag | Actually perform the reconcile actions. Default is dry-run |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json (CI runners, ad-hoc clones) |
+
+## `homeboy runs findings reconcile-run`
+
+```sh
+homeboy runs findings reconcile-run [OPTIONS] <COMPONENT_ID>
+```
+
+Reconcile all structured command outputs in one CI run.
+
+Discovers `<command>.json` files in an output directory, runs the existing per-command reconcile pipeline, and returns aggregate totals suitable for GitHub Action consumption.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Default component ID. Per-output component metadata overrides this when present in the command JSON |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--output-dir` | `<DIR>` | Directory containing structured command outputs such as `audit.json`, `lint.json`, and `test.json`. Defaults to HOMEBOY_OUTPUT_DIR when omitted |
+| `--commands` | `<COMMANDS>` | Comma-separated command list to inspect in the output directory |
+| `--run-url` | `<URL>` | Optional run URL appended to generated issue bodies |
+| `--no-refresh-closed` | flag | Don't refresh the body of closed-not_planned issues with the latest finding count |
+| `--list-limit` | `<LIST_LIMIT>` | Cap the number of issues fetched from the tracker for dedup analysis per command |
+| `--apply` | flag | Actually perform the reconcile actions. Default is dry-run |
+| `--path` | `<PATH>` | Workspace path to discover the component from a portable homeboy.json (CI runners, ad-hoc clones) |
+
+## `homeboy runs findings build`
+
+```sh
+homeboy runs findings build [OPTIONS]
+```
+
+Convert native command output into the canonical reconcile input shape
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--from-output` | `<COMMAND=PATH>` | Native Homeboy command output to normalize. Repeatable as `--from-output audit=/tmp/audit.json` |
+| `--run-url` | `<URL>` | Optional run URL appended to generated issue bodies |
+
+## `homeboy runs finding`
+
+```sh
+homeboy runs finding <FINDING_ID>
+```
+
+Show one recorded finding
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<FINDING_ID>` | yes | _no help text_ |
+
+## `homeboy runs latest-finding`
+
+```sh
+homeboy runs latest-finding [OPTIONS]
+```
+
+Show the latest finding from the latest run matching filters
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--kind` | `<KIND>` | Run kind: bench, rig, trace, etc |
+| `--component` | `<COMPONENT_ID>` | Component ID |
+| `--rig` | `<RIG>` | Rig ID |
+| `--status` | `<STATUS>` | Run status |
+| `--tool` | `<TOOL>` | Finding tool, for example lint |
+| `--file` | `<FILE>` | Finding file path |
+
+## `homeboy runs export`
+
+```sh
+homeboy runs export [OPTIONS]
+```
+
+Export observation records as an inspectable directory bundle
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--run` | `<RUN>` | Export one run by id |
+| `--since` | `<SINCE>` | Export runs started within a duration, e.g. 24h, 7d, 30m |
+| `--output` | `<DIR>` | Output bundle directory. Zip output is intentionally out of scope for v1 |
+
+## `homeboy runs import`
+
+```sh
+homeboy runs import [OPTIONS] [INPUT]
+```
+
+Import an observation bundle (default) or ingest GitHub Actions artifacts (`--from-gh-actions`)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[INPUT]` | no | Bundle directory produced by `homeboy runs export`. Required when not using `--from-gh-actions`. Mutually exclusive with `--from-gh-actions` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--from-gh-actions` | flag | Ingest artifacts directly from GitHub Actions instead of from a portable bundle directory. When set, `--component`, `--repo`, `--artifact-glob`, and one of `--workflow` or `--run-id` are required |
+| `--component` | `<COMPONENT_ID>` | Component ID to stamp on imported runs (gh-actions mode) |
+| `--repo` | `<REPO>` | `owner/repo` form (gh-actions mode) |
+| `--workflow` | `<WORKFLOW>` | Workflow filename or display name (gh-actions mode) |
+| `--run-id` | `<RUN_ID>` | Exact GitHub Actions run id (gh-actions mode) |
+| `--artifact-glob` | `<ARTIFACT_GLOB>` | Glob filter for artifact names (gh-actions mode). Examples: `'design-distribution-*'`, `'*.json'` |
+| `--since` | `<SINCE>` | Restrict the gh-actions ingest window (e.g. 24h, 7d, 30d) |
+| `--limit` | `<LIMIT>` | Maximum runs to inspect per import call (gh-actions mode) |
+
+## `homeboy runs query`
+
+```sh
+homeboy runs query [OPTIONS]
+```
+
+Project JSONPath expressions over imported run artifact rows
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--component` | `<COMPONENT_ID>` | Component ID (matches the synthetic Homeboy run's component_id) |
+| `--kind` | `<KIND>` | Run kind (e.g. `gh-actions`). Defaults to all kinds |
+| `--since` | `<SINCE>` | Restrict to runs started within this duration (e.g. 24h, 7d) |
+| `--select` | `<SELECT>` | One or more JSONPath expressions to project. Comma-separated. Example: `--select '$.theme,$.fonts[*].family'` |
+| `--group-by` | `<GROUP_BY>` | Optional JSONPath expression to group by |
+| `--count` | flag | When set with `--group-by`, emit `(group, count)` instead of full rows |
+| `--format` | `<FORMAT>` | Output format Values: `json`, `table`, `csv`. |
+| `--limit` | `<LIMIT>` | Maximum runs to inspect |
+
+## `homeboy runs refs`
+
+```sh
+homeboy runs refs [OPTIONS]
+```
+
+Emit stable run/artifact refs for matching runs
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--component` | `<COMPONENT_ID>` | Component ID |
+| `--kind` | `<KIND>` | Run kind: bench, rig, trace, gh-actions, etc |
+| `--rig` | `<RIG>` | Rig ID |
+| `--status` | `<STATUS>` | Run status |
+| `--since` | `<SINCE>` | Restrict to runs started within this duration (e.g. 24h, 7d) |
+| `--limit` | `<LIMIT>` | Maximum runs to inspect |
+| `--artifact-kind` | `<ARTIFACT_KINDS>` | Restrict artifact refs to these artifact kinds. Repeatable |
+| `--aggregate-artifact-kind` | `<AGGREGATE_ARTIFACT_KINDS>` | Treat these artifact kinds as aggregate refs in addition to the default schema-blind aggregate detector. Repeatable |
+
+## `homeboy runs resources`
+
+```sh
+homeboy runs resources [OPTIONS]
+```
+
+Inspect resource lifecycle records from resource index files
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--file` | `<PATH>` | Resource lifecycle index JSON file. Repeatable. Defaults to the local observation store |
+| `--sample` | flag | Emit a contract-valid sample index instead of reading files or the observation store |
+| `--run-id` | `<RUN_ID>` | Include only resources owned by this run id |
+| `--owner` | `<OWNER>` | Include only resources owned by this resource owner |
+| `--actionable` | flag | Include only records requiring operator/orchestrator attention |
+| `--cleanup-eligible` | flag | Include only records eligible for cleanup orchestration |
+| `--cleanup-plan` | flag | Emit cleanup planning data for matching resources. This is read-only unless --apply is also passed |
+| `--apply` | flag | Delete apply-intended cleanup-eligible resources. Requires --cleanup-root and remains bounded by --limit |
+| `--cleanup-root` | `<PATH>` | Root directory that cleanup candidates must canonicalize under before apply can delete them |
+| `--limit` | `<LIMIT>` | Maximum cleanup candidates to include in the plan/apply page |
+| `--cleanup-operation` | `<CLEANUP_OPERATION>` | Cleanup operation used by apply. Delete removes files, symlinks, or directories Values: `delete`. |
+
+## `homeboy runs drift`
+
+```sh
+homeboy runs drift [OPTIONS]
+```
+
+Window-based distribution drift over a JSONPath metric
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--component` | `<COMPONENT_ID>` | Component ID (matches the synthetic Homeboy run's component_id) |
+| `--kind` | `<KIND>` | Run kind (e.g. `gh-actions`) |
+| `--metric` | `<METRIC>` | JSONPath expression naming the metric to track. Example: `--metric '$.theme'` or `--metric '$.fonts[*].family'` |
+| `--window` | `<WINDOW>` | Window duration to evaluate (e.g. 24h, 7d) |
+| `--threshold` | `<THRESHOLD>` | Share threshold in `0.0..=1.0`. Values whose share of the window exceeds this threshold are flagged as `dominant=true`. The default (0.0) reports every value |
+| `--baseline` | `<BASELINE>` | Optional baseline window (e.g. 30d) compared against `--window` |
+| `--format` | `<FORMAT>` | Output format Values: `json`, `table`. |
+
+## `homeboy runs loop-sync`
+
+```sh
+homeboy runs loop-sync [OPTIONS] <ARCHIVE_ROOT>
+```
+
+Sync continuous-loop archive directories into observation artifacts
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ARCHIVE_ROOT>` | yes | Local directory containing copied remote loop archives |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--component` | `<COMPONENT_ID>` | Optional component label for filtering the resulting observation run |
+| `--rig` | `<RIG>` | Optional rig/loop label for filtering the resulting observation run |
+| `--label` | `<LABELS>` | Optional free-form labels recorded in run metadata |
+| `--stale-after-minutes` | `<STALE_AFTER_MINUTES>` | Mark heartbeat/session files stale after this many minutes |
+| `--retention-days` | `<RETENTION_DAYS>` | Retention budget used for reporting old archive candidates |
+| `--patch-limit` | `<PATCH_LIMIT>` | Maximum ranked patch candidates to include in triage output |
+| `--dry-run` | flag | Inspect and triage without writing observation runs or artifacts |
+

--- a/docs/reference/cli/commands/runtime.md
+++ b/docs/reference/cli/commands/runtime.md
@@ -1,0 +1,95 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy runtime` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/runtime.md](../../../commands/runtime.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy runtime`
+
+```sh
+homeboy runtime <COMMAND>
+```
+
+Inspect core-owned runtime helper assets
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runtime helper` | Inspect core-bundled runtime helper paths exposed to extension runners |
+| `homeboy runtime refresh` | Refresh a shared runtime package from a source repository or directory |
+| `homeboy runtime promotion-takeover` | Explicitly archive a proven dead or expired runtime-promotion lease |
+| `homeboy runtime controller-prune` | Plan or apply pruning for unreferenced immutable controller runtimes |
+
+## `homeboy runtime helper`
+
+```sh
+homeboy runtime helper <COMMAND>
+```
+
+Inspect core-bundled runtime helper paths exposed to extension runners
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy runtime helper path` | Print the materialized path for a known core runtime helper |
+
+## `homeboy runtime helper path`
+
+```sh
+homeboy runtime helper path [OPTIONS] <HELPER>
+```
+
+Print the materialized path for a known core runtime helper
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<HELPER>` | yes | Known helper filename or injected HOMEBOY_RUNTIME_* env var name |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--plain` | flag | Print only the path, for shell bootstrap usage |
+
+## `homeboy runtime refresh`
+
+```sh
+homeboy runtime refresh [OPTIONS] <RUNTIME_ID>
+```
+
+Refresh a shared runtime package from a source repository or directory
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RUNTIME_ID>` | yes | Runtime package ID to materialize |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--source` | `<SOURCE>` | Git URL, repo root, or runtime package directory to install from |
+| `--ref` | `<REVISION>` | Git ref to check out for URL sources (branch, tag, or commit) |
+
+## `homeboy runtime promotion-takeover`
+
+```sh
+homeboy runtime promotion-takeover
+```
+
+Explicitly archive a proven dead or expired runtime-promotion lease
+
+## `homeboy runtime controller-prune`
+
+```sh
+homeboy runtime controller-prune [OPTIONS]
+```
+
+Plan or apply pruning for unreferenced immutable controller runtimes
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Delete pins not retained by nonterminal durable runs or the active generation |
+| `--ignore-retention` | flag | Purge every unreferenced pin, ignoring the configured controller runtime retention window. Destructive: prefer the configured window |
+

--- a/docs/reference/cli/commands/schedule.md
+++ b/docs/reference/cli/commands/schedule.md
@@ -1,0 +1,140 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy schedule` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/schedule.md](../../../commands/schedule.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy schedule`
+
+```sh
+homeboy schedule <COMMAND>
+```
+
+Declare homeboy commands that run on a cadence
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy schedule add` | Declare a scheduled run |
+| `homeboy schedule list` | List declared schedules with their last and next run |
+| `homeboy schedule show` | Show one schedule and its runtime state |
+| `homeboy schedule remove` | Remove a schedule and its runtime state |
+| `homeboy schedule run` | Run a schedule now, regardless of whether it is due |
+| `homeboy schedule enable` | Enable a disabled schedule |
+| `homeboy schedule disable` | Disable a schedule without deleting it |
+| `homeboy schedule tick` | Run every schedule that is currently due |
+
+## `homeboy schedule add`
+
+```sh
+homeboy schedule add [OPTIONS] <ID>
+```
+
+Declare a scheduled run
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Schedule id |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--command` | `<COMMAND>` | Homeboy command to run, without the leading binary name (for example: --command "fleet check prod") |
+| `--exec` | `<EXEC>` | External program to run. Executed directly, never through a shell |
+| `--exec-arg` | `<EXEC_ARG>` | Argument for the preceding --exec. Repeat for each argument; values are passed through untouched, so an argument may contain spaces |
+| `--working-dir` | `<WORKING_DIR>` | Directory to run the preceding --exec from |
+| `--every` | `<EVERY>` | How often to run: 30m, 24h, 1h30m, 7d |
+| `--notify-on` | `<NOTIFY_ON>` | When to notify: change (default), failure, or always |
+| `--on-overlap` | `<ON_OVERLAP>` | What to do if the previous run is still going: skip (default) or allow |
+| `--notification-transport` | `<NOTIFICATION_TRANSPORT>` | Notification transport id (requires --notification-route) |
+| `--notification-route` | `<NOTIFICATION_ROUTE>` | Notification route (requires --notification-transport) |
+| `--jitter-seconds` | `<JITTER_SECONDS>` | Spread runs across a window, in seconds, so many schedules sharing a cadence do not fire at the same instant |
+| `--description` | `<DESCRIPTION>` | Human-readable note about why this schedule exists |
+| `--force` | flag | Replace an existing schedule with the same id |
+
+## `homeboy schedule list`
+
+```sh
+homeboy schedule list
+```
+
+List declared schedules with their last and next run
+
+## `homeboy schedule show`
+
+```sh
+homeboy schedule show <ID>
+```
+
+Show one schedule and its runtime state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | _no help text_ |
+
+## `homeboy schedule remove`
+
+```sh
+homeboy schedule remove <ID>
+```
+
+Remove a schedule and its runtime state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | _no help text_ |
+
+## `homeboy schedule run`
+
+```sh
+homeboy schedule run <ID>
+```
+
+Run a schedule now, regardless of whether it is due
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | _no help text_ |
+
+## `homeboy schedule enable`
+
+```sh
+homeboy schedule enable <ID>
+```
+
+Enable a disabled schedule
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | _no help text_ |
+
+## `homeboy schedule disable`
+
+```sh
+homeboy schedule disable <ID>
+```
+
+Disable a schedule without deleting it
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | _no help text_ |
+
+## `homeboy schedule tick`
+
+```sh
+homeboy schedule tick [OPTIONS]
+```
+
+Run every schedule that is currently due
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Report what is due without running anything |
+

--- a/docs/reference/cli/commands/self.md
+++ b/docs/reference/cli/commands/self.md
@@ -1,0 +1,107 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy self` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/self.md](../../../commands/self.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy self`
+
+```sh
+homeboy self <COMMAND>
+```
+
+Inspect the active Homeboy binary and install signals
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy self status` | Report active binary, version, and nearby install/update signals |
+| `homeboy self identity` | Report the active binary build identity without external probes |
+| `homeboy self doctor` | Report one authoritative binary/runtime view across the controller and every configured runner, including version drift signals and host resource pressure (machine load, hot Homeboy-adjacent processes, rig leases) |
+| `homeboy self cleanup-runtime-tmp` | Plan or delete orphaned Homeboy runtime temp entries |
+| `homeboy self docs` | Display CLI documentation |
+
+## `homeboy self status`
+
+```sh
+homeboy self status
+```
+
+Report active binary, version, and nearby install/update signals
+
+## `homeboy self identity`
+
+```sh
+homeboy self identity
+```
+
+Report the active binary build identity without external probes
+
+## `homeboy self doctor`
+
+```sh
+homeboy self doctor
+```
+
+Report one authoritative binary/runtime view across the controller and every configured runner, including version drift signals and host resource pressure (machine load, hot Homeboy-adjacent processes, rig leases)
+
+## `homeboy self cleanup-runtime-tmp`
+
+```sh
+homeboy self cleanup-runtime-tmp [OPTIONS]
+```
+
+Plan or delete orphaned Homeboy runtime temp entries
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Delete planned temp entries. Without this flag, only reports the plan |
+| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include entries older than this many days |
+| `--prefix` | `<PREFIX>` | Only include entries whose directory/file name starts with this prefix |
+| `--limit` | `<LIMIT>` | Maximum temp entries to inspect in one invocation |
+| `--run-max-bytes` | `<RUN_MAX_BYTES>` | Maximum aggregate bytes retained for failed runtime run evidence |
+| `--run-max-count` | `<RUN_MAX_COUNT>` | Maximum failed runtime run directories retained |
+| `--cursor` | `<CURSOR>` | Continue bounded runtime-run inspection from a prior next_cursor |
+
+## `homeboy self docs`
+
+```sh
+homeboy self docs [TOPIC] [COMMAND]
+```
+
+Display CLI documentation
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[TOPIC]` | no | Topic path (e.g., 'commands/deploy') or 'list' to show available topics |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy self docs map` | Generate a machine-optimized codebase map for AI documentation |
+
+## `homeboy self docs map`
+
+```sh
+homeboy self docs map [OPTIONS] <COMPONENT_ID>
+```
+
+Generate a machine-optimized codebase map for AI documentation
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component to analyze |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--source-dirs` | `<SOURCE_DIRS>` | Source directories to analyze (comma-separated). Overrides auto-detection |
+| `--include-private` | flag | Include private methods and internals (default: public API surface only) |
+| `--write` | flag | Write markdown documentation files to disk (default: JSON to stdout) |
+| `--output-dir` | `<OUTPUT_DIR>` | Output directory for markdown files (default: docs) |
+

--- a/docs/reference/cli/commands/server.md
+++ b/docs/reference/cli/commands/server.md
@@ -1,0 +1,218 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy server` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/server.md](../../../commands/server.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy server`
+
+```sh
+homeboy server <COMMAND>
+```
+
+Manage SSH server configurations
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy server create` | Register a new SSH server |
+| `homeboy server show` | Display server configuration |
+| `homeboy server set` | Modify server settings |
+| `homeboy server delete` | Remove a server configuration |
+| `homeboy server list` | List all configured servers |
+| `homeboy server connect` | Open a managed SSH control-master session for this server |
+| `homeboy server status` | Check whether a managed SSH session is live |
+| `homeboy server disconnect` | Close a managed SSH control-master session |
+| `homeboy server key` | Manage SSH keys |
+
+## `homeboy server create`
+
+```sh
+homeboy server create [OPTIONS] [ID]
+```
+
+Register a new SSH server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Server ID (CLI mode) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON input spec for create/update (supports single or bulk) |
+| `--skip-existing` | flag | Skip items that already exist (JSON mode only) |
+| `--host` | `<HOST>` | SSH host |
+| `--user` | `<USER>` | SSH username |
+| `--port` | `<PORT>` | SSH port (default: 22) |
+
+## `homeboy server show`
+
+```sh
+homeboy server show <SERVER_ID>
+```
+
+Display server configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+
+## `homeboy server set`
+
+```sh
+homeboy server set [OPTIONS] [ID]
+```
+
+Modify server settings
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Entity ID (optional if provided in JSON body) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON object to merge into the entity (supports @file and - for stdin) |
+| `--base64` | `<BASE64>` | Base64-encoded JSON object (bypasses shell escaping issues) |
+| `--replace` | `<FIELD>` | Replace these fields instead of merging arrays |
+
+## `homeboy server delete`
+
+```sh
+homeboy server delete <SERVER_ID>
+```
+
+Remove a server configuration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+
+## `homeboy server list`
+
+```sh
+homeboy server list
+```
+
+List all configured servers
+
+## `homeboy server connect`
+
+```sh
+homeboy server connect <SERVER_ID>
+```
+
+Open a managed SSH control-master session for this server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+
+## `homeboy server status`
+
+```sh
+homeboy server status <SERVER_ID>
+```
+
+Check whether a managed SSH session is live
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+
+## `homeboy server disconnect`
+
+```sh
+homeboy server disconnect <SERVER_ID>
+```
+
+Close a managed SSH control-master session
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+
+## `homeboy server key`
+
+```sh
+homeboy server key <COMMAND>
+```
+
+Manage SSH keys
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy server key generate` | Generate a new SSH key pair and set it for this server |
+| `homeboy server key show` | Display the public SSH key |
+| `homeboy server key import` | Import an existing SSH private key and set it for this server |
+| `homeboy server key use` | Use an existing SSH private key file path for this server |
+| `homeboy server key unset` | Unset the server SSH identity file (use normal SSH resolution) |
+
+## `homeboy server key generate`
+
+```sh
+homeboy server key generate <SERVER_ID>
+```
+
+Generate a new SSH key pair and set it for this server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+
+## `homeboy server key show`
+
+```sh
+homeboy server key show <SERVER_ID>
+```
+
+Display the public SSH key
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+
+## `homeboy server key import`
+
+```sh
+homeboy server key import <SERVER_ID> <PRIVATE_KEY_PATH>
+```
+
+Import an existing SSH private key and set it for this server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+| `<PRIVATE_KEY_PATH>` | yes | Path to private key file |
+
+## `homeboy server key use`
+
+```sh
+homeboy server key use <SERVER_ID> <PRIVATE_KEY_PATH>
+```
+
+Use an existing SSH private key file path for this server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+| `<PRIVATE_KEY_PATH>` | yes | Path to private key file |
+
+## `homeboy server key unset`
+
+```sh
+homeboy server key unset <SERVER_ID>
+```
+
+Unset the server SSH identity file (use normal SSH resolution)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SERVER_ID>` | yes | Server ID |
+

--- a/docs/reference/cli/commands/ssh.md
+++ b/docs/reference/cli/commands/ssh.md
@@ -1,0 +1,45 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy ssh` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/ssh.md](../../../commands/ssh.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy ssh`
+
+```sh
+homeboy ssh [OPTIONS] [TARGET] [COMMAND]... [COMMAND]
+```
+
+SSH into a project server or configured server
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[TARGET]` | no | Target ID (project or server; project wins when ambiguous) |
+| `[COMMAND]...` | no | Command to execute (omit for interactive shell) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--as-server` | flag | Force interpretation as server ID |
+| `--user` | `<USER>` | Override the SSH user (instead of the server's configured user) |
+| `--raw` | flag | Write only the remote command's stdout to local stdout (and its stderr to local stderr), exiting with the remote exit code. Ideal for piping a remote export straight into a file. Combine with `--output <path>` to also persist the structured envelope. Requires a non-interactive command |
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy ssh list` | List configured SSH server targets |
+
+## `homeboy ssh list`
+
+```sh
+homeboy ssh list
+```
+
+List configured SSH server targets
+

--- a/docs/reference/cli/commands/stack.md
+++ b/docs/reference/cli/commands/stack.md
@@ -1,0 +1,222 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy stack` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/stack.md](../../../commands/stack.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy stack`
+
+```sh
+homeboy stack <COMMAND>
+```
+
+Manage stacks (combined-fixes branches built from base + cherry-picked PRs)
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy stack list` | List all installed stack specs |
+| `homeboy stack show` | Show a stack spec |
+| `homeboy stack create` | Create a new stack spec |
+| `homeboy stack add-pr` | Append a PR entry to the stack's `prs` array |
+| `homeboy stack remove-pr` | Remove a PR entry from the stack's `prs` array |
+| `homeboy stack apply` | Materialize a stack: cherry-pick `base + prs` onto `target` |
+| `homeboy stack rebase` | Rebuild the target branch from fresh base + current spec PRs |
+| `homeboy stack status` | Read-only status report — upstream PR state + local target state |
+| `homeboy stack sync` | Rebase the target branch onto fresh base AND auto-drop merged PRs from the spec |
+| `homeboy stack push` | Push the materialized target branch to its configured remote |
+| `homeboy stack diff` | Preview what `stack sync` would change without mutating target or spec |
+| `homeboy stack inspect` | Spec-less inspection of the current branch as a stack of commits. Replaces the previous `homeboy git stack` command (re-homed into the stack domain) |
+
+## `homeboy stack list`
+
+```sh
+homeboy stack list
+```
+
+List all installed stack specs
+
+## `homeboy stack show`
+
+```sh
+homeboy stack show <STACK_ID>
+```
+
+Show a stack spec
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+
+## `homeboy stack create`
+
+```sh
+homeboy stack create [OPTIONS] <STACK_ID>
+```
+
+Create a new stack spec
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID (used as filename: `~/.config/homeboy/stacks/<id>.json`) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--component` | `<COMPONENT>` | Component identifier (informational; future: rig binding key) |
+| `--component-path` | `<COMPONENT_PATH>` | Local checkout path. Supports `~` and `${env.VAR}` expansion |
+| `--base` | `<BASE>` | Upstream ref to rebuild from, as `<remote>/<branch>` (e.g. `origin/trunk`) |
+| `--target` | `<TARGET>` | Target combined-fixes branch as `<remote>/<branch>` (e.g. `fork/dev/combined-fixes`) |
+| `--description` | `<DESCRIPTION>` | Optional human-readable description |
+
+## `homeboy stack add-pr`
+
+```sh
+homeboy stack add-pr [OPTIONS] <STACK_ID> <REPO> <NUMBER>
+```
+
+Append a PR entry to the stack's `prs` array
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+| `<REPO>` | yes | `<owner>/<repo>` coordinate (e.g. `example-org/studio`) |
+| `<NUMBER>` | yes | PR number |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--note` | `<NOTE>` | Optional human-readable note |
+
+## `homeboy stack remove-pr`
+
+```sh
+homeboy stack remove-pr [OPTIONS] <STACK_ID> <NUMBER>
+```
+
+Remove a PR entry from the stack's `prs` array
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+| `<NUMBER>` | yes | PR number to remove. If multiple entries match (different repos), pass `--repo` to disambiguate |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--repo` | `<REPO>` | Restrict removal to this `<owner>/<repo>` (when the same PR number appears in multiple repos in the stack) |
+
+## `homeboy stack apply`
+
+```sh
+homeboy stack apply [OPTIONS] <STACK_ID>
+```
+
+Materialize a stack: cherry-pick `base + prs` onto `target`.
+
+Stops on the first cherry-pick conflict, leaves the conflicted pick in the checkout, and prints the git commands that resolve or abandon it.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--abort-on-conflict` | flag | Run `git cherry-pick --abort` on conflict instead of leaving the conflicted pick in place for manual resolution |
+
+## `homeboy stack rebase`
+
+```sh
+homeboy stack rebase [OPTIONS] <STACK_ID>
+```
+
+Rebuild the target branch from fresh base + current spec PRs.
+
+Unlike `sync`, `rebase` never edits the stack spec: merged PRs stay listed until an explicit `sync` or `remove-pr`.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--abort-on-conflict` | flag | Run `git cherry-pick --abort` on conflict instead of leaving the conflicted pick in place for manual resolution |
+
+## `homeboy stack status`
+
+```sh
+homeboy stack status <STACK_ID>
+```
+
+Read-only status report — upstream PR state + local target state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+
+## `homeboy stack sync`
+
+```sh
+homeboy stack sync [OPTIONS] <STACK_ID>
+```
+
+Rebase the target branch onto fresh base AND auto-drop merged PRs from the spec.
+
+`sync` is the holistic upkeep verb for a combined-fixes branch: PRs that have been merged upstream (and whose content is in base) are removed from the spec; everything else is cherry-picked onto a freshly-rebuilt target. On the first cherry-pick conflict, the in-progress pick is left in the checkout and a resolve message printed.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Print what WOULD drop and pick without mutating spec or target branch |
+| `--abort-on-conflict` | flag | Run `git cherry-pick --abort` on conflict instead of leaving the conflicted pick in place for manual resolution |
+
+## `homeboy stack push`
+
+```sh
+homeboy stack push <STACK_ID>
+```
+
+Push the materialized target branch to its configured remote
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+
+## `homeboy stack diff`
+
+```sh
+homeboy stack diff <STACK_ID>
+```
+
+Preview what `stack sync` would change without mutating target or spec
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<STACK_ID>` | yes | Stack ID |
+
+## `homeboy stack inspect`
+
+```sh
+homeboy stack inspect [OPTIONS] [COMPONENT_ID]
+```
+
+Spec-less inspection of the current branch as a stack of commits. Replaces the previous `homeboy git stack` command (re-homed into the stack domain)
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID. When omitted, auto-detected from CWD |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--base` | `<REF>` | Base ref to compare against. Defaults to `@{upstream}` of the current branch |
+| `--no-pr` | flag | Skip the GitHub PR lookup pass |
+| `--repo` | `<OWNER/NAME>` | Scope PR lookups to a specific GitHub repo (`owner/name`) |
+| `--path` | `<PATH>` | Workspace path to operate on directly |
+

--- a/docs/reference/cli/commands/status.md
+++ b/docs/reference/cli/commands/status.md
@@ -1,0 +1,45 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy status` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/status.md](../../../commands/status.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy status`
+
+```sh
+homeboy status [OPTIONS] [PROJECT]
+```
+
+Actionable component status overview
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[PROJECT]` | no | Project ID — show version dashboard for a project's components |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--project` | `<ID>` | Scope: project id |
+| `--fleet` | `<ID>` | Scope: fleet id |
+| `--component` | `<ID>` | Scope: registered component id |
+| `--rig` | `<ID>` | Scope: local rig id |
+| `--path` | `<PATH>` | Scope: checkout path, bypassing the registry |
+| `--workspace` | flag | Scope: every configured workspace repo |
+| `--full` | flag | Show the full workspace/context report (the old init behavior) |
+| `--uncommitted` | flag | Show only components with uncommitted changes |
+| `--needs-release` | flag | Show only components that need a release |
+| `--ready` | flag | Show only components ready to deploy |
+| `--docs-only` | flag | Show only components with docs-only changes |
+| `-a`, `--all` | flag | Show all components regardless of current directory context |
+| `--outdated` | flag | Show only outdated components (local != remote) |
+| `--timings` | flag | Emit status phase progress to stderr and include phase timings in JSON |
+| `--refresh` | flag | Refresh remote Git refs before calculating drift and release state |
+| `--unreleased` | flag | Show only components carrying merged-but-unreleased work (commits on origin/<default-branch> that are past the latest release tag) |
+

--- a/docs/reference/cli/commands/trace.md
+++ b/docs/reference/cli/commands/trace.md
@@ -1,0 +1,75 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy trace` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/trace.md](../../../commands/trace.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy trace`
+
+```sh
+homeboy trace [OPTIONS] [COMPONENT] [SCENARIO] [AFTER_JSON]
+```
+
+Capture black-box behavioral traces for a component
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT]` | no | Component ID (optional — auto-detected from CWD if omitted) |
+| `[SCENARIO]` | no | Scenario ID to run, or `list` to discover available scenarios |
+| `[AFTER_JSON]` | no | After aggregate JSON when running `homeboy trace compare before.json after.json` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<PATH>` | Override the component checkout path for this invocation |
+| `--component` | `<COMPONENT_ID>` | Target component for command-shaped trace modes like `compare-variant` and `compare-bundle` |
+| `--scenario` | `<SCENARIO_ID>` | Scenario ID or comma-separated scenario list for command-shaped trace modes like `compare-variant` and `compare-bundle` |
+| `--baseline-target` | `<PATH_OR_REF>` | Baseline path or git ref for `homeboy trace compare COMPONENT SCENARIO` |
+| `--candidate` | `<PATH_OR_REF>` | Candidate path or git ref for `homeboy trace compare COMPONENT SCENARIO` |
+| `--rig` | `<RIG_ID>` | Run trace against a rig-pinned component path after `rig check` passes |
+| `--profile` | `<PROFILE_ID>` | Use a named trace profile declared by a rig |
+| `--profiles` | flag | With `trace list`, list named trace profiles instead of scenarios |
+| `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
+| `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
+| `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
+| `--secret-env` | `<NAME>` | Secret environment variable name to hydrate for the trace runner. Repeatable |
+| `--json-summary` | flag | Print compact machine-readable summary |
+| `--report` | `<REPORT>` | Render a Markdown trace report instead of the JSON envelope Values: `markdown`. |
+| `--experiment` | `<NAME>` | Bundle trace compare inputs, output, report, and overlay metadata under .homeboy/experiments/NAME |
+| `--repeat` | `<N>` | Run the same trace scenario multiple times |
+| `--aggregate` | `<AGGREGATE>` | Aggregate repeated trace output Values: `spans`. |
+| `--schedule` | `<SCHEDULE>` | Run order for repeated trace executions Values: `grouped`, `interleaved`. |
+| `--focus-span` | `<SPAN_ID>` | Highlight a span in aggregate and compare reports. Repeatable |
+| `--metric-guardrail` | `<SPEC>` | Compare scalar metrics with `METRIC[.min\|.median\|.max]:POLICY[:VALUE]`. Repeatable |
+| `--span` | `<ID:FROM:TO>` | Add a span definition as `id:source.event:source.event` |
+| `--phase` | `<[LABEL:]SOURCE.EVENT>` | Add an ordered phase milestone as `[label:]source.event` |
+| `--attach` | `<KIND:TARGET>` | Observe an already-running local target without managing its lifecycle. Repeatable |
+| `--phase-preset` | `<NAME>` | Use a named phase preset declared by the selected rig/workload |
+| `--baseline` | flag | Persist the current run as the new baseline |
+| `--ignore-baseline` | flag | Skip baseline comparison for this run |
+| `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
+| `--regression-threshold` | `<PERCENT>` | Span regression tolerance as a percentage |
+| `--regression-min-delta-ms` | `<MS>` | Minimum span slowdown in milliseconds before a regression can fail |
+| `--overlay` | `<PATCH_FILE>` | Apply a patch file for this trace run, then reverse it afterward |
+| `--variant` | `<NAME>` | Apply a named trace variant declared by the selected rig/workload |
+| `--matrix` | `<MATRIX>` | Expand variants for `trace compare-variant` Values: `none`, `single`, `cumulative`. |
+| `--axis` | `<NAME=VALUE[,VALUE...]>` | Add a scenario matrix axis as `name=value1,value2`. Repeatable |
+| `--output-dir` | `<DIR>` | Directory where trace matrix and compare bundle modes write aggregate, compare, cell, and summary artifacts |
+| `--visual-compare` | flag | Run visual screenshot comparisons for trace compare browser artifacts |
+| `--visual-artifacts-dir` | `<DIR>` | Directory where visual compare artifacts should be written |
+| `--visual-compare-provider` | `<COMMAND>` | Executable implementing the generic Homeboy visual compare provider contract |
+| `--visual-provider-arg` | `<ARG>` | Extra argument forwarded to the visual compare provider before the input JSON path |
+| `--visual-threshold` | `<RATIO>` | Visual mismatch threshold forwarded to the visual compare provider |
+| `--keep-overlay` | flag | Leave overlay changes in place after the trace run |
+| `--canonical` | flag | Require canonical evidence. This is the default; retained for explicit command logs |
+| `--allow-local-toolchain` | flag | Allow intentionally local/development evidence. The output is marked non-canonical |
+| `--stale` | flag | Clean only stale trace overlay locks |
+| `--force` | flag | Remove stale trace overlay locks even when touched files are dirty |
+

--- a/docs/reference/cli/commands/triage.md
+++ b/docs/reference/cli/commands/triage.md
@@ -1,0 +1,118 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy triage` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/triage.md](../../../commands/triage.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy triage`
+
+```sh
+homeboy triage [COMMAND]
+```
+
+Attention reports and watch utilities for components, projects, fleets, and rigs
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy triage component` | Triage one registered component |
+| `homeboy triage project` | Triage every component attached to a project |
+| `homeboy triage fleet` | Triage unique components used across a fleet |
+| `homeboy triage rig` | Triage components declared in a local rig spec |
+| `homeboy triage workspace` | Triage every configured project, rig, and registered component once per repo |
+| `homeboy triage landing` | Summarize mergeability and check blockers for a PR landing fleet |
+
+## `homeboy triage component`
+
+```sh
+homeboy triage component [OPTIONS] [COMPONENT_ID]
+```
+
+Triage one registered component.
+
+When `--path <CHECKOUT>` is supplied, the registry is bypassed and the GitHub remote is resolved directly from the checkout's `origin`. Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees) or when a component's registry record is broken.
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[COMPONENT_ID]` | no | Component ID. Optional when `--path` is supplied |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--path` | `<CHECKOUT>` | Workspace path to triage directly, bypassing the registry |
+
+## `homeboy triage project`
+
+```sh
+homeboy triage project <PROJECT_ID>
+```
+
+Triage every component attached to a project
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | _no help text_ |
+
+## `homeboy triage fleet`
+
+```sh
+homeboy triage fleet <FLEET_ID>
+```
+
+Triage unique components used across a fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<FLEET_ID>` | yes | _no help text_ |
+
+## `homeboy triage rig`
+
+```sh
+homeboy triage rig <RIG_ID>
+```
+
+Triage components declared in a local rig spec
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<RIG_ID>` | yes | _no help text_ |
+
+## `homeboy triage workspace`
+
+```sh
+homeboy triage workspace
+```
+
+Triage every configured project, rig, and registered component once per repo
+
+## `homeboy triage landing`
+
+```sh
+homeboy triage landing [OPTIONS] [PR_REFS]...
+```
+
+Summarize mergeability and check blockers for a PR landing fleet
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[PR_REFS]...` | no | PR numbers, owner/repo#number refs, or GitHub PR URLs |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--repo` | `<REPO>` | Resolve bare PR numbers against this GitHub repo (`owner/name` or URL) |
+| `--branch` | `<PATTERN>` | Include open PRs whose source branch matches this pattern. Repeatable |
+| `--source-issue` | `<NUMBER>` | Include PRs linked to this issue number in each resolved repo. Repeatable |
+| `--ordered` | flag | Preserve supplied PR order and emit dependent-branch rebase plans |
+| `--project` | `<ID>` | Scope: project id |
+| `--fleet` | `<ID>` | Scope: fleet id |
+| `--component` | `<ID>` | Scope: registered component id |
+| `--rig` | `<ID>` | Scope: local rig id |
+| `--path` | `<PATH>` | Scope: checkout path, bypassing the registry |
+| `--workspace` | flag | Scope: every configured workspace repo |
+

--- a/docs/reference/cli/commands/tunnel.md
+++ b/docs/reference/cli/commands/tunnel.md
@@ -1,0 +1,474 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy tunnel` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/tunnel.md](../../../commands/tunnel.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy tunnel`
+
+```sh
+homeboy tunnel <COMMAND>
+```
+
+Manage private service tunnel declarations
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy tunnel service` | Manage private service tunnel declarations |
+| `homeboy tunnel preview-client` | Connect a local preview origin to a Homeboy preview ingress |
+| `homeboy tunnel preview-ingress` | Run and inspect the VPS-side public preview ingress |
+| `homeboy tunnel preview-consumer` | Run a configured preview consumer with a Homeboy-owned public URL |
+| `homeboy tunnel artifact-origin` | Serve the artifact root as a browser/reviewer-facing static origin |
+
+## `homeboy tunnel service`
+
+```sh
+homeboy tunnel service <COMMAND>
+```
+
+Manage private service tunnel declarations
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy tunnel service expose` | Declare a private service tunnel without opening a public listener |
+| `homeboy tunnel service list` | List private service tunnel declarations |
+| `homeboy tunnel service show` | Show a private service tunnel declaration |
+| `homeboy tunnel service set` | Modify a private service tunnel declaration |
+| `homeboy tunnel service remove` | Remove a private service tunnel declaration |
+| `homeboy tunnel service url` | Print the declared private local URL for a service tunnel |
+| `homeboy tunnel service status` | Show declaration, process, health, backend, and evidence status |
+| `homeboy tunnel service start` | Start and supervise a declared local service command |
+| `homeboy tunnel service stop` | Stop a running managed local service and cleanup runtime state |
+
+## `homeboy tunnel service expose`
+
+```sh
+homeboy tunnel service expose [OPTIONS] <ID>
+```
+
+Declare a private service tunnel without opening a public listener
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Service tunnel ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--server` | `<SERVER>` | SSH server that can reach the private service |
+| `--runner-local` | flag | Declare a runner-local service without a separate server declaration. In a runner-local context the runner itself is the server, so a duplicate server declaration is not required (#4606) |
+| `--remote-host` | `<REMOTE_HOST>` | Hostname or IP of the service as seen from the SSH server |
+| `--remote-port` | `<REMOTE_PORT>` | Port of the service as seen from the SSH server |
+| `--scheme` | `<SCHEME>` | URL scheme for the local service URL |
+| `--local-port` | `<LOCAL_PORT>` | Fixed local loopback port to reserve for this service later |
+| `--auth-mode` | `<AUTH_MODE>` | Required auth mode for clients that use the private service Values: `bearer-env`, `header-env`, `basic-env`, `mutual-tls`, `ssh-only`. |
+| `--auth-env` | `<AUTH_ENV>` | Environment variable that supplies auth material for env-backed modes |
+| `--auth-header` | `<AUTH_HEADER>` | Header name for header/bearer auth modes |
+| `--allow-client` | `<ALLOWED_CLIENTS>` | Allowed client label. Repeat for multiple expected clients |
+| `--description` | `<DESCRIPTION>` | Human-readable description |
+| `--preview-policy` | `<PREVIEW_POLICY>` | Workflow preview URL policy for this managed service Values: `none`, `always`, `on-failure`, `manual-approval`, `keep-alive-until`. |
+| `--preview-keep-alive-until` | `<PREVIEW_KEEP_ALIVE_UNTIL>` | RFC3339 expiry for --preview-policy keep-alive-until |
+
+## `homeboy tunnel service list`
+
+```sh
+homeboy tunnel service list
+```
+
+List private service tunnel declarations
+
+## `homeboy tunnel service show`
+
+```sh
+homeboy tunnel service show <ID>
+```
+
+Show a private service tunnel declaration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Service tunnel ID |
+
+## `homeboy tunnel service set`
+
+```sh
+homeboy tunnel service set [OPTIONS] [ID]
+```
+
+Modify a private service tunnel declaration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `[ID]` | no | Entity ID (optional if provided in JSON body) |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--json` | `<JSON>` | JSON object to merge into the entity (supports @file and - for stdin) |
+| `--base64` | `<BASE64>` | Base64-encoded JSON object (bypasses shell escaping issues) |
+| `--replace` | `<FIELD>` | Replace these fields instead of merging arrays |
+
+## `homeboy tunnel service remove`
+
+```sh
+homeboy tunnel service remove <ID>
+```
+
+Remove a private service tunnel declaration
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Service tunnel ID |
+
+## `homeboy tunnel service url`
+
+```sh
+homeboy tunnel service url <ID>
+```
+
+Print the declared private local URL for a service tunnel
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Service tunnel ID |
+
+## `homeboy tunnel service status`
+
+```sh
+homeboy tunnel service status <ID>
+```
+
+Show declaration, process, health, backend, and evidence status
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Service tunnel ID |
+
+## `homeboy tunnel service start`
+
+```sh
+homeboy tunnel service start [OPTIONS] <ID>
+```
+
+Start and supervise a declared local service command
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Service tunnel ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--command` | `<COMMAND>` | Long-running service command to execute through the platform shell |
+| `--cwd` | `<CWD>` | Working directory for the service command |
+| `--env` | `<ENV>` | Environment assignment passed to the service command. Repeat for multiple values |
+| `--host` | `<HOST>` | Local loopback host declared for this service |
+| `--port` | `<PORT>` | Local port declared for this service |
+| `--scheme` | `<SCHEME>` | Local URL scheme |
+| `--health-url` | `<HEALTH_URL>` | Full health-check URL to poll before reporting the service ready |
+| `--health-path` | `<HEALTH_PATH>` | Health-check path appended to the declared local URL |
+| `--readiness-timeout` | `<READINESS_TIMEOUT>` | Seconds to wait for the service health check |
+| `--readiness-kind` | `<READINESS_KIND>` | Readiness contract label reported in service status Values: `process`, `preview`, `proof`. |
+| `--require-listener` | flag | Require the declared local URL host:port to accept TCP connections |
+| `--readiness-artifact` | `<READINESS_ARTIFACT>` | Artifact file whose JSON value proves readiness |
+| `--readiness-artifact-json-pointer` | `<READINESS_ARTIFACT_JSON_POINTER>` | JSON Pointer inside --readiness-artifact whose value must match |
+| `--readiness-artifact-json-equals` | `<READINESS_ARTIFACT_JSON_EQUALS>` | Expected string/JSON value for --readiness-artifact-json-pointer |
+| `--readiness-stdout-regex` | `<READINESS_STDOUT_REGEX>` | Regex that must match captured service stdout before readiness is true |
+| `--public-tunnel-backend` | `<PUBLIC_TUNNEL_BACKEND>` | Public tunnel backend adapter Values: `none`, `command`. |
+| `--public-tunnel-command` | `<PUBLIC_TUNNEL_COMMAND>` | Provider-neutral backend command to supervise when using the command backend |
+| `--public-tunnel-public-url` | `<PUBLIC_TUNNEL_PUBLIC_URL>` | Public URL exposed by the backend command |
+| `--source-run-id` | `<SOURCE_RUN_ID>` | Owning workflow run ID to attach to preview artifacts |
+| `--source-workflow-id` | `<SOURCE_WORKFLOW_ID>` | Owning workflow ID to attach to preview artifacts |
+
+## `homeboy tunnel service stop`
+
+```sh
+homeboy tunnel service stop <ID>
+```
+
+Stop a running managed local service and cleanup runtime state
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Service tunnel ID |
+
+## `homeboy tunnel preview-client`
+
+```sh
+homeboy tunnel preview-client <COMMAND>
+```
+
+Connect a local preview origin to a Homeboy preview ingress
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy tunnel preview-client start` | Start an outbound authenticated reverse channel for one public host |
+| `homeboy tunnel preview-client diagnose-auth` | Compare preview-client token digests without printing token material |
+
+## `homeboy tunnel preview-client start`
+
+```sh
+homeboy tunnel preview-client start [OPTIONS]
+```
+
+Start an outbound authenticated reverse channel for one public host
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--ingress` | `<INGRESS>` | Preview ingress/broker base URL |
+| `--public-host` | `<PUBLIC_HOST>` | Exact public host to register. Wildcards are rejected |
+| `--local-origin` | `<LOCAL_ORIGIN>` | Local HTTP(S) origin to forward requests to |
+| `--session-id` | `<SESSION_ID>` | Preview session ID claimed by this client |
+| `--token-env` | `<TOKEN_ENV>` | Environment variable that contains the preview tunnel bearer token |
+| `--poll-timeout` | `<POLL_TIMEOUT>` | Long-poll timeout in seconds for ingress request claims |
+| `--ready-stdout` | flag | Print the public preview origin to stdout after successful registration |
+
+## `homeboy tunnel preview-client diagnose-auth`
+
+```sh
+homeboy tunnel preview-client diagnose-auth [OPTIONS]
+```
+
+Compare preview-client token digests without printing token material
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--token-env` | `<TOKEN_ENV>` | Environment variable that contains the preview tunnel bearer token |
+| `--token-sha256-env` | `<TOKEN_SHA256_ENV>` | Environment variable containing the allowed client token SHA-256 digest |
+
+## `homeboy tunnel preview-ingress`
+
+```sh
+homeboy tunnel preview-ingress <COMMAND>
+```
+
+Run and inspect the VPS-side public preview ingress
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy tunnel preview-ingress install` | Render a non-destructive operator install plan for a VPS preview ingress domain |
+| `homeboy tunnel preview-ingress install-status` | Render machine-readable operator install status checks without probing a live VPS |
+| `homeboy tunnel preview-ingress route` | Register or replace one active public-host route |
+| `homeboy tunnel preview-ingress unroute` | Remove one preview ingress route |
+| `homeboy tunnel preview-ingress list` | List registered preview ingress routes |
+| `homeboy tunnel preview-ingress status` | Report route lifecycle and recent server failure metadata |
+| `homeboy tunnel preview-ingress serve` | Run the blocking HTTP ingress server behind a TLS terminator |
+
+## `homeboy tunnel preview-ingress install`
+
+```sh
+homeboy tunnel preview-ingress install [OPTIONS]
+```
+
+Render a non-destructive operator install plan for a VPS preview ingress domain
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--server` | `<SERVER>` | Configured Homeboy server ID for the VPS |
+| `--domain` | `<DOMAIN>` | Operator-owned domain, e.g. example.com |
+| `--public-host-pattern` | `<PUBLIC_HOST_PATTERN>` | Wildcard host pattern routed to the ingress, e.g. *-tunnel.example.com |
+| `--bind` | `<BIND>` | Stable loopback bind address for the ingress daemon |
+| `--binary-path` | `<BINARY_PATH>` | Homeboy binary path used by the service unit |
+| `--service-name` | `<SERVICE_NAME>` | systemd service name |
+| `--user` | `<USER>` | System user that runs the ingress service |
+| `--group` | `<GROUP>` | System group that runs the ingress service |
+
+## `homeboy tunnel preview-ingress install-status`
+
+```sh
+homeboy tunnel preview-ingress install-status [OPTIONS]
+```
+
+Render machine-readable operator install status checks without probing a live VPS
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--server` | `<SERVER>` | Configured Homeboy server ID for the VPS |
+| `--domain` | `<DOMAIN>` | Operator-owned domain, e.g. example.com |
+| `--public-host-pattern` | `<PUBLIC_HOST_PATTERN>` | Wildcard host pattern routed to the ingress, e.g. *-tunnel.example.com |
+| `--bind` | `<BIND>` | Stable loopback bind address for the ingress daemon |
+| `--binary-path` | `<BINARY_PATH>` | Homeboy binary path used by the service unit |
+| `--service-name` | `<SERVICE_NAME>` | systemd service name |
+| `--user` | `<USER>` | System user that runs the ingress service |
+| `--group` | `<GROUP>` | System group that runs the ingress service |
+
+## `homeboy tunnel preview-ingress route`
+
+```sh
+homeboy tunnel preview-ingress route [OPTIONS] <SESSION_ID>
+```
+
+Register or replace one active public-host route
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SESSION_ID>` | yes | Preview session ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--public-host` | `<PUBLIC_HOST>` | Public host routed by the TLS/proxy layer, e.g. run-123-tunnel.preview.example.test |
+| `--upstream-origin` | `<UPSTREAM_ORIGIN>` | Local/reverse-channel HTTP origin for this session |
+| `--expires-at` | `<EXPIRES_AT>` | RFC3339 expiry after which ingress returns 410 |
+| `--inactive` | flag | Mark the route disconnected while preserving diagnostics |
+
+## `homeboy tunnel preview-ingress unroute`
+
+```sh
+homeboy tunnel preview-ingress unroute <SESSION_ID>
+```
+
+Remove one preview ingress route
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<SESSION_ID>` | yes | Preview session ID |
+
+## `homeboy tunnel preview-ingress list`
+
+```sh
+homeboy tunnel preview-ingress list
+```
+
+List registered preview ingress routes
+
+## `homeboy tunnel preview-ingress status`
+
+```sh
+homeboy tunnel preview-ingress status [OPTIONS]
+```
+
+Report route lifecycle and recent server failure metadata
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bind` | `<BIND>` | Bind address to include in the status output |
+| `--domain` | `<DOMAIN>` | Operator-owned preview domain |
+| `--public-host-pattern` | `<PUBLIC_HOST_PATTERN>` | Public host pattern routed to this ingress |
+| `--host` | `<HOST>` | Public host to inspect for preview-client registration state |
+
+## `homeboy tunnel preview-ingress serve`
+
+```sh
+homeboy tunnel preview-ingress serve [OPTIONS]
+```
+
+Run the blocking HTTP ingress server behind a TLS terminator
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bind` | `<BIND>` | Loopback bind address for Nginx/Caddy/Cloudflare to proxy to |
+| `--domain` | `<DOMAIN>` | Operator-owned preview domain |
+| `--public-host-pattern` | `<PUBLIC_HOST_PATTERN>` | Public host pattern routed to this ingress |
+| `--token-sha256-env` | `<TOKEN_SHA256_ENV>` | Environment variable containing the allowed client token SHA-256 digest |
+
+## `homeboy tunnel preview-consumer`
+
+```sh
+homeboy tunnel preview-consumer <COMMAND>
+```
+
+Run a configured preview consumer with a Homeboy-owned public URL
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy tunnel preview-consumer run` | Run a command described by a preview-consumer JSON config |
+
+## `homeboy tunnel preview-consumer run`
+
+```sh
+homeboy tunnel preview-consumer run [OPTIONS]
+```
+
+Run a command described by a preview-consumer JSON config
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--config` | `<CONFIG>` | JSON config containing command, args, env, artifact, and extraction rules |
+| `--service-id` | `<SERVICE_ID>` | Service ID whose started tunnel status contains the public preview URL |
+| `--preview-public-url` | `<PREVIEW_PUBLIC_URL>` | Public/tunnel preview origin owned by Homeboy |
+| `--artifacts-dir` | `<ARTIFACTS_DIR>` | Override the config artifact directory |
+| `--non-blocking` | flag | Start the command under supervision and return as soon as the preview is ready, leaving the command running (held preview flows) |
+| `--ready-timeout` | `<READY_TIMEOUT>` | Seconds to wait for the preview to report ready in non-blocking mode before returning while leaving the command running |
+
+## `homeboy tunnel artifact-origin`
+
+```sh
+homeboy tunnel artifact-origin <COMMAND>
+```
+
+Serve the artifact root as a browser/reviewer-facing static origin
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy tunnel artifact-origin serve` | Serve Homeboy artifact-root paths with CORS headers for browser consumers |
+| `homeboy tunnel artifact-origin status` | Print the artifact origin root and public URL mapping without starting a server |
+| `homeboy tunnel artifact-origin inspect` | Map an artifact-origin request path or file path to its served file and public URL |
+| `homeboy tunnel artifact-origin dom-boxes` | Capture DOM bounding boxes for data-figma-node-id elements in static HTML pages |
+
+## `homeboy tunnel artifact-origin serve`
+
+```sh
+homeboy tunnel artifact-origin serve [OPTIONS]
+```
+
+Serve Homeboy artifact-root paths with CORS headers for browser consumers
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bind` | `<BIND>` | Loopback bind address for the local static artifact origin |
+| `--root` | `<ROOT>` | Artifact root to serve. Defaults to Homeboy's configured artifact root |
+| `--ingress` | `<INGRESS>` | Preview ingress/broker URL. With --public-host, keeps a durable outbound reverse connection open for this artifact origin |
+| `--public-host` | `<PUBLIC_HOST>` | Exact public host claimed by the durable artifact origin |
+| `--token-env` | `<TOKEN_ENV>` | Environment variable containing the reverse-client bearer token |
+| `--poll-timeout` | `<POLL_TIMEOUT>` | Long-poll timeout in seconds for ingress request claims |
+
+## `homeboy tunnel artifact-origin status`
+
+```sh
+homeboy tunnel artifact-origin status [OPTIONS]
+```
+
+Print the artifact origin root and public URL mapping without starting a server
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--bind` | `<BIND>` | Loopback bind address expected by the local static artifact origin |
+| `--root` | `<ROOT>` | Artifact root to inspect. Defaults to Homeboy's configured artifact root |
+
+## `homeboy tunnel artifact-origin inspect`
+
+```sh
+homeboy tunnel artifact-origin inspect [OPTIONS] <PATH>
+```
+
+Map an artifact-origin request path or file path to its served file and public URL
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PATH>` | yes | Request path, artifact-root-relative path, or filesystem path to inspect |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--root` | `<ROOT>` | Artifact root to inspect. Defaults to Homeboy's configured artifact root |
+| `--fail-on-missing` | flag | Return a non-zero exit code when the mapped file is missing |
+
+## `homeboy tunnel artifact-origin dom-boxes`
+
+```sh
+homeboy tunnel artifact-origin dom-boxes [OPTIONS]
+```
+
+Capture DOM bounding boxes for data-figma-node-id elements in static HTML pages
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--root` | `<ROOT>` | Artifact directory root containing the static HTML entrypoints |
+| `--entrypoint` | `<ENTRYPOINT>` | HTML entrypoint path, relative to --root; repeat for multiple pages |
+| `--report` | `<REPORT>` | Write the schema payload directly to this JSON file |
+| `--text-sample-limit` | `<TEXT_SAMPLE_LIMIT>` | Maximum normalized characters captured from each element text sample |
+

--- a/docs/reference/cli/commands/upgrade.md
+++ b/docs/reference/cli/commands/upgrade.md
@@ -1,0 +1,35 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy upgrade` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/upgrade.md](../../../commands/upgrade.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy upgrade`
+
+```sh
+homeboy upgrade [OPTIONS]
+```
+
+Upgrade Homeboy to the latest version
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--check` | flag | Check for updates without installing |
+| `--force` | flag | Force upgrade even if already at latest version |
+| `--no-restart` | flag | Skip automatic restart after upgrade |
+| `--skip-extensions` | flag | Skip extension updates (only upgrade the binary) |
+| `--skip-runners` | flag | Skip configured runner upgrades after the local upgrade |
+| `--no-restart-services` | flag | Skip restarting declared binary-resident services after the binary swap. They will be reported as pending with their recovery commands instead |
+| `--upgrade-runner` | `<RUNNER_ID>` | Select the configured runner to converge with the controller. Repeat to target multiple runners |
+| `--runner-only` | flag | Refresh selected runners without promoting the controller |
+| `--method` | `<METHOD>` | Override install method detection (homebrew\|cargo\|source\|binary) |
+| `--source-path` | `<PATH>` | Homeboy source checkout to use with --method source |
+

--- a/docs/reference/cli/commands/worktree.md
+++ b/docs/reference/cli/commands/worktree.md
@@ -1,0 +1,146 @@
+<!-- GENERATED FILE. DO NOT EDIT BY HAND.
+Source of truth: the clap command tree in `crates/homeboy-cli`.
+Regenerate with:
+HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
+Hand-written narrative for these commands lives in `docs/commands/`. -->
+
+# `homeboy worktree` command reference
+
+Generated from the clap command tree. This page is the complete synopsis, argument, flag, and subcommand surface for this command family.
+
+Concepts, recipes, and contracts are hand-written in [docs/commands/worktree.md](../../../commands/worktree.md).
+
+Global flags apply to every command and are documented once in [the root command reference](../homeboy-root-command.md).
+
+## `homeboy worktree`
+
+```sh
+homeboy worktree <COMMAND>
+```
+
+Manage component-backed task worktrees
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy worktree create` | Create a task worktree from a registered component checkout |
+| `homeboy worktree adopt` | Adopt an existing local workspace path for @workspace:<handle> refs |
+| `homeboy worktree queue-create` | Create multiple task worktrees one-at-a-time with queue status JSON |
+| `homeboy worktree list` | List persisted task worktrees |
+| `homeboy worktree status` | Inspect one task worktree and its safety gates |
+| `homeboy worktree remove` | Remove one task worktree after safety checks |
+| `homeboy worktree cleanup` | Remove cleanup-eligible task worktrees after safety checks |
+
+## `homeboy worktree create`
+
+```sh
+homeboy worktree create [OPTIONS] <COMPONENT_ID>
+```
+
+Create a task worktree from a registered component checkout
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component ID to use as the source checkout |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--branch` | `<BRANCH>` | Branch to create in the task worktree |
+| `--from` | `<FROM>` | Base ref for the new worktree branch |
+| `--task-url` | `<TASK_URL>` | Task or issue URL associated with this worktree |
+| `--run-id` | `<RUN_ID>` | Agent-task run ID associated with this worktree |
+| `--cleanup-policy` | `<CLEANUP_POLICY>` | Cleanup policy for lifecycle cleanup Values: `remove-when-safe`, `preserve-on-failure`. |
+
+## `homeboy worktree adopt`
+
+```sh
+homeboy worktree adopt [OPTIONS] <HANDLE> <PATH>
+```
+
+Adopt an existing local workspace path for @workspace:<handle> refs
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<HANDLE>` | yes | Workspace handle resolved by @workspace:<handle> |
+| `<PATH>` | yes | Existing local directory to resolve for this handle |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--kind` | `<KIND>` | Optional generic kind label recorded as provenance |
+| `--provenance-json` | `<PROVENANCE_JSON>` | Optional JSON provenance payload recorded with the adopted path |
+
+## `homeboy worktree queue-create`
+
+```sh
+homeboy worktree queue-create [OPTIONS] <REPO>
+```
+
+Create multiple task worktrees one-at-a-time with queue status JSON
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<REPO>` | yes | Registered component/repo handle, e.g. homeboy |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--branch` | `<BRANCH>` | Branch to create. Repeat for fanout batches |
+| `--from` | `<FROM>` | Base ref for each worktree branch |
+| `--task-url` | `<TASK_URL>` | Task or issue URL associated with these worktrees |
+| `--task-ref` | `<TASK_REF>` | Short task reference associated with these worktrees, e.g. Extra-Chill/homeboy#5786 |
+| `--dry-run` | flag | Print the queue plan/status without creating worktrees |
+| `--retry-after-seconds` | `<RETRY_AFTER_SECONDS>` | Suggested orchestrator wait when queueing is blocked but no retry-after value is available |
+
+## `homeboy worktree list`
+
+```sh
+homeboy worktree list
+```
+
+List persisted task worktrees
+
+## `homeboy worktree status`
+
+```sh
+homeboy worktree status <ID>
+```
+
+Inspect one task worktree and its safety gates
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Task worktree ID, e.g. component@branch-slug |
+
+## `homeboy worktree remove`
+
+```sh
+homeboy worktree remove [OPTIONS] <ID>
+```
+
+Remove one task worktree after safety checks
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<ID>` | yes | Task worktree ID, e.g. component@branch-slug |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--force` | flag | Allow dirty/unpushed worktree removal; hard gates still apply |
+| `--cleanup-branch` | flag | Delete the local task branch after removing the worktree when branch safety allows it |
+| `--allow-unmerged-branch` | flag | Permit deleting an unmerged task branch. Requires --cleanup-branch |
+
+## `homeboy worktree cleanup`
+
+```sh
+homeboy worktree cleanup [OPTIONS]
+```
+
+Remove cleanup-eligible task worktrees after safety checks
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--apply` | flag | Remove planned worktrees and artifacts after safety checks. Without this flag, only reports the plan |
+| `--force` | flag | Allow dirty/unpushed worktree removal; hard gates still apply |
+| `--dry-run` | flag | Deprecated plan-only alias retained for one release; bare cleanup also reports the plan |
+| `--cleanup-artifacts` | flag | Also remove declared rebuildable artifacts from the Homeboy checkout that built this binary |
+| `--cleanup-branches` | flag | Delete merged task branches for removed cleanup candidates |
+| `--allow-unmerged-branches` | flag | Permit deleting unmerged task branches. Requires --cleanup-branches |
+

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,8 +6,9 @@ Reference pages are intentionally dense. If you are deciding what to run next, s
 
 ## CLI
 
+- [Generated CLI reference](cli/commands/index.md) - every command, argument, flag, and subcommand, generated from clap
 - [Root command and global flags](cli/homeboy-root-command.md)
-- [Command index](../commands/commands-index.md)
+- [Command index](../commands/commands-index.md) - hand-written narrative per command family
 - [Contract manifest command](../commands/contract.md)
 
 ## Configuration
@@ -24,5 +25,7 @@ Reference pages are intentionally dense. If you are deciding what to run next, s
 
 ## Extension Commands
 
+Extensions add top-level commands at runtime, so they are not part of the
+clap-generated reference above.
+
 - [Cargo command](../commands/cargo.md)
-- [WP command](../commands/wp.md)


### PR DESCRIPTION
Closes #10324 (partially — see *What remains*).

## Verdict on the issue

Mostly right, with three corrections. **The `~600 commands` figure is wrong, and so is the staged help-tree snapshot it came from.**

| Issue claim | Verdict |
|---|---|
| `~600` live level-2/3 commands | **Wrong: ~530.** See below. |
| `41` files in `docs/commands/` | **Wrong: 44** (40 command docs + 4 support/extension docs). |
| `commands-index.md` lists `api` twice, invisible to both guards | **Correct.** Fixed, with a test. |
| Subcommand coverage enforced for exactly two families | **Correct** (`docs_cover_high_use_command_surfaces`). |
| 30 of 36 `agent-task` subcommands have no `about` | **Correct.** |
| `agent-task fanout` subcommands blank | **Stale — already fixed on main.** All seven now have `about`. |
| "no documented-but-removed commands" | **Nearly correct**, one exception: `agent-task dispatch`. |

### The command count

`/var/lib/datamachine/tmp/opencode/hb-audit/cli-help-tree.txt` reports 601 commands. It is a `--help` scrape and it parsed **positional-argument placeholders as subcommands** — it invented `bench Additional`, `bench Component`, `fuzz Component compare`, and 81 more. Removing those, and reconciling against `homeboy contract manifest` (which walks clap reflectively), the real surface on the 0.321.0 binary is:

- **533 command nodes total, 529 visible, 40 built-in top-level families** (+2 runtime extension commands, `cargo`/`wp`, which are not in the clap tree).

This is a load-bearing correction: it is the direct evidence for *not* scraping `--help`, which is hazard #2 in this repo anyway.

### Stale docs

There is no widespread staleness. Exactly one documented-but-removed command exists across all 44 files:

- **`docs/commands/agent-task.md:99,102,105`** — `homeboy agent-task dispatch`. No `Dispatch` variant exists in `AgentTaskCommand`. The *flags* it shows (`--max-provider-executions`, `--max-same-provider-retries`, `--max-provider-rotations`, `--attempts` alias) are real — they live in `DispatchCoreArgs`, flattened into `agent-task cook`. Fixed by correcting the command name only.

Two near-misses that are **not** bugs and were left alone:

- `docs/commands/review.md` documents `review audit baseline refresh|merge`. That spelling only exists in pre-parse argv rewriting; clap exposes `review audit-baseline`. `review_audit_baseline_manifest_declares_baseline_mutation` already pins this deliberately (#10313), so the doc is describing the accepted argv, not a clap path.
- `docs/commands/cleanup.md` mentions `runner cache-prune`, absent from the 0.321.0 binary. It landed in #10541 after that release. The doc is ahead, not stale.

Issue #10148 (`self doctor` reporting a stale `harvest`) is **already resolved on main**: `harvest` is in `COMMAND_SPECS`, in `--help`, and in the docs index. That issue describes a transient 0.316.0 state.

One genuinely broken link, unrelated to commands: `docs/reference/index.md` pointed at `../commands/wp.md`, which has never existed. Fixed.

## Design

**Reflective walk of `clap::Command`, not `--help` scraping.**

`--help` output is a wire protocol in this repo: `negotiate_leaseless_recovery_contract` parses a *remote* binary's rendered `Options:` block, and `declared_long_options` only accepts bare long options — #10536 found that merely adding a doc comment to `--confirm-no-daemon-owner` emptied the advertised contract and broke recovery between two current-version binaries. #10554 then pinned the 14 `global = true` args with `root_global_flag_surface_is_pinned`.

Scraping `--help` would couple doc generation to that rendering *and* require a built binary. `crates/homeboy-cli/src/cli_surface/reference_docs.rs` only calls read-only `Command`/`Arg` accessors, so it structurally cannot change what `--help` prints.

**Checked in, not generated at build time.**

`crates/homeboy-cli/build.rs` already walks `docs/**/*.md`, embeds each file into the binary, and emits a `rerun-if-changed` per file. Generating this tree during the build would add a second full walk of ~530 command nodes to *every* compile of a workspace whose test run already takes ~40 minutes. Instead the tree is checked in and a unit test asserts it byte-matches clap. Generation cost is paid only on deliberate regeneration:

```sh
HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs
```

Side benefit: because build.rs embeds the tree, `homeboy self docs reference/cli/commands/<command>` works offline with no extra wiring.

**One page per top-level family, not one per node.** 41 files covering ~530 nodes, rather than 530 files. This keeps the embedded-docs count and the `rerun-if-changed` list sane, and maps 1:1 onto the hand-written `docs/commands/<slug>.md` it links to.

**Global flags are excluded from per-command tables** and documented once in the root reference page. They are identical on every node and are pinned as a protocol; repeating them on ~530 pages would bury the per-command surface and would make any global-flag change rewrite the entire generated tree.

## Preserving hand-written prose

Nothing hand-written is read, rewritten, moved, or deleted. The generator owns one new, disjoint directory: `docs/reference/cli/commands/`.

- Each generated page links **back** to `docs/commands/<slug>.md`, resolving the slug through `command_contract::registered_command`, so a family without a registered doc simply gets no backlink instead of a dead link.
- `docs/commands/commands-index.md`, `docs/reference/index.md`, and `docs/index.md` gain a forward link. That is the only change to hand-written files, apart from the three drift fixes above.
- `include_str!`/`include_bytes!` was audited before touching anything (#5300's failure mode is a *compile* break, not a test failure). Only two docs are compile-time dependencies — `docs/commands/commands-index.md` (`cli_surface/mod.rs:689`) and `docs/changelog.md` (`release/changelog.rs:75`). Neither is deleted or moved; the index edit removes a duplicate line the parser already deduped into a `BTreeSet`.

## CI check

`.github/workflows/cli-reference-docs.yml`, path-filtered to `crates/homeboy-cli/**`. Every `#[derive(Subcommand)]` and `#[derive(Args)]` in the workspace lives in that crate (99 files, 0 elsewhere), so a PR that does not touch it cannot move the command surface and pays nothing.

The job runs the generator in **write** mode, uploads the regenerated tree as an artifact unconditionally, then gates on `git diff --exit-code`. A contributor whose PR moved the command surface downloads the correct docs instead of needing a local toolchain. The same assertion also runs as an ordinary unit test inside the existing (differentially scoped) `review test` gate.

## Tests

- `cli_reference_docs_are_current` — byte-currency, with a write mode. Deliberately `assert!` rather than `assert_eq!` on bodies so a stale page reports line counts instead of dumping ~40 KB into the CI log.
- `generated_reference_covers_every_visible_top_level_command` — exactly one page per visible top-level command, plus the index.
- `commands_without_help_text_are_confined_to_agent_task` — pins the *shape* of the missing-`about` debt rather than a count. No other family may acquire the gap; the exact remaining paths are listed in the generated index, so shrinking the set shows up as a reviewed docs diff. (A count would have been wrong: `fanout` was fixed after the issue was filed.)
- `commands_index_lists_each_command_once` — the duplicate-`api` regression guard.

## `--help` handshake: no changes

**No clap doc comment, `about`, `long_about`, `after_help`, arg help, or flag definition is modified by this PR.** The generator is read-only over the clap tree. `root_global_flag_surface_is_pinned` and `leaseless_recovery_help_advertises_a_bare_confirmation_option` are untouched and unaffected. The only Rust change outside the two new `#[cfg(test)]` modules is four lines of `mod` declarations in `cli_surface/mod.rs`.

This is also why the ~200 lines of missing `agent-task` doc comments are **not** in this PR: they are the one change in this area that *does* alter rendered help, and they deserve their own review.

## What remains

1. **41 missing `about` doc comments**, all under `agent-task` (30 direct children + `loop`'s 4 + nested). The generated index enumerates them. This is the issue's item 1 and it should ship alone.
2. **Widen `docs_cover_high_use_command_surfaces`** from `["runner","rig"]` to all 40. Best done after (1), so the generated pages make it pass by construction.
3. **Trim the reference half out of `docs/commands/*.md`** now that it is generated. Not required for correctness and it is a large prose review; deliberately deferred.
4. `docs/reference/cli/homeboy-root-command.md` is hand-written and **already stale**: it documents `--allow-local-fallback`, which is not in the pinned global set. Left alone here to keep this PR's blast radius at zero for the handshake.

## Not verified without cargo

Per host policy, no `cargo build`/`test`/`check`/`clippy` was run here — only `cargo fmt` (clean). Unverified locally, and left to CI:

- **The generated tree does not exist in this first push.** The generator cannot run without a build. The `CLI Reference Docs` job produces it as an artifact; it will be committed in a follow-up push on this branch and the job will then go green.
- Compilation of the two new modules. Every clap accessor used is a stable clap 4 read API (`Command::build`, `get_about`, `get_long_about`, `get_visible_aliases`, `is_subcommand_required_set`, `get_positionals`, `Arg::get_action`, `get_value_names`, `get_possible_values`), but none of it is compiler-checked here.
- The **exact** live node count on this HEAD. The 533/529/40 figures are measured from the installed 0.321.0 binary via `contract manifest`; main has moved since. The generated index will state the true number.
