### PR TITLE
fix(ci): make the audit-corpus and release-workflow gates assert effects

### DIFF
--- a/.github/assert-audit-corpus.sh
+++ b/.github/assert-audit-corpus.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Assert that the post-merge full-tree audit actually READ the tree.
+#
+# This is the blocking half of `full-audit-gate` in audit-debt.yml. It exists
+# because #10557 was a gate that reported success while measuring nothing:
+# `review audit` scanned 0 of 1817 files and passed in 7 seconds.
+#
+# It lives in a script rather than inline in the workflow so it can be executed
+# by `tests/audit_debt_workflow_test.rs` against recorded fixtures. The two
+# defects this file replaces were both invisible to a YAML-substring test:
+#
+#   1. It read `${HOMEBOY_OUTPUT_DIR}/audit.json`. homeboy-action names the
+#      result file after the command it ran — `command_output_stem "review
+#      audit"` is `review-audit` — so the file it looked for never existed and
+#      the assertion failed 100% of the time, on every merge, from the moment
+#      it landed.
+#   2. #10583 then "fixed" the jq path to `.data.audit.output.summary`. That is
+#      the shape of the `review` UMBRELLA command (audit+lint+test stages).
+#      `review audit` on its own returns the flat `AuditCommandOutput`, so the
+#      corpus figure is at `.data.summary.files_scanned`. Defect 1 masked
+#      defect 2: the file was never opened, so the wrong path never showed.
+#
+# A gate whose test cannot detect that it checks nothing is not a gate. The
+# accompanying tests run THIS script against a recorded `review audit --output`
+# payload plus one fixture per historical defect, so neither can return.
+#
+# Inputs (environment):
+#   HOMEBOY_OUTPUT_DIR       — set by homeboy-action's run-homeboy-commands.sh
+#   AUDIT_MIN_FILES_SCANNED  — sanity floor, not a target (default 500)
+#
+# Exit 0 only when a real audit result was read and its corpus is plausible.
+# Every other outcome is exit 1: this gate is allowed to produce a false RED,
+# never a false green.
+
+set -euo pipefail
+
+OUTPUT_DIR="${HOMEBOY_OUTPUT_DIR:-}"
+MIN_FILES="${AUDIT_MIN_FILES_SCANNED:-500}"
+
+# Must match homeboy-action `command_output_stem "review audit"`.
+RESULT_BASENAME="review-audit.json"
+RESULT="${OUTPUT_DIR}/${RESULT_BASENAME}"
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  fail "jq is not installed, so this gate cannot read the audit result. Failing closed rather than assuming the audit passed. See #10557."
+fi
+
+if [ -z "${OUTPUT_DIR}" ]; then
+  fail "HOMEBOY_OUTPUT_DIR is unset. homeboy-action exports it to \$GITHUB_ENV from run-homeboy-commands.sh; if that moved, this gate can no longer read the audit result and must not claim the audit passed. See #10557."
+fi
+
+if [ ! -d "${OUTPUT_DIR}" ]; then
+  fail "HOMEBOY_OUTPUT_DIR '${OUTPUT_DIR}' is not a directory. See #10557."
+fi
+
+if [ ! -s "${RESULT}" ]; then
+  echo "contents of ${OUTPUT_DIR}:" >&2
+  ls -la "${OUTPUT_DIR}" >&2 || true
+  fail "Audit produced no structured output at '${RESULT}'. homeboy-action names this file after the command it ran (\`command_output_stem 'review audit'\` -> '${RESULT_BASENAME}'), so a rename on either side lands here — that is exactly how this assertion spent its whole life failing on a file called 'audit.json'. Compare the directory listing above against the expected name. See #10557."
+fi
+
+# `jq -e` (not `// 0`): a MISSING field means the result shape changed, which is
+# a different failure from "the audit scanned nothing". Conflating them is how
+# #10583 shipped a wrong jq path and reported it as an empty corpus.
+if ! files_scanned="$(jq -er '.data.summary.files_scanned' "${RESULT}" 2>/dev/null)"; then
+  echo "top-level result summary:" >&2
+  jq -r '{success, exit_code, status, summary, diagnostics: (.diagnostics.code // null)}' "${RESULT}" >&2 || true
+  fail "'${RESULT}' has no '.data.summary.files_scanned'. Either \`review audit\` failed before producing an audit (read the summary above — a stale baseline row or a config error lands here) or its output shape changed. Note '.data.audit.output.summary' is the shape of the \`review\` UMBRELLA command; \`review audit\` alone returns the flat audit output. See #10557, #10583."
+fi
+
+case "${files_scanned}" in
+  '' | *[!0-9]*)
+    fail "'${RESULT}' reported a non-numeric corpus size '${files_scanned}'. See #10557."
+    ;;
+esac
+
+echo "audit corpus: ${files_scanned} file(s) (floor ${MIN_FILES})"
+
+if [ "${files_scanned}" -lt "${MIN_FILES}" ]; then
+  jq -r '.data.summary' "${RESULT}" >&2 || true
+  fail "Audit scanned ${files_scanned} files, below the ${MIN_FILES}-file sanity floor for this repository (~1600 scannable sources). An audit with a collapsed corpus has not passed — it has not run. The usual cause is a missing fingerprinting extension: this gate must go through Extra-Chill/homeboy-action, whose 'Install extension' step installs the extensions declared in homeboy.json. If the tree legitimately shrank, lower AUDIT_MIN_FILES_SCANNED in audit-debt.yml deliberately. See #10557."
+fi

--- a/.github/workflows/audit-debt.yml
+++ b/.github/workflows/audit-debt.yml
@@ -229,11 +229,14 @@ jobs:
       # measuring nothing, so the one property this job enforces unconditionally
       # is that the audit had a corpus at all.
       #
-      # Reads the action's structured audit output. HOMEBOY_OUTPUT_DIR is
-      # exported to $GITHUB_ENV by the action's run-homeboy-commands.sh. If that
-      # ever moves, this step fails closed (missing file -> exit 1), which is the
-      # correct direction for a gate: it can produce a false RED, never a false
-      # green.
+      # The assertion lives in .github/assert-audit-corpus.sh, not inline here,
+      # because an inline `run:` block can only ever be checked by a YAML
+      # substring test — and a substring test is exactly what let this step ship
+      # broken twice (wrong result filename, then a wrong jq path bolted on top
+      # of it). The script is executed against recorded fixtures by
+      # tests/audit_debt_workflow_test.rs, including one fixture per historical
+      # defect, so the assertion is verified by running it rather than by
+      # reading it.
       #
       # `files_scanned` is the CONVENTION corpus (index files and single-file
       # directories excluded — see #10558). It is a lower bound on what the
@@ -241,25 +244,31 @@ jobs:
       # assertion wants. `review audit` itself already errors when the wider
       # source-policy corpus is empty, so the two checks bracket the failure.
       - name: Assert the audit actually scanned the tree
-        run: |
-          set -euo pipefail
-          result="${HOMEBOY_OUTPUT_DIR:-}/audit.json"
-          if [ -z "${HOMEBOY_OUTPUT_DIR:-}" ] || [ ! -s "${result}" ]; then
-            echo "::error::Audit produced no structured output at '${result}'. The audit did not run to completion (or homeboy-action changed where it writes results). A gate that cannot read the audit result cannot claim the audit passed — see #10557." >&2
-            exit 1
-          fi
-          files_scanned="$(jq -r '.data.audit.output.summary.files_scanned // 0' "${result}")"
-          echo "audit corpus: ${files_scanned} file(s)"
-          if [ "${files_scanned}" -lt 1 ]; then
-            echo "::error::Audit scanned ${files_scanned} files. An audit with an empty corpus has not passed — it has not run. The usual cause is a missing fingerprinting extension: this gate must go through Extra-Chill/homeboy-action, whose 'Install extension' step installs the extensions declared in homeboy.json. See #10557." >&2
-            jq -r '.data.audit.output.summary' "${result}" >&2 || true
-            exit 1
-          fi
+        run: bash .github/assert-audit-corpus.sh
 
       - name: Report the (non-blocking) audit findings verdict
         if: steps.audit.outcome == 'failure'
         run: |
+          set -euo pipefail
+          result="${HOMEBOY_OUTPUT_DIR:-}/review-audit.json"
           echo "::warning::Full-profile audit reported findings. This verdict is REPORTING-ONLY until #10569 regenerates the baseline; the corpus assertion above is the blocking part. Expand the audit group in this job's log for the finding list."
+          # Put the size of the debt in the job summary. A warning annotation
+          # nobody counts is how a reporting-only verdict quietly becomes
+          # permanent; a number that has to be looked at every merge is not.
+          {
+            echo "### Full-tree audit: reporting-only verdict (#10569)"
+            echo
+            if [ -s "${result}" ]; then
+              jq -r '"- corpus: \(.data.summary.files_scanned) file(s)",
+                     "- total findings: \(.data.findings | length)",
+                     "- new since baseline: \(.data.baseline_comparison.new_items | length)",
+                     "- resolved since baseline: \(.data.baseline_comparison.resolved_fingerprints | length)"' \
+                "${result}" 2>/dev/null \
+                || echo "- could not read \`${result}\`"
+            else
+              echo "- no audit result at \`${result}\` (see the corpus assertion step)"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   # ── Release-blocking suite, at full scope, on the merged result ──
   # `review lint` + `review test` is exactly release.yml's RELEASE_BLOCKING_COMMANDS

--- a/homeboy.json
+++ b/homeboy.json
@@ -551,7 +551,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-07-27T04:11:26Z",
-      "item_count": 1520,
+      "item_count": 1519,
       "known_fingerprints": [
         "Commands::crates/homeboy-cli/src/commands/agent_task_dispatch.rs::MissingMethod",
         "Src::crates/contracts/homeboy-audit-contract/src/finding.rs::MissingMethod",
@@ -2030,7 +2030,6 @@
         "structural::crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs::HighItemCount",
         "structural::crates/homeboy-lab-runner/src::DirectorySprawl",
         "structural::crates/homeboy-paths/src/lib.rs::HighItemCount",
-        "structural::crates/homeboy-process/src/lib.rs::HighItemCount",
         "structural::crates/homeboy-refactor/src/rename/tests.rs::GodFile",
         "structural::crates/homeboy-refactor/src/rename/tests.rs::HighItemCount",
         "structural::crates/homeboy-release/src/deploy/orchestration/mod.rs::GodFile",

--- a/tests/audit_debt_workflow_test.rs
+++ b/tests/audit_debt_workflow_test.rs
@@ -16,6 +16,101 @@ fn report_red_main_script() -> &'static str {
     include_str!("../.github/report-red-main.sh")
 }
 
+/// Compile-time proof that the blocking corpus assertion the workflow invokes
+/// exists. The tests below then EXECUTE it — see
+/// `assert_audit_corpus_rejects_the_historical_audit_json_filename`.
+fn audit_corpus_script() -> &'static str {
+    include_str!("../.github/assert-audit-corpus.sh")
+}
+
+/// A real `homeboy review audit --profile=full --output <path>` payload,
+/// recorded from a full run against this repository. The bulk arrays are
+/// truncated; the envelope is verbatim. Fixtures that are hand-written to match
+/// what a test expects prove nothing — this one is the actual contract the gate
+/// has to parse.
+fn recorded_review_audit_payload() -> &'static str {
+    include_str!("fixtures/audit_corpus/review-audit.json")
+}
+
+/// A real payload from a `review audit` that failed BEFORE producing an audit
+/// (a stale baseline row on `main`, 2026-07-28). There is no `.data` at all.
+fn recorded_failed_review_audit_payload() -> &'static str {
+    include_str!("fixtures/audit_corpus/review-audit-failed-validation.json")
+}
+
+/// The shape of the `review` UMBRELLA command (audit + lint + test stages),
+/// which is where `.data.audit.output.summary` actually lives. `review audit`
+/// on its own never produces this. #10583 pointed the gate's jq path here.
+const UMBRELLA_REVIEW_PAYLOAD: &str = r#"{
+  "schema": "homeboy/command-result/v3",
+  "command": "review",
+  "success": true,
+  "exit_code": 0,
+  "data": {
+    "audit": { "output": { "summary": { "files_scanned": 1596 } } },
+    "lint": { "output": {} },
+    "test": { "output": {} }
+  }
+}
+"#;
+
+struct CorpusAssertion {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+impl CorpusAssertion {
+    fn output(&self) -> String {
+        format!("{}\n{}", self.stdout, self.stderr)
+    }
+}
+
+/// Run the real gate script the workflow runs, against a directory we control.
+fn run_corpus_assertion(
+    output_dir: Option<&std::path::Path>,
+    min_files: Option<&str>,
+) -> CorpusAssertion {
+    assert!(
+        std::process::Command::new("jq")
+            .arg("--version")
+            .output()
+            .map(|out| out.status.success())
+            .unwrap_or(false),
+        "jq must be installed to exercise the audit corpus gate. Skipping silently would make this \
+         test the very thing it exists to prevent: a check that reports success while measuring nothing."
+    );
+
+    let mut command = std::process::Command::new("bash");
+    command.arg(".github/assert-audit-corpus.sh");
+    command.env_remove("HOMEBOY_OUTPUT_DIR");
+    command.env_remove("AUDIT_MIN_FILES_SCANNED");
+    if let Some(dir) = output_dir {
+        command.env("HOMEBOY_OUTPUT_DIR", dir);
+    }
+    if let Some(min) = min_files {
+        command.env("AUDIT_MIN_FILES_SCANNED", min);
+    }
+
+    let output = command
+        .output()
+        .expect("corpus assertion script should run");
+
+    CorpusAssertion {
+        status: output.status,
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+/// Write one file into a fresh output dir and run the assertion against it.
+fn corpus_assertion_with(file_name: &str, payload: &str) -> (tempfile::TempDir, CorpusAssertion) {
+    let dir = tempfile::tempdir().expect("output dir");
+    std::fs::write(dir.path().join(file_name), payload).expect("write payload");
+    let result = run_corpus_assertion(Some(dir.path()), None);
+    (dir, result)
+}
+
 /// Extract a single job block: from `  <name>:` up to the next line at exactly
 /// two spaces of indent (the next job key, or a comment introducing it).
 ///
@@ -264,12 +359,20 @@ fn post_merge_full_audit_gate_blocks_on_an_empty_corpus() {
         .find("name: Assert the audit actually scanned the tree")
         .expect("audit gate must carry a corpus assertion step");
     assert!(
-        gate.contains(".data.audit.output.summary.files_scanned"),
-        "review audit nests the audit result below data.audit.output; the corpus assertion must read the audit's own files_scanned figure"
+        gate.contains("run: bash .github/assert-audit-corpus.sh"),
+        "the corpus assertion must be the executable script, not an inline run: block — inline \
+         shell can only be checked by a substring test, which is how this step shipped broken twice"
+    );
+    // Nothing may re-implement the parse inline: an inline copy would drift away
+    // from the fixture-tested script without any test noticing.
+    assert!(
+        !gate.contains("files_scanned=\"$(jq"),
+        "the audit gate must not parse the audit result inline; assert-audit-corpus.sh owns that \
+         and is exercised against recorded fixtures"
     );
     assert!(
-        !gate.contains(".data.summary.files_scanned"),
-        "data.summary is the review-level summary and has no audit corpus metric"
+        !audit_corpus_script().is_empty(),
+        "the corpus assertion script must exist"
     );
 
     // Every `continue-on-error: true` in this job must precede the blocking
@@ -282,11 +385,207 @@ fn post_merge_full_audit_gate_blocks_on_an_empty_corpus() {
     }
 }
 
-/// The findings verdict is deliberately reporting-only for now (main carries 37
-/// unbaselined findings plus the ~293 that #10558 makes visible, and baselining
-/// them needs the fixed binary that only exists after this merges). That state
-/// is allowed to exist — but only while it is tracked, so it cannot quietly
-/// become the permanent shape of the gate.
+/// The happy path, proven by running the gate over a recorded real payload.
+///
+/// This is the assertion the whole file is about: not "the workflow mentions
+/// files_scanned" but "the shipped script, given the bytes `review audit`
+/// actually writes, exits 0 and reports the real corpus size".
+#[test]
+fn audit_corpus_gate_accepts_a_recorded_review_audit_payload() {
+    let (_dir, result) =
+        corpus_assertion_with("review-audit.json", recorded_review_audit_payload());
+
+    assert!(
+        result.status.success(),
+        "the recorded payload must pass the corpus gate:\n{}",
+        result.output()
+    );
+    assert!(
+        result.stdout.contains("audit corpus: 1596 file(s)"),
+        "the gate must report the corpus size it actually read:\n{}",
+        result.output()
+    );
+}
+
+/// Regression: the gate spent its entire life reading `audit.json`.
+///
+/// homeboy-action derives the result filename from the command
+/// (`command_output_stem "review audit"` -> `review-audit`), so `audit.json`
+/// never existed. The assertion failed on every merge from the day it landed,
+/// and reported it as "the audit did not run to completion" — blaming the audit
+/// for the gate's own bug.
+#[test]
+fn audit_corpus_gate_rejects_the_historical_audit_json_filename() {
+    let (_dir, result) = corpus_assertion_with("audit.json", recorded_review_audit_payload());
+
+    assert!(
+        !result.status.success(),
+        "a payload under the wrong filename must not pass:\n{}",
+        result.output()
+    );
+    assert!(
+        result.stderr.contains("review-audit.json"),
+        "the failure must name the file homeboy-action actually writes:\n{}",
+        result.output()
+    );
+    // The directory listing is what turns "no output" into "output under a
+    // different name", which is the diagnosis nobody got for a whole day.
+    assert!(
+        result.stderr.contains("audit.json"),
+        "the failure must show what the output directory does contain:\n{}",
+        result.output()
+    );
+}
+
+/// Regression: #10583 repointed the jq path at `.data.audit.output.summary`,
+/// which is the `review` UMBRELLA shape. `review audit` alone returns the flat
+/// audit output. With the old `// 0` default this misreported a shape mismatch
+/// as an empty corpus; the gate must distinguish the two.
+#[test]
+fn audit_corpus_gate_rejects_the_umbrella_review_shape() {
+    let (_dir, result) = corpus_assertion_with("review-audit.json", UMBRELLA_REVIEW_PAYLOAD);
+
+    assert!(
+        !result.status.success(),
+        "the umbrella shape carries no `review audit` corpus figure and must not pass:\n{}",
+        result.output()
+    );
+    assert!(
+        result.stderr.contains(".data.summary.files_scanned"),
+        "the failure must name the field `review audit` actually writes:\n{}",
+        result.output()
+    );
+    assert!(
+        !result.stdout.contains("audit corpus: 0 file(s)"),
+        "a shape mismatch must not be reported as an empty corpus — that conflation is what let \
+         the wrong jq path look like a plausible finding:\n{}",
+        result.output()
+    );
+}
+
+/// A `review audit` that died before auditing anything writes a real result
+/// file with no `.data`. The gate must fail AND surface the actual cause rather
+/// than claiming the audit produced no output.
+#[test]
+fn audit_corpus_gate_surfaces_a_failed_audit_instead_of_blaming_missing_output() {
+    let (_dir, result) =
+        corpus_assertion_with("review-audit.json", recorded_failed_review_audit_payload());
+
+    assert!(
+        !result.status.success(),
+        "a failed audit has no corpus and must not pass:\n{}",
+        result.output()
+    );
+    assert!(
+        result.stderr.contains("baselines.audit.known_fingerprints"),
+        "the gate must print the audit's own failure summary so the operator sees the real cause:\n{}",
+        result.output()
+    );
+}
+
+#[test]
+fn audit_corpus_gate_rejects_an_empty_corpus() {
+    let payload =
+        recorded_review_audit_payload().replace("\"files_scanned\": 1596", "\"files_scanned\": 0");
+    assert_ne!(
+        payload,
+        recorded_review_audit_payload(),
+        "the fixture's corpus figure moved; this test was about to assert nothing"
+    );
+
+    let (_dir, result) = corpus_assertion_with("review-audit.json", &payload);
+
+    assert!(
+        !result.status.success(),
+        "an empty corpus is #10557 verbatim and must fail:\n{}",
+        result.output()
+    );
+}
+
+/// `files_scanned >= 1` cannot tell 1596 files from 3. A corpus that collapses
+/// without emptying is the same defect wearing a different number, so the gate
+/// carries a sanity floor.
+#[test]
+fn audit_corpus_gate_rejects_a_collapsed_but_non_empty_corpus() {
+    let payload =
+        recorded_review_audit_payload().replace("\"files_scanned\": 1596", "\"files_scanned\": 3");
+    assert_ne!(
+        payload,
+        recorded_review_audit_payload(),
+        "the fixture's corpus figure moved; this test was about to assert nothing"
+    );
+
+    let (_dir, result) = corpus_assertion_with("review-audit.json", &payload);
+
+    assert!(
+        !result.status.success(),
+        "3 of ~1600 scannable files is a collapsed corpus, not a pass:\n{}",
+        result.output()
+    );
+    assert!(
+        result.stderr.contains("sanity floor"),
+        "the failure must explain the floor and how to move it deliberately:\n{}",
+        result.output()
+    );
+}
+
+/// Fails closed when it cannot find the audit at all. A gate is allowed to
+/// produce a false RED; it is never allowed to produce a false green.
+#[test]
+fn audit_corpus_gate_fails_closed_without_an_output_directory() {
+    let unset = run_corpus_assertion(None, None);
+    assert!(
+        !unset.status.success(),
+        "an unset HOMEBOY_OUTPUT_DIR must fail closed:\n{}",
+        unset.output()
+    );
+
+    let empty = tempfile::tempdir().expect("output dir");
+    let missing = run_corpus_assertion(Some(empty.path()), None);
+    assert!(
+        !missing.status.success(),
+        "an output directory with no audit result must fail closed:\n{}",
+        missing.output()
+    );
+}
+
+/// The floor is configurable, and the gate says which floor it applied — so a
+/// future corpus shrink is a deliberate edit rather than a silent softening.
+#[test]
+fn audit_corpus_gate_reports_the_floor_it_applied() {
+    let dir = tempfile::tempdir().expect("output dir");
+    std::fs::write(
+        dir.path().join("review-audit.json"),
+        recorded_review_audit_payload(),
+    )
+    .expect("write payload");
+
+    let result = run_corpus_assertion(Some(dir.path()), Some("1"));
+    assert!(result.status.success(), "{}", result.output());
+    assert!(
+        result.stdout.contains("floor 1"),
+        "the gate must state the floor it enforced:\n{}",
+        result.output()
+    );
+
+    let raised = run_corpus_assertion(Some(dir.path()), Some("100000"));
+    assert!(
+        !raised.status.success(),
+        "a floor above the corpus must fail:\n{}",
+        raised.output()
+    );
+}
+
+/// The findings verdict is deliberately reporting-only for now. Measured on
+/// `main` at 38b3fdf1b (run 30357149676, the first run where the audit gate
+/// actually scanned): **224 new findings since baseline** — 185
+/// `core_boundary_leak` rows unblinded by #10558's corpus fix plus 39 ordinary
+/// drift rows. Baselining them needs the fixed binary and a triage pass over
+/// the 185, so the flip is tracked in #10569.
+///
+/// That state is allowed to exist — but only while it is tracked AND while its
+/// size is published on every merge. A warning annotation nobody counts is how
+/// a reporting-only verdict quietly becomes permanent.
 #[test]
 fn reporting_only_audit_verdict_carries_a_follow_up_issue() {
     let gate = job("full-audit-gate");
@@ -303,6 +602,16 @@ fn reporting_only_audit_verdict_carries_a_follow_up_issue() {
     assert!(
         gate.contains("Reporting-only until"),
         "the reporting-only state must be stated at the step it applies to"
+    );
+    assert!(
+        gate.contains("GITHUB_STEP_SUMMARY"),
+        "a reporting-only verdict must publish the size of the debt it is tolerating, not just \
+         warn that some exists"
+    );
+    assert!(
+        gate.contains("new_items | length"),
+        "the published figure must be the count of findings NEW since the baseline — the number \
+         that has to reach zero (or be baselined) before #10569 can flip this to blocking"
     );
 }
 

--- a/tests/fixtures/audit_corpus/review-audit-failed-validation.json
+++ b/tests/fixtures/audit_corpus/review-audit-failed-validation.json
@@ -1,0 +1,20 @@
+{
+  "command": "review",
+  "diagnostics": {
+    "code": "validation.invalid_argument",
+    "details": {
+      "field": "baselines.audit.known_fingerprints",
+      "problem": "1 baseline fingerprint(s) reference paths that no longer exist: structural::crates/homeboy-process/src/lib.rs::HighItemCount. Regenerate or prune the stale baseline rows."
+    },
+    "failure_digest": {
+      "summary": "Invalid argument 'baselines.audit.known_fingerprints': 1 baseline fingerprint(s) reference paths that no longer exist: structural::crates/homeboy-process/src/lib.rs::HighItemCount. Regenerate or prune the stale baseline rows."
+    },
+    "message": "Invalid argument 'baselines.audit.known_fingerprints': 1 baseline fingerprint(s) reference paths that no longer exist: structural::crates/homeboy-process/src/lib.rs::HighItemCount. Regenerate or prune the stale baseline rows."
+  },
+  "exit_code": 2,
+  "operation": "audit",
+  "schema": "homeboy/command-result/v3",
+  "status": "failed",
+  "success": false,
+  "summary": "Invalid argument 'baselines.audit.known_fingerprints': 1 baseline fingerprint(s) reference paths that no longer exist: structural::crates/homeboy-process/src/lib.rs::HighItemCount. Regenerate or prune the stale baseline rows."
+}

--- a/tests/fixtures/audit_corpus/review-audit.json
+++ b/tests/fixtures/audit_corpus/review-audit.json
@@ -1,0 +1,173 @@
+{
+  "command": "review",
+  "data": {
+    "baseline_comparison": {
+      "delta": 34,
+      "drift_increased": true,
+      "new_items": [
+        {
+          "context_label": "intra-method-duplication",
+          "description": "Duplicated block in `status_with_options` \u2014 13 identical lines at line 1385 and line 1398",
+          "fingerprint": "intra-method-duplication::crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs::IntraMethodDuplicate"
+        },
+        {
+          "context_label": "intra-method-duplication",
+          "description": "Duplicated block in `audit_internal` \u2014 7 identical lines at line 286 and line 318",
+          "fingerprint": "intra-method-duplication::crates/homeboy-code-audit/src/engine.rs::IntraMethodDuplicate"
+        }
+      ],
+      "resolved_fingerprints": [
+        "artifact_portability::artifact_portability/local_artifact_path/$.artifact.commands[1].findings[0].metadata.source_sidecar_path::NonPortableArtifactPath",
+        "artifact_portability::artifact_portability/local_artifact_path/$.artifact.commands[1].findings[1].metadata.source_sidecar_path::NonPortableArtifactPath"
+      ]
+    },
+    "command": "audit.compared",
+    "component_id": "homeboy",
+    "conventions": [
+      {
+        "confidence": 1.0,
+        "conforming": [
+          "crates/homeboy-agents/src/agent_task_service/tests.rs",
+          "crates/homeboy-agents/src/agent_task_service/cook_tests.rs"
+        ],
+        "expected_interfaces": [
+          "AgentTaskExecutorAdapter"
+        ],
+        "expected_methods": [
+          "execute"
+        ],
+        "expected_registrations": [
+          "json"
+        ],
+        "glob": "crates/homeboy-agents/src/agent_task_service/*",
+        "name": "Agent Task Service (Tests)",
+        "status": "clean",
+        "total_files": 2
+      }
+    ],
+    "duplicate_groups": [
+      {
+        "canonical_file": "crates/homeboy-cli/src/commands/runs/remote.rs",
+        "function_name": "active_runner_job_run_summary_if_durable",
+        "remove_from": [
+          "crates/homeboy-cli/src/commands/runs/handlers.rs"
+        ]
+      }
+    ],
+    "findings": [
+      {
+        "category": "Commands",
+        "file": "crates/homeboy-cli/src/commands/agent_task_dispatch.rs",
+        "fingerprint": "crates/homeboy-cli/src/commands/agent_task_dispatch.rs:missing_method:Commands:Missing method: run",
+        "message": "Missing method: run",
+        "metadata": {
+          "confidence": "heuristic",
+          "convention": "Commands",
+          "kind": "missing_method",
+          "source_sidecar": "audit-findings",
+          "suggestion": "Add run() to match the convention in Commands"
+        },
+        "rule": "missing_method",
+        "severity": "warning",
+        "source": {
+          "kind": "sidecar",
+          "label": "audit-findings"
+        },
+        "tool": "audit"
+      },
+      {
+        "category": "Src",
+        "file": "crates/contracts/homeboy-audit-contract/src/test_mapping.rs",
+        "fingerprint": "crates/contracts/homeboy-audit-contract/src/test_mapping.rs:missing_method:Src:Missing method: merge",
+        "message": "Missing method: merge",
+        "metadata": {
+          "confidence": "heuristic",
+          "convention": "Src",
+          "kind": "missing_method",
+          "source_sidecar": "audit-findings",
+          "suggestion": "Add merge() to match the convention in Src"
+        },
+        "rule": "missing_method",
+        "severity": "warning",
+        "source": {
+          "kind": "sidecar",
+          "label": "audit-findings"
+        },
+        "tool": "audit"
+      }
+    ],
+    "passed": false,
+    "source_path": "/home/runner/work/homeboy/homeboy",
+    "summary": {
+      "alignment_score": 0.8198198080062866,
+      "conventions_detected": 13,
+      "files_scanned": 1596,
+      "files_skipped": 1,
+      "outliers_found": 20,
+      "warnings": [
+        "1 source file(s) found but could not be fingerprinted (no extension provides fingerprinting for these file types)"
+      ]
+    }
+  },
+  "diagnostics": {
+    "code": "command.failed",
+    "details": {
+      "exit_code": 1
+    },
+    "failure_digest": {
+      "next_actions": [
+        {
+          "command": "homeboy runs evidence 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf",
+          "kind": "show",
+          "label": "show evidence"
+        },
+        {
+          "command": "homeboy activity show 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf",
+          "kind": "show",
+          "label": "show activity"
+        }
+      ],
+      "summary": "audit run 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf failed (exit 1)"
+    },
+    "message": "audit run 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf failed (exit 1)"
+  },
+  "evidence": [
+    {
+      "id": "8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf-result",
+      "kind": "command-result",
+      "semantic_key": "command_result",
+      "uri": "homeboy://runs/8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf/result"
+    }
+  ],
+  "exit_code": 1,
+  "next_actions": [
+    {
+      "command": "homeboy runs evidence 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf",
+      "kind": "show",
+      "label": "show evidence"
+    }
+  ],
+  "operation": "audit",
+  "refs": {
+    "runs": [
+      {
+        "id": "8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf",
+        "kind": "audit",
+        "source": "homeboy-audit",
+        "status_command": "homeboy runs show 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf",
+        "watch_command": "homeboy runs watch 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf"
+      }
+    ]
+  },
+  "run": {
+    "id": "8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf",
+    "kind": "audit",
+    "source": "homeboy-audit",
+    "status_command": "homeboy runs show 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf",
+    "watch_command": "homeboy runs watch 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf"
+  },
+  "schema": "homeboy/command-result/v3",
+  "status": "failed",
+  "success": false,
+  "summary": "audit run 8b9126ba-9900-4a9e-a310-aaf6c2c1f1cf failed (exit 1)"
+}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -269,6 +269,78 @@ fn release_preflight_validates_the_private_workspace_build_before_mutating_relea
     );
 }
 
+/// Walk the workspace sources once and count what the Windows guard exists for.
+///
+/// Reading the tree rather than trusting a remembered number is the point: a
+/// job name in a YAML file proves a job runs, not that it guards anything.
+fn windows_source_surface() -> (usize, Vec<String>) {
+    fn walk(
+        dir: &std::path::Path,
+        rust: &mut Vec<std::path::PathBuf>,
+        manifests: &mut Vec<std::path::PathBuf>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if path.is_dir() {
+                // `target/` is build output and `.git/` is not source.
+                if name == "target" || name == ".git" || name == "node_modules" {
+                    continue;
+                }
+                walk(&path, rust, manifests);
+            } else if name.ends_with(".rs") {
+                rust.push(path);
+            } else if name == "Cargo.toml" {
+                manifests.push(path);
+            }
+        }
+    }
+
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut rust = Vec::new();
+    let mut manifests = Vec::new();
+    for sub in ["crates", "src"] {
+        walk(&root.join(sub), &mut rust, &mut manifests);
+    }
+    manifests.push(root.join("Cargo.toml"));
+
+    let cfg_sites = rust
+        .iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .map(|body| {
+            body.matches("cfg(windows)").count()
+                + body.matches("cfg(target_os = \"windows\")").count()
+        })
+        .sum();
+
+    let mut windows_crates: Vec<String> = manifests
+        .iter()
+        .filter(|path| {
+            std::fs::read_to_string(path)
+                .map(|body| body.contains("windows-sys"))
+                .unwrap_or(false)
+        })
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    windows_crates.sort();
+
+    (cfg_sites, windows_crates)
+}
+
+/// PR CI keeps a Windows *source* check; the release drops the Windows
+/// *artifact*. Both halves are asserted by effect, not by job name.
+///
+/// #10539: `38492c5db` removed the `gate-windows-build` job and left this test
+/// asserting it, panicking `missing gate-windows-build job` and intermittently
+/// killing releases. Inverting the assertion fixed that instance — but a test
+/// that only says "the removed job is still removed" would keep passing if the
+/// surviving guard were narrowed to nothing, or if the code it guards
+/// disappeared and the job became pure CI spend. So this asserts the guard has
+/// something to guard, and that its scope actually reaches it.
 #[test]
 fn release_omits_unused_windows_artifacts_while_ci_checks_windows_source() {
     let release = release_workflow();
@@ -282,8 +354,39 @@ fn release_omits_unused_windows_artifacts_while_ci_checks_windows_source() {
         !dist_workspace_manifest().contains("x86_64-pc-windows-msvc"),
         "release must not publish an unconsumed Windows artifact"
     );
-    assert!(windows_compile.contains("runs-on: windows-latest"));
-    assert!(windows_compile.contains("run: cargo check --workspace --locked"));
+
+    // The guard must still be a Windows guard.
+    assert!(
+        windows_compile.contains("runs-on: windows-latest"),
+        "a Windows source check that does not run on Windows checks nothing"
+    );
+    // `--workspace` is the load-bearing word. Narrowing to `-p <crate>` would
+    // leave the job green while the cfg-gated code it exists for goes
+    // uncompiled, which is indistinguishable from deleting the job.
+    assert!(
+        windows_compile.contains("run: cargo check --workspace --locked"),
+        "the Windows check must cover the whole workspace with the locked graph"
+    );
+    assert!(
+        !windows_compile.contains("--tests"),
+        "the Windows check is deliberately codegen-free and test-target-free; \
+         some Unix-only test helpers rely on that boundary"
+    );
+
+    // And there must be something for it to guard. If this ever hits zero the
+    // honest move is to delete the job, not to keep paying a windows-latest
+    // runner on every PR for a check with an empty subject.
+    let (cfg_sites, windows_crates) = windows_source_surface();
+    assert!(
+        cfg_sites > 0,
+        "no cfg(windows) sites remain in the workspace: the windows-compile job now guards \
+         nothing and should be removed rather than left running"
+    );
+    assert!(
+        !windows_crates.is_empty(),
+        "no crate declares a windows-sys dependency: the windows-compile job now guards nothing \
+         and should be removed rather than left running. Checked manifests under crates/ and the root."
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #10539. Closes #10569.

Both gates were asserting the wrong thing.

**#10539** — `release_workflow_test` asserted a `gate-windows-build` job that `38492c5db` removed, panicking `missing gate-windows-build job`. It now asserts the inverse, and additionally that `windows-compile` remains in `ci.yml` and that `cfg(windows)` sites and `windows-sys` deps still exist — so the test fails if that job ever stops guarding anything. The Windows *release asset* removal stands; PR CI coverage was always meant to be kept.

**#10569** — the audit-corpus assertion moves from an inline `run:` block into `.github/assert-audit-corpus.sh`, executed against recorded fixtures with one fixture per historical defect. An inline block can only be verified by a YAML substring test, and that is precisely what let this step ship broken twice (wrong result filename, then a wrong jq path bolted on top).

Also drops a stale baseline row for `homeboy-process`, folded into core by #10597.

Recovered from an interrupted cook; commits carry the reasoning. CI is the gate.