### PR TITLE
fix(lab): poll reverse staging through broker

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -2363,11 +2363,28 @@ impl ProductionLabStagingOperations {
                 events: observed.events,
             });
         }
+        let broker_url = Self::status_for_recipe_transport(request)?
+            .session
+            .and_then(|session| session.broker_url)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "runner",
+                    "durable reverse Lab staging requires its accepted broker endpoint",
+                    Some(request.recipe.runner_id.clone()),
+                    None,
+                )
+            })?;
         loop {
             if cancellation.is_some_and(LabStagingCancellationToken::is_cancelled) {
                 return Err(Self::cancellation_error());
             }
-            match crate::runner_job_log_snapshot(&request.recipe.runner_id, runner_job_id) {
+            match crate::connection::reverse_broker_job_snapshot_at(
+                &broker_url,
+                &request.recipe.runner_id,
+                runner_job_id,
+            )
+            .map(|(job, events)| homeboy_core::api_jobs::RunnerJobLogSnapshot { job, events })
+            {
                 Ok(snapshot) if snapshot.job.status.is_terminal() => return Ok(snapshot),
                 Ok(_) => std::thread::sleep(Duration::from_millis(200)),
                 Err(mut error) => {

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -329,6 +329,26 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         terminal_result.get("exit_code").is_some(),
         "broker terminal result preserves the typed payload: {terminal_result}"
     );
+    let broker_events: serde_json::Value =
+        reqwest::blocking::get(format!("{}/jobs/{}/events", broker.url(), completed.id))
+            .expect("fetch broker events over HTTP")
+            .json()
+            .expect("parse broker events response");
+    let broker_terminal_result = broker_events
+        .pointer("/data/body/events")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|events| {
+            events.iter().rev().find_map(|event| {
+                (event["kind"] == serde_json::json!("result")).then(|| event["data"].clone())
+            })
+        })
+        .expect("broker HTTP response retains terminal result");
+    serde_json::from_value::<homeboy::core::api_jobs::RemoteRunnerJobResult>(
+        broker_terminal_result.clone(),
+    )
+    .unwrap_or_else(|error| {
+        panic!("broker HTTP terminal result must retain its typed contract: {error}\nresult={broker_terminal_result}")
+    });
 
     let (_, duplicate_code) =
         homeboy::runner::run_reverse_worker(homeboy::runner::ReverseRunnerWorkerOptions {


### PR DESCRIPTION
## Summary

- make durable reverse staging poll its accepted broker transport directly
- preserve the existing daemon observer for direct SSH staging
- prove terminal result payloads survive broker HTTP before lifecycle projection

Closes #10582.

## Root cause

The reverse worker completed and persisted a valid terminal result, but the durable staging observer used generic daemon-generation lookup for `/jobs/<id>`. That lookup could resolve the controller daemon endpoint instead of the reverse broker job, leaving the parent agent-task lifecycle permanently running and preventing `project_terminal_runner_result`.

The repeated `missing field exit_code` messages were pre-terminal best-effort evidence refreshes against an empty result. The completed broker result remained valid across HTTP; the regression now proves that boundary explicitly.

## Evidence

- Main Guard: https://github.com/Extra-Chill/homeboy/actions/runs/30357149676
- Failing test job: https://github.com/Extra-Chill/homeboy/actions/runs/30357149676/job/90269549552
- Root-cause note: https://github.com/Extra-Chill/homeboy/issues/10582#issuecomment-5104466841

## Verification

- Before repair: exact acceptance failed locally in `432s` with the parent lifecycle still running.
- After repair: exact acceptance passed in `261s`.
- After rebase onto `60d3b49b6`: exact acceptance passed again in `199s`.
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## AI assistance

OpenCode using OpenAI `gpt-5.6-sol` reproduced the Main Guard failure, isolated broker payload integrity from observer routing, implemented the transport-explicit staging repair and regression, rebased the branch, and ran the verification above. Chris Huber remains responsible for every line.