### PR TITLE
fix: make runner reconnect recovery deterministic

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -31,6 +31,9 @@ enum DaemonCommand {
     EnsureRunning {
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
+        /// Controller-generated idempotency key for a replacement operation.
+        #[arg(long)]
+        replacement_operation_id: Option<String>,
     },
     /// Explicitly replace one proven-dead daemon lease and reconcile its durable jobs
     AdoptOrphan {
@@ -105,6 +108,9 @@ enum DaemonCommand {
         confirm_no_daemon_owner: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
+        /// Controller-generated idempotency key for a replacement operation.
+        #[arg(long)]
+        replacement_operation_id: Option<String>,
     },
     /// Recover one exact lease after its daemon state record was lost
     RecoverMissingLeaseState {
@@ -128,6 +134,9 @@ enum DaemonCommand {
         confirm_control_plane_lost: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
         addr: String,
+        /// Controller-generated idempotency key for a replacement operation.
+        #[arg(long)]
+        replacement_operation_id: Option<String>,
     },
     /// Run the local daemon in the foreground
     Serve {
@@ -228,8 +237,14 @@ pub fn run(args: DaemonArgs) -> CmdResult<DaemonOutput> {
         DaemonCommand::Start { addr } => {
             Ok((DaemonOutput::Start(daemon::start_background(&addr)?), 0))
         }
-        DaemonCommand::EnsureRunning { addr } => Ok((
-            DaemonOutput::EnsureRunning(daemon::ensure_running(&addr)?),
+        DaemonCommand::EnsureRunning {
+            addr,
+            replacement_operation_id,
+        } => Ok((
+            DaemonOutput::EnsureRunning(daemon::ensure_running_with_replacement_operation(
+                &addr,
+                replacement_operation_id.as_deref(),
+            )?),
             0,
         )),
         DaemonCommand::AdoptOrphan {
@@ -290,8 +305,12 @@ pub fn run(args: DaemonArgs) -> CmdResult<DaemonOutput> {
         DaemonCommand::ReconcileLeaselessOrphans {
             confirm_no_daemon_owner: _deprecated_confirm_no_daemon_owner,
             addr,
+            replacement_operation_id,
         } => Ok((
-            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(&addr)?),
+            DaemonOutput::ReconcileLeaselessOrphans(daemon::reconcile_leaseless_orphans(
+                &addr,
+                replacement_operation_id.as_deref(),
+            )?),
             0,
         )),
         DaemonCommand::RecoverMissingLeaseState {
@@ -301,12 +320,14 @@ pub fn run(args: DaemonArgs) -> CmdResult<DaemonOutput> {
             confirm_pid_dead: _deprecated_confirm_pid_dead,
             confirm_control_plane_lost: _deprecated_confirm_control_plane_lost,
             addr,
+            replacement_operation_id,
         } => Ok((
             DaemonOutput::RecoverMissingLeaseState(daemon::recover_missing_lease_state(
                 &lease_id,
                 recorded_pid,
                 &recorded_endpoint,
                 &addr,
+                replacement_operation_id.as_deref(),
             )?),
             0,
         )),

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -212,15 +212,30 @@ pub fn recover_missing_lease_state(
     recorded_pid: u32,
     recorded_endpoint: &str,
     addr: &str,
+    replacement_operation_id: Option<&str>,
 ) -> Result<super::DaemonStateLossRecoveryResult> {
     parse_bind_addr(addr)?;
     let recorded_endpoint = parse_recorded_daemon_endpoint(recorded_endpoint)?;
     let _lock = acquire_daemon_operation_lock()?;
     let receipt_path = crate::paths::daemon_state_loss_recovery_receipt_file(lease_id)?;
     let status = read_status()?;
-    let existing = read_state_loss_receipt(&receipt_path)?;
-    if let Some(receipt) = existing.as_ref() {
-        validate_state_loss_receipt(receipt, lease_id, recorded_pid, recorded_endpoint)?;
+    let mut existing = read_state_loss_receipt(&receipt_path)?;
+    if let Some(receipt) = existing.as_mut() {
+        validate_state_loss_receipt(
+            receipt,
+            lease_id,
+            recorded_pid,
+            recorded_endpoint,
+            replacement_operation_id,
+        )?;
+        // Receipts created before operation IDs were introduced are safe to
+        // adopt only after the immutable recovery inputs above matched.
+        if receipt.replacement_operation_id.is_none() {
+            if let Some(operation_id) = replacement_operation_id {
+                receipt.replacement_operation_id = Some(operation_id.to_string());
+                write_state_loss_receipt(&receipt_path, receipt)?;
+            }
+        }
         if receipt.phase == StateLossRecoveryPhase::ReplacementStarted {
             return receipt.clone().into_result();
         }
@@ -305,6 +320,7 @@ pub fn recover_missing_lease_state(
             phase: StateLossRecoveryPhase::Prepared,
             replacement: None,
             replacement_startup_token: None,
+            replacement_operation_id: replacement_operation_id.map(str::to_string),
         };
         write_state_loss_receipt(&receipt_path, &receipt)?;
         let reconciled = store.reconcile_dead_daemon_lease_jobs(lease_id)?;
@@ -349,6 +365,8 @@ struct StateLossRecoveryReceipt {
     replacement: Option<super::DaemonStartResult>,
     #[serde(default)]
     replacement_startup_token: Option<String>,
+    #[serde(default)]
+    replacement_operation_id: Option<String>,
 }
 
 impl StateLossRecoveryReceipt {
@@ -395,6 +413,7 @@ fn validate_state_loss_receipt(
     lease_id: &str,
     recorded_pid: u32,
     recorded_endpoint: SocketAddr,
+    replacement_operation_id: Option<&str>,
 ) -> Result<()> {
     if receipt.lease_id != lease_id
         || receipt.recorded_pid != recorded_pid
@@ -406,6 +425,18 @@ fn validate_state_loss_receipt(
             Some(lease_id.to_string()),
             None,
         ));
+    }
+    if let Some(operation_id) = replacement_operation_id {
+        if receipt.replacement_operation_id.is_some()
+            && receipt.replacement_operation_id.as_deref() != Some(operation_id)
+        {
+            return Err(Error::validation_invalid_argument(
+                "replacement_operation_id",
+                "state-loss recovery receipt belongs to a different replacement operation",
+                Some(operation_id.to_string()),
+                None,
+            ));
+        }
     }
     Ok(())
 }
@@ -440,18 +471,35 @@ fn write_state_loss_receipt(path: &Path, receipt: &StateLossRecoveryReceipt) -> 
             Some("serialize state-loss receipt".to_string()),
         )
     })?;
-    std::fs::write(&temporary, body).map_err(|error| {
+    let mut file = std::fs::File::create(&temporary).map_err(|error| {
         Error::internal_io(
             error.to_string(),
-            Some(format!("write {}", temporary.display())),
+            Some(format!("create {}", temporary.display())),
         )
     })?;
+    use std::io::Write;
+    file.write_all(&body)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write {}", temporary.display())),
+            )
+        })?;
     std::fs::rename(&temporary, path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some(format!("rename {}", path.display())),
         )
-    })
+    })?;
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("sync {}", parent.display())),
+            )
+        })
 }
 
 fn state_loss_replacement_error(
@@ -785,6 +833,8 @@ struct LeaselessRecoveryReceipt {
     phase: StateLossRecoveryPhase,
     replacement: Option<DaemonStartResult>,
     replacement_startup_token: Option<String>,
+    #[serde(default)]
+    replacement_operation_id: Option<String>,
 }
 
 impl LeaselessRecoveryReceipt {
@@ -808,11 +858,28 @@ impl LeaselessRecoveryReceipt {
 fn replay_leaseless_recovery(
     status: &super::DaemonStatus,
     addr: &str,
+    replacement_operation_id: Option<&str>,
 ) -> Result<Option<DaemonLeaselessRecoveryResult>> {
     let receipt_path = crate::paths::daemon_leaseless_recovery_receipt_file()?;
     let Some(mut receipt) = read_leaseless_recovery_receipt(&receipt_path)? else {
         return Ok(None);
     };
+    if let Some(operation_id) = replacement_operation_id {
+        if receipt.replacement_operation_id.is_some()
+            && receipt.replacement_operation_id.as_deref() != Some(operation_id)
+        {
+            return Err(Error::validation_invalid_argument(
+                "replacement_operation_id",
+                "lease-less recovery receipt belongs to a different replacement operation",
+                Some(operation_id.to_string()),
+                None,
+            ));
+        }
+        if receipt.replacement_operation_id.is_none() {
+            receipt.replacement_operation_id = Some(operation_id.to_string());
+            write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
+        }
+    }
     if receipt.phase == StateLossRecoveryPhase::Prepared {
         if status.freshness.active_jobs > 0 {
             return Ok(None);
@@ -824,7 +891,7 @@ fn replay_leaseless_recovery(
         receipt.phase = StateLossRecoveryPhase::ReplacementStarting;
         receipt.replacement_startup_token = Some(uuid::Uuid::new_v4().to_string());
         write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
-        return replay_leaseless_recovery(status, addr);
+        return replay_leaseless_recovery(status, addr, replacement_operation_id);
     }
     if receipt.phase == StateLossRecoveryPhase::ReplacementStarting {
         if let Some(state) = status.state.as_ref().filter(|_| status.running) {
@@ -923,18 +990,35 @@ fn write_leaseless_recovery_receipt(path: &Path, receipt: &LeaselessRecoveryRece
             Some("serialize lease-less recovery receipt".to_string()),
         )
     })?;
-    std::fs::write(&temporary, body).map_err(|error| {
+    let mut file = std::fs::File::create(&temporary).map_err(|error| {
         Error::internal_io(
             error.to_string(),
-            Some(format!("write {}", temporary.display())),
+            Some(format!("create {}", temporary.display())),
         )
     })?;
+    use std::io::Write;
+    file.write_all(&body)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write {}", temporary.display())),
+            )
+        })?;
     std::fs::rename(&temporary, path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some(format!("rename {}", path.display())),
         )
-    })
+    })?;
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("sync {}", parent.display())),
+            )
+        })
 }
 
 /// Spawn the daemon in the background, then poll the state file until the new
@@ -949,6 +1033,37 @@ pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
 /// is absent or its recorded PID is dead.
 pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
     ensure_running_with_wait(addr, Duration::from_secs(5))
+}
+
+/// The optional controller operation id is intentionally additive. Existing
+/// callers retain the historical ensure-running behavior; controller retries
+/// reuse the durable startup token so a lost response cannot create C.
+pub fn ensure_running_with_replacement_operation(
+    addr: &str,
+    replacement_operation_id: Option<&str>,
+) -> Result<DaemonStartResult> {
+    let Some(operation_id) = replacement_operation_id.filter(|id| !id.trim().is_empty()) else {
+        return ensure_running(addr);
+    };
+    parse_bind_addr(addr)?;
+    let _lock = acquire_daemon_operation_lock_for_ensure(Duration::from_secs(5))?;
+    let status = read_status()?;
+    if let Some(state) = status
+        .state
+        .filter(|state| state.startup_token == operation_id)
+    {
+        if pid_is_running(state.pid) {
+            return Ok(DaemonStartResult {
+                pid: state.pid,
+                address: state.address,
+                state_path: state.state_path,
+                lease_id: state.lease_id,
+            });
+        }
+    }
+    // The startup token is persisted in the daemon lease before the response is
+    // emitted, making response-loss replay converge on the same live daemon.
+    start_or_return_live_unlocked_with_startup_token(addr, operation_id)
 }
 
 /// Replace one explicitly identified, provably dead daemon lease. The operation
@@ -1302,11 +1417,14 @@ where
 /// then fails closed on any related daemon process candidate or any reachable
 /// listener at `addr`. The former `--confirm-no-daemon-owner` gate ran ahead of
 /// both probes.
-pub fn reconcile_leaseless_orphans(addr: &str) -> Result<DaemonLeaselessRecoveryResult> {
+pub fn reconcile_leaseless_orphans(
+    addr: &str,
+    replacement_operation_id: Option<&str>,
+) -> Result<DaemonLeaselessRecoveryResult> {
     parse_bind_addr(addr)?;
     let _lock = acquire_daemon_operation_lock()?;
     let status = read_status()?;
-    if let Some(result) = replay_leaseless_recovery(&status, addr)? {
+    if let Some(result) = replay_leaseless_recovery(&status, addr, replacement_operation_id)? {
         return Ok(result);
     }
     if status.freshness.active_jobs == 0
@@ -1349,6 +1467,7 @@ pub fn reconcile_leaseless_orphans(addr: &str) -> Result<DaemonLeaselessRecovery
         phase: StateLossRecoveryPhase::Prepared,
         replacement: None,
         replacement_startup_token: None,
+        replacement_operation_id: replacement_operation_id.map(str::to_string),
     };
     write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
     let reconciled = store.reconcile_leaseless_orphan_jobs()?;
@@ -1387,9 +1506,12 @@ pub fn reconcile_leaseless_orphans(addr: &str) -> Result<DaemonLeaselessRecovery
         phase: StateLossRecoveryPhase::Reconciled,
         replacement: None,
         replacement_startup_token: None,
+        replacement_operation_id: replacement_operation_id.map(str::to_string),
     };
     write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
-    let startup_token = uuid::Uuid::new_v4().to_string();
+    let startup_token = replacement_operation_id
+        .map(str::to_string)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     receipt.phase = StateLossRecoveryPhase::ReplacementStarting;
     receipt.replacement_startup_token = Some(startup_token.clone());
     write_leaseless_recovery_receipt(&receipt_path, &receipt)?;

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -44,7 +44,8 @@ pub mod runner_workspace_root;
 pub use artifact_download::ArtifactDownload;
 pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions, ServiceIdentity};
 pub use control::{
-    adopt_orphaned_lease, artifact_content_url, ensure_running, fetch_artifact_to_path,
+    adopt_orphaned_lease, artifact_content_url, ensure_running,
+    ensure_running_with_replacement_operation, fetch_artifact_to_path,
     reconcile_dead_lease_orphans, reconcile_leaseless_orphans, recover_missing_child_identity,
     recover_missing_lease_state, start_background, supervise, ArtifactFetchOutcome,
 };

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -14,7 +14,7 @@ use homeboy_core::api_jobs::{
     RemoteRunnerJobResult, RunnerJobSource,
 };
 use homeboy_core::daemon::{
-    DaemonFreshnessReport, DaemonLeaselessRecoveryResult, DaemonStaleReasonCode,
+    DaemonFreshnessReport, DaemonLeaselessRecoveryResult, DaemonStaleReasonCode, DaemonStartResult,
     DaemonStateLossRecoveryResult,
 };
 use homeboy_core::engine::shell;
@@ -38,6 +38,7 @@ use homeboy_core::broker_auth;
 const REVERSE_RUNNER_HEARTBEAT_TTL: Duration = Duration::from_secs(90);
 const REMOTE_LEASELESS_RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_LEASELESS_RECOVERY_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+const REMOTE_RUNNER_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 // A reader may wait for an in-flight reconnect, but never indefinitely behind a
 // controller-local tunnel that disappeared during a link flap.
 const DIRECT_TUNNEL_RECOVERY_WAIT: Duration = Duration::from_secs(30);
@@ -111,7 +112,7 @@ pub(crate) fn rotate_daemon_generation(
         format!("\"{state_dir}\""),
         shell::quote_arg(candidate_homeboy),
     );
-    let output = client.execute(&command);
+    let output = client.execute_with_timeout(&command, REMOTE_RUNNER_CONNECT_TIMEOUT);
     if !output.success {
         return Err(Error::validation_invalid_argument(
             "reconnect",
@@ -368,13 +369,13 @@ fn connect_with_orphan_adoption_and_live_lease(
         ));
     };
 
-    let ssh_probe = client.execute("true");
+    let ssh_probe = client.execute_with_timeout("true", REMOTE_RUNNER_CONNECT_TIMEOUT);
     if !ssh_probe.success {
         return Ok(failed_connect(
             runner_id,
             session_path,
             RunnerFailureKind::SshFailure,
-            command_failure_message("SSH connectivity check failed", &ssh_probe),
+            bounded_remote_failure_message("SSH connectivity check", &ssh_probe),
         ));
     }
 
@@ -409,69 +410,178 @@ fn connect_with_orphan_adoption_and_live_lease(
     let previous_session =
         super::generation_store::admission_session(runner_id, previous_session.as_ref())?
             .or(previous_session);
+    let pending_replacement = super::generation_store::pending_replacement(runner_id)?;
+    // This write precedes every remote mutation. A retry reuses the same key
+    // even when the SSH command completed but its response was lost.
+    let replacement_operation_id = super::generation_store::replacement_operation(runner_id)?;
 
     let mut leaseless_recovery = None;
     let mut state_loss_recovery = None;
-    if let Some(lease_id) = missing_lease_id {
-        let recorded_pid = recorded_pid.ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "recorded_pid",
-                "state-loss recovery requires a recorded PID",
-                None,
-                None,
-            )
-        })?;
-        let recorded_endpoint = recorded_endpoint.ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "recorded_endpoint",
-                "state-loss recovery requires a recorded endpoint",
-                None,
-                None,
-            )
-        })?;
-        let capability = format!(
-            "{} daemon recover-missing-lease-state --help",
-            shell::quote_arg(homeboy),
-        );
-        let capability =
-            client.execute_with_timeout(&capability, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
-        if !capability.success {
-            return Ok(failed_connect(
+    // Recovery creates a new immutable generation. Its endpoint, not the
+    // previous session, is the only safe reconnect target for this attempt.
+    let mut recovery_daemon = pending_replacement
+        .as_ref()
+        .map(remote_daemon_from_session)
+        .transpose()?;
+    // A journaled command means the controller crossed the remote mutation
+    // boundary but did not durably receive B's coordinates. Replay it before
+    // inspecting A or selecting any ordinary replacement path.
+    if recovery_daemon.is_none() {
+        if let Some((kind, command)) =
+            super::generation_store::replacement_operation_replay(runner_id)?
+        {
+            let output = client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
+            if !output.success {
+                return Ok(failed_connect(
+                    runner_id,
+                    session_path,
+                    RunnerFailureKind::DaemonStartupFailure,
+                    format!(
+                        "replay pending replacement operation `{kind}`: {}",
+                        command_failure_message("remote operation failed", &output)
+                    ),
+                ));
+            }
+            let envelope = parse_envelope(&output.stdout).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse pending replacement replay".to_string()),
+                )
+            })?;
+            if !envelope.success {
+                return Ok(failed_connect(
+                    runner_id,
+                    session_path,
+                    RunnerFailureKind::DaemonStartupFailure,
+                    format!("pending replacement operation `{kind}` returned an error envelope"),
+                ));
+            }
+            match kind.as_str() {
+                "state-loss" => {
+                    let recovery = decode_state_loss_recovery(envelope.data)?;
+                    recovery_daemon = Some(remote_daemon_from_recovery(
+                        &recovery.replacement,
+                        &configured_build_identity,
+                    ));
+                    state_loss_recovery = Some(recovery);
+                }
+                "leaseless" => {
+                    let recovery = decode_leaseless_recovery(envelope.data)?;
+                    recovery_daemon = Some(remote_daemon_from_recovery(
+                        &recovery.replacement,
+                        &configured_build_identity,
+                    ));
+                    leaseless_recovery = Some(recovery);
+                }
+                "ensure-running" => {
+                    let receipt: DaemonStartResult =
+                        serde_json::from_value(envelope.data.ok_or_else(|| {
+                            Error::internal_unexpected(
+                                "remote ensure-running replay returned no receipt",
+                            )
+                        })?)
+                        .map_err(|error| {
+                            Error::internal_json(
+                                error.to_string(),
+                                Some("parse pending ensure-running replay".to_string()),
+                            )
+                        })?;
+                    recovery_daemon = Some(remote_daemon_from_recovery(
+                        &receipt,
+                        &configured_build_identity,
+                    ));
+                }
+                _ => {
+                    return Ok(failed_connect(
+                        runner_id,
+                        session_path,
+                        RunnerFailureKind::DaemonStartupFailure,
+                        "pending replacement operation has an unsupported replay kind".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+    if recovery_daemon.is_none() {
+        if let Some(lease_id) = missing_lease_id {
+            let recorded_pid = recorded_pid.ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "recorded_pid",
+                    "state-loss recovery requires a recorded PID",
+                    None,
+                    None,
+                )
+            })?;
+            let recorded_endpoint = recorded_endpoint.ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "recorded_endpoint",
+                    "state-loss recovery requires a recorded endpoint",
+                    None,
+                    None,
+                )
+            })?;
+            let capability = format!(
+                "{} daemon recover-missing-lease-state --help",
+                shell::quote_arg(homeboy),
+            );
+            let capability =
+                client.execute_with_timeout(&capability, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
+            if !capability.success {
+                return Ok(failed_connect(
                 runner_id,
                 session_path,
                 RunnerFailureKind::DaemonStartupFailure,
                 "remote Homeboy does not support `daemon recover-missing-lease-state`; update the runner to a build with the canonical state-loss recovery contract before retrying".to_string(),
             ));
-        }
-        let command =
-            remote_state_loss_recovery_command(homeboy, lease_id, recorded_pid, recorded_endpoint);
-        let recovery = client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
-        if !recovery.success {
-            return Ok(failed_connect(
+            }
+            if !declared_long_options(&capability.stdout).contains("--replacement-operation-id") {
+                return Ok(failed_connect(runner_id, session_path, RunnerFailureKind::DaemonStartupFailure, "remote Homeboy must be upgraded: recover-missing-lease-state does not support --replacement-operation-id".to_string()));
+            }
+            let command = remote_state_loss_recovery_command(
+                homeboy,
+                lease_id,
+                recorded_pid,
+                recorded_endpoint,
+                &replacement_operation_id,
+            );
+            super::generation_store::record_replacement_operation_replay(
                 runner_id,
-                session_path,
-                RunnerFailureKind::DaemonStartupFailure,
-                state_loss_recovery_failure_message(&recovery),
+                "state-loss",
+                &command,
+            )?;
+            let recovery = client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
+            if !recovery.success {
+                return Ok(failed_connect(
+                    runner_id,
+                    session_path,
+                    RunnerFailureKind::DaemonStartupFailure,
+                    state_loss_recovery_failure_message(&recovery),
+                ));
+            }
+            let envelope = parse_envelope(&recovery.stdout).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse state-loss daemon recovery".to_string()),
+                )
+            })?;
+            if !envelope.success {
+                return Ok(failed_connect(
+                    runner_id,
+                    session_path,
+                    RunnerFailureKind::DaemonStartupFailure,
+                    "remote exact state-loss recovery returned an error envelope".to_string(),
+                ));
+            }
+            let recovery = decode_state_loss_recovery(envelope.data)?;
+            recovery_daemon = Some(remote_daemon_from_recovery(
+                &recovery.replacement,
+                &configured_build_identity,
             ));
+            state_loss_recovery = Some(recovery);
         }
-        let envelope = parse_envelope(&recovery.stdout).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("parse state-loss daemon recovery".to_string()),
-            )
-        })?;
-        if !envelope.success {
-            return Ok(failed_connect(
-                runner_id,
-                session_path,
-                RunnerFailureKind::DaemonStartupFailure,
-                "remote exact state-loss recovery returned an error envelope".to_string(),
-            ));
-        }
-        state_loss_recovery = Some(decode_state_loss_recovery(envelope.data)?);
     }
     let mut recovery_evidence = None;
-    if reconcile_leaseless_orphans {
+    if recovery_daemon.is_none() && reconcile_leaseless_orphans {
         let recovery_addr = previous_session
             .as_ref()
             .and_then(|session| session.remote_daemon_address.as_deref())
@@ -485,10 +595,31 @@ fn connect_with_orphan_adoption_and_live_lease(
                 )
             },
             |contract| {
-                client.execute_with_timeout(
-                    &remote_leaseless_recovery_command(homeboy, recovery_addr, contract),
-                    REMOTE_LEASELESS_RECOVERY_TIMEOUT,
+                let command = remote_leaseless_recovery_command(
+                    homeboy,
+                    recovery_addr,
+                    contract,
+                    &replacement_operation_id,
+                );
+                // The negotiated command is persisted before its SSH mutation.
+                // A write failure aborts before the remote operation.
+                if super::generation_store::record_replacement_operation_replay(
+                    runner_id,
+                    "leaseless",
+                    &command,
                 )
+                .is_err()
+                {
+                    return homeboy_core::server::CommandOutput {
+                        success: false,
+                        stdout: String::new(),
+                        stderr: "could not journal replacement operation".to_string(),
+                        exit_code: 1,
+                        timed_out: false,
+                        child_resource: None,
+                    };
+                }
+                client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT)
             },
         );
         let (contract, recovery) = match recovery {
@@ -526,6 +657,10 @@ fn connect_with_orphan_adoption_and_live_lease(
             ));
         }
         let recovery = decode_leaseless_recovery(envelope.data)?;
+        recovery_daemon = Some(remote_daemon_from_recovery(
+            &recovery.replacement,
+            &configured_build_identity,
+        ));
         recovery_evidence = Some(leaseless_recovery_evidence(
             contract,
             &configured_build_identity,
@@ -534,41 +669,42 @@ fn connect_with_orphan_adoption_and_live_lease(
         leaseless_recovery = Some(recovery);
     }
 
-    if let (Some(recovery), Some(evidence)) = (&leaseless_recovery, &recovery_evidence) {
-        let replacement = &recovery.replacement;
-        write_session(&RunnerSession {
-            runner_id: runner.id.clone(),
-            mode: RunnerTunnelMode::DirectSsh,
-            role: RunnerSessionRole::Controller,
-            server_id: Some(server_id.clone()),
-            controller_id: None,
-            broker_url: None,
-            remote_daemon_address: Some(replacement.address.clone()),
-            local_port: None,
-            local_url: None,
-            tunnel_pid: None,
-            remote_daemon_pid: Some(replacement.pid),
-            remote_daemon_lease_id: Some(replacement.lease_id.clone()),
-            homeboy_version: version.clone(),
-            homeboy_build_identity: Some(configured_build_identity.clone()),
-            connected_at: Utc::now().to_rfc3339(),
-            worker_identity: None,
-            worker_pid: None,
-            last_seen_at: None,
-            leaseless_recovery_evidence: serde_json::to_value(&evidence).ok(),
-        })?;
+    // The remote recovery response is the first point at which B's immutable
+    // coordinates exist. Journal them before opening a tunnel so interruption
+    // retries can authenticate B rather than touching the prior generation.
+    if pending_replacement.is_none() {
+        if let Some(daemon) = recovery_daemon.as_ref() {
+            super::generation_store::record_pending_replacement(
+                runner_id,
+                &pending_replacement_session(
+                    runner_id,
+                    &server_id,
+                    daemon,
+                    &version,
+                    &configured_build_identity,
+                    recovery_evidence.as_ref(),
+                )?,
+            )?;
+        }
     }
-
-    let daemon = ensure_remote_daemon(
-        &client,
-        homeboy,
-        runner_id,
-        previous_session.as_ref(),
-        &configured_build_identity,
-        orphan_lease_id,
-        confirmed_no_pid_job_ids,
-        live_lease_expectation,
-    );
+    let daemon = match recovery_daemon {
+        Some(daemon) => Ok(daemon),
+        // Normal reconnects must inspect the live daemon first: a reachable,
+        // compatible generation reattaches, while an idle stale generation
+        // follows ReplaceIdleStale instead of bypassing its fenced lifecycle.
+        None => ensure_remote_daemon(
+            &client,
+            homeboy,
+            runner_id,
+            previous_session.as_ref(),
+            &configured_build_identity,
+            orphan_lease_id,
+            confirmed_no_pid_job_ids,
+            live_lease_expectation,
+            Some(&replacement_operation_id),
+        )
+        .map(|daemon| daemon),
+    };
     let Ok(daemon) = daemon else {
         let (mut report, exit_code) = failed_connect_after_recovery(
             runner_id,
@@ -587,7 +723,7 @@ fn connect_with_orphan_adoption_and_live_lease(
         .build_identity
         .clone()
         .unwrap_or(configured_build_identity.clone());
-    let (local_port, tunnel_pid, local_url, daemon) = match connect_remote_daemon(
+    let connection = connect_remote_daemon(
         &server,
         &client,
         homeboy,
@@ -596,7 +732,8 @@ fn connect_with_orphan_adoption_and_live_lease(
         &expected_identity,
         runner_id,
         &session_path,
-    ) {
+    );
+    let (local_port, tunnel_pid, local_url, daemon) = match connection {
         Ok(connection) => connection,
         Err((mut report, exit_code)) => {
             attach_state_loss_recovery(&mut report, state_loss_recovery);
@@ -654,7 +791,7 @@ fn connect_with_orphan_adoption_and_live_lease(
     // drift still has authenticated promotion provenance to reconcile safely.
     if let Err(error) = promotion_lease
         .assert_generation()
-        .and_then(|_| super::generation_store::record_authenticated_admission(runner_id, &session))
+        .and_then(|_| super::generation_store::promote_pending_replacement(runner_id, &session))
         .and_then(|_| write_session(&session))
     {
         return Ok(session_write_failure_report(
@@ -689,9 +826,91 @@ fn connect_with_orphan_adoption_and_live_lease(
             leaseless_recovery_evidence: recovery_evidence,
             failure_kind: None,
             failure_message: None,
+            failure_evidence: None,
         },
         0,
     ))
+}
+
+fn remote_daemon_from_recovery(
+    replacement: &DaemonStartResult,
+    configured_build_identity: &str,
+) -> RemoteDaemon {
+    RemoteDaemon {
+        address: replacement.address.clone(),
+        pid: Some(replacement.pid),
+        lease_id: Some(replacement.lease_id.clone()),
+        version: None,
+        build_identity: Some(configured_build_identity.to_string()),
+        inspected_freshness: None,
+    }
+}
+
+fn remote_daemon_from_session(session: &RunnerSession) -> Result<RemoteDaemon> {
+    let address = session.remote_daemon_address.clone().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "pending_replacement",
+            "pending replacement has no address",
+            None,
+            None,
+        )
+    })?;
+    let lease_id = session.remote_daemon_lease_id.clone().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "pending_replacement",
+            "pending replacement has no lease",
+            None,
+            None,
+        )
+    })?;
+    let pid = session.remote_daemon_pid.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "pending_replacement",
+            "pending replacement has no PID",
+            None,
+            None,
+        )
+    })?;
+    Ok(RemoteDaemon {
+        address,
+        pid: Some(pid),
+        lease_id: Some(lease_id),
+        version: None,
+        build_identity: session.homeboy_build_identity.clone(),
+        inspected_freshness: None,
+    })
+}
+
+fn pending_replacement_session(
+    runner_id: &str,
+    server_id: &str,
+    daemon: &RemoteDaemon,
+    version: &str,
+    identity: &str,
+    recovery_evidence: Option<&RunnerLeaselessRecoveryEvidence>,
+) -> Result<RunnerSession> {
+    Ok(RunnerSession {
+        runner_id: runner_id.to_string(),
+        mode: RunnerTunnelMode::DirectSsh,
+        role: RunnerSessionRole::Controller,
+        server_id: Some(server_id.to_string()),
+        controller_id: None,
+        broker_url: None,
+        remote_daemon_address: Some(daemon.address.clone()),
+        local_port: None,
+        local_url: None,
+        tunnel_pid: None,
+        remote_daemon_pid: daemon.pid,
+        remote_daemon_lease_id: daemon.lease_id.clone(),
+        homeboy_version: version.to_string(),
+        homeboy_build_identity: Some(identity.to_string()),
+        connected_at: Utc::now().to_rfc3339(),
+        worker_identity: None,
+        worker_pid: None,
+        last_seen_at: None,
+        leaseless_recovery_evidence: recovery_evidence
+            .and_then(|evidence| serde_json::to_value(evidence).ok()),
+    })
 }
 
 fn verify_live_lease_adoption(
@@ -749,6 +968,7 @@ fn remote_leaseless_recovery_command(
     homeboy: &str,
     addr: &str,
     contract: RunnerLeaselessRecoveryContract,
+    replacement_operation_id: &str,
 ) -> String {
     let confirmations = match contract {
         RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner
@@ -756,8 +976,9 @@ fn remote_leaseless_recovery_command(
         | RunnerLeaselessRecoveryContract::ConfirmControlPlaneLost => "--confirm-no-daemon-owner",
     };
     format!(
-        "{} daemon reconcile-leaseless-orphans {confirmations} --addr {}",
+        "{} daemon reconcile-leaseless-orphans {confirmations} --replacement-operation-id {} --addr {}",
         shell::quote_arg(homeboy),
+        shell::quote_arg(replacement_operation_id),
         shell::quote_arg(addr),
     )
 }
@@ -799,6 +1020,10 @@ fn negotiate_leaseless_recovery_contract(
 
     let options = declared_long_options(&output.stdout);
     let confirm_no_daemon_owner = options.contains("--confirm-no-daemon-owner");
+    let replacement_operation_id = options.contains("--replacement-operation-id");
+    if !replacement_operation_id {
+        return Err("lease-less recovery capability probe did not advertise the canonical --replacement-operation-id contract; upgrade the remote Homeboy before mutation".to_string());
+    }
     if confirm_no_daemon_owner
         && !options.contains("--reconcile-leaseless-orphans")
         && !options.contains("--confirm-control-plane-lost")
@@ -922,6 +1147,20 @@ fn leaseless_recovery_failure_message(output: &homeboy_core::server::CommandOutp
     }
 }
 
+fn bounded_remote_failure_message(
+    operation: &str,
+    output: &homeboy_core::server::CommandOutput,
+) -> String {
+    if output.timed_out {
+        format!(
+            "{operation} timed out after {}s; retry the exact runner connect command",
+            REMOTE_RUNNER_CONNECT_TIMEOUT.as_secs()
+        )
+    } else {
+        command_failure_message(&format!("{operation} failed"), output)
+    }
+}
+
 fn state_loss_recovery_failure_message(output: &homeboy_core::server::CommandOutput) -> String {
     if output.timed_out {
         format!(
@@ -938,13 +1177,15 @@ fn remote_state_loss_recovery_command(
     lease_id: &str,
     recorded_pid: u32,
     recorded_endpoint: &str,
+    replacement_operation_id: &str,
 ) -> String {
     format!(
-        "{} daemon recover-missing-lease-state --lease-id {} --recorded-pid {} --recorded-endpoint {} --confirm-pid-dead --confirm-control-plane-lost --addr 127.0.0.1:0",
+        "{} daemon recover-missing-lease-state --lease-id {} --recorded-pid {} --recorded-endpoint {} --confirm-pid-dead --confirm-control-plane-lost --replacement-operation-id {} --addr 127.0.0.1:0",
         shell::quote_arg(homeboy),
         shell::quote_arg(lease_id),
         recorded_pid,
         shell::quote_arg(recorded_endpoint),
+        shell::quote_arg(replacement_operation_id),
     )
 }
 
@@ -1020,6 +1261,7 @@ pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerCo
             leaseless_recovery_evidence: None,
             failure_kind: None,
             failure_message: None,
+            failure_evidence: None,
         },
         0,
     ))

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -35,7 +35,10 @@ pub(super) fn remote_homeboy_version(
     client: &SshClient,
     homeboy: &str,
 ) -> std::result::Result<String, String> {
-    parse_remote_homeboy_version(&client.execute(&remote_homeboy_version_command(homeboy)))
+    parse_remote_homeboy_version(&client.execute_with_timeout(
+        &remote_homeboy_version_command(homeboy),
+        REMOTE_DAEMON_STATUS_TIMEOUT,
+    ))
 }
 
 /// Read the remote Homeboy version under a hard wall-clock bound (#10418).
@@ -93,7 +96,10 @@ pub(super) fn remote_homeboy_identity(
     client: &SshClient,
     homeboy: &str,
 ) -> std::result::Result<RemoteHomeboyIdentity, String> {
-    let output = client.execute(&remote_homeboy_identity_command(homeboy));
+    let output = client.execute_with_timeout(
+        &remote_homeboy_identity_command(homeboy),
+        REMOTE_DAEMON_STATUS_TIMEOUT,
+    );
     if output.success {
         if let Some(identity) = parse_self_identity_output(&output.stdout) {
             return Ok(identity);
@@ -573,6 +579,7 @@ pub(super) fn ensure_remote_daemon(
     orphan_lease_id: Option<&str>,
     confirmed_no_pid_job_ids: &[uuid::Uuid],
     live_lease_expectation: Option<(&str, u32)>,
+    replacement_operation_id: Option<&str>,
 ) -> std::result::Result<RemoteDaemon, String> {
     let mut status = remote_daemon_status(client, homeboy)?;
     probe_remote_daemon_endpoint(client, &mut status);
@@ -611,15 +618,26 @@ pub(super) fn ensure_remote_daemon(
             daemon.inspected_freshness = Some(inspected_freshness);
             return Ok(daemon);
         }
-        RemoteDaemonConnectAction::Start => return remote_daemon_ensure_running(client, homeboy),
+        RemoteDaemonConnectAction::Start => {
+            negotiate_ensure_running_operation_id(client, homeboy, replacement_operation_id)?;
+            journal_ensure_running_replay(runner_id, homeboy, replacement_operation_id)?;
+            return remote_daemon_ensure_running(client, homeboy, replacement_operation_id);
+        }
         RemoteDaemonConnectAction::ReplaceIdleStale => {
+            // Prove idempotent replacement support before stopping A. Otherwise
+            // a controller response loss could leave no recoverable owner.
+            negotiate_ensure_running_operation_id(client, homeboy, replacement_operation_id)?;
+            // Persist B's idempotent receipt key before removing A. A retry then
+            // replays this command before inspecting or replacing any lease.
+            journal_ensure_running_replay(runner_id, homeboy, replacement_operation_id)?;
             let daemon = status.daemon.as_ref().expect("replacement requires daemon");
             let lease_id = daemon
                 .lease_id
                 .as_deref()
                 .expect("replacement requires lease");
             remote_daemon_force_stop(client, homeboy, lease_id)?;
-            let replacement = remote_daemon_ensure_running(client, homeboy)?;
+            let replacement =
+                remote_daemon_ensure_running(client, homeboy, replacement_operation_id)?;
             return verify_remote_daemon_replacement(
                 client,
                 homeboy,
@@ -628,6 +646,41 @@ pub(super) fn ensure_remote_daemon(
             );
         }
     }
+}
+
+fn journal_ensure_running_replay(
+    runner_id: &str,
+    homeboy: &str,
+    replacement_operation_id: Option<&str>,
+) -> std::result::Result<(), String> {
+    if replacement_operation_id.is_none() {
+        return Ok(());
+    }
+    crate::generation_store::record_replacement_operation_replay(
+        runner_id,
+        "ensure-running",
+        &remote_daemon_ensure_running_command(homeboy, replacement_operation_id),
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn negotiate_ensure_running_operation_id(
+    client: &SshClient,
+    homeboy: &str,
+    replacement_operation_id: Option<&str>,
+) -> std::result::Result<(), String> {
+    let Some(_) = replacement_operation_id else {
+        return Ok(());
+    };
+    let command = format!("{} daemon ensure-running --help", shell::quote_arg(homeboy));
+    let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
+    if !output.success {
+        return Err("remote Homeboy must be upgraded: unable to negotiate daemon ensure-running --replacement-operation-id before mutation".to_string());
+    }
+    if !declared_long_options(&output.stdout).contains("--replacement-operation-id") {
+        return Err("remote Homeboy must be upgraded: daemon ensure-running does not support --replacement-operation-id".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1157,12 +1210,10 @@ pub(super) fn remote_daemon_active_jobs(data: &Value) -> usize {
 pub(super) fn remote_daemon_ensure_running(
     client: &SshClient,
     homeboy: &str,
+    replacement_operation_id: Option<&str>,
 ) -> std::result::Result<RemoteDaemon, String> {
-    let command = format!(
-        "{} daemon ensure-running --addr 127.0.0.1:0",
-        shell::quote_arg(homeboy)
-    );
-    let output = client.execute(&command);
+    let command = remote_daemon_ensure_running_command(homeboy, replacement_operation_id);
+    let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
     if !output.success {
         return Err(command_failure_message(
             "remote daemon ensure-running failed",
@@ -1202,6 +1253,19 @@ pub(super) fn remote_daemon_ensure_running(
         build_identity: None,
         inspected_freshness: None,
     })
+}
+
+pub(super) fn remote_daemon_ensure_running_command(
+    homeboy: &str,
+    replacement_operation_id: Option<&str>,
+) -> String {
+    format!(
+        "{} daemon ensure-running {} --addr 127.0.0.1:0",
+        shell::quote_arg(homeboy),
+        replacement_operation_id
+            .map(|id| format!("--replacement-operation-id {}", shell::quote_arg(id)))
+            .unwrap_or_default(),
+    )
 }
 
 /// Start an independent daemon store for a runner generation. Keep HOME intact:

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::session::RunnerConnectFailureEvidence;
 
 pub(super) fn session_is_live(session: &RunnerSession) -> bool {
     session_is_live_with_timeout(session, Duration::from_secs(2))
@@ -1004,8 +1005,25 @@ pub(super) fn failed_connect(
             leaseless_recovery: None,
             state_loss_recovery: None,
             leaseless_recovery_evidence: None,
-            failure_kind: Some(failure_kind),
+            failure_kind: Some(failure_kind.clone()),
             failure_message: Some(failure_message),
+            failure_evidence: Some(RunnerConnectFailureEvidence {
+                recovery_command: format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
+                classification: match failure_kind {
+                    RunnerFailureKind::SshFailure => "ssh".to_string(),
+                    RunnerFailureKind::MissingRemoteHomeboy => "version".to_string(),
+                    RunnerFailureKind::DaemonStartupFailure => "daemon_startup".to_string(),
+                    RunnerFailureKind::TunnelFailure => "tunnel".to_string(),
+                },
+                remote_start_command: None,
+                known_remote_pid: None,
+                known_remote_lease_id: None,
+                remote_address: None,
+                local_address: None,
+                tunnel_state: Some("not_established".to_string()),
+                health_attempt_count: 0,
+                health_attempts: Vec::new(),
+            }),
         },
         20,
     )

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -3,6 +3,11 @@
 use clap::Parser;
 use std::collections::HashMap;
 use std::io::{Read, Write};
+#[cfg(unix)]
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 use super::*;
 
@@ -87,6 +92,46 @@ fn repeated_tunnel_flaps_continue_to_select_the_same_active_daemon() {
         assert_eq!(daemon.lease_id.as_deref(), Some("lease-active"));
         assert_eq!(daemon.pid, Some(4242));
     }
+}
+
+#[test]
+fn recovery_reconnect_uses_the_published_replacement_generation() {
+    let replacement = DaemonStartResult {
+        address: "127.0.0.1:45678".to_string(),
+        pid: 5678,
+        state_path: "/state/generation-b.json".to_string(),
+        lease_id: "lease-generation-b".to_string(),
+    };
+
+    let daemon = remote_daemon_from_recovery(&replacement, "homeboy test+configured");
+
+    assert_eq!(daemon.address, "127.0.0.1:45678");
+    assert_eq!(daemon.pid, Some(5678));
+    assert_eq!(daemon.lease_id.as_deref(), Some("lease-generation-b"));
+    assert_eq!(
+        daemon.build_identity.as_deref(),
+        Some("homeboy test+configured")
+    );
+}
+
+#[test]
+fn recovery_replacement_does_not_reuse_the_interrupted_session_generation() {
+    let interrupted = direct_ssh_session("lease-generation-a");
+    let replacement = DaemonStartResult {
+        address: "127.0.0.1:45678".to_string(),
+        pid: 5678,
+        state_path: "/state/generation-b.json".to_string(),
+        lease_id: "lease-generation-b".to_string(),
+    };
+
+    let daemon = remote_daemon_from_recovery(&replacement, "homeboy test+configured");
+
+    assert_ne!(
+        daemon.address,
+        interrupted.remote_daemon_address.expect("old address")
+    );
+    assert_ne!(daemon.pid, interrupted.remote_daemon_pid);
+    assert_ne!(daemon.lease_id, interrupted.remote_daemon_lease_id);
 }
 
 #[test]
@@ -650,8 +695,13 @@ fn remote_leaseless_recovery_decodes_and_propagates_report() {
 
 #[test]
 fn state_loss_recovery_delegation_decodes_and_serializes_auditable_evidence() {
-    let command =
-        remote_state_loss_recovery_command("/opt/homeboy", "lease-old", 4242, "127.0.0.1:7421");
+    let command = remote_state_loss_recovery_command(
+        "/opt/homeboy",
+        "lease-old",
+        4242,
+        "127.0.0.1:7421",
+        "operation-1",
+    );
     assert!(command.contains("--recorded-endpoint 127.0.0.1:7421"));
     let envelope = parse_envelope(
         r#"{"success":true,"data":{
@@ -729,24 +779,61 @@ fn runner_connect_persists_recovery_evidence_after_daemon_failure() {
     test_support::with_isolated_home(|home| {
         let daemon = home.path().join("remote-homeboy");
         let argv_path = home.path().join("recovery-argv");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let expected_address = address.to_string();
+        let endpoint = std::thread::spawn(move || {
+            // The local reachability check opens a TCP socket before the
+            // health and identity requests.
+            for _ in 0..16 {
+                let (mut stream, _) = listener.accept().expect("endpoint request");
+                let mut request = [0; 4096];
+                let length = stream.read(&mut request).expect("read endpoint request");
+                let request = String::from_utf8_lossy(&request[..length]);
+                let body = if request.starts_with("GET /health ") {
+                    r#"{"freshness":{"fresh":true,"restartable":true,"lease_id":"lease-new","pid":42,"active_jobs":0},"pid":42}"#
+                } else {
+                    r#"{"version":"0.284.0","build_identity":{"display":"homeboy 0.284.0+test"}}"#
+                };
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .expect("endpoint response");
+            }
+        });
         std::fs::write(
             &daemon,
-            r#"#!/bin/sh
+            format!(
+                r#"#!/bin/sh
 case "$1 $2" in
   "self identity")
-printf '%s\n' '{"success":true,"data":{"version":"0.284.0","display":"homeboy 0.284.0+test"}}'
+printf '%s\n' '{{"success":true,"data":{{"version":"0.284.0","display":"homeboy 0.284.0+test"}}}}'
 ;;
 "daemon reconcile-leaseless-orphans")
 if [ "$3" = "--help" ]; then
-  printf '%s\n' 'OPTIONS:' '    --confirm-no-daemon-owner'
+   printf '%s\n' 'OPTIONS:' '    --confirm-no-daemon-owner' '    --replacement-operation-id <ID>'
 else
   printf '%s\n' "$@" > "$HOMEBOY_TEST_RECOVERY_ARGV"
-  printf '%s\n' '{"success":true,"data":{"affected_job_ids":[],"affected_job_count":0,"affected_jobs":[],"historical_lease_ids":[],"evidence_snapshot_path":"/tmp/jobs.snapshot","ownership_proof":["owner lock acquired"],"retry_guidance":"retry","replacement":{"pid":42,"address":"127.0.0.1:7421","state_path":"/tmp/state.json","lease_id":"lease-new"}}}'
+   printf '%s\n' '{{"success":true,"data":{{"affected_job_ids":[],"affected_job_count":0,"affected_jobs":[],"historical_lease_ids":[],"evidence_snapshot_path":"/tmp/jobs.snapshot","ownership_proof":["owner lock acquired"],"retry_guidance":"retry","replacement":{{"pid":42,"address":"{address}","state_path":"/tmp/state.json","lease_id":"lease-new"}}}}}}'
 fi
-;;
-  "daemon status") exit 1 ;;
+ ;;
+"daemon recover-missing-lease-state")
+   if [ "$3" = "--help" ]; then
+     printf '%s\n' 'OPTIONS:' '    --replacement-operation-id <ID>'
+   else
+   printf '%s\n' '{{"success":true,"data":{{"recovered_lease_id":"lease-interrupted","recorded_dead_pid":41,"recorded_endpoint":"127.0.0.1:7419","affected_job_ids":[],"affected_job_count":0,"evidence_snapshot_path":"/tmp/jobs.snapshot","ownership_proof":["owner lock acquired"],"retry_guidance":"retry","replacement":{{"pid":42,"address":"{address}","state_path":"/tmp/state.json","lease_id":"lease-new"}}}}}}'
+   fi
+ ;;
+   "daemon status") exit 99 ;;
 esac
 "#,
+                address = address,
+            ),
         )
         .expect("write remote Homeboy shim");
         let mut permissions = std::fs::metadata(&daemon)
@@ -782,14 +869,11 @@ esac
             connect_with_orphan_adoption("local-runner", None, &[], true, None, None, None)
                 .expect("connect result");
 
+        assert_eq!(exit_code, 0);
+        assert!(report.connected);
         assert_eq!(
-            exit_code, 20,
-            "the shim intentionally rejects status after recovery"
-        );
-        assert!(!report.connected);
-        assert_eq!(
-            report.failure_kind,
-            Some(RunnerFailureKind::DaemonStartupFailure)
+            report.remote_daemon_address.as_deref(),
+            Some(expected_address.as_str())
         );
         assert_eq!(
             report
@@ -821,8 +905,14 @@ esac
         let session = read_session("local-runner")
             .expect("read recovery session")
             .expect("recovery session");
-        assert!(session.local_url.is_none());
-        assert!(session.local_port.is_none());
+        assert_eq!(
+            session.remote_daemon_address.as_deref(),
+            Some(expected_address.as_str())
+        );
+        assert_eq!(session.remote_daemon_lease_id.as_deref(), Some("lease-new"));
+        assert_eq!(session.remote_daemon_pid, Some(42));
+        assert!(session.local_url.is_some());
+        assert_eq!(session.local_port, Some(address.port()));
         let recovery_evidence: crate::RunnerLeaselessRecoveryEvidence = serde_json::from_value(
             session
                 .leaseless_recovery_evidence
@@ -839,20 +929,326 @@ esac
                 .lease_id,
             "lease-new"
         );
+        let argv = std::fs::read_to_string(argv_path).expect("read dispatched recovery argv");
+        assert!(argv.starts_with(
+            "daemon\nreconcile-leaseless-orphans\n--confirm-no-daemon-owner\n--replacement-operation-id\n"
+        ));
+        assert!(argv.ends_with("\n--addr\n127.0.0.1:0\n"));
+        let (state_loss_report, state_loss_exit) = connect_with_orphan_adoption(
+            "local-runner",
+            None,
+            &[],
+            false,
+            Some("lease-interrupted"),
+            Some(41),
+            Some("127.0.0.1:7419"),
+        )
+        .expect("state-loss reconnect result");
+        assert_eq!(state_loss_exit, 0);
+        assert!(state_loss_report.connected);
+        assert_eq!(state_loss_report.remote_daemon_pid, Some(42));
         assert_eq!(
-            std::fs::read_to_string(argv_path).expect("read dispatched recovery argv"),
-            "daemon\nreconcile-leaseless-orphans\n--confirm-no-daemon-owner\n--addr\n127.0.0.1:0\n"
+            state_loss_report
+                .state_loss_recovery
+                .as_ref()
+                .map(|recovery| recovery.replacement.lease_id.as_str()),
+            Some("lease-new")
         );
+        drop(endpoint);
+    });
+}
+
+/// #10430: once recovery creates B, losing the controller's bounded health
+/// requests must leave enough durable evidence for the next invocation to
+/// authenticate B. It must never create an unjournaled C.
+#[cfg(unix)]
+#[test]
+fn recovery_retry_reattaches_journaled_b_after_two_lost_health_requests() {
+    test_support::with_isolated_home(|home| {
+        let daemon = home.path().join("remote-homeboy");
+        let generation_count = home.path().join("daemon-generations");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let health_requests = Arc::new(AtomicUsize::new(0));
+        let health_requests_for_server = Arc::clone(&health_requests);
+        let endpoint = std::thread::spawn(move || {
+            for request_number in 0..7 {
+                let (mut stream, _) = listener.accept().expect("endpoint request");
+                let mut request = [0; 4096];
+                let length = stream.read(&mut request).expect("read endpoint request");
+                let request = String::from_utf8_lossy(&request[..length]);
+                // `wait_for_tcp` proves listener reachability before health.
+                if request.is_empty() {
+                    continue;
+                }
+                if request.starts_with("GET /health ") {
+                    let health_request = health_requests_for_server.fetch_add(1, Ordering::SeqCst);
+                    if health_request < 2 {
+                        // Simulate a controller response loss after B started.
+                        drop(stream);
+                        continue;
+                    }
+                    let body = r#"{"freshness":{"fresh":true,"restartable":true,"lease_id":"lease-b","pid":4242,"active_jobs":0},"pid":4242}"#;
+                    stream
+                        .write_all(format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes())
+                        .expect("health response");
+                } else {
+                    assert!(
+                        request.starts_with("GET /version "),
+                        "request {request_number}: {request}"
+                    );
+                    let body = r#"{"version":"0.284.0","build_identity":{"display":"homeboy 0.284.0+test"},"lease":{"lease_id":"lease-b"}}"#;
+                    stream
+                        .write_all(format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes())
+                        .expect("version response");
+                }
+            }
+        });
+        std::fs::write(
+            &daemon,
+            format!(
+                r#"#!/bin/sh
+case "$1 $2" in
+  "self identity")
+    printf '%s\n' '{{"success":true,"data":{{"version":"0.284.0","display":"homeboy 0.284.0+test"}}}}'
+    ;;
+  "daemon reconcile-leaseless-orphans")
+    if [ "$3" = "--help" ]; then
+      printf '%s\n' 'OPTIONS:' '    --confirm-no-daemon-owner' '    --replacement-operation-id <ID>'
+    else
+      count=0
+      if [ -f "{generation_count}" ]; then count=$(cat "{generation_count}"); fi
+      count=$((count + 1))
+      printf '%s' "$count" > "{generation_count}"
+      printf '%s\n' '{{"success":true,"data":{{"affected_job_ids":[],"affected_job_count":0,"affected_jobs":[],"historical_lease_ids":[],"evidence_snapshot_path":"/tmp/jobs.snapshot","ownership_proof":["owner lock acquired"],"retry_guidance":"retry","replacement":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}}}'
+    fi
+    ;;
+  "daemon status") exit 99 ;;
+esac
+"#,
+                address = address,
+                generation_count = generation_count.display(),
+            ),
+        )
+        .expect("write remote Homeboy shim");
+        let mut permissions = std::fs::metadata(&daemon).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&daemon, permissions).expect("make shim executable");
+        server::create(
+            &serde_json::json!({ "id": "local-runner", "host": "localhost", "user": "test" })
+                .to_string(),
+            false,
+        )
+        .expect("create local server");
+        crate::create(
+            &serde_json::json!({
+                "id": "local-runner",
+                "kind": "ssh",
+                "homeboy_path": daemon,
+            })
+            .to_string(),
+            false,
+        )
+        .expect("enable local runner");
+
+        let (first, first_exit) =
+            connect_with_orphan_adoption("local-runner", None, &[], true, None, None, None)
+                .expect("first connect result");
+        assert_eq!(first_exit, 20);
+        let evidence = first.failure_evidence.expect("known B failure evidence");
+        assert_eq!(evidence.known_remote_lease_id.as_deref(), Some("lease-b"));
+        assert_eq!(evidence.known_remote_pid, Some(4242));
+        assert_eq!(evidence.health_attempt_count, 2);
+        assert_eq!(evidence.health_attempts.len(), 2);
+        assert_eq!(
+            evidence.recovery_command,
+            "homeboy runner connect local-runner"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&generation_count).expect("generation count"),
+            "1"
+        );
+
+        let journal_dir = homeboy_core::paths::runner_sessions_dir()
+            .expect("runner sessions")
+            .join("local-runner");
+        let pending: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(journal_dir.join("pending-replacement.json"))
+                .expect("B journal"),
+        )
+        .expect("B journal JSON");
+        assert_eq!(pending["remote_daemon_lease_id"], "lease-b");
+        assert_eq!(pending["remote_daemon_pid"], 4242);
+        assert!(journal_dir.join("replacement-operation.json").exists());
+
+        let (second, second_exit) =
+            connect_with_orphan_adoption("local-runner", None, &[], true, None, None, None)
+                .expect("second connect result");
+        assert_eq!(
+            second_exit, 0,
+            "second connect failed: {:?}",
+            second.failure_message
+        );
+        assert!(second.connected);
+        assert_eq!(second.remote_daemon_pid, Some(4242));
+        assert_eq!(
+            std::fs::read_to_string(&generation_count).expect("generation count"),
+            "1"
+        );
+        assert_eq!(health_requests.load(Ordering::SeqCst), 3);
+        assert!(!journal_dir.join("pending-replacement.json").exists());
+        assert!(!journal_dir.join("replacement-operation.json").exists());
+        endpoint.join().expect("endpoint");
+    });
+}
+
+/// #10430: normal ensure-running must use the same durable replay boundary as
+/// explicit recovery. If its response is lost after B starts, retrying must
+/// replay B's receipt instead of reconciling leases and creating C.
+#[cfg(unix)]
+#[test]
+fn normal_start_response_loss_replays_b_without_creating_c() {
+    test_support::with_isolated_home(|home| {
+        let daemon = home.path().join("remote-homeboy");
+        let generation_count = home.path().join("daemon-generations");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let health_requests = Arc::new(AtomicUsize::new(0));
+        let health_requests_for_server = Arc::clone(&health_requests);
+        let endpoint = std::thread::spawn(move || {
+            for request_number in 0..4 {
+                let (mut stream, _) = listener.accept().expect("endpoint request");
+                let mut request = [0; 4096];
+                let length = stream.read(&mut request).expect("read endpoint request");
+                let request = String::from_utf8_lossy(&request[..length]);
+                if request.is_empty() {
+                    continue;
+                }
+                if request.starts_with("GET /health ") {
+                    health_requests_for_server.fetch_add(1, Ordering::SeqCst);
+                    let body = r#"{"freshness":{"fresh":true,"restartable":true,"lease_id":"lease-b","pid":4242,"active_jobs":0},"pid":4242}"#;
+                    stream
+                        .write_all(format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes())
+                        .expect("health response");
+                } else {
+                    assert!(
+                        request.starts_with("GET /version "),
+                        "request {request_number}: {request}"
+                    );
+                    let body = r#"{"version":"0.284.0","build_identity":{"display":"homeboy 0.284.0+test"},"lease":{"lease_id":"lease-b"}}"#;
+                    stream
+                        .write_all(format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes())
+                        .expect("version response");
+                }
+            }
+        });
+        std::fs::write(
+            &daemon,
+            format!(
+                r#"#!/bin/sh
+case "$1 $2" in
+  "self identity")
+    printf '%s\n' '{{"success":true,"data":{{"version":"0.284.0","display":"homeboy 0.284.0+test"}}}}'
+    ;;
+  "daemon status")
+    printf '%s\n' '{{"success":true,"data":{{"running":false,"fresh":false,"reachable":false,"freshness":{{"active_jobs":0}}}}}}'
+    ;;
+  "daemon ensure-running")
+    if [ "$3" = "--help" ]; then
+      printf '%s\n' 'OPTIONS:' '    --replacement-operation-id <ID>'
+    elif [ -f "{generation_count}" ]; then
+      printf '%s\n' '{{"success":true,"data":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}'
+    else
+      printf '%s' '1' > "{generation_count}"
+      # The daemon has durably recorded B's operation key, but its SSH response
+      # was lost before the controller could persist B's coordinates.
+      exit 99
+    fi
+    ;;
+esac
+"#,
+                address = address,
+                generation_count = generation_count.display(),
+            ),
+        )
+        .expect("write remote Homeboy shim");
+        let mut permissions = std::fs::metadata(&daemon).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&daemon, permissions).expect("make shim executable");
+        server::create(
+            &serde_json::json!({ "id": "local-runner", "host": "localhost", "user": "test" })
+                .to_string(),
+            false,
+        )
+        .expect("create local server");
+        crate::create(
+            &serde_json::json!({
+                "id": "local-runner",
+                "kind": "ssh",
+                "homeboy_path": daemon,
+            })
+            .to_string(),
+            false,
+        )
+        .expect("enable local runner");
+
+        let (_first, first_exit) =
+            connect_with_orphan_adoption("local-runner", None, &[], false, None, None, None)
+                .expect("first connect result");
+        assert_eq!(first_exit, 20);
+        assert_eq!(
+            std::fs::read_to_string(&generation_count).expect("B start count"),
+            "1"
+        );
+
+        let journal_dir = homeboy_core::paths::runner_sessions_dir()
+            .expect("runner sessions")
+            .join("local-runner");
+        let operation: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(journal_dir.join("replacement-operation.json"))
+                .expect("ensure-running journal"),
+        )
+        .expect("ensure-running journal JSON");
+        assert_eq!(operation["kind"], "ensure-running");
+        assert!(operation["operation_id"].as_str().is_some());
+        assert!(operation["replay_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--replacement-operation-id")));
+
+        let (second, second_exit) =
+            connect_with_orphan_adoption("local-runner", None, &[], false, None, None, None)
+                .expect("second connect result");
+        assert_eq!(
+            second_exit, 0,
+            "second connect failed: {:?}",
+            second.failure_message
+        );
+        assert!(second.connected);
+        assert_eq!(second.remote_daemon_pid, Some(4242));
+        assert_eq!(
+            std::fs::read_to_string(&generation_count).expect("B only start count"),
+            "1",
+            "replay must return B rather than starting C"
+        );
+        assert_eq!(health_requests.load(Ordering::SeqCst), 1);
+        assert!(!journal_dir.join("pending-replacement.json").exists());
+        assert!(!journal_dir.join("replacement-operation.json").exists());
+        endpoint.join().expect("endpoint");
     });
 }
 
 #[test]
 fn state_loss_recovery_delegation_uses_the_canonical_exact_contract() {
-    let command =
-        remote_state_loss_recovery_command("/opt/homeboy", "lease exact", 4242, "127.0.0.1:4242");
+    let command = remote_state_loss_recovery_command(
+        "/opt/homeboy",
+        "lease exact",
+        4242,
+        "127.0.0.1:4242",
+        "operation-1",
+    );
     assert_eq!(
         command,
-        "/opt/homeboy daemon recover-missing-lease-state --lease-id 'lease exact' --recorded-pid 4242 --recorded-endpoint 127.0.0.1:4242 --confirm-pid-dead --confirm-control-plane-lost --addr 127.0.0.1:0"
+        "/opt/homeboy daemon recover-missing-lease-state --lease-id 'lease exact' --recorded-pid 4242 --recorded-endpoint 127.0.0.1:4242 --confirm-pid-dead --confirm-control-plane-lost --replacement-operation-id operation-1 --addr 127.0.0.1:0"
     );
 }
 
@@ -860,7 +1256,7 @@ fn state_loss_recovery_delegation_uses_the_canonical_exact_contract() {
 fn leaseless_recovery_uses_confirm_no_daemon_owner_contract() {
     let contract = negotiate_leaseless_recovery_contract(&command_output(
         true,
-        "OPTIONS:\n    --confirm-no-daemon-owner\n",
+        "OPTIONS:\n    --confirm-no-daemon-owner\n    --replacement-operation-id <ID>\n",
         false,
     ))
     .expect("one-flag contract");
@@ -869,7 +1265,8 @@ fn leaseless_recovery_uses_confirm_no_daemon_owner_contract() {
         contract,
         RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner
     );
-    let command = remote_leaseless_recovery_command("/opt/homeboy", "127.0.0.1:0", contract);
+    let command =
+        remote_leaseless_recovery_command("/opt/homeboy", "127.0.0.1:0", contract, "operation-1");
     assert!(command.contains("--confirm-no-daemon-owner"));
     assert!(!command.contains("--reconcile-leaseless-orphans"));
     assert!(!command.contains("--confirm-control-plane-lost"));
@@ -945,7 +1342,7 @@ fn leaseless_recovery_parses_only_exact_option_declarations() {
 #[test]
 fn leaseless_recovery_evidence_records_selected_contract_and_command_identity() {
     for (help, expected_contract) in [(
-        "Options:\n    --confirm-no-daemon-owner\n",
+        "Options:\n    --confirm-no-daemon-owner\n    --replacement-operation-id <ID>\n",
         RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner,
     )] {
         let contract = negotiate_leaseless_recovery_contract(&command_output(true, help, false))
@@ -1013,6 +1410,31 @@ fn failed_connect_without_recovery_omits_recovery_evidence() {
 
     let serialized = serde_json::to_value(report).expect("serialize failed connect");
     assert!(serialized.get("leaseless_recovery_evidence").is_none());
+    assert_eq!(
+        serialized["failure_evidence"]["tunnel_state"],
+        "not_established"
+    );
+    assert_eq!(
+        serialized["failure_evidence"]["recovery_command"],
+        "homeboy runner connect runner"
+    );
+}
+
+#[test]
+fn hanging_ssh_connect_is_classified_as_a_timeout() {
+    let message = bounded_remote_failure_message(
+        "SSH connectivity check",
+        &homeboy_core::server::CommandOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            success: false,
+            exit_code: 124,
+            timed_out: true,
+            child_resource: None,
+        },
+    );
+    assert!(message.contains("timed out"));
+    assert!(message.contains("runner connect"));
 }
 
 #[test]
@@ -1241,6 +1663,7 @@ fn idle_stale_replacement_uses_actual_endpoint_envelopes_and_reprobes_the_new_ow
                 None,
                 &[],
                 None,
+                None,
             )
             .expect("replacement succeeds");
             assert_eq!(daemon.lease_id.as_deref(), Some("lease-new"));
@@ -1270,6 +1693,7 @@ fn idle_stale_replacement_refuses_a_post_stop_owner_or_identity_change() {
                 None,
                 &[],
                 None,
+                None,
             )
             .expect_err("concurrent stale daemon is refused");
             assert!(error.contains("ownership changed"));
@@ -1292,6 +1716,7 @@ fn idle_stale_replacement_refuses_a_post_stop_identity_change() {
                 configured_identity,
                 None,
                 &[],
+                None,
                 None,
             )
             .expect_err("stale replacement identity is refused");

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use homeboy_core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
+use homeboy_core::engine::shell;
 use homeboy_core::server::{Server, SshClient};
 
 use super::super::session::RunnerStaleRuntimePath;
@@ -15,6 +16,7 @@ use super::{
 };
 use crate::connection::remote_daemon::parse_json_from_mixed_stdout;
 use crate::daemon_repair;
+use crate::session::RunnerConnectFailureEvidence;
 use crate::{RunnerConnectReport, RunnerFailureKind};
 use std::collections::BTreeMap;
 
@@ -33,28 +35,55 @@ struct DaemonHealthReport {
 pub(super) fn connect_remote_daemon(
     server: &Server,
     _client: &SshClient,
-    _homeboy: &str,
+    homeboy: &str,
     daemon: RemoteDaemon,
-    _expected_version: &str,
-    _expected_identity: &str,
+    expected_version: &str,
+    expected_identity: &str,
     runner_id: &str,
     session_path: &Path,
 ) -> std::result::Result<(u16, Option<u32>, String, RemoteDaemon), (RunnerConnectReport, i32)> {
-    let failed_after_tunnel = |tunnel_pid: Option<u32>, message: String| {
+    let failed_after_tunnel = |tunnel_pid: Option<u32>,
+                               message: String,
+                               health_attempts: Vec<String>,
+                               local_url: &str| {
         if let Some(pid) = tunnel_pid {
             terminate_pid(pid);
         }
-        failed_connect(
+        let (mut report, exit_code) = failed_connect(
             runner_id,
             session_path.to_path_buf(),
             RunnerFailureKind::DaemonStartupFailure,
             message,
-        )
+        );
+        report.failure_evidence = Some(RunnerConnectFailureEvidence {
+            recovery_command: format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
+            classification: "daemon_health".to_string(),
+            remote_start_command: Some(format!(
+                "{} daemon ensure-running --addr 127.0.0.1:0",
+                shell::quote_arg(homeboy)
+            )),
+            known_remote_pid: daemon.pid,
+            known_remote_lease_id: daemon.lease_id.clone(),
+            remote_address: Some(daemon.address.clone()),
+            local_address: Some(local_url.to_string()),
+            tunnel_state: Some("established_then_health_failed".to_string()),
+            health_attempt_count: health_attempts.len(),
+            health_attempts,
+        });
+        (report, exit_code)
     };
     let (local_port, tunnel_pid, local_url) =
         open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
     match probe_daemon_health_until_ready(&local_url, &daemon) {
-        Ok(()) => Ok((local_port, tunnel_pid, local_url, daemon)),
+        Ok(()) if endpoint_identity_matches(&local_url, expected_version, expected_identity) => {
+            Ok((local_port, tunnel_pid, local_url, daemon))
+        }
+        Ok(()) => Err(failed_after_tunnel(
+            tunnel_pid,
+            "remote daemon endpoint identity did not match the controller-selected generation; refusing to publish it".to_string(),
+            Vec::new(),
+            &local_url,
+        )),
         Err(DaemonHealthProbeFailure::IdentityMismatch(report)) => Err(failed_after_tunnel(
             tunnel_pid,
             format!(
@@ -62,11 +91,29 @@ pub(super) fn connect_remote_daemon(
                 daemon.lease_id, daemon.pid, report.freshness.lease_id, report.pid,
                 active_job_recovery_guidance(&daemon),
             ),
+            Vec::new(),
+            &local_url,
         )),
-        Err(DaemonHealthProbeFailure::Unreachable(message)) => {
-            Err(failed_after_tunnel(tunnel_pid, message))
+        Err(DaemonHealthProbeFailure::Unreachable { message, attempts }) => {
+            Err(failed_after_tunnel(tunnel_pid, message, attempts, &local_url))
         }
     }
+}
+
+fn endpoint_identity_matches(
+    local_url: &str,
+    expected_version: &str,
+    expected_identity: &str,
+) -> bool {
+    let identity_matches = expected_identity.trim().is_empty()
+        || daemon_http_identity(local_url)
+            .ok()
+            .is_some_and(|identity| identity.trim() == expected_identity.trim());
+    let version_matches = expected_version.trim().is_empty()
+        || daemon_http_version(local_url)
+            .ok()
+            .is_some_and(|version| versions_match(&version, expected_version));
+    identity_matches && version_matches
 }
 
 #[derive(Debug)]
@@ -75,7 +122,10 @@ enum DaemonHealthProbeFailure {
     /// just started. This is authoritative and must fail immediately.
     IdentityMismatch(Box<DaemonHealthReport>),
     /// The daemon endpoint could not be reached within the settle budget.
-    Unreachable(String),
+    Unreachable {
+        message: String,
+        attempts: Vec<String>,
+    },
 }
 
 /// A freshly started daemon can have its TCP listener accepting connections
@@ -91,22 +141,29 @@ fn probe_daemon_health_until_ready(
     local_url: &str,
     daemon: &RemoteDaemon,
 ) -> std::result::Result<(), DaemonHealthProbeFailure> {
-    const SETTLE_BUDGET: Duration = Duration::from_secs(10);
+    const MAX_ATTEMPTS: usize = 2;
     const RETRY_INTERVAL: Duration = Duration::from_millis(250);
 
-    let deadline = std::time::Instant::now() + SETTLE_BUDGET;
-    let mut last_error;
-    loop {
+    let mut attempts = Vec::with_capacity(MAX_ATTEMPTS);
+    for attempt in 1..=MAX_ATTEMPTS {
         match daemon_health_report(local_url) {
             Ok(report) if health_identity_matches(&report, daemon) => return Ok(()),
             Ok(report) => return Err(DaemonHealthProbeFailure::IdentityMismatch(Box::new(report))),
-            Err(message) => last_error = message,
+            Err(message) => attempts.push(format!("attempt {attempt}: {message}")),
         }
-        if std::time::Instant::now() >= deadline {
-            return Err(DaemonHealthProbeFailure::Unreachable(last_error));
+        if attempt < MAX_ATTEMPTS {
+            std::thread::sleep(RETRY_INTERVAL);
         }
-        std::thread::sleep(RETRY_INTERVAL);
     }
+    Err(DaemonHealthProbeFailure::Unreachable {
+        message: format!(
+            "remote daemon health endpoint failed after {MAX_ATTEMPTS} bounded requests: {}",
+            attempts
+                .last()
+                .expect("health probe records failed attempt")
+        ),
+        attempts,
+    })
 }
 
 fn active_job_recovery_guidance(daemon: &RemoteDaemon) -> String {
@@ -143,14 +200,21 @@ fn open_daemon_tunnel(
         ));
     };
 
-    let local_port = reserve_loopback_port().map_err(|err| {
-        failed_connect(
-            runner_id,
-            session_path.to_path_buf(),
-            RunnerFailureKind::TunnelFailure,
-            err.to_string(),
-        )
-    })?;
+    // A loopback runner already shares the controller network namespace, so
+    // its published endpoint is the reachable local endpoint. Avoid reserving
+    // an unrelated port when no SSH forwarding process is needed.
+    let local_port = if matches!(server.host.as_str(), "localhost" | "127.0.0.1" | "::1") {
+        remote_addr.port()
+    } else {
+        reserve_loopback_port().map_err(|err| {
+            failed_connect(
+                runner_id,
+                session_path.to_path_buf(),
+                RunnerFailureKind::TunnelFailure,
+                err.to_string(),
+            )
+        })?
+    };
     let tunnel = open_loopback_tunnel(
         server,
         local_port,

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -1,4 +1,5 @@
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -21,6 +22,81 @@ fn path(runner_id: &str) -> Result<PathBuf> {
     Ok(paths::runner_sessions_dir()?
         .join(runner_id)
         .join("generations.json"))
+}
+
+fn pending_replacement_path(runner_id: &str) -> Result<PathBuf> {
+    Ok(paths::runner_sessions_dir()?
+        .join(runner_id)
+        .join("pending-replacement.json"))
+}
+
+fn replacement_operation_path(runner_id: &str) -> Result<PathBuf> {
+    Ok(paths::runner_sessions_dir()?
+        .join(runner_id)
+        .join("replacement-operation.json"))
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ReplacementOperation {
+    runner_id: String,
+    operation_id: String,
+    #[serde(default)]
+    replay_command: Option<String>,
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+fn write_durable_json<T: serde::Serialize>(path: &std::path::Path, value: &T) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::internal_unexpected("journal has no parent"))?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", parent.display())),
+        )
+    })?;
+    let temporary = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("journal"),
+        uuid::Uuid::new_v4()
+    ));
+    let bytes = serde_json::to_vec_pretty(value).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize replacement journal".to_string()),
+        )
+    })?;
+    let mut file = File::create(&temporary).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", temporary.display())),
+        )
+    })?;
+    file.write_all(&bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write {}", temporary.display())),
+            )
+        })?;
+    std::fs::rename(&temporary, path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("rename {}", path.display())),
+        )
+    })?;
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("sync {}", parent.display())),
+            )
+        })
 }
 
 /// Serialize read-modify-write registry updates independently for each runner.
@@ -302,6 +378,107 @@ pub(crate) fn admission_session(
             .get(&generations.admission_owner)
             .map(|generation| generation.endpoint.clone())
     }))
+}
+
+/// A recovery-created daemon is durable before a controller can authenticate
+/// its tunnel. Retain its exact coordinates so an interruption cannot fall
+/// back to the superseded generation or start a competing daemon.
+pub(crate) fn pending_replacement(runner_id: &str) -> Result<Option<RunnerSession>> {
+    let path = pending_replacement_path(runner_id)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+    })?;
+    let session: RunnerSession = serde_json::from_str(&raw)
+        .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+    if session.runner_id != runner_id {
+        return Err(Error::config_invalid_value(
+            "pending_replacement.runner_id",
+            Some(session.runner_id),
+            format!("pending replacement must match runner `{runner_id}`"),
+        ));
+    }
+    Ok(Some(session))
+}
+
+/// Persist the controller id before invoking a remote lifecycle mutation. The
+/// daemon uses this exact id as its durable startup token/receipt key.
+pub(crate) fn replacement_operation(runner_id: &str) -> Result<String> {
+    with_registry_lock(runner_id, || {
+        let path = replacement_operation_path(runner_id)?;
+        if path.exists() {
+            let operation: ReplacementOperation =
+                serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+                })?)
+                .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+            if operation.runner_id != runner_id {
+                return Err(Error::config_invalid_value(
+                    "replacement_operation.runner_id",
+                    Some(operation.runner_id),
+                    "replacement operation must match its runner",
+                ));
+            }
+            return Ok(operation.operation_id);
+        }
+        let operation_id = uuid::Uuid::new_v4().to_string();
+        write_durable_json(
+            &path,
+            &ReplacementOperation {
+                runner_id: runner_id.to_string(),
+                operation_id: operation_id.clone(),
+                replay_command: None,
+                kind: None,
+            },
+        )?;
+        Ok(operation_id)
+    })
+}
+
+pub(crate) fn replacement_operation_replay(runner_id: &str) -> Result<Option<(String, String)>> {
+    let path = replacement_operation_path(runner_id)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let operation: ReplacementOperation =
+        serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+        })?)
+        .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+    if operation.runner_id != runner_id {
+        return Err(Error::config_invalid_value(
+            "replacement_operation.runner_id",
+            Some(operation.runner_id),
+            "replacement operation must match its runner",
+        ));
+    }
+    Ok(operation.kind.zip(operation.replay_command))
+}
+
+pub(crate) fn record_replacement_operation_replay(
+    runner_id: &str,
+    kind: &str,
+    command: &str,
+) -> Result<()> {
+    with_registry_lock(runner_id, || {
+        let path = replacement_operation_path(runner_id)?;
+        let mut operation: ReplacementOperation =
+            serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+            })?)
+            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+        operation.replay_command = Some(command.to_string());
+        operation.kind = Some(kind.to_string());
+        write_durable_json(&path, &operation)
+    })
+}
+
+pub(crate) fn record_pending_replacement(runner_id: &str, session: &RunnerSession) -> Result<()> {
+    with_registry_lock(runner_id, || {
+        write_durable_json(&pending_replacement_path(runner_id)?, session)
+    })
 }
 
 /// Promote the direct session that status has just health-checked. The
@@ -813,20 +990,72 @@ pub(crate) fn record_authenticated_admission(
         Error::internal_unexpected("authenticated daemon session has no lease ID")
     })?;
     with_registry_lock(runner_id, || {
-        let mut generations = read_locked(runner_id, None)?
-            .unwrap_or_else(|| RollingGenerations::new(generation, session.clone()));
-        #[cfg(test)]
-        pause_authenticated_admission_after_read();
-        if let Some(entry) = generations.generations.get_mut(generation) {
-            // A reattached daemon gets a fresh local tunnel, so update the endpoint
-            // without disturbing jobs already pinned to this lease.
-            entry.endpoint = session.clone();
-        } else {
-            generations.begin(generation, session.clone());
-        }
-        generations.activate(generation);
-        write(runner_id, &generations)
+        record_authenticated_admission_locked(runner_id, session, generation)
     })
+}
+
+/// Promote B only after `connect_remote_daemon` has authenticated its lease,
+/// PID, version, and build identity. Keeping the pending record until this
+/// locked transaction commits makes every interruption retry B first.
+pub(crate) fn promote_pending_replacement(runner_id: &str, session: &RunnerSession) -> Result<()> {
+    let generation = session.remote_daemon_lease_id.as_deref().ok_or_else(|| {
+        Error::internal_unexpected("authenticated daemon session has no lease ID")
+    })?;
+    with_registry_lock(runner_id, || {
+        if let Some(pending) = pending_replacement(runner_id)? {
+            if pending.remote_daemon_lease_id.as_deref() != Some(generation)
+                || pending.remote_daemon_pid != session.remote_daemon_pid
+                || pending.remote_daemon_address != session.remote_daemon_address
+            {
+                return Err(Error::validation_invalid_argument(
+                    "pending_replacement",
+                    "authenticated daemon does not match the pending replacement; refusing authority promotion",
+                    Some(runner_id.to_string()),
+                    None,
+                ));
+            }
+        }
+        record_authenticated_admission_locked(runner_id, session, generation)?;
+        let path = pending_replacement_path(runner_id)?;
+        if path.exists() {
+            std::fs::remove_file(&path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("remove {}", path.display())),
+                )
+            })?;
+        }
+        let operation_path = replacement_operation_path(runner_id)?;
+        if operation_path.exists() {
+            std::fs::remove_file(&operation_path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("remove {}", operation_path.display())),
+                )
+            })?;
+        }
+        Ok(())
+    })
+}
+
+fn record_authenticated_admission_locked(
+    runner_id: &str,
+    session: &RunnerSession,
+    generation: &str,
+) -> Result<()> {
+    let mut generations = read_locked(runner_id, None)?
+        .unwrap_or_else(|| RollingGenerations::new(generation, session.clone()));
+    #[cfg(test)]
+    pause_authenticated_admission_after_read();
+    if let Some(entry) = generations.generations.get_mut(generation) {
+        // A reattached daemon gets a fresh local tunnel, so update the endpoint
+        // without disturbing jobs already pinned to this lease.
+        entry.endpoint = session.clone();
+    } else {
+        generations.begin(generation, session.clone());
+    }
+    generations.activate(generation);
+    write(runner_id, &generations)
 }
 
 pub(crate) fn record_job_run(

--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -63,6 +63,7 @@ fn lab_runner_preparation_falls_back_for_unreachable_default_runner() {
                     leaseless_recovery_evidence: None,
                     failure_kind: Some(super::super::RunnerFailureKind::SshFailure),
                     failure_message: Some("SSH connectivity check failed".to_string()),
+                    failure_evidence: None,
                 },
                 20,
             ))
@@ -682,6 +683,7 @@ fn lab_runner_preparation_connects_disconnected_runner() {
                     leaseless_recovery: None,
                     state_loss_recovery: None,
                     leaseless_recovery_evidence: None,
+                    failure_evidence: None,
                     failure_kind: None,
                     failure_message: None,
                 },
@@ -747,6 +749,7 @@ fn lab_runner_preparation_errors_for_unreachable_explicit_runner() {
                     leaseless_recovery_evidence: None,
                     failure_kind: Some(super::super::RunnerFailureKind::SshFailure),
                     failure_message: Some("SSH connectivity check failed".to_string()),
+                    failure_evidence: None,
                 },
                 20,
             ))
@@ -834,6 +837,7 @@ fn connected_direct_connect_report(runner_id: &str) -> RunnerConnectReport {
         leaseless_recovery_evidence: None,
         failure_kind: None,
         failure_message: None,
+        failure_evidence: None,
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -336,6 +336,7 @@ fn connect_runner_for_offload(
             leaseless_recovery_evidence: None,
             failure_kind: Some(super::RunnerFailureKind::SshFailure),
             failure_message: Some(reason),
+            failure_evidence: None,
         },
         exit_code,
     ))
@@ -461,6 +462,7 @@ fn connected_runner_connect_report_from_session(
                 .and_then(|v| serde_json::from_value(v).ok()),
             failure_kind: None,
             failure_message: None,
+            failure_evidence: None,
         },
         0,
     ))

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -420,6 +420,27 @@ pub enum RunnerFailureKind {
     TunnelFailure,
 }
 
+/// Bounded evidence retained when a direct runner connect cannot complete.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerConnectFailureEvidence {
+    pub recovery_command: String,
+    pub classification: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_start_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub known_remote_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub known_remote_lease_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tunnel_state: Option<String>,
+    pub health_attempt_count: usize,
+    pub health_attempts: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RunnerConnectReport {
     pub runner_id: String,
@@ -461,6 +482,8 @@ pub struct RunnerConnectReport {
     pub failure_kind: Option<RunnerFailureKind>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_evidence: Option<RunnerConnectFailureEvidence>,
 }
 
 /// A read-only indexed snapshot of one runner's persisted active jobs, built

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -298,11 +298,12 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
             phase: super::StateLossRecoveryPhase::ReplacementStarted,
             replacement: Some(replacement.clone()),
             replacement_startup_token: Some("fake-startup-token".to_string()),
+            replacement_operation_id: None,
         };
         let path = crate::paths::daemon_leaseless_recovery_receipt_file().expect("receipt path");
         super::write_leaseless_recovery_receipt(&path, &receipt).expect("write receipt");
 
-        let replay = super::replay_leaseless_recovery(&status, "127.0.0.1:0")
+        let replay = super::replay_leaseless_recovery(&status, "127.0.0.1:0", None)
             .expect("replay lookup")
             .expect("exact completed recovery replays");
 
@@ -1721,6 +1722,7 @@ fn state_loss_receipt_survives_start_failure_and_replay_starts_once() {
             phase: super::StateLossRecoveryPhase::Reconciled,
             replacement: None,
             replacement_startup_token: None,
+            replacement_operation_id: None,
         };
         super::write_state_loss_receipt(&receipt_path, &receipt).expect("persist receipt");
         let error = super::complete_state_loss_replacement(&mut receipt, &receipt_path, || {
@@ -1761,9 +1763,12 @@ fn state_loss_receipt_refuses_mismatched_replay_inputs() {
         phase: super::StateLossRecoveryPhase::Reconciled,
         replacement: None,
         replacement_startup_token: None,
+        replacement_operation_id: None,
     };
     let endpoint = "127.0.0.1:7422".parse().expect("endpoint");
-    assert!(super::validate_state_loss_receipt(&receipt, "lease-old", 4242, endpoint).is_err());
+    assert!(
+        super::validate_state_loss_receipt(&receipt, "lease-old", 4242, endpoint, None).is_err()
+    );
 }
 
 #[test]
@@ -1786,6 +1791,7 @@ fn state_loss_replay_allows_zero_active_jobs_only_with_a_matching_receipt() {
         phase: super::StateLossRecoveryPhase::Reconciled,
         replacement: None,
         replacement_startup_token: None,
+        replacement_operation_id: None,
     };
     assert!(super::validate_state_loss_preconditions(
         "lease-old",
@@ -1795,7 +1801,9 @@ fn state_loss_replay_allows_zero_active_jobs_only_with_a_matching_receipt() {
         Some(&receipt),
     )
     .is_ok());
-    assert!(super::validate_state_loss_receipt(&receipt, "lease-old", 4242, endpoint).is_ok());
+    assert!(
+        super::validate_state_loss_receipt(&receipt, "lease-old", 4242, endpoint, None).is_ok()
+    );
 }
 
 #[test]
@@ -1813,6 +1821,7 @@ fn replacement_starting_replay_adopts_only_the_persisted_startup_token() {
             phase: super::StateLossRecoveryPhase::Reconciled,
             replacement: None,
             replacement_startup_token: None,
+            replacement_operation_id: None,
         };
         let error = super::start_state_loss_replacement_with(&mut receipt, &receipt_path, |_| {
             Err(crate::Error::internal_unexpected(


### PR DESCRIPTION
## Summary
- bound runner-connect SSH, startup, and health operations with classified diagnostics
- journal idempotent daemon replacement operations before mutation and replay the same generation after response loss
- preserve exact recovery commands, tunnel state, PID/lease, and health attempt evidence

Closes #10430

## Verification
- `cargo test -p homeboy-lab-runner connection::tests::recovery`
- focused normal-start response-loss and two-health-failure tests
- focused core ensure-running tests
- `cargo check -p homeboy-core -p homeboy-cli -p homeboy-lab-runner`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested deterministic reconnect recovery and diagnostics. Chris Huber reviewed and owns every line.