### PR TITLE
refactor(lab-runner): convert the last provider singleton

### DIFF
--- a/crates/homeboy-engine-primitives/src/provider_registry.rs
+++ b/crates/homeboy-engine-primitives/src/provider_registry.rs
@@ -54,6 +54,8 @@
 //! `provider_registry_arc!` — `Arc` provider whose accessor clones the `Arc`
 //! out, so the registry lock is released before a (potentially long-running)
 //! call. Used where holding the lock across the call would serialize real work.
+//! Its `optional:` form is the `Arc` counterpart of `with_optional:`: no no-op,
+//! accessor yields `Option<Arc<dyn Trait>>`.
 
 /// Declare a process-global boxed provider registry.
 ///
@@ -134,6 +136,13 @@ macro_rules! provider_registry {
 /// `Arc` out before returning, releasing the registry lock so it is not held
 /// across the provider call.
 ///
+/// Two forms, mirroring [`provider_registry!`]:
+///
+/// - `noop: <expr>` + `active:` — the accessor always yields an `Arc`, falling
+///   back to a freshly-allocated no-op.
+/// - `optional:` (no `noop:`) — the accessor yields `Option<Arc<dyn Trait>>` so
+///   each caller supplies its own "provider absent" behavior.
+///
 /// A poisoned lock always recovers via `into_inner()`.
 #[macro_export]
 macro_rules! provider_registry_arc {
@@ -145,14 +154,7 @@ macro_rules! provider_registry_arc {
         $(#[$active_meta:meta])*
         active: $active_vis:vis fn $active:ident $(,)?
     ) => {
-        fn provider_slot() -> &'static ::std::sync::Mutex<
-            ::std::option::Option<::std::sync::Arc<dyn $provider>>,
-        > {
-            static PROVIDER: ::std::sync::Mutex<
-                ::std::option::Option<::std::sync::Arc<dyn $provider>>,
-            > = ::std::sync::Mutex::new(::std::option::Option::None);
-            &PROVIDER
-        }
+        $crate::__provider_registry_arc_slot!($provider);
 
         $(#[$register_meta])*
         $register_vis fn $register(provider: ::std::sync::Arc<dyn $provider>) {
@@ -171,6 +173,50 @@ macro_rules! provider_registry_arc {
                 ::std::option::Option::Some(provider) => ::std::sync::Arc::clone(provider),
                 ::std::option::Option::None => ::std::sync::Arc::new($noop),
             }
+        }
+    };
+
+    (
+        provider: dyn $provider:path,
+        $(#[$register_meta:meta])*
+        register: $register_vis:vis fn $register:ident,
+        $(#[$active_meta:meta])*
+        optional: $active_vis:vis fn $active:ident $(,)?
+    ) => {
+        $crate::__provider_registry_arc_slot!($provider);
+
+        $(#[$register_meta])*
+        $register_vis fn $register(provider: ::std::sync::Arc<dyn $provider>) {
+            let mut slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *slot = ::std::option::Option::Some(provider);
+        }
+
+        $(#[$active_meta])*
+        $active_vis fn $active(
+        ) -> ::std::option::Option<::std::sync::Arc<dyn $provider>> {
+            let slot = provider_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            slot.as_ref().map(::std::sync::Arc::clone)
+        }
+    };
+}
+
+/// Internal: the `Arc` slot accessor shared by both `provider_registry_arc!`
+/// forms. The `static` lives inside the function body so it cannot collide with
+/// any module-level item at the expansion site.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __provider_registry_arc_slot {
+    ($provider:path) => {
+        fn provider_slot(
+        ) -> &'static ::std::sync::Mutex<::std::option::Option<::std::sync::Arc<dyn $provider>>> {
+            static PROVIDER: ::std::sync::Mutex<
+                ::std::option::Option<::std::sync::Arc<dyn $provider>>,
+            > = ::std::sync::Mutex::new(::std::option::Option::None);
+            &PROVIDER
         }
     };
 }
@@ -240,5 +286,52 @@ mod tests {
         .join();
         assert!(provider_slot().is_poisoned());
         assert_eq!(with_greeter(|g| g.greet()), "real");
+    }
+
+    // A second registry in the same module would collide on the generated
+    // `provider_slot`, so the `Arc` forms get their own modules.
+    mod arc_optional {
+        use super::Greeter;
+        use std::sync::Arc;
+
+        struct RealGreeter;
+
+        impl Greeter for RealGreeter {
+            fn greet(&self) -> String {
+                "real".to_string()
+            }
+        }
+
+        crate::provider_registry_arc! {
+            provider: dyn Greeter,
+            /// Register the greeter used by this test module.
+            register: pub(crate) fn register_greeter,
+            /// The registered greeter, if any.
+            optional: fn active_greeter,
+        }
+
+        // One test: the registry is a process global, so splitting these would
+        // make them order-dependent on each other.
+        #[test]
+        fn yields_none_registers_and_survives_a_poisoned_lock() {
+            assert!(active_greeter().is_none());
+
+            register_greeter(Arc::new(RealGreeter));
+            assert_eq!(
+                active_greeter().map(|g| g.greet()),
+                Some("real".to_string())
+            );
+
+            let _ = std::thread::spawn(|| {
+                let _guard = provider_slot().lock().unwrap();
+                panic!("poison the registry lock");
+            })
+            .join();
+            assert!(provider_slot().is_poisoned());
+            assert_eq!(
+                active_greeter().map(|g| g.greet()),
+                Some("real".to_string())
+            );
+        }
     }
 }

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3561,35 +3561,28 @@ impl LabStagingExecutionAdapter for StageExecutionAdapter {
     }
 }
 
-fn adapter_slot() -> &'static Mutex<Option<Arc<dyn LabStagingExecutionAdapter>>> {
-    static ADAPTER: OnceLock<Mutex<Option<Arc<dyn LabStagingExecutionAdapter>>>> = OnceLock::new();
-    ADAPTER.get_or_init(|| Mutex::new(None))
-}
-
-/// Install an execution adapter after its owner has registered the driver.
-pub(crate) fn install_production_execution_adapter(adapter: Arc<dyn LabStagingExecutionAdapter>) {
-    *adapter_slot().lock().expect("Lab staging adapter lock") = Some(adapter);
+homeboy_engine_primitives::provider_registry_arc! {
+    provider: dyn LabStagingExecutionAdapter,
+    /// Install an execution adapter after its owner has registered the driver.
+    register: pub(crate) fn install_production_execution_adapter,
+    /// The installed production execution adapter, if any. There is no no-op
+    /// adapter: an absent adapter means routing is not ready, which every
+    /// caller below reports in its own shape.
+    optional: fn installed_production_adapter,
 }
 
 pub(crate) fn require_production_adapter() -> Result<Arc<dyn LabStagingExecutionAdapter>> {
-    adapter_slot()
-        .lock()
-        .expect("Lab staging adapter lock")
-        .clone()
-        .ok_or_else(|| {
-            Error::internal_unexpected(
-                "Lab staging controller is registered but its production execution adapter is unavailable",
-            )
-        })
+    installed_production_adapter().ok_or_else(|| {
+        Error::internal_unexpected(
+            "Lab staging controller is registered but its production execution adapter is unavailable",
+        )
+    })
 }
 
 /// Registration makes the durable driver available to its owner. Traffic stays
 /// disabled until every subsequent stage has a production implementation.
 pub(crate) fn routing_ready() -> bool {
-    adapter_slot()
-        .lock()
-        .expect("Lab staging adapter lock")
-        .is_some()
+    installed_production_adapter().is_some()
 }
 
 /// Enable the production staging implementation after generic driver
@@ -3827,6 +3820,15 @@ mod tests {
     use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Drop whatever adapter a previous test installed. The registry is a
+    /// process global, so tests that assert the "no adapter installed" branch
+    /// have to clear it explicitly.
+    fn clear_installed_adapter() {
+        *provider_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
 
     fn recipe_command() -> LabOffloadCommand {
         LabOffloadCommand {
@@ -5300,7 +5302,7 @@ mod tests {
                 .expect("recreated cancellation token")
                 .is_cancelled());
             assert_eq!(cancelled.load(Ordering::SeqCst), 1);
-            *adapter_slot().lock().expect("adapter lock") = None;
+            clear_installed_adapter();
             cancellations()
                 .lock()
                 .expect("lock")
@@ -5353,7 +5355,7 @@ mod tests {
     #[test]
     fn production_adapter_readiness_fails_closed_when_uninstalled() {
         let _serial = global_state_lock().lock().expect("lock");
-        *adapter_slot().lock().expect("lock") = None;
+        clear_installed_adapter();
         assert!(require_production_adapter().is_err());
     }
 
@@ -5671,7 +5673,7 @@ mod tests {
     #[test]
     fn registration_keeps_lab_routing_disabled_without_submission_hook() {
         let _serial = global_state_lock().lock().expect("lock");
-        *adapter_slot().lock().expect("adapter lock") = None;
+        clear_installed_adapter();
         register();
         assert!(!routing_ready());
     }
@@ -5679,11 +5681,11 @@ mod tests {
     #[test]
     fn production_enablement_installs_the_staging_adapter() {
         let _serial = global_state_lock().lock().expect("lock");
-        *adapter_slot().lock().expect("adapter lock") = None;
+        clear_installed_adapter();
         register();
         enable_production_routing();
         assert!(routing_ready());
-        *adapter_slot().lock().expect("adapter lock") = None;
+        clear_installed_adapter();
     }
 
     #[test]


### PR DESCRIPTION
Closes #10293.

Converts the final provider singleton to `provider_registry_arc!`, completing the 35/35 started in #10411.

Authored by a cook that was interrupted before opening the PR. CI is the gate.