### PR TITLE
fix(release): align finalizer runtime baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,9 @@ jobs:
     name: Build
     needs: check
     if: needs.check.outputs.should-release == 'true'
-    runs-on: ubuntu-latest
+    # This binary is executed by the ubuntu-22.04 publication jobs. Build on
+    # the oldest consumer runtime so recovery finalizers cannot require a newer GLIBC.
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -445,6 +445,16 @@ fn release_host_checkout_fetches_full_history_for_finalizer_ancestry_validation(
 }
 
 #[test]
+fn release_shared_binary_uses_the_publication_host_runtime_baseline() {
+    let gate_build = job_section(release_workflow(), "gate-build");
+    let host = job_section(release_workflow(), "host");
+
+    assert!(gate_build.contains("runs-on: ubuntu-22.04"));
+    assert!(host.contains("runs-on: ubuntu-22.04"));
+    assert!(!gate_build.contains("runs-on: ubuntu-latest"));
+}
+
+#[test]
 fn release_recovery_bypasses_quality_gates_and_still_prepares() {
     let check = job_section(release_workflow(), "check");
     let gate_audit = job_section(release_workflow(), "gate-audit");


### PR DESCRIPTION
## Summary

- build the shared current-main release finalizer on `ubuntu-22.04`, matching the publication host that executes it
- prevent recovery binaries from acquiring a newer GLIBC requirement than their oldest consumer
- add workflow contract coverage binding `gate-build` and `host` to the same runtime baseline

## Evidence

[Release run 30352824843](https://github.com/Extra-Chill/homeboy/actions/runs/30352824843) handed the current-main binary to the publication host, where it failed before draft adoption with `GLIBC_2.39 not found`.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test --test release_workflow_test` (26 passed)

Fixes #10577.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode traced the release-run failure, implemented the workflow correction and regression test, and ran verification. Chris Huber reviewed and remains responsible for the change.