### PR TITLE
fix(audit): make the post-merge audit gate actually scan, and unblind the source-policy corpus

### DIFF
--- a/.github/workflows/audit-debt.yml
+++ b/.github/workflows/audit-debt.yml
@@ -136,6 +136,48 @@ jobs:
           path: target/release/homeboy
           retention-days: 1
 
+  # ── Full-tree audit gate ──
+  #
+  # #10557: this job used to invoke `.homeboy-bin/homeboy review audit` directly.
+  # That skipped homeboy-action's `Install extension` step, so no extension
+  # declared `provides.file_extensions`, the audit corpus came back EMPTY, and
+  # the gate reported `files_scanned: 0, files_skipped: 1817, findings: [],
+  # passed: true` — green in 7 seconds on an 1800-file repository. The sibling
+  # lint/test gates below were unaffected because they already go through the
+  # action, which is why the workflow as a whole looked healthy.
+  #
+  # Two changes close it:
+  #
+  #   1. Route through Extra-Chill/homeboy-action, exactly like the lint/test
+  #      gates and the weekly sweep, so the extension is installed and the audit
+  #      has something to fingerprint.
+  #   2. `review audit` itself now hard-errors on an empty corpus
+  #      (engine.rs, "audit.corpus"), so the 7-second green run is impossible
+  #      for EVERY consumer, not just this workflow. The `Assert the audit
+  #      actually scanned` step below is the belt to that braces: it is
+  #      unconditionally blocking and fails closed.
+  #
+  # ── Why the findings verdict is reporting-only, for now ──
+  #
+  # Turning the findings verdict on today turns `main` red immediately, for debt
+  # nobody has triaged and that this PR did not create:
+  #
+  #   * 37 findings on `main` are already unbaselined (`drift_increased: true`,
+  #     28 resolved, net +9) — accumulated since the 2026-07-27 baseline.
+  #   * ~293 core_boundary_leak findings across 38 files become visible for the
+  #     first time now that the source-policy corpus is fixed (#10558): 182
+  #     index files (`mod.rs`/`lib.rs`/`main.rs`) plus 83 files sitting alone in
+  #     a directory were unscannable by ANY source policy.
+  #
+  # Baselining that set requires running the FIXED binary, which only exists
+  # after this merges. So the findings verdict lands reporting-only and the
+  # follow-up issue below flips it — with a regenerated baseline — as its own
+  # reviewed change. `continue-on-error` here is a dated, tracked state, not a
+  # permanent one; `tests/audit_debt_workflow_test.rs` requires the follow-up
+  # issue reference to sit next to it so it cannot quietly become permanent.
+  #
+  # FOLLOW-UP: #10569 — regenerate the audit baseline on main and remove
+  # `continue-on-error` from the audit step below.
   full-audit-gate:
     name: Full-tree audit gate
     if: github.event_name == 'push'
@@ -147,6 +189,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Download homeboy binary
         uses: actions/download-artifact@v4
@@ -162,8 +206,60 @@ jobs:
           fi
           chmod +x .homeboy-bin/homeboy
 
-      - name: Run blocking full-profile audit
-        run: .homeboy-bin/homeboy review audit homeboy --profile=full
+      # Reporting-only until #10569 baselines the pre-existing set. The action
+      # owns the `Install extension` step whose absence caused the 0-file scan.
+      - uses: Extra-Chill/homeboy-action@v2
+        id: audit
+        continue-on-error: true
+        with:
+          binary-path: .homeboy-bin/homeboy
+          commands: review audit
+          expected-commands: review audit,review lint,review test
+          # Full profile enables the whole-tree discovery detectors
+          # (duplication, dead code, source policies, core boundary leaks) that
+          # `--profile=pr` deliberately omits. No `--changed-since`: this gate
+          # exists to see the integrated tree.
+          args: --profile=full
+          # Pure pass/fail gate — the weekly sweep files the tracking issues.
+          # (No `autofix` input: homeboy-action@v2 has none, so passing one is
+          # dead configuration. This gate mutates nothing regardless.)
+          auto-issue: 'false'
+
+      # BLOCKING. #10557's defect was a gate that reported success while
+      # measuring nothing, so the one property this job enforces unconditionally
+      # is that the audit had a corpus at all.
+      #
+      # Reads the action's structured audit output. HOMEBOY_OUTPUT_DIR is
+      # exported to $GITHUB_ENV by the action's run-homeboy-commands.sh. If that
+      # ever moves, this step fails closed (missing file -> exit 1), which is the
+      # correct direction for a gate: it can produce a false RED, never a false
+      # green.
+      #
+      # `files_scanned` is the CONVENTION corpus (index files and single-file
+      # directories excluded — see #10558). It is a lower bound on what the
+      # audit actually read, which is exactly what a "did this run at all"
+      # assertion wants. `review audit` itself already errors when the wider
+      # source-policy corpus is empty, so the two checks bracket the failure.
+      - name: Assert the audit actually scanned the tree
+        run: |
+          set -euo pipefail
+          result="${HOMEBOY_OUTPUT_DIR:-}/audit.json"
+          if [ -z "${HOMEBOY_OUTPUT_DIR:-}" ] || [ ! -s "${result}" ]; then
+            echo "::error::Audit produced no structured output at '${result}'. The audit did not run to completion (or homeboy-action changed where it writes results). A gate that cannot read the audit result cannot claim the audit passed — see #10557." >&2
+            exit 1
+          fi
+          files_scanned="$(jq -r '.data.summary.files_scanned // 0' "${result}")"
+          echo "audit corpus: ${files_scanned} file(s)"
+          if [ "${files_scanned}" -lt 1 ]; then
+            echo "::error::Audit scanned ${files_scanned} files. An audit with an empty corpus has not passed — it has not run. The usual cause is a missing fingerprinting extension: this gate must go through Extra-Chill/homeboy-action, whose 'Install extension' step installs the extensions declared in homeboy.json. See #10557." >&2
+            jq -r '.data.summary' "${result}" >&2 || true
+            exit 1
+          fi
+
+      - name: Report the (non-blocking) audit findings verdict
+        if: steps.audit.outcome == 'failure'
+        run: |
+          echo "::warning::Full-profile audit reported findings. This verdict is REPORTING-ONLY until #10569 regenerates the baseline; the corpus assertion above is the blocking part. Expand the audit group in this job's log for the finding list."
 
   # ── Release-blocking suite, at full scope, on the merged result ──
   # `review lint` + `review test` is exactly release.yml's RELEASE_BLOCKING_COMMANDS
@@ -319,7 +415,8 @@ jobs:
           # auto-enables this on non-PR events, but set it explicitly so the
           # intent of this workflow is unambiguous.
           auto-issue: 'true'
-          # Advisory sweep — never autofix, never push. Findings become the
-          # roadmap; fixes land through their own reviewed PRs.
-          autofix: 'false'
+          # Advisory sweep — never pushes. Findings become the roadmap; fixes
+          # land through their own reviewed PRs. (There is no `autofix` input on
+          # homeboy-action@v2, so the `autofix: 'false'` that used to sit here
+          # was dead configuration asserting a property it did not enforce.)
           app-token: ${{ steps.app-token.outputs.token || '' }}

--- a/crates/homeboy-code-audit/src/audit_runtime_regression_test.rs
+++ b/crates/homeboy-code-audit/src/audit_runtime_regression_test.rs
@@ -119,15 +119,46 @@ fn fixture_workflow_args() -> AuditRunWorkflowArgs {
 }
 
 /// Run the fixture audit through the CI entry point and return the workflow
-/// result.
+/// result. Panics if the audit cannot run at all.
+///
+/// Only the `slow-tests` snapshot/determinism pair uses this strict form; the
+/// default-tier tests go through [`fixture_audit_or_skip`], so this is gated to
+/// avoid a dead-code warning in the default build.
+#[cfg(feature = "slow-tests")]
 fn run_fixture_audit() -> AuditRunWorkflowResult {
     // Audit resolves the component under audit (here, the portable fixture's
     // homeboy.json) through a provider the CLI registers at startup; a core lib
     // test never runs the CLI, so register the component-backed provider so the
     // fixture's audit config is discovered.
     homeboy_core::component::audit_provider::register();
-    run_main_audit_workflow(fixture_workflow_args())
-        .expect("audit workflow runs on the fixture tree")
+    run_main_audit_workflow(fixture_workflow_args()).expect(
+        "audit workflow runs on the fixture tree \
+         (requires an installed extension that fingerprints the fixture's source language)",
+    )
+}
+
+/// `Some(workflow)` when the audit had a corpus; `None` when no installed
+/// extension can fingerprint the fixture's source language.
+///
+/// Before #10557, that second case produced `files_scanned: 0, findings: [],
+/// passed: true` — so every finding assertion below passed VACUOUSLY on a
+/// machine with no extension installed. `review audit` now reports an empty
+/// corpus as a hard error instead, which is the honest answer, so tests that
+/// assert on findings have to distinguish "the audit ran and found nothing"
+/// from "the audit could not run". Skipping loudly is that distinction; it is
+/// not a weakening, because the vacuous pass was never evidence of anything.
+fn fixture_audit_or_skip() -> Option<AuditRunWorkflowResult> {
+    homeboy_core::component::audit_provider::register();
+    match run_main_audit_workflow(fixture_workflow_args()) {
+        Ok(workflow) => Some(workflow),
+        Err(error) if error.to_string().contains("audit scanned 0 files") => {
+            eprintln!(
+                "SKIP: no installed extension can fingerprint the audit_runtime fixture ({error})"
+            );
+            None
+        }
+        Err(error) => panic!("audit workflow failed on the fixture tree: {error}"),
+    }
 }
 
 /// Render a finding set into a deterministic, sorted list of compact,
@@ -157,11 +188,25 @@ fn finding_fingerprints(findings: &[Finding]) -> Vec<String> {
 const EXPECTED_FINDINGS: &[&str] = &[
     "core_boundary_leak::src/boundary_leak.rs",
     "high_item_count::src/god_file.rs",
+    // #10558: `src/commands/mod.rs` is an INDEX file and
+    // `src/commands/thick_adapter.rs` is the only non-index file in its
+    // directory (a singleton group). Both are excluded from convention
+    // discovery — correctly — and both must still be scanned by source
+    // policies. These two entries are the regression guard.
+    "source_policy_violation::src/commands/mod.rs",
+    "source_policy_violation::src/commands/thick_adapter.rs",
     "source_policy_violation::src/policy_violation.rs",
     "thin_command_adapter_violation::src/commands/thick_adapter.rs",
     "unreferenced_export::src/boundary_leak.rs",
     "unreferenced_export::src/god_file.rs",
     "unreferenced_export::src/policy_violation.rs",
+];
+
+/// The two corpus entries above, isolated so the #10558 property has a test of
+/// its own that does not require the slow tier.
+const SOURCE_POLICY_CORPUS_GUARDS: &[&str] = &[
+    "source_policy_violation::src/commands/mod.rs",
+    "source_policy_violation::src/commands/thick_adapter.rs",
 ];
 
 // Runs the full audit workflow against the fixture tree, which requires a
@@ -217,7 +262,9 @@ fn audit_runtime_regression_is_deterministic() {
 /// regression that leaks test-path files reproduces here.
 #[test]
 fn audit_runtime_regression_skips_test_paths() {
-    let workflow = run_fixture_audit();
+    let Some(workflow) = fixture_audit_or_skip() else {
+        return;
+    };
 
     let test_path_findings: Vec<String> = workflow
         .findings
@@ -240,10 +287,89 @@ fn audit_runtime_regression_uses_ci_workflow_entry_point() {
     // A trivial compile-time + runtime assertion that the workflow result type
     // is what we render from. Keeps the intent explicit: the snapshot above is
     // produced by the same function `src/commands/audit.rs::run` calls.
-    let workflow: AuditRunWorkflowResult = run_fixture_audit();
+    let Some(workflow) = fixture_audit_or_skip() else {
+        return;
+    };
+    let workflow: AuditRunWorkflowResult = workflow;
     let _: &Vec<crate::Finding> = &workflow.findings;
     assert!(
         workflow.exit_code == 0 || workflow.exit_code == 1,
         "workflow must produce a normal audit exit code"
     );
+}
+
+/// #10558 regression: source policies must see the files convention discovery
+/// legitimately drops.
+///
+/// Two filters exist for convention SIBLING detection and used to leak into the
+/// source-policy corpus because that corpus was built from `discovery.groups`:
+///
+///   1. index files (`mod.rs`, `lib.rs`, `main.rs`, `index.*`, `__init__.py`),
+///      excluded because they organize other files rather than being peers, and
+///   2. groups with fewer than two members, dropped because a convention needs
+///      peers to exist.
+///
+/// Neither has any meaning for a term scan. On homeboy itself the pair made 264
+/// of 1819 `.rs` files (14.5%) unscannable by ANY source policy — every
+/// `mod.rs`, `lib.rs`, `main.rs`, and every `build.rs` alone in a crate root.
+///
+/// The fixture exercises both in one directory: `src/commands/mod.rs` is an
+/// index file, `src/commands/thick_adapter.rs` is the sole non-index file in
+/// that directory (a singleton group). Both carry the fixture's configured
+/// forbidden term, so both must produce a `source_policy_violation`.
+///
+/// This lives in the default tier (not `slow-tests`) because it is the property
+/// #10558 is about, and it skips — loudly — rather than passing vacuously when
+/// no extension can fingerprint the fixture.
+#[test]
+fn source_policies_scan_index_files_and_singleton_directories() {
+    let Some(workflow) = fixture_audit_or_skip() else {
+        return;
+    };
+
+    let actual = finding_fingerprints(&workflow.findings);
+    for guard in SOURCE_POLICY_CORPUS_GUARDS {
+        assert!(
+            actual.iter().any(|finding| finding == guard),
+            "source-policy corpus regressed to the convention corpus: expected `{guard}`.\n\
+             `mod.rs` (index file) and the sole file in a directory (singleton group) are dropped \n\
+             by convention discovery for reasons that do not apply to a term scan (#10558).\n\
+             actual = {actual:#?}"
+        );
+    }
+}
+
+/// The corpus a source policy scans must be a strict superset of the convention
+/// corpus, never the other way round.
+///
+/// Stated as a property rather than a file list so a future filter added to
+/// convention discovery cannot silently narrow policy coverage again.
+#[test]
+fn source_policy_corpus_is_not_narrowed_by_convention_filters() {
+    let Some(workflow) = fixture_audit_or_skip() else {
+        return;
+    };
+
+    let scanned_by_policy: Vec<String> = workflow
+        .findings
+        .iter()
+        .filter(|finding| {
+            super::super::findings::finding_kind_key(&finding.kind) == "source_policy_violation"
+        })
+        .map(|finding| finding.file.replace('\\', "/"))
+        .collect();
+
+    // `src/policy_violation.rs` sits in a multi-file directory, so it is in the
+    // convention corpus too. The two guards above are NOT. Seeing all three
+    // proves the policy corpus is the union, not the intersection.
+    for expected in [
+        "src/policy_violation.rs",
+        "src/commands/mod.rs",
+        "src/commands/thick_adapter.rs",
+    ] {
+        assert!(
+            scanned_by_policy.iter().any(|file| file == expected),
+            "source policy did not reach {expected}; scanned = {scanned_by_policy:#?}"
+        );
+    }
 }

--- a/crates/homeboy-code-audit/src/descriptor_runtime.rs
+++ b/crates/homeboy-code-audit/src/descriptor_runtime.rs
@@ -33,6 +33,15 @@ pub(super) struct DetectorRunContext<'a> {
     /// the full corpus. Detectors keyed strictly to the file they inspect read
     /// this so scoped runs avoid O(repo) work.
     pub(super) per_file_fingerprints: &'a [&'a fingerprint::FileFingerprint],
+    /// Source-policy corpus: every extension-claimed source file, index files
+    /// (`mod.rs`/`lib.rs`/`main.rs`) included and single-file directories kept,
+    /// narrowed to the changed scope under `--changed-since` (#10558).
+    ///
+    /// Distinct from `per_file_fingerprints` because that view is derived from
+    /// the CONVENTION corpus, whose index-file exclusion and `len() < 2` group
+    /// drop exist for sibling detection and are meaningless for a term scan.
+    /// Detectors that scan file text for configured patterns read this.
+    pub(super) policy_fingerprints: &'a [&'a fingerprint::FileFingerprint],
     /// Shared source snapshot for whole-tree detectors. `None` only on the
     /// root-only fast path when no snapshot-backed detector is enabled.
     pub(super) source_snapshot: Option<&'a CodebaseSnapshot>,
@@ -123,11 +132,11 @@ fn run_generic_descriptor(
             unbounded_output_capture::run(context.per_file_fingerprints)
         }
         GenericDetectorRunner::CoreBoundaryLeaks => source_policy::run(
-            context.per_file_fingerprints,
+            context.policy_fingerprints,
             &config.core_boundary_leaks.to_source_policy_rules(),
         ),
         GenericDetectorRunner::SourcePolicy => {
-            source_policy::run(context.per_file_fingerprints, &config.source_policies)
+            source_policy::run(context.policy_fingerprints, &config.source_policies)
         }
         GenericDetectorRunner::MutatingResourceAccess => mutating_resource_access::run(
             context.per_file_fingerprints,
@@ -326,6 +335,7 @@ mod tests {
             audit_config: &audit_config,
             all_fingerprints: &[],
             per_file_fingerprints: &[],
+            policy_fingerprints: &[],
             source_snapshot: None,
             dead_code_references: None,
         };
@@ -427,6 +437,7 @@ mod tests {
             audit_config: &audit_config,
             all_fingerprints: &fingerprints,
             per_file_fingerprints: &fingerprints,
+            policy_fingerprints: &fingerprints,
             source_snapshot: None,
             dead_code_references: None,
         };

--- a/crates/homeboy-code-audit/src/discovery.rs
+++ b/crates/homeboy-code-audit/src/discovery.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use super::conventions::Language;
 use super::fingerprint::{fingerprint_content, normalize_convention_tags, FileFingerprint};
 use super::walker::{
-    extension_provided_file_extensions, is_extension_provided_source_file, is_test_path,
+    extension_provided_file_extensions, is_extension_provided_file, is_index_file, is_test_path,
 };
 use homeboy_audit_contract::AuditConfig;
 use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
@@ -17,6 +17,31 @@ type DiscoveryGroupKey = (String, Language, bool, Vec<String>);
 pub struct DiscoveryResult {
     /// Grouped files with conventions.
     pub groups: Vec<(String, String, Vec<FileFingerprint>)>,
+    /// Every extension-provided source file that fingerprinted, with NO
+    /// convention-discovery filtering applied (#10558).
+    ///
+    /// `groups` is the convention corpus. Two filters exist purely to make
+    /// convention *sibling* detection correct:
+    ///
+    ///   1. index files (`mod.rs`, `lib.rs`, `main.rs`, `index.*`,
+    ///      `__init__.py`) are dropped by [`is_index_file`] because they
+    ///      organize other files rather than being peers, and
+    ///   2. groups with fewer than two members are dropped by
+    ///      [`groups_from_dir_files`] because a convention needs peers to exist.
+    ///
+    /// Neither has any bearing on a whole-file term scan. When source policies
+    /// borrowed the convention corpus, those two filters silently made 264 of
+    /// this repository's 1819 `.rs` files (14.5%) — including every `mod.rs`,
+    /// `lib.rs`, `main.rs`, and every `build.rs` sitting alone in a crate root —
+    /// unscannable by ANY source policy, regardless of configuration. Module
+    /// roots are exactly where re-exports, feature wiring, and cross-layer glue
+    /// accumulate, so that blind spot was pointed at the most policy-relevant
+    /// files in the tree.
+    ///
+    /// This field is that unfiltered corpus. `entry::source_policy_findings_for_path`
+    /// already scanned this shape (it builds from
+    /// `walker::walk_all_source_files_snapshot`); the engine now agrees with it.
+    pub policy_fingerprints: Vec<FileFingerprint>,
     /// Total source files found by the walker.
     pub files_walked: usize,
     /// Files that were successfully fingerprinted by an extension.
@@ -28,9 +53,14 @@ pub struct DiscoveryResult {
 /// Returns groups of (group_name, glob_pattern, files) for directories that
 /// contain 2+ files of the same language, plus counts of walked vs fingerprinted files.
 ///
+/// Also returns [`DiscoveryResult::policy_fingerprints`]: the same walk WITHOUT
+/// the two convention-only filters, so path-scanning detectors (source policies)
+/// get an honest whole-tree corpus instead of borrowing the convention one.
+///
 /// Consumes a caller-provided source snapshot. Fingerprinting goes through
 /// [`fingerprint_content`] so the snapshot's already-loaded content is reused —
-/// no second `read_to_string`.
+/// no second `read_to_string`. Each file is fingerprinted exactly once and the
+/// result is shared between both corpora.
 pub(crate) fn auto_discover_groups_from_snapshot(
     root: &Path,
     audit_config: &AuditConfig,
@@ -42,38 +72,78 @@ pub(crate) fn auto_discover_groups_from_snapshot(
     // This prevents false positives like test files being flagged for
     // missing production methods (set_up, tear_down are optional hooks).
     let mut dir_files: HashMap<DiscoveryGroupKey, Vec<FileFingerprint>> = HashMap::new();
+    let mut policy_fingerprints: Vec<FileFingerprint> = Vec::new();
     let mut files_walked: usize = 0;
     let mut files_fingerprinted: usize = 0;
     let source_extensions = extension_provided_file_extensions();
 
     for (path, content) in snapshot.iter() {
-        if !is_extension_provided_source_file(path, &source_extensions) {
+        if !is_extension_provided_file(path, &source_extensions) {
             continue;
         }
-        files_walked += 1;
-        if let Some(mut fp) = fingerprint_content(path, root, content) {
-            files_fingerprinted += 1;
-            let parent = path
-                .parent()
-                .and_then(|p| p.strip_prefix(root).ok())
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default();
-            let file_is_test = is_test_path(&fp.relative_path);
-            fp.convention_tags = convention_tags_for(&fp, audit_config);
-            let key = (
-                parent,
-                fp.language.clone(),
-                file_is_test,
-                fp.convention_tags.clone(),
-            );
-            dir_files.entry(key).or_default().push(fp);
+        // Convention discovery excludes index files; the policy corpus does not.
+        // `files_walked` / `files_fingerprinted` keep counting the convention
+        // corpus so the "no extension can fingerprint these files" warning below
+        // keeps its existing meaning.
+        let convention_eligible = !is_index_file(path);
+        if convention_eligible {
+            files_walked += 1;
         }
+        let Some(mut fp) = fingerprint_content(path, root, content) else {
+            continue;
+        };
+        fp.convention_tags = convention_tags_for(&fp, audit_config);
+        policy_fingerprints.push(policy_view(&fp));
+
+        if !convention_eligible {
+            continue;
+        }
+        files_fingerprinted += 1;
+        let parent = path
+            .parent()
+            .and_then(|p| p.strip_prefix(root).ok())
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let file_is_test = is_test_path(&fp.relative_path);
+        let key = (
+            parent,
+            fp.language.clone(),
+            file_is_test,
+            fp.convention_tags.clone(),
+        );
+        dir_files.entry(key).or_default().push(fp);
     }
+
+    policy_fingerprints.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
     DiscoveryResult {
         groups: groups_from_dir_files(dir_files),
+        policy_fingerprints,
         files_walked,
         files_fingerprinted,
+    }
+}
+
+/// The slice of a fingerprint the source-policy corpus needs: path, language,
+/// and raw content.
+///
+/// Source policies are whole-file term scans — `source_policy::run`,
+/// `validate_source_roots`, and `validate_configured_paths` read exactly these
+/// three fields and nothing else. Copying only them keeps the second corpus at
+/// roughly the cost of the file text instead of duplicating every extracted
+/// fact vector (method hashes, call sites, aggregate facts, …) for the whole
+/// tree.
+///
+/// If a detector that needs richer facts is ever moved onto the policy corpus,
+/// widen this — or give it the convention corpus — rather than letting it read
+/// empty fact vectors.
+fn policy_view(fp: &FileFingerprint) -> FileFingerprint {
+    FileFingerprint {
+        relative_path: fp.relative_path.clone(),
+        language: fp.language,
+        content: fp.content.clone(),
+        convention_tags: fp.convention_tags.clone(),
+        ..FileFingerprint::default()
     }
 }
 

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -113,34 +113,52 @@ pub(super) fn audit_internal(
     let files_skipped = discovery
         .files_walked
         .saturating_sub(discovery.files_fingerprinted);
-    if discovery.groups.is_empty() {
-        let mut warnings = Vec::new();
+    // An audit whose corpus is empty has not passed — it has not run (#10557).
+    //
+    // The post-merge `full-audit-gate` invoked the raw binary, so
+    // `homeboy-action`'s extension-install step never ran, no extension declared
+    // `provides.file_extensions`, and `CodebaseSnapshot` yielded nothing. The
+    // audit then reported `files_scanned: 0, files_skipped: 1817, findings: [],
+    // passed: true` and the gate went green in 7 seconds on a 1800-file
+    // repository. Reporting success while measuring nothing is the failure the
+    // gate exists to prevent, so it is a hard error here — in the engine, for
+    // every consumer — rather than something each workflow has to remember to
+    // assert.
+    //
+    // This mirrors the existing `validate_source_roots` /
+    // `validate_configured_paths` contract one level up: configuration that
+    // silently matches zero files is already an error, and a corpus that
+    // silently contains zero files is the same defect with a wider blast radius.
+    if discovery.policy_fingerprints.is_empty() {
         let unclaimed = walker::count_unclaimed_source_files(root);
         let total_skipped = files_skipped + unclaimed;
         if unclaimed > 0 {
-            warnings.push(format!(
-                "Found {} source file(s) but no installed extension provides fingerprinting for these file types. \
-                 Install or update an extension with a `provides.file_extensions` and `scripts.fingerprint` config.",
-                unclaimed
+            return Err(homeboy_error::Error::invalid_argument(
+                "audit.corpus",
+                format!(
+                    "audit scanned 0 files: found {unclaimed} source file(s) that no installed extension \
+                     can fingerprint. An audit with an empty corpus cannot pass — it did not run. \
+                     Install or update an extension declaring `provides.file_extensions` and \
+                     `scripts.fingerprint` for these file types (CI: run the audit through \
+                     Extra-Chill/homeboy-action, whose `Install extension` step does this; \
+                     invoking the binary directly skips it)."
+                ),
             ));
-            log_status!(
-                "audit",
-                "WARNING: {} source files found but none could be fingerprinted (no extension claims these file types)",
-                unclaimed
-            );
-        } else if discovery.files_walked > 0 && discovery.files_fingerprinted == 0 {
-            warnings.push(format!(
-                "Found {} source file(s) but no extension could fingerprint them.",
-                discovery.files_walked
-            ));
-            log_status!(
-                "audit",
-                "WARNING: {} source files found but none could be fingerprinted",
-                discovery.files_walked
-            );
-        } else {
-            log_status!("audit", "No source files found");
         }
+        if discovery.files_walked > 0 {
+            return Err(homeboy_error::Error::invalid_argument(
+                "audit.corpus",
+                format!(
+                    "audit scanned 0 files: found {} extension-claimed source file(s) but the \
+                     extension's fingerprint script produced nothing for any of them. An audit with \
+                     an empty corpus cannot pass — it did not run.",
+                    discovery.files_walked
+                ),
+            ));
+        }
+        // Genuinely nothing to audit (docs-only or empty checkout). That is a
+        // real, honest zero — not a broken instrument.
+        log_status!("audit", "No source files found");
         timing.push_ok("discovery_fingerprinting", discovery_started.elapsed());
         return Ok(AuditWithAnalysis {
             result: CodeAuditResult {
@@ -152,7 +170,7 @@ pub(super) fn audit_internal(
                     outliers_found: 0,
                     alignment_score: None,
                     files_skipped: total_skipped,
-                    warnings,
+                    warnings: Vec::new(),
                 },
                 conventions: vec![],
                 directory_conventions: vec![],
@@ -189,20 +207,31 @@ pub(super) fn audit_internal(
     let detectors_started = std::time::Instant::now();
 
     // Phase 4c: Duplication detection (identical function bodies across files)
+    //
+    // `all_fingerprints` is the CONVENTION corpus: index files removed and
+    // single-file groups dropped. Convention, duplication, and dead-code
+    // detectors need exactly that shape.
     let all_fingerprints: Vec<&fingerprint::FileFingerprint> = discovery
         .groups
         .iter()
         .flat_map(|(_, _, fps)| fps.iter())
         .collect();
 
-    source_policy::validate_configured_paths(&all_fingerprints, &audit_config)?;
+    // `policy_fingerprints` is the SOURCE-POLICY corpus: every extension-claimed
+    // source file, index files included, no group-size filter (#10558). Path
+    // scoping is validated against it too, so a configured `include_path_contains`
+    // is checked against the files policies can actually reach.
+    let policy_fingerprints: Vec<&fingerprint::FileFingerprint> =
+        discovery.policy_fingerprints.iter().collect();
+
+    source_policy::validate_configured_paths(&policy_fingerprints, &audit_config)?;
 
     if plan.detector_enabled("core_boundary_leaks") {
         let rules = audit_config.core_boundary_leaks.to_source_policy_rules();
-        source_policy::validate_source_roots(&all_fingerprints, &rules)?;
+        source_policy::validate_source_roots(&policy_fingerprints, &rules)?;
     }
     if plan.detector_enabled("source_policy") {
-        source_policy::validate_source_roots(&all_fingerprints, &audit_config.source_policies)?;
+        source_policy::validate_source_roots(&policy_fingerprints, &audit_config.source_policies)?;
     }
 
     // Build convention method set ONCE — used by duplication, near-duplicate, and parallel detectors.
@@ -280,6 +309,26 @@ pub(super) fn audit_internal(
         .map(|(_, subset)| subset.as_slice())
         .unwrap_or(all_fingerprints.as_slice());
 
+    // Source policies get the same changed-scope narrowing, applied to THEIR
+    // corpus. Reusing the already-computed `scope_files` set keeps the two
+    // corpora scoped by one identical rule.
+    let scoped_policy_fingerprints: Option<Vec<&fingerprint::FileFingerprint>> =
+        scoped_fingerprints.as_ref().map(|(scope_files, _)| {
+            policy_fingerprints
+                .iter()
+                .copied()
+                .filter(|fp| {
+                    scope_files
+                        .iter()
+                        .any(|scope| fp.relative_path.contains(scope.as_str()))
+                })
+                .collect()
+        });
+    let policy_scan_fingerprints: &[&fingerprint::FileFingerprint] = scoped_policy_fingerprints
+        .as_ref()
+        .map(|subset| subset.as_slice())
+        .unwrap_or(policy_fingerprints.as_slice());
+
     let dead_code_references = dead_code_references.or_else(|| {
         plan.detector_enabled("dead_code")
             .then(|| DeadCodeReferenceAnalysis::build(root, reference_paths))
@@ -290,6 +339,7 @@ pub(super) fn audit_internal(
         audit_config: &audit_config,
         all_fingerprints: &all_fingerprints,
         per_file_fingerprints,
+        policy_fingerprints: policy_scan_fingerprints,
         source_snapshot: Some(&source_snapshot),
         dead_code_references: dead_code_references.as_ref(),
     };
@@ -572,9 +622,12 @@ pub(super) fn audit_internal(
     }
     timing.push_ok("report", report_started.elapsed());
 
-    // Release the scoped fingerprint subset (borrows from `all_fingerprints`)
-    // before dropping the owning corpus. `per_file_fingerprints` is just a
-    // borrowed view, so its borrow ends here via NLL.
+    // Release the scoped fingerprint subsets (they borrow from the two corpora)
+    // before dropping the owning corpora. `per_file_fingerprints` and
+    // `policy_scan_fingerprints` are just borrowed views, so their borrows end
+    // here via NLL.
+    drop(scoped_policy_fingerprints);
+    drop(policy_fingerprints);
     drop(scoped_fingerprints);
     drop(all_fingerprints);
     let analysis = AuditAnalysisContext {
@@ -651,6 +704,9 @@ fn audit_root_only(
         audit_config: &audit_config,
         all_fingerprints: &[],
         per_file_fingerprints: &[],
+        // The root-only fast path never builds a fingerprint corpus, and no
+        // source-policy detector is in `ROOT_ONLY_DETECTOR_IDS`.
+        policy_fingerprints: &[],
         source_snapshot: source_snapshot.as_ref(),
         dead_code_references: None,
     };
@@ -741,3 +797,7 @@ fn audit_root_only(
         duplicate_groups: vec![],
     }
 }
+
+#[cfg(test)]
+#[path = "engine_corpus_test.rs"]
+mod engine_corpus_test;

--- a/crates/homeboy-code-audit/src/engine_corpus_test.rs
+++ b/crates/homeboy-code-audit/src/engine_corpus_test.rs
@@ -1,0 +1,150 @@
+//! Corpus invariants for the audit engine.
+//!
+//! Wired into `engine.rs` via `#[cfg(test)] #[path = ...] mod engine_corpus_test`.
+//!
+//! WHY THIS EXISTS (#10557): the post-merge `full-audit-gate` invoked the raw
+//! `homeboy` binary instead of routing through `homeboy-action`. That skipped
+//! the action's `Install extension` step, so `extension_provided_file_extensions()`
+//! returned nothing, `CodebaseSnapshot` matched nothing, and the audit reported:
+//!
+//! ```json
+//! { "files_scanned": 0, "files_skipped": 1817, "findings": [], "passed": true }
+//! ```
+//!
+//! Green in 7 seconds on a repository with 1800 source files. The workflow test
+//! that was supposed to guard the gate asserted the COMMAND STRING
+//! (`review audit homeboy --profile=full`) and the absence of
+//! `continue-on-error`. Both held. Neither could see that the command scanned
+//! nothing.
+//!
+//! An instrument that reports success while measuring nothing is worse than no
+//! instrument, so the invariant is enforced here — in the engine, for every
+//! consumer of `review audit` — rather than in one workflow's YAML:
+//!
+//!   **an audit that found no files to audit has not passed; it has not run.**
+//!
+//! These tests assert the EFFECT (a corpus existed, or the run failed loudly),
+//! which is the thing the old workflow test could not express.
+
+use std::fs;
+
+/// The invariant, stated so it holds in BOTH environments — with a
+/// fingerprinting extension installed and without one.
+///
+/// * extension available  -> `Ok` with a non-empty corpus.
+/// * no extension         -> `Err` naming the empty corpus.
+///
+/// What must never happen is the third outcome that shipped: `Ok` with
+/// `files_scanned == 0` on a tree that demonstrably contains source files.
+#[test]
+fn audit_never_reports_success_with_an_empty_corpus() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    fs::write(
+        root.join("alpha.rs"),
+        "pub fn run() {}\npub fn helper() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("beta.rs"),
+        "pub fn run() {}\npub fn helper() {}\n",
+    )
+    .unwrap();
+
+    match crate::audit_path_with_id("empty-corpus-guard", &root.to_string_lossy()) {
+        Ok(result) => assert!(
+            result.summary.files_scanned > 0,
+            "audit returned success having scanned {} of 2 source files. \
+             An audit with an empty corpus has not passed — it has not run (#10557). \
+             summary = {:#?}",
+            result.summary.files_scanned,
+            result.summary
+        ),
+        Err(error) => {
+            let message = error.to_string();
+            assert!(
+                message.contains("audit scanned 0 files"),
+                "an empty corpus must fail with the corpus diagnostic, not an unrelated error: {message}"
+            );
+        }
+    }
+}
+
+/// The corpus error must be actionable: it has to say what went wrong AND how a
+/// CI job gets a corpus back. The whole defect was a gate whose failure mode was
+/// invisible; a diagnostic that does not name the cause reproduces it.
+#[test]
+fn empty_corpus_error_names_the_missing_extension_and_the_fix() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    fs::write(root.join("only.rs"), "pub fn run() {}\n").unwrap();
+
+    let Err(error) = crate::audit_path_with_id("empty-corpus-message", &root.to_string_lossy())
+    else {
+        // A fingerprinting extension is installed, so there is no empty corpus
+        // to diagnose here. The invariant itself is covered above.
+        return;
+    };
+
+    let message = error.to_string();
+    for expected in [
+        "audit scanned 0 files",
+        "provides.file_extensions",
+        "homeboy-action",
+    ] {
+        assert!(
+            message.contains(expected),
+            "corpus diagnostic must mention `{expected}`: {message}"
+        );
+    }
+}
+
+/// A tree with genuinely nothing to audit is a real zero, not a broken
+/// instrument. Docs-only components must keep passing.
+#[test]
+fn a_tree_with_no_source_files_is_still_a_clean_pass() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(dir.path().join("README.md"), "# docs only\n").unwrap();
+
+    let result = crate::audit_path_with_id("docs-only", &dir.path().to_string_lossy())
+        .expect("a component with no source files audits cleanly");
+
+    assert_eq!(result.summary.files_scanned, 0);
+    assert!(result.findings.is_empty());
+}
+
+/// #10558: the two convention-discovery filters must not apply to the
+/// source-policy corpus.
+///
+/// `is_extension_provided_file` is the honest "an extension claims this file
+/// type" predicate; index-file exclusion is a separate, convention-only
+/// decision. Keeping them separate is what stops `mod.rs`/`lib.rs`/`main.rs`
+/// from silently leaving the policy corpus again.
+#[test]
+fn index_files_are_extension_provided_even_though_conventions_skip_them() {
+    use std::path::Path;
+
+    let extensions = vec!["rs".to_string()];
+
+    for index in ["src/mod.rs", "src/lib.rs", "src/main.rs"] {
+        let path = Path::new(index);
+        assert!(
+            crate::walker::is_extension_provided_file(path, &extensions),
+            "{index} is a claimed source file and must be reachable by source policies (#10558)"
+        );
+        assert!(
+            crate::walker::is_index_file(path),
+            "{index} must stay excluded from convention sibling detection"
+        );
+    }
+
+    let peer = Path::new("src/thing.rs");
+    assert!(crate::walker::is_extension_provided_file(peer, &extensions));
+    assert!(!crate::walker::is_index_file(peer));
+
+    // Unclaimed file types are still out of scope for both.
+    assert!(!crate::walker::is_extension_provided_file(
+        Path::new("src/thing.py"),
+        &extensions
+    ));
+}

--- a/crates/homeboy-code-audit/src/execution_plan.rs
+++ b/crates/homeboy-code-audit/src/execution_plan.rs
@@ -36,6 +36,32 @@ impl AuditProfile {
         }
     }
 
+    /// Which detector families a profile runs.
+    ///
+    /// ── Why `source_policy` / `core_boundary_leaks` are NOT in `Pr` ──
+    ///
+    /// #10557 observed, correctly, that with the post-merge full-audit gate
+    /// broken these detectors were enforced in zero blocking contexts, and
+    /// suggested adding them to `Pr` as the remedy. They stay out, for three
+    /// reasons that are worth writing down so this is not re-litigated:
+    ///
+    ///  1. Both are `DetectorAccess::Discovery`, so adding either flips
+    ///     `AuditExecutionPlan::requires_discovery()` for `Pr`. That forces the
+    ///     whole-tree walk + fingerprint on EVERY pull request — the exact cost
+    ///     the profile split exists to avoid. It is an architecture change, not
+    ///     a list edit.
+    ///  2. `release.yml` runs `--profile=pr --changed-since <before>`. Widening
+    ///     `Pr` therefore widens the RELEASE gate, against a tree that carries
+    ///     ~1450 latent `core-agnostic-source` findings. Stranding releases on
+    ///     untriaged debt is precisely the failure `.github/workflows/audit-debt.yml`
+    ///     was created to prevent.
+    ///  3. Whole-tree detectors belong on the integrated tree, which is what the
+    ///     post-merge `--profile=full` gate audits. Fixing that gate (#10557) is
+    ///     the cheaper and more correct answer to "enforced nowhere".
+    ///
+    /// If these ever do need PR-time enforcement, the prerequisite is giving
+    /// them a `RootOnly` access mode backed by the source-policy corpus over the
+    /// changed files only — not moving a Discovery detector into `Pr`.
     fn includes_detector(self, family: &DetectorDescriptor) -> bool {
         match self {
             Self::Full => true,
@@ -667,8 +693,29 @@ mod tests {
         assert!(plan.detector_enabled("thin_command_adapter"));
         assert!(!plan.detector_enabled("duplication"));
         assert!(!plan.detector_enabled("dead_code"));
+        // Deliberate — see `AuditProfile::includes_detector`. Both source-policy
+        // families are Discovery detectors; enabling either in `Pr` forces the
+        // whole-tree walk on every PR *and* widens release.yml's
+        // `--profile=pr --changed-since` gate onto untriaged debt. They are
+        // enforced by the post-merge `--profile=full` gate instead (#10557).
         assert!(!plan.detector_enabled("source_policy"));
+        assert!(!plan.detector_enabled("core_boundary_leaks"));
         assert!(!plan.detector_enabled("compiler_warnings"));
+
+        // `requires_discovery()` above is the aggregate answer; this names the
+        // offender when a Discovery detector is added to `Pr`, so the failure
+        // says which one rather than just "the profile got expensive".
+        for descriptor in AuditExecutionPlan::descriptors() {
+            if plan.detector_enabled(descriptor.id) {
+                assert!(
+                    !descriptor.access.requires_discovery(),
+                    "detector `{}` is Discovery-access but enabled in the PR profile: \
+                     every pull request now pays for a whole-tree walk, and release.yml's \
+                     `--profile=pr --changed-since` gate widened with it",
+                    descriptor.id
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/homeboy-code-audit/src/walker.rs
+++ b/crates/homeboy-code-audit/src/walker.rs
@@ -54,13 +54,17 @@ fn source_scan_config() -> ScanConfig {
     }
 }
 
-fn extension_matches(path: &Path, extensions: &[String]) -> bool {
+/// Whether an installed extension claims this file type at all.
+///
+/// This is the honest "is this a source file we can fingerprint" predicate, and
+/// the right admission test for any corpus that is NOT doing convention sibling
+/// detection. Source policies in particular have no reason to be blind to
+/// `mod.rs` / `lib.rs` / `main.rs`; pairing this with an explicit
+/// [`is_index_file`] check at the one call site that wants sibling semantics
+/// keeps the two decisions from silently fusing again (#10558).
+pub(crate) fn is_extension_provided_file(path: &Path, extensions: &[String]) -> bool {
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
     extensions.iter().any(|candidate| candidate == ext)
-}
-
-pub(crate) fn is_extension_provided_source_file(path: &Path, extensions: &[String]) -> bool {
-    extension_matches(path, extensions) && !is_index_file(path)
 }
 
 /// Build the shared audit source snapshot for full audit runs.

--- a/tests/audit_debt_workflow_test.rs
+++ b/tests/audit_debt_workflow_test.rs
@@ -178,11 +178,13 @@ fn post_merge_gates_never_mutate_the_repository() {
     assert!(!workflow.contains("git push"));
     assert!(!workflow.contains("pr-policy-merge: 'true'"));
     // `autofix` is not a homeboy-action@v2 input at all; passing it only earns
-    // an "Unexpected input(s)" warning.
-    for (name, gate) in release_blocking_gates() {
+    // an "Unexpected input(s)" warning while reading like an enforced property.
+    // Asserted on the YAML key shape (not the bare word) so the comments
+    // explaining its absence do not trip this.
+    for line in workflow.lines() {
         assert!(
-            !gate.contains("autofix"),
-            "{name} passes a non-existent input"
+            !line.trim_start().starts_with("autofix:"),
+            "workflow passes `autofix`, which is not a homeboy-action@v2 input: {line}"
         );
     }
 }
@@ -199,13 +201,105 @@ fn superseded_post_merge_runs_are_cancelled() {
     assert!(workflow.contains("github.event_name == 'push' && 'post-merge' || 'sweep'"));
 }
 
+/// The audit gate must be able to SEE the tree it claims to gate.
+///
+/// #10557: the previous version of this test asserted
+/// `gate.contains("review audit homeboy --profile=full")` and
+/// `!gate.contains("continue-on-error: true")`. Both held, and the gate was
+/// still passing in 7 seconds having scanned `files_scanned: 0` of 1817 source
+/// files — because invoking the raw binary skips homeboy-action's `Install
+/// extension` step, no extension declares `provides.file_extensions`, and the
+/// audit corpus comes back empty. The test proved the FLAG; it could not see
+/// the EFFECT.
+///
+/// The effect-level assertion now lives in two places:
+///
+///   * `crates/homeboy-code-audit/src/engine.rs` hard-errors on an empty
+///     corpus (`audit.corpus`), covered by
+///     `crates/homeboy-code-audit/src/engine_corpus_test.rs`. That is the
+///     durable fix — it holds for every consumer of `review audit`, not just
+///     this workflow.
+///   * this test, which asserts the two structural properties a YAML file can
+///     actually carry: the audit runs through the action that installs the
+///     extension, and the job carries an unconditionally-blocking corpus check.
 #[test]
-fn post_merge_full_audit_is_a_blocking_gate() {
+fn post_merge_full_audit_gate_can_actually_see_the_tree() {
     let gate = job("full-audit-gate");
 
     assert!(gate.contains("if: github.event_name == 'push'"));
-    assert!(gate.contains("review audit homeboy --profile=full"));
-    assert!(!gate.contains("continue-on-error: true"));
+
+    // The raw binary has no extension installed, so its corpus is empty. Only
+    // the action's `Install extension` step makes fingerprinting possible.
+    assert!(
+        gate.contains("uses: Extra-Chill/homeboy-action@v2"),
+        "the audit gate must run through homeboy-action, which owns the \
+         `Install extension` step; invoking the binary directly scans 0 files (#10557)"
+    );
+    // The defect verbatim: `.homeboy-bin/homeboy review audit ...` in a `run:`
+    // step. Checked over every non-comment line so a multi-line `run: |` block
+    // cannot smuggle it back.
+    for line in gate.lines() {
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+        assert!(
+            !line.contains("homeboy review audit"),
+            "the audit gate must not invoke the binary directly — that skips the \
+             extension install and scans 0 files (#10557): {line}"
+        );
+    }
+    // The audit must reach homeboy through the action's command input, which is
+    // the path that has an extension installed.
+    assert!(gate.contains("commands: review audit"));
+    assert!(gate.contains("args: --profile=full"));
+}
+
+/// The corpus check is the part of the gate that blocks, and nothing may
+/// tolerate its failure.
+#[test]
+fn post_merge_full_audit_gate_blocks_on_an_empty_corpus() {
+    let gate = job("full-audit-gate");
+
+    let assertion = gate
+        .find("name: Assert the audit actually scanned the tree")
+        .expect("audit gate must carry a corpus assertion step");
+    assert!(
+        gate.contains("files_scanned"),
+        "the corpus assertion must read the audit's own files_scanned figure"
+    );
+
+    // Every `continue-on-error: true` in this job must precede the blocking
+    // assertion, so none of them can cover it.
+    for (offset, _) in gate.match_indices("continue-on-error: true") {
+        assert!(
+            offset < assertion,
+            "the corpus assertion step must not be covered by continue-on-error"
+        );
+    }
+}
+
+/// The findings verdict is deliberately reporting-only for now (main carries 37
+/// unbaselined findings plus the ~293 that #10558 makes visible, and baselining
+/// them needs the fixed binary that only exists after this merges). That state
+/// is allowed to exist — but only while it is tracked, so it cannot quietly
+/// become the permanent shape of the gate.
+#[test]
+fn reporting_only_audit_verdict_carries_a_follow_up_issue() {
+    let gate = job("full-audit-gate");
+
+    if !gate.contains("continue-on-error: true") {
+        // The follow-up landed and the verdict is blocking again. Nothing to guard.
+        return;
+    }
+
+    assert!(
+        gate.contains("#10569"),
+        "a reporting-only audit verdict must name the issue that flips it back to blocking"
+    );
+    assert!(
+        gate.contains("Reporting-only until"),
+        "the reporting-only state must be stated at the step it applies to"
+    );
 }
 
 #[test]

--- a/tests/fixtures/audit_runtime/src/commands/mod.rs
+++ b/tests/fixtures/audit_runtime/src/commands/mod.rs
@@ -1,0 +1,17 @@
+// Fixture module facade. REGRESSION GUARD for #10558.
+//
+// `mod.rs` is an INDEX FILE: `walker::INDEX_FILES` excludes it from convention
+// discovery because module roots organize other files rather than being peers,
+// and including them produces false "missing method" findings. That reasoning is
+// about convention SIBLING detection and has no bearing on a whole-file term
+// scan — but source policies used to borrow the convention corpus, so every
+// `mod.rs`, `lib.rs`, and `main.rs` in a repository was unscannable by ANY
+// source policy regardless of configuration (181 files on homeboy itself).
+//
+// This file carries the fixture's configured forbidden term below. If the
+// source-policy corpus ever regresses to the convention corpus, the
+// `source_policy_violation::src/commands/mod.rs` entry disappears from
+// EXPECTED_FINDINGS and the snapshot harness fails.
+pub fn facade_entry() -> &'static str {
+    "forbiddenmarker"
+}

--- a/tests/fixtures/audit_runtime/src/commands/thick_adapter.rs
+++ b/tests/fixtures/audit_runtime/src/commands/thick_adapter.rs
@@ -1,10 +1,27 @@
 // Fixture command-layer file: trips the thin_command_adapter policy because it
 // contains the configured ORCHESTRATION_MARKER inside a command path.
+//
+// SECOND ROLE — REGRESSION GUARD for #10558's singleton-group filter. This is
+// the only non-index file in `src/commands/`, so convention discovery drops it:
+// `groups_from_dir_files` discards any group with fewer than two members
+// because a convention needs peers to exist. Correct for conventions, and
+// meaningless for a term scan — yet source policies used to inherit it (82 more
+// unscannable files on homeboy itself, on top of the 181 index files).
+//
+// The forbidden term below must therefore produce
+// `source_policy_violation::src/commands/thick_adapter.rs`. If the
+// source-policy corpus regresses to the convention corpus, that entry vanishes
+// and the snapshot harness fails.
 pub fn run_command() {
     // ORCHESTRATION_MARKER: this command module carries orchestration weight.
     let _ = orchestrate();
+    let _ = solo_directory_marker();
 }
 
 fn orchestrate() -> u32 {
     42
+}
+
+fn solo_directory_marker() -> &'static str {
+    "forbiddenmarker"
 }


### PR DESCRIPTION
Fixes #10557. Fixes #10558.

Both issues reproduce exactly as filed. I verified them independently rather than taking the analysis on faith; the numbers below are from commands I ran, and the one place the issues are off is called out at the bottom.

---

## Reproduction

### #10557 — the gate scans 0 files and passes

The gate command was `.homeboy-bin/homeboy review audit homeboy --profile=full`, run without `homeboy-action`'s `Install extension` step. Simulated by pointing `HOME` at a directory with no installed extensions:

```
$ HOME=/var/lib/datamachine/tmp/emptyhome homeboy review audit homeboy \
    --path=<worktree> --profile=full --ignore-baseline --output=no-ext.json
exit=0
passed True
{ "conventions_detected": 0,
  "files_scanned": 0,
  "files_skipped": 1820,
  "warnings": ["Found 1820 source file(s) but no installed extension provides fingerprinting for these file types. ..."] }
findings 0
```

`exit 0`, `passed: true`, zero findings, on a tree with 1819 `.rs` files. Same command with the `rust` extension installed:

```
$ homeboy review audit homeboy --path=<worktree> --profile=full --ignore-baseline
files_scanned = 1586, files_skipped = 1, passed = False, findings = 2356
```

**Mechanism confirmed.** `walker::extension_provided_file_extensions()` unions `provides.file_extensions` across installed extensions. With none installed it returns `[]`, so `ScanConfig { extensions: ExtensionFilter::Only([]) }` matches nothing and `CodebaseSnapshot` is empty. `homeboy-action`'s `scripts/setup/install-extension.sh` runs `homeboy extension install-for-component`, which installs the `rust` extension declared in `homeboy.json`'s `extensions` key — that is the step the raw binary skipped.

### #10558 — 265 of 1821 `.rs` files unscannable by any source policy

I replicated the corpus construction in Python and validated it against ground truth: `engine.rs` sets `summary.files_scanned = total_files`, the sum of fingerprints across `discovery.groups`. The replica must reproduce the observed 1586 exactly.

```
walked (extension-matched, pre-index-filter): 1864
index files dropped:                           181
after index filter (files_walked):            1683
singleton-group files dropped:                  97
CORPUS (== summary.files_scanned):            1586   <- exact match
TOTAL EXCLUDED from source-policy scanning:    278
```

Restricted to `.rs` (and to the `rust`-extension-only configuration CI uses): **265 of 1821 excluded — 182 index files + 83 singleton-directory files.** Every file the issue names as excluded is excluded, including `crates/homeboy-cli/src/cli_surface/mod.rs`, `crates/homeboy-core/src/project/mod.rs`, `crates/homeboy-product-identity/build.rs`, `crates/homeboy-extension/src/test/mod.rs`.

I then replicated `source_policy::run_forbidden_terms` and checked it against the real run on `(rule_id, file, line, term)`:

```
real   : 1204
replica: 1204
symmetric difference: 0
```

**Independent verification complete** — the model is exact, not approximate.

---

## Finding counts, before and after

| | before | after | delta |
|---|---|---|---|
| source-policy corpus (`.rs`, rust extension only) | 1556 / 1821 | 1821 / 1821 | +265 files |
| `core-agnostic-source` findings | 1180 | 1430 | +250 |
| `detector-agnostic-source` findings | 24 | 67 | +43 |
| **total** | **1204** | **1497** | **+293 across 38 files** |

Of the 38 newly-flagged files, 21 are index files and 17 are singleton-directory files. Largest: `crates/homeboy-refactor/src/rename/tests.rs` (37), `crates/homeboy-code-audit/src/detectors/constant_bypass/tests.rs` (24), `crates/homeboy-product-identity/build.rs` (24), `crates/homeboy-extension/src/test/mod.rs` (23).

(With `nodejs` + `wordpress` extensions also installed, as on my host, the figures are +313 across 40 files because `.json`/`.php` enter the corpus. CI installs only `rust`, so the table above is the CI-accurate one.)

---

## What changed

**#10557**

- `full-audit-gate` now routes through `Extra-Chill/homeboy-action@v2`, exactly like the sibling lint/test gates and the weekly sweep.
- **`review audit` hard-errors on an empty corpus** (`engine.rs`, field `audit.corpus`). This is the durable fix: the 7-second green run is now impossible for *every* consumer, not just this workflow. It mirrors the existing `validate_source_roots` contract one level up — configuration matching zero files is already an error; a corpus containing zero files is the same defect with a wider blast radius. A tree with genuinely no source files still passes cleanly.
- The workflow test asserted the command string. It now asserts (a) the gate goes through the action that installs the extension, (b) no `run:` step invokes the binary directly, (c) the job carries an unconditionally-blocking corpus assertion. The *effect* assertion lives in `engine_corpus_test.rs`, stated so it holds in both environments:

  > extension available → `Ok` with a non-empty corpus; no extension → `Err` naming the empty corpus. What must never happen is `Ok` with `files_scanned == 0` on a tree that demonstrably has source files.

**#10558**

- `DiscoveryResult` gains `policy_fingerprints`: every extension-claimed source file, index files included, no group-size filter. Built in the same walk, so each file is fingerprinted once; the policy copy carries only path/language/content (the three fields source policies read) rather than duplicating every extracted fact vector.
- `DetectorRunContext` gains `policy_fingerprints`; `SourcePolicy` and `CoreBoundaryLeaks` read it, as do `validate_configured_paths` and `validate_source_roots`. `--changed-since` narrowing is applied to it using the same `scope_files` set.
- `walker::is_extension_provided_source_file` (which fused "extension claims this" with "not an index file") is split; the index check now sits explicitly at the one call site that wants sibling semantics.
- Fixture coverage: `tests/fixtures/audit_runtime/src/commands/mod.rs` (index file) and `thick_adapter.rs` (sole non-index file in its directory) both carry the fixture's forbidden term, so both must produce a `source_policy_violation`. Two new default-tier tests assert it.

---

## Red-gate decision, and why

**Quantified first.** Running the gate as it will actually behave, against the current baseline:

```
$ homeboy review audit homeboy --path=<worktree> --profile=full
exit=1
[audit] DRIFT INCREASED: 37 new finding(s) since baseline
baseline_comparison: { delta: 9, drift_increased: true, new_items: 37, resolved_fingerprints: 28 }
```

18 `structural`, 5 `constant_bypass_literal`, 3 `skeleton-duplication`, 3 `dead_code`, 2 each of intra-method/near-duplication/parallel-implementation, 1 `core_boundary_leak`, 1 `command_status_contracts`. **None of it caused by this PR** — it is drift accumulated since the 2026-07-27 baseline. On top of that sit the ~293 rows #10558 unblinds.

**Chosen: blocking corpus assertion + reporting-only findings verdict, with a tracked follow-up (#10569).**

Reasoning, including why I did not take the other option:

- Baselining is the right end state, but I cannot produce a correct baseline. `homeboy audit-baseline` / `review audit --baseline` would have to run the **fixed** binary, which only exists after this merges. A baseline generated from the pre-fix binary is missing the ~293 rows by construction, which lands a **permanently red** gate — the exact outcome to avoid, and worse than reporting-only because it is red for a reason nobody can act on from the gate output.
- Hand-writing the ~293 baseline rows was explicitly off the table, and would be fragile besides.
- Reporting-only here is not the #10557 failure mode. That failure was an instrument reporting success while measuring nothing. This gate **measures** — it prints the real finding list — and the property that #10557 is actually about (did the audit run at all) is enforced unconditionally by a separate blocking step.

The reporting-only state is fenced: `reporting_only_audit_verdict_carries_a_follow_up_issue` fails unless the follow-up issue number sits next to `continue-on-error` in the job, and self-disables once `continue-on-error` is removed. #10569 carries the baseline procedure and the triage breakdown.

---

## Should `source_policy` join `AuditProfile::Pr`?

**No.** Decided against, and the reasoning is recorded on `AuditProfile::includes_detector` so it is not re-litigated:

1. Both `source_policy` and `core_boundary_leaks` are `DetectorAccess::Discovery`. Adding either flips `requires_discovery()` for `Pr`, forcing the whole-tree walk + fingerprint on **every pull request** — precisely the cost the profile split exists to avoid. That is an architecture change, not a list edit.
2. `release.yml:320` runs `--profile=pr --changed-since <before>`. Widening `Pr` widens the **release** gate, against a tree carrying ~1430 latent `core-agnostic-source` findings. Stranding releases on untriaged debt is the failure `audit-debt.yml` was created to prevent.
3. "Enforced nowhere" is answered more cheaply and more correctly by making the post-merge full-profile gate real, which is what this PR does. Whole-tree detectors belong on the integrated tree.

I added `assert!(!plan.detector_enabled("core_boundary_leaks"))` and a loop that names any Discovery detector that sneaks into `Pr`, so a future edit fails with the reason rather than just getting slow.

**Stated plainly:** until #10569 flips the verdict to blocking, `core-agnostic-source` is still not enforced in a blocking gate. The follow-up issue is load-bearing, not a formality.

---

## What I found wrong in the issues

Very little — both hold up. Corrections, all minor:

1. **#10558's counts are slightly stale, and understate the impact.** It says "263 of 1816 `.rs` files" and "156 findings across 22 files". On current `main` (after #10556 widened the term list) it is **265 of 1821** and **+293 findings across 38 files**. The 156/22 figure was explicitly measured "before #10556", so this is drift, not an error — but anyone sizing the work from the issue will undercount by ~2x.
2. **#10557's suggested sequencing does not survive contact with the build order.** Step 2 says "in the same PR, regenerate the baseline and triage the 45-row delta". That is not possible: the post-fix finding set requires the post-fix binary. Any baseline generated in the same PR is generated by the pre-fix binary and is wrong by exactly the rows the PR unblinds. Split into a follow-up (#10569).
3. **#10557's "45 unbaselined findings" is now 37**, at `b0c775466` after #10556 landed and changed the baseline. Same shape, different number.
4. **Neither issue mentions that `entry::source_policy_findings_for_path` already had it right.** It builds from `walk_all_source_files_snapshot` — the full corpus, no index exclusion, no group filter. So the two code paths disagreed with each other; the standalone entry point scanned files the engine could not. That is stronger corroboration than either issue offers, and it is what made the fix shape obvious.
5. **Found while here, unrelated to either issue:** `audit-debt.yml` passed `autofix: 'false'` to `homeboy-action@v2`, which has no such input. It read like an enforced "never autofix" property and enforced nothing — the same class of defect, in the same file. Removed, and `post_merge_gates_never_mutate_the_repository` now checks the YAML key shape across the whole workflow instead of only the two release-blocking gates.

---

## What I could NOT verify without cargo

This VPS cannot run `cargo build`/`test`/`check`/`clippy` (16 GB shared with several services; a workspace build OOM-kills the supervisor). `cargo fmt --all` passes, and `rustfmt --check` parses `engine_corpus_test.rs`, so everything is syntactically valid — but **nothing here has been type-checked or executed.** CI is the gate. Specifically unverified:

- that the new borrow structure in `engine.rs` satisfies borrowck (`policy_fingerprints` borrows `discovery.policy_fingerprints` while `discovery.groups` is later moved; explicit `drop()`s added in the order the existing code already used for `all_fingerprints`);
- the `DetectorRunContext` lifetime on the new `policy_fingerprints: &'a [&'a FileFingerprint]` field;
- the four new tests in `engine_corpus_test.rs` and the two in `audit_runtime_regression_test.rs`;
- the updated `EXPECTED_FINDINGS` snapshot (that test is `slow-tests`-gated and does not run in CI at all — I reasoned about each detector's corpus to conclude the two new entries are the only change, but it is reasoning, not a run);
- whether `run_fixture_audit`'s new `#[cfg(feature = "slow-tests")]` gate is needed or over-applied.

All workflow-text assertions I *could* verify, I did — I re-implemented the `job()` extractor and every assertion in `tests/audit_debt_workflow_test.rs` in Python and ran them against the real file: **47/47 pass.**

Refs #10569.
