### PR TITLE
fix(audit): read nested review corpus summary

### DIFF
--- a/.github/workflows/audit-debt.yml
+++ b/.github/workflows/audit-debt.yml
@@ -248,11 +248,11 @@ jobs:
             echo "::error::Audit produced no structured output at '${result}'. The audit did not run to completion (or homeboy-action changed where it writes results). A gate that cannot read the audit result cannot claim the audit passed — see #10557." >&2
             exit 1
           fi
-          files_scanned="$(jq -r '.data.summary.files_scanned // 0' "${result}")"
+          files_scanned="$(jq -r '.data.audit.output.summary.files_scanned // 0' "${result}")"
           echo "audit corpus: ${files_scanned} file(s)"
           if [ "${files_scanned}" -lt 1 ]; then
             echo "::error::Audit scanned ${files_scanned} files. An audit with an empty corpus has not passed — it has not run. The usual cause is a missing fingerprinting extension: this gate must go through Extra-Chill/homeboy-action, whose 'Install extension' step installs the extensions declared in homeboy.json. See #10557." >&2
-            jq -r '.data.summary' "${result}" >&2 || true
+            jq -r '.data.audit.output.summary' "${result}" >&2 || true
             exit 1
           fi
 

--- a/tests/audit_debt_workflow_test.rs
+++ b/tests/audit_debt_workflow_test.rs
@@ -264,8 +264,12 @@ fn post_merge_full_audit_gate_blocks_on_an_empty_corpus() {
         .find("name: Assert the audit actually scanned the tree")
         .expect("audit gate must carry a corpus assertion step");
     assert!(
-        gate.contains("files_scanned"),
-        "the corpus assertion must read the audit's own files_scanned figure"
+        gate.contains(".data.audit.output.summary.files_scanned"),
+        "review audit nests the audit result below data.audit.output; the corpus assertion must read the audit's own files_scanned figure"
+    );
+    assert!(
+        !gate.contains(".data.summary.files_scanned"),
+        "data.summary is the review-level summary and has no audit corpus metric"
     );
 
     // Every `continue-on-error: true` in this job must precede the blocking


### PR DESCRIPTION
## Summary

- read `files_scanned` from the nested audit stage emitted by `review audit`
- print the same nested audit summary when the corpus assertion fails
- lock the exact review-envelope path into workflow regression coverage

Closes #10579.

## Root cause

The gate invoked `homeboy review audit` but read `.data.summary.files_scanned`. That object is the umbrella `ReviewSummary`, which has no corpus metric. The actual `AuditCommandOutput` is nested at `.data.audit.output`, so the `// 0` fallback converted a successful scan into a false zero.

## Evidence

- Main Guard: https://github.com/Extra-Chill/homeboy/actions/runs/30357149676
- Audit assertion: https://github.com/Extra-Chill/homeboy/actions/runs/30357149676/job/90269549529

## Verification

- `cargo fmt --all -- --check`
- `cargo test --test audit_debt_workflow_test -- --nocapture` (`11 passed`)

## AI assistance

OpenCode using OpenAI `gpt-5.6-sol` traced the false zero through the Homeboy action and review output schema, implemented the workflow correction and regression coverage, and ran the verification above. Chris Huber remains responsible for every line.