### PR TITLE
fix: compare deployed package contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "homeboy-core",
  "homeboy-engine-primitives",
  "homeboy-extension",
+ "homeboy-paths",
  "homeboy-product-identity",
  "homeboy-release-contract",
  "libc",

--- a/crates/homeboy-release/Cargo.toml
+++ b/crates/homeboy-release/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-paths = { version = "0.1.0", path = "../homeboy-paths" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-release-contract = { version = "0.1.0", path = "../contracts/homeboy-release-contract" }

--- a/crates/homeboy-release/src/deploy/content_manifest.rs
+++ b/crates/homeboy-release/src/deploy/content_manifest.rs
@@ -1,18 +1,25 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Component as PathComponent, Path};
 use std::time::Duration;
 
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use homeboy_core::content_diff::{self, TreeEntry, TreeEntryKind, TreeScanOptions};
 use homeboy_core::engine::shell;
 use homeboy_core::server::SshClient;
+use homeboy_engine_primitives::content_hash;
 
-use super::types::ContentManifestComparison;
+use super::types::PreparedDeployArtifact;
+use super::types::{ContentManifestComparison, ContentManifestProvenance};
+use homeboy_core::git::release_download::ReleaseArtifactLease;
 
 const ALGORITHM: &str = "sha256-tree-v1";
-const SCOPE: &str = "deployed-tree-excluding-homeboy-runtime";
+const WORKSPACE_SCOPE: &str = "source-tree-installed-tree";
+const PACKAGE_SCOPE: &str = "canonical-package-installed-tree";
+const PACKAGE_UNAVAILABLE_SCOPE: &str = "canonical-package-unavailable";
 const MAX_DIFFERENCES: usize = 20;
 const PROBE_TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -35,13 +42,93 @@ fn deployed_tree_scan_options() -> TreeScanOptions {
     }
 }
 
-#[derive(Default)]
-struct Manifest {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct Entry {
+    kind: char,
+    mode: String,
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct SerializedManifest {
+    entries: BTreeMap<String, Entry>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct Manifest {
     entries: BTreeMap<String, TreeEntry>,
 }
 
+impl PartialEq for Manifest {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries.len() == other.entries.len()
+            && self.entries.iter().all(|(path, entry)| {
+                other
+                    .entries
+                    .get(path)
+                    .is_some_and(|other| entry.matches(other))
+            })
+    }
+}
+
+impl Eq for Manifest {}
+
+impl Serialize for Manifest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let entries = self
+            .entries
+            .iter()
+            .map(|(path, entry)| {
+                (
+                    path,
+                    Entry {
+                        kind: entry.kind.tag(),
+                        mode: entry.mode.clone(),
+                        value: entry.value.clone(),
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut manifest = serializer.serialize_struct("Manifest", 1)?;
+        manifest.serialize_field("entries", &entries)?;
+        manifest.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Manifest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let entries = SerializedManifest::deserialize(deserializer)?
+            .entries
+            .into_iter()
+            .map(|(path, entry)| {
+                let kind = match entry.kind {
+                    'f' => TreeEntryKind::File,
+                    'l' => TreeEntryKind::Symlink,
+                    _ => return Err(serde::de::Error::custom("invalid manifest entry kind")),
+                };
+                Ok((
+                    path,
+                    TreeEntry {
+                        kind,
+                        mode: entry.mode,
+                        value: entry.value,
+                        bytes: 0,
+                    },
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, D::Error>>()?;
+        Ok(Self { entries })
+    }
+}
+
 impl Manifest {
-    fn digest(&self) -> String {
+    pub(super) fn digest(&self) -> String {
         let mut hash = Sha256::new();
         for (path, entry) in &self.entries {
             hash.update(path.as_bytes());
@@ -55,17 +142,65 @@ impl Manifest {
         }
         format!("{:x}", hash.finalize())
     }
+
+    pub(super) fn validate(&self) -> Result<(), String> {
+        for (path, entry) in &self.entries {
+            if normalize_path(path)? != *path {
+                return Err("receipt manifest contains an invalid entry".to_string());
+            }
+            if entry.kind == TreeEntryKind::File
+                && (entry.mode != "0" && entry.mode != "1"
+                    || entry.value.len() != 64
+                    || !entry.value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+            {
+                return Err("receipt manifest contains an invalid file entry".to_string());
+            }
+            if entry.kind == TreeEntryKind::Symlink
+                && validate_link_target(path, &entry.value)? != entry.value
+            {
+                return Err("receipt manifest contains an invalid symlink entry".to_string());
+            }
+        }
+        Ok(())
+    }
 }
 
-pub(super) fn compare(local: &Path, remote: &str, client: &SshClient) -> ContentManifestComparison {
+pub(super) fn compare(
+    local: &Path,
+    remote: &str,
+    client: &SshClient,
+    _exclusions: &[String],
+) -> ContentManifestComparison {
     let local = match local_manifest(local) {
         Ok(manifest) => manifest,
-        Err(error) => return unavailable(format!("local manifest unavailable: {error}")),
+        Err(error) => {
+            return unavailable(
+                format!("local manifest unavailable: {error}"),
+                WORKSPACE_SCOPE,
+                None,
+            )
+        }
     };
-    let remote = match remote_manifest(remote, client) {
+    let remote = match remote_manifest(remote, client, &[]) {
         Ok(Some(manifest)) => manifest,
-        Ok(None) => return comparison(&local, None, "missing", Vec::new(), None),
-        Err(error) => return unavailable(format!("remote manifest unavailable: {error}")),
+        Ok(None) => {
+            return comparison(
+                &local,
+                None,
+                "missing",
+                Vec::new(),
+                None,
+                WORKSPACE_SCOPE,
+                None,
+            )
+        }
+        Err(error) => {
+            return unavailable(
+                format!("remote manifest unavailable: {error}"),
+                WORKSPACE_SCOPE,
+                None,
+            )
+        }
     };
     let differences = differences(&local, &remote);
     let status = if differences.is_empty() {
@@ -73,7 +208,15 @@ pub(super) fn compare(local: &Path, remote: &str, client: &SshClient) -> Content
     } else {
         "different"
     };
-    comparison(&local, Some(&remote), status, differences, None)
+    comparison(
+        &local,
+        Some(&remote),
+        status,
+        differences,
+        None,
+        WORKSPACE_SCOPE,
+        None,
+    )
 }
 
 /// Compare a deployed tree with the canonical archive selected for deployment.
@@ -82,17 +225,39 @@ pub(super) fn compare_archive(
     archive: &Path,
     remote: &str,
     client: &SshClient,
+    exclusions: &[String],
+    artifact: Option<&ReleaseArtifactLease>,
 ) -> ContentManifestComparison {
-    let local = match archive_manifest(archive) {
+    let local = match archive_manifest(archive, exclusions) {
         Ok(manifest) => manifest,
         Err(error) => {
-            return unavailable(format!("canonical package manifest unavailable: {error}"))
+            return unavailable(
+                format!("canonical package manifest unavailable: {error}"),
+                PACKAGE_SCOPE,
+                artifact_provenance(artifact),
+            )
         }
     };
-    let remote = match remote_manifest(remote, client) {
+    let remote = match remote_manifest(remote, client, exclusions) {
         Ok(Some(manifest)) => manifest,
-        Ok(None) => return comparison(&local, None, "missing", Vec::new(), None),
-        Err(error) => return unavailable(format!("remote manifest unavailable: {error}")),
+        Ok(None) => {
+            return comparison(
+                &local,
+                None,
+                "missing",
+                Vec::new(),
+                None,
+                PACKAGE_SCOPE,
+                artifact_provenance(artifact),
+            )
+        }
+        Err(error) => {
+            return unavailable(
+                format!("remote manifest unavailable: {error}"),
+                PACKAGE_SCOPE,
+                artifact_provenance(artifact),
+            )
+        }
     };
     let differences = differences(&local, &remote);
     let status = if differences.is_empty() {
@@ -100,7 +265,94 @@ pub(super) fn compare_archive(
     } else {
         "different"
     };
-    comparison(&local, Some(&remote), status, differences, None)
+    comparison(
+        &local,
+        Some(&remote),
+        status,
+        differences,
+        None,
+        PACKAGE_SCOPE,
+        artifact_provenance(artifact),
+    )
+}
+
+pub(super) fn package_manifest(archive: &Path, exclusions: &[String]) -> Result<Manifest, String> {
+    archive_manifest(archive, exclusions)
+}
+
+pub(super) fn compare_saved_package_manifest(
+    local: &Manifest,
+    remote: &str,
+    client: &SshClient,
+    exclusions: &[String],
+    provenance: ContentManifestProvenance,
+) -> ContentManifestComparison {
+    let remote = match remote_manifest(remote, client, exclusions) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => {
+            return comparison(
+                local,
+                None,
+                "missing",
+                Vec::new(),
+                None,
+                PACKAGE_SCOPE,
+                Some(provenance),
+            )
+        }
+        Err(error) => {
+            return unavailable(
+                format!("remote manifest unavailable: {error}"),
+                PACKAGE_SCOPE,
+                Some(provenance),
+            )
+        }
+    };
+    let differences = differences(local, &remote);
+    comparison(
+        local,
+        Some(&remote),
+        if differences.is_empty() {
+            "match"
+        } else {
+            "different"
+        },
+        differences,
+        None,
+        PACKAGE_SCOPE,
+        Some(provenance),
+    )
+}
+
+pub(super) fn compare_prepared_archive(
+    archive: &Path,
+    remote: &str,
+    client: &SshClient,
+    exclusions: &[String],
+    artifact: &PreparedDeployArtifact,
+) -> ContentManifestComparison {
+    match sha256(archive) {
+        Ok(actual) if actual == artifact.sha256 => compare_archive_with_provenance(
+            archive,
+            remote,
+            client,
+            exclusions,
+            prepared_artifact_provenance(artifact),
+        ),
+        Ok(actual) => canonical_package_unavailable_with_provenance(
+            format!(
+                "prepared package SHA-256 mismatch for '{}': expected {}, got {}",
+                archive.display(),
+                artifact.sha256,
+                actual
+            ),
+            prepared_artifact_provenance_without_sha(artifact),
+        ),
+        Err(error) => canonical_package_unavailable_with_provenance(
+            format!("prepared package unavailable: {error}"),
+            prepared_artifact_provenance_without_sha(artifact),
+        ),
+    }
 }
 
 fn comparison(
@@ -109,10 +361,13 @@ fn comparison(
     status: &str,
     differences: Vec<String>,
     diagnostic: Option<String>,
+    scope: &str,
+    provenance: Option<ContentManifestProvenance>,
 ) -> ContentManifestComparison {
     ContentManifestComparison {
         algorithm: ALGORITHM.to_string(),
-        scope: SCOPE.to_string(),
+        scope: scope.to_string(),
+        provenance,
         local_digest: Some(local.digest()),
         remote_digest: remote.map(Manifest::digest),
         status: status.to_string(),
@@ -121,10 +376,167 @@ fn comparison(
     }
 }
 
-fn unavailable(diagnostic: String) -> ContentManifestComparison {
+pub(super) fn verify_archive_hash(
+    archive: &Path,
+    artifact: &ReleaseArtifactLease,
+) -> Result<(), String> {
+    let actual = sha256(archive)?;
+    if actual != artifact.sha256 {
+        return Err(format!(
+            "canonical package SHA-256 mismatch for '{}': expected {}, got {}",
+            archive.display(),
+            artifact.sha256,
+            actual
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn canonical_package_unavailable(
+    diagnostic: String,
+    artifact_name: Option<&str>,
+) -> ContentManifestComparison {
+    canonical_package_unavailable_with_provenance(
+        diagnostic,
+        ContentManifestProvenance {
+            source: "release-package".to_string(),
+            artifact_name: artifact_name.map(str::to_string),
+            artifact_sha256: None,
+            artifact_tag: None,
+            artifact_commit: None,
+        },
+    )
+}
+
+pub(super) fn canonical_package_unavailable_for_artifact(
+    diagnostic: String,
+    artifact: &ReleaseArtifactLease,
+) -> ContentManifestComparison {
+    canonical_package_unavailable_with_provenance(
+        diagnostic,
+        ContentManifestProvenance {
+            source: "release-package".to_string(),
+            artifact_name: Some(artifact.name.clone()),
+            // The leased digest no longer describes the bytes under inspection.
+            artifact_sha256: None,
+            artifact_tag: Some(artifact.tag.clone()),
+            artifact_commit: artifact.commit.clone(),
+        },
+    )
+}
+
+fn canonical_package_unavailable_with_provenance(
+    diagnostic: String,
+    provenance: ContentManifestProvenance,
+) -> ContentManifestComparison {
     ContentManifestComparison {
         algorithm: ALGORITHM.to_string(),
-        scope: SCOPE.to_string(),
+        scope: PACKAGE_UNAVAILABLE_SCOPE.to_string(),
+        provenance: Some(provenance),
+        local_digest: None,
+        remote_digest: None,
+        status: "unavailable".to_string(),
+        differences: Vec::new(),
+        diagnostic: Some(diagnostic),
+    }
+}
+
+pub(super) fn local_build_package_unavailable(
+    diagnostic: String,
+    artifact_name: Option<&str>,
+) -> ContentManifestComparison {
+    canonical_package_unavailable_with_provenance(
+        diagnostic,
+        ContentManifestProvenance {
+            source: "local-build".to_string(),
+            artifact_name: artifact_name.map(str::to_string),
+            artifact_sha256: None,
+            artifact_tag: None,
+            artifact_commit: None,
+        },
+    )
+}
+
+fn compare_archive_with_provenance(
+    archive: &Path,
+    remote: &str,
+    client: &SshClient,
+    exclusions: &[String],
+    provenance: ContentManifestProvenance,
+) -> ContentManifestComparison {
+    let local = match archive_manifest(archive, exclusions) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            return canonical_package_unavailable_with_provenance(
+                format!("canonical package manifest unavailable: {error}"),
+                provenance,
+            )
+        }
+    };
+    let remote = match remote_manifest(remote, client, exclusions) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => {
+            return comparison(
+                &local,
+                None,
+                "missing",
+                Vec::new(),
+                None,
+                PACKAGE_SCOPE,
+                Some(provenance),
+            )
+        }
+        Err(error) => {
+            return canonical_package_unavailable_with_provenance(
+                format!("remote manifest unavailable: {error}"),
+                provenance,
+            )
+        }
+    };
+    let differences = differences(&local, &remote);
+    comparison(
+        &local,
+        Some(&remote),
+        if differences.is_empty() {
+            "match"
+        } else {
+            "different"
+        },
+        differences,
+        None,
+        PACKAGE_SCOPE,
+        Some(provenance),
+    )
+}
+
+fn prepared_artifact_provenance(artifact: &PreparedDeployArtifact) -> ContentManifestProvenance {
+    ContentManifestProvenance {
+        source: "prepared-artifact".to_string(),
+        artifact_name: Some(artifact.effective_path().to_string()),
+        artifact_sha256: Some(artifact.sha256.clone()),
+        artifact_tag: Some(artifact.tag.clone()),
+        artifact_commit: Some(artifact.source_commit.clone()),
+    }
+}
+
+fn prepared_artifact_provenance_without_sha(
+    artifact: &PreparedDeployArtifact,
+) -> ContentManifestProvenance {
+    ContentManifestProvenance {
+        artifact_sha256: None,
+        ..prepared_artifact_provenance(artifact)
+    }
+}
+
+fn unavailable(
+    diagnostic: String,
+    scope: &str,
+    provenance: Option<ContentManifestProvenance>,
+) -> ContentManifestComparison {
+    ContentManifestComparison {
+        algorithm: ALGORITHM.to_string(),
+        scope: scope.to_string(),
+        provenance,
         local_digest: None,
         remote_digest: None,
         status: "unavailable".to_string(),
@@ -134,22 +546,41 @@ fn unavailable(diagnostic: String) -> ContentManifestComparison {
 }
 
 fn local_manifest(root: &Path) -> Result<Manifest, String> {
+    local_manifest_with_exclusions(root, &[])
+}
+
+fn local_manifest_with_exclusions(root: &Path, exclusions: &[String]) -> Result<Manifest, String> {
     if !root.exists() {
         return Err(format!("{} does not exist", root.display()));
     }
-    let entries = content_diff::scan_tree(root, &deployed_tree_scan_options())
-        .map_err(|error| error.to_string())?;
+    let entries = content_diff::scan_tree(
+        root,
+        &TreeScanOptions {
+            excludes: exclusions.to_vec(),
+            ..deployed_tree_scan_options()
+        },
+    )
+    .map_err(|error| error.to_string())?;
+    let entries = entries
+        .into_iter()
+        .map(|(path, mut entry)| {
+            if entry.kind == TreeEntryKind::Symlink {
+                entry.value = validate_link_target(&path, &entry.value)?;
+            }
+            Ok((path, entry))
+        })
+        .collect::<Result<BTreeMap<_, _>, String>>()?;
     Ok(Manifest { entries })
 }
 
-fn archive_manifest(path: &Path) -> Result<Manifest, String> {
+fn archive_manifest(path: &Path, exclusions: &[String]) -> Result<Manifest, String> {
     let file = fs::File::open(path).map_err(|error| error.to_string())?;
     let mut archive = zip::ZipArchive::new(file).map_err(|error| error.to_string())?;
     let mut names = Vec::new();
     for index in 0..archive.len() {
         let entry = archive.by_index(index).map_err(|error| error.to_string())?;
         if !entry.is_dir() {
-            names.push(entry.name().trim_matches('/').to_string());
+            names.push(normalize_path(entry.name())?);
         }
     }
     let root = archive_root(&names);
@@ -159,30 +590,59 @@ fn archive_manifest(path: &Path) -> Result<Manifest, String> {
         if entry.is_dir() {
             continue;
         }
-        let name = entry.name().trim_matches('/');
-        if name.is_empty() || ignored(name) {
-            continue;
-        }
+        let name = normalize_path(entry.name())?;
         let relative = root
             .as_deref()
             .and_then(|root| {
                 name.strip_prefix(root)
                     .and_then(|path| path.strip_prefix('/'))
             })
-            .unwrap_or(name)
+            .unwrap_or(&name)
             .to_string();
-        let mode = content_diff::executable_mode_tag(entry.unix_mode().unwrap_or(0));
+        if relative.is_empty() {
+            return Err("archive entry resolves to the package root".to_string());
+        }
+        // Deploy scopes describe the installed payload, not an archive wrapper.
+        if ignored(&relative, exclusions) {
+            continue;
+        }
+        let kind = if entry
+            .unix_mode()
+            .is_some_and(|mode| mode & 0o170000 == 0o120000)
+        {
+            TreeEntryKind::Symlink
+        } else {
+            TreeEntryKind::File
+        };
         let mut hash = Sha256::new();
-        std::io::copy(&mut entry, &mut hash).map_err(|error| error.to_string())?;
-        manifest.entries.insert(
-            relative,
-            TreeEntry {
-                kind: TreeEntryKind::File,
-                mode,
-                value: format!("{:x}", hash.finalize()),
-                bytes: 0,
-            },
-        );
+        let value = if kind == TreeEntryKind::Symlink {
+            let mut target = String::new();
+            std::io::Read::read_to_string(&mut entry, &mut target)
+                .map_err(|error| error.to_string())?;
+            validate_link_target(&relative, &target)?
+        } else {
+            std::io::copy(&mut entry, &mut hash).map_err(|error| error.to_string())?;
+            format!("{:x}", hash.finalize())
+        };
+        if manifest
+            .entries
+            .insert(
+                relative,
+                TreeEntry {
+                    kind,
+                    mode: if kind == TreeEntryKind::Symlink {
+                        "0".to_string()
+                    } else {
+                        content_diff::executable_mode_tag(entry.unix_mode().unwrap_or(0))
+                    },
+                    value,
+                    bytes: 0,
+                },
+            )
+            .is_some()
+        {
+            return Err("archive contains duplicate normalized paths".to_string());
+        }
     }
     Ok(manifest)
 }
@@ -197,9 +657,17 @@ fn archive_root(names: &[String]) -> Option<String> {
     .then(|| first.to_string())
 }
 
-fn remote_manifest(root: &str, client: &SshClient) -> Result<Option<Manifest>, String> {
+fn sha256(path: &Path) -> Result<String, String> {
+    content_hash::sha256_file(path).map_err(|error| error.to_string())
+}
+
+fn remote_manifest(
+    root: &str,
+    client: &SshClient,
+    exclusions: &[String],
+) -> Result<Option<Manifest>, String> {
     if client.is_local {
-        return local_manifest(Path::new(root)).map(Some);
+        return local_manifest_with_exclusions(Path::new(root), exclusions).map(Some);
     }
     // The target computes hashes and returns compact records; content never crosses SSH.
     let command = format!("root={}; test -e \"$root\" || exit 44; if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then exit 45; fi; find \"$root\" -mindepth 1 \\( -path '*/.git/*' -o -name .git -o -name '.homeboy-*' \\) -prune -o -type f -exec sh -c 'for f do rel=${{f#\"$1\"/}}; if command -v sha256sum >/dev/null 2>&1; then set -- $(sha256sum \"$f\"); else set -- $(shasum -a 256 \"$f\"); fi; mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"f\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$1\"; done' sh \"$root\" {{}} + -o -type l -exec sh -c 'for f do rel=${{f#\"$1\"/}}; mode=$(stat -c %a \"$f\" 2>/dev/null || stat -f %Lp \"$f\"); printf \"l\\t%s\\t%s\\t%s\\n\" \"$rel\" \"$mode\" \"$(readlink \"$f\")\"; done' sh \"$root\" {{}} +", shell::quote_path(root));
@@ -213,10 +681,10 @@ fn remote_manifest(root: &str, client: &SshClient) -> Result<Option<Manifest>, S
     if !output.success {
         return Err("remote does not provide a supported SHA-256 command".to_string());
     }
-    parse_remote_manifest(&output.stdout).map(Some)
+    parse_remote_manifest(&output.stdout, exclusions).map(Some)
 }
 
-fn parse_remote_manifest(output: &str) -> Result<Manifest, String> {
+fn parse_remote_manifest(output: &str, exclusions: &[String]) -> Result<Manifest, String> {
     let mut manifest = Manifest::default();
     for line in output.lines() {
         let mut fields = line.splitn(4, '\t');
@@ -225,7 +693,8 @@ fn parse_remote_manifest(output: &str) -> Result<Manifest, String> {
         else {
             return Err("malformed remote manifest evidence".to_string());
         };
-        if path.contains('\n') || ignored(path) {
+        let path = normalize_path(path)?;
+        if ignored(&path, exclusions) {
             continue;
         }
         let kind = match kind {
@@ -245,8 +714,21 @@ fn parse_remote_manifest(output: &str) -> Result<Manifest, String> {
         {
             return Err("malformed remote SHA-256 evidence".to_string());
         }
+        if kind == TreeEntryKind::Symlink {
+            let value = validate_link_target(&path, value)?;
+            manifest.entries.insert(
+                path,
+                TreeEntry {
+                    kind,
+                    mode,
+                    value,
+                    bytes: 0,
+                },
+            );
+            continue;
+        }
         manifest.entries.insert(
-            path.to_string(),
+            path,
             TreeEntry {
                 kind,
                 mode,
@@ -264,8 +746,77 @@ fn parse_remote_manifest(output: &str) -> Result<Manifest, String> {
 /// This is the whole exclusion policy: version-control metadata and this
 /// product's own transport scratch files. It is intentionally narrower than
 /// recovery's exclusion set — see [`deployed_tree_scan_options`].
-fn ignored(path: &str) -> bool {
-    content_diff::excluded(path, &[]) || content_diff::runtime_artifact(path)
+fn ignored(path: &str, exclusions: &[String]) -> bool {
+    content_diff::excluded(path, exclusions) || content_diff::runtime_artifact(path)
+}
+
+fn normalize_path(path: &str) -> Result<String, String> {
+    let path = path.replace('\\', "/");
+    if path.starts_with('/')
+        || path
+            .bytes()
+            .any(|byte| matches!(byte, b'\0' | b'\n' | b'\r' | b'\t'))
+    {
+        return Err(format!("unsafe manifest path '{path}'"));
+    }
+    let mut parts = Vec::new();
+    for part in path.split('/') {
+        match part {
+            "" | "." => continue,
+            ".." => return Err(format!("unsafe manifest path '{path}'")),
+            _ => parts.push(part),
+        }
+    }
+    if parts.is_empty()
+        || Path::new(&path)
+            .components()
+            .any(|part| matches!(part, PathComponent::Prefix(_)))
+    {
+        return Err(format!("unsafe manifest path '{path}'"));
+    }
+    Ok(parts.join("/"))
+}
+
+fn validate_link_target(entry: &str, target: &str) -> Result<String, String> {
+    if target.is_empty()
+        || target.starts_with('/')
+        || target
+            .bytes()
+            .any(|byte| matches!(byte, b'\0' | b'\n' | b'\r' | b'\t'))
+    {
+        return Err("unsafe manifest symlink target".to_string());
+    }
+    let mut resolved: Vec<&str> = entry.split('/').collect();
+    resolved.pop();
+    for part in target.split('/') {
+        match part {
+            "" | "." => continue,
+            ".." => {
+                if resolved.pop().is_none() {
+                    return Err("symlink target escapes package root".to_string());
+                }
+            }
+            _ => {
+                resolved.push(part);
+            }
+        }
+    }
+    if resolved.is_empty() {
+        return Err("unsafe manifest symlink target".to_string());
+    }
+    Ok(resolved.join("/"))
+}
+
+fn artifact_provenance(
+    artifact: Option<&ReleaseArtifactLease>,
+) -> Option<ContentManifestProvenance> {
+    artifact.map(|artifact| ContentManifestProvenance {
+        source: "release-package".to_string(),
+        artifact_name: Some(artifact.name.clone()),
+        artifact_sha256: Some(artifact.sha256.clone()),
+        artifact_tag: Some(artifact.tag.clone()),
+        artifact_commit: artifact.commit.clone(),
+    })
 }
 
 fn differences(local: &Manifest, remote: &Manifest) -> Vec<String> {
@@ -323,6 +874,7 @@ mod tests {
                 is_local: true,
                 env: Default::default(),
             },
+            &[],
         );
         assert_eq!(result.status, "different");
         assert!(result.differences.iter().any(|p| p == "changed"));
@@ -332,8 +884,13 @@ mod tests {
     }
     #[test]
     fn remote_manifest_requires_well_formed_hash_evidence() {
-        assert!(parse_remote_manifest("f\tpath\t644\n").is_err());
-        assert!(parse_remote_manifest("f\tpath\t644\tnot-a-hash\n").is_err());
+        assert!(parse_remote_manifest("f\tpath\t644\n", &[]).is_err());
+        assert!(parse_remote_manifest("f\tpath\t644\tnot-a-hash\n", &[]).is_err());
+        assert!(parse_remote_manifest(
+            "f\t../path\t644\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+            &[]
+        )
+        .is_err());
     }
 
     /// #10290: deploy and recovery now share one walker, and this pins the two
@@ -374,13 +931,13 @@ mod tests {
     #[test]
     fn deploy_exclusion_policy_is_vcs_metadata_and_transport_scratch_only() {
         let scratch = homeboy_core::product_identity::PRODUCT_IDENTITY.artifact_prefix;
-        assert!(ignored(".git"));
-        assert!(ignored(".git/config"));
-        assert!(ignored(&format!("{scratch}upload.tmp")));
-        assert!(ignored(&format!("assets/{scratch}upload.tmp")));
-        assert!(!ignored(".gitignore"));
-        assert!(!ignored("vendor/library.php"));
-        assert!(!ignored("node_modules/pkg/index.js"));
+        assert!(ignored(".git", &[]));
+        assert!(ignored(".git/config", &[]));
+        assert!(ignored(&format!("{scratch}upload.tmp"), &[]));
+        assert!(ignored(&format!("assets/{scratch}upload.tmp"), &[]));
+        assert!(!ignored(".gitignore", &[]));
+        assert!(!ignored("vendor/library.php", &[]));
+        assert!(!ignored("node_modules/pkg/index.js", &[]));
     }
     #[test]
     #[cfg(unix)]
@@ -443,17 +1000,17 @@ mod tests {
 
         let client = local_client();
         assert_eq!(
-            compare_archive(&package, remote.to_str().expect("path"), &client).status,
+            compare_archive(&package, remote.to_str().expect("path"), &client, &[], None).status,
             "match"
         );
 
         fs::write(remote.join("assets/app.js"), "modified").expect("drift");
-        let drift = compare_archive(&package, remote.to_str().expect("path"), &client);
+        let drift = compare_archive(&package, remote.to_str().expect("path"), &client, &[], None);
         assert_eq!(drift.status, "different");
         assert_eq!(drift.differences, vec!["assets/app.js"]);
 
         fs::remove_file(remote.join("plugin.php")).expect("missing");
-        let missing = compare_archive(&package, remote.to_str().expect("path"), &client);
+        let missing = compare_archive(&package, remote.to_str().expect("path"), &client, &[], None);
         assert!(missing.differences.contains(&"plugin.php".to_string()));
     }
 
@@ -468,18 +1025,140 @@ mod tests {
         let client = local_client();
 
         assert_eq!(
-            compare_archive(&stale, remote.to_str().expect("path"), &client).status,
+            compare_archive(&stale, remote.to_str().expect("path"), &client, &[], None).status,
             "different"
         );
         assert_eq!(
             compare_archive(
                 &temp.path().join("missing.zip"),
                 remote.to_str().expect("path"),
-                &client
+                &client,
+                &[],
+                None,
             )
             .status,
             "unavailable"
         );
+    }
+
+    #[test]
+    fn package_unavailable_evidence_retains_canonical_scope_and_provenance() {
+        let temp = tempfile::tempdir().expect("temp");
+        let package = temp.path().join("package.zip");
+        write_zip(&package, &[("plugin/version", "1.0.0")]);
+        let artifact = release_artifact(&package);
+        let result = compare_archive(
+            &temp.path().join("missing.zip"),
+            temp.path().to_str().expect("path"),
+            &local_client(),
+            &[],
+            Some(&artifact),
+        );
+        assert_eq!(result.status, "unavailable");
+        assert_eq!(result.scope, PACKAGE_SCOPE);
+        assert_eq!(
+            result
+                .provenance
+                .as_ref()
+                .and_then(|provenance| provenance.artifact_sha256.as_deref()),
+            Some(artifact.sha256.as_str())
+        );
+    }
+
+    #[test]
+    fn package_manifest_normalizes_lexical_paths_and_rejects_collisions() {
+        let temp = tempfile::tempdir().expect("temp");
+        let package = temp.path().join("package.zip");
+        write_zip(
+            &package,
+            &[("./plugin//main.php", "one"), ("plugin/main.php", "two")],
+        );
+        assert!(archive_manifest(&package, &[]).is_err());
+        assert_eq!(
+            normalize_path("./plugin//main.php/").expect("normal path"),
+            "plugin/main.php"
+        );
+        assert!(parse_remote_manifest("l\tdir/current\t777\t../outside\n", &[]).is_ok());
+    }
+
+    #[test]
+    fn release_archive_hash_must_match_the_leased_payload_before_use() {
+        let temp = tempfile::tempdir().expect("temp");
+        let package = temp.path().join("package.zip");
+        write_zip(&package, &[("plugin/version", "1.0.0")]);
+        let artifact = release_artifact(&package);
+        assert!(verify_archive_hash(&package, &artifact).is_ok());
+        fs::write(&package, "mutated bytes").expect("mutate");
+        assert!(verify_archive_hash(&package, &artifact).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn package_manifest_applies_configured_generated_exclusions() {
+        let temp = tempfile::tempdir().expect("temp");
+        let package = temp.path().join("package.zip");
+        let remote = temp.path().join("remote");
+        fs::create_dir_all(&remote).expect("remote");
+        write_zip(
+            &package,
+            &[
+                ("plugin/plugin.php", "release"),
+                ("plugin/cache/state.json", "package state"),
+            ],
+        );
+        fs::write(remote.join("plugin.php"), "release").expect("plugin");
+        fs::create_dir_all(remote.join("cache")).expect("cache");
+        fs::write(remote.join("cache/state.json"), "runtime state").expect("state");
+
+        let result = compare_archive(
+            &package,
+            remote.to_str().expect("path"),
+            &local_client(),
+            &["cache/**".to_string()],
+            None,
+        );
+        assert_eq!(result.status, "match");
+        assert_eq!(result.scope, PACKAGE_SCOPE);
+    }
+
+    #[test]
+    fn package_manifest_rejects_unsafe_archive_paths_and_links() {
+        let temp = tempfile::tempdir().expect("temp");
+        let traversal = temp.path().join("traversal.zip");
+        write_zip(&traversal, &[("plugin/../outside", "bad")]);
+        assert!(archive_manifest(&traversal, &[]).is_err());
+
+        assert!(parse_remote_manifest("l\tcurrent\t777\t../outside\n", &[]).is_err());
+        assert!(parse_remote_manifest("l\tcurrent\t777\t/outside\n", &[]).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn archive_symlinks_match_local_and_remote_installs_after_normalization() {
+        let temp = tempfile::tempdir().expect("temp");
+        let package = temp.path().join("package.zip");
+        write_zip(
+            &package,
+            &[("plugin/target", "same"), ("plugin/link", "./target")],
+        );
+        mark_zip_entry_as_symlink(&package, "plugin/link");
+        let archive = archive_manifest(&package, &[]).expect("archive manifest");
+
+        let local = temp.path().join("installed");
+        fs::create_dir_all(&local).expect("installed");
+        fs::write(local.join("target"), "same").expect("target");
+        std::os::unix::fs::symlink("./target", local.join("link")).expect("link");
+        assert!(differences(&archive, &local_manifest(&local).expect("local manifest")).is_empty());
+
+        let remote = parse_remote_manifest(
+            &format!(
+                "f\ttarget\t644\t{}\nl\tlink\t777\t./target\n",
+                sha256(&local.join("target")).expect("hash")
+            ),
+            &[],
+        )
+        .expect("remote manifest");
+        assert!(differences(&archive, &remote).is_empty());
     }
 
     fn write_zip(path: &Path, entries: &[(&str, &str)]) {
@@ -491,6 +1170,46 @@ mod tests {
             std::io::Write::write_all(&mut zip, contents.as_bytes()).expect("zip contents");
         }
         zip.finish().expect("finish zip");
+    }
+
+    fn mark_zip_entry_as_symlink(path: &Path, name: &str) {
+        let mut bytes = fs::read(path).expect("zip bytes");
+        let mut offset = 0;
+        while offset + 46 <= bytes.len() {
+            if bytes[offset..].starts_with(b"PK\x01\x02") {
+                let name_len =
+                    u16::from_le_bytes([bytes[offset + 28], bytes[offset + 29]]) as usize;
+                let extra_len =
+                    u16::from_le_bytes([bytes[offset + 30], bytes[offset + 31]]) as usize;
+                let comment_len =
+                    u16::from_le_bytes([bytes[offset + 32], bytes[offset + 33]]) as usize;
+                let entry_name = std::str::from_utf8(&bytes[offset + 46..offset + 46 + name_len])
+                    .expect("entry name");
+                if entry_name == name {
+                    bytes[offset + 38..offset + 42]
+                        .copy_from_slice(&(0o120777_u32 << 16).to_le_bytes());
+                    fs::write(path, bytes).expect("updated zip");
+                    return;
+                }
+                offset += 46 + name_len + extra_len + comment_len;
+            } else {
+                offset += 1;
+            }
+        }
+        panic!("zip entry not found: {name}");
+    }
+
+    fn release_artifact(path: &Path) -> ReleaseArtifactLease {
+        ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
+            path: path.to_path_buf(),
+            tag: "v1.0.0".to_string(),
+            commit: Some("release-commit".to_string()),
+            url: "https://example.test/package.zip".to_string(),
+            name: "package.zip".to_string(),
+            size: fs::metadata(path).expect("metadata").len(),
+            sha256: sha256(path).expect("sha"),
+        })
+        .expect("lease")
     }
 
     fn local_client() -> SshClient {

--- a/crates/homeboy-release/src/deploy/execution/prepare.rs
+++ b/crates/homeboy-release/src/deploy/execution/prepare.rs
@@ -27,6 +27,9 @@ pub(crate) struct PreparedComponentDeploy {
     pub build_exit_code: Option<i32>,
     pub artifact_path: Option<PathBuf>,
     pub artifact_source: Option<DeployArtifactSource>,
+    pub canonical_release_artifact: Option<ReleaseArtifactLease>,
+    pub package_manifest: Option<super::super::content_manifest::Manifest>,
+    pub payload_sha256: Option<String>,
     pub build_provenance: BuildProvenance,
     pub cleanup_local_artifact: bool,
 }
@@ -71,6 +74,9 @@ pub(crate) fn prepare_component_deploy(
 
     // Try downloading release artifact from GitHub instead of building locally.
     // This is the preferred path when the component has remote_url set.
+    // An explicit prepared artifact is the selected payload, even if a release
+    // asset was resolved earlier for this component.
+    let canonical_release_artifact = selected_release_artifact(config, release_artifact.clone());
     let release_artifact: Option<PathBuf> = if let Some(prepared_artifact) =
         config.prepared_artifact.as_ref()
     {
@@ -241,6 +247,43 @@ pub(crate) fn prepare_component_deploy(
     };
     let build_provenance =
         capture_build_provenance(component, build_source, build_ran, artifact_path.as_deref());
+    let exclusions = homeboy_core::component::resolve_component_scope(
+        component,
+        homeboy_core::component::ScopeCommand::Deploy,
+    )
+    .exclude;
+    let (package_manifest, payload_sha256) = match artifact_path.as_deref().filter(|path| {
+        path.extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+    }) {
+        Some(path) => match (
+            super::super::content_manifest::package_manifest(path, &exclusions),
+            crate::deploy::sha256_file(path),
+        ) {
+            (Ok(manifest), Ok(sha256)) => (Some(manifest), Some(sha256)),
+            (Err(error), _) => {
+                return Err(failed_component_deploy_result(
+                    component,
+                    base_path,
+                    local_version,
+                    remote_version,
+                    build_exit_code,
+                    format!("unable to capture deployed package receipt: {error}"),
+                ));
+            }
+            (_, Err(error)) => {
+                return Err(failed_component_deploy_result(
+                    component,
+                    base_path,
+                    local_version,
+                    remote_version,
+                    build_exit_code,
+                    format!("unable to capture deployed package receipt: {error}"),
+                ));
+            }
+        },
+        None => (None, None),
+    };
 
     Ok(PreparedComponentDeploy {
         component: component.clone(),
@@ -251,6 +294,9 @@ pub(crate) fn prepare_component_deploy(
         build_exit_code,
         artifact_path,
         artifact_source,
+        canonical_release_artifact,
+        package_manifest,
+        payload_sha256,
         build_provenance,
         cleanup_local_artifact,
     })
@@ -303,4 +349,51 @@ pub(super) fn failed_component_deploy_result(
 ) -> ComponentDeployResult {
     ComponentDeployResult::failed(component, base_path, local_version, remote_version, error)
         .with_build_exit_code(build_exit_code)
+}
+
+fn selected_release_artifact(
+    config: &DeployConfig,
+    release_artifact: Option<ReleaseArtifactLease>,
+) -> Option<ReleaseArtifactLease> {
+    config
+        .prepared_artifact
+        .is_none()
+        .then_some(release_artifact)
+        .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deploy::PreparedDeployArtifact;
+
+    #[test]
+    fn prepared_artifact_does_not_inherit_an_unrelated_release_lease() {
+        let mut config = DeployConfig::check_all_no_pull_head();
+        config.prepared_artifact = Some(PreparedDeployArtifact {
+            component_id: "fixture".to_string(),
+            path: "prepared.zip".to_string(),
+            durable_path: "prepared.zip".to_string(),
+            size_bytes: 1,
+            sha256: "prepared".to_string(),
+            version: "1.0.0".to_string(),
+            tag: "v1.0.0".to_string(),
+            source_commit: "commit".to_string(),
+        });
+        let path = tempfile::NamedTempFile::new().expect("release asset");
+        std::fs::write(path.path(), "release").expect("release bytes");
+        let lease =
+            ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
+                path: path.path().to_path_buf(),
+                tag: "v1.0.0".to_string(),
+                commit: None,
+                url: "https://example.test/release.zip".to_string(),
+                name: "release.zip".to_string(),
+                size: 7,
+                sha256: crate::deploy::sha256_file(path.path()).expect("sha"),
+            })
+            .expect("lease");
+
+        assert!(selected_release_artifact(&config, Some(lease)).is_none());
+    }
 }

--- a/crates/homeboy-release/src/deploy/execution/strategies.rs
+++ b/crates/homeboy-release/src/deploy/execution/strategies.rs
@@ -252,6 +252,48 @@ pub(super) fn execute_artifact_deploy(
         .with_build_exit_code(prepared.build_exit_code);
         return with_prepared_artifact_source(result, prepared);
     };
+    if let (Some(expected_manifest), Some(expected_sha256)) =
+        (&prepared.package_manifest, &prepared.payload_sha256)
+    {
+        let exclusions = homeboy_core::component::resolve_component_scope(
+            component,
+            homeboy_core::component::ScopeCommand::Deploy,
+        )
+        .exclude;
+        let manifest_matches =
+            super::super::content_manifest::package_manifest(artifact_path, &exclusions)
+                .is_ok_and(|manifest| manifest == *expected_manifest);
+        let sha_matches = crate::deploy::sha256_file(artifact_path)
+            .is_ok_and(|sha256| sha256 == *expected_sha256);
+        if !manifest_matches || !sha_matches {
+            let result = ComponentDeployResult::failed(
+                component,
+                base_path,
+                prepared.local_version.clone(),
+                prepared.remote_version.clone(),
+                "prepared package changed after preflight; refusing transfer".to_string(),
+            )
+            .with_remote_path(install_dir.to_string())
+            .with_build_exit_code(prepared.build_exit_code);
+            return with_prepared_artifact_source(result, prepared);
+        }
+    }
+    if let Some(artifact) = prepared.canonical_release_artifact.as_ref() {
+        if let Err(error) =
+            super::super::content_manifest::verify_archive_hash(artifact_path, artifact)
+        {
+            let result = ComponentDeployResult::failed(
+                component,
+                base_path,
+                prepared.local_version.clone(),
+                prepared.remote_version.clone(),
+                error,
+            )
+            .with_remote_path(install_dir.to_string())
+            .with_build_exit_code(prepared.build_exit_code);
+            return with_prepared_artifact_source(result, prepared);
+        }
+    }
     let artifact_input_metadata = match artifact_inputs::resolve_metadata(component) {
         Ok(inputs) => inputs,
         Err(err) => {

--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -13,6 +13,7 @@ mod planning;
 mod policy;
 pub(crate) mod preparation;
 pub(crate) mod provenance;
+mod receipt;
 mod safety_and_artifact;
 mod smoke;
 mod transfer;

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::release::version;
-use homeboy_core::component::Component;
+use homeboy_core::component::{resolve_component_scope, Component, ScopeCommand};
 use homeboy_core::context::RemoteProjectContext;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::project::Project;
@@ -142,7 +142,7 @@ pub(super) fn deploy_components(
         validate_effective_remote_paths(&components, &project, base_path)?;
     }
 
-    let resolved_release_artifacts =
+    let (resolved_release_artifacts, unavailable_canonical_packages) =
         resolve_release_artifacts_for_deploy(&components, config, release_artifacts)?;
 
     // Resolve first, then materialize immutable detached worktrees for real deploys.
@@ -225,6 +225,7 @@ pub(super) fn deploy_components(
             config,
             &ctx.client,
             &resolved_release_artifacts,
+            &unavailable_canonical_packages,
         ));
     }
     if config.dry_run {
@@ -396,15 +397,33 @@ pub(super) fn deploy_components(
     // Re-probe immediately before the first destructive write. A same-version
     // mismatch is remote-only content drift, not an ordinary local update.
     for prepared in prepared_deployments.iter() {
-        let Some(local_path) = prepared
-            .artifact_path
-            .as_deref()
-            .filter(|path| path.is_dir())
-        else {
-            continue;
+        let exclusions = resolve_component_scope(&prepared.component, ScopeCommand::Deploy).exclude;
+        let manifest = match (
+            prepared.artifact_path.as_deref(),
+            prepared.canonical_release_artifact.as_ref(),
+        ) {
+            (Some(archive), Some(artifact)) => {
+                super::content_manifest::verify_archive_hash(archive, artifact).map_err(
+                    |error| {
+                        Error::validation_invalid_argument("release_artifact", error, None, None)
+                    },
+                )?;
+                super::content_manifest::compare_archive(
+                    archive,
+                    &prepared.install_dir,
+                    &ctx.client,
+                    &exclusions,
+                    Some(artifact),
+                )
+            }
+            (Some(local_path), None) if local_path.is_dir() => super::content_manifest::compare(
+                local_path,
+                &prepared.install_dir,
+                &ctx.client,
+                &exclusions,
+            ),
+            _ => continue,
         };
-        let manifest =
-            super::content_manifest::compare(local_path, &prepared.install_dir, &ctx.client);
         if prepared.local_version == prepared.remote_version
             && !config.force
             && manifest.status != "match"
@@ -432,6 +451,22 @@ pub(super) fn deploy_components(
 
     for prepared in prepared_deployments.iter() {
         let component = &prepared.component;
+        if prepared.package_manifest.is_some() {
+            let version = prepared.local_version.as_deref().unwrap_or_default();
+            if let Err(error) =
+                super::receipt::invalidate(&project, &component.id, &prepared.install_dir, version)
+            {
+                failed += 1;
+                results.push(ComponentDeployResult::failed(
+                    component,
+                    base_path,
+                    prepared.local_version.clone(),
+                    prepared.remote_version.clone(),
+                    format!("unable to invalidate prior deployed-package receipt: {error}"),
+                ));
+                continue;
+            }
+        }
 
         let mut result = execute_preflighted_component_deploy(prepared, ctx, base_path, &project);
 
@@ -499,7 +534,32 @@ pub(super) fn deploy_components(
         } else if let Some(prepared_artifact) = config.prepared_artifact.as_ref() {
             build_provenance.built_from_commit = Some(prepared_artifact.source_commit.clone());
         }
-        result = result.with_build_provenance(build_provenance);
+        result = result.with_build_provenance(build_provenance.clone());
+
+        if result.status == "deployed" {
+            if let (Some(manifest), Some(payload_sha256)) = (
+                prepared.package_manifest.clone(),
+                prepared.payload_sha256.clone(),
+            ) {
+                let exclusions = resolve_component_scope(component, ScopeCommand::Deploy).exclude;
+                let version = prepared.local_version.as_deref().unwrap_or_default();
+                if let Err(error) = super::receipt::write(
+                    &project,
+                    &component.id,
+                    &prepared.install_dir,
+                    version,
+                    manifest,
+                    payload_sha256,
+                    build_provenance,
+                    exclusions,
+                ) {
+                    result.status = "failed".to_string();
+                    result.error = Some(format!(
+                        "deployment completed but authoritative deployed-package receipt could not be persisted: {error}"
+                    ));
+                }
+            }
+        }
 
         if result.status == "deployed" {
             succeeded += 1;
@@ -564,39 +624,49 @@ fn resolve_release_artifacts_for_deploy(
     components: &[Component],
     config: &DeployConfig,
     release_artifacts: &mut ReleaseArtifactStore,
-) -> Result<HashMap<String, ReleaseArtifactLease>> {
+) -> Result<(
+    HashMap<String, ReleaseArtifactLease>,
+    HashMap<String, String>,
+)> {
     let mut resolved_release_artifacts: HashMap<String, ReleaseArtifactLease> = HashMap::new();
+    let mut unavailable_canonical_packages = HashMap::new();
     if config.dry_run {
-        return Ok(resolved_release_artifacts);
+        return Ok((resolved_release_artifacts, unavailable_canonical_packages));
     }
 
     for component in components {
+        if config
+            .prepared_artifact
+            .as_ref()
+            .is_some_and(|artifact| artifact.component_id == component.id)
+        {
+            continue;
+        }
         if let ReleaseArtifactPlan::Reuse { tag, .. } =
             release_artifact_plan(component, config, false, false)
         {
-            let artifact = match resolve_planned_release_artifact(
-                component,
-                &tag,
-                release_artifacts,
-            ) {
-                Ok(artifact) => artifact,
-                Err(error) if config.check => {
-                    homeboy_core::log_status!(
-                        "deploy",
-                        "Canonical release package unavailable for '{}' ({error}); using legacy source-tree check",
-                        component.id
-                    );
-                    continue;
-                }
-                Err(error) => {
-                    return Err(Error::validation_invalid_argument(
-                        "releaseArtifact",
-                        error,
-                        None,
-                        None,
-                    ))
-                }
-            };
+            let artifact =
+                match resolve_planned_release_artifact(component, &tag, release_artifacts) {
+                    Ok(artifact) => artifact,
+                    Err(error) if config.check => {
+                        homeboy_core::log_status!(
+                            "deploy",
+                            "Canonical release package unavailable for '{}' ({error})",
+                            component.id
+                        );
+                        unavailable_canonical_packages
+                            .insert(component.id.clone(), error.to_string());
+                        continue;
+                    }
+                    Err(error) => {
+                        return Err(Error::validation_invalid_argument(
+                            "releaseArtifact",
+                            error,
+                            None,
+                            None,
+                        ))
+                    }
+                };
             homeboy_core::log_status!(
                 "deploy",
                 "Verified release asset: tag={} name={} size={} sha256={} source={}",
@@ -610,7 +680,7 @@ fn resolve_release_artifacts_for_deploy(
         }
     }
 
-    Ok(resolved_release_artifacts)
+    Ok((resolved_release_artifacts, unavailable_canonical_packages))
 }
 
 fn validate_preflighted_component_identities(
@@ -1059,9 +1129,8 @@ mod tests {
         assert_eq!(err.details["field"].as_str(), Some("build_command"));
     }
 
-    // A check resolves the canonical package when available, but an unavailable
-    // release asset must retain legacy source-tree checking rather than abort a
-    // project-wide read-only probe. Dry-run still resolves nothing. (#10253)
+    // A check records unavailable canonical-package evidence without reverting
+    // to unrelated source-tree bytes. Dry-run still resolves nothing. (#10253)
     #[test]
     fn check_tolerates_missing_canonical_package_and_dry_run_skips_resolution() {
         with_isolated_home(|_| {
@@ -1078,21 +1147,22 @@ mod tests {
             check_config.check = true;
             check_config.expected_version = Some("9.9.9".to_string());
             let mut store = ReleaseArtifactStore::default();
-            let resolved = resolve_release_artifacts_for_deploy(
+            let (resolved, unavailable) = resolve_release_artifacts_for_deploy(
                 &[component.clone()],
                 &check_config,
                 &mut store,
             )
-            .expect("check mode must retain legacy behavior when canonical package is missing");
+            .expect("check mode must preserve canonical package evidence when missing");
             assert!(
                 resolved.is_empty(),
                 "missing canonical package must not produce a partial authority"
             );
+            assert!(unavailable["cli-binary"].contains("release"));
 
             let mut dry_run_config = base_deploy_config();
             dry_run_config.dry_run = true;
             dry_run_config.expected_version = Some("9.9.9".to_string());
-            let resolved = resolve_release_artifacts_for_deploy(
+            let (resolved, unavailable) = resolve_release_artifacts_for_deploy(
                 &[component.clone()],
                 &dry_run_config,
                 &mut store,
@@ -1102,6 +1172,7 @@ mod tests {
                 resolved.is_empty(),
                 "dry-run must resolve no release assets"
             );
+            assert!(unavailable.is_empty());
 
             // A real deploy still resolves — and surfaces the failure loudly.
             let mut deploy_config = base_deploy_config();
@@ -1982,7 +2053,14 @@ mod tests {
         let missing_path = dir.path().join("missing");
         std::fs::create_dir_all(ready_path.join("dist")).expect("ready dist");
         std::fs::create_dir_all(&missing_path).expect("missing component dir");
-        std::fs::write(ready_path.join("dist/ready.zip"), b"artifact").expect("ready artifact");
+        let file =
+            std::fs::File::create(ready_path.join("dist/ready.zip")).expect("ready artifact");
+        let mut zip = zip::ZipWriter::new(file);
+        zip.start_file("ready.php", zip::write::FileOptions::default())
+            .expect("zip entry");
+        use std::io::Write as _;
+        zip.write_all(b"ready").expect("zip contents");
+        zip.finish().expect("finish zip");
 
         let components = vec![
             artifact_component("ready", &ready_path.to_string_lossy(), "dist/ready.zip"),

--- a/crates/homeboy-release/src/deploy/orchestration/modes.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/modes.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use homeboy_core::component::Component;
+use homeboy_core::component::{resolve_component_scope, Component, ScopeCommand};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git::release_download::ReleaseArtifactLease;
 use homeboy_core::project::Project;
@@ -29,6 +29,7 @@ pub(super) fn run_check_mode(
     config: &DeployConfig,
     client: &SshClient,
     canonical_packages: &HashMap<String, ReleaseArtifactLease>,
+    unavailable_canonical_packages: &HashMap<String, String>,
 ) -> DeployOrchestrationResult {
     let mut git_probe_cache = GitProbeCache::default();
     let mut results: Vec<ComponentDeployResult> = components
@@ -37,20 +38,65 @@ pub(super) fn run_check_mode(
             let mut status =
                 calculate_component_status_with_git_cache(c, remote_versions, &mut git_probe_cache);
             let release_state = calculate_release_state(c);
-            let manifest = if let Some(package) = canonical_packages.get(&c.id) {
-                super::super::content_manifest::compare_archive(
-                    &package.path,
-                    &super::super::path_roots::resolve_effective_remote_path(project, c, base_path)
-                        .unwrap_or_default(),
+            let prepared = config
+                .prepared_artifact
+                .as_ref()
+                .filter(|artifact| artifact.component_id == c.id);
+            let target = super::super::path_roots::resolve_effective_remote_path(project, c, base_path)
+                .unwrap_or_default();
+            let manifest = if let Some(artifact) = prepared {
+                super::super::content_manifest::compare_prepared_archive(
+                    std::path::Path::new(artifact.effective_path()),
+                    &target,
                     client,
+                    &resolve_component_scope(c, ScopeCommand::Deploy).exclude,
+                    artifact,
+                )
+            } else if let Some(package) = canonical_packages.get(&c.id) {
+                match super::super::content_manifest::verify_archive_hash(&package.path, package) {
+                    Ok(()) => super::super::content_manifest::compare_archive(
+                        &package.path,
+                        &target,
+                        client,
+                        &resolve_component_scope(c, ScopeCommand::Deploy).exclude,
+                        Some(package),
+                    ),
+                    Err(error) => {
+                        super::super::content_manifest::canonical_package_unavailable_for_artifact(
+                            error, package,
+                        )
+                    }
+                }
+            } else if let Some(diagnostic) = unavailable_canonical_packages.get(&c.id) {
+                super::super::content_manifest::canonical_package_unavailable(
+                    diagnostic.clone(),
+                    c.build_artifact.as_deref(),
                 )
             } else {
-                super::super::content_manifest::compare(
-                    std::path::Path::new(&c.local_path),
-                    &super::super::path_roots::resolve_effective_remote_path(project, c, base_path)
-                        .unwrap_or_default(),
-                    client,
-                )
+                let version = local_versions.get(&c.id).map(String::as_str).unwrap_or_default();
+                match super::super::receipt::load(
+                    project,
+                    &c.id,
+                    &target,
+                    version,
+                    &resolve_component_scope(c, ScopeCommand::Deploy).exclude,
+                ) {
+                    Ok(Some(receipt)) => super::super::content_manifest::compare_saved_package_manifest(
+                        &receipt.manifest,
+                        &target,
+                        client,
+                        &receipt.exclusions,
+                        receipt.provenance(),
+                    ),
+                    Ok(None) => super::super::content_manifest::local_build_package_unavailable(
+                        "canonical package is unavailable in check mode and no deployed-package receipt matches this target and version".to_string(),
+                        c.build_artifact.as_deref(),
+                    ),
+                    Err(error) => super::super::content_manifest::local_build_package_unavailable(
+                        format!("deployed-package receipt unavailable: {error}"),
+                        c.build_artifact.as_deref(),
+                    ),
+                }
             };
             if manifest.status == "missing" {
                 status = ComponentStatus::Missing;
@@ -638,6 +684,7 @@ mod tests {
             &config,
             &local_client(),
             &HashMap::new(),
+            &HashMap::new(),
         );
         assert_eq!(checked.results[0].status, "checked");
         assert_eq!(checked.results[0].local_version.as_deref(), Some("1.2.3"));
@@ -717,15 +764,28 @@ mod tests {
             &config,
             &local_client(),
             &packages,
+            &HashMap::new(),
         );
         assert_eq!(
             clean.results[0].component_status,
             Some(ComponentStatus::UpToDate)
         );
+        let manifest = clean.results[0]
+            .content_manifest
+            .as_ref()
+            .expect("package manifest");
+        assert_eq!(manifest.scope, "canonical-package-installed-tree");
+        assert_eq!(
+            manifest
+                .provenance
+                .as_ref()
+                .and_then(|provenance| provenance.artifact_tag.as_deref()),
+            Some("v1.0.0")
+        );
 
         std::fs::write(remote.join("plugin.php"), "modified").expect("drift");
         let drift = run_check_mode(
-            &[component],
+            std::slice::from_ref(&component),
             &versions,
             &versions,
             &[],
@@ -734,10 +794,331 @@ mod tests {
             &config,
             &local_client(),
             &packages,
+            &HashMap::new(),
         );
         assert_eq!(
             drift.results[0].component_status,
             Some(ComponentStatus::RemoteModified)
+        );
+
+        std::fs::write(&packages["plugin"].path, "mutated after lease").expect("mutate package");
+        let mutated = run_check_mode(
+            std::slice::from_ref(&component),
+            &versions,
+            &versions,
+            &[],
+            &Project::default(),
+            ".",
+            &config,
+            &local_client(),
+            &packages,
+            &HashMap::new(),
+        );
+        let manifest = mutated.results[0]
+            .content_manifest
+            .as_ref()
+            .expect("unavailable canonical package evidence");
+        assert_eq!(manifest.status, "unavailable");
+        assert_eq!(manifest.scope, "canonical-package-unavailable");
+        assert_eq!(
+            manifest
+                .provenance
+                .as_ref()
+                .and_then(|provenance| provenance.artifact_sha256.as_deref()),
+            None
+        );
+    }
+
+    #[test]
+    fn prepared_artifact_is_selected_ahead_of_a_release_asset_during_check() {
+        let temp = tempfile::tempdir().expect("temp");
+        let remote = temp.path().join("plugin");
+        std::fs::create_dir_all(&remote).expect("remote");
+        std::fs::write(remote.join("plugin.php"), "prepared").expect("remote payload");
+        let prepared_path = temp.path().join("prepared.zip");
+        let release_path = temp.path().join("release.zip");
+        for (path, contents) in [
+            (&prepared_path, b"prepared".as_slice()),
+            (&release_path, b"release".as_slice()),
+        ] {
+            let file = std::fs::File::create(path).expect("package");
+            let mut zip = zip::ZipWriter::new(file);
+            zip.start_file("plugin.php", zip::write::FileOptions::default())
+                .expect("entry");
+            use std::io::Write as _;
+            zip.write_all(contents).expect("contents");
+            zip.finish().expect("finish");
+        }
+        let release =
+            ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
+                path: release_path.clone(),
+                tag: "v1.0.0".to_string(),
+                commit: None,
+                url: "https://example.test/release.zip".to_string(),
+                name: "release.zip".to_string(),
+                size: std::fs::metadata(&release_path).expect("metadata").len(),
+                sha256: crate::deploy::sha256_file(&release_path).expect("sha"),
+            })
+            .expect("lease");
+        let component = Component {
+            id: "plugin".to_string(),
+            remote_path: remote.display().to_string(),
+            ..Component::default()
+        };
+        let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let mut config = DeployConfig::check_all_no_pull_head();
+        config.prepared_artifact = Some(PreparedDeployArtifact {
+            component_id: "plugin".to_string(),
+            path: prepared_path.display().to_string(),
+            durable_path: prepared_path.display().to_string(),
+            size_bytes: std::fs::metadata(&prepared_path).expect("metadata").len(),
+            sha256: crate::deploy::sha256_file(&prepared_path).expect("sha"),
+            version: "1.0.0".to_string(),
+            tag: "v1.0.0".to_string(),
+            source_commit: "prepared-commit".to_string(),
+        });
+        let result = run_check_mode(
+            &[component],
+            &versions,
+            &versions,
+            &[],
+            &Project::default(),
+            ".",
+            &config,
+            &local_client(),
+            &HashMap::from([("plugin".to_string(), release)]),
+            &HashMap::new(),
+        );
+        let manifest = result.results[0]
+            .content_manifest
+            .as_ref()
+            .expect("manifest");
+        assert_eq!(manifest.status, "match");
+        assert_eq!(
+            manifest.provenance.as_ref().expect("provenance").source,
+            "prepared-artifact"
+        );
+    }
+
+    #[test]
+    fn check_reports_mixed_version_and_content_drift_against_the_package() {
+        let temp = tempfile::tempdir().expect("temp");
+        let remote = temp.path().join("plugin");
+        std::fs::create_dir_all(&remote).expect("remote");
+        std::fs::write(remote.join("plugin.php"), "Version: 2.0.0\nmodified")
+            .expect("remote plugin");
+        let package = temp.path().join("plugin.zip");
+        let file = std::fs::File::create(&package).expect("package");
+        let mut zip = zip::ZipWriter::new(file);
+        zip.start_file("plugin/plugin.php", zip::write::FileOptions::default())
+            .expect("entry");
+        use std::io::Write as _;
+        zip.write_all(b"Version: 1.0.0\nrelease").expect("contents");
+        zip.finish().expect("finish");
+        let bytes = std::fs::read(&package).expect("package bytes");
+        let lease =
+            ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
+                path: package.clone(),
+                tag: "v1.0.0".to_string(),
+                commit: Some("release-commit".to_string()),
+                url: "https://example.test/plugin.zip".to_string(),
+                name: "plugin.zip".to_string(),
+                size: bytes.len() as u64,
+                sha256: crate::deploy::sha256_file(&package).expect("sha"),
+            })
+            .expect("lease");
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: temp.path().display().to_string(),
+            remote_path: remote.display().to_string(),
+            ..Component::default()
+        };
+        let local_versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let remote_versions = HashMap::from([("plugin".to_string(), "2.0.0".to_string())]);
+        let result = run_check_mode(
+            &[component],
+            &local_versions,
+            &remote_versions,
+            &[],
+            &Project::default(),
+            ".",
+            &DeployConfig::check_all_no_pull_head(),
+            &local_client(),
+            &HashMap::from([("plugin".to_string(), lease)]),
+            &HashMap::new(),
+        );
+        assert_eq!(
+            result.results[0].component_status,
+            Some(ComponentStatus::MixedDrift)
+        );
+        assert_eq!(
+            result.results[0]
+                .content_manifest
+                .as_ref()
+                .expect("manifest")
+                .status,
+            "different"
+        );
+    }
+
+    #[test]
+    fn check_reports_unavailable_canonical_package_without_reading_the_source_tree() {
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: "/source/tree/must-not-be-read".to_string(),
+            build_artifact: Some("dist/plugin.zip".to_string()),
+            ..Component::default()
+        };
+        let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let result = run_check_mode(
+            &[component],
+            &versions,
+            &versions,
+            &[],
+            &Project::default(),
+            ".",
+            &DeployConfig::check_all_no_pull_head(),
+            &local_client(),
+            &HashMap::new(),
+            &HashMap::from([(
+                "plugin".to_string(),
+                "release asset download failed".to_string(),
+            )]),
+        );
+        let manifest = result.results[0]
+            .content_manifest
+            .as_ref()
+            .expect("canonical unavailable evidence");
+        assert_eq!(manifest.status, "unavailable");
+        assert_eq!(manifest.scope, "canonical-package-unavailable");
+        assert_eq!(
+            manifest
+                .provenance
+                .as_ref()
+                .and_then(|provenance| provenance.artifact_name.as_deref()),
+            Some("dist/plugin.zip")
+        );
+    }
+
+    #[test]
+    fn tagged_and_skip_build_checks_require_a_canonical_package_or_receipt() {
+        let temp = tempfile::tempdir().expect("temp");
+        let source = temp.path().join("monorepo");
+        let remote = temp.path().join("installed");
+        std::fs::create_dir_all(source.join("packages/plugin")).expect("source");
+        std::fs::create_dir_all(&remote).expect("remote");
+        std::fs::write(source.join("README.md"), "source only").expect("source file");
+        std::fs::write(source.join("packages/plugin/plugin.php"), "installed")
+            .expect("source file");
+        std::fs::write(remote.join("plugin.php"), "installed").expect("remote file");
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: source.display().to_string(),
+            remote_path: remote.display().to_string(),
+            build_artifact: Some("packages/plugin/plugin.zip".to_string()),
+            ..Component::default()
+        };
+        let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        for mut config in [
+            DeployConfig {
+                tagged: true,
+                ..DeployConfig::check_all_no_pull_head()
+            },
+            DeployConfig {
+                skip_build: true,
+                ..DeployConfig::check_all_no_pull_head()
+            },
+        ] {
+            config.check = true;
+            let result = run_check_mode(
+                std::slice::from_ref(&component),
+                &versions,
+                &versions,
+                &[],
+                &Project::default(),
+                ".",
+                &config,
+                &local_client(),
+                &HashMap::new(),
+                &HashMap::new(),
+            );
+            let manifest = result.results[0]
+                .content_manifest
+                .as_ref()
+                .expect("canonical package evidence");
+            assert_eq!(manifest.status, "unavailable");
+            assert_eq!(manifest.scope, "canonical-package-unavailable");
+            assert_eq!(
+                manifest
+                    .provenance
+                    .as_ref()
+                    .map(|provenance| provenance.source.as_str()),
+                Some("local-build")
+            );
+        }
+    }
+
+    #[test]
+    fn check_reports_unavailable_when_local_build_artifact_has_no_package_coverage() {
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: "/source/tree/must-not-be-read".to_string(),
+            build_artifact: Some("dist/plugin.zip".to_string()),
+            ..Component::default()
+        };
+        let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let result = run_check_mode(
+            &[component],
+            &versions,
+            &versions,
+            &[],
+            &Project::default(),
+            ".",
+            &DeployConfig::check_all_no_pull_head(),
+            &local_client(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(
+            result.results[0]
+                .content_manifest
+                .as_ref()
+                .expect("manifest")
+                .status,
+            "unavailable"
+        );
+    }
+
+    #[test]
+    fn check_does_not_use_package_coverage_without_an_immutable_payload() {
+        let component = Component {
+            id: "plugin".to_string(),
+            local_path: "/source/tree/must-not-be-read".to_string(),
+            build_artifact: Some("dist/plugin.zip".to_string()),
+            ..Component::default()
+        };
+        let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let result = run_check_mode(
+            &[component],
+            &versions,
+            &versions,
+            &[],
+            &Project::default(),
+            ".",
+            &DeployConfig::check_all_no_pull_head(),
+            &local_client(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        let manifest = result.results[0]
+            .content_manifest
+            .as_ref()
+            .expect("manifest");
+        assert_eq!(manifest.status, "unavailable");
+        let diagnostic = manifest.diagnostic.as_deref().expect("diagnostic");
+        assert!(
+            diagnostic.contains("no deployed-package receipt"),
+            "{diagnostic}"
         );
     }
 

--- a/crates/homeboy-release/src/deploy/receipt.rs
+++ b/crates/homeboy-release/src/deploy/receipt.rs
@@ -1,0 +1,211 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use homeboy_core::project::Project;
+
+use super::content_manifest::Manifest;
+use super::types::{BuildProvenance, ContentManifestProvenance};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct DeployedPackageReceipt {
+    project_id: String,
+    component_id: String,
+    target: String,
+    version: String,
+    pub(super) manifest: Manifest,
+    pub(super) payload_sha256: String,
+    pub(super) build_provenance: BuildProvenance,
+    package_scope: String,
+    manifest_digest: String,
+    pub(super) exclusions: Vec<String>,
+}
+
+impl DeployedPackageReceipt {
+    pub(super) fn provenance(&self) -> ContentManifestProvenance {
+        ContentManifestProvenance {
+            source: "deployed-package-receipt".to_string(),
+            artifact_name: self
+                .build_provenance
+                .artifact_identity
+                .as_ref()
+                .map(|identity| identity.path.clone()),
+            artifact_sha256: Some(self.payload_sha256.clone()),
+            artifact_tag: self.build_provenance.built_from_ref.clone(),
+            artifact_commit: self.build_provenance.built_from_commit.clone(),
+        }
+    }
+}
+
+pub(super) fn load(
+    project: &Project,
+    component_id: &str,
+    target: &str,
+    version: &str,
+    exclusions: &[String],
+) -> Result<Option<DeployedPackageReceipt>, String> {
+    let path = path(project, component_id, target, version)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let receipt: DeployedPackageReceipt =
+        serde_json::from_slice(&read_no_follow(&path)?).map_err(|error| {
+            format!(
+                "invalid deployed package receipt '{}': {error}",
+                path.display()
+            )
+        })?;
+    receipt.validate(project, component_id, target, version, exclusions)?;
+    Ok(Some(receipt))
+}
+
+pub(super) fn write(
+    project: &Project,
+    component_id: &str,
+    target: &str,
+    version: &str,
+    manifest: Manifest,
+    payload_sha256: String,
+    build_provenance: BuildProvenance,
+    exclusions: Vec<String>,
+) -> Result<(), String> {
+    let path = path(project, component_id, target, version)?;
+    let parent = path.parent().expect("receipt path has a parent");
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    restrict_directory(parent)?;
+    let receipt = DeployedPackageReceipt {
+        project_id: project.id.clone(),
+        component_id: component_id.to_string(),
+        target: target.to_string(),
+        version: version.to_string(),
+        manifest_digest: manifest.digest(),
+        manifest,
+        payload_sha256,
+        build_provenance,
+        package_scope: "canonical-package-installed-tree".to_string(),
+        exclusions,
+    };
+    let temporary = parent.join(format!(".receipt-{}.tmp", uuid::Uuid::new_v4()));
+    let mut file = create_private_file(&temporary)?;
+    file.write_all(&serde_json::to_vec(&receipt).map_err(|error| error.to_string())?)
+        .map_err(|error| error.to_string())?;
+    file.sync_all().map_err(|error| error.to_string())?;
+    fs::rename(&temporary, &path).map_err(|error| error.to_string())?;
+    sync_directory(parent)
+}
+
+impl DeployedPackageReceipt {
+    fn validate(
+        &self,
+        project: &Project,
+        component_id: &str,
+        target: &str,
+        version: &str,
+        exclusions: &[String],
+    ) -> Result<(), String> {
+        if self.project_id != project.id
+            || self.component_id != component_id
+            || self.target != target
+            || self.version != version
+            || self.package_scope != "canonical-package-installed-tree"
+            || self.exclusions != exclusions
+        {
+            return Err(
+                "deployed-package receipt does not match the requested deployment identity"
+                    .to_string(),
+            );
+        }
+        self.manifest.validate()?;
+        if self.manifest.digest() != self.manifest_digest
+            || self.payload_sha256.len() != 64
+            || !self
+                .payload_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(
+                "deployed-package receipt manifest integrity validation failed".to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn invalidate(
+    project: &Project,
+    component_id: &str,
+    target: &str,
+    version: &str,
+) -> Result<(), String> {
+    let path = path(project, component_id, target, version)?;
+    match fs::remove_file(&path) {
+        Ok(()) => sync_directory(path.parent().expect("receipt path has a parent")),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn create_private_file(path: &Path) -> Result<fs::File, String> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(path).map_err(|error| error.to_string())
+}
+
+fn read_no_follow(path: &Path) -> Result<Vec<u8>, String> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(path).map_err(|error| error.to_string())?;
+    let mut bytes = Vec::new();
+    std::io::Read::read_to_end(&mut file, &mut bytes).map_err(|error| error.to_string())?;
+    Ok(bytes)
+}
+
+fn restrict_directory(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn sync_directory(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        fs::File::open(path)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn path(
+    project: &Project,
+    component_id: &str,
+    target: &str,
+    version: &str,
+) -> Result<PathBuf, String> {
+    let mut hash = Sha256::new();
+    for value in [&project.id, component_id, target, version] {
+        hash.update(value.as_bytes());
+        hash.update([0]);
+    }
+    Ok(homeboy_paths::homeboy_data()
+        .map_err(|error| error.to_string())?
+        .join("deploy-receipts")
+        .join(format!("{:x}.json", hash.finalize())))
+}

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -413,6 +413,8 @@ pub use homeboy_release_contract::{ReleaseState, ReleaseStateBuckets, ReleaseSta
 pub struct ContentManifestComparison {
     pub algorithm: String,
     pub scope: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ContentManifestProvenance>,
     pub local_digest: Option<String>,
     pub remote_digest: Option<String>,
     pub status: String,
@@ -420,6 +422,20 @@ pub struct ContentManifestComparison {
     pub differences: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostic: Option<String>,
+}
+
+/// The immutable payload identity used as the local side of a content comparison.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContentManifestProvenance {
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_commit: Option<String>,
 }
 
 /// Result for a single component deployment.


### PR DESCRIPTION
## Summary
- compare installed trees against the exact prepared or release package payload
- persist validated deployment receipts for later tagged-package parity checks
- harden archive scope, symlink handling, exclusions, integrity checks, and receipt finalization

Closes #10489

## Verification
- `cargo test -p homeboy-release content_manifest`
- `cargo test -p homeboy-release modes`
- focused deploy receipt and prepared-artifact tests
- `cargo check -p homeboy-release`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested package-scoped deploy comparison and durable receipts. Chris Huber reviewed and owns every line.