### PR TITLE
fix: recover substantive Cook candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -653,6 +653,7 @@ pub(crate) fn record_aggregate(
     crate::controller_scratch::finalize_run(&record.run_id)?;
     store::write_aggregate_and_record(record, aggregate)?;
     record_terminal_artifact_projection(record, aggregate)?;
+    update_cook_candidate_after_completion(record, aggregate, None)?;
     Ok(record.clone())
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1105,6 +1105,7 @@ pub fn reconcile_terminal_artifact_projection(run_id: &str) -> Result<bool> {
     let _plan = store::read_controller_plan(&record.run_id)?;
     let aggregate = store::read_aggregate(&record.run_id)?;
     record_terminal_artifact_projection(&mut record, &aggregate)?;
+    update_cook_candidate_after_completion(&record, &aggregate, None)?;
     Ok(true)
 }
 
@@ -1720,8 +1721,26 @@ pub fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
     store::read_aggregate(&run_id)
 }
 
+/// Read an immutable attempt directly; unlike `read_aggregate`, this never
+/// treats a Cook ID as an alias for its latest attempt.
+pub fn read_attempt_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
+    store::read_aggregate(&sanitize_run_id(run_id))
+}
+
 pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
-    let record = status(run_id)?;
+    let selected_run_id = match cook_index(run_id).and_then(|_| select_cook_candidate(run_id)) {
+        Ok(selection) if selection.incomplete => {
+            return Err(Error::validation_invalid_argument(
+                "cook_id",
+                "candidate selection is incomplete after its bounded recovery window",
+                Some(run_id.to_string()),
+                None,
+            ));
+        }
+        Ok(selection) if !selection.run_id.is_empty() => selection.run_id,
+        _ => run_id.to_string(),
+    };
+    let record = status(&selected_run_id)?;
     record.aggregate_path.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
@@ -1755,7 +1774,15 @@ pub fn record_cook_attempt(
     metadata.insert("cook_id".to_string(), json!(sanitize_run_id(cook_id)));
     metadata.insert("cook_attempt".to_string(), json!(attempt));
     store::write_record(&record)?;
-    store::write_cook_index_attempt(cook_id, attempt, run_id, recorded_at)
+    // Completion can precede Cook registration during handoff recovery. Re-read
+    // its persisted aggregate after the Cook identity is durable, then commit the
+    // attempt and substantive pointer in the same index write.
+    let candidate = store::read_aggregate(&record.run_id)
+        .ok()
+        .and_then(|aggregate| {
+            substantive_candidate_from_aggregate(&record.run_id, attempt, &aggregate, None)
+        });
+    store::write_cook_index_attempt(cook_id, attempt, run_id, recorded_at, candidate)
 }
 
 /// Record the controller-owned boundary that a resumed Cook must advance.
@@ -1790,6 +1817,283 @@ pub fn record_cook_recovery_checkpoint(
 
 pub fn cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
     store::read_cook_index(&sanitize_run_id(cook_id))
+}
+
+#[cfg(test)]
+pub(crate) fn replace_cook_index_for_test(index: &AgentTaskCookIndex) -> Result<()> {
+    store::write_cook_index_for_test(index)
+}
+
+/// The bounded controller-owned answer to which Cook attempt still owns a
+/// candidate. The mutable latest-attempt alias is chronological history, not
+/// candidate authority: a later metadata-only attempt must not erase a patch.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCookCandidateSelection {
+    pub schema: String,
+    pub cook_id: String,
+    pub run_id: String,
+    pub attempt: u32,
+    pub latest_attempt_run_id: String,
+    pub reason: String,
+    #[serde(default)]
+    pub incomplete: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped_newer_attempts: Vec<AgentTaskCookCandidateSkippedAttempt>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped_newer_run_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCookCandidateSkippedAttempt {
+    pub run_id: String,
+    pub reason: String,
+}
+
+const COOK_CANDIDATE_SELECTION_WINDOW: usize = 64;
+
+/// Select the latest attempt with controller-readable actionable patch bytes.
+/// Ties use run ID so duplicate attempt numbers remain deterministic. When no
+/// attempt has candidate bytes, retain the legacy latest attempt for old runs.
+pub fn select_cook_candidate(cook_id: &str) -> Result<AgentTaskCookCandidateSelection> {
+    let index = cook_index(cook_id)?;
+    if let Some(candidate) = index.latest_substantive_candidate.as_ref() {
+        if substantive_candidate(&candidate.run_id).as_ref()
+            == Some(&(candidate.task_id.clone(), candidate.artifact_id.clone()))
+        {
+            return Ok(AgentTaskCookCandidateSelection {
+                schema: "homeboy/agent-task-cook-candidate-selection/v1".to_string(),
+                cook_id: index.cook_id,
+                run_id: candidate.run_id.clone(),
+                attempt: candidate.attempt,
+                latest_attempt_run_id: index.latest_run_id,
+                reason: "latest_substantive_candidate_pointer".to_string(),
+                incomplete: false,
+                selected_task_id: Some(candidate.task_id.clone()),
+                selected_artifact_id: Some(candidate.artifact_id.clone()),
+                skipped_newer_attempts: Vec::new(),
+                skipped_newer_run_ids: Vec::new(),
+            });
+        }
+    }
+    // Legacy indexes predate the durable pointer. Their recovery path reads at
+    // most this fixed tail window and reports incomplete rather than widening.
+    let attempts = index
+        .attempts
+        .iter()
+        .rev()
+        .take(COOK_CANDIDATE_SELECTION_WINDOW)
+        .collect::<Vec<_>>();
+    let latest_attempt_run_id = index.latest_run_id.clone();
+    let mut skipped_newer_run_ids = Vec::new();
+    let mut skipped_newer_attempts = Vec::new();
+    for attempt in attempts.iter().take(COOK_CANDIDATE_SELECTION_WINDOW) {
+        if let Some((task_id, artifact_id)) = substantive_candidate(&attempt.run_id) {
+            return Ok(AgentTaskCookCandidateSelection {
+                schema: "homeboy/agent-task-cook-candidate-selection/v1".to_string(),
+                cook_id: index.cook_id,
+                run_id: attempt.run_id.clone(),
+                attempt: attempt.attempt,
+                latest_attempt_run_id,
+                reason: if skipped_newer_run_ids.is_empty() {
+                    "latest_attempt_has_substantive_candidate".to_string()
+                } else {
+                    "latest_substantive_candidate_after_non_substantive_attempts".to_string()
+                },
+                incomplete: false,
+                selected_task_id: Some(task_id),
+                selected_artifact_id: Some(artifact_id),
+                skipped_newer_attempts,
+                skipped_newer_run_ids,
+            });
+        }
+        skipped_newer_run_ids.push(attempt.run_id.clone());
+        skipped_newer_attempts.push(AgentTaskCookCandidateSkippedAttempt {
+            run_id: attempt.run_id.clone(),
+            reason: "no_verified_canonical_promotable_patch".to_string(),
+        });
+    }
+    if index.attempts.len() > COOK_CANDIDATE_SELECTION_WINDOW {
+        return Ok(AgentTaskCookCandidateSelection {
+            schema: "homeboy/agent-task-cook-candidate-selection/v1".to_string(),
+            cook_id: index.cook_id,
+            run_id: String::new(),
+            attempt: 0,
+            latest_attempt_run_id,
+            reason: "selection_window_exhausted_without_promotable_candidate".to_string(),
+            incomplete: true,
+            selected_task_id: None,
+            selected_artifact_id: None,
+            skipped_newer_attempts,
+            skipped_newer_run_ids,
+        });
+    }
+    let latest = attempts.first().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "cook_id",
+            "durable Cook index has no attempts",
+            Some(cook_id.to_string()),
+            None,
+        )
+    })?;
+    Ok(AgentTaskCookCandidateSelection {
+        schema: "homeboy/agent-task-cook-candidate-selection/v1".to_string(),
+        cook_id: index.cook_id,
+        run_id: latest.run_id.clone(),
+        attempt: latest.attempt,
+        latest_attempt_run_id,
+        reason: "no_substantive_candidate_evidence_preserve_latest_attempt_compatibility"
+            .to_string(),
+        incomplete: false,
+        selected_task_id: None,
+        selected_artifact_id: None,
+        skipped_newer_attempts,
+        skipped_newer_run_ids,
+    })
+}
+
+pub(crate) fn update_cook_candidate_after_completion(
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+    promotion: Option<Value>,
+) -> Result<()> {
+    let Some(cook_id) = record.metadata.get("cook_id").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let Some(attempt) = record.metadata.get("cook_attempt").and_then(Value::as_u64) else {
+        return Ok(());
+    };
+    let Some(candidate) =
+        substantive_candidate_from_aggregate(&record.run_id, attempt as u32, aggregate, promotion)
+    else {
+        return Ok(());
+    };
+    store::update_cook_index(cook_id, |index| {
+        replace_latest_substantive_candidate(index, candidate)
+    })?;
+    Ok(())
+}
+
+fn replace_latest_substantive_candidate(
+    index: &mut AgentTaskCookIndex,
+    candidate: AgentTaskCookLatestSubstantiveCandidate,
+) -> bool {
+    let replace = index
+        .latest_substantive_candidate
+        .as_ref()
+        .is_none_or(|current| {
+            candidate.attempt > current.attempt
+                || (candidate.attempt == current.attempt && candidate.run_id >= current.run_id)
+        });
+    if replace {
+        index.latest_substantive_candidate = Some(candidate);
+    }
+    replace
+}
+
+fn substantive_candidate_from_aggregate(
+    run_id: &str,
+    attempt: u32,
+    aggregate: &AgentTaskAggregate,
+    promotion: Option<Value>,
+) -> Option<AgentTaskCookLatestSubstantiveCandidate> {
+    let (task_id, artifact_id) = substantive_candidate_in_aggregate(run_id, aggregate)?;
+    let outcome = aggregate
+        .outcomes
+        .iter()
+        .find(|outcome| outcome.task_id == task_id)?;
+    let artifact = outcome
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.id == artifact_id)?;
+    let promotion_provenance = promotion
+        .as_ref()
+        .and_then(|value| value.get("provenance").cloned());
+    let destination_provenance = promotion.as_ref().map(|value| {
+        json!({
+            "to_worktree": value.get("to_worktree"),
+            "target": value.get("target"),
+        })
+    });
+    Some(AgentTaskCookLatestSubstantiveCandidate {
+        schema: "homeboy/agent-task-cook-latest-substantive-candidate/v1".to_string(),
+        run_id: run_id.to_string(),
+        attempt,
+        task_id,
+        artifact_id,
+        artifact_kind: artifact.kind.clone(),
+        artifact_sha256: artifact.sha256.clone(),
+        artifact_size_bytes: artifact.size_bytes,
+        integrity: json!({
+            "sha256": artifact.sha256,
+            "size_bytes": artifact.size_bytes,
+            "controller_projection": "verified",
+            "canonical_patch": true,
+        }),
+        promotion_provenance,
+        destination_provenance,
+        recorded_at: now_timestamp(),
+    })
+}
+
+fn substantive_candidate(run_id: &str) -> Option<(String, String)> {
+    // Candidate recovery is a bounded scan. Avoid the aggregate reader's
+    // reconciliation path when this controller record never projected one.
+    let record = exact_record(run_id).ok()?;
+    let aggregate_path = record.aggregate_path?;
+    if !std::path::Path::new(&aggregate_path).exists() {
+        return None;
+    }
+    let Ok(aggregate) = store::read_aggregate(run_id) else {
+        return None;
+    };
+    substantive_candidate_in_aggregate(run_id, &aggregate)
+}
+
+fn substantive_candidate_in_aggregate(
+    run_id: &str,
+    aggregate: &AgentTaskAggregate,
+) -> Option<(String, String)> {
+    let outcome = aggregate.selected_outcome().or_else(|| {
+        (aggregate.outcomes.len() == 1)
+            .then(|| aggregate.outcomes.first())
+            .flatten()
+    });
+    let Some(outcome) = outcome else {
+        return None;
+    };
+    // Metadata alone (and typed artifact envelopes) cannot authorize recovery.
+    // Selection requires controller-readable bytes that pass the same integrity
+    // and canonical patch normalization used by promotion.
+    outcome.artifacts.iter().find_map(|artifact| {
+        if !crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact) {
+            return None;
+        }
+        let Some(path) = crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
+            run_id,
+            &outcome.task_id,
+            artifact,
+        )
+        .ok()
+        .flatten() else {
+            return None;
+        };
+        std::fs::canonicalize(path)
+            .ok()
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .and_then(|bytes| {
+                (crate::agent_task_promotion::validate_artifact_content(artifact, &bytes).is_ok()
+                    && crate::agent_task_promotion::normalize_promotion_patch(
+                        &bytes,
+                        "candidate-selection",
+                    )
+                    .is_ok_and(|patch| !patch.content.trim().is_empty()))
+                .then(|| (outcome.task_id.clone(), artifact.id.clone()))
+            })
+    })
 }
 
 /// Read one durable attempt without resolving a cook ID through its latest
@@ -1832,13 +2136,17 @@ pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRe
             .as_array_mut()
             .expect("promotions array")
             .push(promotion.clone());
-        metadata.insert("latest_promotion".to_string(), promotion);
+        metadata.insert("latest_promotion".to_string(), promotion.clone());
         true
     })?;
-    match record {
-        Some(record) => Ok(record),
-        None => store::read_record(&run_id),
+    let record = match record {
+        Some(record) => record,
+        None => store::read_record(&run_id)?,
+    };
+    if let Ok(aggregate) = store::read_aggregate(&run_id) {
+        update_cook_candidate_after_completion(&record, &aggregate, Some(promotion))?;
     }
+    Ok(record)
 }
 
 /// Persist the controller publication result separately from promotion so a

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -201,8 +201,32 @@ pub struct AgentTaskCookIndex {
     pub schema: String,
     pub cook_id: String,
     pub latest_run_id: String,
+    /// The latest completed attempt with controller-validated canonical patch
+    /// bytes. Unlike `latest_run_id`, empty retries never replace this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_substantive_candidate: Option<AgentTaskCookLatestSubstantiveCandidate>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub attempts: Vec<AgentTaskCookIndexAttempt>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCookLatestSubstantiveCandidate {
+    pub schema: String,
+    pub run_id: String,
+    pub attempt: u32,
+    pub task_id: String,
+    pub artifact_id: String,
+    pub artifact_kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_size_bytes: Option<u64>,
+    pub integrity: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub promotion_provenance: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_provenance: Option<Value>,
+    pub recorded_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -265,6 +265,7 @@ mod tests {
             status: status.to_string(),
             attempts: Vec::new(),
             finalization,
+            selected_candidate: None,
             stop_reason: None,
             terminal_phase: None,
             terminal_failure_classification: None,
@@ -277,6 +278,10 @@ mod tests {
         AgentTaskCookFailureContext {
             cook_id: "cook-abc".to_string(),
             latest_run_id: "run-1".to_string(),
+            selected_run_id: None,
+            selected_task_id: None,
+            selected_artifact_id: None,
+            promotion_provenance: None,
             durable_recipe_ref: "recipe".to_string(),
             lifecycle_state: "failed".to_string(),
             phase: "controller".to_string(),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -669,6 +669,10 @@ pub struct AgentTaskCookReport {
     pub attempts: Vec<AgentTaskCookAttemptReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finalization: Option<Value>,
+    /// Candidate authority is separate from `latest_run_id`, which remains the
+    /// chronological invocation/index compatibility field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_candidate: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<String>,
     /// Preserves the lifecycle-owned failure boundary when cook stops before
@@ -691,6 +695,14 @@ pub struct AgentTaskCookReport {
 pub struct AgentTaskCookFailureContext {
     pub cook_id: String,
     pub latest_run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_artifact_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub promotion_provenance: Option<Value>,
     pub durable_recipe_ref: String,
     pub lifecycle_state: String,
     pub phase: String,
@@ -1883,18 +1895,13 @@ where
         .find(|attempt| attempt.run_id == options.initial_run_id)
         .map(|attempt| attempt.attempt)
         .unwrap_or(1);
-    let resumed_run_id = (!verification_pending_continuation)
-        .then(|| agent_task_lifecycle::cook_index(&options.cook_id).ok())
-        .flatten()
-        .map(|index| index.latest_run_id)
-        .filter(|run_id| run_id != &options.initial_run_id)
-        .filter(|run_id| {
-            recipe
-                .attempts
-                .iter()
-                .find(|attempt| attempt.run_id == *run_id)
-                .is_some_and(|attempt| attempt.attempt >= requested_attempt)
-        });
+    let resumed_run_id = resumable_cook_run_id(
+        &recipe,
+        &options.cook_id,
+        &options.initial_run_id,
+        requested_attempt,
+        verification_pending_continuation,
+    );
     let mut run_id = resumed_run_id
         .clone()
         .unwrap_or_else(|| options.initial_run_id.clone());
@@ -2696,6 +2703,27 @@ where
         1,
         Some(&run_id),
     ))
+}
+
+fn resumable_cook_run_id(
+    recipe: &super::AgentTaskCookRecipe,
+    cook_id: &str,
+    initial_run_id: &str,
+    requested_attempt: u32,
+    verification_pending_continuation: bool,
+) -> Option<String> {
+    (!verification_pending_continuation)
+        .then(|| agent_task_lifecycle::select_cook_candidate(cook_id).ok())
+        .flatten()
+        .map(|selection| selection.run_id)
+        .filter(|run_id| run_id != initial_run_id)
+        .filter(|run_id| {
+            recipe
+                .attempts
+                .iter()
+                .find(|attempt| attempt.run_id == *run_id)
+                .is_some_and(|attempt| attempt.attempt >= requested_attempt)
+        })
 }
 
 /// A multi-candidate Cook has one controller-owned destination. Reject ambiguous

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -1115,6 +1115,19 @@ fn materialize_adoption_attempt(
 fn resolve_cook_adoption_attempt(
     recipe: &super::AgentTaskCookRecipe,
 ) -> Result<&super::AgentTaskCookRecipeAttempt> {
+    if let Ok(selection) = agent_task_lifecycle::select_cook_candidate(&recipe.cook_id) {
+        if selection.reason
+            != "no_substantive_candidate_evidence_preserve_latest_attempt_compatibility"
+        {
+            if let Some(attempt) = recipe
+                .attempts
+                .iter()
+                .find(|attempt| attempt.run_id == selection.run_id)
+            {
+                return Ok(attempt);
+            }
+        }
+    }
     let first = recipe
         .attempts
         .first()

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -109,9 +109,14 @@ pub(crate) fn promote_attempt(
 /// Cook only promotes the candidate selected by the scheduler. A single-task
 /// aggregate has no selection projection and retains the historical behavior.
 pub(crate) fn selected_candidate_task_id(run_id: &str) -> Result<Option<String>> {
-    let aggregate = agent_task_lifecycle::read_aggregate(run_id)?;
+    let aggregate = agent_task_lifecycle::read_attempt_aggregate(run_id)?;
     Ok(aggregate
         .selected_outcome()
+        .or_else(|| {
+            (aggregate.outcomes.len() == 1)
+                .then(|| aggregate.outcomes.first())
+                .flatten()
+        })
         .map(|outcome| outcome.task_id.clone()))
 }
 
@@ -1739,6 +1744,7 @@ pub(crate) fn cook_report(
     let failure_context = (exit_code != 0)
         .then(|| cook_failure_context(&cook_id, latest_run_id.as_deref()))
         .flatten();
+    let selected_candidate = cook_selected_candidate_provenance(&cook_id);
     AgentTaskRunResult {
         value: AgentTaskCookReport {
             schema: "homeboy/agent-task-cook/v1",
@@ -1749,6 +1755,7 @@ pub(crate) fn cook_report(
             status: status.to_string(),
             attempts,
             finalization,
+            selected_candidate,
             stop_reason,
             terminal_phase: None,
             terminal_failure_classification: None,
@@ -1759,6 +1766,23 @@ pub(crate) fn cook_report(
     }
 }
 
+fn cook_selected_candidate_provenance(cook_id: &str) -> Option<Value> {
+    let selection = agent_task_lifecycle::select_cook_candidate(cook_id).ok()?;
+    let mut value = serde_json::to_value(&selection).ok()?;
+    if selection.incomplete || selection.run_id.is_empty() {
+        return Some(value);
+    }
+    let record = agent_task_lifecycle::exact_record(&selection.run_id).ok()?;
+    if let Some(promotion) = record.metadata.get("latest_promotion") {
+        value["applied_promotion"] = serde_json::json!({
+            "identity": promotion.pointer("/patch_artifact/sha256"),
+            "destination": promotion.get("to_worktree"),
+            "fingerprint": promotion.pointer("/provenance/candidate"),
+        });
+    }
+    Some(value)
+}
+
 /// Build recovery coordinates from durable controller records only. Provider
 /// output, gate output, and filesystem paths stay behind `diagnose` so a failed
 /// command envelope cannot disclose private evidence.
@@ -1767,15 +1791,18 @@ fn cook_failure_context(
     latest_run_id: Option<&str>,
 ) -> Option<super::AgentTaskCookFailureContext> {
     let recipe = super::load_recipe(cook_id).ok()?;
-    let latest_run_id = latest_run_id
+    let chronological_latest_run_id = latest_run_id
         .map(str::to_string)
-        .or_else(|| {
-            agent_task_lifecycle::cook_index(cook_id)
-                .ok()
-                .map(|index| index.latest_run_id)
-        })
         .or_else(|| recipe.attempts.last().map(|attempt| attempt.run_id.clone()))?;
-    let record = agent_task_lifecycle::status(&latest_run_id).ok();
+    let selection = agent_task_lifecycle::select_cook_candidate(cook_id).ok();
+    let selected_run_id = selection
+        .as_ref()
+        .filter(|selection| !selection.incomplete && !selection.run_id.is_empty())
+        .map(|selection| selection.run_id.clone());
+    let record_run_id = selected_run_id
+        .as_deref()
+        .unwrap_or(&chronological_latest_run_id);
+    let record = agent_task_lifecycle::status(record_run_id).ok();
     let provider_executions_consumed = recipe
         .attempts
         .iter()
@@ -1797,7 +1824,7 @@ fn cook_failure_context(
         .unwrap_or_else(|| "recipe_persisted_without_lifecycle_record".to_string());
     let recovery_legal = record.is_some();
     let promotion_claim =
-        agent_task_lifecycle::operation_claim(&latest_run_id, &format!("promote:{latest_run_id}"))
+        agent_task_lifecycle::operation_claim(record_run_id, &format!("promote:{record_run_id}"))
             .ok()
             .flatten();
     let blocking_claim = promotion_claim.as_ref().and_then(|claim| {
@@ -1826,15 +1853,13 @@ fn cook_failure_context(
             vec![
                 super::AgentTaskCookRecoveryAction {
                     action: "status".to_string(),
-                    command: format!("homeboy agent-task status {latest_run_id} --full"),
+                    command: format!(
+                        "homeboy agent-task status {chronological_latest_run_id} --full"
+                    ),
                 },
                 super::AgentTaskCookRecoveryAction {
                     action: "diagnose".to_string(),
-                    command: format!("homeboy agent-task diagnose {latest_run_id}"),
-                },
-                super::AgentTaskCookRecoveryAction {
-                    action: "resume".to_string(),
-                    command: format!("homeboy agent-task cook-continue {latest_run_id}"),
+                    command: format!("homeboy agent-task diagnose {chronological_latest_run_id}"),
                 },
             ]
         })
@@ -1844,13 +1869,79 @@ fn cook_failure_context(
             2,
             super::AgentTaskCookRecoveryAction {
                 action: "reconcile".to_string(),
-                command: format!("homeboy agent-task reconcile {latest_run_id} --dry-run"),
+                command: format!(
+                    "homeboy agent-task reconcile {chronological_latest_run_id} --dry-run"
+                ),
             },
         );
     }
+    let promotion_provenance = selected_run_id
+        .as_deref()
+        .and_then(|run_id| agent_task_lifecycle::exact_record(run_id).ok())
+        .and_then(|record| record.metadata.get("latest_promotion").cloned());
+    if let Some(selection) = selection.as_ref().filter(|selection| !selection.incomplete) {
+        if let (Some(task_id), Some(artifact_id), Some(destination)) = (
+            selection.selected_task_id.as_deref(),
+            selection.selected_artifact_id.as_deref(),
+            promotion_provenance
+                .as_ref()
+                .and_then(|promotion| promotion.get("to_worktree"))
+                .and_then(Value::as_str),
+        ) {
+            if promotion_provenance
+                .as_ref()
+                .is_some_and(destination_candidate_is_proven)
+            {
+                legal_actions.push(super::AgentTaskCookRecoveryAction {
+                    action: "review_selected_candidate".to_string(),
+                    command: format!(
+                        "homeboy agent-task review {} --to-worktree {destination}",
+                        selection.run_id
+                    ),
+                });
+                legal_actions.push(super::AgentTaskCookRecoveryAction {
+                    action: "finalize_selected_candidate".to_string(),
+                    command: format!(
+                        "homeboy agent-task finalize-pr --recover {}",
+                        selection.run_id
+                    ),
+                });
+            } else {
+                legal_actions.push(super::AgentTaskCookRecoveryAction {
+                    action: "promote_selected_candidate".to_string(),
+                    command: format!(
+                        "homeboy agent-task promote {} --to-worktree {destination} --task-id {task_id} --artifact-id {artifact_id}",
+                        selection.run_id
+                    ),
+                });
+                legal_actions.push(super::AgentTaskCookRecoveryAction {
+                    action: "review_selected_candidate".to_string(),
+                    command: format!(
+                        "homeboy agent-task review {} --to-worktree {destination}",
+                        selection.run_id
+                    ),
+                });
+                legal_actions.push(super::AgentTaskCookRecoveryAction {
+                    action: "finalize_selected_candidate".to_string(),
+                    command: format!(
+                        "homeboy agent-task finalize-pr --recover {}",
+                        selection.run_id
+                    ),
+                });
+            }
+        }
+    }
     Some(super::AgentTaskCookFailureContext {
         cook_id: cook_id.to_string(),
-        latest_run_id,
+        latest_run_id: chronological_latest_run_id,
+        selected_run_id,
+        selected_task_id: selection
+            .as_ref()
+            .and_then(|selection| selection.selected_task_id.clone()),
+        selected_artifact_id: selection
+            .as_ref()
+            .and_then(|selection| selection.selected_artifact_id.clone()),
+        promotion_provenance,
         durable_recipe_ref: format!("homeboy://agent-task/cooks/{cook_id}/recipe"),
         lifecycle_state,
         phase,
@@ -1868,6 +1959,33 @@ fn cook_failure_context(
         next_actions: legal_actions.clone(),
         legal_actions,
     })
+}
+
+fn destination_candidate_is_proven(promotion: &Value) -> bool {
+    promotion
+        .get("provenance")
+        .and_then(|provenance| provenance.get("candidate"))
+        .is_some_and(|candidate| !candidate.is_null())
+        && promotion
+            .get("command_evidence")
+            .and_then(Value::as_array)
+            .is_some_and(|commands| {
+                commands.iter().any(|command| {
+                    command
+                        .get("command")
+                        .and_then(Value::as_array)
+                        .is_some_and(|argv| {
+                            argv.iter().map(Value::as_str).eq([
+                                Some("git"),
+                                Some("apply"),
+                                Some("--reverse"),
+                                Some("--check"),
+                                Some("-"),
+                            ])
+                        })
+                        && command.get("exit_code").and_then(Value::as_i64) == Some(0)
+                })
+            })
 }
 
 pub(crate) fn source_spec_path(spec: &str) -> Option<PathBuf> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -959,9 +959,17 @@ pub fn resolve_cook_continuation_run_id(cook_or_attempt_id: &str) -> Result<Stri
     {
         return Ok(cook_or_attempt_id.to_string());
     }
-    Ok(agent_task_lifecycle::cook_index(&recipe.cook_id)
-        .ok()
-        .map(|index| index.latest_run_id)
+    let selection = agent_task_lifecycle::select_cook_candidate(&recipe.cook_id)?;
+    if selection.incomplete {
+        return Err(Error::validation_invalid_argument(
+            "cook_id",
+            "candidate selection is incomplete after its bounded recovery window",
+            Some(recipe.cook_id.clone()),
+            None,
+        ));
+    }
+    Ok(Some(selection.run_id)
+        .filter(|run_id| !run_id.is_empty())
         .filter(|run_id| {
             recipe
                 .attempts

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -140,6 +140,64 @@ fn seed_missing_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
     .unwrap();
 }
 
+fn seed_substantive_candidate_aggregate(
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    patch_path: &std::path::Path,
+    patch: &str,
+) {
+    use crate::agent_task::{AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus};
+    use crate::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+    };
+
+    std::fs::write(patch_path, patch).expect("write candidate patch");
+    let task = plan.tasks.first().expect("candidate plan has one task");
+    agent_task_lifecycle::record_run_aggregate(
+        run_id,
+        plan,
+        &AgentTaskAggregate {
+            schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: plan.plan_id.clone(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals {
+                succeeded: 1,
+                ..Default::default()
+            },
+            outcomes: vec![AgentTaskOutcome {
+                schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: task.task_id.clone(),
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: None,
+                failure_classification: None,
+                artifacts: vec![AgentTaskArtifact {
+                    id: "candidate".to_string(),
+                    kind: "patch".to_string(),
+                    path: Some(patch_path.display().to_string()),
+                    size_bytes: Some(patch.len() as u64),
+                    sha256: Some(homeboy_engine_primitives::content_hash::sha256_hex(
+                        patch.as_bytes(),
+                    )),
+                    ..Default::default()
+                }],
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }],
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: Default::default(),
+        },
+    )
+    .expect("persist candidate aggregate");
+}
+
 #[test]
 fn candidate_selection_uses_the_winner_for_review_form_and_status_projection() {
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -4621,6 +4679,508 @@ fn adoption_by_cook_id_uses_the_first_of_repeated_equivalent_recipe_attempts() {
 
         assert_eq!(recipe.cook_id, cook_id);
         assert_eq!(record.run_id, first_run_id);
+    });
+}
+
+#[test]
+fn adoption_by_cook_id_selects_the_latest_substantive_candidate_not_a_newer_empty_attempt() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let cook_id = "cook-adopt-substantive-attempt";
+        let first_run_id = "cook-adopt-substantive-attempt-1";
+        let second_run_id = "cook-adopt-substantive-attempt-2";
+        let third_run_id = "cook-adopt-substantive-attempt-3";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = first_run_id.to_string();
+        super::super::persist_initial_recipe(&options).expect("persist recipe");
+        super::super::record_recipe_attempt(cook_id, 2, second_run_id, &options.initial_plan)
+            .expect("persist second recipe attempt");
+        super::super::record_recipe_attempt(cook_id, 3, third_run_id, &options.initial_plan)
+            .expect("persist third recipe attempt");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(first_run_id))
+            .expect("persist first lifecycle record");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(second_run_id))
+            .expect("persist second lifecycle record");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(third_run_id))
+            .expect("persist third lifecycle record");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, first_run_id)
+            .expect("index first attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, second_run_id)
+            .expect("index substantive attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 3, third_run_id)
+            .expect("index unavailable later attempt");
+        seed_substantive_candidate_aggregate(
+            second_run_id,
+            &options.initial_plan,
+            &temp.path().join("second.patch"),
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+        seed_substantive_candidate_aggregate(
+            third_run_id,
+            &options.initial_plan,
+            &temp.path().join("third.patch"),
+            "this is deliberately nonempty but not a unified diff\n",
+        );
+
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
+            .expect("select persisted candidate");
+        assert_eq!(selection.run_id, second_run_id);
+        assert_eq!(selection.reason, "latest_substantive_candidate_pointer");
+        assert!(selection.skipped_newer_run_ids.is_empty());
+        assert_eq!(selection.latest_attempt_run_id, third_run_id);
+        let (_, source_path) = super::super::promotion_source(cook_id)
+            .expect("promotion reads the older readable candidate");
+        assert_eq!(
+            source_path,
+            Some(
+                agent_task_lifecycle::aggregate_source(second_run_id)
+                    .unwrap()
+                    .1
+            )
+        );
+
+        let (record, _) = resolve_adoption_target(cook_id).expect("adoption follows selection");
+        assert_eq!(record.run_id, second_run_id);
+        assert_eq!(
+            super::super::resolve_cook_continuation_run_id(cook_id)
+                .expect("continuation follows selection"),
+            second_run_id
+        );
+        let recipe = super::super::load_recipe(cook_id).expect("load recipe");
+        assert_eq!(
+            resumable_cook_run_id(&recipe, cook_id, first_run_id, 1, false),
+            Some(second_run_id.to_string()),
+            "continuation must keep the selected substantive attempt, not the latest alias"
+        );
+    });
+}
+
+#[test]
+fn record_cook_attempt_recovers_an_aggregate_completed_before_attempt_registration() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let cook_id = "cook-aggregate-before-registration";
+        let run_id = "cook-aggregate-before-registration-1";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+            .expect("persist lifecycle record");
+        seed_substantive_candidate_aggregate(
+            run_id,
+            &options.initial_plan,
+            &temp.path().join("candidate.patch"),
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id)
+            .expect("register completed attempt");
+
+        let pointer = agent_task_lifecycle::cook_index(cook_id)
+            .expect("read index")
+            .latest_substantive_candidate
+            .expect("completed aggregate becomes the durable candidate");
+        assert_eq!(pointer.run_id, run_id);
+        assert_eq!(pointer.attempt, 1);
+    });
+}
+
+#[test]
+fn legacy_substantive_candidate_selection_is_explicitly_incomplete_after_64_newer_skips() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-substantive-bounded-window";
+        let attempts = (1..=65)
+            .map(
+                |attempt| crate::agent_task_lifecycle::AgentTaskCookIndexAttempt {
+                    attempt,
+                    run_id: format!("{cook_id}-{attempt}"),
+                    recorded_at: "2026-01-01T00:00:00Z".to_string(),
+                },
+            )
+            .collect();
+        agent_task_lifecycle::replace_cook_index_for_test(
+            &crate::agent_task_lifecycle::AgentTaskCookIndex {
+                schema: crate::agent_task_lifecycle::schemas::COOK_INDEX.to_string(),
+                cook_id: cook_id.to_string(),
+                latest_run_id: format!("{cook_id}-65"),
+                latest_substantive_candidate: None,
+                attempts,
+            },
+        )
+        .expect("persist complete cook index once");
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
+            .expect("bounded selection returns an explicit result");
+        assert!(selection.incomplete);
+        assert_eq!(
+            selection.reason,
+            "selection_window_exhausted_without_promotable_candidate"
+        );
+        assert!(selection.run_id.is_empty());
+        assert_eq!(selection.latest_attempt_run_id, format!("{cook_id}-65"));
+        assert_eq!(selection.skipped_newer_run_ids.len(), 64);
+        assert_eq!(selection.skipped_newer_attempts.len(), 64);
+    });
+}
+
+#[test]
+fn cook_index_serialization_remains_compatible_with_indexes_without_a_candidate_pointer() {
+    let legacy = serde_json::json!({
+        "schema": "homeboy/agent-task-cook-index/v1",
+        "cook_id": "legacy-cook",
+        "latest_run_id": "legacy-run",
+        "attempts": [{"attempt": 1, "run_id": "legacy-run", "recorded_at": "2026-01-01T00:00:00Z"}]
+    });
+    let index: crate::agent_task_lifecycle::AgentTaskCookIndex =
+        serde_json::from_value(legacy).expect("read legacy Cook index");
+    assert!(index.latest_substantive_candidate.is_none());
+    let serialized = serde_json::to_value(index).expect("serialize Cook index");
+    assert!(serialized.get("latest_substantive_candidate").is_none());
+}
+
+#[test]
+fn cook_report_emits_selected_candidate_provenance_without_redefining_latest_run_id() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let cook_id = "cook-selected-candidate-provenance";
+        let selected_run_id = "cook-selected-candidate-provenance-1";
+        let latest_run_id = "cook-selected-candidate-provenance-2";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        for (attempt, run_id) in [(1, selected_run_id), (2, latest_run_id)] {
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("persist lifecycle record");
+            agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id)
+                .expect("persist attempt index entry");
+        }
+        seed_substantive_candidate_aggregate(
+            selected_run_id,
+            &options.initial_plan,
+            &temp.path().join("selected.patch"),
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+        seed_substantive_candidate_aggregate(
+            latest_run_id,
+            &options.initial_plan,
+            &temp.path().join("malformed.patch"),
+            "nonempty malformed newer artifact\n",
+        );
+        agent_task_lifecycle::rewrite_record_for_test(selected_run_id, |record| {
+            record.metadata["latest_promotion"] = serde_json::json!({
+                "patch_artifact": { "sha256": "candidate-sha" },
+                "to_worktree": "fixture@destination",
+                "provenance": { "candidate": "candidate-fingerprint" }
+            });
+        })
+        .expect("persist promotion provenance");
+
+        let report = cook_report(
+            cook_id.to_string(),
+            "completed",
+            Vec::new(),
+            None,
+            None,
+            0,
+            Some(latest_run_id),
+        );
+        assert_eq!(report.value.latest_run_id.as_deref(), Some(latest_run_id));
+        let provenance = report
+            .value
+            .selected_candidate
+            .expect("selected candidate provenance");
+        assert_eq!(provenance["latest_attempt_run_id"], latest_run_id);
+        assert_eq!(provenance["run_id"], selected_run_id);
+        assert_eq!(
+            provenance["selected_task_id"],
+            options.initial_plan.tasks[0].task_id
+        );
+        assert_eq!(provenance["selected_artifact_id"], "candidate");
+        assert_eq!(
+            provenance["skipped_newer_attempts"][0]["run_id"],
+            latest_run_id
+        );
+        assert_eq!(provenance["applied_promotion"]["identity"], "candidate-sha");
+        assert_eq!(
+            provenance["applied_promotion"]["destination"],
+            "fixture@destination"
+        );
+        assert_eq!(
+            provenance["applied_promotion"]["fingerprint"],
+            "candidate-fingerprint"
+        );
+    });
+}
+
+#[test]
+fn resume_promoted_patch_guidance_keeps_the_exhausted_zero_byte_attempt_as_latest() {
+    // #10156 acceptance: a gate-feedback retry can exhaust after producing no
+    // patch without obscuring the earlier applied candidate or its review path.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let cook_id = "cook-10156-substantive-recovery";
+        let candidate_run_id = "cook-10156-substantive-recovery-attempt-1";
+        let exhausted_run_id = "cook-10156-substantive-recovery-attempt-2";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = candidate_run_id.to_string();
+        super::super::persist_initial_recipe(&options).expect("persist Cook recipe");
+        super::super::record_recipe_attempt(cook_id, 2, exhausted_run_id, &options.initial_plan)
+            .expect("persist exhausted retry recipe entry");
+        for (attempt, run_id) in [(1, candidate_run_id), (2, exhausted_run_id)] {
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("persist lifecycle record");
+            agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id)
+                .expect("persist attempt index entry");
+        }
+
+        let patch = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        seed_substantive_candidate_aggregate(
+            candidate_run_id,
+            &options.initial_plan,
+            &temp.path().join("candidate.patch"),
+            patch,
+        );
+        // The follow-up executor ran, but emitted a zero-byte patch before its
+        // execution allowance was exhausted. It remains chronologically latest.
+        seed_substantive_candidate_aggregate(
+            exhausted_run_id,
+            &options.initial_plan,
+            &temp.path().join("zero-byte.patch"),
+            "",
+        );
+        agent_task_lifecycle::rewrite_record_for_test(candidate_run_id, |record| {
+            record.metadata["review_form"] = test_review_form_outputs();
+            record.metadata["infrastructure"] = serde_json::json!({
+                "runner_id": "fixture-lab",
+                "provider_execution": 1,
+            });
+            record.metadata["latest_promotion"] = serde_json::json!({
+                "patch_artifact": { "sha256": homeboy_engine_primitives::content_hash::sha256_hex(patch.as_bytes()) },
+                "to_worktree": "fixture@destination",
+                "command_evidence": [{
+                    "command": ["git", "apply", "--reverse", "--check", "-"],
+                    "exit_code": 0,
+                }],
+                "provenance": {
+                    "candidate": { "kind": "git", "fingerprint": { "head": "candidate-head", "tree": "candidate-tree" } },
+                    "resumed_post_apply_promotion": true,
+                },
+            });
+        })
+        .expect("persist candidate promotion and metadata");
+        agent_task_lifecycle::rewrite_record_for_test(exhausted_run_id, |record| {
+            record.metadata["provider_executions_consumed"] = serde_json::json!(2);
+            record.metadata["terminal"] = serde_json::json!("execution_budget_exhausted");
+        })
+        .expect("persist exhausted retry terminal state");
+        let latest_empty_run_id = format!("{cook_id}-attempt-66");
+        for attempt in 3..=66 {
+            let run_id = format!("{cook_id}-attempt-{attempt}");
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&run_id))
+                .expect("persist empty follow-up lifecycle attempt");
+            agent_task_lifecycle::record_cook_attempt(cook_id, attempt, &run_id)
+                .expect("register empty follow-up attempt");
+        }
+        let index = agent_task_lifecycle::cook_index(cook_id).expect("read durable index");
+        assert_eq!(index.latest_run_id, latest_empty_run_id);
+        let pointer = index
+            .latest_substantive_candidate
+            .expect("first completed candidate remains durable authority");
+        assert_eq!(pointer.run_id, candidate_run_id);
+        assert_eq!(pointer.attempt, 1);
+
+        let report = cook_report(
+            cook_id.to_string(),
+            "execution_budget_exhausted",
+            Vec::new(),
+            None,
+            Some(
+                "provider execution stopped because max_provider_executions was exhausted"
+                    .to_string(),
+            ),
+            1,
+            Some(&latest_empty_run_id),
+        );
+
+        assert_eq!(
+            report.value.latest_run_id.as_deref(),
+            Some(latest_empty_run_id.as_str())
+        );
+        let selected = report
+            .value
+            .selected_candidate
+            .expect("selected candidate provenance");
+        assert_eq!(selected["run_id"], candidate_run_id);
+        assert_eq!(selected["latest_attempt_run_id"], latest_empty_run_id);
+        assert_eq!(
+            selected["selected_task_id"],
+            options.initial_plan.tasks[0].task_id
+        );
+        assert_eq!(selected["selected_artifact_id"], "candidate");
+        let context = report.value.failure_context.expect("recovery context");
+        assert_eq!(context.latest_run_id, latest_empty_run_id);
+        assert_eq!(context.selected_run_id.as_deref(), Some(candidate_run_id));
+        let actions = context.legal_actions;
+        assert!(actions
+            .iter()
+            .all(|action| action.action != "promote_selected_candidate"));
+        let review_action = actions
+            .iter()
+            .find(|action| action.action == "review_selected_candidate")
+            .expect("selected-candidate review action");
+        assert_eq!(
+            review_action.command,
+            format!(
+                "homeboy agent-task review {candidate_run_id} --to-worktree fixture@destination"
+            )
+        );
+        assert!(actions.iter().any(|action| {
+            action.command == format!("homeboy agent-task finalize-pr --recover {candidate_run_id}")
+        }));
+
+        agent_task_lifecycle::rewrite_record_for_test(candidate_run_id, |record| {
+            record.metadata["latest_promotion"]["command_evidence"][0]["exit_code"] =
+                serde_json::json!(1);
+        })
+        .expect("remove destination proof");
+        let unproven = cook_report(
+            cook_id.to_string(),
+            "execution_budget_exhausted",
+            Vec::new(),
+            None,
+            None,
+            1,
+            Some(&latest_empty_run_id),
+        )
+        .value
+        .failure_context
+        .expect("unproven destination context");
+        assert!(unproven.legal_actions.iter().any(|action| {
+            action.command == format!(
+                "homeboy agent-task promote {candidate_run_id} --to-worktree fixture@destination --task-id provider --artifact-id candidate"
+            )
+        }));
+
+        let selected_record = agent_task_lifecycle::status(candidate_run_id).unwrap();
+        let promotion = &selected_record.metadata["latest_promotion"];
+        assert_eq!(
+            promotion["command_evidence"][0]["command"],
+            serde_json::json!(["git", "apply", "--reverse", "--check", "-"])
+        );
+        assert_eq!(
+            promotion["provenance"]["candidate"]["fingerprint"]["head"],
+            "candidate-head"
+        );
+        assert_eq!(
+            promotion["provenance"]["resumed_post_apply_promotion"],
+            true
+        );
+        assert_eq!(
+            promotion["command_evidence"].as_array().unwrap().len(),
+            1,
+            "recovery verifies the destination without reapplying the patch"
+        );
+        assert_eq!(
+            selected_record.metadata["review_form"],
+            test_review_form_outputs()
+        );
+        assert_eq!(
+            selected_record.metadata["infrastructure"]["runner_id"],
+            "fixture-lab"
+        );
+    });
+}
+
+#[test]
+fn substantive_candidate_selection_breaks_duplicate_attempt_ties_by_run_id() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let cook_id = "cook-substantive-tie-break";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        for run_id in [
+            "cook-substantive-tie-break-a",
+            "cook-substantive-tie-break-b",
+        ] {
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("persist lifecycle record");
+            agent_task_lifecycle::record_cook_attempt(cook_id, 7, run_id)
+                .expect("persist duplicate attempt index entry");
+            seed_substantive_candidate_aggregate(
+                run_id,
+                &options.initial_plan,
+                &temp.path().join(format!("{run_id}.patch")),
+                "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+            );
+        }
+
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
+            .expect("select deterministic duplicate-attempt winner");
+        assert_eq!(selection.run_id, "cook-substantive-tie-break-b");
+        assert_eq!(selection.attempt, 7);
+        assert_eq!(selection.reason, "latest_substantive_candidate_pointer");
+    });
+}
+
+#[test]
+fn first_attempt_named_as_cook_id_reads_its_own_substantive_aggregate() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().unwrap();
+        let cook_id = "cook-attempt-id-collision";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        for (attempt, run_id) in [(1, cook_id), (2, "cook-attempt-id-collision-2")] {
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).unwrap();
+            agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id).unwrap();
+        }
+        seed_substantive_candidate_aggregate(
+            cook_id,
+            &options.initial_plan,
+            &temp.path().join("first.patch"),
+            "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+        seed_missing_review_form_aggregate("cook-attempt-id-collision-2", &options.initial_plan);
+        assert_eq!(
+            super::super::selected_candidate_task_id(cook_id).unwrap(),
+            Some(options.initial_plan.tasks[0].task_id.clone())
+        );
+        assert_eq!(
+            agent_task_lifecycle::select_cook_candidate(cook_id)
+                .unwrap()
+                .run_id,
+            cook_id
+        );
+    });
+}
+
+#[test]
+fn large_cook_index_selects_the_deterministic_top_64_window() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-large-index";
+        let attempts = (1..=10_000)
+            .map(
+                |attempt| crate::agent_task_lifecycle::AgentTaskCookIndexAttempt {
+                    attempt,
+                    run_id: format!("{cook_id}-{attempt}"),
+                    recorded_at: "2026-01-01T00:00:00Z".to_string(),
+                },
+            )
+            .collect();
+        agent_task_lifecycle::replace_cook_index_for_test(
+            &crate::agent_task_lifecycle::AgentTaskCookIndex {
+                schema: crate::agent_task_lifecycle::schemas::COOK_INDEX.to_string(),
+                cook_id: cook_id.to_string(),
+                latest_run_id: format!("{cook_id}-10000"),
+                latest_substantive_candidate: None,
+                attempts,
+            },
+        )
+        .unwrap();
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id).unwrap();
+        assert!(selection.incomplete);
+        assert_eq!(selection.latest_attempt_run_id, format!("{cook_id}-10000"));
+        assert_eq!(selection.skipped_newer_run_ids.len(), 64);
+        assert_eq!(
+            selection.skipped_newer_run_ids[0],
+            format!("{cook_id}-10000")
+        );
+        assert_eq!(
+            selection.skipped_newer_run_ids[63],
+            format!("{cook_id}-9937")
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use serde_json::{json, Value};
 
 use super::{
-    sanitize_run_id, AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskRunRecord,
-    AgentTaskRunState,
+    sanitize_run_id, AgentTaskCookIndex, AgentTaskCookIndexAttempt,
+    AgentTaskCookLatestSubstantiveCandidate, AgentTaskRunRecord, AgentTaskRunState,
 };
 use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use homeboy_core::engine::local_files::{
@@ -219,6 +219,7 @@ pub(super) fn write_cook_index_attempt(
     attempt: u32,
     run_id: &str,
     recorded_at: String,
+    candidate: Option<AgentTaskCookLatestSubstantiveCandidate>,
 ) -> Result<AgentTaskCookIndex> {
     let cook_id = sanitize_run_id(cook_id);
     let run_id = sanitize_run_id(run_id);
@@ -230,6 +231,7 @@ pub(super) fn write_cook_index_attempt(
             schema: super::records::schemas::COOK_INDEX.to_string(),
             cook_id: cook_id.clone(),
             latest_run_id: run_id.clone(),
+            latest_substantive_candidate: None,
             attempts: Vec::new(),
         }
     };
@@ -259,12 +261,46 @@ pub(super) fn write_cook_index_attempt(
         .expect("Cook index has the recorded attempt")
         .run_id
         .clone();
+    if let Some(candidate) = candidate {
+        let replace = index
+            .latest_substantive_candidate
+            .as_ref()
+            .is_none_or(|current| {
+                candidate.attempt > current.attempt
+                    || (candidate.attempt == current.attempt && candidate.run_id >= current.run_id)
+            });
+        if replace {
+            index.latest_substantive_candidate = Some(candidate);
+        }
+    }
     write_json(&path, &index)?;
     Ok(index)
 }
 
+#[cfg(test)]
+pub(super) fn write_cook_index_for_test(index: &AgentTaskCookIndex) -> Result<()> {
+    write_json(&cook_index_path(&sanitize_run_id(&index.cook_id))?, index)
+}
+
 pub(super) fn read_cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
     read_json(&cook_index_path(cook_id)?)
+}
+
+pub(super) fn update_cook_index(
+    cook_id: &str,
+    mutate: impl FnOnce(&mut AgentTaskCookIndex) -> bool,
+) -> Result<Option<AgentTaskCookIndex>> {
+    let path = cook_index_path(&sanitize_run_id(cook_id))?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let mut index = read_json(&path)?;
+    if mutate(&mut index) {
+        // `write_json` is atomic; this makes the pointer update one durable
+        // index transaction without nesting the configuration lock it owns.
+        write_json(&path, &index)?;
+    }
+    Ok(Some(index))
 }
 
 pub(super) fn record_exists(run_id: &str) -> Result<bool> {

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -2366,6 +2366,7 @@ pub(crate) fn compact_cook_report(value: Value, full: bool) -> Value {
         "attempts": attempts.iter().take(COMPACT_TASK_LIMIT).map(|attempt| compact_fields(attempt, &["attempt", "run_id", "run_state", "aggregate_path"])).collect::<Vec<_>>(),
         "attempts_omitted": attempts.len().saturating_sub(COMPACT_TASK_LIMIT),
         "finalization": value.get("finalization").map(|finalization| compact_fields(finalization, &["schema", "status", "pr_number", "pr_url", "updated_at", "created_at"])),
+        "selected_candidate": value.get("selected_candidate").map(|candidate| compact_fields(candidate, &["latest_attempt_run_id", "run_id", "attempt", "selected_task_id", "selected_artifact_id", "reason", "incomplete", "skipped_newer_attempts", "applied_promotion"])),
     });
     if let Some(run_id) = latest_run_id {
         summary["full_command"] = json!(format!("homeboy agent-task status {run_id} --full"));
@@ -3280,7 +3281,8 @@ mod tests {
             "status": "failed",
             "stop_reason": "x".repeat(COMPACT_TEXT_LIMIT + 1),
             "attempts": attempts,
-            "finalization": { "status": "blocked", "nested_evidence": { "large": "x".repeat(COMPACT_TEXT_LIMIT + 1) } }
+            "finalization": { "status": "blocked", "nested_evidence": { "large": "x".repeat(COMPACT_TEXT_LIMIT + 1) } },
+            "selected_candidate": { "latest_attempt_run_id": "run-14", "run_id": "run-12", "selected_task_id": "task-12", "selected_artifact_id": "patch-12", "reason": "canonical", "skipped_newer_attempts": [{"run_id":"run-14","reason":"malformed"}] }
         });
 
         let compact = compact_cook_report(report.clone(), false);
@@ -3292,6 +3294,11 @@ mod tests {
         );
         assert_eq!(compact["attempts_omitted"], 3);
         assert!(compact["attempts"][0].get("promotion").is_none());
+        assert_eq!(compact["selected_candidate"]["run_id"], "run-12");
+        assert_eq!(
+            compact["selected_candidate"]["selected_artifact_id"],
+            "patch-12"
+        );
         assert_eq!(
             compact["full_command"],
             "homeboy agent-task status run-14 --full"


### PR DESCRIPTION
## Summary
- persist a durable latest-substantive-candidate pointer across Cook attempts
- keep latest execution, selected candidate, promotion, and destination provenance distinct
- emit exact destination-aware recovery actions without reapplying an already-present candidate

Closes #10156

## Verification
- substantive candidate ordering and >64 empty-attempt regressions
- destination reverse-apply/fingerprint guidance test
- compact Cook provenance tests
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested durable substantive-candidate recovery. Chris Huber reviewed and owns every line.