### PR TITLE
fix: make agent task retries idempotent

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
@@ -618,7 +618,7 @@ pub(super) fn execute_retry_action(
     action: &AgentTaskLoopPolicyActionRecord,
     target_run_id: &str,
 ) -> Result<(Value, i32)> {
-    let retry = agent_task_service::retry(target_run_id, None, false)?;
+    let retry = agent_task_service::retry(target_run_id, None, false, false)?;
     let retry_run_id = retry.record.run_id.clone();
     if !record
         .task_lineage

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -570,6 +570,12 @@ fn record_lab_offload_proxy(
     if record.state.is_terminal() {
         return Ok(record);
     }
+    let now = chrono::Utc::now();
+    record.lab_handoff = Some(AgentTaskLabHandoff::pending(
+        runner_id,
+        now.to_rfc3339(),
+        (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds())).to_rfc3339(),
+    ));
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
     // This record is the controller's durable projection of a runner handoff.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -443,7 +443,14 @@ where
         }
         // A runner re-submitting a retry must not erase the predecessor identity
         // that makes the reservation discoverable through the indexed lookup.
-        for key in ["retry_of", "retry_requested_at", "retry_origin"] {
+        for key in [
+            "retry_of",
+            "retried_from",
+            "retry_root",
+            "retries",
+            "retry_requested_at",
+            "retry_origin",
+        ] {
             if let Some(value) = existing.metadata.get(key) {
                 record.metadata[key] = value.clone();
             }
@@ -1612,7 +1619,77 @@ pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
 }
 
 pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRunRecord> {
+    retry_with_force_inner(run_id, requested_run_id, false, false)
+}
+
+pub(crate) fn record_metadata_value(run_id: &str, key: &str, value: Value) -> Result<()> {
+    store::mutate_record(&sanitize_run_id(run_id), |record| {
+        record
+            .ensure_metadata_object()
+            .insert(key.to_string(), value.clone());
+        record.updated_at = Some(now_timestamp());
+        true
+    })
+    .map(|_| ())
+}
+
+/// Reserve one successor for the complete retry lineage before admitting it.
+/// The advisory lock spans processes, so a lost CLI response can be retried
+/// without creating a second queued controller run.
+pub fn retry_with_force(
+    run_id: &str,
+    requested_run_id: Option<&str>,
+    force: bool,
+) -> Result<AgentTaskRunRecord> {
+    retry_with_force_inner(run_id, requested_run_id, force, true)
+}
+
+fn retry_with_force_inner(
+    run_id: &str,
+    requested_run_id: Option<&str>,
+    force: bool,
+    enforce_lineage_reservation: bool,
+) -> Result<AgentTaskRunRecord> {
     let source = store::read_record(&resolve_run_id(run_id)?)?;
+    let root_run_id = retry_root_run_id(&source)?;
+    let _reservation = enforce_lineage_reservation
+        .then(|| RetryLineageLock::lock(&root_run_id))
+        .transpose()?;
+    let mut requested_run_id = requested_run_id;
+    if enforce_lineage_reservation {
+        let records = store::read_records()?;
+        let mut successors = records
+            .into_iter()
+            .filter(|record| record.run_id != root_run_id)
+            .filter(|record| retry_root_run_id(record).ok().as_deref() == Some(&root_run_id))
+            .collect::<Vec<_>>();
+        successors.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+        if let Some(active) = successors.iter().find(|record| !record.state.is_terminal()) {
+            if !force {
+                // A caller can lose the response after the first durable write.
+                // Replaying its exact requested successor is an idempotent read,
+                // not an attempt to allocate beside the active reservation.
+                if requested_run_id == Some(active.run_id.as_str()) {
+                    return Ok(active.clone());
+                }
+                return Err(active_retry_successor_error(active));
+            }
+            if requested_run_id == Some(active.run_id.as_str()) {
+                requested_run_id = None;
+            }
+        }
+        if !successors.is_empty() && !force {
+            return Err(Error::validation_invalid_argument(
+                "force",
+                format!(
+                    "retry lineage rooted at '{}' already has terminal successor(s); use --force to create another retry",
+                    root_run_id
+                ),
+                Some(root_run_id),
+                None,
+            ));
+        }
+    }
     let mut plan = load_controller_plan(&source.run_id)?;
     super::cook_workspace_restore::restore_initial_cook_candidate_workspace(&mut plan)?;
     super::cook_workspace_restore::restore_follow_up_cook_candidate_workspace(&mut plan)?;
@@ -1648,8 +1725,12 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
         metadata.insert("retry_origin".to_string(), Value::Object(retry_origin));
     }
     metadata.insert("retry_of".to_string(), json!(source.run_id));
+    if enforce_lineage_reservation {
+        metadata.insert("retried_from".to_string(), json!(source.run_id));
+        metadata.insert("retry_root".to_string(), json!(root_run_id));
+    }
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
-    submit_plan_with_runtime_admission_on_runner_with_metadata(
+    let record = submit_plan_with_runtime_admission_on_runner_with_metadata(
         &plan,
         requested_run_id,
         execution_runner_id(),
@@ -1660,7 +1741,105 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
                 || Ok(store::read_record(run_id)?.state.is_terminal()),
             )
         },
+    )?;
+    if enforce_lineage_reservation {
+        persist_retry_lineage(&source.run_id, &root_run_id, &record.run_id)?;
+    }
+    Ok(record)
+}
+
+const RETRY_LINEAGE_LIMIT: usize = 16;
+
+struct RetryLineageLock {
+    #[allow(dead_code)]
+    file: File,
+}
+
+impl RetryLineageLock {
+    fn lock(root_run_id: &str) -> Result<Self> {
+        let path = paths::homeboy_data()?
+            .join("agent-task-runs")
+            .join("retry-lineages")
+            .join(format!("{}.lock", sanitize_run_id(root_run_id)));
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| Error::internal_io(error.to_string(), None))?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(path.display().to_string()))
+            })?;
+        #[cfg(unix)]
+        if unsafe { libc::flock(std::os::fd::AsRawFd::as_raw_fd(&file), libc::LOCK_EX) } != 0 {
+            return Err(Error::internal_io(
+                std::io::Error::last_os_error().to_string(),
+                Some(format!("lock retry lineage {root_run_id}")),
+            ));
+        }
+        Ok(Self { file })
+    }
+}
+
+fn retry_root_run_id(record: &AgentTaskRunRecord) -> Result<String> {
+    let mut current = record.clone();
+    for _ in 0..RETRY_LINEAGE_LIMIT {
+        let Some(parent) = current.metadata.get("retry_of").and_then(Value::as_str) else {
+            return Ok(current.run_id);
+        };
+        current = store::read_record(&sanitize_run_id(parent))?;
+    }
+    Err(Error::validation_invalid_argument(
+        "retry_of",
+        "retry lineage exceeds the supported depth",
+        Some(record.run_id.clone()),
+        None,
+    ))
+}
+
+fn active_retry_successor_error(record: &AgentTaskRunRecord) -> Error {
+    Error::validation_invalid_argument(
+        "run_id",
+        format!(
+            "active retry successor '{}' is {:?}; inspect it with `homeboy agent-task status {}`",
+            record.run_id, record.state, record.run_id
+        ),
+        Some(record.run_id.clone()),
+        Some(vec![format!("homeboy agent-task status {}", record.run_id)]),
     )
+}
+
+fn persist_retry_lineage(source_run_id: &str, root_run_id: &str, child_run_id: &str) -> Result<()> {
+    let mut targets = vec![sanitize_run_id(source_run_id)];
+    let root_run_id = sanitize_run_id(root_run_id);
+    if !targets.contains(&root_run_id) {
+        targets.push(root_run_id.clone());
+    }
+    for run_id in targets {
+        store::mutate_record(&run_id, |record| {
+            let metadata = record.ensure_metadata_object();
+            let lineage = metadata
+                .entry("retries".to_string())
+                .or_insert_with(|| json!([]));
+            if !lineage.is_array() {
+                *lineage = json!([]);
+            }
+            let retries = lineage.as_array_mut().expect("retry lineage is an array");
+            if !retries.iter().any(|entry| entry == child_run_id) {
+                retries.push(json!(child_run_id));
+                if retries.len() > RETRY_LINEAGE_LIMIT {
+                    retries.drain(..retries.len() - RETRY_LINEAGE_LIMIT);
+                }
+            }
+            metadata.insert("retry_root".to_string(), json!(root_run_id));
+            record.updated_at = Some(now_timestamp());
+            true
+        })?;
+    }
+    Ok(())
 }
 
 /// Find the one lifecycle-first Cook retry reservation that can be bound to an

--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -194,6 +194,46 @@ pub fn complete_cook_operation(run_id: &str, operation_key: &str, result: Value)
     Ok(())
 }
 
+/// Restore a completed claim only when the caller has independently recovered
+/// the durable side effect. This repairs an interrupted source-record rewrite
+/// without allowing an arbitrary completion marker to invent work.
+pub fn recover_completed_cook_operation(
+    run_id: &str,
+    operation_key: &str,
+    result: Value,
+) -> Result<()> {
+    let run_id = sanitize_run_id(run_id);
+    let now = now_timestamp();
+    store::mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let claims = metadata
+            .entry(OPERATION_CLAIMS_KEY.to_string())
+            .or_insert_with(|| json!([]));
+        if !claims.is_array() {
+            *claims = json!([]);
+        }
+        let claims = claims.as_array_mut().expect("operation claims array");
+        if let Some(claim) = claims
+            .iter()
+            .find(|claim| claim["operation_key"] == json!(operation_key))
+        {
+            return claim["state"] != json!("completed");
+        }
+        claims.push(json!({
+            "operation_key": operation_key,
+            "state": "completed",
+            "leased_at": now,
+            "completed_at": now,
+            "owner_pid": std::process::id(),
+            "result": result,
+            "recovered_from_authoritative_successor": true,
+        }));
+        record.updated_at = Some(now.clone());
+        true
+    })?;
+    Ok(())
+}
+
 /// Terminalize a claimed operation that did not produce its external result.
 /// Failed claims retain their exact bounded diagnostic but are intentionally
 /// reclaimable by a later explicit continuation.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -45,6 +45,89 @@ fn retry_first_visible_record_always_has_indexed_predecessor_identity() {
 }
 
 #[test]
+fn retry_lineage_refuses_an_active_successor_and_requires_force_after_terminal_successors() {
+    with_isolated_home(|_| {
+        let source_id = "retry-lineage-source";
+        submit_plan(&test_plan(), Some(source_id)).expect("submit source");
+
+        let first = retry_with_force(source_id, Some("retry-lineage-first"), false)
+            .expect("first retry reserves successor");
+        let replayed = retry_with_force(source_id, Some("retry-lineage-first"), false)
+            .expect("exact active retry reservation is idempotent");
+        assert_eq!(replayed.run_id, first.run_id);
+        let active = retry_with_force(source_id, Some("retry-lineage-second"), false)
+            .expect_err("active successor prevents duplicate retry");
+        assert!(active.message.contains("retry-lineage-first"));
+        assert!(active
+            .message
+            .contains("homeboy agent-task status retry-lineage-first"));
+
+        let forced_active = retry_with_force(source_id, Some("retry-lineage-first"), true)
+            .expect("force creates a distinct successor beside the active retry");
+        assert_ne!(forced_active.run_id, first.run_id);
+        assert_eq!(forced_active.metadata["retried_from"], source_id);
+        assert_eq!(forced_active.metadata["retry_root"], source_id);
+
+        cancel_run(&first.run_id, Some("test terminal successor")).expect("terminalize successor");
+        cancel_run(
+            &forced_active.run_id,
+            Some("test terminal forced successor"),
+        )
+        .expect("terminalize forced successor");
+        let terminal = retry_with_force(source_id, Some("retry-lineage-second"), false)
+            .expect_err("terminal successor requires explicit force");
+        assert_eq!(terminal.details["field"], "force");
+
+        let forced = retry_with_force(source_id, Some("retry-lineage-second"), true)
+            .expect("force creates next retry");
+        assert_eq!(forced.metadata["retried_from"], source_id);
+        assert_eq!(forced.metadata["retry_root"], source_id);
+        let source = exact_record(source_id).expect("source record");
+        assert_eq!(
+            source.metadata["retries"],
+            json!([
+                "retry-lineage-first",
+                forced_active.run_id,
+                "retry-lineage-second"
+            ])
+        );
+    });
+}
+
+#[test]
+fn runner_resubmission_preserves_existing_retry_lineage_metadata() {
+    with_isolated_home(|_| {
+        let source_id = "retry-resubmission-source";
+        let first_retry_id = "retry-resubmission-first";
+        let second_retry_id = "retry-resubmission-second";
+        let plan = test_plan();
+        submit_plan(&plan, Some(source_id)).expect("submit source");
+        retry_with_force(source_id, Some(first_retry_id), false).expect("reserve first retry");
+        retry_with_force(first_retry_id, Some(second_retry_id), true)
+            .expect("record descendant retry");
+
+        let resubmitted = submit_plan_with_runtime_admission_on_runner(
+            &plan,
+            Some(first_retry_id),
+            Some("fixture-runner".to_string()),
+            |_| Ok(json!({ "runner": "fixture-runtime" })),
+        )
+        .expect("runner resubmits the existing retry record");
+
+        assert_eq!(resubmitted.metadata["retried_from"], source_id);
+        assert_eq!(resubmitted.metadata["retry_root"], source_id);
+        assert_eq!(resubmitted.metadata["retries"], json!([second_retry_id]));
+        assert_eq!(resubmitted.metadata["retry_of"], source_id);
+        assert_eq!(
+            exact_record(first_retry_id)
+                .expect("persisted resubmitted retry")
+                .metadata["retries"],
+            json!([second_retry_id])
+        );
+    });
+}
+
+#[test]
 fn cook_progress_is_durable_across_active_and_terminal_lifecycle_states() {
     with_isolated_home(|_| {
         let run_id = "cook-progress-lifecycle";

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1760,6 +1760,7 @@ where
     validate_cook_workspace(&options)?;
     validate_cook_candidate_group(&options.initial_plan)?;
     materialize_initial_cook_attempt(&options)?;
+    record_active_cook_worktree_warning(&options)?;
     // Durable identity now exists and resolves through the Cook alias. Publish
     // it before every remaining long controller phase — gate toolchain
     // preflight, transport preparation, and Lab materialization — so a caller
@@ -2808,6 +2809,51 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
             Some(vec!["Re-run Cook without a source CWD override so Homeboy binds the declared task worktree.".to_string()]),
         ));
     }
+    Ok(())
+}
+
+fn record_active_cook_worktree_warning(options: &AgentTaskCookServiceOptions) -> Result<()> {
+    let Some(source) = options.source_worktree_path.as_deref() else {
+        return Ok(());
+    };
+    let target = std::fs::canonicalize(source).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(source.display().to_string()))
+    })?;
+    let mut active = agent_task_lifecycle::list_records()?
+        .into_iter()
+        .filter(|record| record.run_id != options.initial_run_id && !record.state.is_terminal())
+        .filter(|record| record.metadata.get("cook_id").is_some())
+        .filter_map(|record| {
+            let plan = agent_task_lifecycle::load_plan_for_execution(&record.run_id).ok()?;
+            let matches_target = plan.tasks.iter().any(|task| {
+                task.workspace
+                    .root
+                    .as_deref()
+                    .and_then(|root| std::fs::canonicalize(root).ok())
+                    .as_ref()
+                    == Some(&target)
+            });
+            matches_target.then_some(record)
+        })
+        .collect::<Vec<_>>();
+    active.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+    if active.is_empty() {
+        return Ok(());
+    }
+    let run_ids = active
+        .iter()
+        .map(|record| record.run_id.clone())
+        .collect::<Vec<_>>();
+    agent_task_lifecycle::record_metadata_value(
+        &options.initial_run_id,
+        "cook_active_worktree_warning",
+        serde_json::json!({
+            "schema": "homeboy/cook-active-worktree-warning/v1",
+            "canonical_worktree": target,
+            "active_run_ids": run_ids,
+            "status_commands": active.iter().map(|record| format!("homeboy agent-task status {}", record.run_id)).collect::<Vec<_>>(),
+        }),
+    )?;
     Ok(())
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1862,13 +1862,62 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
 }
 
 #[test]
+fn active_cooks_on_the_same_canonical_worktree_record_a_nonblocking_warning() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let workspace = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let mut options = batch_cook_options(
+            "cook-worktree-warning",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.to_worktree = workspace.display().to_string();
+        options.source_worktree_path = Some(workspace.clone());
+        options.initial_plan.tasks[0].workspace.root = Some(workspace.display().to_string());
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .expect("submit current Cook");
+
+        for run_id in ["active-cook-z", "active-cook-a"] {
+            let mut plan = options.initial_plan.clone();
+            plan.plan_id = run_id.to_string();
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit active Cook");
+            agent_task_lifecycle::record_cook_attempt(run_id, 1, run_id).expect("mark active Cook");
+        }
+
+        super::record_active_cook_worktree_warning(&options)
+            .expect("active worktree warning must not block Cook");
+
+        let current = agent_task_lifecycle::status(&options.initial_run_id)
+            .expect("current Cook remains inspectable");
+        assert_eq!(
+            current.state,
+            agent_task_lifecycle::AgentTaskRunState::Queued
+        );
+        assert_eq!(
+            current.metadata["cook_active_worktree_warning"],
+            serde_json::json!({
+                "schema": "homeboy/cook-active-worktree-warning/v1",
+                "canonical_worktree": workspace,
+                "active_run_ids": ["active-cook-a", "active-cook-z"],
+                "status_commands": [
+                    "homeboy agent-task status active-cook-a",
+                    "homeboy agent-task status active-cook-z"
+                ],
+            })
+        );
+    });
+}
+
+#[test]
 fn retryable_pre_provider_retry_stays_attached_to_its_cook() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-pre-provider-retry";
         let options = retryable_pre_provider_cook(cook_id, 2);
         let first_run_id = options.initial_run_id.as_str();
 
-        let retry = crate::agent_task_service::retry(first_run_id, None, false)
+        let retry = crate::agent_task_service::retry(first_run_id, None, false, false)
             .expect("corrected environment retry remains Cook-owned");
         let retry_run_id = retry.record.run_id.clone();
         let completed = crate::agent_task_service::execution::run_submitted(
@@ -1920,7 +1969,7 @@ fn retryable_pre_provider_retry_without_a_recipe_uses_legacy_lifecycle_retry() {
         )
         .expect("record retryable legacy failure");
 
-        let retry = crate::agent_task_service::retry(run_id, Some("legacy-retry"), false)
+        let retry = crate::agent_task_service::retry(run_id, Some("legacy-retry"), false, false)
             .expect("legacy retry remains supported");
 
         assert_eq!(retry.record.run_id, "legacy-retry");
@@ -1961,9 +2010,13 @@ fn retryable_pre_provider_retry_rejects_a_lifecycle_reservation_collision_withou
         agent_task_lifecycle::submit_plan(&unrelated, Some(collision_id))
             .expect("submit unrelated run");
 
-        let error =
-            crate::agent_task_service::retry(&options.initial_run_id, Some(collision_id), false)
-                .expect_err("colliding lifecycle reservation is rejected before Cook mutation");
+        let error = crate::agent_task_service::retry(
+            &options.initial_run_id,
+            Some(collision_id),
+            false,
+            false,
+        )
+        .expect_err("colliding lifecycle reservation is rejected before Cook mutation");
 
         assert_eq!(error.details["field"], "new_run_id");
         assert_eq!(
@@ -1992,7 +2045,7 @@ fn retryable_pre_provider_retry_enforces_the_persisted_attempt_budget() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = retryable_pre_provider_cook("cook-retry-budget", 1);
 
-        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false)
+        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
             .expect_err("retry cannot exceed the persisted Cook budget");
 
         assert_eq!(
@@ -2026,8 +2079,9 @@ fn retryable_pre_provider_retry_repairs_lifecycle_reserved_attempts_idempotently
         agent_task_lifecycle::retry(&options.initial_run_id, Some(&submitted_run_id))
             .expect("submit retry before Cook metadata binding");
 
-        let repaired = crate::agent_task_service::retry(&options.initial_run_id, None, false)
-            .expect("repair submitted retry");
+        let repaired =
+            crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+                .expect("repair submitted retry");
         assert_eq!(repaired.record.run_id, submitted_run_id);
         assert_eq!(repaired.record.metadata["cook_id"], options.cook_id);
         assert_eq!(repaired.record.metadata["cook_attempt"], 2);
@@ -2066,7 +2120,7 @@ fn retryable_pre_provider_retry_concurrently_claims_one_successor() {
                 let run_id = options.initial_run_id.clone();
                 std::thread::spawn(move || {
                     barrier.wait();
-                    crate::agent_task_service::retry(&run_id, None, false)
+                    crate::agent_task_service::retry(&run_id, None, false, false)
                         .expect("concurrent retry converges")
                         .record
                         .run_id
@@ -2136,7 +2190,7 @@ fn retryable_pre_provider_retry_process_worker() {
     let Ok(run_id) = std::env::var("HOMEBOY_RETRY_PROCESS_WORKER") else {
         return;
     };
-    crate::agent_task_service::retry(&run_id, None, false).expect("process retry converges");
+    crate::agent_task_service::retry(&run_id, None, false, false).expect("process retry converges");
 }
 
 #[test]
@@ -2154,7 +2208,7 @@ fn retryable_pre_provider_retry_rejects_unowned_same_plan_collision_without_retr
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&pending_run_id))
             .expect("occupy pending attempt with same plan");
 
-        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false)
+        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
             .expect_err("unowned same-plan run is not repaired without retry proof");
 
         assert!(error
@@ -2187,7 +2241,7 @@ fn retryable_pre_provider_retry_returns_terminal_successor_without_reexecution()
         )
         .expect("complete successor successfully");
 
-        let retry = crate::agent_task_service::retry(&options.initial_run_id, None, true)
+        let retry = crate::agent_task_service::retry(&options.initial_run_id, None, true, false)
             .expect("terminal successor is authoritative");
 
         assert_eq!(retry.record.run_id, successor_run_id);
@@ -2223,7 +2277,7 @@ fn retryable_pre_provider_retry_rejects_pending_attempt_owned_by_another_cook() 
         agent_task_lifecycle::record_cook_attempt("another-cook", 1, &pending_run_id)
             .expect("mark conflicting Cook ownership");
 
-        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false)
+        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
             .expect_err("conflicting Cook owner must not be rebound");
 
         assert!(error

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -386,6 +386,7 @@ pub fn retry(
     run_id: &str,
     new_run_id: Option<&str>,
     run: bool,
+    force: bool,
 ) -> Result<AgentTaskRetryServiceResult> {
     let source = agent_task_lifecycle::status(run_id)?;
     let cook_retry = retryable_cook_attempt(&source)?;
@@ -405,9 +406,11 @@ pub fn retry(
                 .map(str::to_string)
                 .or(discovered_run_id)
                 .unwrap_or_else(|| {
-                    agent_task_lifecycle::cook_attempt_run_id(
-                        &cook_retry.cook_id,
-                        cook_retry.attempt,
+                    // All concurrent retries of one Cook attempt must reserve
+                    // the same lifecycle successor before claim reconciliation.
+                    format!(
+                        "{}-attempt-{}-retry",
+                        cook_retry.cook_id, cook_retry.attempt
                     )
                 });
             let retry_exists = agent_task_lifecycle::run_record_exists(&retry_run_id)?;
@@ -450,7 +453,7 @@ pub fn retry(
             }
             record
         }
-        None => agent_task_lifecycle::retry(&source.run_id, new_run_id)?,
+        None => agent_task_lifecycle::retry_with_force(&source.run_id, new_run_id, force)?,
     };
     Ok(AgentTaskRetryServiceResult { record, run })
 }
@@ -467,12 +470,31 @@ fn reserve_cook_retry_lifecycle(
         Duration::from_secs(30),
     )? {
         agent_task_lifecycle::ClaimOutcome::Acquired => {
-            agent_task_lifecycle::retry(&source.run_id, Some(retry_run_id))?;
-            agent_task_lifecycle::complete_cook_operation(
+            // The Cook operation claim coordinates recipe/index binding; the
+            // lifecycle retry lock also makes the first durable successor
+            // idempotent across concurrent controllers and processes.
+            agent_task_lifecycle::retry_with_force(&source.run_id, Some(retry_run_id), false)?;
+            let result = json!({ "run_id": retry_run_id });
+            if let Err(error) = agent_task_lifecycle::complete_cook_operation(
                 &source.run_id,
                 &operation_key,
-                json!({ "run_id": retry_run_id }),
-            )?;
+                result.clone(),
+            ) {
+                let recovered = agent_task_lifecycle::find_unbound_cook_retry_successor(
+                    &source.run_id,
+                    &retry.cook_id,
+                    retry.attempt,
+                    &retry.plan,
+                )?;
+                if recovered.as_ref().map(|record| record.run_id.as_str()) != Some(retry_run_id) {
+                    return Err(error);
+                }
+                agent_task_lifecycle::recover_completed_cook_operation(
+                    &source.run_id,
+                    &operation_key,
+                    result,
+                )?;
+            }
             Ok(retry_run_id.to_string())
         }
         agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -209,6 +209,9 @@ pub struct RetryArgs {
     pub new_run_id: Option<String>,
     #[arg(long)]
     pub run: bool,
+    /// Permit a new retry after every prior retry in this lineage is terminal.
+    #[arg(long, visible_alias = "allow-duplicate")]
+    pub force: bool,
 }
 #[derive(Args, Debug)]
 pub struct CancelArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -911,7 +911,12 @@ where
 }
 
 pub(super) fn retry(args: RetryArgs) -> CmdResult<Value> {
-    let result = agent_task_service::retry(&args.run_id, args.new_run_id.as_deref(), args.run)?;
+    let result = agent_task_service::retry(
+        &args.run_id,
+        args.new_run_id.as_deref(),
+        args.run,
+        args.force,
+    )?;
     if result.run {
         return run_submitted_with_executor(
             result.record.run_id,

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1874,6 +1874,7 @@ fn retry_command_submits_new_queued_run() {
             run_id: "run-retry-source".to_string(),
             new_run_id: Some("run-retry-cli".to_string()),
             run: false,
+            force: false,
         })
         .expect("retry queued");
         let record: AgentTaskRunRecord = serde_json::from_value(value).expect("record");
@@ -1883,6 +1884,25 @@ fn retry_command_submits_new_queued_run() {
         assert_eq!(record.state, AgentTaskRunState::Queued);
         assert_eq!(record.metadata["retry_of"], json!("run-retry-source"));
     });
+}
+
+#[test]
+fn retry_force_alias_parses_as_force() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "retry",
+        "retry-source",
+        "--allow-duplicate",
+    ])
+    .expect("retry force alias parses");
+    let Commands::AgentTask(args) = cli.command else {
+        panic!("agent-task retry command");
+    };
+    let AgentTaskCommand::Retry(args) = args.command else {
+        panic!("retry command");
+    };
+    assert!(args.force);
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -1335,8 +1335,12 @@ fn materialize_agent_task_retry_handoff(
         return Ok(None);
     }
 
-    let retry_result =
-        crate::agents::agent_task_service::retry(&retry.run_id, retry.new_run_id.as_deref(), true)?;
+    let retry_result = crate::agents::agent_task_service::retry(
+        &retry.run_id,
+        retry.new_run_id.as_deref(),
+        true,
+        retry.force,
+    )?;
     if !retry_result.run {
         return Ok(None);
     }

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1155,6 +1155,31 @@ fn detached_retry_materializes_failed_plan_and_persists_bounded_preacceptance_fa
         assert!(remote_cli.detach_after_handoff);
         let replacement = agent_task_lifecycle::status(&handoff.run_id).expect("replacement");
         assert_eq!(replacement.metadata["retry_of"], "failed-run");
+        assert_eq!(replacement.metadata["retried_from"], "failed-run");
+        assert_eq!(replacement.metadata["retry_root"], "failed-run");
+        assert_eq!(
+            agent_task_lifecycle::status("failed-run")
+                .expect("source retry lineage")
+                .metadata["retries"],
+            serde_json::json!(["failed-run-retry-on-lab"])
+        );
+
+        // The Lab executes `run-plan` against the durable replacement. Its
+        // re-submission must retain retry lineage so later reconciliation can
+        // still resolve the retry reservation through the controller store.
+        agent_task_lifecycle::submit_plan(&handoff.plan, Some(&handoff.run_id))
+            .expect("resubmit replacement from Lab handoff");
+        let resubmitted =
+            agent_task_lifecycle::status(&handoff.run_id).expect("resubmitted replacement");
+        assert_eq!(resubmitted.metadata["retry_of"], "failed-run");
+        assert_eq!(resubmitted.metadata["retried_from"], "failed-run");
+        assert_eq!(resubmitted.metadata["retry_root"], "failed-run");
+        assert_eq!(
+            agent_task_lifecycle::status("failed-run")
+                .expect("source retry lineage remains idempotent")
+                .metadata["retries"],
+            serde_json::json!(["failed-run-retry-on-lab"])
+        );
 
         stage_retry_lab_handoff_before_preacceptance(Some(&handoff), Some("homeboy-lab"))
             .expect("stage replacement handoff before Lab preacceptance");

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use super::persistence::{
     apply_event_retention, job_not_found, lookup_tombstone, timestamp_ms, validate_transition,
-    write_durable_store_with_tombstones, ReplayTombstoneKind,
+    ReplayTombstoneKind,
 };
 use super::store::{JobStore, RemoteRunnerSubmission, StoredJob};
 use super::types::{Job, JobEvent, JobEventKind, JobStatus};
@@ -602,7 +602,7 @@ impl JobStore {
             .as_ref()
             .map(|_| request.submission_payload_fingerprint())
             .transpose()?;
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
         if let Some(submission_key) = submission_key.as_deref() {
             let fingerprint = submission_fingerprint
                 .as_deref()
@@ -630,19 +630,24 @@ impl JobStore {
                             "durable runner submission index references a missing job",
                         )
                     })?;
-                let evidence = serde_json::json!({
-                    "schema": "homeboy/remote-runner-submission/v1",
-                    "submission_key": submission_key,
-                    "payload_fingerprint": fingerprint,
-                    "decision": "replay",
-                    "accepted_job_id": job.id,
-                });
-                drop(inner);
-                self.append_event(
+                if job.status.is_terminal() {
+                    // The original terminal snapshot is authoritative. A replay
+                    // is an observation, not new work or a legal state mutation.
+                    return Ok(job);
+                }
+                Self::append_event_already_locked(
+                    self,
+                    &mut *inner,
                     job.id,
                     JobEventKind::Progress,
                     Some("remote runner submission replayed".to_string()),
-                    Some(evidence),
+                    Some(serde_json::json!({
+                        "schema": "homeboy/remote-runner-submission/v1",
+                        "submission_key": submission_key,
+                        "payload_fingerprint": fingerprint,
+                        "decision": "replay",
+                        "accepted_job_id": job.id,
+                    })),
                 )?;
                 return Ok(job);
             }
@@ -766,25 +771,8 @@ impl JobStore {
         // Persist job creation, queue evidence, and key index as one locked
         // snapshot. This is the admission commit point used by lost-response
         // recovery and daemon restart replay.
-        if let Some(persistence) = &self.persistence {
-            let mut durable = super::store::DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-                submission_keys: inner.submission_keys.clone(),
-                expired_submission_keys: inner.expired_submission_keys.clone(),
-                controller_submissions: inner.controller_submissions.clone(),
-                expired_controller_submissions: inner.expired_controller_submissions.clone(),
-                compaction: inner.compaction.clone(),
-            };
-            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
-            {
-                inner.jobs.remove(&job.id);
-                if let Some(submission_key) = request.submission_key() {
-                    inner.submission_keys.remove(submission_key);
-                }
-                return Err(error);
-            }
-        }
         Ok(job)
+        })
     }
 
     pub fn claim_remote_runner_job(
@@ -813,9 +801,7 @@ impl JobStore {
 
         let now = timestamp_ms();
         let lease_ms = lease_ms.max(1);
-        let mut claimed: Option<(Uuid, RemoteRunnerJobRequest)> = None;
-        {
-            let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let claimed = self.durable_transaction(|inner| {
             if let Some(limit) = concurrency_limit {
                 let running = inner
                     .jobs
@@ -832,7 +818,7 @@ impl JobStore {
             }
             let mut candidates: Vec<_> = inner
                 .jobs
-                .values_mut()
+                .values()
                 .filter(|stored| {
                     stored.remote_runner.is_some()
                         && stored.job.status == JobStatus::Queued
@@ -847,37 +833,48 @@ impl JobStore {
                     stored.job.id,
                 )
             });
-            if let Some(stored) = candidates.into_iter().next() {
-                stored.job.status = JobStatus::Running;
-                stored.job.updated_at_ms = now;
-                stored.job.started_at_ms = Some(now);
-                stored.job.claim_id = Some(Uuid::new_v4().to_string());
-                stored.job.claimed_by_runner_id = Some(runner_id.to_string());
-                stored.job.claimed_at_ms = Some(now);
-                stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms));
-                let remote_runner = stored
-                    .remote_runner
-                    .as_ref()
-                    .expect("filtered remote runner job has request");
-                let request = remote_runner
-                    .execution_request
-                    .as_ref()
-                    .unwrap_or(&remote_runner.request)
-                    .dispatch_request();
-                claimed = Some((stored.job.id, request));
+            if let Some(job_id) = candidates
+                .into_iter()
+                .next()
+                .map(|candidate| candidate.job.id)
+            {
+                let (job, request) = {
+                    let stored = inner.jobs.get_mut(&job_id).expect("candidate exists");
+                    stored.job.status = JobStatus::Running;
+                    stored.job.updated_at_ms = now;
+                    stored.job.started_at_ms = Some(now);
+                    stored.job.claim_id = Some(Uuid::new_v4().to_string());
+                    stored.job.claimed_by_runner_id = Some(runner_id.to_string());
+                    stored.job.claimed_at_ms = Some(now);
+                    stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms));
+                    let remote_runner = stored
+                        .remote_runner
+                        .as_ref()
+                        .expect("filtered remote runner job has request");
+                    let request = remote_runner
+                        .execution_request
+                        .as_ref()
+                        .unwrap_or(&remote_runner.request)
+                        .dispatch_request();
+                    (stored.job.clone(), request)
+                };
+                Self::append_event_already_locked(
+                    self,
+                    inner,
+                    job_id,
+                    JobEventKind::Status,
+                    Some("remote runner job claimed".to_string()),
+                    Some(serde_json::json!({ "status": JobStatus::Running })),
+                )?;
+                return Ok(Some((job, request)));
             }
-        }
+            Ok(None)
+        })?;
 
-        let Some((job_id, request)) = claimed else {
+        let Some((job, request)) = claimed else {
             return Ok(None);
         };
-
-        self.persist()?;
-        self.append_status_event(job_id, JobStatus::Running, "remote runner job claimed")?;
-        Ok(Some(RemoteRunnerJobClaim {
-            job: self.get(job_id)?,
-            request,
-        }))
+        Ok(Some(RemoteRunnerJobClaim { job, request }))
     }
 
     pub fn append_remote_runner_event(
@@ -930,8 +927,7 @@ impl JobStore {
             )?;
         }
 
-        {
-            let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
             let stored = inner
                 .jobs
                 .get_mut(&job_id)
@@ -944,8 +940,8 @@ impl JobStore {
                     artifact
                 })
                 .collect();
-        }
-        self.persist()?;
+            Ok(())
+        })?;
 
         self.transition(
             job_id,
@@ -970,16 +966,15 @@ impl JobStore {
     ) -> Result<Job> {
         self.ensure_remote_runner_claim(job_id, runner_id, claim_id)?;
         let now = timestamp_ms();
-        {
-            let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
             let stored = inner
                 .jobs
                 .get_mut(&job_id)
                 .ok_or_else(|| job_not_found(job_id))?;
             stored.job.updated_at_ms = now;
             stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms.max(1)));
-        }
-        self.persist()?;
+            Ok(())
+        })?;
         self.get(job_id)
     }
 
@@ -1024,79 +1019,77 @@ impl JobStore {
             ));
         }
 
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        let Some(local_runner) = stored.local_runner.as_ref() else {
-            return Err(Error::validation_invalid_argument(
-                "job_id",
-                "job has no daemon-local runner projection",
-                Some(job_id.to_string()),
-                None,
-            ));
-        };
-        let Some(lifecycle) = local_runner.lifecycle.as_ref() else {
-            return Err(Error::validation_invalid_argument(
-                "job_id",
-                "daemon-local runner projection has no lifecycle metadata",
-                Some(job_id.to_string()),
-                None,
-            ));
-        };
-        let Some(durable_run_id) = lifecycle
-            .durable_run_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|id| !id.is_empty())
-        else {
-            return Err(Error::validation_invalid_argument(
-                "job_id",
-                "daemon-local runner projection has no durable run ID",
-                Some(job_id.to_string()),
-                None,
-            ));
-        };
-        if local_runner.runner_id != expected_runner_id {
-            return Err(Error::validation_invalid_argument(
-                "expected_runner_id",
-                "daemon-local runner projection belongs to a different runner",
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-        if durable_run_id != expected_durable_run_id {
-            return Err(Error::validation_invalid_argument(
-                "expected_durable_run_id",
-                "daemon-local runner projection belongs to a different durable run",
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-        if stored.job.status.is_terminal() {
-            return Ok(stored.job.clone());
-        }
-        validate_transition(stored.job.status, JobStatus::Cancelled)?;
-        let now = timestamp_ms();
-        stored.job.status = JobStatus::Cancelled;
-        stored.job.updated_at_ms = now;
-        stored.job.finished_at_ms = Some(now);
-        let event = JobEvent {
-            sequence: self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1,
-            job_id,
-            kind: JobEventKind::Status,
-            timestamp_ms: now,
-            message: Some("cancelled via strict runner projection".to_string()),
-            data: Some(serde_json::json!({ "status": JobStatus::Cancelled })),
-        };
-        stored.events.push(event);
-        apply_event_retention(&mut stored.events, self.event_retention_limit());
-        stored.job.event_count = stored.events.len();
-        let job = stored.job.clone();
-        drop(inner);
-        self.persist()?;
-        Ok(job)
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let Some(local_runner) = stored.local_runner.as_ref() else {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "job has no daemon-local runner projection",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            };
+            let Some(lifecycle) = local_runner.lifecycle.as_ref() else {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "daemon-local runner projection has no lifecycle metadata",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            };
+            let Some(durable_run_id) = lifecycle
+                .durable_run_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+            else {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "daemon-local runner projection has no durable run ID",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            };
+            if local_runner.runner_id != expected_runner_id {
+                return Err(Error::validation_invalid_argument(
+                    "expected_runner_id",
+                    "daemon-local runner projection belongs to a different runner",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if durable_run_id != expected_durable_run_id {
+                return Err(Error::validation_invalid_argument(
+                    "expected_durable_run_id",
+                    "daemon-local runner projection belongs to a different durable run",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if stored.job.status.is_terminal() {
+                return Ok(stored.job.clone());
+            }
+            validate_transition(stored.job.status, JobStatus::Cancelled)?;
+            let now = timestamp_ms();
+            stored.job.status = JobStatus::Cancelled;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            let event = JobEvent {
+                sequence: self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1,
+                job_id,
+                kind: JobEventKind::Status,
+                timestamp_ms: now,
+                message: Some("cancelled via strict runner projection".to_string()),
+                data: Some(serde_json::json!({ "status": JobStatus::Cancelled })),
+            };
+            stored.events.push(event);
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+            Ok(stored.job.clone())
+        })
     }
 
     pub(crate) fn reconcile_expired_remote_runner_claims(&self, now_ms: u64) -> Result<Vec<Job>> {

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -1,15 +1,19 @@
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::thread::{self, JoinHandle};
 
+use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+use super::persistence::read_durable_store;
+#[cfg(test)]
+use super::persistence::reconcile_stale_jobs;
 use super::persistence::{
     apply_event_retention, compact_terminal_jobs, job_not_found, lookup_tombstone,
     prepare_tombstone_store, timestamp_ms, tombstone_store_report, validate_transition,
@@ -17,8 +21,6 @@ use super::persistence::{
     DEFAULT_EVENT_RETENTION_LIMIT, DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
     DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
 };
-#[cfg(test)]
-use super::persistence::{read_durable_store, reconcile_stale_jobs};
 use super::remote_runner;
 use super::remote_runner::JobArtifactMetadata;
 use super::types::{Job, JobEvent, JobEventKind, JobStatus, RunnerJobProjection};
@@ -52,6 +54,8 @@ pub struct JobStore {
     pub(super) daemon_lease_id: Option<String>,
     #[cfg(test)]
     terminal_write_failures: Arc<AtomicU64>,
+    #[cfg(test)]
+    durable_write_failures: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +64,17 @@ pub(super) struct JobStorePersistence {
     pub(super) event_retention_limit: usize,
     pub(super) terminal_job_retention_limit: usize,
     pub(super) terminal_job_retention_bytes: usize,
+}
+
+/// The advisory lock held for one authoritative durable-store transaction.
+///
+/// Keep this private: callers must use [`JobStore::durable_transaction`] so
+/// they cannot mutate a stale in-memory snapshot between reload and commit.
+pub(super) struct DurableStoreTransaction {
+    // `flock` is process-wide on some targets but is not reentrant across file
+    // descriptors. Serialize local stores before taking the cross-process lock.
+    _process_guard: MutexGuard<'static, ()>,
+    _file: File,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -214,6 +229,154 @@ pub struct JobHandle {
 }
 
 impl JobStore {
+    pub(super) fn begin_durable_transaction(&self) -> Result<Option<DurableStoreTransaction>> {
+        let Some(persistence) = &self.persistence else {
+            return Ok(None);
+        };
+        static DURABLE_STORE_PROCESS_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let process_guard = DURABLE_STORE_PROCESS_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("durable store process mutex poisoned");
+        let parent = persistence
+            .path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+        let name = persistence
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("jobs.json");
+        let path = parent.join(format!(".{name}.transaction.lock"));
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(format!("open {}", path.display())))
+            })?;
+        file.lock_exclusive().map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("lock {}", path.display())))
+        })?;
+        Ok(Some(DurableStoreTransaction {
+            _process_guard: process_guard,
+            _file: file,
+        }))
+    }
+
+    pub(super) fn reload_durable_snapshot_already_locked(
+        &self,
+        path: &std::path::Path,
+        inner: &mut JobStoreInner,
+    ) -> Result<()> {
+        let durable = read_durable_store(path)?;
+        let next_sequence = durable
+            .jobs
+            .iter()
+            .flat_map(|stored| stored.events.iter().map(|event| event.sequence))
+            .max()
+            .unwrap_or_default();
+        inner.jobs = durable
+            .jobs
+            .into_iter()
+            .map(|stored| (stored.job.id, stored))
+            .collect();
+        inner.submission_keys = durable.submission_keys;
+        inner.expired_submission_keys = durable.expired_submission_keys;
+        inner.controller_submissions = durable.controller_submissions;
+        inner.expired_controller_submissions = durable.expired_controller_submissions;
+        inner.compaction = durable.compaction;
+        self.next_event_sequence
+            .fetch_max(next_sequence, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Apply one mutation to the current durable snapshot and commit it before
+    /// releasing the inter-process lock. The closure is the only supported path
+    /// for a durable whole-snapshot mutation.
+    pub(super) fn durable_transaction<T>(
+        &self,
+        mutation: impl FnOnce(&mut JobStoreInner) -> Result<T>,
+    ) -> Result<T> {
+        let transaction = self.begin_durable_transaction()?;
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        if let Some(persistence) = &self.persistence {
+            self.reload_durable_snapshot_already_locked(&persistence.path, &mut inner)?;
+        }
+        let prior = inner.clone();
+        let output = match mutation(&mut inner) {
+            Ok(output) => output,
+            Err(error) => {
+                *inner = prior;
+                return Err(error);
+            }
+        };
+        if transaction.is_some() {
+            if let Err(error) = self.persist_inner_already_locked(&mut inner) {
+                *inner = prior;
+                return Err(error);
+            }
+        }
+        drop(inner);
+        drop(transaction);
+        Ok(output)
+    }
+
+    /// Commit the supplied authoritative in-memory state. The caller holds the
+    /// durable transaction lock and `inner` mutex; this helper never reloads or
+    /// acquires either lock.
+    pub(super) fn persist_inner_already_locked(&self, inner: &mut JobStoreInner) -> Result<()> {
+        let Some(persistence) = &self.persistence else {
+            return Ok(());
+        };
+        #[cfg(test)]
+        if self
+            .durable_write_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(Error::internal_io(
+                "injected durable store write failure",
+                None,
+            ));
+        }
+        let mut durable = DurableJobStore {
+            jobs: inner.jobs.values().cloned().collect(),
+            submission_keys: inner.submission_keys.clone(),
+            expired_submission_keys: inner.expired_submission_keys.clone(),
+            controller_submissions: inner.controller_submissions.clone(),
+            expired_controller_submissions: inner.expired_controller_submissions.clone(),
+            compaction: inner.compaction.clone(),
+        };
+        compact_terminal_jobs(
+            &mut durable,
+            persistence.event_retention_limit,
+            persistence.terminal_job_retention_limit,
+            persistence.terminal_job_retention_bytes,
+        );
+        write_durable_store_with_tombstones(&persistence.path, &mut durable)?;
+        inner.jobs = durable
+            .jobs
+            .into_iter()
+            .map(|stored| (stored.job.id, stored))
+            .collect();
+        inner.submission_keys = durable.submission_keys;
+        inner.expired_submission_keys = durable.expired_submission_keys;
+        inner.controller_submissions = durable.controller_submissions;
+        inner.expired_controller_submissions = durable.expired_controller_submissions;
+        inner.compaction = durable.compaction;
+        Ok(())
+    }
+
     /// Count non-terminal jobs without opening or reconciling the durable store.
     ///
     /// Daemon status runs in a separate CLI process, so using [`Self::open`]
@@ -383,9 +546,35 @@ impl JobStore {
             daemon_lease_id: None,
             #[cfg(test)]
             terminal_write_failures: Arc::new(AtomicU64::new(0)),
+            #[cfg(test)]
+            durable_write_failures: Arc::new(AtomicU64::new(0)),
         };
 
-        store.persist()?;
+        store.durable_transaction(|inner| {
+            let mut durable = DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+                submission_keys: inner.submission_keys.clone(),
+                expired_submission_keys: inner.expired_submission_keys.clone(),
+                controller_submissions: inner.controller_submissions.clone(),
+                expired_controller_submissions: inner.expired_controller_submissions.clone(),
+                compaction: inner.compaction.clone(),
+            };
+            let next_sequence = reconcile_stale_jobs(&mut durable, event_retention_limit);
+            inner.jobs = durable
+                .jobs
+                .into_iter()
+                .map(|stored| (stored.job.id, stored))
+                .collect();
+            inner.submission_keys = durable.submission_keys;
+            inner.expired_submission_keys = durable.expired_submission_keys;
+            inner.controller_submissions = durable.controller_submissions;
+            inner.expired_controller_submissions = durable.expired_controller_submissions;
+            inner.compaction = durable.compaction;
+            store
+                .next_event_sequence
+                .fetch_max(next_sequence, Ordering::SeqCst);
+            Ok(())
+        })?;
         Ok(store)
     }
 
@@ -516,8 +705,10 @@ impl JobStore {
             daemon_lease_id: None,
             #[cfg(test)]
             terminal_write_failures: Arc::new(AtomicU64::new(0)),
+            #[cfg(test)]
+            durable_write_failures: Arc::new(AtomicU64::new(0)),
         };
-        store.persist()?;
+        store.durable_transaction(|_| Ok(()))?;
         Ok(store)
     }
 
@@ -618,39 +809,39 @@ impl JobStore {
         idempotency_key: &str,
         now: u64,
     ) -> Result<AdmissionReservation> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        if let Some(stored) = inner
-            .jobs
-            .values_mut()
-            .filter(|stored| stored.admission_idempotency_key.as_deref() == Some(idempotency_key))
-            .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
-        {
-            if stored.job.status.is_terminal() {
-                return Err(Error::validation_invalid_argument(
-                    "idempotency_key",
-                    "admission idempotency key belongs to a terminal reservation",
-                    Some(idempotency_key.to_string()),
-                    None,
-                ));
+        self.durable_transaction(|inner| {
+            if let Some(stored) = inner
+                .jobs
+                .values_mut()
+                .filter(|stored| {
+                    stored.admission_idempotency_key.as_deref() == Some(idempotency_key)
+                })
+                .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
+            {
+                if stored.job.status.is_terminal() {
+                    return Err(Error::validation_invalid_argument(
+                        "idempotency_key",
+                        "admission idempotency key belongs to a terminal reservation",
+                        Some(idempotency_key.to_string()),
+                        None,
+                    ));
+                }
+                let lease = stored.admission_lease.as_mut().ok_or_else(|| {
+                    Error::internal_unexpected("active admission reservation is missing its lease")
+                })?;
+                lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
+                lease.renewals = lease.renewals.saturating_add(1);
+                stored.job.updated_at_ms = now;
+                let reservation = AdmissionReservation {
+                    job: stored.job.clone(),
+                    token: lease.token.clone(),
+                    expires_at_ms: lease.expires_at_ms,
+                    created: false,
+                };
+                return Ok(reservation);
             }
-            let lease = stored.admission_lease.as_mut().ok_or_else(|| {
-                Error::internal_unexpected("active admission reservation is missing its lease")
-            })?;
-            lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
-            lease.renewals = lease.renewals.saturating_add(1);
-            stored.job.updated_at_ms = now;
-            let reservation = AdmissionReservation {
-                job: stored.job.clone(),
-                token: lease.token.clone(),
-                expires_at_ms: lease.expires_at_ms,
-                created: false,
-            };
-            drop(inner);
-            self.persist()?;
-            return Ok(reservation);
-        }
-        drop(inner);
-        self.create_admission_inner(metadata, Some(idempotency_key.to_string()), now)
+            self.create_admission_inner(inner, metadata, Some(idempotency_key.to_string()), now)
+        })
     }
 
     pub(crate) fn create_admission_at(
@@ -658,7 +849,7 @@ impl JobStore {
         metadata: Value,
         now: u64,
     ) -> Result<AdmissionReservation> {
-        self.create_admission_inner(metadata, None, now)
+        self.durable_transaction(|inner| self.create_admission_inner(inner, metadata, None, now))
     }
 
     /// Legacy, tokenless admission used only by pre-lease protocol clients
@@ -680,19 +871,20 @@ impl JobStore {
 
     fn create_admission_inner(
         &self,
+        inner: &mut JobStoreInner,
         metadata: Value,
         idempotency_key: Option<String>,
         now: u64,
     ) -> Result<AdmissionReservation> {
-        let (job, created) = self.create_or_reuse_active_local_runner_job(
+        let (job, created) = self.create_or_reuse_active_local_runner_job_inner(
+            inner,
             "runner.admission",
             None,
             Some(metadata),
             None,
             None,
             idempotency_key.clone(),
-        );
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        )?;
         let stored = inner.jobs.get_mut(&job.id).expect("admission exists");
         if !created {
             let (token, expires_at_ms) = {
@@ -715,8 +907,6 @@ impl JobStore {
                 expires_at_ms,
                 created: false,
             };
-            drop(inner);
-            self.persist()?;
             return Ok(reservation);
         }
         let lease = AdmissionLease {
@@ -725,8 +915,6 @@ impl JobStore {
             renewals: 0,
         };
         stored.admission_lease = Some(lease.clone());
-        drop(inner);
-        self.persist()?;
         Ok(AdmissionReservation {
             job,
             token: lease.token,
@@ -741,61 +929,59 @@ impl JobStore {
         token: &str,
         now: u64,
     ) -> Result<AdmissionReservation> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        let (token, expires_at_ms) = {
-            let lease = Self::admission_lease_for_live_job(stored, token, now)?;
-            lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
-            lease.renewals = lease.renewals.saturating_add(1);
-            (lease.token.clone(), lease.expires_at_ms)
-        };
-        stored.job.updated_at_ms = now;
-        let reservation = AdmissionReservation {
-            job: stored.job.clone(),
-            token,
-            expires_at_ms,
-            created: false,
-        };
-        drop(inner);
-        self.persist()?;
-        Ok(reservation)
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let (token, expires_at_ms) = {
+                let lease = Self::admission_lease_for_live_job(stored, token, now)?;
+                lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
+                lease.renewals = lease.renewals.saturating_add(1);
+                (lease.token.clone(), lease.expires_at_ms)
+            };
+            stored.job.updated_at_ms = now;
+            let reservation = AdmissionReservation {
+                job: stored.job.clone(),
+                token,
+                expires_at_ms,
+                created: false,
+            };
+            Ok(reservation)
+        })
     }
 
     pub(crate) fn release_admission_at(&self, job_id: Uuid, token: &str, now: u64) -> Result<Job> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        let lease = stored.admission_lease.as_ref().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "job_id",
-                "job is not an admission reservation",
-                Some(job_id.to_string()),
-                None,
-            )
-        })?;
-        if lease.token != token {
-            return Err(Error::validation_invalid_argument(
-                "admission_token",
-                "admission reservation token does not match",
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-        if !stored.job.status.is_terminal() {
-            stored.job.status = JobStatus::Cancelled;
-            stored.job.updated_at_ms = now;
-            stored.job.finished_at_ms = Some(now);
-            stored.job.stale_reason = Some("admission reservation released".to_string());
-        }
-        let job = stored.job.clone();
-        drop(inner);
-        self.persist()?;
-        Ok(job)
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let lease = stored.admission_lease.as_ref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not an admission reservation",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if lease.token != token {
+                return Err(Error::validation_invalid_argument(
+                    "admission_token",
+                    "admission reservation token does not match",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if !stored.job.status.is_terminal() {
+                stored.job.status = JobStatus::Cancelled;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = Some("admission reservation released".to_string());
+            }
+            let job = stored.job.clone();
+            Ok(job)
+        })
     }
 
     pub(crate) fn admission_is_leased(&self, job_id: Uuid) -> Result<bool> {
@@ -808,29 +994,26 @@ impl JobStore {
     }
 
     pub(crate) fn reconcile_expired_admissions_at(&self, now: u64) -> Result<Vec<Uuid>> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let expired = inner
-            .jobs
-            .values_mut()
-            .filter_map(|stored| {
-                let lease = stored.admission_lease.as_ref()?;
-                if !stored.job.status.is_terminal() && lease.expires_at_ms <= now {
-                    stored.job.status = JobStatus::Failed;
-                    stored.job.updated_at_ms = now;
-                    stored.job.finished_at_ms = Some(now);
-                    stored.job.stale_reason =
-                        Some("admission reservation lease expired".to_string());
-                    Some(stored.job.id)
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        drop(inner);
-        if !expired.is_empty() {
-            self.persist()?;
-        }
-        Ok(expired)
+        self.durable_transaction(|inner| {
+            let expired = inner
+                .jobs
+                .values_mut()
+                .filter_map(|stored| {
+                    let lease = stored.admission_lease.as_ref()?;
+                    if !stored.job.status.is_terminal() && lease.expires_at_ms <= now {
+                        stored.job.status = JobStatus::Failed;
+                        stored.job.updated_at_ms = now;
+                        stored.job.finished_at_ms = Some(now);
+                        stored.job.stale_reason =
+                            Some("admission reservation lease expired".to_string());
+                        Some(stored.job.id)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            Ok(expired)
+        })
     }
 
     pub(crate) fn reconcile_expired_admissions(&self) -> Result<Vec<Uuid>> {
@@ -855,6 +1038,30 @@ impl JobStore {
         local_runner: Option<LocalRunnerJob>,
         admission_idempotency_key: Option<String>,
     ) -> (Job, bool) {
+        self.durable_transaction(|inner| {
+            self.create_or_reuse_active_local_runner_job_inner(
+                inner,
+                operation,
+                source_snapshot,
+                metadata,
+                path_materialization_plan,
+                local_runner,
+                admission_idempotency_key,
+            )
+        })
+        .expect("local runner job creation must persist")
+    }
+
+    fn create_or_reuse_active_local_runner_job_inner(
+        &self,
+        inner: &mut JobStoreInner,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        local_runner: Option<LocalRunnerJob>,
+        admission_idempotency_key: Option<String>,
+    ) -> Result<(Job, bool)> {
         let now = timestamp_ms();
         let runner_job_projection = metadata
             .as_ref()
@@ -889,7 +1096,6 @@ impl JobStore {
             runner_job_projection,
         };
 
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
         if let Some(idempotency_key) = admission_idempotency_key.as_deref() {
             if let Some(existing) = inner
                 .jobs
@@ -904,7 +1110,7 @@ impl JobStore {
                 .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
                 .map(|stored| stored.job.clone())
             {
-                return (existing, false);
+                return Ok((existing, false));
             }
         } else if let Some(durable_run_id) = durable_run_id.as_deref() {
             if let Some(existing) = inner
@@ -919,7 +1125,7 @@ impl JobStore {
                 .min_by_key(|stored| (stored.job.created_at_ms, stored.job.id))
                 .map(|stored| stored.job.clone())
             {
-                return (existing, false);
+                return Ok((existing, false));
             }
         }
         let consumes_admission = local_runner.is_some();
@@ -952,19 +1158,24 @@ impl JobStore {
                 }
             }
         }
-        drop(inner);
-
-        if let Some(metadata) = metadata {
-            self.append_status_event_with_data(job.id, JobStatus::Queued, "job queued", metadata)
-        } else {
-            self.append_status_event(job.id, JobStatus::Queued, "job queued")
-        }
-        .expect("newly-created job must accept queued status event");
-        (
-            self.get(job.id)
-                .expect("newly-created job must be readable after insert"),
+        let data = metadata.unwrap_or_else(|| serde_json::json!({ "status": JobStatus::Queued }));
+        Self::append_event_already_locked(
+            self,
+            inner,
+            job.id,
+            JobEventKind::Status,
+            Some("job queued".to_string()),
+            Some(data),
+        )?;
+        Ok((
+            inner
+                .jobs
+                .get(&job.id)
+                .expect("newly-created job exists")
+                .job
+                .clone(),
             true,
-        )
+        ))
     }
 
     fn admission_lease_for_live_job<'a>(
@@ -1080,6 +1291,11 @@ impl JobStore {
         self.terminal_write_failures.store(count, Ordering::SeqCst);
     }
 
+    #[cfg(test)]
+    pub(crate) fn fail_next_durable_writes(&self, count: u64) {
+        self.durable_write_failures.store(count, Ordering::SeqCst);
+    }
+
     pub(crate) fn controller_job_state(&self, job_id: Uuid) -> Result<ControllerJobState> {
         let inner = self.inner.lock().expect("job store mutex poisoned");
         inner
@@ -1103,73 +1319,73 @@ impl JobStore {
         job_id: Uuid,
         reason: String,
     ) -> Result<Job> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        let prior = stored.clone();
-        let controller = stored.controller_job.as_mut().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "job_id",
-                "job is not a controller job",
-                Some(job_id.to_string()),
-                None,
-            )
-        })?;
-        if stored.job.status == JobStatus::Cancelled || controller.cancellation_requested {
-            return Ok(stored.job.clone());
-        }
-        if stored.job.status.is_terminal() {
-            return Err(Error::validation_invalid_argument(
-                "status",
-                "cannot cancel a terminal controller job that did not stop by cancellation",
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-        // Persist the intent before releasing this lock. Dispatchers only observe
-        // cancellation through this durable state, never through a transient flag.
-        controller.cancellation_requested = true;
-        controller.cancellation_reason = Some(reason.clone());
-        let claimless = stored.job.status == JobStatus::Queued
-            && controller.execution_claim_id.is_none()
-            && controller.checkpoint.is_none();
-        let now = timestamp_ms();
-        stored.job.updated_at_ms = now;
-        if claimless {
-            // A response-handoff failure leaves no worker to observe this request.
-            // Terminalize while holding the claim lock so dispatch cannot start it.
-            stored.job.status = JobStatus::Cancelled;
-            stored.job.finished_at_ms = Some(now);
-        }
-        if let Some(persistence) = &self.persistence {
-            let mut durable = DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-                submission_keys: inner.submission_keys.clone(),
-                expired_submission_keys: inner.expired_submission_keys.clone(),
-                controller_submissions: inner.controller_submissions.clone(),
-                expired_controller_submissions: inner.expired_controller_submissions.clone(),
-                compaction: inner.compaction.clone(),
-            };
-            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
-            {
-                *inner.jobs.get_mut(&job_id).expect("controller job exists") = prior;
-                return Err(error);
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let controller = stored.controller_job.as_mut().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a controller job",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if stored.job.status == JobStatus::Cancelled || controller.cancellation_requested {
+                return Ok(stored.job.clone());
             }
-        }
-        drop(inner);
-        if claimless {
-            self.append_status_event(job_id, JobStatus::Cancelled, reason)?;
-            return self.get(job_id);
-        }
-        self.append_event(
-            job_id,
-            JobEventKind::Progress,
-            Some("controller job cancellation requested".to_string()),
-            Some(serde_json::json!({ "phase": "cancellation_requested", "reason": reason })),
-        )?;
-        self.get(job_id)
+            if stored.job.status.is_terminal() {
+                return Err(Error::validation_invalid_argument(
+                    "status",
+                    "cannot cancel a terminal controller job that did not stop by cancellation",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            // Persist the intent before releasing this lock. Dispatchers only observe
+            // cancellation through this durable state, never through a transient flag.
+            controller.cancellation_requested = true;
+            controller.cancellation_reason = Some(reason.clone());
+            let claimless = stored.job.status == JobStatus::Queued
+                && controller.execution_claim_id.is_none()
+                && controller.checkpoint.is_none();
+            let now = timestamp_ms();
+            stored.job.updated_at_ms = now;
+            if claimless {
+                // A response-handoff failure leaves no worker to observe this request.
+                // Terminalize while holding the claim lock so dispatch cannot start it.
+                stored.job.status = JobStatus::Cancelled;
+                stored.job.finished_at_ms = Some(now);
+            }
+            if claimless {
+                Self::append_event_already_locked(
+                    self,
+                    inner,
+                    job_id,
+                    JobEventKind::Status,
+                    Some(reason),
+                    Some(serde_json::json!({ "status": JobStatus::Cancelled })),
+                )?;
+            } else {
+                Self::append_event_already_locked(
+                    self,
+                    inner,
+                    job_id,
+                    JobEventKind::Progress,
+                    Some("controller job cancellation requested".to_string()),
+                    Some(
+                        serde_json::json!({ "phase": "cancellation_requested", "reason": reason }),
+                    ),
+                )?;
+            }
+            Ok(inner
+                .jobs
+                .get(&job_id)
+                .expect("controller job exists")
+                .job
+                .clone())
+        })
     }
 
     pub(crate) fn controller_cancellation_requested(&self, job_id: Uuid) -> bool {
@@ -1183,17 +1399,19 @@ impl JobStore {
     }
 
     pub(crate) fn record_controller_prepared(&self, job_id: Uuid, prepared: Value) -> Result<()> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let controller = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?
-            .controller_job
-            .as_mut()
-            .ok_or_else(|| Error::internal_unexpected("controller worker lost its typed state"))?;
-        controller.checkpoint = Some(prepared);
-        drop(inner);
-        self.persist()
+        self.durable_transaction(|inner| {
+            let controller = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?
+                .controller_job
+                .as_mut()
+                .ok_or_else(|| {
+                    Error::internal_unexpected("controller worker lost its typed state")
+                })?;
+            controller.checkpoint = Some(prepared);
+            Ok(())
+        })
     }
 
     pub(crate) fn complete_controller_cancellation(&self, job_id: Uuid) -> Result<Job> {
@@ -1264,62 +1482,7 @@ impl JobStore {
         message: String,
         data: Value,
     ) -> Result<Job> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let prior = inner.clone();
-        let now = timestamp_ms();
-        let first_sequence = self.next_event_sequence.fetch_add(2, Ordering::SeqCst) + 1;
-        let job = {
-            let stored = inner
-                .jobs
-                .get_mut(&job_id)
-                .ok_or_else(|| job_not_found(job_id))?;
-            let controller = stored.controller_job.as_mut().ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "job_id",
-                    "job is not a controller job",
-                    Some(job_id.to_string()),
-                    None,
-                )
-            })?;
-            if status == JobStatus::Succeeded && controller.cancellation_requested {
-                return Err(Error::validation_invalid_argument(
-                    "status",
-                    "cannot complete a controller job after durable cancellation was requested",
-                    Some(job_id.to_string()),
-                    None,
-                ));
-            }
-            validate_transition(stored.job.status, status)?;
-            stored.events.push(JobEvent {
-                sequence: first_sequence,
-                job_id,
-                kind: event_kind,
-                timestamp_ms: now,
-                message: Some(message.clone()),
-                data: Some(data),
-            });
-            stored.events.push(JobEvent {
-                sequence: first_sequence + 1,
-                job_id,
-                kind: JobEventKind::Status,
-                timestamp_ms: now,
-                message: Some(message),
-                data: Some(serde_json::json!({ "status": status })),
-            });
-            apply_event_retention(&mut stored.events, self.event_retention_limit());
-            stored.job.event_count = stored.events.len();
-            stored.job.status = status;
-            stored.job.updated_at_ms = now;
-            stored.job.finished_at_ms = Some(now);
-            controller.execution_claim_id = None;
-            stored.job.clone()
-        };
-        for submission in inner.controller_submissions.values_mut() {
-            if submission.job_id == job_id {
-                submission.terminal_job = Some(job.clone());
-            }
-        }
-        if let Some(persistence) = &self.persistence {
+        self.durable_transaction(|inner| {
             #[cfg(test)]
             if self
                 .terminal_write_failures
@@ -1328,43 +1491,66 @@ impl JobStore {
                 })
                 .is_ok()
             {
-                *inner = prior;
                 return Err(Error::internal_io(
                     "injected controller terminal persistence failure",
-                    Some(persistence.path.display().to_string()),
+                    None,
                 ));
             }
-            let mut durable = DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-                submission_keys: inner.submission_keys.clone(),
-                expired_submission_keys: inner.expired_submission_keys.clone(),
-                controller_submissions: inner.controller_submissions.clone(),
-                expired_controller_submissions: inner.expired_controller_submissions.clone(),
-                compaction: inner.compaction.clone(),
+            let now = timestamp_ms();
+            let first_sequence = self.next_event_sequence.fetch_add(2, Ordering::SeqCst) + 1;
+            let job = {
+                let stored = inner
+                    .jobs
+                    .get_mut(&job_id)
+                    .ok_or_else(|| job_not_found(job_id))?;
+                let controller = stored.controller_job.as_mut().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "job_id",
+                        "job is not a controller job",
+                        Some(job_id.to_string()),
+                        None,
+                    )
+                })?;
+                if status == JobStatus::Succeeded && controller.cancellation_requested {
+                    return Err(Error::validation_invalid_argument(
+                        "status",
+                        "cannot complete a controller job after durable cancellation was requested",
+                        Some(job_id.to_string()),
+                        None,
+                    ));
+                }
+                validate_transition(stored.job.status, status)?;
+                stored.events.push(JobEvent {
+                    sequence: first_sequence,
+                    job_id,
+                    kind: event_kind,
+                    timestamp_ms: now,
+                    message: Some(message.clone()),
+                    data: Some(data),
+                });
+                stored.events.push(JobEvent {
+                    sequence: first_sequence + 1,
+                    job_id,
+                    kind: JobEventKind::Status,
+                    timestamp_ms: now,
+                    message: Some(message),
+                    data: Some(serde_json::json!({ "status": status })),
+                });
+                apply_event_retention(&mut stored.events, self.event_retention_limit());
+                stored.job.event_count = stored.events.len();
+                stored.job.status = status;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                controller.execution_claim_id = None;
+                stored.job.clone()
             };
-            compact_terminal_jobs(
-                &mut durable,
-                persistence.event_retention_limit,
-                persistence.terminal_job_retention_limit,
-                persistence.terminal_job_retention_bytes,
-            );
-            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
-            {
-                *inner = prior;
-                return Err(error);
+            for submission in inner.controller_submissions.values_mut() {
+                if submission.job_id == job_id {
+                    submission.terminal_job = Some(job.clone());
+                }
             }
-            inner.jobs = durable
-                .jobs
-                .into_iter()
-                .map(|stored| (stored.job.id, stored))
-                .collect();
-            inner.submission_keys = durable.submission_keys;
-            inner.expired_submission_keys = durable.expired_submission_keys;
-            inner.controller_submissions = durable.controller_submissions;
-            inner.expired_controller_submissions = durable.expired_controller_submissions;
-            inner.compaction = durable.compaction;
-        }
-        Ok(job)
+            Ok(job)
+        })
     }
 
     pub(crate) fn append_event(
@@ -1374,38 +1560,9 @@ impl JobStore {
         message: Option<String>,
         data: Option<Value>,
     ) -> Result<JobEvent> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        if kind != JobEventKind::Status && stored.job.status.is_terminal() {
-            return Err(Error::validation_invalid_argument(
-                "status",
-                format!("cannot append {:?} event to terminal job", kind),
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-
-        let event = JobEvent {
-            sequence: self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1,
-            job_id,
-            kind,
-            timestamp_ms: timestamp_ms(),
-            message,
-            data,
-        };
-
-        stored.events.push(event.clone());
-        apply_event_retention(&mut stored.events, self.event_retention_limit());
-        stored.job.event_count = stored.events.len();
-        stored.job.updated_at_ms = event.timestamp_ms;
-        drop(inner);
-
-        self.persist()?;
-
-        Ok(event)
+        self.durable_transaction(|inner| {
+            Self::append_event_already_locked(self, inner, job_id, kind, message, data)
+        })
     }
 
     pub(crate) fn run_background<T, F>(&self, operation: impl Into<String>, run: F) -> JobRunner
@@ -1426,7 +1583,7 @@ impl JobStore {
     ) -> Result<ControllerJobSubmissionOutcome> {
         let fingerprint = controller_submission_fingerprint(&controller_job);
         let now = timestamp_ms();
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
         if let Some(existing) = inner.controller_submissions.get(&idempotency_key) {
             if existing.fingerprint != fingerprint {
                 return Err(controller_idempotency_conflict(&idempotency_key));
@@ -1434,7 +1591,7 @@ impl JobStore {
             let job = inner.jobs.get(&existing.job_id).ok_or_else(|| {
                 Error::internal_unexpected("controller submission index points at a missing job")
             })?;
-            return Ok(ControllerJobSubmissionOutcome::Existing(job.job.clone()));
+                return Ok(ControllerJobSubmissionOutcome::Existing(job.job.clone()));
         }
         if inner
             .expired_controller_submissions
@@ -1534,26 +1691,8 @@ impl JobStore {
                 terminal_job: None,
             },
         );
-        // Persist the initial event, job, and submission index as one admission
-        // commit. Roll back memory on failure so retries cannot observe a ghost.
-        if let Some(persistence) = &self.persistence {
-            let mut durable = DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-                submission_keys: inner.submission_keys.clone(),
-                expired_submission_keys: inner.expired_submission_keys.clone(),
-                controller_submissions: inner.controller_submissions.clone(),
-                expired_controller_submissions: inner.expired_controller_submissions.clone(),
-                compaction: inner.compaction.clone(),
-            };
-            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
-            {
-                inner.jobs.remove(&job_id);
-                inner.controller_submissions.remove(&idempotency_key);
-                return Err(error);
-            }
-        }
-        drop(inner);
         Ok(ControllerJobSubmissionOutcome::Submitted(job_id))
+        })
     }
 
     /// Claim a controller job before starting a worker. This is intentionally a
@@ -1563,45 +1702,45 @@ impl JobStore {
         job_id: Uuid,
         recovery: bool,
     ) -> Result<ControllerJobState> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        let controller = stored.controller_job.as_mut().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "job_id",
-                "job is not a controller job",
-                Some(job_id.to_string()),
-                None,
-            )
-        })?;
-        if stored.job.status.is_terminal() || (!recovery && controller.execution_claim_id.is_some())
-        {
-            return Err(Error::validation_invalid_argument(
-                "job_id",
-                "controller job is already claimed or terminal",
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-        if recovery && (controller.checkpoint.is_none() || controller.recovery_attempted) {
-            return Err(Error::validation_invalid_argument(
-                "job_id",
-                "controller job has no recoverable checkpoint",
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-        controller.execution_claim_id = Some(Uuid::new_v4().to_string());
-        controller.recovery_attempted |= recovery;
-        stored.job.status = JobStatus::Running;
-        stored.job.started_at_ms.get_or_insert_with(timestamp_ms);
-        stored.job.updated_at_ms = timestamp_ms();
-        let controller = controller.clone();
-        drop(inner);
-        self.persist()?;
-        Ok(controller)
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let controller = stored.controller_job.as_mut().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a controller job",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if stored.job.status.is_terminal()
+                || (!recovery && controller.execution_claim_id.is_some())
+            {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "controller job is already claimed or terminal",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            if recovery && (controller.checkpoint.is_none() || controller.recovery_attempted) {
+                return Err(Error::validation_invalid_argument(
+                    "job_id",
+                    "controller job has no recoverable checkpoint",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            controller.execution_claim_id = Some(Uuid::new_v4().to_string());
+            controller.recovery_attempted |= recovery;
+            stored.job.status = JobStatus::Running;
+            stored.job.started_at_ms.get_or_insert_with(timestamp_ms);
+            stored.job.updated_at_ms = timestamp_ms();
+            let controller = controller.clone();
+            Ok(controller)
+        })
     }
 
     /// Atomically claim queued work for the explicit second phase of controller
@@ -1611,44 +1750,29 @@ impl JobStore {
         &self,
         job_id: Uuid,
     ) -> Result<ControllerJobStartOutcome> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        let prior = stored.clone();
-        let controller = stored.controller_job.as_mut().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "job_id",
-                "job is not a controller job",
-                Some(job_id.to_string()),
-                None,
-            )
-        })?;
-        if stored.job.status != JobStatus::Queued || controller.execution_claim_id.is_some() {
-            return Ok(ControllerJobStartOutcome::Existing);
-        }
-        controller.execution_claim_id = Some(Uuid::new_v4().to_string());
-        stored.job.status = JobStatus::Running;
-        stored.job.started_at_ms.get_or_insert_with(timestamp_ms);
-        stored.job.updated_at_ms = timestamp_ms();
-        let controller = controller.clone();
-        if let Some(persistence) = &self.persistence {
-            let mut durable = DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-                submission_keys: inner.submission_keys.clone(),
-                expired_submission_keys: inner.expired_submission_keys.clone(),
-                controller_submissions: inner.controller_submissions.clone(),
-                expired_controller_submissions: inner.expired_controller_submissions.clone(),
-                compaction: inner.compaction.clone(),
-            };
-            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
-            {
-                *inner.jobs.get_mut(&job_id).expect("controller job exists") = prior;
-                return Err(error);
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let controller = stored.controller_job.as_mut().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not a controller job",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if stored.job.status != JobStatus::Queued || controller.execution_claim_id.is_some() {
+                return Ok(ControllerJobStartOutcome::Existing);
             }
-        }
-        Ok(ControllerJobStartOutcome::Claimed(controller))
+            controller.execution_claim_id = Some(Uuid::new_v4().to_string());
+            stored.job.status = JobStatus::Running;
+            stored.job.started_at_ms.get_or_insert_with(timestamp_ms);
+            stored.job.updated_at_ms = timestamp_ms();
+            let controller = controller.clone();
+            Ok(ControllerJobStartOutcome::Claimed(controller))
+        })
     }
 
     pub(crate) fn active_controller_jobs(&self) -> Vec<(Uuid, ControllerJobState)> {
@@ -1672,27 +1796,25 @@ impl JobStore {
     /// than replaying it on startup; its durable request and key remain evidence
     /// for the domain layer to inspect or retry with a new idempotency key.
     pub(crate) fn reconcile_unresolved_controller_jobs(&self) -> Result<Vec<Uuid>> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let now = timestamp_ms();
-        let mut reconciled = Vec::new();
-        for stored in inner.jobs.values_mut() {
-            if stored.controller_job.is_some()
-                && matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
-            {
-                stored.job.status = JobStatus::Failed;
-                stored.job.updated_at_ms = now;
-                stored.job.finished_at_ms = Some(now);
-                stored.job.stale_reason = Some(
-                    "controller job was unresolved after daemon restart; not replayed".to_string(),
-                );
-                reconciled.push(stored.job.id);
+        self.durable_transaction(|inner| {
+            let now = timestamp_ms();
+            let mut reconciled = Vec::new();
+            for stored in inner.jobs.values_mut() {
+                if stored.controller_job.is_some()
+                    && matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                {
+                    stored.job.status = JobStatus::Failed;
+                    stored.job.updated_at_ms = now;
+                    stored.job.finished_at_ms = Some(now);
+                    stored.job.stale_reason = Some(
+                        "controller job was unresolved after daemon restart; not replayed"
+                            .to_string(),
+                    );
+                    reconciled.push(stored.job.id);
+                }
             }
-        }
-        drop(inner);
-        if !reconciled.is_empty() {
-            self.persist()?;
-        }
-        Ok(reconciled)
+            Ok(reconciled)
+        })
     }
 
     pub(crate) fn run_background_with_source_snapshot<T, F>(
@@ -1980,8 +2102,7 @@ impl JobStore {
         message: impl Into<String>,
     ) -> Result<Job> {
         let message = message.into();
-        {
-            let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
             let stored = inner
                 .jobs
                 .get_mut(&job_id)
@@ -2021,12 +2142,20 @@ impl JobStore {
             if next_status.is_terminal() {
                 stored.job.finished_at_ms = Some(now);
             }
-        }
-
-        self.persist()?;
-
-        self.append_status_event(job_id, next_status, message)?;
-        self.get(job_id)
+            Self::append_event_already_locked(
+                self,
+                inner,
+                job_id,
+                JobEventKind::Status,
+                Some(message),
+                Some(serde_json::json!({ "status": next_status })),
+            )?;
+            inner
+                .jobs
+                .get(&job_id)
+                .map(|stored| stored.job.clone())
+                .ok_or_else(|| job_not_found(job_id))
+        })
     }
 
     pub(crate) fn reserve_local_child(&self, job_id: Uuid) -> Result<()> {
@@ -2059,85 +2188,55 @@ impl JobStore {
     ) -> Result<bool> {
         let reservation_id = Uuid::new_v4().to_string();
         let reservation_expires_at_ms = now.saturating_add(LOCAL_CHILD_RESERVATION_LEASE_MS);
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let prior = inner
-            .jobs
-            .get(&job_id)
-            .cloned()
-            .ok_or_else(|| job_not_found(job_id))?;
-        if let Some((runner_id, capacity)) = runner_capacity {
-            let active = inner.jobs.values().filter(|candidate| {
-                candidate.job.id != job_id
-                    && matches!(candidate.job.status, JobStatus::Queued | JobStatus::Running)
-                    && candidate.local_child.is_some()
-                    && candidate
-                        .local_runner
-                        .as_ref()
-                        .is_some_and(|runner| runner.runner_id == runner_id)
-            });
-            if active.count() >= capacity {
-                return Ok(false);
-            }
-        }
-        let stored = inner.jobs.get_mut(&job_id).expect("job exists");
-        if stored.job.status != JobStatus::Queued {
-            return Err(Error::validation_invalid_argument(
-                "status",
-                "local child reservation requires a queued job",
-                Some(job_id.to_string()),
-                None,
-            ));
-        }
-        stored.local_child = Some(LocalChildExecution {
-            reservation_id: reservation_id.clone(),
-            reservation_expires_at_ms: Some(reservation_expires_at_ms),
-            process: None,
-        });
-        let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
-        stored.events.push(JobEvent {
-            sequence,
-            job_id,
-            kind: JobEventKind::Progress,
-            timestamp_ms: now,
-            message: Some("local runner child reserved before spawn".to_string()),
-            data: Some(serde_json::json!({
-                "phase": "child_reserved",
-                "reservation_id": reservation_id,
-                "reservation_expires_at_ms": reservation_expires_at_ms,
-            })),
-        });
-        stored.job.event_count = stored.events.len();
-        if let Some(persistence) = &self.persistence {
-            let mut durable = DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-                submission_keys: inner.submission_keys.clone(),
-                expired_submission_keys: inner.expired_submission_keys.clone(),
-                controller_submissions: inner.controller_submissions.clone(),
-                expired_controller_submissions: inner.expired_controller_submissions.clone(),
-                compaction: inner.compaction.clone(),
-            };
-            compact_terminal_jobs(
-                &mut durable,
-                persistence.event_retention_limit,
-                persistence.terminal_job_retention_limit,
-                persistence.terminal_job_retention_bytes,
-            );
-            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
-            {
-                inner.jobs.insert(job_id, prior);
-                return Err(error);
-            }
-            inner.jobs = durable
+        self.durable_transaction(|inner| {
+            inner
                 .jobs
-                .iter()
-                .cloned()
-                .map(|stored| (stored.job.id, stored))
-                .collect();
-            inner.controller_submissions = durable.controller_submissions;
-            inner.expired_controller_submissions = durable.expired_controller_submissions;
-            inner.compaction = durable.compaction;
-        }
-        Ok(true)
+                .get(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            if let Some((runner_id, capacity)) = runner_capacity {
+                let active = inner.jobs.values().filter(|candidate| {
+                    candidate.job.id != job_id
+                        && matches!(candidate.job.status, JobStatus::Queued | JobStatus::Running)
+                        && candidate.local_child.is_some()
+                        && candidate
+                            .local_runner
+                            .as_ref()
+                            .is_some_and(|runner| runner.runner_id == runner_id)
+                });
+                if active.count() >= capacity {
+                    return Ok(false);
+                }
+            }
+            let stored = inner.jobs.get_mut(&job_id).expect("job exists");
+            if stored.job.status != JobStatus::Queued {
+                return Err(Error::validation_invalid_argument(
+                    "status",
+                    "local child reservation requires a queued job",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            stored.local_child = Some(LocalChildExecution {
+                reservation_id: reservation_id.clone(),
+                reservation_expires_at_ms: Some(reservation_expires_at_ms),
+                process: None,
+            });
+            let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+            stored.events.push(JobEvent {
+                sequence,
+                job_id,
+                kind: JobEventKind::Progress,
+                timestamp_ms: now,
+                message: Some("local runner child reserved before spawn".to_string()),
+                data: Some(serde_json::json!({
+                    "phase": "child_reserved",
+                    "reservation_id": reservation_id,
+                    "reservation_expires_at_ms": reservation_expires_at_ms,
+                })),
+            });
+            stored.job.event_count = stored.events.len();
+            Ok(true)
+        })
     }
 
     /// Terminalize expired pre-spawn reservations. A PID-bound child has
@@ -2152,75 +2251,72 @@ impl JobStore {
         &self,
         now: u64,
     ) -> Result<Vec<Uuid>> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let expired = inner
-            .jobs
-            .values()
-            .filter(|stored| {
-                stored.job.status == JobStatus::Queued
-                    && stored.local_child.as_ref().is_some_and(|child| {
-                        child.process.is_none()
-                            && child
-                                .reservation_expires_at_ms
-                                .is_some_and(|expires_at| expires_at <= now)
-                    })
-            })
-            .map(|stored| stored.job.id)
-            .collect::<Vec<_>>();
+        self.durable_transaction(|inner| {
+            let expired = inner
+                .jobs
+                .values()
+                .filter(|stored| {
+                    stored.job.status == JobStatus::Queued
+                        && stored.local_child.as_ref().is_some_and(|child| {
+                            child.process.is_none()
+                                && child
+                                    .reservation_expires_at_ms
+                                    .is_some_and(|expires_at| expires_at <= now)
+                        })
+                })
+                .map(|stored| stored.job.id)
+                .collect::<Vec<_>>();
 
-        for job_id in &expired {
-            let stored = inner.jobs.get_mut(job_id).expect("expired job exists");
-            let child = stored
-                .local_child
-                .as_ref()
-                .expect("expired reservation exists");
-            let reason = "local child reservation lease expired before spawn";
-            stored.job.status = JobStatus::Failed;
-            stored.job.updated_at_ms = now;
-            stored.job.finished_at_ms = Some(now);
-            stored.job.stale_reason = Some(reason.to_string());
-            let terminal_result = serde_json::json!({
-                "status": JobStatus::Failed,
-                "reason": "local_child_reservation_expired",
-                "retryable": true,
-                "reservation_id": child.reservation_id,
-                "reservation_expires_at_ms": child.reservation_expires_at_ms,
-            });
-            for (kind, message, data) in [
-                (
-                    JobEventKind::Error,
-                    reason.to_string(),
-                    terminal_result.clone(),
-                ),
-                (
-                    JobEventKind::Result,
-                    "retryable terminal reservation failure".to_string(),
-                    terminal_result.clone(),
-                ),
-                (
-                    JobEventKind::Status,
-                    "job marked failed after local child reservation lease expiry".to_string(),
-                    terminal_result,
-                ),
-            ] {
-                let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
-                stored.events.push(JobEvent {
-                    sequence,
-                    job_id: *job_id,
-                    kind,
-                    timestamp_ms: now,
-                    message: Some(message),
-                    data: Some(data),
+            for job_id in &expired {
+                let stored = inner.jobs.get_mut(job_id).expect("expired job exists");
+                let child = stored
+                    .local_child
+                    .as_ref()
+                    .expect("expired reservation exists");
+                let reason = "local child reservation lease expired before spawn";
+                stored.job.status = JobStatus::Failed;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = Some(reason.to_string());
+                let terminal_result = serde_json::json!({
+                    "status": JobStatus::Failed,
+                    "reason": "local_child_reservation_expired",
+                    "retryable": true,
+                    "reservation_id": child.reservation_id,
+                    "reservation_expires_at_ms": child.reservation_expires_at_ms,
                 });
+                for (kind, message, data) in [
+                    (
+                        JobEventKind::Error,
+                        reason.to_string(),
+                        terminal_result.clone(),
+                    ),
+                    (
+                        JobEventKind::Result,
+                        "retryable terminal reservation failure".to_string(),
+                        terminal_result.clone(),
+                    ),
+                    (
+                        JobEventKind::Status,
+                        "job marked failed after local child reservation lease expiry".to_string(),
+                        terminal_result,
+                    ),
+                ] {
+                    let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                    stored.events.push(JobEvent {
+                        sequence,
+                        job_id: *job_id,
+                        kind,
+                        timestamp_ms: now,
+                        message: Some(message),
+                        data: Some(data),
+                    });
+                }
+                apply_event_retention(&mut stored.events, self.event_retention_limit());
+                stored.job.event_count = stored.events.len();
             }
-            apply_event_retention(&mut stored.events, self.event_retention_limit());
-            stored.job.event_count = stored.events.len();
-        }
-        drop(inner);
-        if !expired.is_empty() {
-            self.persist()?;
-        }
-        Ok(expired)
+            Ok(expired)
+        })
     }
 
     /// Explicit, per-job legacy recovery. The supplied PID/start ticks must
@@ -2284,40 +2380,40 @@ impl JobStore {
                 ));
             }
         }
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let stored = inner
-            .jobs
-            .get_mut(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?;
-        if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
-            || stored.local_child.is_some()
-        {
-            return Err(Error::validation_invalid_argument(
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
+                || stored.local_child.is_some()
+            {
+                return Err(Error::validation_invalid_argument(
                 "job_id",
                 "legacy recovery requires one active job with no persisted local child identity",
                 Some(job_id.to_string()),
                 None,
             ));
-        }
-        let now = timestamp_ms();
-        stored.local_child = Some(LocalChildExecution {
-            reservation_id: format!("operator-recovery-{job_id}"),
-            reservation_expires_at_ms: None,
-            process: Some(LocalChildProcessIdentity {
-                pid,
-                process_group_id: None,
-                discriminator: LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks {
-                    ticks: expected_starttime_ticks,
-                },
-            }),
-        });
-        stored.job.status = JobStatus::Failed;
-        stored.job.updated_at_ms = now;
-        stored.job.finished_at_ms = Some(now);
-        stored.job.stale_reason =
-            Some("operator-proven legacy child identity was absent or reused".to_string());
-        let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
-        stored.events.push(JobEvent {
+            }
+            let now = timestamp_ms();
+            stored.local_child = Some(LocalChildExecution {
+                reservation_id: format!("operator-recovery-{job_id}"),
+                reservation_expires_at_ms: None,
+                process: Some(LocalChildProcessIdentity {
+                    pid,
+                    process_group_id: None,
+                    discriminator: LocalChildStartDiscriminator::LinuxProcStatStarttimeTicks {
+                        ticks: expected_starttime_ticks,
+                    },
+                }),
+            });
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason =
+                Some("operator-proven legacy child identity was absent or reused".to_string());
+            let sequence = self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+            stored.events.push(JobEvent {
             sequence,
             job_id,
             kind: JobEventKind::Status,
@@ -2332,10 +2428,14 @@ impl JobStore {
                 "process": { "root_pid": pid, "linux_starttime_ticks": expected_starttime_ticks },
             })),
         });
-        stored.job.event_count = stored.events.len();
-        drop(inner);
-        self.persist()?;
-        self.get(job_id)
+            stored.job.event_count = stored.events.len();
+            Ok(inner
+                .jobs
+                .get(&job_id)
+                .expect("recovered job exists")
+                .job
+                .clone())
+        })
     }
 
     pub(crate) fn start_with_reserved_child_identity(
@@ -2345,15 +2445,12 @@ impl JobStore {
         process_group_id: Option<u32>,
         discriminator: LocalChildStartDiscriminator,
     ) -> Result<Job> {
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let (prior, started) = {
+        self.durable_transaction(|inner| {
+        let started = {
             let stored = inner
                 .jobs
                 .get_mut(&job_id)
                 .ok_or_else(|| job_not_found(job_id))?;
-            // Retain the unclaimed reservation so a failed durable write never
-            // leaves queued visibility paired with an uncommitted child PID.
-            let prior = stored.clone();
             validate_transition(stored.job.status, JobStatus::Running)?;
             let local_child = stored.local_child.as_mut().ok_or_else(|| {
                 Error::internal_unexpected("local child spawned without a durable reservation")
@@ -2386,40 +2483,10 @@ impl JobStore {
             });
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();
-            (prior, stored.job.clone())
+            stored.job.clone()
         };
-
-        if let Some(persistence) = &self.persistence {
-            let mut durable = DurableJobStore {
-                jobs: inner.jobs.values().cloned().collect(),
-                submission_keys: inner.submission_keys.clone(),
-                expired_submission_keys: inner.expired_submission_keys.clone(),
-                controller_submissions: inner.controller_submissions.clone(),
-                expired_controller_submissions: inner.expired_controller_submissions.clone(),
-                compaction: inner.compaction.clone(),
-            };
-            compact_terminal_jobs(
-                &mut durable,
-                persistence.event_retention_limit,
-                persistence.terminal_job_retention_limit,
-                persistence.terminal_job_retention_bytes,
-            );
-            if let Err(error) = write_durable_store_with_tombstones(&persistence.path, &mut durable)
-            {
-                *inner.jobs.get_mut(&job_id).expect("job exists") = prior;
-                return Err(error);
-            }
-            inner.jobs = durable
-                .jobs
-                .iter()
-                .cloned()
-                .map(|stored| (stored.job.id, stored))
-                .collect();
-            inner.controller_submissions = durable.controller_submissions;
-            inner.expired_controller_submissions = durable.expired_controller_submissions;
-            inner.compaction = durable.compaction;
-        }
         Ok(started)
+        })
     }
 
     pub(super) fn ensure_transition(&self, job_id: Uuid, next_status: JobStatus) -> Result<()> {
@@ -2486,40 +2553,42 @@ impl JobStore {
             .map(|persistence| persistence.terminal_job_retention_bytes)
             .unwrap_or(usize::MAX)
     }
+}
 
-    pub(super) fn persist(&self) -> Result<()> {
-        let Some(persistence) = &self.persistence else {
-            return Ok(());
-        };
-
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
-        let mut durable = DurableJobStore {
-            jobs: inner.jobs.values().cloned().collect(),
-            submission_keys: inner.submission_keys.clone(),
-            expired_submission_keys: inner.expired_submission_keys.clone(),
-            controller_submissions: inner.controller_submissions.clone(),
-            expired_controller_submissions: inner.expired_controller_submissions.clone(),
-            compaction: inner.compaction.clone(),
-        };
-        compact_terminal_jobs(
-            &mut durable,
-            self.event_retention_limit(),
-            self.terminal_job_retention_limit(),
-            self.terminal_job_retention_bytes(),
-        );
-        write_durable_store_with_tombstones(&persistence.path, &mut durable)?;
-        inner.jobs = durable
+impl JobStore {
+    pub(super) fn append_event_already_locked(
+        &self,
+        inner: &mut JobStoreInner,
+        job_id: Uuid,
+        kind: JobEventKind,
+        message: Option<String>,
+        data: Option<Value>,
+    ) -> Result<JobEvent> {
+        let stored = inner
             .jobs
-            .iter()
-            .cloned()
-            .map(|stored| (stored.job.id, stored))
-            .collect();
-        inner.submission_keys = durable.submission_keys;
-        inner.expired_submission_keys = durable.expired_submission_keys;
-        inner.controller_submissions = durable.controller_submissions;
-        inner.expired_controller_submissions = durable.expired_controller_submissions;
-        inner.compaction = durable.compaction;
-        Ok(())
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        if kind != JobEventKind::Status && stored.job.status.is_terminal() {
+            return Err(Error::validation_invalid_argument(
+                "status",
+                format!("cannot append {:?} event to terminal job", kind),
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        let event = JobEvent {
+            sequence: self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1,
+            job_id,
+            kind,
+            timestamp_ms: timestamp_ms(),
+            message,
+            data,
+        };
+        stored.events.push(event.clone());
+        apply_event_retention(&mut stored.events, self.event_retention_limit());
+        stored.job.event_count = stored.events.len();
+        stored.job.updated_at_ms = event.timestamp_ms;
+        Ok(event)
     }
 }
 

--- a/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
+++ b/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
@@ -192,7 +192,7 @@ impl JobStore {
                 None,
             ));
         }
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
         let active = inner
             .jobs
             .values()
@@ -275,12 +275,11 @@ impl JobStore {
             apply_event_retention(&mut stored.events, self.event_retention_limit());
             stored.job.event_count = stored.events.len();
         }
-        drop(inner);
-        self.persist()?;
         Ok(DaemonLeaseJobDiagnostics {
             expected_lease_id: expected_lease_id.to_string(),
             matching_job_ids: expected.into_iter().collect(),
             ..DaemonLeaseJobDiagnostics::default()
+        })
         })
     }
 
@@ -301,7 +300,7 @@ impl JobStore {
             ));
         };
         let now = timestamp_ms();
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
         let active_job_ids = inner
             .jobs
             .values()
@@ -387,12 +386,11 @@ impl JobStore {
         }
         apply_event_retention(&mut stored.events, self.event_retention_limit());
         stored.job.event_count = stored.events.len();
-        drop(inner);
-        self.persist()?;
         Ok(DaemonLeaseJobDiagnostics {
             expected_lease_id: expected_lease_id.to_string(),
             matching_job_ids: vec![*job_id],
             ..DaemonLeaseJobDiagnostics::default()
+        })
         })
     }
 
@@ -425,25 +423,25 @@ impl JobStore {
         let mut reconciled = Vec::with_capacity(terminal.len());
         for (job_id, result) in terminal {
             let now = timestamp_ms();
-            let mut inner = self.inner.lock().expect("job store mutex poisoned");
-            let stored = inner.jobs.get_mut(&job_id).expect("terminal job exists");
-            stored.job.status = result.status;
-            stored.job.updated_at_ms = now;
-            stored.job.finished_at_ms = Some(now);
-            stored.job.stale_reason = None;
-            for artifact in result.artifacts {
-                if !stored
-                    .job
-                    .artifacts
-                    .iter()
-                    .any(|existing| existing.id == artifact.id)
-                {
-                    stored.job.artifacts.push(artifact);
+            self.durable_transaction(|inner| {
+                let stored = inner.jobs.get_mut(&job_id).expect("terminal job exists");
+                stored.job.status = result.status;
+                stored.job.updated_at_ms = now;
+                stored.job.finished_at_ms = Some(now);
+                stored.job.stale_reason = None;
+                for artifact in result.artifacts {
+                    if !stored
+                        .job
+                        .artifacts
+                        .iter()
+                        .any(|existing| existing.id == artifact.id)
+                    {
+                        stored.job.artifacts.push(artifact);
+                    }
                 }
-            }
-            drop(inner);
-            self.persist()?;
-            reconciled.push(job_id);
+                reconciled.push(job_id);
+                Ok(())
+            })?;
         }
         Ok(reconciled)
     }
@@ -549,13 +547,13 @@ impl JobStore {
         }
         for (job_id, resolution) in &matching {
             if let LinkedDurableRunResolution::Terminal(recovered) = resolution {
-                let mut inner = self.inner.lock().expect("job store mutex poisoned");
-                let stored = inner.jobs.get_mut(job_id).expect("job exists");
-                stored.job.status = recovered.status;
-                stored.job.finished_at_ms = Some(timestamp_ms());
-                stored.job.updated_at_ms = stored.job.finished_at_ms.expect("timestamp");
-                drop(inner);
-                self.persist()?;
+                self.durable_transaction(|inner| {
+                    let stored = inner.jobs.get_mut(job_id).expect("job exists");
+                    stored.job.status = recovered.status;
+                    stored.job.finished_at_ms = Some(timestamp_ms());
+                    stored.job.updated_at_ms = stored.job.finished_at_ms.expect("timestamp");
+                    Ok(())
+                })?;
             }
         }
         if matching
@@ -684,7 +682,7 @@ impl JobStore {
             ));
         }
 
-        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        self.durable_transaction(|inner| {
         let mut diagnostics = diagnostics;
         let mut dispositions = Vec::with_capacity(diagnostics.matching_job_ids.len());
         let mut ambiguous_job_ids = Vec::new();
@@ -885,9 +883,8 @@ impl JobStore {
         }
         diagnostics.protected_job_ids.sort();
         diagnostics.preserved_remote_job_ids.sort();
-        drop(inner);
-        self.persist()?;
         Ok(diagnostics)
+        })
     }
 
     /// Terminalize all active jobs after an operator has proved that no daemon

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -906,17 +906,18 @@ fn terminal_job_retention_compacts_existing_store_without_losing_active_recovery
             job.id
         })
         .collect::<Vec<_>>();
-    {
-        let mut inner = store.inner.lock().expect("job store mutex poisoned");
-        for (index, job_id) in terminal.iter().enumerate() {
-            let stored = inner.jobs.get_mut(job_id).expect("terminal job exists");
-            let timestamp = (index as u64 + 1) * 100;
-            stored.job.created_at_ms = timestamp;
-            stored.job.updated_at_ms = timestamp;
-            stored.job.finished_at_ms = Some(timestamp);
-        }
-    }
-    store.persist().expect("seed store persists");
+    store
+        .durable_transaction(|inner| {
+            for (index, job_id) in terminal.iter().enumerate() {
+                let stored = inner.jobs.get_mut(job_id).expect("terminal job exists");
+                let timestamp = (index as u64 + 1) * 100;
+                stored.job.created_at_ms = timestamp;
+                stored.job.updated_at_ms = timestamp;
+                stored.job.finished_at_ms = Some(timestamp);
+            }
+            Ok(())
+        })
+        .expect("seed store persists");
 
     let compacted = JobStore::open_without_reconciliation_with_retention(&path, 3, 2)
         .expect("existing store compacts on open");
@@ -1229,6 +1230,55 @@ fn remote_runner_submission_key_replays_one_redacted_durable_job() {
 }
 
 #[test]
+fn remote_runner_submit_and_claim_roll_back_after_a_durable_write_failure() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("broker store");
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({ "submission_key": "write-failure" }));
+
+    store.fail_next_durable_writes(1);
+    assert!(store.submit_remote_runner_job(request.clone()).is_err());
+    assert!(store.list().is_empty(), "failed submit rolls back memory");
+    assert!(
+        JobStore::open_without_reconciliation(&path)
+            .expect("reopen")
+            .list()
+            .is_empty(),
+        "failed submit rolls back disk"
+    );
+
+    let job = store
+        .submit_remote_runner_job(request)
+        .expect("retry submits");
+    store.fail_next_durable_writes(1);
+    assert!(store
+        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+        .is_err());
+    assert_eq!(
+        store.get(job.id).expect("memory job").status,
+        JobStatus::Queued
+    );
+    assert_eq!(
+        JobStore::open_without_reconciliation(&path)
+            .expect("reopen")
+            .get(job.id)
+            .expect("disk job")
+            .status,
+        JobStatus::Queued
+    );
+    assert_eq!(
+        store
+            .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+            .expect("claim retry")
+            .expect("claim")
+            .job
+            .id,
+        job.id
+    );
+}
+
+#[test]
 fn remote_runner_submission_key_survives_restart_and_rejects_conflicts() {
     let temp = tempfile::tempdir().expect("tempdir");
     let path = temp.path().join("jobs.json");
@@ -1284,6 +1334,136 @@ fn remote_runner_submission_key_concurrent_replay_creates_one_job() {
         .expect("second submit");
     assert_eq!(first.id, second.id);
     assert_eq!(store.list().len(), 1);
+}
+
+#[test]
+fn remote_runner_submission_key_concurrent_independent_stores_create_one_job() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let first_store = JobStore::open_without_reconciliation(&path).expect("first broker store");
+    let second_store = JobStore::open_without_reconciliation(&path).expect("second broker store");
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({ "submission_key": "agent-task:v1:independent-brokers" }));
+
+    let first_barrier = std::sync::Arc::clone(&barrier);
+    let first_request = request.clone();
+    let first = std::thread::spawn(move || {
+        first_barrier.wait();
+        first_store.submit_remote_runner_job(first_request)
+    });
+    let second = std::thread::spawn(move || {
+        barrier.wait();
+        second_store.submit_remote_runner_job(request)
+    });
+
+    let first = first.join().expect("first submit").expect("first job");
+    let second = second.join().expect("second submit").expect("second job");
+    assert_eq!(first.id, second.id);
+
+    let recovered = JobStore::open_without_reconciliation(&path).expect("reopen broker store");
+    assert_eq!(recovered.list().len(), 1);
+    assert!(recovered
+        .events(first.id)
+        .expect("events")
+        .iter()
+        .any(|event| { event.message.as_deref() == Some("remote runner submission replayed") }));
+}
+
+#[test]
+fn remote_runner_submission_retry_preserves_concurrent_claim() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let submitter = JobStore::open_without_reconciliation(&path).expect("submitter store");
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({ "submission_key": "agent-task:v1:claim-interleaving" }));
+    let accepted = submitter
+        .submit_remote_runner_job(request.clone())
+        .expect("initial submission");
+    let claimer = JobStore::open_without_reconciliation(&path).expect("claimer store");
+    let retry = JobStore::open_without_reconciliation(&path).expect("retry store");
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+    let claim_barrier = std::sync::Arc::clone(&barrier);
+    let claim = std::thread::spawn(move || {
+        claim_barrier.wait();
+        claimer.claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, Some(1))
+    });
+    let replay = std::thread::spawn(move || {
+        barrier.wait();
+        retry.submit_remote_runner_job(request)
+    });
+
+    let claimed = claim.join().expect("claim thread").expect("claim result");
+    let replayed = replay
+        .join()
+        .expect("replay thread")
+        .expect("replay result");
+    assert_eq!(replayed.id, accepted.id);
+    assert_eq!(claimed.expect("job claimed").job.id, accepted.id);
+
+    let recovered = JobStore::open_without_reconciliation(&path).expect("reopen broker store");
+    assert_eq!(recovered.list().len(), 1);
+    assert_eq!(
+        recovered.get(accepted.id).expect("claimed job").status,
+        JobStatus::Running
+    );
+}
+
+#[test]
+fn remote_runner_submission_terminal_replay_returns_original_projection_without_progress() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("broker store");
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({ "submission_key": "agent-task:v1:terminal-lost-response" }));
+    let accepted = store
+        .submit_remote_runner_job(request.clone())
+        .expect("initial submission");
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, Some(1))
+        .expect("claim")
+        .expect("job claimed");
+    let claim_id = claim.job.claim_id.expect("claim id");
+    let terminal = store
+        .finish_remote_runner_job(
+            accepted.id,
+            "homeboy-lab",
+            &claim_id,
+            RemoteRunnerJobResult {
+                exit_code: 0,
+                stdout: None,
+                stderr: None,
+                patch: None,
+                mutation_artifacts: None,
+                data: None,
+                observation_run_ids: Vec::new(),
+                observation_run_details: Vec::new(),
+                observation_run_details_compatibility_degraded: false,
+                artifacts: Vec::new(),
+                artifact_refs: Vec::new(),
+                metrics: None,
+                capture: None,
+            },
+        )
+        .expect("terminal result");
+    let events_before = store.events(accepted.id).expect("terminal events");
+
+    let replay = JobStore::open_without_reconciliation(&path)
+        .expect("restarted broker")
+        .submit_remote_runner_job(request)
+        .expect("lost-response replay");
+    let events_after = JobStore::open_without_reconciliation(&path)
+        .expect("reopen broker")
+        .events(accepted.id)
+        .expect("terminal events after replay");
+
+    assert_eq!(replay.id, terminal.id);
+    assert_eq!(replay.status, JobStatus::Succeeded);
+    assert_eq!(events_after.len(), events_before.len());
+    assert!(!events_after
+        .iter()
+        .any(|event| event.message.as_deref() == Some("remote runner submission replayed")));
 }
 
 #[test]
@@ -1345,17 +1525,13 @@ fn compacted_submission_key_expires_without_creating_a_duplicate() {
             .submit_remote_runner_job(request.clone())
             .expect("submit");
         store
-            .inner
-            .lock()
-            .expect("store")
-            .jobs
-            .get_mut(&job.id)
-            .expect("job")
-            .job
-            .status = JobStatus::Succeeded;
+            .durable_transaction(|inner| {
+                inner.jobs.get_mut(&job.id).expect("job").job.status = JobStatus::Succeeded;
+                Ok(())
+            })
+            .expect("terminalize and compact job");
         requests.push((key.to_string(), request));
     }
-    store.persist().expect("compact terminal jobs");
     let expired_key = "agent-task:v1:compact-one".to_string();
     assert!(super::super::persistence::tombstone_path(&path).exists());
     assert!(
@@ -1396,15 +1572,11 @@ fn replay_tombstones_keep_terminal_payload_memory_bounded_across_restart() {
             .submit_remote_runner_job(request.clone())
             .expect("submit");
         store
-            .inner
-            .lock()
-            .expect("store")
-            .jobs
-            .get_mut(&job.id)
-            .expect("job")
-            .job
-            .status = JobStatus::Succeeded;
-        store.persist().expect("compact terminal job");
+            .durable_transaction(|inner| {
+                inner.jobs.get_mut(&job.id).expect("job").job.status = JobStatus::Succeeded;
+                Ok(())
+            })
+            .expect("terminalize and compact job");
         if index == 0 {
             first = Some(request);
         }
@@ -1457,7 +1629,9 @@ fn corrupt_replay_tombstone_journal_fails_closed() {
         .expect("job")
         .job
         .status = JobStatus::Succeeded;
-    store.persist().expect("persist first");
+    store
+        .durable_transaction(|_| Ok(()))
+        .expect("persist first");
     let mut second = remote_runner_request("homeboy-lab", Some("extrachill"));
     second.metadata = Some(json!({ "submission_key": "agent-task:v1:corrupt-two" }));
     let second_job = store
@@ -1472,7 +1646,9 @@ fn corrupt_replay_tombstone_journal_fails_closed() {
         .expect("job")
         .job
         .status = JobStatus::Succeeded;
-    store.persist().expect("compact first");
+    store
+        .durable_transaction(|_| Ok(()))
+        .expect("compact first");
     fs::write(
         super::super::persistence::tombstone_path(&path),
         "not json\n",


### PR DESCRIPTION
## Summary
- refuse duplicate active retries unless explicitly forced and persist retry lineage
- serialize all durable job-store writers through one reload-mutate-persist transaction
- preserve lost-response replay, rollback safety, and same-worktree Cook warnings

Closes #7399

## Verification
- `cargo test -p homeboy-core api_jobs --lib`
- retry concurrency and cross-process successor tests
- retry lineage, force alias, handoff, and Cook warning tests
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested retry idempotency, lineage, and durable transaction safety. Chris Huber reviewed and owns every line.