### PR TITLE
fix(release): preserve GitHub failure diagnostics

### DIFF
--- a/crates/homeboy-redaction/src/lib.rs
+++ b/crates/homeboy-redaction/src/lib.rs
@@ -315,7 +315,7 @@ fn normalize_key(key: &str) -> String {
 }
 
 fn redact_authorization_schemes(value: &str, replacement: &str) -> String {
-    let pattern = Regex::new(r"(?i)\b(bearer|basic)\s+[^\s,;]+")
+    let pattern = Regex::new(r"(?i)\b(bearer|basic|token)\s+[^\s,;]+")
         .expect("authorization redaction regex is valid");
     let value = pattern
         .replace_all(value, |captures: &Captures<'_>| {
@@ -376,6 +376,10 @@ mod tests {
         assert_eq!(
             policy.redact_string("proxy Basic dXNlcjpzZWNyZXQ="),
             "proxy Basic [REDACTED]"
+        );
+        assert_eq!(
+            policy.redact_string("Authorization: ToKeN ghp_secret"),
+            "Authorization: ToKeN [REDACTED]"
         );
     }
 

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -4,6 +4,10 @@ use crate::release::types::ReleaseState;
 use homeboy_core::component::GithubConfig;
 use homeboy_core::engine::shell::quote_arg;
 use homeboy_core::git::release_download::GitHubRepo;
+use homeboy_core::redaction::RedactionPolicy;
+use homeboy_engine_primitives::command::{
+    isolate_process_tree, wait_with_bounded_output_supervised, SupervisedCommandTermination,
+};
 use homeboy_engine_primitives::content_hash;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -19,6 +23,8 @@ const DEFAULT_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS: u64 = 30 * 60;
 const GITHUB_RELEASE_DOWNLOAD_DIAGNOSTIC_BYTES: usize = 8 * 1024;
 const GITHUB_RELEASE_DOWNLOAD_READER_CLEANUP_TIMEOUT: Duration = Duration::from_millis(500);
 const GITHUB_RELEASE_DOWNLOAD_PIPE_CHUNKS_PER_TURN: usize = 4;
+const GITHUB_COMMAND_DIAGNOSTIC_TEXT_LIMIT: usize = 4096;
+const GITHUB_COMMAND_OUTPUT_LIMIT: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GhCommandOutput {
@@ -27,6 +33,36 @@ pub(crate) struct GhCommandOutput {
     pub exit_code: Option<i32>,
     pub timed_out: bool,
 }
+
+/// Safe, bounded evidence from a failed `gh` invocation for persisted release
+/// step data. Command arguments are intentionally not retained because release
+/// notes and upload paths can contain credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct GitHubCommandFailureDiagnostic {
+    pub operation: String,
+    pub endpoint: String,
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+    pub stdout: String,
+    pub stderr: String,
+    pub http_status: Option<u16>,
+    pub github_request_id: Option<String>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GitHubReleaseMetadataError {
+    pub message: String,
+    pub diagnostics: Vec<GitHubCommandFailureDiagnostic>,
+}
+
+impl std::fmt::Display for GitHubReleaseMetadataError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GitHubReleaseMetadataError {}
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct GitHubReleaseMetadata {
@@ -405,7 +441,7 @@ pub(crate) fn gh_release_metadata(
     config: &GithubConfig,
     tag: &str,
     repo_flag: &str,
-) -> Result<GitHubReleaseMetadata, String> {
+) -> Result<GitHubReleaseMetadata, GitHubReleaseMetadataError> {
     // `gh release view --json` uses GraphQL, whose release asset shape omits
     // the REST digest field. Recovery authority requires that digest, including
     // for drafts, so read the REST API directly.
@@ -415,11 +451,24 @@ pub(crate) fn gh_release_metadata(
         github_release_upload_timeout(),
     );
     if !output.timed_out && output.exit_code == Some(0) {
-        return serde_json::from_str(&output.stdout)
-            .map_err(|error| format!("GitHub REST release metadata was invalid: {error}"));
+        return serde_json::from_str(&output.stdout).map_err(|error| GitHubReleaseMetadataError {
+            message: format!("GitHub REST release metadata was invalid: {error}"),
+            diagnostics: vec![gh_failure_diagnostic(
+                "gh api release metadata",
+                &endpoint,
+                &output,
+            )],
+        });
     }
     if output.timed_out {
-        return Err(gh_failure_detail("gh api release metadata", &output));
+        return Err(GitHubReleaseMetadataError {
+            message: gh_failure_detail("gh api release metadata", &output),
+            diagnostics: vec![gh_failure_diagnostic(
+                "gh api release metadata",
+                &endpoint,
+                &output,
+            )],
+        });
     }
 
     // `releases/tags/{tag}` resolves published releases only -- GitHub returns
@@ -435,13 +484,29 @@ pub(crate) fn gh_release_metadata(
     // that strands a release undiagnosable -- which is exactly what run
     // 30313665269 left behind for v0.321.1: a step error naming only the
     // expected 404, with no trace of why the draft lookup did not recover it.
-    gh_draft_release_metadata(github, config, tag, repo_flag).map_err(|draft_error| {
-        format!(
+    gh_draft_release_metadata(github, config, tag, repo_flag)
+        .map_err(|draft_error| metadata_fallback_error(&endpoint, &output, draft_error))
+}
+
+fn metadata_fallback_error(
+    endpoint: &str,
+    output: &GhCommandOutput,
+    draft_error: GitHubReleaseMetadataError,
+) -> GitHubReleaseMetadataError {
+    let mut diagnostics = vec![gh_failure_diagnostic(
+        "gh api release metadata",
+        endpoint,
+        output,
+    )];
+    diagnostics.extend(draft_error.diagnostics);
+    GitHubReleaseMetadataError {
+        message: format!(
             "{}; the draft fallback also failed: {}",
-            gh_failure_detail("gh api release metadata", &output),
-            draft_error
-        )
-    })
+            gh_failure_detail("gh api release metadata", output),
+            draft_error.message
+        ),
+        diagnostics,
+    }
 }
 
 /// Resolve a draft release by scanning the list endpoint, which -- unlike
@@ -457,7 +522,7 @@ fn gh_draft_release_metadata(
     config: &GithubConfig,
     tag: &str,
     repo_flag: &str,
-) -> Result<GitHubReleaseMetadata, String> {
+) -> Result<GitHubReleaseMetadata, GitHubReleaseMetadataError> {
     let endpoint = format!("repos/{repo_flag}/releases");
     let filter = format!(".[] | select(.tag_name == \"{tag}\")");
     let output = run_gh_command(
@@ -469,21 +534,29 @@ fn gh_draft_release_metadata(
         github_release_upload_timeout(),
     );
     if output.timed_out || output.exit_code != Some(0) {
-        let detail = gh_failure_detail("gh api releases list", &output);
-        let stderr = output.stderr.trim();
-        return Err(if stderr.is_empty() {
-            detail
-        } else {
-            format!("{detail}: {stderr}")
+        return Err(GitHubReleaseMetadataError {
+            message: gh_failure_detail("gh api releases list", &output),
+            diagnostics: vec![gh_failure_diagnostic(
+                "gh api releases list",
+                &endpoint,
+                &output,
+            )],
         });
     }
     parse_listed_release_metadata(&output.stdout).ok_or_else(|| {
-        if output.stdout.trim().is_empty() {
-            format!("no GitHub Release (published or draft) on {repo_flag} matched tag {tag}")
-        } else {
-            format!(
-                "the release list entry for {tag} on {repo_flag} was not valid release metadata"
-            )
+        let malformed = !output.stdout.trim().is_empty();
+        GitHubReleaseMetadataError {
+            message: if malformed {
+                format!(
+                    "the release list entry for {tag} on {repo_flag} was not valid release metadata"
+                )
+            } else {
+                format!("no GitHub Release (published or draft) on {repo_flag} matched tag {tag}")
+            },
+            diagnostics: malformed
+                .then(|| gh_failure_diagnostic("gh api releases list", &endpoint, &output))
+                .into_iter()
+                .collect(),
         }
     })
 }
@@ -1098,44 +1171,162 @@ pub(crate) fn gh_failure_detail(command: &str, output: &GhCommandOutput) -> Stri
     }
 }
 
+pub(crate) fn gh_failure_diagnostic(
+    operation: &str,
+    endpoint: &str,
+    output: &GhCommandOutput,
+) -> GitHubCommandFailureDiagnostic {
+    let stdout = gh_diagnostic_text(&output.stdout);
+    let stderr = gh_diagnostic_text(&output.stderr);
+    let http_status = parse_http_status(&stderr).or_else(|| parse_http_status(&stdout));
+    let github_request_id =
+        parse_github_request_id(&stderr).or_else(|| parse_github_request_id(&stdout));
+    GitHubCommandFailureDiagnostic {
+        operation: gh_diagnostic_text(operation),
+        endpoint: gh_diagnostic_text(endpoint),
+        exit_code: output.exit_code,
+        timed_out: output.timed_out,
+        summary: gh_failure_summary(operation, output, http_status, github_request_id.as_deref()),
+        http_status,
+        github_request_id,
+        stdout,
+        stderr,
+    }
+}
+
+pub(crate) fn gh_diagnostic_text(value: &str) -> String {
+    let policy = RedactionPolicy::default()
+        .with_sensitive_key("signature")
+        .with_sensitive_key("sig");
+    let redacted = serde_json::from_str(value)
+        .map(|json| policy.redact_json(&json).to_string())
+        .unwrap_or_else(|_| policy.redact_env_value(value));
+    bound_diagnostic_text(&redacted)
+}
+
+fn gh_failure_summary(
+    operation: &str,
+    output: &GhCommandOutput,
+    http_status: Option<u16>,
+    github_request_id: Option<&str>,
+) -> String {
+    let mut evidence = Vec::new();
+    if let Some(status) = http_status {
+        evidence.push(format!("HTTP {status}"));
+    }
+    if let Some(request_id) = github_request_id {
+        evidence.push(format!("GitHub request ID {request_id}"));
+    }
+    let detail = gh_failure_detail(operation, output);
+    if evidence.is_empty() {
+        bound_diagnostic_text(&detail)
+    } else {
+        bound_diagnostic_text(&format!("{detail} ({})", evidence.join(", ")))
+    }
+}
+
+fn bound_diagnostic_text(value: &str) -> String {
+    bound_text(value, GITHUB_COMMAND_DIAGNOSTIC_TEXT_LIMIT)
+}
+
+fn bound_command_output(value: &str) -> String {
+    bound_text(value, GITHUB_COMMAND_OUTPUT_LIMIT)
+}
+
+fn bound_text(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        return value.to_string();
+    }
+    let mut end = limit;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...[truncated]", &value[..end])
+}
+
+fn parse_http_status(value: &str) -> Option<u16> {
+    for marker in ["HTTP ", "HTTP/1.1 ", "HTTP/2 ", "\"status\":"] {
+        let mut start = 0;
+        while let Some(offset) = value[start..].find(marker) {
+            let code_start = start + offset + marker.len();
+            let code_start = code_start
+                + value[code_start..]
+                    .chars()
+                    .take_while(|character| character.is_whitespace())
+                    .map(char::len_utf8)
+                    .sum::<usize>();
+            if let Some(code) = value.get(code_start..code_start + 3) {
+                if let Ok(code) = code.parse() {
+                    return Some(code);
+                }
+            }
+            start = code_start;
+        }
+    }
+    None
+}
+
+fn parse_github_request_id(value: &str) -> Option<String> {
+    let lower = value.to_ascii_lowercase();
+    for marker in [
+        "x-github-request-id:",
+        "x-github-request-id=",
+        "\"request_id\":\"",
+    ] {
+        if let Some(offset) = lower.find(marker) {
+            let start = offset + marker.len();
+            let start = start
+                + value[start..]
+                    .chars()
+                    .take_while(|character| character.is_whitespace())
+                    .map(char::len_utf8)
+                    .sum::<usize>();
+            let end = value[start..]
+                .find(|character: char| matches!(character, '\n' | '\r' | ' ' | '"' | ','))
+                .map(|offset| start + offset)
+                .unwrap_or(value.len());
+            if start < end {
+                return Some(bound_diagnostic_text(&value[start..end]));
+            }
+        }
+    }
+    None
+}
+
 pub(crate) fn run_gh_command(mut command: Command, timeout: Duration) -> GhCommandOutput {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    isolate_process_tree(&mut command);
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
             return GhCommandOutput {
                 stdout: String::new(),
-                stderr: error.to_string(),
+                stderr: gh_diagnostic_text(&error.to_string()),
                 exit_code: None,
                 timed_out: false,
             }
         }
     };
-    let started = Instant::now();
-    let (status, timed_out) = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break (Some(status), false),
-            Ok(None) if started.elapsed() >= timeout => {
-                let _ = child.kill();
-                break (child.wait().ok(), true);
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
-            Err(_) => break (None, false),
-        }
-    };
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    if let Some(mut stream) = child.stdout.take() {
-        let _ = stream.read_to_end(&mut stdout);
-    }
-    if let Some(mut stream) = child.stderr.take() {
-        let _ = stream.read_to_end(&mut stderr);
-    }
-    GhCommandOutput {
-        stdout: String::from_utf8_lossy(&stdout).to_string(),
-        stderr: String::from_utf8_lossy(&stderr).to_string(),
-        exit_code: status.and_then(|status| status.code()),
-        timed_out,
+    match wait_with_bounded_output_supervised(
+        &mut child,
+        GITHUB_COMMAND_OUTPUT_LIMIT,
+        timeout,
+        timeout,
+        || false,
+        |_, _| Ok(()),
+    ) {
+        Ok(supervised) => GhCommandOutput {
+            stdout: bound_command_output(&String::from_utf8_lossy(&supervised.output.stdout)),
+            stderr: bound_command_output(&String::from_utf8_lossy(&supervised.output.stderr)),
+            exit_code: supervised.output.status.code(),
+            timed_out: supervised.termination == SupervisedCommandTermination::TimedOut,
+        },
+        Err(error) => GhCommandOutput {
+            stdout: String::new(),
+            stderr: gh_diagnostic_text(&format!("could not supervise gh command: {error}")),
+            exit_code: None,
+            timed_out: false,
+        },
     }
 }
 
@@ -1268,6 +1459,154 @@ mod tests {
         assert!(!metadata.is_draft);
         assert!(parse_listed_release_metadata("").is_none());
         assert!(parse_listed_release_metadata("not json").is_none());
+    }
+
+    fn failed_output(
+        stdout: &str,
+        stderr: &str,
+        exit_code: Option<i32>,
+        timed_out: bool,
+    ) -> GhCommandOutput {
+        GhCommandOutput {
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            exit_code,
+            timed_out,
+        }
+    }
+
+    #[test]
+    fn metadata_fallback_retains_primary_404_and_draft_list_failure() {
+        let primary = failed_output("", "HTTP 404: Not Found", Some(1), false);
+        let draft = GitHubReleaseMetadataError {
+            message: "gh api releases list exited with status 1".to_string(),
+            diagnostics: vec![gh_failure_diagnostic(
+                "gh api releases list",
+                "repos/example/repo/releases",
+                &failed_output("", "HTTP 403: forbidden", Some(1), false),
+            )],
+        };
+
+        let error = metadata_fallback_error("repos/example/repo/releases/tags/v1", &primary, draft);
+
+        assert!(error.message.contains("draft fallback also failed"));
+        assert_eq!(error.diagnostics.len(), 2);
+        assert_eq!(error.diagnostics[0].http_status, Some(404));
+        assert_eq!(error.diagnostics[1].http_status, Some(403));
+    }
+
+    #[test]
+    fn failure_diagnostic_extracts_403_request_id_and_timeout_without_dangling_detail() {
+        let output = failed_output(
+            "",
+            "HTTP 403: forbidden\nX-GitHub-Request-Id: AB12:CD34\nAuthorization: Bearer secret",
+            Some(1),
+            false,
+        );
+        let diagnostic = gh_failure_diagnostic(
+            "gh api releases list",
+            "repos/example/repo/releases",
+            &output,
+        );
+        assert_eq!(diagnostic.http_status, Some(403));
+        assert_eq!(diagnostic.github_request_id.as_deref(), Some("AB12:CD34"));
+        assert_eq!(
+            diagnostic.summary,
+            "gh api releases list exited with status 1 (HTTP 403, GitHub request ID AB12:CD34)"
+        );
+        assert!(!diagnostic.stderr.contains("secret"));
+
+        let timeout = gh_failure_diagnostic(
+            "gh release upload",
+            "repos/example/repo/releases/v1/assets",
+            &failed_output("", "", Some(124), true),
+        );
+        assert_eq!(timeout.summary, "gh release upload timed out");
+        assert!(timeout.stderr.is_empty());
+    }
+
+    #[test]
+    fn failure_diagnostic_parses_whitespace_json_status_and_redacts_url_userinfo() {
+        let diagnostic = gh_failure_diagnostic(
+            "gh api",
+            "https://user:password@example.test/repos/example/repo",
+            &failed_output("{\"status\": 403}", "", Some(1), false),
+        );
+        assert_eq!(diagnostic.http_status, Some(403));
+        assert!(diagnostic.summary.contains("HTTP 403"));
+        assert!(!diagnostic.endpoint.contains("user:password"));
+        assert!(!diagnostic.endpoint.contains("password"));
+    }
+
+    #[test]
+    fn failure_diagnostic_redacts_signed_url_secrets_and_bounds_output() {
+        let output = failed_output(
+            &format!(
+                "{} https://example.test/file?X-Amz-Signature=secret&token=also-secret",
+                "x".repeat(5000)
+            ),
+            "",
+            Some(1),
+            false,
+        );
+        let diagnostic = gh_failure_diagnostic(
+            "gh api",
+            "repos/example/repo/releases?access_token=secret",
+            &output,
+        );
+        assert!(!diagnostic.stdout.contains("secret"));
+        assert!(!diagnostic.stdout.contains("also-secret"));
+        assert!(!diagnostic.endpoint.contains("secret"));
+        assert!(diagnostic.stdout.len() <= GITHUB_COMMAND_DIAGNOSTIC_TEXT_LIMIT + 16);
+        assert!(diagnostic.stdout.ends_with("...[truncated]"));
+    }
+
+    #[test]
+    fn diagnostic_text_redacts_json_secret_values() {
+        let redacted = gh_diagnostic_text(
+            r#"{"access_token":"secret","token": "escaped\\u0073ecret","secret":"another-secret"}"#,
+        );
+        assert!(redacted.contains(r#""access_token":"[REDACTED]""#));
+        assert!(redacted.contains(r#""token":"[REDACTED]""#));
+        assert!(redacted.contains(r#""secret":"[REDACTED]""#));
+        assert!(!redacted.contains("another-secret"));
+        assert!(!redacted.contains("escaped"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn diagnostic_text_redacts_sensitive_headers_and_signed_urls() {
+        let redacted = gh_diagnostic_text(
+            "Cookie: session=secret\nSet-Cookie: sid=secret\nProxy-Authorization: Basic secret\nAuthorization: token ghp_secret\nX-Api-Key: secret\nhttps://user:password@example.test/path?X-Amz-Signature=secret&token=secret",
+        );
+        for secret in [
+            "session=secret",
+            "sid=secret",
+            "Basic secret",
+            "ghp_secret",
+            "password",
+            "token=secret",
+        ] {
+            assert!(!redacted.contains(secret), "leaked {secret}: {redacted}");
+        }
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn gh_spawn_failure_is_bounded_and_diagnostic_ready() {
+        let output = run_gh_command(
+            Command::new("homeboy-gh-does-not-exist"),
+            Duration::from_secs(1),
+        );
+        let diagnostic = gh_failure_diagnostic(
+            "gh api releases list",
+            "repos/example/repo/releases",
+            &output,
+        );
+        assert_eq!(diagnostic.exit_code, None);
+        assert_eq!(diagnostic.operation, "gh api releases list");
+        assert_eq!(diagnostic.endpoint, "repos/example/repo/releases");
+        assert!(diagnostic.stderr.len() <= GITHUB_COMMAND_DIAGNOSTIC_TEXT_LIMIT);
     }
 
     fn remote_asset(name: &str, size: u64, digest: Option<String>) -> GitHubReleaseAsset {
@@ -1404,6 +1743,74 @@ mod tests {
         assert_eq!(output.exit_code, Some(7));
         assert!(output.stderr.is_empty());
         assert!(!output.timed_out);
+    }
+
+    #[test]
+    fn bounded_command_retains_large_release_metadata_but_diagnostics_stay_compact() {
+        let assets = (0..200)
+            .map(|index| {
+                serde_json::json!({
+                    "id": index,
+                    "name": format!("release-asset-{index:03}.tar.xz"),
+                    "size": 1,
+                    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                })
+            })
+            .collect::<Vec<_>>();
+        let metadata = serde_json::json!({
+            "tag_name": "v1.2.3",
+            "draft": true,
+            "assets": assets,
+        })
+        .to_string();
+        assert!(metadata.len() > GITHUB_COMMAND_DIAGNOSTIC_TEXT_LIMIT);
+
+        let mut command = Command::new("sh");
+        command.args(["-c", "printf '%s' \"$1\"", "sh", &metadata]);
+        let output = run_gh_command(command, Duration::from_secs(1));
+
+        assert_eq!(output.exit_code, Some(0));
+        assert!(output.stdout.len() > GITHUB_COMMAND_DIAGNOSTIC_TEXT_LIMIT);
+        assert!(output.stdout.len() <= GITHUB_COMMAND_OUTPUT_LIMIT);
+        assert_eq!(
+            serde_json::from_str::<GitHubReleaseMetadata>(&output.stdout)
+                .expect("large metadata remains parseable")
+                .assets
+                .len(),
+            200
+        );
+        assert_eq!(
+            parse_listed_release_metadata(&output.stdout)
+                .expect("large draft-list record remains parseable")
+                .assets
+                .len(),
+            200
+        );
+
+        let diagnostic =
+            gh_failure_diagnostic("gh api release metadata", "repos/example/repo", &output);
+        assert!(diagnostic.stdout.len() <= GITHUB_COMMAND_DIAGNOSTIC_TEXT_LIMIT + 16);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_command_times_out_with_continuous_output() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "(while :; do printf x; done) & wait"]);
+        let output = run_gh_command(command, Duration::from_millis(30));
+        assert!(output.timed_out);
+        assert!(output.stdout.len() <= GITHUB_COMMAND_OUTPUT_LIMIT);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_command_closes_inherited_descendant_pipes() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 30 & printf done"]);
+        let started = Instant::now();
+        let output = run_gh_command(command, Duration::from_secs(1));
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert_eq!(output.stdout, "done");
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use run::validate_declared_build_artifact;
 // step to gate tag-availability preflight, so they are part of the module's
 // non-test surface.
 pub(crate) use gh_cli::{
-    download_small_release_asset, gh_failure_detail, gh_is_authenticated, gh_is_available,
+    download_small_release_asset, gh_failure_diagnostic, gh_is_authenticated, gh_is_available,
     gh_release_exists, gh_release_metadata, github_release_publications,
     github_release_upload_timeout, reconcile_release_publications, run_gh_command,
     validate_draft_adoption, verify_release_publications,

--- a/crates/homeboy-release/src/release/executor/github_release/notes.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/notes.rs
@@ -9,7 +9,9 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_core::git::release_download::GitHubRepo;
 
-use super::gh_cli::{gh_command, safe_filename};
+use super::gh_cli::{
+    gh_command, gh_failure_diagnostic, github_release_upload_timeout, run_gh_command, safe_filename,
+};
 
 /// The exact GitHub Release body Homeboy posts, with provenance.
 ///
@@ -227,21 +229,21 @@ fn github_generated_notes(
         args.extend_from_slice(&["-f", &previous_field]);
     }
 
-    let output = gh_command(github, config, &args).output().map_err(|e| {
-        Error::internal_io(
-            format!("Failed to invoke gh: {}", e),
-            Some("gh api releases/generate-notes".to_string()),
-        )
-    })?;
+    let output = run_gh_command(
+        gh_command(github, config, &args),
+        github_release_upload_timeout(),
+    );
 
-    if !output.status.success() {
+    if output.timed_out || output.exit_code != Some(0) {
+        let diagnostic =
+            gh_failure_diagnostic("gh api releases/generate-notes", &endpoint, &output);
         return Err(Error::internal_unexpected(format!(
-            "gh api releases/generate-notes failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            "{}",
+            diagnostic.summary
         )));
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    Ok(output.stdout.trim().to_string())
 }
 
 pub(crate) fn github_changelog_url(

--- a/crates/homeboy-release/src/release/executor/github_release/results.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/results.rs
@@ -4,11 +4,22 @@ use crate::release::types::ReleaseStepResult;
 use homeboy_core::git::release_download::GitHubRepo;
 
 use super::super::{step_failed, step_success};
-use super::gh_cli::ReleaseAssetPublication;
+use super::gh_cli::{gh_diagnostic_text, GitHubCommandFailureDiagnostic, ReleaseAssetPublication};
 use super::notes::GitHubReleaseBody;
 use super::repair::{
     existing_draft_repair_hints, repair_data, repair_hints, GitHubReleaseRepairCommands,
 };
+
+fn github_command_error_details(
+    diagnostics: &[GitHubCommandFailureDiagnostic],
+) -> Option<serde_json::Value> {
+    (!diagnostics.is_empty()).then(|| {
+        serde_json::json!({
+            "code": "github_command_failed",
+            "failures": diagnostics,
+        })
+    })
+}
 
 pub(crate) fn published_release_url(
     github: &GitHubRepo,
@@ -98,8 +109,9 @@ pub(crate) fn unfinished_release_result(
     reason: &str,
     error: &str,
     repair: GitHubReleaseRepairCommands,
+    diagnostics: &[GitHubCommandFailureDiagnostic],
 ) -> ReleaseStepResult {
-    let data = serde_json::json!({
+    let mut data = serde_json::json!({
         "skipped": false,
         "release_created": true,
         "published": false,
@@ -110,6 +122,9 @@ pub(crate) fn unfinished_release_result(
         "repo": github.repo,
         "repair": repair_data(&repair),
     });
+    if let Some(details) = github_command_error_details(diagnostics) {
+        data["error_details"] = details;
+    }
 
     step_failed(
         "github.release",
@@ -160,13 +175,15 @@ pub(crate) fn create_failed_result(
     tag: &str,
     github: &GitHubRepo,
     reason: &str,
-    stdout: String,
-    stderr: String,
+    output: &super::gh_cli::GhCommandOutput,
     repair: GitHubReleaseRepairCommands,
     body: &GitHubReleaseBody,
     persisted_notes_path: Option<&str>,
+    diagnostics: &[GitHubCommandFailureDiagnostic],
 ) -> ReleaseStepResult {
-    let data = serde_json::json!({
+    let stdout = gh_diagnostic_text(&output.stdout);
+    let stderr = gh_diagnostic_text(&output.stderr);
+    let mut data = serde_json::json!({
         "skipped": false,
         "release_created": false,
         "reason": reason,
@@ -184,6 +201,9 @@ pub(crate) fn create_failed_result(
         "release_body_source": body.source_label(),
         "release_body_file": persisted_notes_path,
     });
+    if let Some(details) = github_command_error_details(diagnostics) {
+        data["error_details"] = details;
+    }
 
     let detail = stderr.trim();
     let error = if detail.is_empty() {
@@ -214,8 +234,11 @@ pub(crate) fn upload_failed_result(
     timed_out: bool,
     artifact_count: usize,
     repair: GitHubReleaseRepairCommands,
+    diagnostics: &[GitHubCommandFailureDiagnostic],
 ) -> ReleaseStepResult {
-    let data = serde_json::json!({
+    let stdout = gh_diagnostic_text(&stdout);
+    let stderr = gh_diagnostic_text(&stderr);
+    let mut data = serde_json::json!({
         "skipped": false,
         "release_created": true,
         "reason": "gh-upload-failed",
@@ -230,6 +253,9 @@ pub(crate) fn upload_failed_result(
         "artifact_count": artifact_count,
         "repair": repair_data(&repair),
     });
+    if let Some(details) = github_command_error_details(diagnostics) {
+        data["error_details"] = details;
+    }
 
     let detail = stderr.trim();
     let error = if timed_out {

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -21,7 +21,7 @@ use super::results::{
     upload_success_result_with_publications,
 };
 use super::{
-    download_small_release_asset, gh_failure_detail, gh_release_metadata,
+    download_small_release_asset, gh_failure_diagnostic, gh_release_metadata,
     github_release_upload_timeout, reconcile_release_publications, run_gh_command,
     validate_draft_adoption, verify_release_publications,
 };
@@ -174,6 +174,7 @@ pub(crate) fn run_github_release(
                     "release-state-unreadable",
                     &detail,
                     repair,
+                    &error.diagnostics,
                 ));
             }
         };
@@ -207,10 +208,26 @@ pub(crate) fn run_github_release(
                     Error::validation_invalid_argument("release assets", error, None, None)
                 })?;
             // Re-read immediately before un-drafting so a concurrent asset edit cannot race validation.
-            let current = gh_release_metadata(&github, &component.github, &tag, &repo_flag)
-                .map_err(|error| {
-                    Error::validation_invalid_argument("github.release", error, None, None)
-                })?;
+            let current = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
+                Ok(metadata) => metadata,
+                Err(error) => {
+                    let repair = repair_commands(None, None);
+                    let detail = format!(
+                        "GitHub Release {} exists for {} but its publication state could not be re-read before publishing: {}",
+                        tag, repo_flag, error
+                    );
+                    homeboy_core::log_status!("release", "✗ {}", detail);
+                    log_repair_commands(&repair);
+                    return Ok(unfinished_release_result(
+                        &tag,
+                        &github,
+                        "release-state-reread-failed",
+                        &detail,
+                        repair,
+                        &error.diagnostics,
+                    ));
+                }
+            };
             let current_sidecars = current
                 .assets
                 .iter()
@@ -236,11 +253,22 @@ pub(crate) fn run_github_release(
                 github_release_upload_timeout(),
             );
             if output.timed_out || output.exit_code != Some(0) {
-                return Err(Error::validation_invalid_argument(
-                    "github.release",
-                    gh_failure_detail("gh release edit --draft=false", &output),
-                    None,
-                    None,
+                let repair = repair_commands(None, None);
+                let diagnostic = gh_failure_diagnostic(
+                    "gh release edit --draft=false",
+                    &format!("repos/{repo_flag}/releases/{tag}"),
+                    &output,
+                );
+                let detail = diagnostic.summary.clone();
+                homeboy_core::log_status!("release", "✗ {}", diagnostic.summary);
+                log_repair_commands(&repair);
+                return Ok(unfinished_release_result(
+                    &tag,
+                    &github,
+                    "draft-adoption-publish-failed",
+                    &detail,
+                    repair,
+                    &[diagnostic],
                 ));
             }
             return Ok(published_existing_draft_result(
@@ -284,6 +312,7 @@ pub(crate) fn run_github_release(
                     "draft-release-has-no-assets",
                     &detail,
                     repair,
+                    &[],
                 ));
             }
             ExistingReleaseAction::PublishDraft => {
@@ -301,12 +330,13 @@ pub(crate) fn run_github_release(
                 );
                 if publish_output.timed_out || publish_output.exit_code != Some(0) {
                     let repair = repair_commands(None, None);
-                    let detail = format!(
-                        "{}: {}",
-                        gh_failure_detail("gh release edit --draft=false", &publish_output),
-                        publish_output.stderr.trim()
+                    let diagnostic = gh_failure_diagnostic(
+                        "gh release edit --draft=false",
+                        &format!("repos/{repo_flag}/releases/{tag}"),
+                        &publish_output,
                     );
-                    homeboy_core::log_status!("release", "✗ {}", detail);
+                    let detail = diagnostic.summary.clone();
+                    homeboy_core::log_status!("release", "✗ {}", diagnostic.summary);
                     log_repair_commands(&repair);
                     return Ok(unfinished_release_result(
                         &tag,
@@ -314,6 +344,7 @@ pub(crate) fn run_github_release(
                         "draft-publish-failed",
                         &detail,
                         repair,
+                        &[diagnostic],
                     ));
                 }
                 let url = published_release_url(&github, &tag, "", &publish_output.stdout);
@@ -374,37 +405,42 @@ pub(crate) fn run_github_release(
             .is_some_and(|output| output.timed_out || output.exit_code != Some(0))
         {
             let upload_output = upload_output.expect("checked upload output");
-            let detail = gh_failure_detail("gh release upload", &upload_output);
-            let stderr = upload_output.stderr;
-            let stdout = upload_output.stdout;
+            let diagnostic = gh_failure_diagnostic(
+                "gh release upload",
+                &format!("repos/{repo_flag}/releases/{tag}/assets"),
+                &upload_output,
+            );
             let repair = repair_commands(None, None);
-            homeboy_core::log_status!("release", "✗ {}: {}", detail, stderr.trim());
+            homeboy_core::log_status!("release", "✗ {}", diagnostic.summary);
             log_repair_commands(&repair);
             return Ok(upload_failed_result(
                 &tag,
                 &github,
-                stdout,
-                stderr,
+                upload_output.stdout,
+                upload_output.stderr,
                 upload_output.exit_code,
                 upload_output.timed_out,
                 artifact_paths.len(),
                 repair,
+                &[diagnostic],
             ));
         }
 
         let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
             Ok(metadata) => metadata,
             Err(error) => {
+                let diagnostics = error.diagnostics;
                 return Ok(upload_failed_result(
                     &tag,
                     &github,
                     String::new(),
-                    error,
+                    error.message,
                     None,
                     false,
                     artifact_paths.len(),
                     repair_commands(None, None),
-                ))
+                    &diagnostics,
+                ));
             }
         };
         if let Err(error) = verify_release_publications(
@@ -423,6 +459,7 @@ pub(crate) fn run_github_release(
                 false,
                 artifact_paths.len(),
                 repair_commands(None, None),
+                &[],
             ));
         }
         if metadata.is_draft {
@@ -432,6 +469,11 @@ pub(crate) fn run_github_release(
                 github_release_upload_timeout(),
             );
             if publish_output.timed_out || publish_output.exit_code != Some(0) {
+                let diagnostic = gh_failure_diagnostic(
+                    "gh release edit --draft=false",
+                    &format!("repos/{repo_flag}/releases/{tag}"),
+                    &publish_output,
+                );
                 return Ok(upload_failed_result(
                     &tag,
                     &github,
@@ -441,6 +483,7 @@ pub(crate) fn run_github_release(
                     publish_output.timed_out,
                     artifact_paths.len(),
                     repair_commands(None, None),
+                    &[diagnostic],
                 ));
             }
         }
@@ -515,18 +558,12 @@ pub(crate) fn run_github_release(
         create_args.push(path);
     }
 
-    let output = gh_command(&github, &component.github, &create_args)
-        .output()
-        .map_err(|e| {
-            Error::internal_io(
-                format!("Failed to invoke gh: {}", e),
-                Some("gh release create".to_string()),
-            )
-        })?;
+    let output = run_gh_command(
+        gh_command(&github, &component.github, &create_args),
+        github_release_upload_timeout(),
+    );
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if output.timed_out || output.exit_code != Some(0) {
         let repair = repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref());
         // Distinguish the path that brought us here so operators (and tests)
         // can see whether the fallback-after-generated-notes-failure also
@@ -536,33 +573,40 @@ pub(crate) fn run_github_release(
         } else {
             "generated-notes-failed"
         };
-        homeboy_core::log_status!("release", "✗ `gh release create` failed: {}", stderr.trim());
+        let diagnostic = gh_failure_diagnostic(
+            "gh release create",
+            &format!("repos/{repo_flag}/releases"),
+            &output,
+        );
+        homeboy_core::log_status!("release", "✗ {}", diagnostic.summary);
         log_repair_commands(&repair);
         return Ok(create_failed_result(
             &tag,
             &github,
             reason,
-            stdout,
-            stderr,
+            &output,
             repair,
             &body,
             persisted_notes_path.as_deref(),
+            &[diagnostic],
         ));
     }
 
     let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
         Ok(metadata) => metadata,
         Err(error) => {
+            let diagnostics = error.diagnostics;
             return Ok(upload_failed_result(
                 &tag,
                 &github,
                 String::new(),
-                error,
+                error.message,
                 None,
                 false,
                 artifact_paths.len(),
                 repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref()),
-            ))
+                &diagnostics,
+            ));
         }
     };
     if let Err(error) = verify_release_publications(
@@ -581,6 +625,7 @@ pub(crate) fn run_github_release(
             false,
             artifact_paths.len(),
             repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref()),
+            &[],
         ));
     }
     let publish_args = ["release", "edit", &tag, "--draft=false", "-R", &repo_flag];
@@ -589,6 +634,11 @@ pub(crate) fn run_github_release(
         github_release_upload_timeout(),
     );
     if publish_output.timed_out || publish_output.exit_code != Some(0) {
+        let diagnostic = gh_failure_diagnostic(
+            "gh release edit --draft=false",
+            &format!("repos/{repo_flag}/releases/{tag}"),
+            &publish_output,
+        );
         return Ok(upload_failed_result(
             &tag,
             &github,
@@ -598,11 +648,11 @@ pub(crate) fn run_github_release(
             publish_output.timed_out,
             artifact_paths.len(),
             repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref()),
+            &[diagnostic],
         ));
     }
 
-    let draft_response = String::from_utf8_lossy(&output.stdout);
-    let url = published_release_url(&github, &tag, &draft_response, &publish_output.stdout);
+    let url = published_release_url(&github, &tag, &output.stdout, &publish_output.stdout);
     homeboy_core::log_status!("release", "Published verified GitHub Release: {}", url);
     Ok(step_success(
         "github.release",

--- a/crates/homeboy-release/src/release/executor/github_release/tests/notes_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/notes_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::release::types::ReleaseState;
 
+use super::super::gh_cli::GhCommandOutput;
 use super::super::{
     build_github_release_body, create_failed_result, fallback_release_notes, GitHubReleaseBody,
 };
@@ -131,11 +132,16 @@ fn create_failed_result_exposes_exact_release_body_and_persisted_file() {
         "v0.10.6",
         &test_repo(),
         "generated-notes-failed",
-        String::new(),
-        "HTTP 502".to_string(),
+        &GhCommandOutput {
+            stdout: String::new(),
+            stderr: "HTTP 502".to_string(),
+            exit_code: Some(1),
+            timed_out: false,
+        },
         test_repair(),
         &body,
         Some("build/v0.10.6-release-notes.md"),
+        &[],
     );
 
     assert_eq!(data_str(&result, "release_body"), Some(body.body.as_str()));

--- a/crates/homeboy-release/src/release/executor/github_release/tests/result_builders.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/result_builders.rs
@@ -2,6 +2,7 @@
 
 use crate::release::types::ReleaseStepStatus;
 
+use super::super::gh_cli::{gh_failure_diagnostic, GhCommandOutput};
 use super::super::{
     create_failed_result, not_created_result, published_existing_draft_result,
     published_release_url, unfinished_release_result, upload_failed_result, upload_success_result,
@@ -46,11 +47,16 @@ fn create_failed_result_reports_generated_notes_failed_as_failure() {
         "v0.10.6",
         &test_repo(),
         "generated-notes-failed",
-        String::new(),
-        "HTTP 502: bad gateway".to_string(),
+        &GhCommandOutput {
+            stdout: String::new(),
+            stderr: "HTTP 502: bad gateway".to_string(),
+            exit_code: Some(1),
+            timed_out: false,
+        },
         test_repair(),
         &test_body(),
         Some("build/v0.10.6-release-notes.md"),
+        &[],
     );
 
     assert_eq!(result.status, ReleaseStepStatus::Failed);
@@ -76,11 +82,16 @@ fn create_failed_result_reports_plain_create_failure() {
         "v0.10.6",
         &test_repo(),
         "gh-command-failed",
-        String::new(),
-        "release v0.10.6 already exists".to_string(),
+        &GhCommandOutput {
+            stdout: String::new(),
+            stderr: "release v0.10.6 already exists".to_string(),
+            exit_code: Some(1),
+            timed_out: false,
+        },
         test_repair(),
         &test_body(),
         Some("build/v0.10.6-release-notes.md"),
+        &[],
     );
 
     assert_eq!(result.status, ReleaseStepStatus::Failed);
@@ -100,6 +111,7 @@ fn upload_failed_result_is_failed_but_records_release_exists() {
         false,
         1,
         test_repair(),
+        &[],
     );
 
     assert_eq!(result.status, ReleaseStepStatus::Failed);
@@ -128,6 +140,7 @@ fn upload_timeout_is_classified_and_preserves_empty_stderr() {
         true,
         1,
         test_repair(),
+        &[],
     );
     assert_eq!(data_bool(&result, "timed_out"), Some(true));
     assert_eq!(
@@ -139,6 +152,54 @@ fn upload_timeout_is_classified_and_preserves_empty_stderr() {
         Some(124)
     );
     assert!(result.error.as_deref().unwrap().contains("timed out"));
+}
+
+#[test]
+fn upload_failed_result_sanitizes_persisted_output() {
+    let result = upload_failed_result(
+        "v0.10.6",
+        &test_repo(),
+        format!(
+            "https://user:password@example.test/file?token=secret {}",
+            "x".repeat(5000)
+        ),
+        "Authorization: Bearer secret".to_string(),
+        Some(1),
+        false,
+        1,
+        test_repair(),
+        &[],
+    );
+    let data = result.data.as_ref().expect("failed result data");
+    let stdout = data["stdout"].as_str().expect("sanitized stdout");
+    let stderr = data["stderr"].as_str().expect("sanitized stderr");
+    assert!(!stdout.contains("password"));
+    assert!(!stdout.contains("secret"));
+    assert!(!stderr.contains("secret"));
+    assert!(stdout.len() <= 4096 + "...[truncated]".len());
+}
+
+#[test]
+fn create_failed_result_sanitizes_persisted_output() {
+    let result = create_failed_result(
+        "v0.10.6",
+        &test_repo(),
+        "gh-command-failed",
+        &GhCommandOutput {
+            stdout: "token=secret".repeat(1000),
+            stderr: "Authorization: Bearer secret".to_string(),
+            exit_code: Some(1),
+            timed_out: false,
+        },
+        test_repair(),
+        &test_body(),
+        None,
+        &[],
+    );
+    let data = result.data.as_ref().expect("failed result data");
+    assert!(!data["stdout"].as_str().unwrap().contains("secret"));
+    assert!(!data["stderr"].as_str().unwrap().contains("secret"));
+    assert!(data["stdout"].as_str().unwrap().len() <= 4096 + "...[truncated]".len());
 }
 
 #[test]
@@ -202,6 +263,7 @@ fn an_unfinished_release_is_failed_so_the_tag_is_never_reported_as_delivered() {
         "draft-publish-failed",
         "`gh release edit --draft=false` failed for v0.320.0: HTTP 502",
         test_repair(),
+        &[],
     );
 
     assert_eq!(result.status, ReleaseStepStatus::Failed);
@@ -234,6 +296,7 @@ fn an_empty_draft_is_refused_with_the_same_failed_contract() {
         "draft-release-has-no-assets",
         "Refusing to publish an empty release over the pushed tag.",
         test_repair(),
+        &[],
     );
 
     assert_eq!(result.status, ReleaseStepStatus::Failed);
@@ -242,6 +305,47 @@ fn an_empty_draft_is_refused_with_the_same_failed_contract() {
         data_str(&result, "reason"),
         Some("draft-release-has-no-assets")
     );
+}
+
+#[test]
+fn failed_results_retain_structured_command_diagnostics() {
+    let output = GhCommandOutput {
+        stdout: String::new(),
+        stderr: "HTTP 403\nX-GitHub-Request-Id: request-123\nAuthorization: token ghp_secret"
+            .to_string(),
+        exit_code: Some(1),
+        timed_out: false,
+    };
+    let diagnostic = gh_failure_diagnostic(
+        "gh release edit --draft=false",
+        "repos/example-org/studio-web/releases/v0.10.6",
+        &output,
+    );
+    let result = unfinished_release_result(
+        "v0.10.6",
+        &test_repo(),
+        "draft-publish-failed",
+        "gh release edit --draft=false exited with status 1",
+        test_repair(),
+        &[diagnostic],
+    );
+
+    let details = result
+        .data
+        .as_ref()
+        .and_then(|data| data.get("error_details"))
+        .expect("structured diagnostic details retained");
+    assert_eq!(details["code"], "github_command_failed");
+    let failures = details
+        .get("failures")
+        .and_then(|value| value.as_array())
+        .expect("structured diagnostic retained");
+    assert_eq!(failures[0]["http_status"], 403);
+    assert_eq!(failures[0]["github_request_id"], "request-123");
+    assert!(!failures[0]["stderr"]
+        .as_str()
+        .unwrap()
+        .contains("ghp_secret"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve bounded, redacted GitHub command diagnostics for metadata, draft fallback, create, upload, and publish failures
- expose operation, endpoint, exit/timeout state, HTTP status, GitHub request ID, and bounded stdout/stderr through `data.error_details`
- use Homeboy's canonical redaction policy and supervised bounded process runner instead of local unbounded subprocess capture
- retain both the published-tag lookup and draft-list fallback failures when recovery cannot resolve a release

Fixes #10516.
Supports the current trusted-runtime recovery described in #10519.

## Safety

- functional command output is bounded to 1 MiB so large release asset inventories remain parseable
- persisted diagnostics are separately redacted and bounded to 4 KiB
- command argv remains excluded because release notes and paths can contain sensitive values
- canonical redaction now covers GitHub's `Authorization: token ...` scheme
- timed-out and completed children use shared process-tree isolation and descendant cleanup

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-redaction` (8 passed)
- `cargo test -p homeboy-release github_release` (107 passed)
- strict independent review found no remaining findings

The full `homeboy-release` suite currently has five failures outside this module on current main surfaces (deploy guard/group behavior, semver ordering, and extension fixture configuration). The complete GitHub release slice is green.

## AI Assistance

- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** root-cause tracing, implementation, security review, bounded-process and redaction integration, and test execution. Chris Huber remains responsible for every line.
