### PR TITLE
refactor(cli): one watch loop, and pin the ScopeArgs boundary

### DIFF
--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -9,6 +9,7 @@ use homeboy::core::activity::{
 use homeboy::core::notification_payload::{
     NotifyAction, NotifyAttachment, NotifyEventKind, NotifyPayload, NotifySubject,
 };
+use homeboy::core::notification_route::{self, NotificationRoute};
 use homeboy::core::notify::{self, NotifyEvent, NotifyOutcome};
 use homeboy::core::{Error, Result};
 
@@ -16,9 +17,8 @@ use super::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandJobRef, CommandNextAction,
     CommandNextActionKind, CommandResultRefs, CommandRunRef,
 };
+use super::utils::watch::{watch_loop, WatchConfig, WatchPoller, WatchResult, TIMEOUT_EXIT_CODE};
 use super::CmdResult;
-
-const TIMEOUT_EXIT_CODE: i32 = 124;
 
 #[derive(Args, Clone)]
 pub struct ActivityArgs {
@@ -206,50 +206,61 @@ fn show(id: &str) -> CmdResult<ActivityOutput> {
     ))
 }
 
+/// Production poller: resolve one activity item across every activity source.
+///
+/// Deliberately **non**-reconciling, which is the load-bearing behavioural
+/// difference from `runs watch`'s `StorePoller`. An activity read must not
+/// mutate an observation record — `activity_reads_do_not_reconcile_stale_running_records`
+/// pins that — so the two commands share the poll loop (`utils::watch`) but not
+/// the poller. This is why #10315's prescribed fix ("construct an
+/// `ActivityPoller: RunPoller`") could not be taken literally: `RunPoller`
+/// yielded a `RunRecord`, and an activity item is a projection over four stores
+/// that frequently has no `RunRecord` behind it at all.
+struct ActivityPoller;
+
+impl WatchPoller for ActivityPoller {
+    type Item = ActivityItem;
+
+    fn poll(&self, id: &str) -> Result<ActivityItem> {
+        activity::resolve_activity(id)
+    }
+
+    fn is_terminal(&self, item: &ActivityItem) -> bool {
+        !activity::is_active(item.state)
+    }
+}
+
 fn watch(args: ActivityWatchArgs) -> CmdResult<ActivityOutput> {
     let interval = parse_duration(&args.interval)?;
     let timeout = args.timeout.as_deref().map(parse_duration).transpose()?;
-    let started = Instant::now();
-    let mut poll_count = 0;
+    let config = WatchConfig { interval, timeout };
 
-    loop {
-        let item = activity::resolve_activity(&args.id)?;
-        poll_count += 1;
-        eprintln!(
-            "activity {}: {:?} (poll {})",
-            args.id, item.state, poll_count
-        );
-        if !activity::is_active(item.state) {
-            return Ok(watch_output(
-                args,
-                item,
-                false,
-                started.elapsed(),
-                poll_count,
-            ));
-        }
-        if let Some(timeout) = timeout {
-            if started.elapsed() >= timeout {
-                return Ok(watch_output(
-                    args,
-                    item,
-                    true,
-                    started.elapsed(),
-                    poll_count,
-                ));
-            }
-        }
-        std::thread::sleep(interval);
-    }
+    let started = Instant::now();
+    let id = args.id.clone();
+    let result = watch_loop(
+        &ActivityPoller,
+        &args.id,
+        &config,
+        std::thread::sleep,
+        || started.elapsed(),
+        |item, poll_count| emit_progress(&id, item, poll_count),
+    )?;
+
+    Ok(watch_output(args, result))
+}
+
+fn emit_progress(id: &str, item: &ActivityItem, poll_count: u64) {
+    eprintln!("activity {}: {:?} (poll {})", id, item.state, poll_count);
 }
 
 fn watch_output(
     args: ActivityWatchArgs,
-    item: ActivityItem,
-    timed_out: bool,
-    waited: Duration,
-    poll_count: u64,
+    result: WatchResult<ActivityItem>,
 ) -> (ActivityOutput, i32) {
+    let timed_out = result.timed_out();
+    let waited = result.waited;
+    let poll_count = result.poll_count;
+    let item = result.item;
     let notify = maybe_notify(&args, &item, timed_out);
     let exit_code = if timed_out {
         TIMEOUT_EXIT_CODE
@@ -269,7 +280,7 @@ fn watch_output(
             schema: activity::ACTIVITY_REPORT_SCHEMA,
             command: "activity.watch",
             id: args.id,
-            state: item.state.clone(),
+            state: item.state,
             terminal: !timed_out,
             timed_out,
             waited_secs: waited.as_secs(),
@@ -413,6 +424,35 @@ fn maybe_notify(
     if !args.notify {
         return None;
     }
+    // The invocation's route, bound once by `cli_runtime` from
+    // `--notification-transport`/`--notification-route` or the matching
+    // environment. This used to be dropped: the event was built with
+    // `transport: None, route: None`, so `activity watch --notify
+    // --notification-route ...` silently delivered to the configured default
+    // transport with no route at all (#10315, found by #10538).
+    //
+    // Unlike `runs watch`, there is no run-scoped fallback available here:
+    // `ActivityItem` is a cross-store projection with no metadata channel, so
+    // it cannot carry the route `ObservationStore::start_run` stamped onto the
+    // record. Honouring the caller's explicit route is the available — and the
+    // requested — answer.
+    let route = notification_route::current();
+    Some(notify::dispatch(&activity_notify_event(
+        item,
+        timed_out,
+        route.as_ref(),
+    )))
+}
+
+/// Build the completion notification for a watched activity item.
+///
+/// Split out from [`maybe_notify`] so the routing decision is unit-testable
+/// without an installed transport to dispatch through.
+fn activity_notify_event(
+    item: &ActivityItem,
+    timed_out: bool,
+    route: Option<&NotificationRoute>,
+) -> NotifyEvent {
     let status = if timed_out {
         "timed_out".to_string()
     } else {
@@ -461,19 +501,18 @@ fn maybe_notify(
                 ),
         );
 
-    Some(notify::dispatch(
-        &NotifyEvent {
-            title: format!("homeboy activity {status}"),
-            body: format!("{} {}", item.kind, item.id),
-            status,
-            run_id: item.id.clone(),
-            kind,
-            transport: None,
-            route: None,
-            payload: None,
-        }
-        .with_payload(payload),
-    ))
+    NotifyEvent {
+        title: format!("homeboy activity {status}"),
+        body: format!("{} {}", item.kind, item.id),
+        status,
+        run_id: item.id.clone(),
+        kind,
+        transport: None,
+        route: None,
+        payload: None,
+    }
+    .with_route(route)
+    .with_payload(payload)
 }
 
 /// Project an activity evidence ref into a deliverable attachment.
@@ -550,9 +589,55 @@ mod tests {
     use super::*;
     use crate::cli_surface::Cli;
     use clap::Parser;
+    use homeboy::core::activity::{ActivityCrossRefs, ActivityNextAction, ActivityRunnerRefs};
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
     use homeboy::test_support::with_isolated_home;
     use serde_json::json;
+
+    fn activity_item(state: ActivityState) -> ActivityItem {
+        ActivityItem {
+            id: "run-1".to_string(),
+            kind: "observation_run".to_string(),
+            source_store: "observation".to_string(),
+            state,
+            created_at: "2026-05-02T16:46:46Z".to_string(),
+            updated_at: None,
+            finished_at: None,
+            command: Some("homeboy bench".to_string()),
+            cwd: None,
+            runner: ActivityRunnerRefs::default(),
+            refs: ActivityCrossRefs::default(),
+            artifacts: Vec::new(),
+            evidence: Vec::new(),
+            source_projections: Vec::new(),
+            state_conflicts: Vec::new(),
+            next_actions: vec![ActivityNextAction {
+                label: "show".to_string(),
+                command: "homeboy activity show run-1".to_string(),
+            }],
+        }
+    }
+
+    fn watch_args() -> ActivityWatchArgs {
+        ActivityWatchArgs {
+            id: "run-1".to_string(),
+            timeout: None,
+            interval: "2s".to_string(),
+            notify: false,
+        }
+    }
+
+    fn watch_result(
+        state: ActivityState,
+        conclusion: crate::commands::utils::watch::WatchConclusion,
+    ) -> WatchResult<ActivityItem> {
+        WatchResult {
+            item: activity_item(state),
+            conclusion,
+            poll_count: 3,
+            waited: Duration::from_secs(6),
+        }
+    }
 
     #[test]
     fn empty_state_summary_is_explicit() {
@@ -624,5 +709,162 @@ mod tests {
             assert_eq!(after, before);
             assert_eq!(after.status, RunStatus::Running.as_str());
         });
+    }
+
+    /// `activity watch` and `runs watch` are separate commands over separate
+    /// domain models, but they must agree on the timeout exit code. It used to
+    /// be declared once per command; both now read the shared constant, and
+    /// this pins the value against the GNU `timeout(1)` convention.
+    #[test]
+    fn timeout_exit_code_matches_the_shared_watch_contract() {
+        use crate::commands::utils::watch::WatchConclusion;
+
+        assert_eq!(TIMEOUT_EXIT_CODE, 124);
+        let (_, exit_code) = watch_output(
+            watch_args(),
+            watch_result(ActivityState::Running, WatchConclusion::TimedOut),
+        );
+        assert_eq!(exit_code, TIMEOUT_EXIT_CODE);
+    }
+
+    #[test]
+    fn watch_output_preserves_its_schema_and_accounting() {
+        use crate::commands::utils::watch::WatchConclusion;
+
+        let (output, exit_code) = watch_output(
+            watch_args(),
+            watch_result(ActivityState::Succeeded, WatchConclusion::Terminal),
+        );
+        assert_eq!(exit_code, 0);
+        let ActivityOutput::Watch(output) = output else {
+            panic!("watch returns a watch output");
+        };
+        // The wire shape is unchanged by the shared-loop extraction.
+        assert_eq!(output.command, "activity.watch");
+        assert_eq!(output.schema, activity::ACTIVITY_REPORT_SCHEMA);
+        assert_eq!(output.id, "run-1");
+        assert_eq!(output.state, ActivityState::Succeeded);
+        assert!(output.terminal);
+        assert!(!output.timed_out);
+        assert_eq!(output.poll_count, 3);
+        assert_eq!(output.waited_secs, 6);
+        assert_eq!(output.next_actions, vec!["homeboy activity show run-1"]);
+    }
+
+    #[test]
+    fn a_failed_watch_exits_nonzero_and_a_timeout_is_not_terminal() {
+        use crate::commands::utils::watch::WatchConclusion;
+
+        let (_, failed) = watch_output(
+            watch_args(),
+            watch_result(ActivityState::Failed, WatchConclusion::Terminal),
+        );
+        assert_eq!(failed, 1);
+
+        let (output, _) = watch_output(
+            watch_args(),
+            watch_result(ActivityState::Running, WatchConclusion::TimedOut),
+        );
+        let ActivityOutput::Watch(output) = output else {
+            panic!("watch returns a watch output");
+        };
+        assert!(!output.terminal);
+        assert!(output.timed_out);
+    }
+
+    /// The activity poller must classify exactly the states
+    /// `activity::is_active` calls active, so the shared loop stops on the same
+    /// snapshots the hand-rolled loop stopped on.
+    #[test]
+    fn activity_poller_terminality_matches_the_active_predicate() {
+        for state in [
+            ActivityState::Unknown,
+            ActivityState::Queued,
+            ActivityState::Running,
+            ActivityState::Succeeded,
+            ActivityState::PartialFailure,
+            ActivityState::Failed,
+            ActivityState::Cancelled,
+            ActivityState::TimedOut,
+            ActivityState::Stale,
+        ] {
+            let item = activity_item(state);
+            assert_eq!(
+                ActivityPoller.is_terminal(&item),
+                !activity::is_active(state),
+                "{state:?} terminality"
+            );
+        }
+    }
+
+    /// Regression for the defect #10538 surfaced: the event was built with
+    /// `transport: None, route: None` and never consulted the bound route, so
+    /// `--notification-route` was silently dropped by this command alone.
+    #[test]
+    fn notify_event_carries_the_invocation_route() {
+        let route =
+            homeboy::core::notification_route::NotificationRoute::new("test.transport", "route-42")
+                .expect("route");
+        let event = activity_notify_event(
+            &activity_item(ActivityState::Succeeded),
+            false,
+            Some(&route),
+        );
+        assert_eq!(event.transport.as_deref(), Some("test.transport"));
+        assert_eq!(event.route.as_deref(), Some("route-42"));
+    }
+
+    #[test]
+    fn notify_event_stays_route_less_without_a_bound_route() {
+        let event = activity_notify_event(&activity_item(ActivityState::Succeeded), false, None);
+        assert!(event.transport.is_none());
+        assert!(event.route.is_none());
+    }
+
+    /// End-to-end wiring: `maybe_notify` must read the thread-local route
+    /// `cli_runtime` binds for the whole invocation from
+    /// `--notification-transport`/`--notification-route`.
+    ///
+    /// No extension declares `test.transport` in an isolated home, so delivery
+    /// fails — but it fails *naming the routed transport*, which is only
+    /// possible if the bound route reached the event. Before this fix the
+    /// event was transport-less and would have resolved to the configured
+    /// operations default instead.
+    #[test]
+    fn watch_notification_delivers_to_the_bound_cli_route() {
+        with_isolated_home(|_| {
+            let route = NotificationRoute::new("test.transport", "route-42").expect("route");
+            let outcome = notification_route::with_current(Some(route), || {
+                maybe_notify(
+                    &ActivityWatchArgs {
+                        notify: true,
+                        ..watch_args()
+                    },
+                    &activity_item(ActivityState::Succeeded),
+                    false,
+                )
+            })
+            .expect("--notify requests a notification");
+
+            assert!(!outcome.delivered);
+            assert!(outcome.error.unwrap_or_default().contains("test.transport"));
+        });
+    }
+
+    #[test]
+    fn watch_without_notify_dispatches_nothing() {
+        assert!(maybe_notify(
+            &watch_args(),
+            &activity_item(ActivityState::Succeeded),
+            false
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn timed_out_notification_is_needs_attention() {
+        let event = activity_notify_event(&activity_item(ActivityState::Running), true, None);
+        assert_eq!(event.kind, NotifyEventKind::NeedsAttention);
+        assert_eq!(event.status, "timed_out");
     }
 }

--- a/crates/homeboy-cli/src/commands/runs/watch.rs
+++ b/crates/homeboy-cli/src/commands/runs/watch.rs
@@ -14,7 +14,7 @@
 //! - `--timeout` bounds the total wait; on expiry the watch returns the
 //!   last-seen state with a distinct timeout exit code.
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use clap::Args;
 use serde::Serialize;
@@ -27,10 +27,9 @@ use super::common::{parse_duration, RunSummary};
 use super::types::{actionable_for_run_summary, RunsOutput};
 use super::{reconcile, CmdResult};
 use crate::commands::utils::response::CommandActionableMetadata;
-
-/// Exit code returned when the run did not settle before `--timeout`. Matches
-/// the GNU `timeout(1)` convention so wrappers can recognize the case.
-pub(super) const TIMEOUT_EXIT_CODE: i32 = 124;
+use crate::commands::utils::watch::{
+    watch_loop, WatchConclusion, WatchConfig, WatchPoller, WatchResult, TIMEOUT_EXIT_CODE,
+};
 
 #[derive(Args, Clone)]
 pub struct RunsWatchArgs {
@@ -75,21 +74,22 @@ pub struct RunsWatchOutput {
     pub notify: Option<NotifyOutcome>,
 }
 
-/// Abstraction over "fetch the current state of this run" so the watch loop is
-/// testable without a real store, clock, or sleeps.
-pub(super) trait RunPoller {
-    fn poll(&self, run_id: &str) -> homeboy::core::Result<RunRecord>;
-}
-
 /// Production poller: refresh the requested mirrored runner evidence, reconcile
 /// its owner, then read the freshest local record. Fleet reconciliation remains
 /// an explicit `runs reconcile` operation rather than a side effect of a focused
 /// watch.
+///
+/// The reconciling read is what makes this poller distinct from
+/// `activity watch`'s: `runs watch` deliberately transitions an owner-dead run
+/// to `stale` so the watch can surface it instead of blocking, while activity
+/// reads are deliberately non-reconciling.
 struct StorePoller<'a> {
     store: &'a ObservationStore,
 }
 
-impl RunPoller for StorePoller<'_> {
+impl WatchPoller for StorePoller<'_> {
+    type Item = RunRecord;
+
     fn poll(&self, run_id: &str) -> homeboy::core::Result<RunRecord> {
         let run = runs_service::require_run(self.store, run_id)?;
         runs_service::refresh_selected_mirrored_daemon_evidence_best_effort(self.store, &run);
@@ -97,24 +97,10 @@ impl RunPoller for StorePoller<'_> {
         reconcile::reconcile_owned_stale_running_run(self.store, &run)?;
         runs_service::require_run(self.store, run_id)
     }
-}
 
-struct WatchConfig {
-    interval: Duration,
-    timeout: Option<Duration>,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub(super) enum WatchConclusion {
-    Terminal,
-    TimedOut,
-}
-
-pub(super) struct WatchResult {
-    run: RunRecord,
-    conclusion: WatchConclusion,
-    poll_count: u64,
-    waited: Duration,
+    fn is_terminal(&self, run: &RunRecord) -> bool {
+        is_terminal_status(&run.status)
+    }
 }
 
 pub fn watch_run(args: RunsWatchArgs) -> CmdResult<RunsOutput> {
@@ -129,7 +115,7 @@ pub fn watch_run(args: RunsWatchArgs) -> CmdResult<RunsOutput> {
 
     let started = Instant::now();
     let run_id = args.run_id.clone();
-    let result = run_watch_loop(
+    let result = watch_loop(
         &poller,
         &args.run_id,
         &config,
@@ -141,51 +127,6 @@ pub fn watch_run(args: RunsWatchArgs) -> CmdResult<RunsOutput> {
     let notify = maybe_notify(&args, &result);
     let (output, exit_code) = build_output(&args.run_id, result, notify);
     Ok((RunsOutput::Watch(output), exit_code))
-}
-
-/// The core poll loop, generic over the run source, the sleep function, and the
-/// clock so tests can drive it deterministically.
-fn run_watch_loop<P, S, C>(
-    poller: &P,
-    run_id: &str,
-    config: &WatchConfig,
-    mut sleep: S,
-    elapsed: C,
-    mut progress: impl FnMut(&RunRecord, u64),
-) -> homeboy::core::Result<WatchResult>
-where
-    P: RunPoller,
-    S: FnMut(Duration),
-    C: Fn() -> Duration,
-{
-    let mut poll_count: u64 = 0;
-    loop {
-        let run = poller.poll(run_id)?;
-        poll_count += 1;
-        progress(&run, poll_count);
-
-        if is_terminal_status(&run.status) {
-            return Ok(WatchResult {
-                run,
-                conclusion: WatchConclusion::Terminal,
-                poll_count,
-                waited: elapsed(),
-            });
-        }
-
-        if let Some(timeout) = config.timeout {
-            if elapsed() >= timeout {
-                return Ok(WatchResult {
-                    run,
-                    conclusion: WatchConclusion::TimedOut,
-                    poll_count,
-                    waited: elapsed(),
-                });
-            }
-        }
-
-        sleep(config.interval);
-    }
 }
 
 /// A run is terminal when it is not `running`. An unrecognized status is treated
@@ -209,18 +150,18 @@ fn exit_code_for_status(status: &str) -> i32 {
 
 fn build_output(
     run_id: &str,
-    result: WatchResult,
+    result: WatchResult<RunRecord>,
     notify: Option<NotifyOutcome>,
 ) -> (RunsWatchOutput, i32) {
-    let timed_out = result.conclusion == WatchConclusion::TimedOut;
-    let status = result.run.status.clone();
+    let timed_out = result.timed_out();
+    let status = result.item.status.clone();
     let exit_code = if timed_out {
         TIMEOUT_EXIT_CODE
     } else {
         exit_code_for_status(&status)
     };
 
-    let run = super::run_summary(result.run);
+    let run = super::run_summary(result.item);
     let actionable = actionable_for_run_summary(&run);
 
     (
@@ -240,16 +181,16 @@ fn build_output(
     )
 }
 
-fn maybe_notify(args: &RunsWatchArgs, result: &WatchResult) -> Option<NotifyOutcome> {
+fn maybe_notify(args: &RunsWatchArgs, result: &WatchResult<RunRecord>) -> Option<NotifyOutcome> {
     if !args.notify || result.conclusion != WatchConclusion::Terminal {
         return None;
     }
     let route = homeboy::core::notification_route::NotificationRoute::from_metadata(
-        &result.run.metadata_json,
+        &result.item.metadata_json,
     );
     let event =
-        NotifyEvent::run_completed_with_route(&args.run_id, &result.run.status, route.as_ref())
-            .with_payload(notify::run_completed_payload(&result.run));
+        NotifyEvent::run_completed_with_route(&args.run_id, &result.item.status, route.as_ref())
+            .with_payload(notify::run_completed_payload(&result.item));
     Some(notify::dispatch(&event))
 }
 
@@ -267,6 +208,7 @@ fn emit_progress(run_id: &str, run: &RunRecord, poll_count: u64) {
 mod tests {
     use std::cell::Cell;
     use std::collections::VecDeque;
+    use std::time::Duration;
 
     use super::*;
 
@@ -282,7 +224,9 @@ mod tests {
         }
     }
 
-    impl RunPoller for ScriptedPoller {
+    impl WatchPoller for ScriptedPoller {
+        type Item = RunRecord;
+
         fn poll(&self, run_id: &str) -> homeboy::core::Result<RunRecord> {
             let mut states = self.states.borrow_mut();
             // Hold the last scripted state once the queue is down to one entry,
@@ -293,6 +237,10 @@ mod tests {
                 *states.front().expect("at least one scripted status")
             };
             Ok(run_record(run_id, status))
+        }
+
+        fn is_terminal(&self, run: &RunRecord) -> bool {
+            is_terminal_status(&run.status)
         }
     }
 
@@ -322,10 +270,13 @@ mod tests {
 
     /// Drive the loop with a virtual clock: each simulated sleep advances time,
     /// so timeouts are exercised without real waiting.
-    fn run_loop(poller: &ScriptedPoller, cfg: &WatchConfig) -> homeboy::core::Result<WatchResult> {
+    fn run_loop(
+        poller: &ScriptedPoller,
+        cfg: &WatchConfig,
+    ) -> homeboy::core::Result<WatchResult<RunRecord>> {
         let clock = Cell::new(Duration::ZERO);
         let advance = |by: Duration| clock.set(clock.get() + by);
-        run_watch_loop(
+        watch_loop(
             poller,
             "run-1",
             cfg,

--- a/crates/homeboy-cli/src/commands/triage.rs
+++ b/crates/homeboy-cli/src/commands/triage.rs
@@ -87,7 +87,18 @@ pub struct TriageArgs {
     timeout: String,
 
     /// Delay between GitHub polls.
-    #[arg(long, global = true, value_name = "DURATION", default_value = "60s")]
+    ///
+    /// Spelled `--interval` to match `activity watch` and `runs watch`, whose
+    /// operators otherwise have to remember a third vocabulary for the same
+    /// concept (#10315). `--poll-interval` is retained as a visible alias
+    /// because it is a published spelling; nothing that worked stops working.
+    #[arg(
+        long = "interval",
+        visible_alias = "poll-interval",
+        global = true,
+        value_name = "DURATION",
+        default_value = "60s"
+    )]
     poll_interval: String,
 }
 
@@ -347,6 +358,47 @@ mod tests {
         assert_eq!(cli.args.timeout, "5m");
         assert_eq!(cli.args.poll_interval, "30s");
         assert!(cli.args.command.is_none());
+    }
+
+    /// `--interval` is the canonical spelling shared with `activity watch` and
+    /// `runs watch`; `--poll-interval` is the published spelling this command
+    /// shipped with. Both must resolve to the same field, and the default must
+    /// not move.
+    #[test]
+    fn watch_interval_accepts_both_spellings() {
+        for spelling in ["--interval", "--poll-interval"] {
+            let cli = TestCli::try_parse_from([
+                "triage",
+                "--watch",
+                "Extra-Chill/homeboy#2238",
+                spelling,
+                "45s",
+            ])
+            .unwrap_or_else(|error| panic!("{spelling} should parse: {error}"));
+            assert_eq!(cli.args.poll_interval, "45s", "{spelling}");
+        }
+
+        let default = TestCli::try_parse_from(["triage", "--watch", "Extra-Chill/homeboy#2238"])
+            .expect("bare watch parses");
+        assert_eq!(default.args.poll_interval, "60s");
+    }
+
+    /// The two spellings are one argument, not two: supplying both is a
+    /// duplicate value for the same id, and the last one wins rather than
+    /// silently producing two independent intervals.
+    #[test]
+    fn watch_interval_spellings_are_one_argument() {
+        let cli = TestCli::try_parse_from([
+            "triage",
+            "--watch",
+            "Extra-Chill/homeboy#2238",
+            "--poll-interval",
+            "30s",
+            "--interval",
+            "45s",
+        ])
+        .expect("both spellings parse");
+        assert_eq!(cli.args.poll_interval, "45s");
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/utils/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/mod.rs
@@ -4,4 +4,7 @@ pub mod execution_provenance;
 pub mod resolve;
 pub mod resource_policy;
 pub mod response;
+#[cfg(test)]
+mod scope_boundary_tests;
 pub mod tty;
+pub mod watch;

--- a/crates/homeboy-cli/src/commands/utils/scope_boundary_tests.rs
+++ b/crates/homeboy-cli/src/commands/utils/scope_boundary_tests.rs
@@ -1,0 +1,229 @@
+//! Pins the boundary of the shared [`ScopeArgs`](super::args::ScopeArgs) group.
+//!
+//! #10312 asked for `Scope` to be promoted to a clap arg group and flattened
+//! into eight commands. Three of them (`triage landing`, `build`, `status`)
+//! migrated in #10510. The other five did **not**, and each refusal is a real
+//! property of that command's argument shape rather than an omission:
+//!
+//! | Command | Why it is not one scope |
+//! |---|---|
+//! | `deploy` | Its selectors *combine* (`deploy --project P --component C`) instead of excluding each other. |
+//! | `refactor` | `-c/--component` is `Append` and `--components` is delimited — a multi-entity target. Its `component`/`path` arg ids also already collide with the group's. |
+//! | `release` | `--project` carries the short `-p`, which the deliberately long-only group cannot supply, and `--path` is a per-component checkout override. |
+//! | `cleanup artifacts` | Has no entity selection at all; flattening would add five flags with nothing behind them. |
+//! | `review` | Already delegates to `PositionalComponentArgs`; there is no six-way switch to remove. |
+//!
+//! Prose in a merged PR body does not survive contact with the next cook, so
+//! the reasons live here as executable assertions. If one of these commands
+//! *should* migrate, these tests are the checklist of what has to change with
+//! it — every one of them is a user-facing invocation that would break.
+//!
+//! Lives in its own file rather than inside `args.rs`'s `mod tests` because
+//! `args.rs` is already the largest file in `commands/utils` and the audit
+//! flags god files.
+
+use crate::cli_surface::Cli;
+use clap::{Command, CommandFactory, Parser};
+
+/// Every selector the shared group owns.
+const SHARED_GROUP: [&str; 6] = ["project", "fleet", "component", "rig", "path", "workspace"];
+
+/// The command nodes #10510 migrated onto the shared group.
+const MIGRATED: [&[&str]; 3] = [&["triage", "landing"], &["build"], &["status"]];
+
+fn parses(argv: &[&str]) -> bool {
+    Cli::try_parse_from(argv).is_ok()
+}
+
+fn node<'a>(root: &'a Command, path: &[&str]) -> &'a Command {
+    let mut current = root;
+    for name in path {
+        current = current
+            .find_subcommand(name)
+            .unwrap_or_else(|| panic!("`{name}` should exist in the command tree"));
+    }
+    current
+}
+
+fn declared_longs(command: &Command) -> Vec<&str> {
+    command
+        .get_arguments()
+        .filter_map(clap::Arg::get_long)
+        .collect()
+}
+
+fn declared_ids(command: &Command) -> Vec<&str> {
+    command
+        .get_arguments()
+        .map(|arg| arg.get_id().as_str())
+        .collect()
+}
+
+/// The migrated commands really do carry the whole group, so a regression that
+/// silently drops one selector is caught here and not by an operator.
+#[test]
+fn migrated_commands_carry_the_whole_shared_group() {
+    let root = Cli::command();
+    for path in MIGRATED {
+        let longs = declared_longs(node(&root, path));
+        for selector in SHARED_GROUP {
+            assert!(
+                longs.contains(&selector),
+                "`homeboy {}` should declare --{selector}",
+                path.join(" ")
+            );
+        }
+    }
+}
+
+/// `--fleet` is only ever an entity choice, and entity choice is the shared
+/// group's job. Any node that declares `--fleet` without the rest of the group
+/// is a hand-rolled selector — exactly the duplication #10312 exists to kill.
+///
+/// `deploy` is the one deliberate exception and is asserted by name so that
+/// migrating it, or adding a second exception, is a reviewed decision rather
+/// than a silent one.
+#[test]
+fn hand_rolled_entity_selection_is_confined_to_deploy() {
+    fn collect(command: &Command, path: &mut Vec<String>, out: &mut Vec<String>) {
+        let longs = declared_longs(command);
+        if longs.contains(&"fleet") && !SHARED_GROUP.iter().all(|selector| longs.contains(selector))
+        {
+            out.push(path.join(" "));
+        }
+        for subcommand in command.get_subcommands() {
+            path.push(subcommand.get_name().to_string());
+            collect(subcommand, path, out);
+            path.pop();
+        }
+    }
+
+    let mut offenders = Vec::new();
+    collect(
+        &Cli::command(),
+        &mut vec!["homeboy".to_string()],
+        &mut offenders,
+    );
+    offenders.sort();
+
+    assert_eq!(
+        offenders,
+        vec!["homeboy deploy".to_string()],
+        "a command declares --fleet outside the shared scope group; either \
+         flatten ScopeArgs into it or document why its selectors combine",
+    );
+}
+
+/// `deploy`'s selectors are additive, not exclusive: `--project P --component C`
+/// means "these components, on that project". The shared group makes exactly
+/// that combination a parse error, so flattening it here would break a
+/// documented recipe (`DEPLOY_RECIPES`, `deploy.rs:17`).
+#[test]
+fn deploy_combines_selectors_the_shared_group_makes_exclusive() {
+    assert!(parses(&[
+        "homeboy",
+        "deploy",
+        "--project",
+        "growth",
+        "--component",
+        "homeboy",
+    ]));
+    assert!(parses(&["homeboy", "deploy", "-p", "growth", "--shared"]));
+    // ...and its `--component` is a multi-value target, not one entity.
+    assert!(parses(&["homeboy", "deploy", "-c", "alpha", "-c", "beta"]));
+}
+
+/// `refactor` targets many components at once. The group is one entity.
+#[test]
+fn refactor_targets_many_components_at_once() {
+    assert!(parses(&[
+        "homeboy",
+        "refactor",
+        "rename",
+        "--from",
+        "alpha",
+        "--to",
+        "beta",
+        "--component",
+        "one",
+        "--component",
+        "two",
+    ]));
+    assert!(parses(&[
+        "homeboy",
+        "refactor",
+        "rename",
+        "--from",
+        "alpha",
+        "--to",
+        "beta",
+        "--components",
+        "one,two",
+    ]));
+}
+
+/// Beyond the semantics, `refactor` cannot even flatten the group *alongside*
+/// its existing args: it already owns the `component` and `path` arg ids
+/// through `PositionalComponentArgs`, and clap rejects duplicate ids.
+#[test]
+fn refactor_already_owns_the_arg_ids_the_shared_group_needs() {
+    let root = Cli::command();
+    let ids = declared_ids(node(&root, &["refactor"]));
+    assert!(ids.contains(&"component"), "refactor declares `component`");
+    assert!(ids.contains(&"path"), "refactor declares `path`");
+}
+
+/// `release --project` is spelled `-p` too. The shared group is deliberately
+/// long-flag-only — `deploy -p`, `deploy -c`, and `refactor -c` already mean
+/// different things — so migrating `release` would silently delete a short flag
+/// that automation uses.
+#[test]
+fn release_project_selector_keeps_a_short_flag_the_group_cannot_supply() {
+    assert!(parses(&["homeboy", "release", "-p", "growth"]));
+    assert!(parses(&["homeboy", "release", "--project", "growth"]));
+
+    let root = Cli::command();
+    let landing = node(&root, &["triage", "landing"]);
+    let project = landing
+        .get_arguments()
+        .find(|arg| arg.get_id().as_str() == "project")
+        .expect("the shared group declares --project");
+    assert!(
+        project.get_short().is_none(),
+        "ScopeArgs is long-flag-only by construction",
+    );
+}
+
+/// `cleanup artifacts` selects a *checkout root*, not an entity. There is no
+/// project, fleet, rig, or component concept behind it, so flattening the group
+/// would advertise five flags with nothing implementing them.
+#[test]
+fn cleanup_artifacts_has_no_entity_selection_to_migrate() {
+    assert!(parses(&[
+        "homeboy",
+        "cleanup",
+        "artifacts",
+        "--path",
+        "/tmp/checkout",
+    ]));
+    for selector in ["--project", "--fleet", "--component", "--rig"] {
+        assert!(
+            !parses(&["homeboy", "cleanup", "artifacts", selector, "x"]),
+            "{selector} should not exist on cleanup artifacts",
+        );
+    }
+    assert!(!parses(&["homeboy", "cleanup", "artifacts", "--workspace"]));
+}
+
+/// `review` selects one component positionally through the older shared group
+/// (`PositionalComponentArgs`). There was never a six-way switch here to remove.
+#[test]
+fn review_selects_a_component_positionally() {
+    assert!(parses(&["homeboy", "review", "--path", "/tmp/checkout"]));
+    for selector in ["--fleet", "--rig"] {
+        assert!(
+            !parses(&["homeboy", "review", selector, "x"]),
+            "{selector} should not exist on review",
+        );
+    }
+}

--- a/crates/homeboy-cli/src/commands/utils/watch.rs
+++ b/crates/homeboy-cli/src/commands/utils/watch.rs
@@ -1,0 +1,300 @@
+//! One poll loop for every `homeboy ... watch` command.
+//!
+//! `activity watch` and `runs watch` each grew their own copy of the same
+//! bounded poll loop, the same `124` timeout exit code, and the same
+//! terminal/timeout conclusion shape (#10315). They are **not** the same
+//! command — see [`WatchPoller::Item`] — but the loop between them is
+//! identical, so it lives here once and each command supplies only what is
+//! genuinely its own: what it polls, when that is terminal, and how it renders
+//! the result.
+//!
+//! The loop is generic over the poller, the sleep function, and the clock so a
+//! test can drive it deterministically without a store, a real clock, or real
+//! sleeps.
+
+use std::time::Duration;
+
+/// Exit code returned when a watch did not settle before its timeout.
+///
+/// Matches the GNU `timeout(1)` convention so wrappers can recognize the case.
+/// Every watch surface shares this constant; it used to be declared once per
+/// watch command, which is exactly how two commands drift.
+pub const TIMEOUT_EXIT_CODE: i32 = 124;
+
+/// "Fetch the current state of the thing being watched", abstracted so the loop
+/// is testable without a real store, clock, or sleeps.
+pub trait WatchPoller {
+    /// The polled snapshot.
+    ///
+    /// This is an associated type rather than one shared record because the
+    /// watch surfaces poll genuinely different domains: `runs watch` polls a
+    /// `RunRecord` out of the observation store, while `activity watch` polls
+    /// an `ActivityItem` — a projection across the observation store, the
+    /// agent-task store, runner sessions, and daemon jobs, which has no
+    /// `RunRecord` behind it at all.
+    type Item;
+
+    /// Read the current snapshot for `id`.
+    fn poll(&self, id: &str) -> homeboy::core::Result<Self::Item>;
+
+    /// True when the snapshot has settled and the watch should return.
+    ///
+    /// Owned by the poller because "terminal" is a per-domain judgement: a run
+    /// status the caller cannot classify is treated as terminal so the watch
+    /// surfaces it rather than blocking forever, and an activity item is
+    /// terminal exactly when it is no longer queued or running.
+    fn is_terminal(&self, item: &Self::Item) -> bool;
+}
+
+/// The two bounds every watch loop runs under.
+#[derive(Debug, Clone, Copy)]
+pub struct WatchConfig {
+    /// Delay between polls.
+    pub interval: Duration,
+    /// Total wall-clock bound, or `None` for an intentional indefinite watch.
+    pub timeout: Option<Duration>,
+}
+
+/// Why the loop returned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchConclusion {
+    /// The watched item reached a terminal state.
+    Terminal,
+    /// [`WatchConfig::timeout`] expired first.
+    TimedOut,
+}
+
+/// The last-seen snapshot plus the loop's accounting.
+pub struct WatchResult<T> {
+    pub item: T,
+    pub conclusion: WatchConclusion,
+    pub poll_count: u64,
+    pub waited: Duration,
+}
+
+impl<T> WatchResult<T> {
+    pub fn timed_out(&self) -> bool {
+        self.conclusion == WatchConclusion::TimedOut
+    }
+}
+
+/// Poll `id` until it settles or the timeout expires.
+///
+/// Ordering is load-bearing and is the shape both commands already had: poll,
+/// report progress, check terminal, *then* check the timeout. A snapshot that
+/// is terminal on the poll that also exhausts the timeout is reported as
+/// terminal, not as a timeout.
+pub fn watch_loop<P, S, C>(
+    poller: &P,
+    id: &str,
+    config: &WatchConfig,
+    mut sleep: S,
+    elapsed: C,
+    mut progress: impl FnMut(&P::Item, u64),
+) -> homeboy::core::Result<WatchResult<P::Item>>
+where
+    P: WatchPoller,
+    S: FnMut(Duration),
+    C: Fn() -> Duration,
+{
+    let mut poll_count: u64 = 0;
+    loop {
+        let item = poller.poll(id)?;
+        poll_count += 1;
+        progress(&item, poll_count);
+
+        if poller.is_terminal(&item) {
+            return Ok(WatchResult {
+                item,
+                conclusion: WatchConclusion::Terminal,
+                poll_count,
+                waited: elapsed(),
+            });
+        }
+
+        if let Some(timeout) = config.timeout {
+            if elapsed() >= timeout {
+                return Ok(WatchResult {
+                    item,
+                    conclusion: WatchConclusion::TimedOut,
+                    poll_count,
+                    waited: elapsed(),
+                });
+            }
+        }
+
+        sleep(config.interval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
+
+    /// A poller over a trivial item type, so these tests exercise the loop
+    /// itself rather than either command's domain model.
+    struct ScriptedPoller {
+        states: RefCell<VecDeque<&'static str>>,
+        polled_ids: RefCell<Vec<String>>,
+    }
+
+    impl ScriptedPoller {
+        fn new(states: &[&'static str]) -> Self {
+            Self {
+                states: RefCell::new(states.iter().copied().collect()),
+                polled_ids: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl WatchPoller for ScriptedPoller {
+        type Item = &'static str;
+
+        fn poll(&self, id: &str) -> homeboy::core::Result<Self::Item> {
+            self.polled_ids.borrow_mut().push(id.to_string());
+            let mut states = self.states.borrow_mut();
+            // Hold the last scripted state once the queue is down to one entry,
+            // so a "never terminal" script can be polled indefinitely.
+            if states.len() > 1 {
+                Ok(states.pop_front().expect("non-empty script"))
+            } else {
+                Ok(*states.front().expect("at least one scripted state"))
+            }
+        }
+
+        fn is_terminal(&self, item: &Self::Item) -> bool {
+            *item != "running"
+        }
+    }
+
+    fn config(timeout_secs: Option<u64>) -> WatchConfig {
+        WatchConfig {
+            interval: Duration::from_secs(1),
+            timeout: timeout_secs.map(Duration::from_secs),
+        }
+    }
+
+    /// Drive the loop with a virtual clock: each simulated sleep advances time,
+    /// so timeouts are exercised without real waiting.
+    fn drive(
+        poller: &ScriptedPoller,
+        cfg: &WatchConfig,
+    ) -> homeboy::core::Result<WatchResult<&'static str>> {
+        let clock = Cell::new(Duration::ZERO);
+        watch_loop(
+            poller,
+            "watched-1",
+            cfg,
+            |by| clock.set(clock.get() + by),
+            || clock.get(),
+            |_item, _poll| {},
+        )
+    }
+
+    #[test]
+    fn loop_returns_on_the_first_terminal_snapshot() {
+        let poller = ScriptedPoller::new(&["running", "running", "pass"]);
+        let result = drive(&poller, &config(None)).expect("loop");
+        assert_eq!(result.conclusion, WatchConclusion::Terminal);
+        assert!(!result.timed_out());
+        assert_eq!(result.poll_count, 3);
+        assert_eq!(result.item, "pass");
+    }
+
+    #[test]
+    fn loop_times_out_when_the_item_never_settles() {
+        let poller = ScriptedPoller::new(&["running"]);
+        let result = drive(&poller, &config(Some(3))).expect("loop");
+        assert_eq!(result.conclusion, WatchConclusion::TimedOut);
+        assert!(result.timed_out());
+        assert_eq!(result.item, "running");
+        assert!(result.waited >= Duration::from_secs(3));
+    }
+
+    #[test]
+    fn a_terminal_snapshot_wins_over_an_expired_timeout() {
+        // Terminal is checked before the timeout, so an item that settles on the
+        // same poll that exhausts the budget is reported as terminal.
+        let poller = ScriptedPoller::new(&["pass"]);
+        let result = drive(&poller, &config(Some(0))).expect("loop");
+        assert_eq!(result.conclusion, WatchConclusion::Terminal);
+        assert_eq!(result.poll_count, 1);
+    }
+
+    #[test]
+    fn an_already_terminal_item_never_sleeps() {
+        let poller = ScriptedPoller::new(&["pass"]);
+        let slept = Cell::new(0u32);
+        let clock = Cell::new(Duration::ZERO);
+        let result = watch_loop(
+            &poller,
+            "watched-1",
+            &config(None),
+            |_| slept.set(slept.get() + 1),
+            || clock.get(),
+            |_item, _poll| {},
+        )
+        .expect("loop");
+        assert_eq!(result.poll_count, 1);
+        assert_eq!(slept.get(), 0);
+    }
+
+    #[test]
+    fn progress_is_reported_once_per_poll_with_a_monotonic_count() {
+        let poller = ScriptedPoller::new(&["running", "running", "fail"]);
+        let clock = Cell::new(Duration::ZERO);
+        let observed = RefCell::new(Vec::new());
+        watch_loop(
+            &poller,
+            "watched-1",
+            &config(None),
+            |by| clock.set(clock.get() + by),
+            || clock.get(),
+            |item, poll| observed.borrow_mut().push((*item, poll)),
+        )
+        .expect("loop");
+        assert_eq!(
+            observed.into_inner(),
+            vec![("running", 1), ("running", 2), ("fail", 3)]
+        );
+    }
+
+    #[test]
+    fn every_poll_uses_the_requested_id() {
+        let poller = ScriptedPoller::new(&["running", "running", "pass"]);
+        drive(&poller, &config(None)).expect("loop");
+        assert_eq!(
+            poller.polled_ids.into_inner(),
+            vec!["watched-1".to_string(); 3]
+        );
+    }
+
+    #[test]
+    fn a_poll_error_aborts_the_loop() {
+        struct FailingPoller;
+        impl WatchPoller for FailingPoller {
+            type Item = ();
+
+            fn poll(&self, _id: &str) -> homeboy::core::Result<Self::Item> {
+                Err(homeboy::core::Error::internal_unexpected("poll failed"))
+            }
+
+            fn is_terminal(&self, _item: &Self::Item) -> bool {
+                unreachable!("a failing poll never yields an item")
+            }
+        }
+
+        let clock = Cell::new(Duration::ZERO);
+        let result = watch_loop(
+            &FailingPoller,
+            "watched-1",
+            &config(None),
+            |_| {},
+            || clock.get(),
+            |_item, _poll| {},
+        );
+        assert!(result.is_err());
+    }
+}

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -47,8 +47,10 @@ component-first, target-first, environment, and workspace commands.
 ```sh
 homeboy triage --watch Extra-Chill/homeboy#2238 --until merged
 homeboy triage --watch Extra-Chill/homeboy#2238 --until green-mergeable --auto-merge
-homeboy triage --watch https://github.com/Extra-Chill/homeboy#2238 --until closed --timeout 10m --poll-interval 30s
+homeboy triage --watch https://github.com/Extra-Chill/homeboy#2238 --until closed --timeout 10m --interval 30s
 ```
+
+`--interval` is the same spelling `homeboy activity watch` and `homeboy runs watch` use for the delay between polls. `--poll-interval` remains a visible alias, so existing automation keeps working.
 
 Supported `--until` states:
 

--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -6,7 +6,7 @@ Hand-written narrative for these commands lives in `docs/commands/`. -->
 
 # Homeboy CLI reference (generated)
 
-`homeboy` exposes 524 visible commands across 40 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
+`homeboy` exposes 523 visible commands across 40 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
 
 Hand-written narrative lives in the [commands index](../../../commands/commands-index.md). Global flags are documented in [the root command reference](../homeboy-root-command.md). Machine-readable safety, docs, output, and Lab metadata come from `homeboy contract manifest`.
 

--- a/docs/reference/cli/commands/runner.md
+++ b/docs/reference/cli/commands/runner.md
@@ -320,7 +320,7 @@ Inventory or remove stale managed Homeboy binary slots on a runner
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete eligible slots. Omit for inventory only |
-| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum slot age before an unselected slot is eligible |
+| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum slot age before an unselected slot is eligible. Defaults to the shared runner age floor (`cleanup::RUNNER_MIN_AGE_HOURS`) |
 
 ## `homeboy runner exec`
 
@@ -628,8 +628,8 @@ Preview or remove orphaned runner-side Lab workspaces
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete the previewed orphaned workspaces. Without this flag, the command is a dry run |
-| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum workspace age before it can be considered orphaned |
-| `--limit` | `<LIMIT>` | Maximum number of orphan candidates to report or remove |
+| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum workspace age before it can be considered orphaned. Defaults to the shared runner age floor (`cleanup::RUNNER_MIN_AGE_HOURS`) |
+| `--limit` | `<LIMIT>` | Maximum number of orphan candidates to report or remove per pass. Defaults to the shared page size (`cleanup::RUNNER_WORKSPACE_PAGE_LIMIT`) |
 | `--passes` | `<PASSES>` | Maximum apply passes to run. Each pass re-scans and removes at most --limit candidates |
 | `--cursor` | `<CURSOR>` | Opaque continuation cursor returned by an incomplete workspace-prune scan |
 

--- a/docs/reference/cli/commands/runs.md
+++ b/docs/reference/cli/commands/runs.md
@@ -30,7 +30,6 @@ Inspect persisted observation runs and artifacts
 | `homeboy runs fuzz-compare` | Compare two persisted fuzz runs by exact run id |
 | `homeboy runs hotspots` | Aggregate hotspot rankings across persisted fuzz run artifacts |
 | `homeboy runs reconcile` | Mark orphaned running observation records stale |
-| `homeboy runs retention` | Plan or apply bounded retention of terminal observation rows and dependent records |
 | `homeboy runs watch` | Block and stream a run's status until it reaches a terminal state, exiting with a code that reflects pass/fail. Works for attached and detached/offloaded runs |
 | `homeboy runs cancel` | Cooperatively cancel a persisted foreground run before its next stage |
 | `homeboy runs show` | Show one persisted observation run |
@@ -188,20 +187,6 @@ Mark orphaned running observation records stale
 | --- | --- | --- |
 | `--dry-run` | flag | Preview orphaned running records without mutating them |
 | `--limit` | `<LIMIT>` | Maximum running records to inspect |
-
-## `homeboy runs retention`
-
-```sh
-homeboy runs retention [OPTIONS]
-```
-
-Plan or apply bounded retention of terminal observation rows and dependent records
-
-| Option | Value | Description |
-| --- | --- | --- |
-| `--apply` | flag | Delete the planned terminal rows. Without this flag, only reports the plan |
-| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include terminal runs finished more than this many days ago |
-| `--limit` | `<LIMIT>` | Maximum terminal run rows to inspect and remove in one invocation |
 
 ## `homeboy runs watch`
 
@@ -457,13 +442,13 @@ Plan or delete persisted local run artifacts and their database records
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete planned artifact files/directories and their DB rows. Without this flag, only reports the plan |
-| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include artifacts older than this many days |
+| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include artifacts older than this many days. Defaults to the configured `retention.terminal_run_days` |
 | `--run-id` | `<RUN_ID>` | Limit cleanup to one run id |
 | `--kind` | `<KIND>` | Limit cleanup to one artifact kind |
 | `--type` | `<ARTIFACT_TYPE>` | Limit cleanup to one artifact type (`file` or `directory`) |
 | `--run-kind` | `<RUN_KIND>` | Limit cleanup to one run kind (`bench`, `trace`, etc.) |
 | `--component` | `<COMPONENT_ID>` | Limit cleanup to one component id |
-| `--limit` | `<LIMIT>` | Maximum artifact rows to inspect in one invocation |
+| `--limit` | `<LIMIT>` | Maximum artifact rows to inspect in one invocation. Defaults to the configured `retention.limit` |
 
 ## `homeboy runs artifact postprocess`
 

--- a/docs/reference/cli/commands/self.md
+++ b/docs/reference/cli/commands/self.md
@@ -63,11 +63,11 @@ Plan or delete orphaned Homeboy runtime temp entries
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete planned temp entries. Without this flag, only reports the plan |
-| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include entries older than this many days |
+| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include entries older than this many days. Defaults to the configured `retention.runtime_tmp_days` |
 | `--prefix` | `<PREFIX>` | Only include entries whose directory/file name starts with this prefix |
-| `--limit` | `<LIMIT>` | Maximum temp entries to inspect in one invocation |
-| `--run-max-bytes` | `<RUN_MAX_BYTES>` | Maximum aggregate bytes retained for failed runtime run evidence |
-| `--run-max-count` | `<RUN_MAX_COUNT>` | Maximum failed runtime run directories retained |
+| `--limit` | `<LIMIT>` | Maximum temp entries to inspect in one invocation. Defaults to the configured `retention.limit` |
+| `--run-max-bytes` | `<RUN_MAX_BYTES>` | Maximum aggregate bytes retained for failed runtime run evidence. Defaults to the configured `retention.runtime_run_max_bytes` |
+| `--run-max-count` | `<RUN_MAX_COUNT>` | Maximum failed runtime run directories retained. Defaults to the configured `retention.runtime_run_max_count` |
 | `--cursor` | `<CURSOR>` | Continue bounded runtime-run inspection from a prior next_cursor |
 
 ## `homeboy self docs`


### PR DESCRIPTION
Refs #10312, #10315.

## Verdict up front

- **#10315: `activity watch` and `runs watch` are NOT the same command.** They poll different stores, return different domain types, emit different output schemas, and differ deliberately in reconcile behaviour. What *was* duplicated is the poll loop, the `124` timeout constant, and the terminal/timeout conclusion shape. That is extracted; both commands, both names, and both wire shapes survive intact.
- **#10315's prescribed fix is not implementable as written** — see below.
- **#10312: all five remaining commands stay deferred**, with two of #10510's reasons upgraded to stronger ones. The reasons are now executable tests instead of prose in a merged PR body, plus a structural pin that stops a *new* hand-rolled six-way selector from appearing.
- **One live defect fixed** (the one #10538 surfaced): `activity watch --notify` silently ignored `--notification-route`.

---

## #10315 — evidence that they are not duplicates

| | `activity watch` | `runs watch` |
|---|---|---|
| resolver | `activity::resolve_activity` — a projection across the observation store, the agent-task store, runner sessions, and daemon jobs (`activity.rs:125-132` matches on `item.id`, `refs.run_id`, `refs.agent_task_run_id`, `refs.runner_job_id`) | `runs_service::require_run` — observation store, mirrored runner runs, run labels (`runs_service/run_lookup.rs:5-18`) |
| item type | `ActivityItem` / `ActivityState` (`= RunLifecycleStatus`) | `RunRecord` / `RunStatus` |
| output | `activity.watch` — `schema`, `id`, `state`, `item`, `next_actions` | `runs.watch` — `run_id`, `status`, `run` |
| reconciles on poll | **no**, deliberately | **yes**, deliberately |

The decisive one: **`homeboy runs watch <runner-job-id>` cannot work.** `require_run` never consults the runner-session, agent-task, or daemon-job sources, so it returns `missing_run_error`. `activity watch` is the only surface that can watch those ids. This is why `activity_run_ref` points observation runs at `homeboy runs watch` (`activity.rs:375`) while `activity_job_ref` points runner jobs at `homeboy activity watch` (`activity.rs:385`) — the issue read that as "the module points users at the other one", but it is a division of labour, not an accident.

The non-reconciling read is not incidental either: `activity_reads_do_not_reconcile_stale_running_records` asserts that a `watch` over a stale-owner run leaves the record byte-identical. Collapsing activity onto `StorePoller` would have broken that test and changed observable behaviour.

### The prescribed fix could not be taken literally

> Make `activity::watch` construct an `ActivityPoller: RunPoller` and call it.

`RunPoller::poll` returned `homeboy::core::Result<RunRecord>`. An activity item frequently has **no `RunRecord` behind it at all** (agent-task runs, runner jobs, controller jobs). So `ActivityPoller` could not implement `RunPoller`.

What is implementable — and what this PR does — is to make the loop generic over the polled item:

```rust
pub trait WatchPoller {
    type Item;
    fn poll(&self, id: &str) -> homeboy::core::Result<Self::Item>;
    fn is_terminal(&self, item: &Self::Item) -> bool;
}
```

`crates/homeboy-cli/src/commands/utils/watch.rs` owns the loop, `WatchConfig`, `WatchConclusion`, `WatchResult<T>`, and the single `TIMEOUT_EXIT_CODE = 124`. `runs/watch.rs::StorePoller` and `activity.rs::ActivityPoller` supply only what is genuinely theirs. `runs/watch.rs` loses `RunPoller`, its private `WatchConfig`/`WatchConclusion`/`WatchResult`/`run_watch_loop`, and its copy of the constant; `activity.rs` loses its hand-rolled loop and its copy of the constant.

### A divergence the issue did not mention: the two duration parsers are not interchangeable

`runs::common::parse_duration` **rejects zero** (`"duration amount must be greater than zero"`, `common.rs:105-112`). `activity::parse_duration` **accepts it** — and activity's own test depends on that, calling `watch(... timeout: "0s", interval: "0s" ...)`.

So the parsers are deliberately left alone. Unifying on the runs parser would break an existing test and forbid `activity watch --interval 0s`; unifying on the activity parser would let `runs watch --interval 0s` spin-poll and would leak into the `--since` parsing that `runs gh-actions`/`query`/`drift` share. The loop is shared; the parsers are not, and the reason is now in a comment.

### Live defect fixed

Confirmed the #10538 finding. `activity.rs` built its notification as:

```rust
NotifyEvent { ..., transport: None, route: None, payload: None }.with_payload(payload)
```

`notify::dispatch` falls back to `config.notifications.default_transport` when `event.transport` is `None`, and emits `--route` only when `event.route` is `Some`. So `homeboy activity watch <id> --notify --notification-transport X --notification-route Y` delivered to the *configured default* transport with **no route**. `--notification-route` was silently discarded by this command alone.

Fixed by reading `notification_route::current()` — the thread-local `cli_runtime.rs:562` binds for the whole invocation from `--notification-transport`/`--notification-route` or `HOMEBOY_NOTIFICATION_*`.

`runs watch` is deliberately left as-is: it reads `NotificationRoute::from_metadata(&run.metadata_json)`, i.e. the route `ObservationStore::start_run` stamped onto the record at creation (`observation/store/runs.rs:86-87`). That is the stronger, run-scoped contract. `activity watch` cannot use it — `ActivityItem` is a cross-store projection with no metadata channel — so the caller's explicit route is the available and requested answer. Noted in the code.

### `triage --poll-interval` → `--interval`

Aligned as the issue asked, with `visible_alias = "poll-interval"` (the `deploy.rs:53` pattern). Purely additive: nothing that parsed before stops parsing. Tests cover both spellings, the unchanged `60s` default, and that they are one argument rather than two.

### Two "other watch loops" the issue listed — one is, one isn't

- **`triage --watch`** (`homeboy-triage/src/watch.rs:174`) is a real poll loop, but over the GitHub REST API against `--until <STATE>` targets with optional `--auto-merge`. It shares no store, no item type, and no exit-code contract. Only the flag *vocabulary* was worth aligning, which is what this PR did.
- **`runner job logs --follow`** (`runner/jobs.rs:130,177`) is **not a watch loop of this shape** and the issue is wrong to list it as one. It is a log-streaming follow loop with transport reconnection (`MAX_RECONNECTS`), cursor emission for exactly-once resume, and a cooperative shutdown handler. It has **no timeout at all**, takes `--poll-ms` in milliseconds, and has no terminal-state exit-code contract. Converging it would change user-visible behaviour, not remove duplication.

### Not folded in

The "related gap" (multi-id / `--batch` watching) is feature work with a new resolver dependency on `agent_task_batch::status`, not consolidation. Left for its own issue.

---

## #10312 — per-command status for the remaining five

`#10510` migrated `triage landing`, `build`, `status`. All five remaining are **confirmed deferred**. Two reasons are stronger than the ones #10510 gave.

| Command | Status | Why |
|---|---|---|
| **`deploy`** | deferred (confirmed) | Its selectors **combine** rather than exclude: `deploy --project P --component C` is a documented recipe (`DEPLOY_RECIPES`, `deploy.rs:17`), and the shared group makes exactly that combination a parse error. `--component` is `Option<Vec<String>>`, a multi-value target. Test: `deploy_combines_selectors_the_shared_group_makes_exclusive`. |
| **`refactor`** | deferred (confirmed, **stronger reason**) | #10510 said "multi-entity target", which is true (`-c` is `Append`, `--components` is delimited). The harder blocker is mechanical: `refactor` **already owns the `component` and `path` arg ids** through its flattened `PositionalComponentArgs`, and `ScopeArgs` declares both. Flattening would be a duplicate-id panic, not a semantic debate. Tests: `refactor_targets_many_components_at_once`, `refactor_already_owns_the_arg_ids_the_shared_group_needs`. |
| **`release`** | deferred (confirmed, **stronger reason**) | #10510 cited `--project` composing with `--outdated`. The real blockers are (a) its positional is `components: Vec<String>` — `release comp-a comp-b` is a *multi*-component target, so the group's singular `--component` would be a second, conflicting spelling of the same thing; and (b) `--project` carries the short `-p`, which the deliberately long-only group cannot supply, so migrating would silently delete a published short flag. Its `--path` is also a per-component checkout override (`path_override`, `release/mod.rs:418`) that *composes* with the positional, not a standalone scope. Test: `release_project_selector_keeps_a_short_flag_the_group_cannot_supply`. |
| **`cleanup artifacts`** | deferred (confirmed) | No entity selection exists. `--path: PathBuf` selects a *checkout root* for managed-worktree discovery; `--self` targets the source checkout that built the binary. Flattening would advertise five flags with nothing implementing them and change `--path`'s type. Test: `cleanup_artifacts_has_no_entity_selection_to_migrate`. |
| **`review`** | deferred (confirmed) | Already delegates to `PositionalComponentArgs`. There was never a six-way switch here to remove. Test: `review_selects_a_component_positionally`. |

### The structural finding

**The duplication #10312 was filed about is gone.** A full-tree walk finds exactly one command node that declares `--fleet` without the rest of the shared group: `deploy`. `hand_rolled_entity_selection_is_confined_to_deploy` asserts that offender list **by exact value**, so adding a new hand-rolled six-way selector — or migrating `deploy` — fails the test and forces a reviewed decision. `migrated_commands_carry_the_whole_shared_group` pins the other direction for `triage landing` / `build` / `status`.

### `strip_component_target_args`

Unchanged, and still not deletable — #10510 is right and the issue is wrong. `route.rs` must hand a *rewritten argv* to a remote runner and clap cannot re-serialize a parsed `Commands` back to argv. (It has also drifted from the issue's cited location: `route.rs:2140`, not `:1817`.)

### Other single-`--project` selectors are not in scope

`runner exec`, `runner dispatch`, `extension list`, and `release changes` each declare a lone `--project`. None is a six-way switch; giving them fleet/rig/workspace paths is feature work, not consolidation.

---

## `--help` handshake: explicitly NOT broken

**One CLI surface change in this PR: `triage`'s `--poll-interval` gains the primary spelling `--interval` plus a `visible_alias`.**

- `negotiate_leaseless_recovery_contract` (`connection.rs:784-813`) parses **only** `homeboy daemon reconcile-leaseless-orphans --help`, and `declared_long_options` (`:815-837`) accepts only bare long options in the `Options:` block.
- `triage`'s `--timeout`/`--interval` are `global = true` on **`TriageArgs`**, not on `Cli`. They propagate to `triage`'s subcommands and nowhere else. They cannot appear in `daemon reconcile-leaseless-orphans --help`.
- `root_global_flag_surface_is_pinned` (#10554) lists the 14 root globals; neither `timeout` nor `interval`/`poll-interval` is among them, and this PR adds, removes, and renames **zero** root globals — so that test is untouched.
- No `daemon` argument, doc comment, or `--confirm-*` flag is touched.

Everything else in this PR is internal: a new non-command module, a poller trait, a notification-route read, and tests.

## Generated CLI docs: no regeneration needed

`reference_docs.rs::documented_options` (`:286-294`) filters out `arg.is_global_set()`. Every argument on `TriageArgs` is `global = true`, which is why `docs/reference/cli/commands/triage.md` has **no Options table for `homeboy triage` at all** today. The renamed flag is therefore invisible to the generated tree, and `cli_surface::reference_docs`' byte-match test is unaffected. Verified by inspection of the generated file; no other command surface changed.

`docs/commands/triage.md` (hand-written narrative) **was** updated, since it showed `--poll-interval` in a recipe.

## Corrections to the issues

**#10315:**
1. "the same command implemented twice" / "identical output field sets" — **wrong**. Six fields overlap (`terminal`, `timed_out`, `waited_secs`, `poll_count`, `notify`, `_homeboy_actionable`); `runs.watch` additionally has `run_id`/`status`/`run` and `activity.watch` has `schema`/`id`/`state`/`item`/`next_actions`. Different types, different resolvers, different stores.
2. "Make `activity::watch` construct an `ActivityPoller: RunPoller`" — **not implementable**; `RunPoller` yielded `RunRecord`.
3. `runner job logs --follow` listed as a comparable watch loop — **wrong shape**; see above.
4. Unmentioned: the two `parse_duration`s disagree on zero, and activity's own test depends on it.
5. Line refs drifted: `activity.rs:16` → `:21`; loop `:204-279` → `:209-284`; output fields `:77-97` → `:82-102`; `:370` → `:375`. `runs/watch.rs:33` and `:57-76` were correct.

**#10312:**
1. "Delete … `strip_component_target_args` (`route.rs` can construct `Scope::Path{..}` directly)" — **impossible**, as #10510 established. Also now at `:2140`.
2. "Flatten into … `refactor`, `review`, `cleanup`, `release`" — **four of those cannot take it**, and `refactor`'s blocker is a hard clap arg-id collision, not a judgement call.
3. Neither issue was already fixed on main; `git log` shows #10510 landed the partial `ScopeArgs` work and nothing since has touched either surface.

## What I could not verify without cargo

Per this host's constraints (16 GB shared; `cargo build`/`test`/`check`/`clippy` OOM the supervisor), **only `cargo fmt` was run** — and it was verified to actually reach the new files with a deliberate mis-format probe, per the #10565 lesson. Everything below is CI's to confirm:

- That it compiles. The higher-risk spots I reasoned through by hand: the `WatchResult<RunRecord>` partial move in `build_output` (reads `waited`/`poll_count` after `item` moves), temporary-lifetime binding of `Cli::command()` in the new structural tests, and `Vec<String> == Vec<&str>` / tuple-`PartialEq` inference in the new assertions.
- That `hand_rolled_entity_selection_is_confined_to_deploy` yields exactly `["homeboy deploy"]`. Established by grep, not by running it: the only fields producing `--fleet` in the entire workspace are `ScopeArgs::fleet` and `DeployArgs::fleet`, there is no `long = "fleet"` override anywhere, and every `derive(Args)` in the workspace lives in `homeboy-cli`.
- That the new parse assertions match clap's real behaviour, in particular `release -p growth` and `refactor rename --components one,two` resolving past their optional-subcommand ambiguity.
- That `watch_notification_delivers_to_the_bound_cli_route` reaches `missing_transport` under `with_isolated_home` rather than finding an installed transport.
- That `cargo fmt`'s macro blind spot (#10565) does not apply here — neither new module is declared inside a `macro_rules!` body, and the probe confirmed rustfmt reaches both.
