### PR TITLE
fix: retain nested test evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "homeboy-upgrade",
  "libc",
  "reqwest",
+ "rusqlite",
  "semver",
  "serde",
  "serde_json",
@@ -819,6 +820,7 @@ dependencies = [
  "shellexpand",
  "tempfile",
  "uuid",
+ "windows-sys 0.61.2",
  "zip",
 ]
 

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -53,8 +53,12 @@ clap = { version = "4.5", features = ["derive", "string"] }
 sha2 = "0.10.9"
 fs4 = "0.13"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 # Enable homeboy-core's shared hermetic test fixtures for this crate's test build.
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-agents = { version = "0.1.0", path = "../homeboy-agents", features = ["test-support"] }
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/homeboy-cli/src/commands/review/observation.rs
+++ b/crates/homeboy-cli/src/commands/review/observation.rs
@@ -229,8 +229,16 @@ fn stage_observation<T: serde::Serialize + ReviewArtifactFindings>(
         "summary": command.summary,
         "hint": stage.hint,
         "skipped_reason": stage.skipped_reason,
-        "run_id": null,
+        "run_id": stage.output.as_ref().and_then(stage_run_id),
     })
+}
+
+fn stage_run_id<T: serde::Serialize>(output: &T) -> Option<String> {
+    serde_json::to_value(output)
+        .ok()?
+        .pointer("/_homeboy_actionable/run/id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -9,11 +9,22 @@ use homeboy::core::observation::{
 };
 use homeboy_extension::test as extension_test;
 use homeboy_extension::test::{
-    detect_test_drift, report, run_self_check_test_workflow_with_progress, TestCommandOutput,
-    TestRunWorkflowArgs,
+    build_test_summary, detect_test_drift, parse_test_failures_from_text,
+    parse_test_results_failures_file, parse_test_results_file, parse_test_results_text, report,
+    run_self_check_test_workflow_with_progress, test_failure_summary_items, TestAnalysisInput,
+    TestCommandOutput, TestFailure, TestRunWorkflowArgs,
 };
 use homeboy_extension::ExtensionCapability;
-use std::path::{Path, PathBuf};
+use serde_json::Value;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, FromRawFd};
+#[cfg(windows)]
+use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Component, Path, PathBuf};
 
 use super::source_command::{resolve_ci_job_for_command, resolve_source_context};
 use super::utils::args::{
@@ -262,16 +273,37 @@ pub fn run(args: TestArgs) -> CmdResult<TestCommandOutput> {
         },
         runner.run_dir(),
     );
-    let scratch_succeeded = workflow
-        .as_ref()
-        .is_ok_and(|workflow| workflow.exit_code == 0);
-    let workflow = runner.finish_with_scratch_outcome(
-        observation,
-        workflow,
-        scratch_succeeded,
-        |observation, workflow| finish_test_observation(Some(observation), workflow),
-        |observation, error| finish_test_observation_error(Some(observation), error),
-    )?;
+    let mut workflow = workflow;
+    let mut collection_failed = false;
+    if let (Some(observation), Ok(workflow_result)) = (observation.as_ref(), workflow.as_mut()) {
+        if let Err(error) = persist_declared_test_artifacts(observation, workflow_result) {
+            collection_failed = true;
+            workflow = Err(homeboy::core::Error::internal_unexpected(format!(
+                "test artifact collection failure: {error}"
+            )));
+        }
+    }
+    let scratch_succeeded = collection_failed
+        || workflow
+            .as_ref()
+            .is_ok_and(|workflow| workflow.exit_code == 0);
+    let workflow = if collection_failed {
+        runner.finish_with_finalized_error_cleanup(
+            observation,
+            workflow,
+            scratch_succeeded,
+            |observation, workflow| finish_test_observation(Some(observation), workflow),
+            |observation, error| finish_test_observation_error(Some(observation), error),
+        )
+    } else {
+        runner.finish_with_scratch_outcome(
+            observation,
+            workflow,
+            scratch_succeeded,
+            |observation, workflow| finish_test_observation(Some(observation), workflow),
+            |observation, error| finish_test_observation_error(Some(observation), error),
+        )
+    }?;
 
     let (mut output, exit_code) = report::from_main_workflow_with_ci_context(
         workflow,
@@ -412,6 +444,463 @@ fn finish_test_observation(
     persist_validation_progress_artifacts(&observation);
     persist_child_supervision_artifact(&observation);
     observation.active.finish(status, Some(metadata));
+}
+
+/// Persist provider-declared test artifacts before the runner connection or
+/// scratch run directory disappears. The declaration shape stays opaque: this
+/// boundary only recognizes a generic `artifact://files/<relative path>`
+/// locator rooted in the invocation run directory.
+fn persist_declared_test_artifacts(
+    observation: &TestObservation,
+    workflow: &mut extension_test::TestRunWorkflowResult,
+) -> homeboy::core::Result<()> {
+    let Some(run_dir) = observation
+        .run_dir
+        .as_ref()
+        .and_then(|path| RunDir::from_existing(path.clone()).ok())
+    else {
+        return Ok(());
+    };
+
+    let mut reported_locator_replacements = Vec::new();
+    for (timing_index, timing) in workflow.extension_phase_timings.iter_mut().enumerate() {
+        for (artifact_index, declaration) in timing.artifacts.iter_mut().enumerate() {
+            let Some(locator) = artifact_locator(declaration).map(str::to_string) else {
+                continue;
+            };
+            let Some(relative_path) = artifact_locator_relative_path(&locator) else {
+                let record = record_unavailable_test_artifact(
+                    observation,
+                    timing_index,
+                    artifact_index,
+                    &timing.name,
+                    &locator,
+                    "the locator has no controller-local file provenance",
+                )?;
+                reported_locator_replacements.push(reported_test_artifact_locator_replacement(
+                    &record, &locator,
+                ));
+                *declaration = persisted_test_artifact_declaration(&record, &timing.name);
+                continue;
+            };
+            let mut source =
+                match open_test_artifact_no_follow(&run_dir.path().join("files"), &relative_path) {
+                    Ok(source) => source,
+                    Err(error) => {
+                        let record = record_unavailable_test_artifact(
+                    observation,
+                    timing_index,
+                    artifact_index,
+                    &timing.name,
+                    &locator,
+                    &format!("the declared controller-local artifact file is unavailable: {error}"),
+                )?;
+                        reported_locator_replacements.push(
+                            reported_test_artifact_locator_replacement(&record, &locator),
+                        );
+                        *declaration = persisted_test_artifact_declaration(&record, &timing.name);
+                        continue;
+                    }
+                };
+            let record = observation
+                .active
+                .store()
+                .record_artifact_from_open_file_with_metadata(
+                    observation.active.run_id(),
+                    "test_artifact",
+                    &mut source,
+                    serde_json::json!({
+                        "source": "extension_phase_timing",
+                        "phase": timing.name,
+                        "locator": &locator,
+                    }),
+                )?;
+            reported_locator_replacements.push(reported_test_artifact_locator_replacement(
+                &record, &locator,
+            ));
+            *declaration = persisted_test_artifact_declaration(&record, &timing.name);
+        }
+    }
+    enrich_test_result_from_persisted_artifacts(observation, workflow)?;
+    rewrite_reported_artifact_locators(workflow, &reported_locator_replacements);
+    Ok(())
+}
+
+fn rewrite_reported_artifact_locators(
+    workflow: &mut extension_test::TestRunWorkflowResult,
+    replacements: &[(String, String)],
+) {
+    let Some(raw_output) = workflow.raw_output.as_mut() else {
+        return;
+    };
+    for (locator, replacement) in replacements {
+        raw_output.stdout_tail = raw_output.stdout_tail.replace(locator, replacement);
+        raw_output.stderr_tail = raw_output.stderr_tail.replace(locator, replacement);
+    }
+}
+
+fn open_test_artifact_no_follow(
+    files_root: &Path,
+    relative_path: &Path,
+) -> homeboy::core::Result<std::fs::File> {
+    #[cfg(windows)]
+    {
+        return open_test_artifact_no_follow_windows(files_root, relative_path);
+    }
+
+    #[cfg(unix)]
+    {
+        return open_test_artifact_no_follow_unix(files_root, relative_path);
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (files_root, relative_path);
+        return Err(homeboy::core::Error::internal_unexpected(
+            "descriptor-relative test artifact ingestion requires Unix openat support",
+        ));
+    }
+}
+
+#[cfg(windows)]
+fn open_test_artifact_no_follow_windows(
+    files_root: &Path,
+    relative_path: &Path,
+) -> homeboy::core::Result<std::fs::File> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+    };
+
+    let mut current = files_root.to_path_buf();
+    let components = relative_path.components().collect::<Vec<_>>();
+    for (index, component) in components.iter().enumerate() {
+        let Component::Normal(name) = component else {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "artifact",
+                "test artifact path must contain normal relative components",
+                Some(relative_path.display().to_string()),
+                None,
+            ));
+        };
+        current.push(name);
+        let final_component = index + 1 == components.len();
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).custom_flags(
+            FILE_FLAG_OPEN_REPARSE_POINT
+                | if final_component {
+                    0
+                } else {
+                    FILE_FLAG_BACKUP_SEMANTICS
+                },
+        );
+        let file = options.open(&current).map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "open test artifact component {}",
+                    current.display()
+                )),
+            )
+        })?;
+        let metadata = file.metadata().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "inspect test artifact component {}",
+                    current.display()
+                )),
+            )
+        })?;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+            || (!final_component && !metadata.is_dir())
+            || (final_component && !metadata.is_file())
+        {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "artifact",
+                "test artifact path contains a reparse point or non-regular component",
+                Some(relative_path.display().to_string()),
+                None,
+            ));
+        }
+        if final_component {
+            return Ok(file);
+        }
+    }
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "artifact",
+        "test artifact path is empty",
+        Some(relative_path.display().to_string()),
+        None,
+    ))
+}
+
+#[cfg(unix)]
+fn open_test_artifact_no_follow_unix(
+    files_root: &Path,
+    relative_path: &Path,
+) -> homeboy::core::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    options.custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW);
+    let mut directory = options.open(files_root).map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some(format!("open test artifact root {}", files_root.display())),
+        )
+    })?;
+    let components = relative_path.components().collect::<Vec<_>>();
+    for (index, component) in components.iter().enumerate() {
+        let Component::Normal(name) = component else {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "artifact",
+                "test artifact path must contain normal relative components",
+                Some(relative_path.display().to_string()),
+                None,
+            ));
+        };
+        let name = std::ffi::CString::new(name.as_bytes()).map_err(|_| {
+            homeboy::core::Error::validation_invalid_argument(
+                "artifact",
+                "test artifact path contains an embedded NUL byte",
+                Some(relative_path.display().to_string()),
+                None,
+            )
+        })?;
+        let final_component = index + 1 == components.len();
+        let flags = libc::O_RDONLY
+            | libc::O_CLOEXEC
+            | libc::O_NOFOLLOW
+            | if final_component {
+                0
+            } else {
+                libc::O_DIRECTORY
+            };
+        // Each artifact-controlled component is resolved from its opened parent.
+        let descriptor = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+        if descriptor < 0 {
+            return Err(homeboy::core::Error::internal_io(
+                std::io::Error::last_os_error().to_string(),
+                Some(format!(
+                    "open test artifact component {}",
+                    relative_path.display()
+                )),
+            ));
+        }
+        let opened = unsafe { std::fs::File::from_raw_fd(descriptor) };
+        directory = opened;
+    }
+    let file = directory;
+    let metadata = file.metadata().map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("inspect opened test artifact".to_string()),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "artifact",
+            "opened test artifact is not a regular file",
+            Some(relative_path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(file)
+}
+
+fn enrich_test_result_from_persisted_artifacts(
+    observation: &TestObservation,
+    workflow: &mut extension_test::TestRunWorkflowResult,
+) -> homeboy::core::Result<()> {
+    let artifacts = observation
+        .active
+        .store()
+        .list_artifacts(observation.active.run_id())?;
+    let mut parsed_failures = None;
+    let mut persisted_refs = Vec::new();
+    for artifact in artifacts {
+        let locator = artifact
+            .metadata_json
+            .get("locator")
+            .and_then(Value::as_str);
+        let Some(locator) = locator else { continue };
+        if artifact.artifact_type != "file" {
+            continue;
+        }
+        persisted_refs.push((
+            locator.to_string(),
+            format!(
+                "homeboy://run/{}/artifact/{}",
+                observation.active.run_id(),
+                artifact.id
+            ),
+        ));
+        if locator.ends_with("test-results.json") && workflow.test_counts.is_none() {
+            workflow.test_counts = parse_test_results_file(Path::new(&artifact.path))?;
+        }
+        if locator.ends_with("test-results.json") && parsed_failures.is_none() {
+            parsed_failures = parse_test_results_failures_file(
+                Path::new(&artifact.path),
+                workflow.test_counts.as_ref(),
+            )?;
+        }
+        if locator.ends_with("phpunit-output.log") {
+            let output = std::fs::read_to_string(&artifact.path).map_err(|error| {
+                homeboy::core::Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read persisted test artifact {}", artifact.id)),
+                )
+            })?;
+            if workflow.test_counts.is_none() {
+                workflow.test_counts = parse_test_results_text(&output);
+            }
+            if parsed_failures.is_none() {
+                parsed_failures =
+                    parse_test_failures_from_text(&output, workflow.test_counts.as_ref());
+            }
+        }
+    }
+    if let Some(raw_output) = workflow.raw_output.as_mut() {
+        for (locator, reference) in persisted_refs {
+            raw_output.stdout_tail = raw_output.stdout_tail.replace(&locator, &reference);
+            raw_output.stderr_tail = raw_output.stderr_tail.replace(&locator, &reference);
+        }
+    }
+    if workflow.failure_analysis_input.is_none() {
+        workflow.failure_analysis_input = parsed_failures;
+    }
+    if workflow.failure_analysis_input.is_none()
+        && workflow
+            .test_counts
+            .as_ref()
+            .is_some_and(|counts| counts.failed > 0)
+    {
+        let counts = workflow.test_counts.as_ref().expect("checked above");
+        let input = TestAnalysisInput {
+            failures: vec![TestFailure {
+                test_name: "provider test results".to_string(),
+                test_file: String::new(),
+                error_type: "test_failure".to_string(),
+                message: format!(
+                    "{} test failure(s) reported by persisted test results",
+                    counts.failed
+                ),
+                source_file: String::new(),
+                source_line: 0,
+            }],
+            total: counts.total,
+            passed: counts.passed,
+        };
+        workflow.failure_analysis_input = Some(input);
+    }
+    if workflow.findings.is_none() {
+        workflow.findings = workflow
+            .failure_analysis_input
+            .as_ref()
+            .and_then(homeboy::core::observation::homeboy_findings_from_test_analysis_input);
+    }
+    let mut summary = build_test_summary(
+        workflow.test_counts.as_ref(),
+        workflow.analysis.as_ref(),
+        workflow.exit_code,
+    );
+    if let Some(input) = &workflow.failure_analysis_input {
+        summary.failures = test_failure_summary_items(&input.failures);
+    }
+    workflow.summary = Some(summary);
+    Ok(())
+}
+
+fn record_unavailable_test_artifact(
+    observation: &TestObservation,
+    timing_index: usize,
+    artifact_index: usize,
+    phase: &str,
+    locator: &str,
+    reason: &str,
+) -> homeboy::core::Result<homeboy::core::observation::ArtifactRecord> {
+    let artifact = homeboy::core::observation::ArtifactRecord {
+        id: format!(
+            "{}-test-artifact-{timing_index}-{artifact_index}",
+            observation.active.run_id()
+        ),
+        run_id: observation.active.run_id().to_string(),
+        kind: "test_artifact".to_string(),
+        artifact_type: "metadata-only".to_string(),
+        path: format!("metadata-only:{locator}"),
+        url: None,
+        public_url: None,
+        viewer_url: None,
+        viewer_links: Vec::new(),
+        sha256: None,
+        size_bytes: None,
+        mime: None,
+        metadata_json: serde_json::json!({
+            "source": "extension_phase_timing",
+            "phase": phase,
+            "locator": locator,
+            "unavailable_reason": reason,
+        }),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    observation.active.store().import_artifact(&artifact)?;
+    Ok(artifact)
+}
+
+fn persisted_test_artifact_declaration(
+    artifact: &homeboy::core::observation::ArtifactRecord,
+    phase: &str,
+) -> Value {
+    serde_json::json!({
+        "schema": "homeboy/review-artifact/v1",
+        "run_id": artifact.run_id,
+        "artifact_id": artifact.id,
+        "ref": format!("homeboy://run/{}/artifact/{}", artifact.run_id, artifact.id),
+        "phase": phase,
+        "available": artifact.artifact_type == "file",
+        "unavailable_reason": artifact.metadata_json.get("unavailable_reason"),
+    })
+}
+
+fn reported_test_artifact_locator_replacement(
+    artifact: &homeboy::core::observation::ArtifactRecord,
+    locator: &str,
+) -> (String, String) {
+    let reference = format!("homeboy://run/{}/artifact/{}", artifact.run_id, artifact.id);
+    let replacement = if artifact.artifact_type == "file" {
+        reference
+    } else {
+        let reason = artifact
+            .metadata_json
+            .get("unavailable_reason")
+            .and_then(Value::as_str)
+            .unwrap_or("evidence collection unavailable");
+        format!("{reference} (evidence collection unavailable: {reason})")
+    };
+    (locator.to_string(), replacement)
+}
+
+fn artifact_locator(declaration: &Value) -> Option<&str> {
+    ["path", "url", "ref", "uri"]
+        .into_iter()
+        .find_map(|key| declaration.get(key).and_then(Value::as_str))
+        .filter(|locator| !locator.trim().is_empty())
+}
+
+fn artifact_locator_relative_path(locator: &str) -> Option<PathBuf> {
+    let relative = locator.strip_prefix("artifact://files/")?;
+    let relative = Path::new(relative);
+    if relative.as_os_str().is_empty() || relative.is_absolute() {
+        return None;
+    }
+    let components = relative.components().collect::<Vec<_>>();
+    if components
+        .iter()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+    let normalized = components.iter().collect::<PathBuf>();
+    (normalized.as_os_str() == relative.as_os_str()).then_some(normalized)
 }
 
 fn persist_test_findings(
@@ -793,6 +1282,99 @@ mod tests {
     }
 
     #[test]
+    fn injected_artifact_store_failure_terminalizes_collection_and_cleans_scratch() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let args = sample_args();
+            let runner = ObservedWorkflowRunner::create("test homeboy").expect("runner");
+            let scratch_path = runner.run_dir().path().to_path_buf();
+            let files = scratch_path.join("files");
+            fs::create_dir(&files).expect("artifact files dir");
+            fs::write(files.join("test-results.json"), b"{\"failed\":1}").expect("result bytes");
+            let observation = start_test_observation(
+                "homeboy",
+                home.path(),
+                &args,
+                "test",
+                Some(runner.run_dir()),
+            )
+            .expect("observation");
+            let run_id = observation.active.run_id().to_string();
+            runner.bind_run_id(&run_id).expect("bind run id");
+            let database = homeboy::core::observation::store::database_path()
+                .expect("observation database path");
+            rusqlite::Connection::open(database)
+                .expect("open observation database")
+                .execute_batch(
+                    "CREATE TRIGGER fail_test_artifact_insert BEFORE INSERT ON artifacts WHEN NEW.kind = 'test_artifact' BEGIN SELECT RAISE(ABORT, 'injected test artifact store failure'); END;",
+                )
+                .expect("install artifact insertion fault");
+            let mut workflow = extension_test::TestRunWorkflowResult {
+                status: "failed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 1,
+                test_counts: None,
+                findings: None,
+                failure_analysis_input: None,
+                coverage: None,
+                baseline_comparison: None,
+                analysis: None,
+                autofix: None,
+                hints: None,
+                test_scope: None,
+                summary: None,
+                raw_output: None,
+                extension_phase_timings: vec![homeboy_extension::ExtensionPhaseTiming {
+                    name: "provider-test".to_string(),
+                    duration_ms: 1,
+                    status: Some("failed".to_string()),
+                    message: None,
+                    artifacts: vec![serde_json::json!({
+                        "ref": "artifact://files/test-results.json"
+                    })],
+                    metadata: Default::default(),
+                }],
+            };
+            let collection_error = persist_declared_test_artifacts(&observation, &mut workflow)
+                .expect_err("injected artifact store failure must propagate");
+            assert!(collection_error
+                .to_string()
+                .contains("injected test artifact store failure"));
+            let error = homeboy::core::Error::internal_unexpected(format!(
+                "test artifact collection failure: {collection_error}"
+            ));
+
+            let result = runner.finish_with_finalized_error_cleanup(
+                Some(observation),
+                Err::<extension_test::TestRunWorkflowResult, _>(error),
+                true,
+                |observation, workflow| finish_test_observation(Some(observation), workflow),
+                |observation, error| finish_test_observation_error(Some(observation), error),
+            );
+
+            let error = result.expect_err("collection failure must be terminal");
+            assert!(error
+                .to_string()
+                .contains("test artifact collection failure"));
+            let run = ObservationStore::open_initialized()
+                .expect("store")
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run exists");
+            assert_eq!(run.status, "error");
+            assert_eq!(run.metadata_json["observation_status"], "error");
+            assert!(run.metadata_json["error"]
+                .as_str()
+                .expect("error metadata")
+                .contains("injected test artifact store failure"));
+            assert!(
+                !scratch_path.exists(),
+                "terminal collection failures clean scratch after recording the error"
+            );
+        });
+    }
+
+    #[test]
     fn test_observation_persists_test_failures_and_analysis_clusters() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
@@ -815,26 +1397,24 @@ mod tests {
             let analysis = extension_test::analyze::analyze("homeboy", &input);
             let cluster_fingerprint = format!("test-cluster::{}", analysis.clusters[0].id);
 
-            finish_test_observation(
-                Some(observation),
-                &extension_test::TestRunWorkflowResult {
-                    status: "failed".to_string(),
-                    component: "homeboy".to_string(),
-                    exit_code: 1,
-                    test_counts: None,
-                    findings: None,
-                    failure_analysis_input: Some(input),
-                    coverage: None,
-                    baseline_comparison: None,
-                    analysis: Some(analysis),
-                    autofix: None,
-                    hints: None,
-                    test_scope: None,
-                    summary: None,
-                    raw_output: None,
-                    extension_phase_timings: Vec::new(),
-                },
-            );
+            let workflow = extension_test::TestRunWorkflowResult {
+                status: "failed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 1,
+                test_counts: None,
+                findings: None,
+                failure_analysis_input: Some(input),
+                coverage: None,
+                baseline_comparison: None,
+                analysis: Some(analysis),
+                autofix: None,
+                hints: None,
+                test_scope: None,
+                summary: None,
+                raw_output: None,
+                extension_phase_timings: Vec::new(),
+            };
+            finish_test_observation(Some(observation), &workflow);
 
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
@@ -938,6 +1518,240 @@ mod tests {
                 .any(|artifact| artifact.kind == "validation_command_1_stderr"));
             run_dir.cleanup();
         });
+    }
+
+    #[test]
+    fn failing_test_persists_declared_artifacts_and_records_missing_provenance() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let args = sample_args();
+            let run_dir = RunDir::create().expect("run dir");
+            let files = run_dir.path().join("files");
+            fs::create_dir(&files).expect("artifact files dir");
+            fs::write(files.join("test-results.json"), b"{\"failed\":1}").expect("result bytes");
+            fs::write(
+                files.join("phpunit-output.log"),
+                b"PHPUnit 10.0\n\nThere was 1 failure:\n\n1) Tests\\ExampleTest::test_it_fails\nFailed asserting that false is true.\n\n/workspace/tests/ExampleTest.php:42\n\nFAILURES!\nTests: 1, Assertions: 1, Failures: 1\n",
+            )
+            .expect("log bytes");
+            let outside = home.path().join("outside.log");
+            fs::write(&outside, b"outside bytes").expect("outside bytes");
+            std::os::unix::fs::symlink(&outside, files.join("symlink.log"))
+                .expect("symlink artifact");
+            let outside_dir = home.path().join("outside-dir");
+            fs::create_dir(&outside_dir).expect("outside directory");
+            fs::write(outside_dir.join("escaped.log"), b"escaped bytes").expect("escaped bytes");
+            std::os::unix::fs::symlink(&outside_dir, files.join("nested"))
+                .expect("intermediate symlink artifact");
+            let observation =
+                start_test_observation("homeboy", home.path(), &args, "test", Some(&run_dir))
+                    .expect("observation");
+            let run_id = observation.active.run_id().to_string();
+            let timing = homeboy_extension::ExtensionPhaseTiming {
+                name: "provider-test".to_string(),
+                duration_ms: 1,
+                status: Some("failed".to_string()),
+                message: None,
+                artifacts: vec![
+                    serde_json::json!({ "ref": "artifact://files/test-results.json" }),
+                    serde_json::json!({ "ref": "artifact://files/phpunit-output.log" }),
+                    serde_json::json!({ "ref": "artifact://files/missing.log" }),
+                    serde_json::json!({ "ref": "artifact://files/../outside.log" }),
+                    serde_json::json!({ "ref": "artifact://files/symlink.log" }),
+                    serde_json::json!({ "ref": "artifact://files/nested/escaped.log" }),
+                ],
+                metadata: Default::default(),
+            };
+            let mut workflow = extension_test::TestRunWorkflowResult {
+                status: "failed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 1,
+                test_counts: None,
+                findings: None,
+                failure_analysis_input: None,
+                coverage: None,
+                baseline_comparison: None,
+                analysis: None,
+                autofix: None,
+                hints: None,
+                test_scope: None,
+                summary: None,
+                raw_output: None,
+                extension_phase_timings: vec![timing],
+            };
+            persist_declared_test_artifacts(&observation, &mut workflow)
+                .expect("persist declared artifacts");
+            assert_eq!(
+                workflow.test_counts.as_ref().map(|counts| counts.failed),
+                Some(1)
+            );
+            assert_eq!(
+                workflow
+                    .failure_analysis_input
+                    .as_ref()
+                    .map(|input| input.failures.len()),
+                Some(1)
+            );
+            let failure = &workflow
+                .failure_analysis_input
+                .as_ref()
+                .expect("parsed PHPUnit failure")
+                .failures[0];
+            assert_eq!(failure.test_name, "Tests\\ExampleTest::test_it_fails");
+            assert_eq!(failure.message, "Failed asserting that false is true.");
+            assert_eq!(failure.source_file, "/workspace/tests/ExampleTest.php");
+            assert_eq!(failure.source_line, 42);
+            assert!(workflow
+                .findings
+                .as_ref()
+                .is_some_and(|findings| !findings.is_empty()));
+            assert_eq!(
+                workflow.findings.as_ref().expect("findings")[0].message,
+                "phpunit_failure: Failed asserting that false is true."
+            );
+            assert_eq!(
+                workflow.findings.as_ref().expect("findings")[0].metadata["test_name"],
+                "Tests\\ExampleTest::test_it_fails"
+            );
+            assert_eq!(
+                workflow.summary.as_ref().expect("summary").failures[0].test_name,
+                "Tests\\ExampleTest::test_it_fails"
+            );
+            assert_eq!(
+                workflow.summary.as_ref().expect("summary").failures[0].message,
+                "Failed asserting that false is true."
+            );
+            assert_eq!(
+                workflow.extension_phase_timings[0].artifacts[0]["ref"],
+                format!(
+                    "homeboy://run/{run_id}/artifact/{}",
+                    workflow.extension_phase_timings[0].artifacts[0]["artifact_id"]
+                        .as_str()
+                        .expect("artifact id")
+                )
+            );
+            assert!(workflow.extension_phase_timings[0].artifacts[0]
+                .get("source_locator")
+                .is_none());
+            finish_test_observation(Some(observation), &workflow);
+
+            run_dir.cleanup();
+            let artifacts = ObservationStore::open_initialized()
+                .expect("store")
+                .list_artifacts(&run_id)
+                .expect("artifacts");
+            assert_eq!(artifacts.len(), 6);
+            assert!(artifacts.iter().any(|artifact| {
+                artifact.artifact_type == "file"
+                    && fs::read(&artifact.path).ok().as_deref() == Some(b"{\"failed\":1}")
+            }));
+            assert!(artifacts.iter().any(|artifact| {
+                artifact.artifact_type == "file"
+                    && fs::read(&artifact.path)
+                        .ok()
+                        .is_some_and(|contents| contents.starts_with(b"PHPUnit 10.0"))
+            }));
+            let missing = artifacts
+                .iter()
+                .find(|artifact| artifact.artifact_type == "metadata-only")
+                .expect("missing provenance record");
+            assert_eq!(
+                missing.metadata_json["locator"],
+                "artifact://files/missing.log"
+            );
+            assert!(missing.metadata_json["unavailable_reason"]
+                .as_str()
+                .expect("reason")
+                .contains("unavailable"));
+            assert_eq!(
+                artifacts
+                    .iter()
+                    .filter(|artifact| artifact.artifact_type == "metadata-only")
+                    .count(),
+                4
+            );
+            assert!(artifacts.iter().any(|artifact| {
+                artifact.metadata_json["locator"] == "artifact://files/../outside.log"
+            }));
+            assert!(artifacts.iter().any(|artifact| {
+                artifact.metadata_json["locator"] == "artifact://files/symlink.log"
+            }));
+            assert!(artifacts.iter().any(|artifact| {
+                artifact.metadata_json["locator"] == "artifact://files/nested/escaped.log"
+            }));
+        });
+    }
+
+    #[test]
+    fn test_artifact_locator_requires_a_normal_relative_path() {
+        for locator in [
+            "artifact://files/../escape.log",
+            "artifact://files/./result.log",
+            "artifact://files//result.log",
+            "artifact://files/",
+        ] {
+            assert!(
+                artifact_locator_relative_path(locator).is_none(),
+                "{locator}"
+            );
+        }
+        assert!(artifact_locator_relative_path("artifact://files/result.log").is_some());
+    }
+
+    #[test]
+    fn rewritten_unavailable_artifact_locator_never_leaks_provider_reference() {
+        let mut workflow = extension_test::TestRunWorkflowResult {
+            status: "failed".to_string(),
+            component: "fixture".to_string(),
+            exit_code: 1,
+            test_counts: None,
+            findings: None,
+            failure_analysis_input: None,
+            coverage: None,
+            baseline_comparison: None,
+            analysis: None,
+            autofix: None,
+            hints: None,
+            test_scope: None,
+            summary: None,
+            raw_output: Some(extension_test::RawTestOutput {
+                stdout_tail: "artifact://files/missing.log".to_string(),
+                stderr_tail: String::new(),
+                truncated: false,
+                stdout_truncated: false,
+                stderr_truncated: false,
+                stdout_seen_bytes: 0,
+                stdout_retained_bytes: 0,
+                stderr_seen_bytes: 0,
+                stderr_retained_bytes: 0,
+                stdout_limit_bytes: 0,
+                stderr_limit_bytes: 0,
+            }),
+            extension_phase_timings: vec![homeboy_extension::ExtensionPhaseTiming {
+                name: "provider".to_string(),
+                duration_ms: 0,
+                status: None,
+                message: None,
+                artifacts: vec![serde_json::json!({
+                    "ref": "homeboy://run/run-1/artifact/artifact-1",
+                    "available": false,
+                    "unavailable_reason": "the declared controller-local artifact file is unavailable",
+                })],
+                metadata: Default::default(),
+            }],
+        };
+
+        rewrite_reported_artifact_locators(
+            &mut workflow,
+            &[ (
+                "artifact://files/missing.log".to_string(),
+                "homeboy://run/run-1/artifact/artifact-1 (evidence collection unavailable: the declared controller-local artifact file is unavailable)".to_string(),
+            )],
+        );
+        let output = workflow.raw_output.expect("raw output").stdout_tail;
+        assert!(!output.contains("artifact://"));
+        assert!(output.contains("homeboy://run/run-1/artifact/artifact-1"));
+        assert!(output.contains("evidence collection unavailable"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/observed_workflow.rs
+++ b/crates/homeboy-core/src/observation/observed_workflow.rs
@@ -245,6 +245,53 @@ impl ObservedWorkflowRunner {
         F: FnOnce(O, &T),
         E: FnOnce(O, &crate::Error),
     {
+        self.finish_with_scratch_outcome_inner(
+            observation,
+            workflow,
+            scratch_succeeded,
+            false,
+            finish_success,
+            finish_error,
+        )
+    }
+
+    /// Use only after the caller's error finalizer has durably recorded the
+    /// terminal observation. Ordinary finalization errors retain scratch.
+    pub fn finish_with_finalized_error_cleanup<O, T, F, E>(
+        self,
+        observation: Option<O>,
+        workflow: crate::Result<T>,
+        scratch_succeeded: bool,
+        finish_success: F,
+        finish_error: E,
+    ) -> crate::Result<T>
+    where
+        F: FnOnce(O, &T),
+        E: FnOnce(O, &crate::Error),
+    {
+        self.finish_with_scratch_outcome_inner(
+            observation,
+            workflow,
+            scratch_succeeded,
+            true,
+            finish_success,
+            finish_error,
+        )
+    }
+
+    fn finish_with_scratch_outcome_inner<O, T, F, E>(
+        self,
+        observation: Option<O>,
+        workflow: crate::Result<T>,
+        scratch_succeeded: bool,
+        finalized_error_cleanup: bool,
+        finish_success: F,
+        finish_error: E,
+    ) -> crate::Result<T>
+    where
+        F: FnOnce(O, &T),
+        E: FnOnce(O, &crate::Error),
+    {
         let result = match self.resource_run.write_to_run_dir(&self.run_dir) {
             Ok(_) => finish_observed_workflow(observation, workflow, finish_success, finish_error),
             Err(error) => {
@@ -254,7 +301,7 @@ impl ObservedWorkflowRunner {
                 Err(error)
             }
         };
-        if result.is_ok() && scratch_succeeded {
+        if scratch_succeeded && (result.is_ok() || finalized_error_cleanup) {
             self.run_dir.cleanup();
         }
         result
@@ -431,6 +478,22 @@ mod tests {
             resource_summary_path.is_file(),
             "completed but failed workflows retain evidence"
         );
+    }
+
+    #[test]
+    fn observed_workflow_runner_retains_scratch_for_unfinalized_errors() {
+        let runner = ObservedWorkflowRunner::create("test demo").expect("runner");
+        let resource_summary_path = runner.run_dir().step_file("resource-summary.json");
+        let result = runner.finish_with_scratch_outcome(
+            None::<()>,
+            Err::<i32, _>(crate::Error::internal_unexpected("finalization failed")),
+            true,
+            |_, _| {},
+            |_, _| {},
+        );
+
+        assert!(result.is_err());
+        assert!(resource_summary_path.is_file());
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use rusqlite::{params, OptionalExtension};
@@ -418,6 +419,57 @@ impl ObservationStore {
         metadata_json: serde_json::Value,
     ) -> Result<ArtifactRecord> {
         self.record_artifact_with_id_and_metadata(run_id, kind, path, None, metadata_json)
+    }
+
+    /// Persist bytes from an already-open regular file without reopening its
+    /// source pathname. The handle is copied to a controller-owned temporary
+    /// file first, then the normal immutable artifact publication path owns it.
+    pub fn record_artifact_from_open_file_with_metadata(
+        &self,
+        run_id: &str,
+        kind: &str,
+        source: &mut fs::File,
+        metadata_json: serde_json::Value,
+    ) -> Result<ArtifactRecord> {
+        let metadata = source.metadata().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("inspect opened artifact file".to_string()),
+            )
+        })?;
+        if !metadata.is_file() {
+            return Err(Error::validation_invalid_argument(
+                "artifact",
+                "opened artifact source is not a regular file",
+                None,
+                None,
+            ));
+        }
+        let mut snapshot = tempfile::NamedTempFile::new().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create artifact snapshot".to_string()),
+            )
+        })?;
+        std::io::copy(source, snapshot.as_file_mut()).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("copy opened artifact snapshot".to_string()),
+            )
+        })?;
+        snapshot.as_file_mut().flush().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("flush artifact snapshot".to_string()),
+            )
+        })?;
+        snapshot.as_file().sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("sync artifact snapshot".to_string()),
+            )
+        })?;
+        self.record_artifact_with_metadata(run_id, kind, snapshot.path(), metadata_json)
     }
 
     /// Record verified file bytes under a caller-provided stable logical id.
@@ -1600,6 +1652,40 @@ mod tests {
                     .file_name()
                     .to_string_lossy()
                     .starts_with(".artifact-")));
+        });
+    }
+
+    #[test]
+    fn opened_artifact_snapshot_uses_bytes_from_the_open_descriptor() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("test").cwd_path(home.path()).build())
+                .expect("run");
+            let source = home.path().join("test-results.json");
+            let replacement = home.path().join("replacement.json");
+            fs::write(&source, b"original bytes").expect("write original source");
+            let mut opened = fs::File::open(&source).expect("open original source");
+            fs::write(&replacement, b"replacement bytes").expect("write replacement source");
+            fs::rename(&replacement, &source).expect("replace source pathname");
+
+            let artifact = store
+                .record_artifact_from_open_file_with_metadata(
+                    &run.id,
+                    "test_artifact",
+                    &mut opened,
+                    serde_json::json!({ "locator": "artifact://files/test-results.json" }),
+                )
+                .expect("persist opened source");
+
+            assert_eq!(
+                fs::read(&source).expect("replacement bytes"),
+                b"replacement bytes"
+            );
+            assert_eq!(
+                fs::read(&artifact.path).expect("persisted bytes"),
+                b"original bytes"
+            );
         });
     }
 

--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -27,8 +27,9 @@ pub use baseline::{
 };
 pub use drift::{ChangeType, DriftReport, DriftedTest, ProductionChange};
 pub use parsing::{
-    build_test_summary, parse_coverage_file, parse_failures_file, parse_test_results_file,
-    parse_test_results_file_with_spec, parse_test_results_text, parse_test_results_text_with_spec,
+    build_test_summary, parse_coverage_file, parse_failures_file, parse_test_failures_from_text,
+    parse_test_results_failures_file, parse_test_results_file, parse_test_results_file_with_spec,
+    parse_test_results_text, parse_test_results_text_with_spec, test_failure_summary_items,
     CoverageOutput, TestSummaryOutput,
 };
 pub use report::TestCommandOutput;

--- a/crates/homeboy-extension/src/test/parsing.rs
+++ b/crates/homeboy-extension/src/test/parsing.rs
@@ -89,6 +89,159 @@ pub fn build_test_summary(
     }
 }
 
+pub fn test_failure_summary_items(failures: &[TestFailure]) -> Vec<TestFailureSummaryItem> {
+    failures
+        .iter()
+        .take(20)
+        .map(|failure| TestFailureSummaryItem {
+            test_name: failure.test_name.clone(),
+            message: failure.message.clone(),
+            file: (!failure.test_file.is_empty()).then(|| failure.test_file.clone()),
+            line: (failure.source_line != 0).then_some(failure.source_line),
+        })
+        .collect()
+}
+
+pub fn parse_test_failures_from_text(
+    text: &str,
+    counts: Option<&TestCounts>,
+) -> Option<TestAnalysisInput> {
+    let mut failures = Vec::new();
+    if let Ok(payload) = serde_json::from_str::<serde_json::Value>(text) {
+        collect_nested_result_failures(&payload, &mut failures);
+    }
+    if failures.is_empty() {
+        failures = parse_phpunit_failure_blocks(text);
+    }
+    (!failures.is_empty()).then(|| TestAnalysisInput {
+        failures,
+        total: counts.map(|counts| counts.total).unwrap_or(0),
+        passed: counts.map(|counts| counts.passed).unwrap_or(0),
+    })
+}
+
+pub fn parse_test_results_failures_file(
+    path: &std::path::Path,
+    counts: Option<&TestCounts>,
+) -> Result<Option<TestAnalysisInput>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = local_files::read_file(path, "read test results failures")?;
+    Ok(parse_test_failures_from_text(&content, counts))
+}
+
+fn collect_nested_result_failures(value: &serde_json::Value, failures: &mut Vec<TestFailure>) {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_nested_result_failures(item, failures);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            let status = object.get("status").and_then(serde_json::Value::as_str);
+            let failed = matches!(status, Some("failed" | "failure" | "error"));
+            let name = ["test_name", "testName", "name", "test_id"]
+                .into_iter()
+                .find_map(|key| object.get(key).and_then(serde_json::Value::as_str));
+            let message = ["message", "exception", "throwable"]
+                .into_iter()
+                .find_map(|key| object.get(key).and_then(serde_json::Value::as_str));
+            if failed {
+                if let (Some(test_name), Some(message)) = (name, message) {
+                    failures.push(TestFailure {
+                        test_name: test_name.to_string(),
+                        test_file: object
+                            .get("file")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        error_type: object
+                            .get("type")
+                            .or_else(|| object.get("class"))
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("test_failure")
+                            .to_string(),
+                        message: message.to_string(),
+                        source_file: object
+                            .get("source")
+                            .or_else(|| object.get("file"))
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        source_line: object
+                            .get("line")
+                            .and_then(serde_json::Value::as_u64)
+                            .and_then(|line| u32::try_from(line).ok())
+                            .unwrap_or(0),
+                    });
+                }
+            }
+            for child in object.values() {
+                collect_nested_result_failures(child, failures);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_phpunit_failure_blocks(text: &str) -> Vec<TestFailure> {
+    let header =
+        regex::Regex::new(r"^\d+\)\s+(.+)$").expect("PHPUnit failure header regex is valid");
+    let location =
+        regex::Regex::new(r"(?m)^(.+?):(\d+)$").expect("PHPUnit failure location regex is valid");
+    let mut failures = Vec::new();
+    let mut current: Option<(String, String)> = None;
+    for line in text.lines() {
+        if let Some(captures) = header.captures(line) {
+            if let Some((test_name, detail)) = current.take() {
+                append_phpunit_failure(&mut failures, &location, &test_name, &detail);
+            }
+            current = Some((captures[1].trim().to_string(), String::new()));
+        } else if let Some((_, detail)) = current.as_mut() {
+            detail.push_str(line);
+            detail.push('\n');
+        }
+    }
+    if let Some((test_name, detail)) = current {
+        append_phpunit_failure(&mut failures, &location, &test_name, &detail);
+    }
+    failures
+}
+
+fn append_phpunit_failure(
+    failures: &mut Vec<TestFailure>,
+    location: &regex::Regex,
+    test_name: &str,
+    detail: &str,
+) {
+    let Some(message) = detail
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with("/"))
+    else {
+        return;
+    };
+    let (source_file, source_line) = location
+        .captures_iter(detail)
+        .last()
+        .map(|location| {
+            (
+                location[1].to_string(),
+                location[2].parse::<u32>().unwrap_or(0),
+            )
+        })
+        .unwrap_or_default();
+    failures.push(TestFailure {
+        test_name: test_name.to_string(),
+        test_file: source_file.clone(),
+        error_type: "phpunit_failure".to_string(),
+        message: message.to_string(),
+        source_file,
+        source_line,
+    });
+}
+
 pub fn parse_failures_file(path: &std::path::Path) -> Result<Option<TestAnalysisInput>> {
     if !path.exists() {
         return Ok(None);
@@ -579,6 +732,41 @@ mod tests {
         assert_eq!(counts.passed, 2);
         assert_eq!(counts.failed, 1);
         assert_eq!(counts.skipped, 0);
+    }
+
+    #[test]
+    fn nested_result_payload_preserves_concrete_failure_details() {
+        let counts = TestCounts::new(2, 1, 1, 0);
+        let parsed = parse_test_failures_from_text(
+            r#"{
+                "suites": [{
+                    "tests": [{
+                        "status": "failed",
+                        "testName": "Tests\\ExampleTest::test_it_fails",
+                        "message": "Failed asserting that false is true.",
+                        "file": "tests/ExampleTest.php",
+                        "line": 42,
+                        "type": "PHPUnit\\Framework\\AssertionFailedError"
+                    }]
+                }]
+            }"#,
+            Some(&counts),
+        )
+        .expect("nested failure payload");
+
+        assert_eq!(parsed.total, 2);
+        assert_eq!(parsed.passed, 1);
+        assert_eq!(parsed.failures.len(), 1);
+        assert_eq!(
+            parsed.failures[0].test_name,
+            "Tests\\ExampleTest::test_it_fails"
+        );
+        assert_eq!(
+            parsed.failures[0].message,
+            "Failed asserting that false is true."
+        );
+        assert_eq!(parsed.failures[0].source_file, "tests/ExampleTest.php");
+        assert_eq!(parsed.failures[0].source_line, 42);
     }
 
     #[test]

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -582,6 +582,12 @@ fn run_main_test_workflow_inner(
     } else {
         None
     };
+    let mut extension_phase_timings = output.extension_phase_timings;
+    merge_reported_test_artifact_locators(
+        &mut extension_phase_timings,
+        &output.stdout,
+        &output.stderr,
+    );
 
     // When tests failed with no parseable counts, surface a dedicated hint so
     // the user understands `raw_output` is the only signal about what went
@@ -617,7 +623,7 @@ fn run_main_test_workflow_inner(
         test_scope: changed_scope,
         summary,
         raw_output,
-        extension_phase_timings: output.extension_phase_timings,
+        extension_phase_timings,
     })
 }
 
@@ -1120,11 +1126,81 @@ pub fn run_self_check_test_workflow_with_progress(
     })
 }
 
+fn merge_reported_test_artifact_locators(
+    timings: &mut Vec<ExtensionPhaseTiming>,
+    stdout: &str,
+    stderr: &str,
+) {
+    const MAX_LOCATORS: usize = 32;
+    let locator = regex::Regex::new(r"artifact://files/[A-Za-z0-9._/-]+")
+        .expect("artifact locator regex is valid");
+    let mut reported = std::collections::BTreeSet::new();
+    for value in [stdout, stderr] {
+        for candidate in locator.find_iter(value).map(|matched| matched.as_str()) {
+            let relative = candidate.trim_start_matches("artifact://files/");
+            let path = std::path::Path::new(relative);
+            if !path.as_os_str().is_empty()
+                && !path.is_absolute()
+                && path
+                    .components()
+                    .all(|component| matches!(component, std::path::Component::Normal(_)))
+            {
+                reported.insert(candidate.to_string());
+            }
+        }
+    }
+    if reported.is_empty() {
+        return;
+    }
+    let existing = timings
+        .iter()
+        .flat_map(|timing| timing.artifacts.iter())
+        .filter_map(|artifact| artifact.get("ref").and_then(serde_json::Value::as_str))
+        .collect::<std::collections::BTreeSet<_>>();
+    let artifacts = reported
+        .into_iter()
+        .filter(|candidate| !existing.contains(candidate.as_str()))
+        .take(MAX_LOCATORS)
+        .map(|reference| serde_json::json!({ "ref": reference }))
+        .collect::<Vec<_>>();
+    if !artifacts.is_empty() {
+        timings.push(ExtensionPhaseTiming {
+            name: "provider-reported-test-artifacts".to_string(),
+            duration_ms: 0,
+            status: Some("reported".to_string()),
+            message: None,
+            artifacts,
+            metadata: Default::default(),
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test::TestFailure;
     use homeboy_core::component::ComponentScriptsConfig;
+
+    #[test]
+    fn reported_artifact_locators_are_normalized_and_deduplicated() {
+        let mut timings = Vec::new();
+        merge_reported_test_artifact_locators(
+            &mut timings,
+            "artifact://files/test-results.json artifact://files/../escape.log",
+            "artifact://files/phpunit-output.log artifact://files/test-results.json",
+        );
+
+        assert_eq!(timings.len(), 1);
+        assert_eq!(timings[0].artifacts.len(), 2);
+        assert_eq!(
+            timings[0].artifacts[0]["ref"],
+            "artifact://files/phpunit-output.log"
+        );
+        assert_eq!(
+            timings[0].artifacts[1]["ref"],
+            "artifact://files/test-results.json"
+        );
+    }
     use homeboy_core::test_support::{exec_capable_tempdir, with_isolated_home};
 
     fn run_git(dir: &Path, args: &[&str]) -> String {

--- a/crates/homeboy-review/src/review/artifact_findings.rs
+++ b/crates/homeboy-review/src/review/artifact_findings.rs
@@ -10,6 +10,10 @@ pub trait ReviewArtifactFindings {
     fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
         Vec::new()
     }
+
+    fn review_artifacts(&self) -> Vec<Value> {
+        Vec::new()
+    }
 }
 
 impl ReviewArtifactFindings for AuditCommandOutput {
@@ -57,6 +61,13 @@ impl ReviewArtifactFindings for LintCommandOutput {
 impl ReviewArtifactFindings for TestCommandOutput {
     fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
         self.findings.clone().unwrap_or_default()
+    }
+
+    fn review_artifacts(&self) -> Vec<Value> {
+        self.extension_phase_timings
+            .iter()
+            .flat_map(|timing| timing.artifacts.iter().cloned())
+            .collect()
     }
 }
 

--- a/crates/homeboy-review/src/review/mod.rs
+++ b/crates/homeboy-review/src/review/mod.rs
@@ -308,7 +308,11 @@ pub fn artifact_command<T: Serialize + ReviewArtifactFindings>(
             .as_ref()
             .map(ReviewArtifactFindings::review_artifact_findings)
             .unwrap_or_default(),
-        artifacts: Vec::new(),
+        artifacts: stage
+            .output
+            .as_ref()
+            .map(ReviewArtifactFindings::review_artifacts)
+            .unwrap_or_default(),
     }
 }
 
@@ -340,6 +344,7 @@ fn generated_at_now() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_extension::{test::TestCommandOutput, ExtensionPhaseTiming};
 
     #[test]
     fn stage_skipped_helper_marks_not_ran() {
@@ -376,6 +381,65 @@ mod tests {
         assert_eq!(failed_command.status, "failed");
         assert_eq!(failed_command.exit_code, 1);
         assert_eq!(failed_command.summary, "3 finding(s); failed");
+    }
+
+    #[test]
+    fn test_stage_artifact_keeps_child_run_and_controller_artifact_identity() {
+        let output = TestCommandOutput {
+            passed: false,
+            status: "failed".to_string(),
+            component: "fixture".to_string(),
+            exit_code: 1,
+            phase: None,
+            failure: None,
+            test_counts: None,
+            findings: None,
+            coverage: None,
+            baseline_comparison: None,
+            analysis: None,
+            autofix: None,
+            hints: None,
+            drift: None,
+            auto_fix_drift: None,
+            test_scope: None,
+            summary: None,
+            raw_output: None,
+            ci_context: None,
+            extension_phase_timings: vec![ExtensionPhaseTiming {
+                name: "provider".to_string(),
+                duration_ms: 1,
+                status: Some("failed".to_string()),
+                message: None,
+                artifacts: vec![serde_json::json!({
+                    "run_id": "child-test-run",
+                    "artifact_id": "result-artifact",
+                    "ref": "homeboy://run/child-test-run/artifact/result-artifact"
+                })],
+                metadata: Default::default(),
+            }],
+            actionable: Some(serde_json::json!({
+                "run": { "id": "child-test-run" }
+            })),
+        };
+        let stage = ReviewStage {
+            stage: "test".to_string(),
+            ran: true,
+            passed: false,
+            exit_code: 1,
+            finding_count: 0,
+            hint: "inspect".to_string(),
+            skipped_reason: None,
+            output: Some(output),
+        };
+
+        let command = artifact_command(&stage);
+
+        assert_eq!(command.artifacts[0]["run_id"], "child-test-run");
+        assert_eq!(command.artifacts[0]["artifact_id"], "result-artifact");
+        assert_eq!(
+            command.artifacts[0]["ref"],
+            "homeboy://run/child-test-run/artifact/result-artifact"
+        );
     }
 
     #[test]

--- a/tests/wp_codebox_test_artifact_evidence.rs
+++ b/tests/wp_codebox_test_artifact_evidence.rs
@@ -1,0 +1,197 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+#[test]
+fn failing_provider_test_artifacts_remain_retrievable_after_scratch_cleanup() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = temp.path().join("home");
+    let project = temp.path().join("project");
+    let extension = home.join(".config/homeboy/extensions/wp-codebox-fixture");
+    fs::create_dir_all(&project).expect("project dir");
+    fs::create_dir_all(&extension).expect("extension dir");
+    fs::write(
+        project.join("homeboy.json"),
+        r#"{"id":"wp-codebox-fixture"}"#,
+    )
+    .expect("project manifest");
+    fs::write(
+        extension.join("wp-codebox-fixture.json"),
+        r#"{
+  "name": "WP Codebox artifact fixture",
+  "version": "1.0.0",
+  "test": { "extension_script": "test.sh" }
+}"#,
+    )
+    .expect("extension manifest");
+    write_executable(
+        &extension.join("test.sh"),
+        r##"#!/bin/sh
+mkdir -p "$HOMEBOY_RUN_DIR/files"
+printf '%s' '{"total":3,"passed":2,"failed":1,"results":[{"status":"failed","name":"WP_Codebox_Test::test_database_connection","message":"Expected wpdb connection to succeed.","file":"tests/WP_Codebox_Test.php","line":73}]}' > "$HOMEBOY_RUN_DIR/files/test-results.json"
+printf '%s\n' 'PHPUnit 10.0' '' 'There was 1 failure:' '' '1) WP_Codebox_Test::test_database_connection' 'Expected wpdb connection to succeed.' '' 'tests/WP_Codebox_Test.php:73' '' 'FAILURES!' 'Tests: 3, Assertions: 4, Failures: 1' > "$HOMEBOY_RUN_DIR/files/phpunit-output.log"
+printf '%s\n' 'artifact://files/test-results.json' 'artifact://files/phpunit-output.log'
+exit 1
+"##,
+    );
+
+    let test = run_homeboy(
+        &home,
+        [
+            "--placement",
+            "local",
+            "review",
+            "test",
+            "--path",
+            project.to_str().expect("project path"),
+            "--extension",
+            "wp-codebox-fixture",
+            "--skip-lint",
+            "--json-summary",
+        ],
+    );
+    assert_eq!(
+        test.status.code(),
+        Some(1),
+        "test stderr: {}",
+        stderr(&test)
+    );
+    let test_json = json_output(&test, "test");
+    let payload = &test_json["data"];
+    assert_eq!(payload["status"], "failed");
+    assert_eq!(payload["test_counts"]["total"], 3);
+    assert_eq!(payload["test_counts"]["passed"], 2);
+    assert_eq!(payload["test_counts"]["failed"], 1);
+    assert_eq!(
+        payload["summary"]["failures"][0]["test_name"],
+        "WP_Codebox_Test::test_database_connection"
+    );
+    assert_eq!(
+        payload["summary"]["failures"][0]["message"],
+        "Expected wpdb connection to succeed."
+    );
+    let run_id = test_json["run"]["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("test run id missing from {test_json}"));
+    assert!(
+        !test_json.to_string().contains("artifact://"),
+        "serialized test output must expose durable evidence references only: {test_json}"
+    );
+
+    let listed = run_homeboy(&home, ["runs", "artifacts", run_id]);
+    assert!(
+        listed.status.success(),
+        "artifacts stderr: {}",
+        stderr(&listed)
+    );
+    let listed_json = json_output(&listed, "runs artifacts");
+    let artifacts = listed_json["data"]["payload"]["artifacts"]
+        .as_array()
+        .expect("artifact rows");
+    let results = artifact_by_locator(artifacts, "artifact://files/test-results.json");
+    let phpunit = artifact_by_locator(artifacts, "artifact://files/phpunit-output.log");
+    assert_eq!(results["type"], "file");
+    assert_eq!(phpunit["type"], "file");
+    let phase_artifacts = payload["extension_phase_timings"][0]["artifacts"]
+        .as_array()
+        .expect("serialized phase artifacts");
+    assert_eq!(phase_artifacts.len(), 2);
+    assert!(phase_artifacts.iter().all(|artifact| {
+        artifact["artifact_id"]
+            .as_str()
+            .is_some_and(|id| !id.is_empty())
+            && artifact["ref"]
+                .as_str()
+                .is_some_and(|reference| reference.starts_with("homeboy://run/"))
+            && artifact.get("source_locator").is_none()
+    }));
+
+    let results_output = temp.path().join("retrieved-test-results.json");
+    let fetched_results = artifact_get(&home, run_id, results, &results_output);
+    assert_eq!(
+        fs::read(&results_output).expect("retrieved results bytes"),
+        br#"{"total":3,"passed":2,"failed":1,"results":[{"status":"failed","name":"WP_Codebox_Test::test_database_connection","message":"Expected wpdb connection to succeed.","file":"tests/WP_Codebox_Test.php","line":73}]}"#
+    );
+    assert_eq!(
+        fetched_results["data"]["payload"]["size_bytes"],
+        fs::read(&results_output)
+            .expect("retrieved results byte count")
+            .len()
+    );
+
+    let phpunit_output = temp.path().join("retrieved-phpunit-output.log");
+    let fetched_phpunit = artifact_get(&home, run_id, phpunit, &phpunit_output);
+    let phpunit_bytes = fs::read_to_string(&phpunit_output).expect("retrieved phpunit bytes");
+    assert!(phpunit_bytes.contains("WP_Codebox_Test::test_database_connection"));
+    assert!(phpunit_bytes.contains("Tests: 3, Assertions: 4, Failures: 1"));
+    assert_eq!(
+        fetched_phpunit["data"]["payload"]["size_bytes"],
+        phpunit_bytes.len()
+    );
+}
+
+fn artifact_get(home: &Path, run_id: &str, artifact: &Value, output: &Path) -> Value {
+    let artifact_id = artifact["id"].as_str().expect("artifact id");
+    let fetched = run_homeboy(
+        home,
+        [
+            "runs",
+            "artifact",
+            "get",
+            run_id,
+            artifact_id,
+            "--output",
+            output.to_str().expect("output path"),
+        ],
+    );
+    assert!(
+        fetched.status.success(),
+        "artifact get stderr: {}",
+        stderr(&fetched)
+    );
+    json_output(&fetched, "runs artifact get")
+}
+
+fn artifact_by_locator<'a>(artifacts: &'a [Value], locator: &str) -> &'a Value {
+    artifacts
+        .iter()
+        .find(|artifact| artifact["metadata_json"]["locator"] == locator)
+        .unwrap_or_else(|| panic!("missing indexed artifact {locator}: {artifacts:?}"))
+}
+
+fn run_homeboy<const N: usize>(home: &Path, args: [&str; N]) -> Output {
+    Command::new(homeboy_bin())
+        .args(args)
+        .env("HOME", home)
+        .env_remove("XDG_DATA_HOME")
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("homeboy command")
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).expect("extension script");
+    let mut permissions = fs::metadata(path).expect("script metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("script executable");
+}
+
+fn json_output(output: &Output, command: &str) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{command} JSON: {error}; stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary
- ingest provider-reported `artifact://files/...` test outputs before scratch cleanup
- persist safe controller-owned artifact references and concrete PHPUnit diagnostics
- fail closed on evidence publication errors and support retrieval through `runs artifact get`

Closes #10427

## Verification
- `cargo test --test wp_codebox_test_artifact_evidence`
- focused artifact publication and failure tests
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested the nested test-evidence lifecycle. Chris Huber reviewed and owns every line.