### PR TITLE
Allow intentional assetless GitHub Releases

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/delivery.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/delivery.rs
@@ -24,15 +24,12 @@ pub(crate) enum ExistingReleaseAction {
     /// Published release and nothing to attach in this run: a genuine
     /// idempotent no-op.
     AlreadyPublished,
-    /// Unpublished Draft carrying assets, with nothing further to attach. The
-    /// artifacts were already uploaded (by this pipeline's earlier publish
-    /// stage or a previous attempt); publishing is the only remaining action
-    /// that makes the pushed tag deliverable.
+    /// Unpublished Draft ready to publish, either because its assets were
+    /// already uploaded or because the component does not declare an artifact.
     PublishDraft,
-    /// Unpublished Draft with no assets, and nothing to attach. Publishing here
-    /// would mark an empty release `latest` and point every downloader at a
-    /// release with no binaries — strictly worse than the Draft. Fail loudly
-    /// instead and hand the operator the repair commands.
+    /// Unpublished Draft for an artifact-expecting component with no assets and
+    /// nothing to attach. Publishing here would mark an incomplete release
+    /// `latest`, so fail loudly and hand the operator the repair commands.
     EmptyDraft,
     /// This run carries artifacts. Reconcile and verify the assets first; the
     /// publish decision is made only after verification succeeds.
@@ -42,11 +39,13 @@ pub(crate) enum ExistingReleaseAction {
 /// Classify an already-existing GitHub Release.
 ///
 /// `has_artifacts` is whether *this run* resolved release artifacts to attach;
-/// `existing_asset_count` is how many assets the release already carries.
+/// `existing_asset_count` is how many assets the release already carries;
+/// `expects_artifacts` reflects whether the component declares a build artifact.
 pub(crate) fn existing_release_action(
     is_draft: bool,
     has_artifacts: bool,
     existing_asset_count: usize,
+    expects_artifacts: bool,
 ) -> ExistingReleaseAction {
     if has_artifacts {
         return ExistingReleaseAction::ReconcileAssets;
@@ -54,7 +53,7 @@ pub(crate) fn existing_release_action(
     if !is_draft {
         return ExistingReleaseAction::AlreadyPublished;
     }
-    if existing_asset_count == 0 {
+    if existing_asset_count == 0 && expects_artifacts {
         return ExistingReleaseAction::EmptyDraft;
     }
     ExistingReleaseAction::PublishDraft

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -279,7 +279,12 @@ pub(crate) fn run_github_release(
             ));
         }
 
-        match existing_release_action(metadata.is_draft, has_artifacts, metadata.assets.len()) {
+        match existing_release_action(
+            metadata.is_draft,
+            has_artifacts,
+            metadata.assets.len(),
+            component.build_artifact.is_some(),
+        ) {
             ExistingReleaseAction::AlreadyPublished => {
                 homeboy_core::log_status!(
                     "release",
@@ -295,10 +300,8 @@ pub(crate) fn run_github_release(
                 ));
             }
             ExistingReleaseAction::EmptyDraft => {
-                // Publishing an assetless draft would make it `latest` and send
-                // every downloader (and the Homebrew formula) to a release with
-                // no binaries. That is worse than leaving the draft for the
-                // recovery path, which can still upload artifacts into it.
+                // The component declares a downloadable artifact, so publishing
+                // its empty draft would make an incomplete release `latest`.
                 let repair = repair_commands(None, None);
                 let detail = format!(
                     "GitHub Release {} for {} is an unpublished draft with no assets, and this run has no artifacts to attach. Refusing to publish an empty release over the pushed tag.",

--- a/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
@@ -20,7 +20,7 @@ use super::super::{existing_release_action, ExistingReleaseAction};
 #[test]
 fn published_release_with_nothing_to_attach_is_an_idempotent_no_op() {
     assert_eq!(
-        existing_release_action(false, false, 13),
+        existing_release_action(false, false, 13, true),
         ExistingReleaseAction::AlreadyPublished
     );
 }
@@ -31,7 +31,7 @@ fn published_release_with_no_assets_is_still_an_idempotent_no_op() {
     // assets is a delivery problem for `verify-published` to report, not a
     // reason for this step to re-publish something already public.
     assert_eq!(
-        existing_release_action(false, false, 0),
+        existing_release_action(false, false, 0, true),
         ExistingReleaseAction::AlreadyPublished
     );
 }
@@ -42,24 +42,32 @@ fn stranded_draft_carrying_assets_is_published_not_skipped() {
     // already uploaded every asset, and only the un-draft edit is missing.
     // Reporting `skipped` here is what let those tags sit undeliverable.
     assert_eq!(
-        existing_release_action(true, false, 15),
+        existing_release_action(true, false, 15, true),
         ExistingReleaseAction::PublishDraft
     );
     assert_eq!(
-        existing_release_action(true, false, 1),
+        existing_release_action(true, false, 1, true),
         ExistingReleaseAction::PublishDraft
     );
 }
 
 #[test]
-fn empty_draft_is_refused_rather_than_published() {
+fn empty_draft_for_artifact_component_is_refused_rather_than_published() {
     // Publishing an assetless draft marks it `latest` and points every
     // downloader (and the Homebrew formula) at a release with no binaries.
     // That is strictly worse than leaving the draft for the recovery path,
     // which can still upload artifacts into it.
     assert_eq!(
-        existing_release_action(true, false, 0),
+        existing_release_action(true, false, 0, true),
         ExistingReleaseAction::EmptyDraft
+    );
+}
+
+#[test]
+fn empty_draft_for_assetless_component_is_published() {
+    assert_eq!(
+        existing_release_action(true, false, 0, false),
+        ExistingReleaseAction::PublishDraft
     );
 }
 
@@ -71,7 +79,7 @@ fn a_run_carrying_artifacts_always_reconciles_before_any_publish_decision() {
     for is_draft in [true, false] {
         for existing in [0usize, 1, 15] {
             assert_eq!(
-                existing_release_action(is_draft, true, existing),
+                existing_release_action(is_draft, true, existing, true),
                 ExistingReleaseAction::ReconcileAssets,
                 "is_draft={is_draft} existing_assets={existing}"
             );
@@ -86,7 +94,7 @@ fn no_input_combination_reports_a_draft_as_already_published() {
     for existing in [0usize, 1, 13, 15] {
         for has_artifacts in [true, false] {
             assert_ne!(
-                existing_release_action(true, has_artifacts, existing),
+                existing_release_action(true, has_artifacts, existing, true),
                 ExistingReleaseAction::AlreadyPublished,
                 "a draft must never classify as published (has_artifacts={has_artifacts}, existing_assets={existing})"
             );


### PR DESCRIPTION
## Summary
Let Homeboy publish an existing empty draft when the component does not declare a release artifact, while retaining fail-closed recovery for artifact-bearing components.

## What changed
- Pass the component's declared build-artifact expectation into the existing-release decision.
- Publish empty drafts for intentional assetless components and continue blocking empty drafts for artifact-expecting components.
- Extend the pure delivery-policy matrix with explicit assetless and artifact-bearing cases.

## How to test
1. Run `cargo fmt --check`; expect Formatting is clean..
2. Run `cargo test -p homeboy-release delivery_tests`; expect All seven GitHub release delivery-policy tests pass..

## Compatibility
Artifact-bearing releases retain their current empty-draft safety gate; runs with artifacts, drafts with existing assets, and already-published releases preserve existing behavior.

## Evidence
- Base advanced after verification: verified main at 60d3b49b6dd4a7178830a001db50df4aeeb573a0; publication observed 70e8fab3b3161dc3235d9ab6fb87eea7a5c188b8. Candidate ancestry was validated against the verified snapshot.
- CI expected: Homeboy
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/10578
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/homeboy-extensions/actions/runs/30357098784
- Reviewer-resolvable evidence from source\_refs\[2\]: https://github.com/Extra-Chill/homeboy-extensions/releases/tag/wordpress-v3.34.8
- Verified finalization base: main at 60d3b49b6dd4a7178830a001db50df4aeeb573a0
- github-release-delivery: passed (7 policy tests) (Passed)
- rustfmt: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** I traced the source-only extension release against Homeboy's artifact-bearing recovery invariant, identified the missing component-contract discriminator, implemented the narrow policy input, and verified both sides of the decision matrix.

## Source relationships
- Closes Extra-Chill/homeboy#10578
