### PR TITLE
fix: unify canonical candidate status

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/candidate.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/candidate.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CandidateState {
+    Finalized,
+    Promoted,
     PatchAvailable,
     NoChangesProduced,
     Empty,
@@ -23,6 +25,8 @@ impl Default for CandidateState {
 impl CandidateState {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
+            Self::Finalized => "finalized",
+            Self::Promoted => "promoted",
             Self::PatchAvailable => "patch_available",
             Self::NoChangesProduced => "no_changes_produced",
             Self::Empty => "empty",
@@ -37,10 +41,24 @@ impl CandidateState {
     pub(crate) fn is_recoverable(self) -> bool {
         self == Self::PatchAvailable
     }
+
+    pub(crate) fn is_available(self) -> bool {
+        matches!(
+            self,
+            Self::Finalized | Self::Promoted | Self::PatchAvailable
+        )
+    }
 }
 
+const MAX_ATTEMPTS_SCANNED: usize = 64;
+const MAX_OUTCOMES_SCANNED: usize = 256;
+const MAX_ARTIFACTS_SCANNED: usize = 256;
+
+/// The canonical terminal result for a Cook's candidate evidence. Evidence is
+/// monotonic: a finalized PR, promoted/adopted candidate, or durable patch
+/// remains authoritative even when a later provider attempt is empty or fails.
 #[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct CandidateCounts {
+pub(crate) struct CandidateResult {
     pub(crate) available: usize,
     pub(crate) empty: usize,
     pub(crate) missing: usize,
@@ -49,13 +67,25 @@ pub(crate) struct CandidateCounts {
     pub(crate) retained_only: usize,
     pub(crate) unknown: usize,
     pub(crate) diff_bytes: u64,
+    pub(crate) finalized: bool,
+    pub(crate) promoted: bool,
+    pub(crate) attempts_omitted: usize,
+    pub(crate) outcomes_omitted: usize,
+    pub(crate) artifacts_omitted: usize,
     no_changes_produced: bool,
 }
 
-impl CandidateCounts {
+impl CandidateResult {
     pub(crate) fn state(self) -> CandidateState {
-        if self.available > 0 {
+        if self.finalized {
+            CandidateState::Finalized
+        } else if self.promoted {
+            CandidateState::Promoted
+        } else if self.available > 0 {
             CandidateState::PatchAvailable
+        } else if self.is_degraded() {
+            // An incomplete scan cannot honestly prove that no candidate exists.
+            CandidateState::Unknown
         } else if self.conflicting > 0 {
             CandidateState::Conflicting
         } else if self.unreadable > 0 {
@@ -73,8 +103,15 @@ impl CandidateCounts {
         }
     }
 
+    pub(crate) fn is_degraded(self) -> bool {
+        self.attempts_omitted > 0 || self.outcomes_omitted > 0 || self.artifacts_omitted > 0
+    }
+
     fn record(&mut self, state: CandidateState, size: Option<u64>) {
         match state {
+            CandidateState::Finalized | CandidateState::Promoted => {
+                unreachable!("terminal facts are recorded directly")
+            }
             CandidateState::PatchAvailable => {
                 self.available += 1;
                 self.diff_bytes += size.unwrap_or_default();
@@ -93,19 +130,30 @@ impl CandidateCounts {
 /// Classify promotion candidates from immutable aggregate artifacts. Finalized
 /// mirrored artifacts are authoritative; runner-local refs are only a fallback
 /// when no such artifact exists, so stale aliases cannot downgrade recovery.
-pub(crate) fn classify_candidates(payload: &Value) -> CandidateCounts {
-    let artifacts = aggregate_artifacts(payload);
+pub(crate) fn classify_candidates(payload: &Value) -> CandidateResult {
+    if let Some(projected) = payload
+        .get("canonical_candidate")
+        .and_then(candidate_result_from_projection)
+    {
+        return projected;
+    }
+    let (artifacts, attempts_omitted, outcomes_omitted, artifacts_omitted) =
+        aggregate_artifacts(payload);
     let canonical: Vec<&Value> = artifacts
         .iter()
         .copied()
-        .filter(|artifact| is_patch(artifact) && is_canonical_mirror(artifact))
+        .filter(|artifact| {
+            is_patch(artifact)
+                && is_display_apply_artifact(artifact)
+                && is_canonical_mirror(artifact)
+        })
         .collect();
     let using_canonical = !canonical.is_empty();
     let artifacts = if !using_canonical {
         artifacts
             .iter()
             .copied()
-            .filter(|artifact| is_patch(artifact))
+            .filter(|artifact| is_patch(artifact) && is_display_apply_artifact(artifact))
             .collect()
     } else {
         canonical
@@ -122,7 +170,10 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateCounts {
         by_identity.entry(identity).or_default().push(artifact);
     }
 
-    let mut counts = CandidateCounts::default();
+    let mut counts = CandidateResult::default();
+    counts.attempts_omitted = attempts_omitted;
+    counts.outcomes_omitted = outcomes_omitted;
+    counts.artifacts_omitted = artifacts_omitted;
     for artifacts in by_identity.into_values() {
         let artifact = artifacts[0];
         let size = artifact.get("size_bytes").and_then(Value::as_u64);
@@ -164,23 +215,250 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateCounts {
         && counts.conflicting == 0
         && counts.retained_only == 0
         && aggregate_outcomes_are_no_op(payload);
+    counts.finalized =
+        has_finalized_pr(payload) || payload.get("record").is_some_and(has_finalized_pr);
+    counts.promoted = !counts.finalized
+        && (has_promoted_candidate(payload)
+            || payload.get("record").is_some_and(has_promoted_candidate));
     counts
 }
 
-fn aggregate_artifacts(payload: &Value) -> Vec<&Value> {
-    payload
-        .pointer("/aggregate/outcomes")
+/// The bounded candidate contract carried by compact status responses.
+pub(crate) fn canonical_candidate_projection(result: CandidateResult) -> Value {
+    json!({
+        "schema": "homeboy/agent-task-candidate/v1",
+        "state": result.state().as_str(),
+        "diff_bytes": result.diff_bytes,
+        "counts": {
+            "patch_available": result.available,
+            "empty": result.empty,
+            "missing": result.missing,
+            "unreadable": result.unreadable,
+            "conflicting": result.conflicting,
+            "retained_only": result.retained_only,
+            "unknown": result.unknown,
+        },
+        "scan": {
+            "attempts_omitted": result.attempts_omitted,
+            "outcomes_omitted": result.outcomes_omitted,
+            "artifacts_omitted": result.artifacts_omitted,
+            "degraded": result.is_degraded(),
+        },
+    })
+}
+
+fn candidate_result_from_projection(value: &Value) -> Option<CandidateResult> {
+    if value.get("schema").and_then(Value::as_str) != Some("homeboy/agent-task-candidate/v1") {
+        return None;
+    }
+    let state = match value.get("state").and_then(Value::as_str)? {
+        "finalized" => CandidateState::Finalized,
+        "promoted" => CandidateState::Promoted,
+        "patch_available" => CandidateState::PatchAvailable,
+        "no_changes_produced" => CandidateState::NoChangesProduced,
+        "empty" => CandidateState::Empty,
+        "missing" => CandidateState::Missing,
+        "unreadable" => CandidateState::Unreadable,
+        "conflicting" => CandidateState::Conflicting,
+        "retained_only" => CandidateState::RetainedOnly,
+        "unknown" => CandidateState::Unknown,
+        _ => return None,
+    };
+    let count = |key| {
+        value
+            .pointer(&format!("/counts/{key}"))
+            .and_then(Value::as_u64)
+            .and_then(|count| usize::try_from(count).ok())
+            .unwrap_or_default()
+    };
+    let omitted = |key| {
+        value
+            .pointer(&format!("/scan/{key}"))
+            .and_then(Value::as_u64)
+            .and_then(|count| usize::try_from(count).ok())
+            .unwrap_or_default()
+    };
+    Some(CandidateResult {
+        available: count("patch_available"),
+        empty: count("empty"),
+        missing: count("missing"),
+        unreadable: count("unreadable"),
+        conflicting: count("conflicting"),
+        retained_only: count("retained_only"),
+        unknown: count("unknown"),
+        diff_bytes: value
+            .get("diff_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        finalized: state == CandidateState::Finalized,
+        promoted: state == CandidateState::Promoted,
+        attempts_omitted: omitted("attempts_omitted"),
+        outcomes_omitted: omitted("outcomes_omitted"),
+        artifacts_omitted: omitted("artifacts_omitted"),
+        no_changes_produced: state == CandidateState::NoChangesProduced,
+        ..Default::default()
+    })
+}
+
+fn aggregate_artifacts(payload: &Value) -> (Vec<&Value>, usize, usize, usize) {
+    let mut artifacts = Vec::new();
+    let mut attempts_omitted = 0;
+    let mut outcomes_omitted = 0;
+    let mut artifacts_omitted = 0;
+    for aggregate in [
+        payload.get("aggregate"),
+        payload
+            .get("record")
+            .and_then(|record| record.get("aggregate")),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        scan_aggregate_artifacts(
+            aggregate,
+            true,
+            &mut artifacts,
+            &mut outcomes_omitted,
+            &mut artifacts_omitted,
+        );
+    }
+    for (index, attempt) in payload
+        .get("attempts")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
-        .flat_map(|outcome| {
-            outcome
-                .get("artifacts")
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
+        .enumerate()
+    {
+        let scanned = index < MAX_ATTEMPTS_SCANNED;
+        if !scanned {
+            attempts_omitted += 1;
+        }
+        if let Some(aggregate) = attempt.get("aggregate") {
+            scan_aggregate_artifacts(
+                aggregate,
+                scanned,
+                &mut artifacts,
+                &mut outcomes_omitted,
+                &mut artifacts_omitted,
+            );
+        }
+    }
+    (
+        artifacts,
+        attempts_omitted,
+        outcomes_omitted,
+        artifacts_omitted,
+    )
+}
+
+/// Count omitted entries from array lengths while only visiting individual
+/// artifacts that remain within the classification budget.
+fn scan_aggregate_artifacts<'a>(
+    aggregate: &'a Value,
+    scanned: bool,
+    artifacts: &mut Vec<&'a Value>,
+    outcomes_omitted: &mut usize,
+    artifacts_omitted: &mut usize,
+) {
+    let outcomes = aggregate
+        .get("outcomes")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    if !scanned {
+        *outcomes_omitted += outcomes.len();
+        *artifacts_omitted += outcomes.iter().map(outcome_artifact_count).sum::<usize>();
+        return;
+    }
+    for (index, outcome) in outcomes.iter().enumerate() {
+        if index >= MAX_OUTCOMES_SCANNED {
+            *outcomes_omitted += 1;
+            *artifacts_omitted += outcome_artifact_count(outcome);
+            continue;
+        }
+        let outcome_artifacts = outcome
+            .get("artifacts")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let remaining = MAX_ARTIFACTS_SCANNED.saturating_sub(artifacts.len());
+        let scanned_count = outcome_artifacts.len().min(remaining);
+        artifacts.extend(outcome_artifacts.iter().take(scanned_count));
+        *artifacts_omitted += outcome_artifacts.len().saturating_sub(scanned_count);
+    }
+}
+
+fn outcome_artifact_count(outcome: &Value) -> usize {
+    outcome
+        .get("artifacts")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len)
+}
+
+fn has_promoted_candidate(payload: &Value) -> bool {
+    promotion_has_candidate(payload.get("latest_promotion"))
+        || promotion_has_candidate(payload.pointer("/metadata/latest_promotion"))
+        || payload
+            .get("attempts")
+            .and_then(Value::as_array)
+            .is_some_and(|attempts| {
+                attempts
+                    .iter()
+                    .take(MAX_ATTEMPTS_SCANNED)
+                    .any(|attempt| promotion_has_candidate(attempt.get("promotion")))
+            })
+        || successful_adoption(payload)
+}
+
+fn successful_adoption(payload: &Value) -> bool {
+    let Some(adoption) = payload.get("candidate_adoption") else {
+        return false;
+    };
+    adoption.get("state").and_then(Value::as_str) == Some("completed")
+        && adoption.get("terminal_error").is_none_or(Value::is_null)
+        && matches!(
+            adoption.pointer("/result/status").and_then(Value::as_str),
+            Some("review_ready" | "green_no_finalize")
+        )
+}
+
+fn has_finalized_pr(payload: &Value) -> bool {
+    [
+        payload.get("finalization"),
+        payload.get("cook_finalization"),
+        payload.pointer("/metadata/cook_finalization"),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|finalization| {
+        finalization.get("status").and_then(Value::as_str) == Some("review_ready")
+            && finalization
+                .get("pr_url")
+                .or_else(|| finalization.get("pull_request_url"))
+                .and_then(Value::as_str)
+                .is_some_and(|url| !url.trim().is_empty())
+    })
+}
+
+fn promotion_has_candidate(promotion: Option<&Value>) -> bool {
+    let Some(promotion) = promotion else {
+        return false;
+    };
+    matches!(
+        promotion.get("status").and_then(Value::as_str),
+        Some("verification_pending" | "applied" | "gate_failed")
+    ) && (promotion
+        .get("patch_artifact")
+        .or_else(|| promotion.get("patch"))
+        .and_then(|artifact| {
+            artifact
+                .get("id")
+                .or_else(|| artifact.get("artifact_id"))
+                .and_then(Value::as_str)
         })
-        .collect()
+        .or_else(|| promotion.get("patch_artifact_id").and_then(Value::as_str))
+        .or_else(|| promotion.get("artifact_id").and_then(Value::as_str))
+        .is_some_and(|id| !id.trim().is_empty()))
 }
 
 fn aggregate_outcomes_are_no_op(payload: &Value) -> bool {
@@ -201,6 +479,15 @@ fn is_patch(artifact: &Value) -> bool {
         artifact.get("kind").and_then(Value::as_str),
         Some("patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact")
     )
+}
+
+fn is_display_apply_artifact(artifact: &Value) -> bool {
+    !["rejected", "false_positive"].into_iter().any(|key| {
+        artifact
+            .pointer(&format!("/metadata/{key}"))
+            .and_then(Value::as_bool)
+            == Some(true)
+    })
 }
 
 fn is_canonical_mirror(artifact: &Value) -> bool {
@@ -287,5 +574,207 @@ mod tests {
             classify_candidates(&lab_fixture(vec![first, second])).state(),
             CandidateState::Conflicting
         );
+    }
+
+    #[test]
+    fn terminal_candidate_precedence_preserves_authoritative_evidence_across_retries() {
+        let scenarios = [
+            (
+                "successful candidate plus empty retry",
+                json!({
+                    "attempts": [
+                        { "aggregate": { "outcomes": [{ "artifacts": [mirrored_patch("candidate", 32_318)] }] } },
+                        { "aggregate": { "outcomes": [{ "artifacts": [{ "id": "retry", "kind": "patch", "size_bytes": 0 }] }] } }
+                    ]
+                }),
+                CandidateState::PatchAvailable,
+            ),
+            (
+                "promoted PR",
+                json!({ "finalization": { "status": "review_ready", "pr_url": "https://example.test/pull/1" } }),
+                CandidateState::Finalized,
+            ),
+            (
+                "adoption",
+                json!({ "candidate_adoption": { "candidate_sha": "abc123", "state": "completed", "result": { "status": "review_ready" } } }),
+                CandidateState::Promoted,
+            ),
+            (
+                "failed final attempt",
+                json!({
+                    "attempts": [
+                        { "promotion": { "status": "applied", "patch_artifact": { "id": "candidate" } } },
+                        { "aggregate": { "outcomes": [{ "status": "failed", "artifacts": [] }] } }
+                    ]
+                }),
+                CandidateState::Promoted,
+            ),
+        ];
+
+        for (name, payload, expected) in scenarios {
+            assert_eq!(classify_candidates(&payload).state(), expected, "{name}");
+        }
+
+        let no_candidate = json!({
+            "attempts": [
+                { "aggregate": { "outcomes": [{ "status": "succeeded", "artifacts": [{ "id": "empty", "kind": "patch", "size_bytes": 0 }] }] } },
+                { "aggregate": { "outcomes": [{ "status": "failed", "artifacts": [] }] } }
+            ]
+        });
+        assert_eq!(
+            classify_candidates(&no_candidate).state(),
+            CandidateState::Empty
+        );
+    }
+
+    #[test]
+    fn active_or_unsuccessful_adoption_never_becomes_candidate_evidence() {
+        for state in ["verification_running", "failed", "cancelled"] {
+            let result = classify_candidates(&json!({
+                "candidate_adoption": {
+                    "candidate_sha": "claimed-but-not-adopted",
+                    "state": state,
+                    "result": { "status": "review_ready" }
+                }
+            }));
+            assert_eq!(result.state(), CandidateState::Unknown, "{state}");
+        }
+
+        let unsuccessful = classify_candidates(&json!({
+            "candidate_adoption": {
+                "candidate_sha": "blocked",
+                "state": "completed",
+                "result": { "status": "execution_budget_exhausted" }
+            }
+        }));
+        assert_eq!(unsuccessful.state(), CandidateState::Unknown);
+
+        let unsuccessful_finalization = classify_candidates(&json!({
+            "finalization": {
+                "status": "failed",
+                "pr_url": "https://example.test/pull/1"
+            }
+        }));
+        assert_eq!(unsuccessful_finalization.state(), CandidateState::Unknown);
+    }
+
+    #[test]
+    fn rejected_or_false_positive_patches_never_become_candidates() {
+        for flag in ["rejected", "false_positive"] {
+            let mut artifact = json!({
+                "id": flag,
+                "kind": "patch",
+                "size_bytes": 32_318,
+                "url": "homeboy://agent-task/run/rejected/artifacts#patch",
+                "metadata": { "executor_artifact_finalized": true }
+            });
+            artifact["metadata"][flag] = Value::Bool(true);
+            let result = classify_candidates(&lab_fixture(vec![artifact]));
+            assert_eq!(result.state(), CandidateState::Unknown, "{flag}");
+            assert_eq!(result.available, 0, "{flag}");
+        }
+    }
+
+    #[test]
+    fn bounded_history_preserves_candidate_precedence_and_marks_incomplete_scans() {
+        let attempts = (0..=MAX_ATTEMPTS_SCANNED)
+            .map(|attempt| {
+                json!({
+                    "aggregate": { "outcomes": [{ "artifacts": [
+                        if attempt == 0 { mirrored_patch("canonical", 32_318) }
+                        else { json!({ "id": format!("empty-{attempt}"), "kind": "patch", "size_bytes": 0 }) }
+                    ] }] }
+                })
+            })
+            .collect::<Vec<_>>();
+        let result = classify_candidates(&json!({ "attempts": attempts }));
+        assert_eq!(result.state(), CandidateState::PatchAvailable);
+        assert_eq!(result.attempts_omitted, 1);
+        assert!(result.is_degraded());
+
+        let artifacts = (0..=MAX_ARTIFACTS_SCANNED)
+            .map(
+                |index| json!({ "id": format!("empty-{index}"), "kind": "patch", "size_bytes": 0 }),
+            )
+            .collect::<Vec<_>>();
+        let result = classify_candidates(&json!({
+            "aggregate": { "outcomes": [{ "artifacts": artifacts }] }
+        }));
+        assert_eq!(result.state(), CandidateState::Unknown);
+        assert_eq!(result.artifacts_omitted, 1);
+        assert!(result.is_degraded());
+
+        let outcomes = (0..=MAX_OUTCOMES_SCANNED)
+            .map(|_| json!({ "artifacts": [] }))
+            .collect::<Vec<_>>();
+        let result = classify_candidates(&json!({
+            "aggregate": { "outcomes": outcomes }
+        }));
+        assert_eq!(result.state(), CandidateState::Unknown);
+        assert_eq!(result.outcomes_omitted, 1);
+        assert!(result.is_degraded());
+    }
+
+    #[test]
+    fn bounded_history_counts_all_multi_extra_omissions_from_structure() {
+        let root_outcomes = std::iter::once(json!({
+            "artifacts": (0..MAX_ARTIFACTS_SCANNED + 3)
+                .map(|index| json!({ "id": format!("root-{index}"), "kind": "patch" }))
+                .collect::<Vec<_>>()
+        }))
+        .chain((0..MAX_OUTCOMES_SCANNED + 2).map(|index| {
+            json!({
+                "artifacts": [{ "id": format!("outcome-{index}"), "kind": "patch" }]
+            })
+        }))
+        .collect::<Vec<_>>();
+        let attempts = (0..MAX_ATTEMPTS_SCANNED + 3)
+            .map(|index| {
+                let outcomes = if index < MAX_ATTEMPTS_SCANNED {
+                    vec![]
+                } else {
+                    vec![json!({
+                        "artifacts": [
+                            { "id": format!("attempt-{index}-a"), "kind": "patch" },
+                            { "id": format!("attempt-{index}-b"), "kind": "patch" }
+                        ]
+                    })]
+                };
+                json!({ "aggregate": { "outcomes": outcomes } })
+            })
+            .collect::<Vec<_>>();
+        let result = classify_candidates(&json!({
+            "aggregate": { "outcomes": root_outcomes },
+            "attempts": attempts,
+        }));
+
+        assert_eq!(result.attempts_omitted, 3);
+        assert_eq!(result.outcomes_omitted, 6);
+        assert_eq!(result.artifacts_omitted, 267);
+        assert!(result.is_degraded());
+    }
+
+    #[test]
+    fn review_envelope_reads_terminal_facts_from_its_record() {
+        let promoted = classify_candidates(&json!({
+            "record": { "metadata": { "latest_promotion": {
+                "status": "applied", "patch_artifact": { "id": "patch" }
+            }}}
+        }));
+        assert_eq!(promoted.state(), CandidateState::Promoted);
+
+        let finalized = classify_candidates(&json!({
+            "record": { "metadata": { "cook_finalization": {
+                "status": "review_ready", "pr_url": "https://example.test/pull/1"
+            }}}
+        }));
+        assert_eq!(finalized.state(), CandidateState::Finalized);
+
+        let adopted = classify_candidates(&json!({
+            "record": { "candidate_adoption": {
+                "state": "completed", "result": { "status": "review_ready" }
+            }}
+        }));
+        assert_eq!(adopted.state(), CandidateState::Promoted);
     }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -27,7 +27,7 @@ use super::args::{
     CancelArgs, DiagnoseArgs, EvidenceArgs, LogsArgs, ReplayProviderBoundaryArgs,
     RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs,
 };
-use super::candidate::{classify_candidates, CandidateState};
+use super::candidate::{canonical_candidate_projection, classify_candidates, CandidateState};
 use crate::commands::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandArtifactRef, CommandNextAction,
     CommandNextActionKind, CommandResultRefs, CommandRunRef, ACTIONABLE_METADATA_KEY,
@@ -84,6 +84,8 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
     attach_transport_proxy_recovery_guidance(&mut value, &args.run_id);
     if args.full {
+        let aggregate = completed_run_aggregate(&args.run_id).and_then(Result::ok);
+        attach_full_status_candidate(&mut value, aggregate.as_ref(), &args.run_id);
         bound_full_reader_payload(&mut value);
         attach_runner_probe(&mut value, &runner_probe);
         attach_agent_task_status_actionable(&mut value, &args.run_id);
@@ -94,6 +96,30 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     attach_runner_probe(&mut summary, &runner_probe);
     attach_agent_task_status_actionable(&mut summary, &args.run_id);
     Ok((summary, 0))
+}
+
+fn attach_full_status_candidate(
+    value: &mut Value,
+    aggregate: Option<&AgentTaskAggregate>,
+    run_id: &str,
+) {
+    if let Some(aggregate) = aggregate {
+        if let Value::Object(fields) = value {
+            fields.insert(
+                "aggregate".to_string(),
+                serde_json::to_value(aggregate).unwrap_or(Value::Null),
+            );
+        }
+    }
+    let canonical = classify_candidates(value);
+    let liveness = liveness_summary(value, run_id, canonical.state());
+    if let Value::Object(fields) = value {
+        fields.insert(
+            "canonical_candidate".to_string(),
+            canonical_candidate_projection(canonical),
+        );
+        fields.insert("liveness".to_string(), liveness);
+    }
 }
 
 /// Project the read-side runner-probe decision into the status payload.
@@ -344,7 +370,7 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
         ..Default::default()
     };
 
-    if classify_candidates(value).state().is_recoverable() {
+    if classify_candidates(value).state().is_available() {
         let review_command = format!("homeboy agent-task review {run_id}");
         metadata.next_actions.push(
             CommandNextAction::new("review run", review_command)
@@ -783,6 +809,9 @@ const DIAGNOSE_ACTION_BASIS_DIAGNOSIS: &str = "diagnosis";
 /// enough to act on, so the generic recovery set is emitted as an explicit
 /// fallback rather than as the only behavior.
 const DIAGNOSE_ACTION_BASIS_FALLBACK: &str = "generic_fallback";
+/// Basis marker for a recoverable canonical candidate that takes precedence
+/// over a later failed provider attempt.
+const DIAGNOSE_ACTION_BASIS_CANDIDATE: &str = "canonical_candidate";
 
 /// One failed task and how its executor classified the failure. This is the
 /// typed input to the classification→action table: it is read from durable
@@ -831,9 +860,26 @@ fn attach_diagnose_actionable(
     runner_id: Option<&str>,
 ) {
     let run_id = record.run_id.as_str();
+    let candidate_payload = candidate_result_payload(
+        &serde_json::to_value(record).unwrap_or(Value::Null),
+        aggregate,
+    );
+    let candidate_recoverable = classify_candidates(&candidate_payload)
+        .state()
+        .is_available();
     let failures = aggregate.map(diagnosed_failures).unwrap_or_default();
-    let (next_actions, basis) =
-        diagnose_next_actions(run_id, &failures, missing_artifacts, runner_id);
+    let (next_actions, basis) = if candidate_recoverable {
+        (
+            vec![CommandNextAction::new(
+                "review the canonical candidate",
+                format!("homeboy agent-task review {}", quote_arg(run_id)),
+            )
+            .with_kind(CommandNextActionKind::Show)],
+            DIAGNOSE_ACTION_BASIS_CANDIDATE,
+        )
+    } else {
+        diagnose_next_actions(run_id, &failures, missing_artifacts, runner_id)
+    };
     if let Value::Object(map) = value {
         map.insert(
             "next_action_basis".to_string(),
@@ -1919,7 +1965,7 @@ pub(crate) fn execution_states_from_aggregate(
 ) -> Value {
     let review =
         homeboy::agents::agent_tasks::AgentTaskAggregateReport::from(aggregate.outcomes.clone());
-    let canonical = classify_candidates(&json!({ "aggregate": aggregate }));
+    let canonical = classify_candidates(&candidate_result_payload(record, Some(aggregate)));
     let candidate_state = canonical.state();
     let provider = aggregate
         .outcomes
@@ -1951,9 +1997,9 @@ pub(crate) fn execution_states_from_aggregate(
         .map(|task| {
             let reason_code = if task.status == AgentTaskOutcomeStatus::NoOp {
                 "no_changes_produced"
-            } else if candidate_state != CandidateState::PatchAvailable
-                && task.decision
-                    == homeboy::agents::agent_tasks::AgentTaskReconciliationDecision::ApplyCandidate
+            } else if task.decision
+                == homeboy::agents::agent_tasks::AgentTaskReconciliationDecision::ApplyCandidate
+                && candidate_state != CandidateState::PatchAvailable
             {
                 candidate_state.as_str()
             } else {
@@ -2016,6 +2062,12 @@ pub(crate) fn execution_states_from_aggregate(
         "candidate": {
             "state": candidate_state.as_str(),
             "tasks": candidates,
+            "scan": {
+                "attempts_omitted": canonical.attempts_omitted,
+                "outcomes_omitted": canonical.outcomes_omitted,
+                "artifacts_omitted": canonical.artifacts_omitted,
+                "degraded": canonical.is_degraded(),
+            },
         },
         "gate": {
             "state": match promotion_status {
@@ -2217,17 +2269,26 @@ fn collect_nested_diagnostics(
 /// run-record `Value` (already enriched with `diagnostic_summary`); the plan is
 /// loaded best-effort to map task ids back to issue URLs and prompt titles.
 fn compact_status_summary(record: &Value, run_id: &str) -> Value {
-    let plan = agent_task_lifecycle::load_plan(run_id).ok();
     let aggregate = completed_run_aggregate(run_id).and_then(Result::ok);
+    compact_status_summary_with_aggregate(record, run_id, aggregate.as_ref())
+}
+
+fn compact_status_summary_with_aggregate(
+    record: &Value,
+    run_id: &str,
+    aggregate: Option<&AgentTaskAggregate>,
+) -> Value {
+    let plan = agent_task_lifecycle::load_plan(run_id).ok();
     let task_table = task_source_table(record, plan.as_ref());
     let tasks_omitted = record
         .get("tasks")
         .and_then(Value::as_array)
         .map_or(0, |tasks| tasks.len().saturating_sub(COMPACT_TASK_LIMIT));
-    let ref_inventory = ref_inventory(record, aggregate.as_ref());
+    let ref_inventory = ref_inventory(record, aggregate);
     let (refs, refs_omitted) = compact_refs(&ref_inventory);
     let risk_flags = risk_flags(record);
-    let work_summary = work_summary(record, aggregate.as_ref(), &ref_inventory);
+    let work_summary = work_summary(record, aggregate, &ref_inventory);
+    let canonical_candidate = classify_candidates(&candidate_result_payload(record, aggregate));
 
     let mut summary = json!({
         "schema": "homeboy/agent-task-status-summary/v1",
@@ -2235,6 +2296,7 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         "state": record.get("state").cloned().unwrap_or(Value::Null),
         "timestamps": compact_fields(record, &["created_at", "updated_at", "started_at", "completed_at"]),
         "work_summary": work_summary,
+        "canonical_candidate": canonical_candidate_projection(canonical_candidate),
         "artifact_refs": refs.clone(),
         "artifact_refs_omitted": refs_omitted,
         "totals": record.get("totals").cloned().unwrap_or(Value::Null),
@@ -2246,7 +2308,7 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
         "execution_location": execution_location(record),
         "queue_visibility": queue_visibility(record),
         "execution_budget": plan.as_ref().map(|plan| &plan.options.execution_budget),
-        "liveness": liveness_summary(record, run_id),
+        "liveness": liveness_summary(record, run_id, canonical_candidate.state()),
         "full_command": format!("homeboy agent-task status {run_id} --full"),
     });
 
@@ -2291,9 +2353,31 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
                     "run_id",
                     "task_id",
                     "artifact_id",
+                    "patch_artifact_id",
+                    "patch_artifact",
+                    "patch",
                     "updated_at",
                     "created_at",
                     "command",
+                ],
+            );
+        }
+    }
+    if let Some(cook_finalization) = record
+        .get("metadata")
+        .and_then(|metadata| metadata.get("cook_finalization"))
+    {
+        if !cook_finalization.is_null() {
+            summary["cook_finalization"] = compact_fields(
+                cook_finalization,
+                &[
+                    "schema",
+                    "status",
+                    "pr_number",
+                    "pr_url",
+                    "pull_request_url",
+                    "updated_at",
+                    "created_at",
                 ],
             );
         }
@@ -2428,7 +2512,7 @@ fn bounded_value(value: &Value) -> Value {
     }
 }
 
-fn liveness_summary(record: &Value, run_id: &str) -> Value {
+fn liveness_summary(record: &Value, run_id: &str, candidate_state: CandidateState) -> Value {
     let metadata = record.get("metadata").unwrap_or(&Value::Null);
     let provider_handle_count = record
         .get("provider_handles")
@@ -2451,7 +2535,7 @@ fn liveness_summary(record: &Value, run_id: &str) -> Value {
         .and_then(|queue| queue.get("state"))
         .and_then(Value::as_str)
         == Some("waiting_for_capacity");
-    let candidate_recoverable = classify_candidates(record).state().is_recoverable();
+    let candidate_recoverable = candidate_state.is_recoverable();
 
     // A local cook runs the provider in an in-process thread, so it has neither
     // provider handles nor a runner job id. `reserve_provider_execution` still
@@ -2753,7 +2837,7 @@ fn work_summary(
     let committed_changes = provider_committed_changes(record)
         || aggregate.is_some_and(aggregate_has_committed_changes)
         || latest_promotion.is_some_and(promotion_reports_committed_changes);
-    let canonical = classify_candidates(&json!({ "aggregate": aggregate }));
+    let canonical = classify_candidates(&candidate_result_payload(record, aggregate));
     let classification = work_classification(
         record,
         promotion_status,
@@ -2775,6 +2859,12 @@ fn work_summary(
             "retained_only": canonical.retained_only,
             "unknown": canonical.unknown,
         },
+        "candidate_scan": {
+            "attempts_omitted": canonical.attempts_omitted,
+            "outcomes_omitted": canonical.outcomes_omitted,
+            "artifacts_omitted": canonical.artifacts_omitted,
+            "degraded": canonical.is_degraded(),
+        },
         "provider_execution_status": provider_status,
         "promotion_status": promotion_status,
         "artifact_ref_count": artifact_ref_count,
@@ -2782,6 +2872,17 @@ fn work_summary(
         "committed_changes_detected": committed_changes,
         "artifact_command": record.get("run_id").and_then(Value::as_str).map(|run_id| format!("homeboy agent-task artifacts {run_id}")),
     })
+}
+
+/// Combine the current record with the immutable aggregate before projecting a
+/// candidate result. Promotion, finalization, and adoption facts live on the
+/// record while patch facts live in the aggregate; neither may erase the other.
+fn candidate_result_payload(record: &Value, aggregate: Option<&AgentTaskAggregate>) -> Value {
+    let mut payload = record.clone();
+    if let Some(aggregate) = aggregate {
+        payload["aggregate"] = serde_json::to_value(aggregate).unwrap_or(Value::Null);
+    }
+    payload
 }
 
 fn deduped_ref_count<'a>(refs: impl Iterator<Item = &'a CompactRef>) -> usize {
@@ -2821,8 +2922,11 @@ fn work_classification(
     if committed_changes && promotion_status.is_some_and(is_no_change_promotion_status) {
         return "committed_changes_pending_promotion";
     }
-    if candidate_state == CandidateState::PatchAvailable {
-        return "provider_completed_patch_available";
+    match candidate_state {
+        CandidateState::Finalized => return "pull_request_finalized",
+        CandidateState::Promoted => return "promoted_changes",
+        CandidateState::PatchAvailable => return "provider_completed_patch_available",
+        _ => {}
     }
     if promotion_status.is_some_and(is_no_change_promotion_status) {
         if artifact_ref_count == 0 && evidence_ref_count == 0 {
@@ -3098,7 +3202,7 @@ mod tests {
         assert_eq!(summary["liveness"]["status"], "terminal");
         assert_eq!(
             summary["liveness"]["next_action"],
-            "homeboy agent-task review agent-task-run-1"
+            "homeboy agent-task status <run-id> --full"
         );
         assert!(summary["queue_visibility"]["concurrency_note"]
             .as_str()
@@ -3159,6 +3263,142 @@ mod tests {
             accepted_handoff["liveness"]["provider_boundary"]["runner_job_id"],
             "accepted-daemon-job"
         );
+    }
+
+    #[test]
+    fn compact_status_envelope_preserves_candidate_lifecycle_parity() {
+        let promoted_record = json!({
+            "run_id": "agent-task-promoted",
+            "state": "succeeded",
+            "tasks": [],
+            "metadata": { "latest_promotion": {
+                "status": "applied", "patch_artifact": { "id": "patch" }
+            }}
+        });
+        let promoted = compact_status_summary(&promoted_record, "agent-task-promoted");
+        assert_eq!(promoted["latest_promotion"]["status"], "applied");
+        assert_eq!(
+            classify_candidates(&promoted).state(),
+            CandidateState::Promoted
+        );
+
+        let finalized_record = json!({
+            "run_id": "agent-task-finalized",
+            "state": "succeeded",
+            "tasks": [],
+            "metadata": { "cook_finalization": {
+                "status": "review_ready", "pr_url": "https://example.test/pull/1"
+            }}
+        });
+        let finalized = compact_status_summary(&finalized_record, "agent-task-finalized");
+        assert_eq!(finalized["cook_finalization"]["status"], "review_ready");
+        assert_eq!(
+            classify_candidates(&finalized).state(),
+            CandidateState::Finalized
+        );
+    }
+
+    #[test]
+    fn default_status_projects_durable_patch_candidate_for_rendering_and_actions() {
+        let record = json!({
+            "run_id": "agent-task-durable-patch",
+            "state": "succeeded",
+            "tasks": [],
+        });
+        let aggregate: AgentTaskAggregate = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-aggregate/v1",
+            "plan_id": "plan-durable-patch",
+            "status": "succeeded",
+            "totals": {
+                "queued": 0, "running": 0, "blocked": 0, "skipped": 0,
+                "succeeded": 1, "failed": 0, "cancelled": 0, "timed_out": 0
+            },
+            "outcomes": [{
+                "schema": "homeboy/agent-task-outcome/v1",
+                "task_id": "cook",
+                "status": "succeeded",
+                "summary": "patch ready",
+                "failure_classification": null,
+                "artifacts": [{
+                    "schema": "homeboy/agent-task-artifact/v1",
+                    "id": "durable-patch",
+                    "kind": "patch",
+                    "size_bytes": 32_318,
+                    "metadata": { "changed_file_count": 7 }
+                }],
+                "evidence_refs": [],
+                "metadata": {},
+                "outputs": {}
+            }]
+        }))
+        .expect("durable aggregate");
+
+        let mut compact = compact_status_summary_with_aggregate(
+            &record,
+            "agent-task-durable-patch",
+            Some(&aggregate),
+        );
+        assert_eq!(
+            compact["canonical_candidate"]["schema"],
+            "homeboy/agent-task-candidate/v1"
+        );
+        assert_eq!(compact["canonical_candidate"]["state"], "patch_available");
+        assert_eq!(compact["canonical_candidate"]["diff_bytes"], 32_318);
+        assert_eq!(compact["canonical_candidate"]["scan"]["degraded"], false);
+        assert!(compact.get("aggregate").is_none());
+
+        attach_agent_task_status_actionable(&mut compact, "agent-task-durable-patch");
+        let rendered = crate::commands::agent_task_summary::render_agent_task_summary(
+            crate::commands::agent_task_summary::AgentTaskSummaryKind::Status,
+            &compact,
+        )
+        .expect("status summary");
+
+        assert!(rendered.contains("Candidate state: patch_available"));
+        assert!(rendered.contains("Patch candidates: 1 non-empty / 0 empty"));
+        assert!(!rendered.contains("Patch candidates: 1 non-empty / 0 empty /"));
+        assert!(rendered.contains("Diff bytes: 32318"));
+        assert!(rendered.contains("Changed files: unknown"));
+        assert!(rendered.contains("Next: homeboy agent-task review agent-task-durable-patch"));
+        assert!(compact[ACTIONABLE_METADATA_KEY]["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .iter()
+            .any(
+                |action| action["command"] == "homeboy agent-task review agent-task-durable-patch"
+            ));
+
+        let mut full = record.clone();
+        attach_full_status_candidate(&mut full, Some(&aggregate), "agent-task-durable-patch");
+        attach_agent_task_status_actionable(&mut full, "agent-task-durable-patch");
+        let full_rendered = crate::commands::agent_task_summary::render_agent_task_summary(
+            crate::commands::agent_task_summary::AgentTaskSummaryKind::Status,
+            &full,
+        )
+        .expect("full status summary");
+
+        assert_eq!(
+            full["aggregate"]["outcomes"][0]["artifacts"][0]["size_bytes"],
+            32_318
+        );
+        assert_eq!(full["canonical_candidate"], compact["canonical_candidate"]);
+        assert_eq!(
+            compact["liveness"]["next_action"],
+            "homeboy agent-task review agent-task-durable-patch"
+        );
+        assert_eq!(full["liveness"], compact["liveness"]);
+        assert!(full_rendered.contains("Status: succeeded"));
+        assert!(full_rendered.contains("Patch candidates: 1 non-empty / 0 empty"));
+        assert!(full_rendered.contains("Changed files: 7"));
+        assert!(!full_rendered.contains("no_patch_produced"));
+        assert!(full_rendered.contains("Next: homeboy agent-task review agent-task-durable-patch"));
+        assert!(full[ACTIONABLE_METADATA_KEY]["next_actions"]
+            .as_array()
+            .expect("full next actions")
+            .iter()
+            .any(
+                |action| action["command"] == "homeboy agent-task review agent-task-durable-patch"
+            ));
     }
 
     #[test]
@@ -3378,6 +3618,38 @@ mod tests {
         assert_eq!(summary["work_summary"]["classification"], "no_changes");
         assert_eq!(summary["work_summary"]["artifact_ref_count"], 0);
         assert_eq!(summary["work_summary"]["evidence_ref_count"], 0);
+    }
+
+    #[test]
+    fn work_summary_distinguishes_available_promoted_and_finalized_candidates() {
+        let available = work_summary(&json!({ "state": "succeeded" }), None, &[]);
+        assert_eq!(available["classification"], "no_changes");
+
+        let promoted = work_summary(
+            &json!({
+                "state": "succeeded",
+                "metadata": { "latest_promotion": {
+                    "status": "applied", "patch_artifact": { "id": "patch" }
+                }}
+            }),
+            None,
+            &[],
+        );
+        assert_eq!(promoted["candidate_state"], "promoted");
+        assert_eq!(promoted["classification"], "promoted_changes");
+
+        let finalized = work_summary(
+            &json!({
+                "state": "succeeded",
+                "metadata": { "cook_finalization": {
+                    "status": "review_ready", "pr_url": "https://example.test/pull/1"
+                }}
+            }),
+            None,
+            &[],
+        );
+        assert_eq!(finalized["candidate_state"], "finalized");
+        assert_eq!(finalized["classification"], "pull_request_finalized");
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1334,6 +1334,30 @@ fn execution_states_prefer_adopted_normalized_gate_outcome_over_stale_attempt_fa
     assert_eq!(states["promotion"]["state"], "applied");
 }
 
+#[test]
+fn execution_states_keep_promoted_candidate_after_a_failed_provider_attempt() {
+    let states = super::super::status::execution_states_from_aggregate(
+        &aggregate_for_execution_outcome(fixture_execution_outcome(
+            AgentTaskOutcomeStatus::Failed,
+            Some(AgentTaskFailureClassification::Provider),
+            Vec::new(),
+            Value::Null,
+        )),
+        &json!({
+            "metadata": {
+                "latest_promotion": {
+                    "status": "applied",
+                    "patch_artifact": { "id": "canonical-patch" }
+                }
+            }
+        }),
+    );
+
+    assert_eq!(states["provider"][0]["state"], "failed");
+    assert_eq!(states["candidate"]["state"], "promoted");
+    assert_eq!(states["promotion"]["state"], "applied");
+}
+
 fn execution_states(outcome: AgentTaskOutcome, promotion_status: &str) -> Value {
     super::super::status::execution_states_from_aggregate(
         &aggregate_for_execution_outcome(outcome),

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -61,7 +61,12 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     let aggregate_path = string_value(payload, &["aggregate_path"])
         .or_else(|| string_value(payload, &["record", "aggregate_path"]));
     let metrics = code_production_metrics(payload);
-    let state = effective_run_state(raw_state, tasks_attempted, metrics.non_empty_patches);
+    let state = effective_run_state(
+        raw_state,
+        tasks_attempted,
+        metrics.candidate_state,
+        metrics.candidate_scan_degraded,
+    );
     let artifact_count = aggregate_artifact_count(payload);
     let first_artifact = string_value(
         payload,
@@ -89,7 +94,7 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     if let Some(artifact) = first_artifact {
         lines.push(format!("First artifact: {artifact}"));
     }
-    if metrics.candidate_state == CandidateState::PatchAvailable {
+    if metrics.candidate_state.is_available() {
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
     } else {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
@@ -103,7 +108,12 @@ fn render_status_summary(payload: &Value) -> Option<String> {
     let tasks_planned = array_len(payload, &["tasks"]).unwrap_or(0);
     let tasks_attempted = status_attempted_task_count(payload);
     let metrics = code_production_metrics(payload);
-    let state = effective_run_state(raw_state, tasks_attempted, metrics.non_empty_patches);
+    let state = effective_run_state(
+        raw_state,
+        tasks_attempted,
+        metrics.candidate_state,
+        metrics.candidate_scan_degraded,
+    );
     let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"]);
 
@@ -119,7 +129,7 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Diagnostic: {diagnostic}"));
     }
     lines.push(format!("Artifacts: {artifact_count}"));
-    if metrics.candidate_state == CandidateState::PatchAvailable {
+    if metrics.candidate_state.is_available() {
         if let Some(path) = aggregate_path {
             lines.push(format!("Aggregate: {path}"));
         }
@@ -186,7 +196,7 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         .and_then(|_| usize_value(payload, &["aggregate_review", "summary", "failed"]))
         .unwrap_or(0);
     let metrics = code_production_metrics(payload);
-    let promotable = metrics.non_empty_patches > 0;
+    let promotable = metrics.candidate_state == CandidateState::PatchAvailable;
     let patch = promotable
         .then(|| string_value(payload, &["promotion_candidates", "0", "artifact_id"]))
         .flatten();
@@ -196,7 +206,11 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         .then(|| command_line(payload, &["promotion_candidates", "0", "command"]))
         .flatten();
 
-    let outcome = if promotable {
+    let outcome = if metrics.candidate_state == CandidateState::Finalized {
+        "pull request finalized"
+    } else if metrics.candidate_state == CandidateState::Promoted {
+        "patch promoted"
+    } else if promotable {
         "patch produced, not promoted"
     } else if raw_apply_candidates > 0 {
         "no-op: patch artifacts produced but empty"
@@ -284,6 +298,7 @@ struct CodeProductionMetrics {
     /// zero (#9742).
     changed_files_unknown_patches: usize,
     candidate_state: CandidateState,
+    candidate_scan_degraded: bool,
 }
 
 fn code_production_lines(metrics: &CodeProductionMetrics) -> Vec<String> {
@@ -321,39 +336,59 @@ fn code_production_lines(metrics: &CodeProductionMetrics) -> Vec<String> {
 fn code_production_metrics(payload: &Value) -> CodeProductionMetrics {
     let mut metrics = CodeProductionMetrics::default();
     let canonical = classify_candidates(payload);
-    if canonical.state() != CandidateState::Unknown {
+    if payload.get("aggregate").is_none()
+        && payload
+            .pointer("/canonical_candidate/schema")
+            .and_then(Value::as_str)
+            == Some("homeboy/agent-task-candidate/v1")
+    {
         metrics.non_empty_patches = canonical.available;
         metrics.empty_patches = canonical.empty;
+        metrics.diff_bytes = canonical.diff_bytes;
         metrics.unknown_size_patches = canonical.unknown
             + canonical.missing
             + canonical.unreadable
             + canonical.conflicting
             + canonical.retained_only;
-        metrics.diff_bytes = canonical.diff_bytes;
+        // Compact projections intentionally omit patch contents and changed-file
+        // metadata, so never present their absent detail as a verified zero.
+        metrics.changed_files_unknown_patches = canonical.available;
         metrics.candidate_state = canonical.state();
+        metrics.candidate_scan_degraded = canonical.is_degraded();
         return metrics;
     }
-    for patch in collect_patch_artifacts(payload) {
-        match patch.size_bytes {
-            Some(size) if size > 0 => {
-                metrics.non_empty_patches += 1;
-                metrics.diff_bytes += size;
-                match patch.changed_files {
-                    Some(count) => metrics.changed_files += count,
-                    None => metrics.changed_files_unknown_patches += 1,
+    // Metrics intentionally come from the display/review artifacts so rejected,
+    // unreadable, and changed-file evidence retains its established semantics.
+    // The candidate classifier only annotates that evidence with terminal state.
+    if !canonical.is_degraded() {
+        for patch in collect_patch_artifacts(payload) {
+            match patch.size_bytes {
+                Some(size) if size > 0 => {
+                    metrics.non_empty_patches += 1;
+                    metrics.diff_bytes += size;
+                    match patch.changed_files {
+                        Some(count) => metrics.changed_files += count,
+                        None => metrics.changed_files_unknown_patches += 1,
+                    }
                 }
+                Some(_) => metrics.empty_patches += 1,
+                None => metrics.unknown_size_patches += 1,
             }
-            Some(_) => metrics.empty_patches += 1,
-            None => metrics.unknown_size_patches += 1,
         }
     }
-    metrics.candidate_state = if metrics.non_empty_patches > 0 {
+    let measured_state = if metrics.non_empty_patches > 0 {
         CandidateState::PatchAvailable
     } else if metrics.empty_patches > 0 {
         CandidateState::Empty
     } else {
         CandidateState::Unknown
     };
+    metrics.candidate_state = if canonical.state() == CandidateState::Unknown {
+        measured_state
+    } else {
+        canonical.state()
+    };
+    metrics.candidate_scan_degraded = canonical.is_degraded();
     metrics
 }
 
@@ -402,6 +437,42 @@ fn collect_patch_artifacts(payload: &Value) -> Vec<PatchArtifact> {
                         size_bytes: u64_value(artifact, &["size_bytes"]),
                         changed_files: resolve_changed_files(artifact),
                     })
+            })
+            .collect();
+    }
+
+    if let Some(attempts) = value_at(payload, &["attempts"]).and_then(Value::as_array) {
+        let artifacts: Vec<&Value> = attempts
+            .iter()
+            .flat_map(|attempt| {
+                value_at(attempt, &["aggregate", "outcomes"])
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .flat_map(|outcome| {
+                        value_at(outcome, &["artifacts"])
+                            .and_then(Value::as_array)
+                            .into_iter()
+                            .flatten()
+                    })
+            })
+            .collect();
+        let canonical: Vec<&Value> = artifacts
+            .iter()
+            .copied()
+            .filter(|artifact| is_canonical_mirror(artifact))
+            .collect();
+        let artifacts = if canonical.is_empty() {
+            artifacts
+        } else {
+            canonical
+        };
+        return artifacts
+            .into_iter()
+            .filter(|artifact| is_display_apply_artifact(artifact))
+            .map(|artifact| PatchArtifact {
+                size_bytes: u64_value(artifact, &["size_bytes"]),
+                changed_files: resolve_changed_files(artifact),
             })
             .collect();
     }
@@ -456,6 +527,13 @@ fn is_display_apply_artifact(artifact: &Value) -> bool {
         return false;
     }
     !(artifact_flag(artifact, "rejected") || artifact_flag(artifact, "false_positive"))
+}
+
+fn is_canonical_mirror(artifact: &Value) -> bool {
+    value_at(artifact, &["metadata", "executor_artifact_finalized"]).and_then(Value::as_bool)
+        == Some(true)
+        || string_value(artifact, &["url"])
+            .is_some_and(|url| url.starts_with("homeboy://agent-task/run/"))
 }
 
 fn artifact_flag(artifact: &Value, key: &str) -> bool {
@@ -547,8 +625,18 @@ fn strip_diff_path_prefix(token: &str) -> String {
 /// A run whose lifecycle state is `succeeded` but that produced zero promotion
 /// candidates did not actually patch anything. Surface that honestly as
 /// `no_patch_produced` instead of advertising success (#4610).
-fn effective_run_state(raw_state: &str, tasks_attempted: usize, patch_candidates: usize) -> &str {
-    if raw_state == "succeeded" && tasks_attempted > 0 && patch_candidates == 0 {
+fn effective_run_state(
+    raw_state: &str,
+    tasks_attempted: usize,
+    candidate_state: CandidateState,
+    candidate_scan_degraded: bool,
+) -> &str {
+    if raw_state == "succeeded"
+        && candidate_state == CandidateState::Unknown
+        && candidate_scan_degraded
+    {
+        "unknown"
+    } else if raw_state == "succeeded" && tasks_attempted > 0 && !candidate_state.is_available() {
         "no_patch_produced"
     } else {
         raw_state
@@ -655,6 +743,84 @@ mod tests {
         assert!(summary.contains("Patch candidates: 0 non-empty / 3 empty\n"));
         assert!(summary.contains("Next: homeboy agent-task logs agent-task-abe47e4d\n"));
         assert!(!summary.contains("Next: homeboy agent-task review"));
+    }
+
+    #[test]
+    fn cook_summary_keeps_a_canonical_candidate_after_an_empty_retry() {
+        let payload = json!({
+            "run_id": "agent-task-canonical",
+            "state": "succeeded",
+            "task_count": 2,
+            "attempts": [
+                {
+                    "aggregate": {
+                        "outcomes": [{
+                            "artifacts": [{
+                                "id": "canonical-patch",
+                                "kind": "patch",
+                                "size_bytes": 32318,
+                                "url": "homeboy://agent-task/run/agent-task-canonical/artifacts#task=cook&artifact=canonical-patch",
+                                "metadata": { "executor_artifact_finalized": true }
+                            }]
+                        }]
+                    }
+                },
+                {
+                    "aggregate": {
+                        "outcomes": [{
+                            "artifacts": [{ "id": "empty-retry", "kind": "patch", "size_bytes": 0 }]
+                        }]
+                    }
+                }
+            ]
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Status: succeeded\n"));
+        assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
+        assert!(summary.contains("Candidate state: patch_available\n"));
+        assert!(summary.contains("Next: homeboy agent-task review agent-task-canonical\n"));
+        assert!(!summary.contains("no_patch_produced"));
+    }
+
+    #[test]
+    fn finalized_pr_summary_is_not_reported_as_an_unpromoted_empty_patch() {
+        let payload = json!({
+            "run_id": "agent-task-finalized",
+            "state": "succeeded",
+            "task_count": 1,
+            "aggregate": { "outcomes": [{ "artifacts": [{ "id": "empty", "kind": "patch", "size_bytes": 0 }] }] },
+            "finalization": { "status": "review_ready", "pr_url": "https://example.test/pull/1" }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Status: succeeded\n"));
+        assert!(summary.contains("Candidate state: finalized\n"));
+        assert!(summary.contains("Next: homeboy agent-task review agent-task-finalized\n"));
+        assert!(!summary.contains("no_patch_produced"));
+    }
+
+    #[test]
+    fn oversized_empty_artifacts_keep_the_terminal_summary_unknown() {
+        let artifacts = (0..257)
+            .map(
+                |index| json!({ "id": format!("empty-{index}"), "kind": "patch", "size_bytes": 0 }),
+            )
+            .collect::<Vec<_>>();
+        let payload = json!({
+            "run_id": "agent-task-truncated",
+            "state": "succeeded",
+            "task_count": 1,
+            "aggregate": { "outcomes": [{ "artifacts": artifacts }] }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Status: unknown\n"));
+        assert!(summary.contains("Candidate state: unknown\n"));
+        assert!(!summary.contains("Status: no_patch_produced\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- derive compact, full, human, liveness, and actionable status from one canonical candidate projection
- preserve promoted/finalized states and bound degraded artifact scans
- exclude rejected and false-positive artifacts from patch availability

Closes #9957

## Verification
- candidate classifier tests
- all agent-task summary tests
- compact/full 32,318-byte patch parity regressions
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested canonical candidate status reconciliation. Chris Huber reviewed and owns every line.