### PR TITLE
refactor(artifacts): collapse structurally identical artifact-ref types

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/artifact_contract.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/artifact_contract.rs
@@ -1,8 +1,13 @@
-//! Product-neutral artifact and evidence contract primitives.
+//! Product-neutral artifact contract primitives.
 //!
 //! These contracts intentionally stay small and generic. Producers may carry
 //! domain-specific fields through `extra`, while core owns the shared schema,
 //! field aliases, and non-empty target normalization.
+//!
+//! Evidence *references* (a labelled pointer at an artifact) live in
+//! `homeboy-artifact-ref-contract` as `EvidenceRef`. There is no second
+//! `EvidenceContract` shape: the one that used to live here had no producer and
+//! no consumer anywhere in the workspace (#10310).
 
 use std::collections::BTreeMap;
 
@@ -77,7 +82,6 @@ impl Default for ArtifactRecord {
 }
 
 pub const ARTIFACT_CONTRACT_SCHEMA: &str = "homeboy/artifact-contract/v1";
-pub const EVIDENCE_CONTRACT_SCHEMA: &str = "homeboy/evidence-contract/v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArtifactContract {
@@ -150,48 +154,6 @@ impl ArtifactContract {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct EvidenceContract {
-    #[serde(default = "evidence_contract_schema")]
-    pub schema: String,
-    pub kind: String,
-    pub target: String,
-    pub label: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub semantic_key: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub artifact: Option<ArtifactContract>,
-    #[serde(default, skip_serializing_if = "Value::is_null")]
-    pub metadata: Value,
-    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra: BTreeMap<String, Value>,
-}
-
-impl EvidenceContract {
-    pub fn from_value(value: Value) -> Result<Self, String> {
-        contract_from_value(value, Self::normalize)
-    }
-
-    fn normalize(&mut self) -> Result<(), String> {
-        normalize_schema_and_kind(
-            &mut self.schema,
-            &mut self.kind,
-            EVIDENCE_CONTRACT_SCHEMA,
-            "evidence contract",
-        )?;
-        self.target = required_trimmed("target", &self.target)?;
-        self.label = trim_or_default(&self.label, &self.kind);
-        self.role = normalize_optional_string(self.role.take());
-        self.semantic_key = normalize_optional_string(self.semantic_key.take());
-        if let Some(artifact) = &mut self.artifact {
-            artifact.normalize()?;
-        }
-        Ok(())
-    }
-}
-
 fn normalize_schema_and_kind(
     schema: &mut String,
     kind: &mut String,
@@ -216,10 +178,6 @@ where
 
 fn artifact_contract_schema() -> String {
     ARTIFACT_CONTRACT_SCHEMA.to_string()
-}
-
-fn evidence_contract_schema() -> String {
-    EVIDENCE_CONTRACT_SCHEMA.to_string()
 }
 
 fn normalize_optional_string(value: Option<String>) -> Option<String> {
@@ -295,26 +253,6 @@ mod tests {
         .expect_err("target error");
 
         assert!(err.contains("path, url, or public_url"));
-    }
-
-    #[test]
-    fn evidence_contract_normalizes_label_and_nested_artifact() {
-        let evidence = EvidenceContract::from_value(json!({
-            "kind": " proof ",
-            "target": " https://example.test/proof ",
-            "label": " ",
-            "artifact": {
-                "kind": "proof-json",
-                "path": "proof.json"
-            }
-        }))
-        .expect("evidence contract");
-
-        assert_eq!(evidence.schema, EVIDENCE_CONTRACT_SCHEMA);
-        assert_eq!(evidence.kind, "proof");
-        assert_eq!(evidence.label, "proof");
-        assert_eq!(evidence.target, "https://example.test/proof");
-        assert_eq!(evidence.artifact.expect("artifact").artifact_type, "file");
     }
 
     #[test]

--- a/crates/contracts/homeboy-lifecycle-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/lib.rs
@@ -14,8 +14,7 @@ pub mod rig_snapshot;
 pub mod timeline;
 
 pub use artifact_contract::{
-    ArtifactContract, ArtifactRecord, ArtifactViewerLink, EvidenceContract,
-    ARTIFACT_CONTRACT_SCHEMA, EVIDENCE_CONTRACT_SCHEMA,
+    ArtifactContract, ArtifactRecord, ArtifactViewerLink, ARTIFACT_CONTRACT_SCHEMA,
 };
 pub use lifecycle::{
     LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,

--- a/crates/homeboy-agents/src/agent_task/artifacts.rs
+++ b/crates/homeboy-agents/src/agent_task/artifacts.rs
@@ -184,6 +184,19 @@ impl AgentTaskArtifact {
     }
 }
 
+/// A durable, Homeboy-owned reference to one piece of agent-task evidence.
+///
+/// `kind` classifies the ref (`runner_job_log`, `run_evidence`,
+/// `artifact_bundle`, ...) so operators can pick the right follow-up without
+/// guessing at URI shapes. `uri` is the canonical `homeboy://` (or other
+/// reviewer-facing) address; `label` is optional display text.
+///
+/// This is the single `{kind, uri, label}` evidence-reference shape for
+/// `homeboy-agents`. It replaced two byte-identical clones in #10310:
+/// `AgentTaskLoopFailedChildEvidenceRef` (loop-controller diagnostics) and
+/// `ControllerRunEvidenceRef` (controller run-failure summaries). Both had the
+/// same three fields with the same serde attributes, so the collapse is
+/// wire-compatible in both directions.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskEvidenceRef {
     pub kind: String,

--- a/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
@@ -83,8 +83,7 @@ pub use proof::{
 pub use reports::*;
 pub use request::*;
 pub use run_failure_summary::{
-    build_run_failure_summary, ControllerRunEvidenceRef, ControllerRunFailureSummary,
-    CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA,
+    build_run_failure_summary, ControllerRunFailureSummary, CONTROLLER_RUN_FAILURE_SUMMARY_SCHEMA,
 };
 pub use spec::*;
 #[cfg(test)]

--- a/crates/homeboy-agents/src/agent_task_controller_service/run_failure_summary.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/run_failure_summary.rs
@@ -16,6 +16,8 @@
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::agent_task::AgentTaskEvidenceRef;
+
 /// Owner surface that a controller run blocker is attributed to.
 ///
 /// Ordered roughly outside-in so the most specific reachable surface wins when
@@ -43,19 +45,6 @@ impl OwnerSurface {
             OwnerSurface::AgentOutput => "agent_output",
         }
     }
-}
-
-/// A durable, Homeboy-owned reference to evidence behind a controller failure.
-///
-/// `kind` classifies the ref (`runner_job_log`, `run_evidence`,
-/// `artifact_bundle`, ...) so operators can pick the right follow-up without
-/// guessing at URI shapes.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct ControllerRunEvidenceRef {
-    pub kind: String,
-    pub uri: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
 }
 
 /// Compact, operator-facing root-cause summary for a failed controller run.
@@ -89,7 +78,7 @@ pub struct ControllerRunFailureSummary {
     pub failure_phase: Option<String>,
     /// Durable evidence refs (runner job logs, run evidence, artifact bundles).
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub evidence_refs: Vec<ControllerRunEvidenceRef>,
+    pub evidence_refs: Vec<AgentTaskEvidenceRef>,
     /// Provider-owned runtime context for the failed run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_context: Option<Value>,
@@ -266,13 +255,13 @@ fn collect_evidence_refs(
     loop_id: &str,
     failed_action: Option<&Value>,
     status: &Value,
-) -> Vec<ControllerRunEvidenceRef> {
-    let mut refs: Vec<ControllerRunEvidenceRef> = Vec::new();
+) -> Vec<AgentTaskEvidenceRef> {
+    let mut refs: Vec<AgentTaskEvidenceRef> = Vec::new();
 
     // Persisted run evidence: the controller record itself is the durable index.
     push_ref(
         &mut refs,
-        ControllerRunEvidenceRef {
+        AgentTaskEvidenceRef {
             kind: "run_evidence".to_string(),
             uri: format!("homeboy agent-task controller status {loop_id}"),
             label: Some("persisted controller run evidence".to_string()),
@@ -288,7 +277,7 @@ fn collect_evidence_refs(
         for job_id in find_all_strings(action, &["runner_job_id", "job_id"]) {
             push_ref(
                 &mut refs,
-                ControllerRunEvidenceRef {
+                AgentTaskEvidenceRef {
                     kind: "runner_job_log".to_string(),
                     uri: runner_id
                         .as_ref()
@@ -303,7 +292,7 @@ fn collect_evidence_refs(
         for run_id in find_all_strings(action, &["run_id"]) {
             push_ref(
                 &mut refs,
-                ControllerRunEvidenceRef {
+                AgentTaskEvidenceRef {
                     kind: "run_evidence".to_string(),
                     uri: format!("homeboy agent-task status {run_id} --full"),
                     label: Some(format!("agent-task run {run_id} evidence")),
@@ -333,13 +322,13 @@ fn collect_evidence_refs(
 
 /// Extract declared artifact/evidence refs (`uri`/`url`/`path`) from any nested
 /// `artifacts`, `artifact_refs`, or `evidence_refs` arrays.
-fn collect_declared_refs(value: &Value) -> Vec<ControllerRunEvidenceRef> {
+fn collect_declared_refs(value: &Value) -> Vec<AgentTaskEvidenceRef> {
     let mut out = Vec::new();
     collect_declared_refs_into(value, &mut out);
     out
 }
 
-fn collect_declared_refs_into(value: &Value, out: &mut Vec<ControllerRunEvidenceRef>) {
+fn collect_declared_refs_into(value: &Value, out: &mut Vec<AgentTaskEvidenceRef>) {
     match value {
         Value::Object(map) => {
             for key in [
@@ -369,7 +358,7 @@ fn collect_declared_refs_into(value: &Value, out: &mut Vec<ControllerRunEvidence
     }
 }
 
-fn declared_ref_from_item(container_key: &str, item: &Value) -> Option<ControllerRunEvidenceRef> {
+fn declared_ref_from_item(container_key: &str, item: &Value) -> Option<AgentTaskEvidenceRef> {
     let uri = string_field(item, "uri")
         .or_else(|| string_field(item, "url"))
         .or_else(|| string_field(item, "path"))?;
@@ -385,16 +374,16 @@ fn declared_ref_from_item(container_key: &str, item: &Value) -> Option<Controlle
     let label = string_field(item, "label")
         .or_else(|| string_field(item, "name"))
         .or_else(|| string_field(item, "role"));
-    Some(ControllerRunEvidenceRef { kind, uri, label })
+    Some(AgentTaskEvidenceRef { kind, uri, label })
 }
 
-fn collect_source_like_refs(value: &Value) -> Vec<ControllerRunEvidenceRef> {
+fn collect_source_like_refs(value: &Value) -> Vec<AgentTaskEvidenceRef> {
     let mut out = Vec::new();
     collect_source_like_refs_into(value, &mut out);
     out
 }
 
-fn collect_source_like_refs_into(value: &Value, out: &mut Vec<ControllerRunEvidenceRef>) {
+fn collect_source_like_refs_into(value: &Value, out: &mut Vec<AgentTaskEvidenceRef>) {
     match value {
         Value::Object(map) => {
             for (key, nested) in map {
@@ -432,10 +421,10 @@ fn collect_source_like_ref_value(
     kind: &str,
     key: &str,
     value: &Value,
-    out: &mut Vec<ControllerRunEvidenceRef>,
+    out: &mut Vec<AgentTaskEvidenceRef>,
 ) {
     match value {
-        Value::String(text) if !text.trim().is_empty() => out.push(ControllerRunEvidenceRef {
+        Value::String(text) if !text.trim().is_empty() => out.push(AgentTaskEvidenceRef {
             kind: kind.to_string(),
             uri: text.trim().to_string(),
             label: Some(key.to_string()),
@@ -446,7 +435,7 @@ fn collect_source_like_ref_value(
                 .or_else(|| string_field(value, "path"))
                 .or_else(|| string_field(value, "ref"))
             {
-                out.push(ControllerRunEvidenceRef {
+                out.push(AgentTaskEvidenceRef {
                     kind: kind.to_string(),
                     uri,
                     label: string_field(value, "label").or_else(|| Some(key.to_string())),
@@ -669,7 +658,7 @@ fn find_all_strings_into(value: &Value, fields: &[&str], out: &mut Vec<String>) 
     }
 }
 
-fn push_ref(refs: &mut Vec<ControllerRunEvidenceRef>, candidate: ControllerRunEvidenceRef) {
+fn push_ref(refs: &mut Vec<AgentTaskEvidenceRef>, candidate: AgentTaskEvidenceRef) {
     if !refs.iter().any(|existing| existing.uri == candidate.uri) {
         refs.push(candidate);
     }

--- a/crates/homeboy-agents/src/agent_task_loop_controller/diagnostics.rs
+++ b/crates/homeboy-agents/src/agent_task_loop_controller/diagnostics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::agent_task::AgentTaskEvidenceRef;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -118,7 +119,7 @@ pub struct AgentTaskLoopFailedChildActionDiagnostic {
     pub repeated_failure: Option<AgentTaskLoopRepeatedFailureDiagnostic>,
     pub next_command: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub evidence_refs: Vec<AgentTaskLoopFailedChildEvidenceRef>,
+    pub evidence_refs: Vec<AgentTaskEvidenceRef>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -135,14 +136,6 @@ pub struct AgentTaskLoopRepeatedFailureDiagnostic {
     pub matching_failed_child_action_count: usize,
     pub guidance: String,
     pub next_command: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AgentTaskLoopFailedChildEvidenceRef {
-    pub kind: String,
-    pub uri: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
 }
 
 /// Canonical projection from a (possibly absent) recorded gate-bundle result
@@ -203,6 +196,30 @@ pub struct AgentTaskLoopPendingActionDiagnostic {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #10310 collapsed `AgentTaskLoopFailedChildEvidenceRef` onto
+    /// `AgentTaskEvidenceRef`. Both were `{kind, uri, label}` with identical
+    /// serde attributes, so diagnostics written by an older binary must still
+    /// deserialize, and the re-serialized shape must be unchanged.
+    #[test]
+    fn failed_child_evidence_refs_keep_the_pre_collapse_wire_shape() {
+        let evidence_refs = serde_json::json!([
+            { "kind": "runner_job_log", "uri": "homeboy://jobs/1", "label": "runner job 1" },
+            { "kind": "run_evidence", "uri": "homeboy://runs/2" }
+        ]);
+        let refs: Vec<AgentTaskEvidenceRef> =
+            serde_json::from_value(evidence_refs.clone()).expect("legacy evidence refs");
+
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].kind, "runner_job_log");
+        assert_eq!(refs[0].label.as_deref(), Some("runner job 1"));
+        assert_eq!(refs[1].uri, "homeboy://runs/2");
+        assert_eq!(refs[1].label, None);
+        assert_eq!(
+            serde_json::to_value(&refs).expect("evidence refs serialize"),
+            evidence_refs
+        );
+    }
 
     #[test]
     fn acceptance_gate_status_bridges_from_bundle_status() {

--- a/crates/homeboy-agents/src/agent_task_loop_controller/service.rs
+++ b/crates/homeboy-agents/src/agent_task_loop_controller/service.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::agent_task::AgentTaskEvidenceRef;
 use crate::agent_task_lifecycle;
 use chrono::{DateTime, Utc};
 use homeboy_core::engine::local_files::write_json_file as write_json;
@@ -513,12 +514,12 @@ fn load_child_aggregate_value(run_id: &str) -> Option<Value> {
 
 fn evidence_refs_from_run(
     run: &agent_task_lifecycle::AgentTaskRunRecord,
-) -> Vec<AgentTaskLoopFailedChildEvidenceRef> {
+) -> Vec<AgentTaskEvidenceRef> {
     let mut refs = Vec::new();
     for artifact in &run.artifact_refs {
         push_failed_child_evidence_ref(
             &mut refs,
-            AgentTaskLoopFailedChildEvidenceRef {
+            AgentTaskEvidenceRef {
                 kind: artifact.kind.clone(),
                 uri: artifact.uri.clone(),
                 label: artifact.label.clone(),
@@ -526,15 +527,10 @@ fn evidence_refs_from_run(
         );
     }
     if let Some(executor) = &run.latest_executor_evidence {
+        // `refs()` already yields `AgentTaskEvidenceRef`; before #10310 this had
+        // to be re-spelled field-by-field into a structurally identical clone.
         for evidence in executor.refs() {
-            push_failed_child_evidence_ref(
-                &mut refs,
-                AgentTaskLoopFailedChildEvidenceRef {
-                    kind: evidence.kind,
-                    uri: evidence.uri,
-                    label: evidence.label,
-                },
-            );
+            push_failed_child_evidence_ref(&mut refs, evidence);
         }
     }
     refs
@@ -564,8 +560,8 @@ fn root_cause_from_run_evidence(run: &agent_task_lifecycle::AgentTaskRunRecord) 
 }
 
 fn push_failed_child_evidence_ref(
-    refs: &mut Vec<AgentTaskLoopFailedChildEvidenceRef>,
-    reference: AgentTaskLoopFailedChildEvidenceRef,
+    refs: &mut Vec<AgentTaskEvidenceRef>,
+    reference: AgentTaskEvidenceRef,
 ) {
     if reference.uri.trim().is_empty() {
         return;
@@ -691,10 +687,7 @@ fn is_root_cause_message(message: &str) -> bool {
         || lower.contains("secret")
 }
 
-fn classify_failed_child_owner(
-    diagnostic: &str,
-    evidence_refs: &[AgentTaskLoopFailedChildEvidenceRef],
-) -> String {
+fn classify_failed_child_owner(diagnostic: &str, evidence_refs: &[AgentTaskEvidenceRef]) -> String {
     let lower = diagnostic.to_ascii_lowercase();
     if lower.contains("runtime_task_ability_unavailable") || lower.contains("ability unavailable") {
         "agent_runtime".to_string()

--- a/crates/homeboy-cli/src/command_contract.rs
+++ b/crates/homeboy-cli/src/command_contract.rs
@@ -121,8 +121,8 @@ pub use crate::core::run_outcome_envelope::{
 };
 pub use crate::core::runner_execution_envelope::{
     PathMaterializationEntry, PathMaterializationMode, PathMaterializationPlan,
-    PathMaterializationProjection, RunnerExecutionArtifactRef, RunnerExecutionNextAction,
-    RunnerExecutionProjection, RunnerExecutionRecord, PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
+    PathMaterializationProjection, RunnerExecutionNextAction, RunnerExecutionProjection,
+    RunnerExecutionRecord, PATH_MATERIALIZATION_MODE_EXISTING_REMOTE,
     PATH_MATERIALIZATION_MODE_GIT, PATH_MATERIALIZATION_MODE_SNAPSHOT,
     PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_REQUIRE_PATHS,
     PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT, PATH_MATERIALIZATION_PLAN_SCHEMA,

--- a/crates/homeboy-cli/src/command_contract/constants.rs
+++ b/crates/homeboy-cli/src/command_contract/constants.rs
@@ -17,7 +17,7 @@ use crate::command_contract::{
     RUNNER_ARTIFACT_ROOT_DIR_SUFFIX,
 };
 use crate::core::artifact_address::ARTIFACT_ADDRESS_SCHEMA;
-use crate::core::artifact_contract::{ARTIFACT_CONTRACT_SCHEMA, EVIDENCE_CONTRACT_SCHEMA};
+use crate::core::artifact_contract::ARTIFACT_CONTRACT_SCHEMA;
 use crate::core::artifact_dom_boxes::ARTIFACT_DOM_BOXES_SCHEMA;
 use crate::core::artifact_ref::{
     ARTIFACT_REF_SCHEMA, HOMEBOY_REF_SCHEME, RUNNER_ARTIFACT_REF_SCHEME,
@@ -492,7 +492,6 @@ fn represented_artifact_schema_ids() -> Vec<String> {
     vec![
         RUNNER_ARTIFACT_MANIFEST_SCHEMA.to_string(),
         ARTIFACT_CONTRACT_SCHEMA.to_string(),
-        EVIDENCE_CONTRACT_SCHEMA.to_string(),
         ARTIFACT_REF_SCHEMA.to_string(),
         ARTIFACT_ADDRESS_SCHEMA.to_string(),
         ARTIFACT_DOM_BOXES_SCHEMA.to_string(),

--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -329,7 +329,7 @@ fn actionable_for_activity_item(item: &ActivityItem) -> CommandActionableMetadat
         evidence: item
             .evidence
             .iter()
-            .map(|evidence| super::utils::response::CommandEvidenceRef {
+            .map(|evidence| super::utils::response::CommandArtifactRef {
                 id: evidence.id.clone(),
                 kind: evidence.kind.clone(),
                 uri: evidence.uri.clone(),

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -29,9 +29,8 @@ use super::args::{
 };
 use super::candidate::{classify_candidates, CandidateState};
 use crate::commands::utils::response::{
-    CommandActionableMetadata, CommandAgentTaskRef, CommandArtifactRef, CommandEvidenceRef,
-    CommandNextAction, CommandNextActionKind, CommandResultRefs, CommandRunRef,
-    ACTIONABLE_METADATA_KEY,
+    CommandActionableMetadata, CommandAgentTaskRef, CommandArtifactRef, CommandNextAction,
+    CommandNextActionKind, CommandResultRefs, CommandRunRef, ACTIONABLE_METADATA_KEY,
 };
 
 /// Cap the number of detail refs rendered in the compact summary so a noisy
@@ -1170,7 +1169,7 @@ fn diagnose_artifact_refs(aggregate: &AgentTaskAggregate) -> Vec<CommandArtifact
         .collect()
 }
 
-fn diagnose_evidence_refs(aggregate: &AgentTaskAggregate) -> Vec<CommandEvidenceRef> {
+fn diagnose_evidence_refs(aggregate: &AgentTaskAggregate) -> Vec<CommandArtifactRef> {
     aggregate
         .outcomes
         .iter()
@@ -1181,7 +1180,7 @@ fn diagnose_evidence_refs(aggregate: &AgentTaskAggregate) -> Vec<CommandEvidence
                 .map(move |evidence| (outcome.task_id.as_str(), evidence))
         })
         .take(COMPACT_REF_LIMIT)
-        .map(|(task_id, evidence)| CommandEvidenceRef {
+        .map(|(task_id, evidence)| CommandArtifactRef {
             id: format!("{task_id}:{}", evidence.kind),
             kind: evidence.kind.clone(),
             uri: evidence.uri.clone(),

--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -1440,14 +1440,7 @@ fn handoff_runner_execution_record(
                 .or_else(|| handoff.durable_run_id.clone()),
         )
         .with_path_materialization_plan(handoff.path_materialization_plan.clone())
-        .with_artifact_refs(handoff.evidence.artifact_refs.iter().map(|artifact| {
-            crate::core::runner_execution_envelope::RunnerExecutionArtifactRef {
-                id: artifact.id.clone(),
-                name: artifact.name.clone(),
-                path: artifact.path.clone(),
-                url: artifact.url.clone(),
-            }
-        }))
+        .with_artifact_refs(handoff.evidence.artifact_refs.iter().cloned())
         .with_next_actions(handoff.evidence.next_commands.iter().map(|command| {
             crate::core::runner_execution_envelope::RunnerExecutionNextAction {
                 label: command.label.clone(),

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/compare.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/compare.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::super::types::{
-    ArtifactComparison, ArtifactRef, AssertionComparison, AssertionStats, BrowserEvidenceVariant,
-    BrowserEvidenceVariantComparison, MetricComparison, MetricStats,
+    ArtifactComparison, AssertionComparison, AssertionStats, BrowserEvidenceArtifactLink,
+    BrowserEvidenceVariant, BrowserEvidenceVariantComparison, MetricComparison, MetricStats,
 };
 use super::BrowserEvidenceSample;
 
@@ -114,7 +114,7 @@ fn variant_for_sample(sample: &BrowserEvidenceSample) -> BrowserEvidenceVariant 
     }
 }
 
-fn artifact_refs(samples: &[&BrowserEvidenceSample]) -> Vec<ArtifactRef> {
+fn artifact_refs(samples: &[&BrowserEvidenceSample]) -> Vec<BrowserEvidenceArtifactLink> {
     samples
         .iter()
         .flat_map(|sample| {

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/mod.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use super::types::{ArtifactRef, AssertionStats};
+use super::types::{AssertionStats, BrowserEvidenceArtifactLink};
 
 mod compare;
 mod parse;
@@ -16,7 +16,7 @@ pub(super) use visual::attach_visual_comparisons;
 #[derive(Debug, Clone)]
 pub(super) struct EvidenceSet {
     pub(super) samples: Vec<BrowserEvidenceSample>,
-    pub(super) artifacts: BTreeSet<ArtifactRef>,
+    pub(super) artifacts: BTreeSet<BrowserEvidenceArtifactLink>,
     pub(super) notes: Vec<String>,
 }
 
@@ -33,8 +33,8 @@ pub(super) struct BrowserEvidenceSample {
     pub(super) lifecycle_metrics: BTreeMap<String, f64>,
     pub(super) console_errors: Option<f64>,
     pub(super) page_errors: Option<f64>,
-    pub(super) artifacts: BTreeSet<ArtifactRef>,
-    pub(super) source_artifact: Option<ArtifactRef>,
+    pub(super) artifacts: BTreeSet<BrowserEvidenceArtifactLink>,
+    pub(super) source_artifact: Option<BrowserEvidenceArtifactLink>,
     pub(super) notes: Vec<String>,
 }
 

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/parse.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/parse.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use homeboy_extension::trace::{trace_browser_artifact_map_fields, trace_browser_summary_extract};
 use homeboy_extension::TraceBrowserEvidenceAdapterConfig;
 
-use super::super::types::{ArtifactRef, AssertionFailure, AssertionStats};
+use super::super::types::{AssertionFailure, AssertionStats, BrowserEvidenceArtifactLink};
 use super::BrowserEvidenceSample;
 
 pub(super) fn assertion_stats(value: Option<&Value>) -> AssertionStats {
@@ -118,7 +118,7 @@ pub(super) fn collect_declared_browser_summary_adapters(
 
 pub(super) fn collect_declared_artifact_map_adapters(
     object: &Map<String, Value>,
-    artifacts: &mut BTreeSet<ArtifactRef>,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
     adapters: &[TraceBrowserEvidenceAdapterConfig],
 ) {
     for field in trace_browser_artifact_map_fields(adapters) {
@@ -128,7 +128,7 @@ pub(super) fn collect_declared_artifact_map_adapters(
 
 pub(super) fn collect_artifacts(
     object: &Map<String, Value>,
-    artifacts: &mut BTreeSet<ArtifactRef>,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
 ) {
     let Some(values) = object.get("artifacts").and_then(Value::as_array) else {
         return;
@@ -138,19 +138,22 @@ pub(super) fn collect_artifacts(
             .unwrap_or_else(|| "artifact".to_string());
         let target = first_value_string(artifact, &["url", "href", "path", "target"]);
         if let Some(target) = target {
-            artifacts.insert(ArtifactRef { label, target });
+            artifacts.insert(BrowserEvidenceArtifactLink { label, target });
         }
     }
 }
 
-fn collect_artifact_map(value: Option<&Value>, artifacts: &mut BTreeSet<ArtifactRef>) {
+fn collect_artifact_map(
+    value: Option<&Value>,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
+) {
     let Some(files) = value.and_then(Value::as_object) else {
         return;
     };
     for (label, value) in files {
         match value {
             Value::String(target) if !target.is_empty() => {
-                artifacts.insert(ArtifactRef {
+                artifacts.insert(BrowserEvidenceArtifactLink {
                     label: label.clone(),
                     target: target.clone(),
                 });
@@ -161,7 +164,7 @@ fn collect_artifact_map(value: Option<&Value>, artifacts: &mut BTreeSet<Artifact
                     .filter_map(Value::as_str)
                     .filter(|target| !target.is_empty())
                 {
-                    artifacts.insert(ArtifactRef {
+                    artifacts.insert(BrowserEvidenceArtifactLink {
                         label: label.clone(),
                         target: target.to_string(),
                     });
@@ -234,7 +237,7 @@ pub(super) fn artifact_ref(
     path: &Path,
     include_local_paths: bool,
     label: Option<String>,
-) -> ArtifactRef {
+) -> BrowserEvidenceArtifactLink {
     let target = if include_local_paths {
         path.display().to_string()
     } else {
@@ -243,7 +246,7 @@ pub(super) fn artifact_ref(
             .display()
             .to_string()
     };
-    ArtifactRef {
+    BrowserEvidenceArtifactLink {
         label: label.unwrap_or_else(|| "source".to_string()),
         target,
     }

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/reader.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/reader.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use homeboy_extension::trace::trace_browser_summary_has_signal;
 use homeboy_extension::TraceBrowserEvidenceAdapterConfig;
 
-use super::super::types::ArtifactRef;
+use super::super::types::BrowserEvidenceArtifactLink;
 use super::parse::{
     artifact_ref, assertion_stats, browser_metric_names, collect_artifacts,
     collect_declared_artifact_map_adapters, collect_declared_browser_summary_adapters,
@@ -171,7 +171,7 @@ fn canonical_path(path: &Path) -> PathBuf {
 /// artifact maps) from a parsed JSON value.
 fn collect_artifact_targets(
     value: &Value,
-    artifacts: &mut BTreeSet<ArtifactRef>,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
     adapters: &[TraceBrowserEvidenceAdapterConfig],
 ) {
     match value {
@@ -206,10 +206,10 @@ fn collect_json_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()>
 fn collect_samples(
     value: &Value,
     inherited: &SampleContext,
-    source: &ArtifactRef,
+    source: &BrowserEvidenceArtifactLink,
     source_dir: Option<&Path>,
     samples: &mut Vec<BrowserEvidenceSample>,
-    artifacts: &mut BTreeSet<ArtifactRef>,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
     adapters: &[TraceBrowserEvidenceAdapterConfig],
 ) {
     match value {
@@ -230,10 +230,10 @@ fn collect_samples(
 fn collect_object_samples(
     object: &Map<String, Value>,
     inherited: &SampleContext,
-    source: &ArtifactRef,
+    source: &BrowserEvidenceArtifactLink,
     source_dir: Option<&Path>,
     samples: &mut Vec<BrowserEvidenceSample>,
-    artifacts: &mut BTreeSet<ArtifactRef>,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
     adapters: &[TraceBrowserEvidenceAdapterConfig],
 ) {
     let context = context_for_object(object, inherited);
@@ -362,8 +362,8 @@ fn has_provenance_signal(object: &Map<String, Value>) -> bool {
 
 fn collect_provenance_artifacts(
     value: &Value,
-    source: &ArtifactRef,
-    artifacts: &mut BTreeSet<ArtifactRef>,
+    source: &BrowserEvidenceArtifactLink,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
     adapters: &[TraceBrowserEvidenceAdapterConfig],
 ) {
     match value {
@@ -387,7 +387,7 @@ fn collect_provenance_artifacts(
 
 fn collect_object_artifacts(
     object: &Map<String, Value>,
-    artifacts: &mut BTreeSet<ArtifactRef>,
+    artifacts: &mut BTreeSet<BrowserEvidenceArtifactLink>,
     adapters: &[TraceBrowserEvidenceAdapterConfig],
 ) {
     collect_artifacts(object, artifacts);
@@ -397,7 +397,7 @@ fn collect_object_artifacts(
 fn sample_from_object(
     object: &Map<String, Value>,
     context: &SampleContext,
-    source: &ArtifactRef,
+    source: &BrowserEvidenceArtifactLink,
     source_dir: Option<&Path>,
     adapters: &[TraceBrowserEvidenceAdapterConfig],
 ) -> BrowserEvidenceSample {

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/visual.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/implementation/visual.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use super::super::types::{
-    ArtifactRef, BrowserEvidenceVariant, BrowserEvidenceVariantComparison, VisualCompareResult,
+    BrowserEvidenceArtifactLink, BrowserEvidenceVariant, BrowserEvidenceVariantComparison,
+    VisualCompareResult,
 };
 use super::super::VisualCompareOptions;
 
@@ -51,7 +52,7 @@ pub(in crate::commands::report::browser_evidence_compare) fn attach_visual_compa
     Ok(())
 }
 
-fn screenshot_path(artifacts: &[ArtifactRef]) -> Option<String> {
+fn screenshot_path(artifacts: &[BrowserEvidenceArtifactLink]) -> Option<String> {
     let source_parent = artifacts.iter().find_map(|artifact| {
         (artifact.label == "source")
             .then(|| PathBuf::from(&artifact.target))
@@ -171,7 +172,7 @@ fn visual_compare_result_from_value(
                         .get("path")
                         .and_then(Value::as_str)
                         .or_else(|| value.as_str())?;
-                    Some(ArtifactRef {
+                    Some(BrowserEvidenceArtifactLink {
                         label: label.clone(),
                         target: redact_visual_artifact_target(
                             path,

--- a/crates/homeboy-cli/src/commands/report/browser_evidence_compare/types.rs
+++ b/crates/homeboy-cli/src/commands/report/browser_evidence_compare/types.rs
@@ -151,12 +151,25 @@ pub struct MetricStats {
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ArtifactComparison {
-    pub baseline: Vec<ArtifactRef>,
-    pub candidate: Vec<ArtifactRef>,
+    pub baseline: Vec<BrowserEvidenceArtifactLink>,
+    pub candidate: Vec<BrowserEvidenceArtifactLink>,
 }
 
+/// A labelled link scraped out of a browser-evidence blob.
+///
+/// Deliberately *not* the canonical `homeboy_core::artifact_ref::ArtifactRef`:
+/// this carries no artifact identity at all. It is recovered from arbitrary
+/// third-party evidence JSON where the only two things reliably present are a
+/// display label and a target path/URL. It is `Ord` because the reader dedupes
+/// links in a `BTreeSet`, and `Serialize`-only because it is report output that
+/// is never read back.
+///
+/// It was named `ArtifactRef` until #10310, which made it one of three
+/// unrelated types sharing that name across the workspace. Renamed rather than
+/// merged: a display link and an addressable artifact reference are different
+/// things. The serialized `{label, target}` shape is unchanged.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ArtifactRef {
+pub struct BrowserEvidenceArtifactLink {
     pub label: String,
     pub target: String,
 }
@@ -169,7 +182,7 @@ pub struct VisualCompareResult {
     pub total_pixels: Option<u64>,
     pub dimension_mismatch: Option<bool>,
     pub artifacts_directory: String,
-    pub artifacts: Vec<ArtifactRef>,
+    pub artifacts: Vec<BrowserEvidenceArtifactLink>,
 }
 
 fn is_default_u64(value: &u64) -> bool {

--- a/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
+++ b/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use homeboy::core::build_identity::BuildIdentity;
 use homeboy::core::engine::shell::quote_arg;
 use homeboy::core::runner_execution_envelope::{
-    RunnerExecutionArtifactDeclaration, RunnerExecutionArtifactRef, RunnerExecutionEnvelope,
+    LabRunnerWorkloadArtifactRef, RunnerExecutionArtifactDeclaration, RunnerExecutionEnvelope,
     RunnerExecutionLifecyclePolicy, RunnerExecutionRecord, RunnerExecutionResultRefs,
     RUNNER_EXECUTION_ENVELOPE_SCHEMA,
 };
@@ -746,11 +746,11 @@ fn artifact_declarations(
 
 fn execution_artifact_refs(
     evidence_paths: &[LabRefreshPlanEvidencePath],
-) -> Vec<RunnerExecutionArtifactRef> {
+) -> Vec<LabRunnerWorkloadArtifactRef> {
     evidence_paths
         .iter()
         .enumerate()
-        .map(|(index, evidence_path)| RunnerExecutionArtifactRef {
+        .map(|(index, evidence_path)| LabRunnerWorkloadArtifactRef {
             id: artifact_name(evidence_path, index),
             name: Some(evidence_path.kind.to_string()),
             path: Some(evidence_path.path.clone()),

--- a/crates/homeboy-cli/src/commands/runs/refs.rs
+++ b/crates/homeboy-cli/src/commands/runs/refs.rs
@@ -45,8 +45,8 @@ pub struct RunsRefsOutput {
     pub artifact_count: usize,
     pub aggregate_artifact_count: usize,
     pub runs: Vec<RunRef>,
-    pub artifacts: Vec<ArtifactRef>,
-    pub aggregate_artifacts: Vec<ArtifactRef>,
+    pub artifacts: Vec<RunsRefsArtifactRef>,
+    pub aggregate_artifacts: Vec<RunsRefsArtifactRef>,
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
@@ -83,8 +83,20 @@ pub struct RunRef {
     pub evidence_commands: RunEvidenceCommands,
 }
 
+/// One row of `homeboy runs refs` output.
+///
+/// Deliberately *not* the canonical `homeboy_core::artifact_ref::ArtifactRef`:
+/// this is a store projection built for an operator, so it carries the
+/// content-integrity columns the canonical wire ref does not (`mime`,
+/// `size_bytes`, `sha256`) plus a ready-to-paste `get_command`, and omits the
+/// wire ref's `schema`/`public_url`/`role`/`semantic_key`. It is
+/// `Serialize`-only because it is CLI output that is never read back.
+///
+/// It was named `ArtifactRef` until #10310, which made it one of three
+/// unrelated types sharing that name across the workspace. Renamed rather than
+/// merged; the serialized shape is unchanged.
 #[derive(Serialize, Debug, Clone, PartialEq)]
-pub struct ArtifactRef {
+pub struct RunsRefsArtifactRef {
     pub run_id: String,
     pub artifact_id: String,
     pub ref_id: String,
@@ -192,8 +204,8 @@ fn run_ref(run: &RunRecord) -> RunRef {
     }
 }
 
-fn artifact_ref(artifact: &ArtifactRecord) -> ArtifactRef {
-    ArtifactRef {
+fn artifact_ref(artifact: &ArtifactRecord) -> RunsRefsArtifactRef {
+    RunsRefsArtifactRef {
         run_id: artifact.run_id.clone(),
         artifact_id: artifact.id.clone(),
         ref_id: format!("homeboy://run/{}/artifact/{}", artifact.run_id, artifact.id),

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -32,7 +32,7 @@ pub struct CommandResultEnvelope<T: Serialize> {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<CommandArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub evidence: Vec<CommandEvidenceRef>,
+    pub evidence: Vec<CommandArtifactRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostics: Option<CommandDiagnostics>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,7 +77,7 @@ pub struct CommandActionableMetadata {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<CommandArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub evidence: Vec<CommandEvidenceRef>,
+    pub evidence: Vec<CommandArtifactRef>,
 }
 
 impl CommandActionableMetadata {
@@ -246,17 +246,18 @@ pub struct CommandAgentTaskRef {
     pub review_command: Option<String>,
 }
 
+/// A pointer at one artifact or piece of evidence carried by a command-result
+/// envelope.
+///
+/// `artifacts` and `evidence` on [`CommandActionableMetadata`] both hold this
+/// shape. They used to hold two structurally identical types
+/// (`CommandArtifactRef` / `CommandEvidenceRef`); the distinction was never in
+/// the type, only in which field the value landed in — which is exactly how
+/// core already models it (`ActivityItem.artifacts` and `ActivityItem.evidence`
+/// are both `Vec<ActivityEvidenceRef>`). Collapsed in #10310; the serialized
+/// shape is unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandArtifactRef {
-    pub id: String,
-    pub kind: String,
-    pub uri: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub semantic_key: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommandEvidenceRef {
     pub id: String,
     pub kind: String,
     pub uri: String,
@@ -586,7 +587,7 @@ fn envelope_for_data(
 
     if evidence.is_empty() {
         if let Some(run) = &run {
-            evidence.push(CommandEvidenceRef {
+            evidence.push(CommandArtifactRef {
                 id: format!("{}-result", run.id),
                 kind: "command-result".to_string(),
                 uri: format!("homeboy://runs/{}/result", run.id),
@@ -1183,6 +1184,63 @@ pub fn write_json_to_file_for_identity(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// #10310 collapsed `CommandEvidenceRef` onto `CommandArtifactRef`. They
+    /// were the same four fields with the same serde attributes; only the
+    /// envelope field they landed in ever distinguished them. Both lists must
+    /// still serialize with the identical element shape.
+    #[test]
+    fn actionable_artifacts_and_evidence_share_one_serialized_element_shape() {
+        let metadata = CommandActionableMetadata {
+            artifacts: vec![CommandArtifactRef {
+                id: "summary".to_string(),
+                kind: "artifact".to_string(),
+                uri: "homeboy://runs/run-1/artifact/summary".to_string(),
+                semantic_key: Some("run.summary".to_string()),
+            }],
+            evidence: vec![CommandArtifactRef {
+                id: "summary".to_string(),
+                kind: "artifact".to_string(),
+                uri: "homeboy://runs/run-1/artifact/summary".to_string(),
+                semantic_key: Some("run.summary".to_string()),
+            }],
+            ..Default::default()
+        };
+
+        let value = serde_json::to_value(&metadata).expect("serialize actionable metadata");
+        assert_eq!(value["artifacts"][0], value["evidence"][0]);
+        assert_eq!(
+            value["artifacts"][0],
+            json!({
+                "id": "summary",
+                "kind": "artifact",
+                "uri": "homeboy://runs/run-1/artifact/summary",
+                "semantic_key": "run.summary"
+            })
+        );
+    }
+
+    /// `semantic_key` stays omitted rather than serialized as `null`, so
+    /// pre-collapse payloads compare equal.
+    #[test]
+    fn actionable_ref_omits_absent_semantic_key() {
+        let value = serde_json::to_value(CommandArtifactRef {
+            id: "log".to_string(),
+            kind: "log".to_string(),
+            uri: "homeboy://runs/run-1/artifact/log".to_string(),
+            semantic_key: None,
+        })
+        .expect("serialize artifact ref");
+
+        assert_eq!(
+            value,
+            json!({
+                "id": "log",
+                "kind": "log",
+                "uri": "homeboy://runs/run-1/artifact/log"
+            })
+        );
+    }
 
     #[test]
     fn preflight_failures_keep_resolved_nested_command_identity() {

--- a/crates/homeboy-core/src/artifact_contract.rs
+++ b/crates/homeboy-core/src/artifact_contract.rs
@@ -1,39 +1,21 @@
-//! Re-exports the pure artifact/evidence contract types from
-//! `homeboy-lifecycle-contract` and provides the conversions that couple them
-//! to core's observation records and `ArtifactRef` (which cannot live in the
-//! leaf contract crate).
-
-use std::collections::BTreeMap;
-
-use serde_json::Value;
+//! Re-exports the pure artifact contract type from `homeboy-lifecycle-contract`
+//! and provides the one conversion that couples it to `ArtifactRef`.
+//!
+//! Historically this module also carried `artifact_contract_from_record` and
+//! `artifact_contract_from_ref`, plus an `EvidenceContract` re-export. All three
+//! had zero call sites workspace-wide and were removed in #10310. The module
+//! docs also used to claim these conversions "cannot live in the leaf contract
+//! crate" because they couple to `ArtifactRecord` — but `ArtifactRecord` is
+//! itself defined in `homeboy-lifecycle-contract`. The real reason the surviving
+//! conversion lives here is `ArtifactRef`, which is owned by a *different* leaf
+//! crate (`homeboy-artifact-ref-contract`) that lifecycle-contract does not
+//! depend on.
 
 use crate::artifact_ref::{ArtifactRef, ARTIFACT_REF_SCHEMA};
-use crate::observation::ArtifactRecord;
 
 pub use homeboy_lifecycle_contract::artifact_contract::{
-    ArtifactContract, EvidenceContract, ARTIFACT_CONTRACT_SCHEMA, EVIDENCE_CONTRACT_SCHEMA,
+    ArtifactContract, ARTIFACT_CONTRACT_SCHEMA,
 };
-
-/// Build an [`ArtifactContract`] from an observation [`ArtifactRecord`].
-pub fn artifact_contract_from_record(record: &ArtifactRecord) -> ArtifactContract {
-    ArtifactContract {
-        schema: ARTIFACT_CONTRACT_SCHEMA.to_string(),
-        kind: record.kind.clone(),
-        artifact_type: record.artifact_type.clone(),
-        path: Some(record.path.clone()),
-        url: record.url.clone(),
-        public_url: record.public_url.clone(),
-        role: None,
-        label: None,
-        semantic_key: None,
-        size_bytes: record
-            .size_bytes
-            .and_then(|value| u64::try_from(value).ok()),
-        sha256: record.sha256.clone(),
-        metadata: record.metadata_json.clone(),
-        extra: BTreeMap::new(),
-    }
-}
 
 /// Convert an [`ArtifactContract`] into an [`ArtifactRef`].
 pub fn artifact_contract_to_ref(
@@ -60,21 +42,60 @@ pub fn artifact_contract_to_ref(
     }
 }
 
-/// Build an [`ArtifactContract`] from an [`ArtifactRef`].
-pub fn artifact_contract_from_ref(artifact: ArtifactRef) -> ArtifactContract {
-    ArtifactContract {
-        schema: ARTIFACT_CONTRACT_SCHEMA.to_string(),
-        kind: artifact.kind,
-        artifact_type: artifact.artifact_type,
-        path: Some(artifact.path),
-        url: artifact.url,
-        public_url: artifact.public_url,
-        role: artifact.role,
-        label: None,
-        semantic_key: artifact.semantic_key,
-        size_bytes: None,
-        sha256: None,
-        metadata: Value::Null,
-        extra: BTreeMap::new(),
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// `artifact_contract_to_ref` is the only surviving contract<->ref
+    /// conversion. `artifact_contract_from_record` and
+    /// `artifact_contract_from_ref` had zero call sites and were removed in
+    /// #10310 along with `EvidenceContract`.
+    #[test]
+    fn artifact_contract_to_ref_carries_target_and_semantics() {
+        let contract = ArtifactContract::from_value(json!({
+            "kind": "transcript",
+            "type": "json",
+            "path": "artifacts/run.json",
+            "public_url": "https://example.test/run.json",
+            "role": "primary-output",
+            "semantic_key": "task.transcript"
+        }))
+        .expect("artifact contract");
+
+        let reference = artifact_contract_to_ref(&contract, "artifact-1", "run-1");
+
+        assert_eq!(reference.schema, ARTIFACT_REF_SCHEMA);
+        assert_eq!(reference.id, "artifact-1");
+        assert_eq!(reference.run_id, "run-1");
+        assert_eq!(reference.kind, "transcript");
+        assert_eq!(reference.artifact_type, "json");
+        assert_eq!(reference.path, "artifacts/run.json");
+        assert_eq!(
+            reference.public_url.as_deref(),
+            Some("https://example.test/run.json")
+        );
+        assert_eq!(reference.role.as_deref(), Some("primary-output"));
+        assert_eq!(reference.semantic_key.as_deref(), Some("task.transcript"));
+        assert_eq!(
+            reference.canonical_uri(),
+            "homeboy://run/run-1/artifact/artifact-1"
+        );
+    }
+
+    /// A contract with no `path` still yields a non-empty ref target by falling
+    /// back to `url` then `public_url`.
+    #[test]
+    fn artifact_contract_to_ref_falls_back_to_url_for_the_ref_path() {
+        let contract = ArtifactContract::from_value(json!({
+            "kind": "log",
+            "url": "https://example.test/build.log"
+        }))
+        .expect("artifact contract");
+
+        let reference = artifact_contract_to_ref(&contract, "artifact-2", "run-2");
+
+        assert_eq!(reference.path, "https://example.test/build.log");
+        assert_eq!(reference.public_url, None);
     }
 }

--- a/crates/homeboy-core/src/run_outcome_envelope.rs
+++ b/crates/homeboy-core/src/run_outcome_envelope.rs
@@ -3,7 +3,8 @@ use serde_json::Value;
 
 use crate::api_jobs::JobArtifactMetadata;
 use crate::artifact_ref::{artifact_uri, ArtifactRef, EvidenceRef, ARTIFACT_REF_SCHEMA};
-use crate::runner_execution_envelope::{RunnerExecutionArtifactRef, RunnerExecutionRecord};
+use crate::lab_contract::LabRunnerWorkloadArtifactRef;
+use crate::runner_execution_envelope::RunnerExecutionRecord;
 use homeboy_lab_runner_contract::RunnerArtifactRef;
 
 pub const RUN_OUTCOME_ENVELOPE_SCHEMA: &str = "homeboy/run-outcome-envelope/v1";
@@ -115,7 +116,7 @@ impl RunOutcomeEnvelope {
     pub fn add_runner_execution_artifact_refs(
         &mut self,
         run_id: &str,
-        artifacts: impl IntoIterator<Item = RunnerExecutionArtifactRef>,
+        artifacts: impl IntoIterator<Item = LabRunnerWorkloadArtifactRef>,
     ) {
         for artifact in artifacts {
             self.push_artifact_ref(runner_execution_artifact_ref(run_id, artifact));
@@ -217,7 +218,7 @@ fn runner_artifact_ref(run_id: &str, artifact: RunnerArtifactRef) -> ArtifactRef
 
 fn runner_execution_artifact_ref(
     run_id: &str,
-    artifact: RunnerExecutionArtifactRef,
+    artifact: LabRunnerWorkloadArtifactRef,
 ) -> ArtifactRef {
     project_artifact_ref(
         run_id,
@@ -377,7 +378,7 @@ mod tests {
         let record = RunnerExecutionRecord::terminal("job-1", "lab-a", "daemon", 0)
             .with_job_id("job-1")
             .with_mirror_run_id(Some("run-1".to_string()))
-            .with_artifact_refs(vec![RunnerExecutionArtifactRef {
+            .with_artifact_refs(vec![LabRunnerWorkloadArtifactRef {
                 id: "report".to_string(),
                 name: Some("summary".to_string()),
                 path: Some("artifacts/summary.json".to_string()),
@@ -434,7 +435,7 @@ mod tests {
         );
         let execution = runner_execution_artifact_ref(
             "run-1",
-            RunnerExecutionArtifactRef {
+            LabRunnerWorkloadArtifactRef {
                 id: "execution".to_string(),
                 name: None,
                 path: None,

--- a/crates/homeboy-core/src/runner_execution_envelope.rs
+++ b/crates/homeboy-core/src/runner_execution_envelope.rs
@@ -5,9 +5,20 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::env_materialization_plan::EnvMaterializationPlan;
-use crate::lab_contract::{LabRunnerWorkload, LabRunnerWorkloadArtifactRef};
+use crate::lab_contract::LabRunnerWorkload;
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
+
+/// The one `{id, name, path, url}` artifact reference carried by runner
+/// execution records, projections, and lab workloads.
+///
+/// This module used to define its own `RunnerExecutionArtifactRef` with exactly
+/// these four fields and exactly these serde attributes, while the same file
+/// already imported `LabRunnerWorkloadArtifactRef` for
+/// `RunnerExecutionResultRefs.artifacts`. Two names, one shape, one file.
+/// Collapsed onto the leaf-contract type in #10310; the serialized shape is
+/// unchanged.
+pub use crate::lab_contract::LabRunnerWorkloadArtifactRef;
 
 pub const RUNNER_EXECUTION_ENVELOPE_SCHEMA: &str = "homeboy/runner-execution-envelope/v1";
 pub const RUNNER_EXECUTION_RECORD_SCHEMA: &str = "homeboy/runner-execution-record/v1";
@@ -129,7 +140,7 @@ pub struct RunnerExecutionRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub orchestration_provenance: Option<OrchestrationTargetProvenance>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifact_refs: Vec<RunnerExecutionArtifactRef>,
+    pub artifact_refs: Vec<LabRunnerWorkloadArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<RunnerExecutionNextAction>,
 }
@@ -154,7 +165,7 @@ pub struct RunnerExecutionProjection {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub materialized_paths: Vec<PathMaterializationProjection>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifact_refs: Vec<RunnerExecutionArtifactRef>,
+    pub artifact_refs: Vec<LabRunnerWorkloadArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<RunnerExecutionNextAction>,
 }
@@ -245,17 +256,6 @@ impl OrchestrationTargetProvenance {
         self.extensions = extensions;
         self
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerExecutionArtifactRef {
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -358,7 +358,7 @@ impl RunnerExecutionRecord {
 
     pub fn with_artifact_refs(
         mut self,
-        artifact_refs: impl IntoIterator<Item = RunnerExecutionArtifactRef>,
+        artifact_refs: impl IntoIterator<Item = LabRunnerWorkloadArtifactRef>,
     ) -> Self {
         self.artifact_refs = artifact_refs.into_iter().collect();
         self
@@ -702,7 +702,7 @@ mod tests {
         let record = RunnerExecutionRecord::terminal("job-1", "lab-a", "daemon", 0)
             .with_job_id("job-1")
             .with_mirror_run_id(Some("run-1".to_string()))
-            .with_artifact_refs(vec![RunnerExecutionArtifactRef {
+            .with_artifact_refs(vec![LabRunnerWorkloadArtifactRef {
                 id: "artifact-1".to_string(),
                 name: Some("report".to_string()),
                 path: Some("artifacts/report.json".to_string()),
@@ -864,5 +864,65 @@ mod tests {
             projection.materialized_paths[1].role,
             PATH_MATERIALIZATION_ROLE_REQUIRED_PATH
         );
+    }
+
+    /// #10310 collapsed `RunnerExecutionArtifactRef` onto
+    /// `LabRunnerWorkloadArtifactRef`. Both were `{id, name, path, url}` with
+    /// identical serde attributes, so records written by an older binary must
+    /// still deserialize and re-serialize byte-identically.
+    #[test]
+    fn runner_execution_record_artifact_refs_keep_the_pre_collapse_wire_shape() {
+        let payload = json!({
+            "schema": RUNNER_EXECUTION_RECORD_SCHEMA,
+            "execution_id": "job-1",
+            "runner_id": "lab-a",
+            "transport": "daemon",
+            "status": "succeeded",
+            "artifact_refs": [
+                {
+                    "id": "report",
+                    "name": "summary",
+                    "path": "artifacts/summary.json",
+                    "url": "https://example.test/summary.json"
+                },
+                { "id": "bare" }
+            ]
+        });
+
+        let record: RunnerExecutionRecord =
+            serde_json::from_value(payload.clone()).expect("legacy record deserializes");
+        assert_eq!(record.artifact_refs.len(), 2);
+        assert_eq!(record.artifact_refs[0].id, "report");
+        assert_eq!(record.artifact_refs[0].name.as_deref(), Some("summary"));
+        assert_eq!(
+            record.artifact_refs[0].path.as_deref(),
+            Some("artifacts/summary.json")
+        );
+        assert_eq!(record.artifact_refs[1].id, "bare");
+        assert_eq!(record.artifact_refs[1].name, None);
+
+        let reserialized = serde_json::to_value(&record).expect("record serializes");
+        assert_eq!(reserialized["artifact_refs"], payload["artifact_refs"]);
+    }
+
+    /// The lab workload result refs and the runner execution record refs are
+    /// now literally the same type, so a value crosses between them without a
+    /// field-by-field rebuild.
+    #[test]
+    fn workload_result_refs_and_execution_record_refs_share_one_type() {
+        let artifact = LabRunnerWorkloadArtifactRef {
+            id: "report".to_string(),
+            name: None,
+            path: Some("artifacts/summary.json".to_string()),
+            url: None,
+        };
+        let result_refs = RunnerExecutionResultRefs {
+            artifacts: vec![artifact.clone()],
+            ..Default::default()
+        };
+        let record = RunnerExecutionRecord::terminal("job-1", "lab-a", "daemon", 0)
+            .with_artifact_refs(result_refs.artifacts.iter().cloned());
+
+        assert_eq!(record.artifact_refs, vec![artifact]);
     }
 }

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -10,7 +10,9 @@ use crate::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_
 use homeboy_core::api_jobs::{Job, JobEvent, JobStatus, RunnerJobLifecycleMetadata};
 use homeboy_core::engine::command::CommandCaptureMetadata;
 use homeboy_core::error::{Error, ErrorCode, Result};
-use homeboy_core::lab_contract::{run_location_index_path, LabRunnerWorkload};
+use homeboy_core::lab_contract::{
+    run_location_index_path, LabRunnerWorkload, LabRunnerWorkloadArtifactRef,
+};
 use homeboy_core::redaction::redact_argv;
 use homeboy_core::source_snapshot::SourceSnapshot;
 
@@ -1384,7 +1386,7 @@ pub(super) fn detached_handoff_output(
                 Some(&source_snapshot),
                 &[],
             ))
-            .with_artifact_refs([RunnerExecutionArtifactRef {
+            .with_artifact_refs([LabRunnerWorkloadArtifactRef {
                 id: "run_location_index".to_string(),
                 name: Some("run location index".to_string()),
                 path: Some(run_location_index_path),

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -15,13 +15,12 @@ use homeboy_core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
 use homeboy_core::engine::command::CommandCaptureMetadata;
 use homeboy_core::env_materialization_plan::EnvMaterializationPlan;
 use homeboy_core::error::{Error, ErrorCode, Result};
-use homeboy_core::lab_contract::LabRunnerWorkload;
+use homeboy_core::lab_contract::{LabRunnerWorkload, LabRunnerWorkloadArtifactRef};
 use homeboy_core::observation::{NewRunRecord, ObservationStore, RunStatus};
 use homeboy_core::runner_execution_envelope::{
     BinaryProvenance, ExtensionProvenance, OrchestrationTargetProvenance, PathMaterializationEntry,
-    PathMaterializationPlan, RunnerExecutionArtifactRef, RunnerExecutionNextAction,
-    RunnerExecutionRecord, SourceSnapshotIdentity,
-    PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
+    PathMaterializationPlan, RunnerExecutionNextAction, RunnerExecutionRecord,
+    SourceSnapshotIdentity, PATH_MATERIALIZATION_OWNER_RUNNER_EXEC_SOURCE_SNAPSHOT,
 };
 use homeboy_core::secret_env_plan::SecretEnvPlan;
 use homeboy_core::source_snapshot::SourceSnapshot;
@@ -373,7 +372,7 @@ fn runner_execution_record_for_output(
     let mut artifact_refs = job_artifact_refs(artifacts);
     if let Some(result) = runner_result {
         artifact_refs.extend(result.artifact_refs.iter().map(|artifact| {
-            RunnerExecutionArtifactRef {
+            LabRunnerWorkloadArtifactRef {
                 id: artifact.artifact_id.clone(),
                 name: artifact.name.clone(),
                 path: artifact.path.clone(),
@@ -522,10 +521,10 @@ fn extension_provenance(required_extensions: &[String]) -> Vec<ExtensionProvenan
     extensions
 }
 
-fn job_artifact_refs(artifacts: &[JobArtifactMetadata]) -> Vec<RunnerExecutionArtifactRef> {
+fn job_artifact_refs(artifacts: &[JobArtifactMetadata]) -> Vec<LabRunnerWorkloadArtifactRef> {
     artifacts
         .iter()
-        .map(|artifact| RunnerExecutionArtifactRef {
+        .map(|artifact| LabRunnerWorkloadArtifactRef {
             id: artifact.id.clone(),
             name: artifact.name.clone(),
             path: artifact.path.clone(),

--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -6,7 +6,7 @@ Hand-written narrative for these commands lives in `docs/commands/`. -->
 
 # Homeboy CLI reference (generated)
 
-`homeboy` exposes 524 visible commands across 40 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
+`homeboy` exposes 523 visible commands across 40 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
 
 Hand-written narrative lives in the [commands index](../../../commands/commands-index.md). Global flags are documented in [the root command reference](../homeboy-root-command.md). Machine-readable safety, docs, output, and Lab metadata come from `homeboy contract manifest`.
 

--- a/docs/reference/cli/commands/runner.md
+++ b/docs/reference/cli/commands/runner.md
@@ -320,7 +320,7 @@ Inventory or remove stale managed Homeboy binary slots on a runner
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete eligible slots. Omit for inventory only |
-| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum slot age before an unselected slot is eligible |
+| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum slot age before an unselected slot is eligible. Defaults to the shared runner age floor (`cleanup::RUNNER_MIN_AGE_HOURS`) |
 
 ## `homeboy runner exec`
 
@@ -628,8 +628,8 @@ Preview or remove orphaned runner-side Lab workspaces
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete the previewed orphaned workspaces. Without this flag, the command is a dry run |
-| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum workspace age before it can be considered orphaned |
-| `--limit` | `<LIMIT>` | Maximum number of orphan candidates to report or remove |
+| `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum workspace age before it can be considered orphaned. Defaults to the shared runner age floor (`cleanup::RUNNER_MIN_AGE_HOURS`) |
+| `--limit` | `<LIMIT>` | Maximum number of orphan candidates to report or remove per pass. Defaults to the shared page size (`cleanup::RUNNER_WORKSPACE_PAGE_LIMIT`) |
 | `--passes` | `<PASSES>` | Maximum apply passes to run. Each pass re-scans and removes at most --limit candidates |
 | `--cursor` | `<CURSOR>` | Opaque continuation cursor returned by an incomplete workspace-prune scan |
 

--- a/docs/reference/cli/commands/runs.md
+++ b/docs/reference/cli/commands/runs.md
@@ -30,7 +30,6 @@ Inspect persisted observation runs and artifacts
 | `homeboy runs fuzz-compare` | Compare two persisted fuzz runs by exact run id |
 | `homeboy runs hotspots` | Aggregate hotspot rankings across persisted fuzz run artifacts |
 | `homeboy runs reconcile` | Mark orphaned running observation records stale |
-| `homeboy runs retention` | Plan or apply bounded retention of terminal observation rows and dependent records |
 | `homeboy runs watch` | Block and stream a run's status until it reaches a terminal state, exiting with a code that reflects pass/fail. Works for attached and detached/offloaded runs |
 | `homeboy runs cancel` | Cooperatively cancel a persisted foreground run before its next stage |
 | `homeboy runs show` | Show one persisted observation run |
@@ -188,20 +187,6 @@ Mark orphaned running observation records stale
 | --- | --- | --- |
 | `--dry-run` | flag | Preview orphaned running records without mutating them |
 | `--limit` | `<LIMIT>` | Maximum running records to inspect |
-
-## `homeboy runs retention`
-
-```sh
-homeboy runs retention [OPTIONS]
-```
-
-Plan or apply bounded retention of terminal observation rows and dependent records
-
-| Option | Value | Description |
-| --- | --- | --- |
-| `--apply` | flag | Delete the planned terminal rows. Without this flag, only reports the plan |
-| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include terminal runs finished more than this many days ago |
-| `--limit` | `<LIMIT>` | Maximum terminal run rows to inspect and remove in one invocation |
 
 ## `homeboy runs watch`
 
@@ -457,13 +442,13 @@ Plan or delete persisted local run artifacts and their database records
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete planned artifact files/directories and their DB rows. Without this flag, only reports the plan |
-| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include artifacts older than this many days |
+| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include artifacts older than this many days. Defaults to the configured `retention.terminal_run_days` |
 | `--run-id` | `<RUN_ID>` | Limit cleanup to one run id |
 | `--kind` | `<KIND>` | Limit cleanup to one artifact kind |
 | `--type` | `<ARTIFACT_TYPE>` | Limit cleanup to one artifact type (`file` or `directory`) |
 | `--run-kind` | `<RUN_KIND>` | Limit cleanup to one run kind (`bench`, `trace`, etc.) |
 | `--component` | `<COMPONENT_ID>` | Limit cleanup to one component id |
-| `--limit` | `<LIMIT>` | Maximum artifact rows to inspect in one invocation |
+| `--limit` | `<LIMIT>` | Maximum artifact rows to inspect in one invocation. Defaults to the configured `retention.limit` |
 
 ## `homeboy runs artifact postprocess`
 

--- a/docs/reference/cli/commands/self.md
+++ b/docs/reference/cli/commands/self.md
@@ -63,11 +63,11 @@ Plan or delete orphaned Homeboy runtime temp entries
 | Option | Value | Description |
 | --- | --- | --- |
 | `--apply` | flag | Delete planned temp entries. Without this flag, only reports the plan |
-| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include entries older than this many days |
+| `--older-than-days` | `<OLDER_THAN_DAYS>` | Only include entries older than this many days. Defaults to the configured `retention.runtime_tmp_days` |
 | `--prefix` | `<PREFIX>` | Only include entries whose directory/file name starts with this prefix |
-| `--limit` | `<LIMIT>` | Maximum temp entries to inspect in one invocation |
-| `--run-max-bytes` | `<RUN_MAX_BYTES>` | Maximum aggregate bytes retained for failed runtime run evidence |
-| `--run-max-count` | `<RUN_MAX_COUNT>` | Maximum failed runtime run directories retained |
+| `--limit` | `<LIMIT>` | Maximum temp entries to inspect in one invocation. Defaults to the configured `retention.limit` |
+| `--run-max-bytes` | `<RUN_MAX_BYTES>` | Maximum aggregate bytes retained for failed runtime run evidence. Defaults to the configured `retention.runtime_run_max_bytes` |
+| `--run-max-count` | `<RUN_MAX_COUNT>` | Maximum failed runtime run directories retained. Defaults to the configured `retention.runtime_run_max_count` |
 | `--cursor` | `<CURSOR>` | Continue bounded runtime-run inspection from a prior next_cursor |
 
 ## `homeboy self docs`


### PR DESCRIPTION
Closes #10310.

Collapses five structurally identical artifact-reference types onto one primitive, and refreshes the generated CLI reference that was already stale on main.

Authored by a cook that was interrupted before it could open the PR, so the PR body is thinner than usual — the commits carry the reasoning. CI is the gate.