### PR TITLE
fix(diagnostics): stop collapsing signal kills into provider_empty_stdout and stop redacting log prose

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -551,6 +551,33 @@ pub(super) fn run_materialized_provider_command_once(
             json!({ "provider": provider.id, "command": command }),
         );
     };
+    // A signal-terminated executor and an executor that ran to completion
+    // without emitting an outcome are different failures with different
+    // causes. Collapsing an external kill (OOM killer, runner/daemon shutdown,
+    // operator SIGTERM) into `provider_empty_stdout` points the operator at
+    // the provider when the real cause was the kill. Homeboy's own deadline
+    // and liveness kills return above, so a signal here means termination was
+    // initiated outside this wait loop.
+    if let Some(signal) = exit_signal(&status) {
+        if serde_json::from_str::<AgentTaskOutcome>(&stdout).is_err() {
+            return signal_termination_outcome(
+                request,
+                provider,
+                &command,
+                &status,
+                signal,
+                &stdout,
+                &stderr,
+                SignalTerminationContext {
+                    elapsed_ms: started.elapsed().as_millis(),
+                    requested_timeout_ms,
+                    process_timeout_ms: process_timeout.as_millis(),
+                    liveness_timeout_ms: request.limits.liveness_timeout_ms,
+                    execution_deadline_unix_ms: request.limits.execution_deadline_unix_ms,
+                },
+            );
+        }
+    }
     if stdout.is_empty() {
         return failure_outcome(
             request,
@@ -993,6 +1020,182 @@ fn executor_process_diagnostic_data(
     })
 }
 
+/// Timing/budget context captured at the moment a provider process was
+/// observed to have died from a signal. Recorded verbatim in the diagnostic so
+/// an operator can tell "no deadline was configured" apart from "a deadline
+/// expired" without re-deriving it from the aggregate.
+pub(super) struct SignalTerminationContext {
+    pub elapsed_ms: u128,
+    pub requested_timeout_ms: u64,
+    pub process_timeout_ms: u128,
+    pub liveness_timeout_ms: Option<u64>,
+    pub execution_deadline_unix_ms: Option<u64>,
+}
+
+/// Human-readable name for the POSIX signals a provider process realistically
+/// dies from. Unknown signals fall back to their number so the diagnostic
+/// never loses the raw value.
+fn signal_name(signal: i32) -> Option<&'static str> {
+    Some(match signal {
+        1 => "SIGHUP",
+        2 => "SIGINT",
+        3 => "SIGQUIT",
+        4 => "SIGILL",
+        6 => "SIGABRT",
+        8 => "SIGFPE",
+        9 => "SIGKILL",
+        11 => "SIGSEGV",
+        13 => "SIGPIPE",
+        14 => "SIGALRM",
+        15 => "SIGTERM",
+        24 => "SIGXCPU",
+        25 => "SIGXFSZ",
+        _ => return None,
+    })
+}
+
+fn signal_label(signal: i32) -> String {
+    match signal_name(signal) {
+        Some(name) => format!("signal {signal} ({name})"),
+        None => format!("signal {signal}"),
+    }
+}
+
+/// Best-effort attribution of who ended the process. Homeboy's own deadline and
+/// liveness kills never reach this path, so anything observed here was
+/// initiated outside the provider wait loop. The specific signal still narrows
+/// the likely source, which is the difference between "look at the provider"
+/// and "look at host memory pressure".
+fn signal_termination_initiator(signal: i32) -> &'static str {
+    match signal {
+        9 => "external_sigkill",
+        15 => "external_sigterm",
+        2 | 3 => "external_interrupt",
+        1 => "external_hangup",
+        4 | 6 | 8 | 11 => "provider_crash",
+        _ => "external_signal",
+    }
+}
+
+fn signal_termination_hints(signal: i32, stdout: &str, stderr: &str) -> Vec<String> {
+    let mut hints = Vec::new();
+    match signal {
+        9 => {
+            hints.push("SIGKILL is what the Linux OOM killer sends: check `dmesg -T | grep -i -e oom -e 'killed process'` and cgroup `memory.events` on the host or CI runner that ran this provider.".to_string());
+            hints.push("SIGKILL cannot be trapped, so no provider-side diagnostics exist. Re-run with more memory headroom or lower provider concurrency before blaming the provider.".to_string());
+        }
+        15 | 2 | 3 | 1 => {
+            hints.push("Termination was requested from outside this Homeboy wait loop (operator, supervisor, runner/daemon shutdown, CI job cancellation, or a parent process-group kill).".to_string());
+            hints.push("Check the supervising process (systemd unit, CI job timeout, terminal that owns the process group) before treating this as a provider defect.".to_string());
+        }
+        4 | 6 | 8 | 11 => {
+            hints.push("This signal indicates the provider process itself crashed (illegal instruction, abort, arithmetic fault, or segfault). Capture a core dump or provider-side logs.".to_string());
+        }
+        _ => {}
+    }
+    if stdout.is_empty() && stderr.is_empty() {
+        hints.push("No stdout/stderr was captured before termination, which is expected for an uncatchable or immediate kill. Absence of provider output is not evidence of a provider defect here.".to_string());
+    }
+    hints
+}
+
+/// Classify a provider process that died from a signal without leaving a
+/// parseable outcome. Deliberately reuses the existing `provider_error` status
+/// and `provider` failure classification: the wire enums are consumed by
+/// independently released extensions, so this fix is additive at the schema
+/// level and only replaces the misleading diagnostic class/message/data.
+#[allow(clippy::too_many_arguments)]
+fn signal_termination_outcome(
+    request: &AgentTaskRequest,
+    provider: &AgentTaskExecutorProvider,
+    command: &str,
+    status: &std::process::ExitStatus,
+    signal: i32,
+    stdout: &str,
+    stderr: &str,
+    context: SignalTerminationContext,
+) -> AgentTaskOutcome {
+    let mut data = executor_process_diagnostic_data(
+        &provider.id,
+        &provider.backend,
+        command,
+        status,
+        stdout,
+        stderr,
+        &provider_output_redactions(request, provider),
+    );
+    if let Some(object) = data.as_object_mut() {
+        object.insert(
+            "signal_name".to_string(),
+            signal_name(signal)
+                .map(|name| Value::String(name.to_string()))
+                .unwrap_or(Value::Null),
+        );
+        object.insert(
+            "termination_initiator".to_string(),
+            Value::String(signal_termination_initiator(signal).to_string()),
+        );
+        object.insert(
+            "homeboy_initiated_termination".to_string(),
+            Value::Bool(false),
+        );
+        object.insert(
+            "likely_oom_kill".to_string(),
+            Value::Bool(signal == 9 && stdout.is_empty() && stderr.is_empty()),
+        );
+        object.insert(
+            "elapsed_ms".to_string(),
+            Value::from(u64::try_from(context.elapsed_ms).unwrap_or(u64::MAX)),
+        );
+        object.insert(
+            "timeout_ms".to_string(),
+            Value::from(context.requested_timeout_ms),
+        );
+        object.insert(
+            "process_timeout_ms".to_string(),
+            Value::from(u64::try_from(context.process_timeout_ms).unwrap_or(u64::MAX)),
+        );
+        object.insert(
+            "liveness_timeout_ms".to_string(),
+            context
+                .liveness_timeout_ms
+                .map(Value::from)
+                .unwrap_or(Value::Null),
+        );
+        object.insert(
+            "execution_deadline_unix_ms".to_string(),
+            context
+                .execution_deadline_unix_ms
+                .map(Value::from)
+                .unwrap_or(Value::Null),
+        );
+        object.insert(
+            "signal_remediation_hints".to_string(),
+            Value::from(signal_termination_hints(signal, stdout, stderr)),
+        );
+    }
+
+    let stdout_note = if stdout.is_empty() {
+        "no stdout was captured".to_string()
+    } else {
+        format!("{} bytes of unparseable stdout were captured", stdout.len())
+    };
+
+    failure_outcome(
+        request,
+        AgentTaskOutcomeStatus::ProviderError,
+        AgentTaskFailureClassification::Provider,
+        "agent_task.provider_signal_terminated",
+        format!(
+            "provider '{}' was terminated by {} after {}ms before producing an outcome ({stdout_note}); termination was not initiated by Homeboy's provider deadline or liveness watchdog",
+            provider.id,
+            signal_label(signal),
+            context.elapsed_ms
+        ),
+        data,
+    )
+}
+
 fn surface_provider_process_failure(
     outcome: &mut AgentTaskOutcome,
     request: &AgentTaskRequest,
@@ -1024,7 +1227,7 @@ fn surface_provider_process_failure(
     let exit_description = status
         .code()
         .map(|code| format!("status {code}"))
-        .or_else(|| exit_signal(status).map(|signal| format!("signal {signal}")))
+        .or_else(|| exit_signal(status).map(signal_label))
         .unwrap_or_else(|| "unknown status".to_string());
     let stderr_tail = data
         .get("stderr")

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -459,6 +459,82 @@ fn provider_empty_stdout_captures_bounded_stderr_and_exit_context() {
         .any(|reference| reference.kind == "executor-result"));
 }
 
+/// A provider killed by an external SIGTERM must not be reported as
+/// "the provider produced no output". The two failures have different causes
+/// and different remediations, and collapsing them sends operators at the
+/// provider when the real cause was the kill.
+#[cfg(unix)]
+#[test]
+fn provider_external_sigterm_is_not_reported_as_empty_stdout() {
+    let command = format!(
+        "node {}",
+        script("process.kill(process.pid, 'SIGTERM'); setInterval(() => {}, 1000);")
+    );
+    let (request, provider) = request("task-external-sigterm", command);
+
+    let outcome = run_provider_command(&request, &provider, None);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
+    assert_eq!(
+        outcome.diagnostics[0].class, "agent_task.provider_signal_terminated",
+        "{:?}",
+        outcome.diagnostics
+    );
+    let data = &outcome.diagnostics[0].data;
+    assert_eq!(data["signal"], json!(15));
+    assert_eq!(data["signal_name"], json!("SIGTERM"));
+    assert_eq!(data["exit_code"], serde_json::Value::Null);
+    assert_eq!(data["termination_initiator"], json!("external_sigterm"));
+    assert_eq!(data["homeboy_initiated_termination"], json!(false));
+    assert_eq!(data["likely_oom_kill"], json!(false));
+    assert!(data["elapsed_ms"].is_u64(), "{data}");
+    assert_eq!(data["execution_deadline_unix_ms"], serde_json::Value::Null);
+    assert!(outcome
+        .summary
+        .as_deref()
+        .expect("summary")
+        .contains("SIGTERM"));
+}
+
+/// SIGKILL with no captured output is the signature of the Linux OOM killer,
+/// which is a real failure mode on both this host and CI runners. The
+/// diagnostic has to say so instead of blaming the provider for silence it
+/// could not have avoided.
+#[cfg(unix)]
+#[test]
+fn provider_sigkill_records_probable_oom_context() {
+    let command = format!(
+        "node {}",
+        // Distinct body length keeps this script file separate from the
+        // SIGTERM script, which is keyed by body length.
+        script("process.kill(process.pid, 'SIGKILL'); setInterval(() => {}, 10_000);")
+    );
+    let (request, provider) = request("task-external-sigkill", command);
+
+    let outcome = run_provider_command(&request, &provider, None);
+
+    assert_eq!(
+        outcome.diagnostics[0].class, "agent_task.provider_signal_terminated",
+        "{:?}",
+        outcome.diagnostics
+    );
+    let data = &outcome.diagnostics[0].data;
+    assert_eq!(data["signal"], json!(9));
+    assert_eq!(data["signal_name"], json!("SIGKILL"));
+    assert_eq!(data["termination_initiator"], json!("external_sigkill"));
+    assert_eq!(data["likely_oom_kill"], json!(true));
+    let hints = data["signal_remediation_hints"]
+        .as_array()
+        .expect("signal remediation hints");
+    assert!(
+        hints
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .any(|hint| hint.contains("OOM")),
+        "{hints:?}"
+    );
+}
+
 #[test]
 fn provider_empty_stdout_records_failed_run_with_executor_evidence() {
     homeboy_core::test_support::with_isolated_home(|_| {

--- a/crates/homeboy-redaction/src/lib.rs
+++ b/crates/homeboy-redaction/src/lib.rs
@@ -3,6 +3,20 @@ use serde_json::{Map, Value};
 
 const DEFAULT_REPLACEMENT: &str = "[REDACTED]";
 
+/// Trailing key segments that describe *how* a credential is carried rather
+/// than naming a different thing. `session_id`, `token_value`, and
+/// `auth_header` are still credential keys; `proxy_auth_smoke` is not.
+const GENERIC_KEY_QUALIFIERS: &[&str] = &[
+    "b64", "base64", "data", "env", "hash", "header", "id", "ids", "plain", "raw", "str", "string",
+    "val", "value", "var",
+];
+
+/// Longest run of letters still treated as an ordinary English word when it
+/// follows a bare `bearer`/`basic`/`token` in free-form log text. Real bearer
+/// credentials and Basic base64 blobs are longer than this and are not pure
+/// letters.
+const PROSE_WORD_MAX_LEN: usize = 12;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RedactionPolicy {
     sensitive_keys: Vec<String>,
@@ -106,6 +120,59 @@ impl RedactionPolicy {
         self.sensitive_headers
             .iter()
             .any(|sensitive| header == *sensitive || header.contains(sensitive))
+    }
+
+    /// Stricter sibling of [`RedactionPolicy::is_sensitive_key`] for keys that
+    /// were *inferred from free-form text* rather than read out of a real
+    /// key position.
+    ///
+    /// `is_sensitive_key` matches any key that merely **contains** a sensitive
+    /// token. That is the right fail-closed rule for structured positions —
+    /// JSON object keys, HTTP header names, query parameter names, env var
+    /// names, CLI flags — where the key genuinely names a value and a false
+    /// positive costs nothing but a redacted field.
+    ///
+    /// It is the wrong rule for prose. In console output, any word that
+    /// happens to contain `auth`, `key`, `sid`, or `session` becomes a
+    /// "sensitive key", and the token after the next `:` or `=` is destroyed.
+    /// That is how `=== http-client-proxy-auth-smoke: 3 FAIL of 15 ===` lost
+    /// its failure count: `http_client_proxy_auth_smoke` contains `auth`.
+    ///
+    /// Credential keys name the credential with their *head noun*, so this
+    /// predicate requires the sensitive token to be the final key segment
+    /// (optionally followed by one generic carrier qualifier). Structured
+    /// callers keep the broad rule; only inferred keys are held to this one.
+    pub fn is_credential_key_name(&self, key: &str) -> bool {
+        let segments = key_segments(key);
+        if segments.is_empty() {
+            return false;
+        }
+        if self.matches_credential_suffix(&segments) {
+            return true;
+        }
+        if segments.len() > 1
+            && GENERIC_KEY_QUALIFIERS.contains(&segments[segments.len() - 1].as_str())
+        {
+            return self.matches_credential_suffix(&segments[..segments.len() - 1]);
+        }
+        false
+    }
+
+    fn matches_credential_suffix(&self, segments: &[String]) -> bool {
+        if segments.is_empty() {
+            return false;
+        }
+        let joined = segments.join("_");
+        self.sensitive_keys
+            .iter()
+            .chain(self.sensitive_headers.iter())
+            .any(|sensitive| {
+                let sensitive = normalize_key(sensitive);
+                if sensitive.is_empty() {
+                    return false;
+                }
+                joined == sensitive || joined.ends_with(&format!("_{sensitive}"))
+            })
     }
 
     pub fn redact_string(&self, value: &str) -> String {
@@ -315,11 +382,44 @@ fn normalize_key(key: &str) -> String {
 }
 
 fn redact_authorization_schemes(value: &str, replacement: &str) -> String {
-    let pattern = Regex::new(r"(?i)\b(bearer|basic|token)\s+[^\s,;]+")
+    // An explicit authorization key is unambiguous provenance: whatever
+    // follows it is a credential no matter what it looks like. Redact it
+    // unconditionally, preserving any scheme name so the diagnostic still
+    // says *how* the request authenticated.
+    //
+    // This also closes a gap in the previous implementation, which only
+    // redacted after a recognized scheme word: `Authorization: opaquevalue`
+    // (no scheme) survived both this pass and the inline-assignment pass,
+    // because the latter deliberately skips `authorization` keys.
+    let header = Regex::new(
+        r"(?i)\b((?:proxy-)?authorization)(\s*[:=]\s*)((?:bearer|basic|token|digest|negotiate)\s+)?([^\s,;]+)",
+    )
+    .expect("authorization header redaction regex is valid");
+    let value = header
+        .replace_all(value, |captures: &Captures<'_>| {
+            format!(
+                "{}{}{}{replacement}",
+                &captures[1],
+                &captures[2],
+                captures.get(3).map_or("", |scheme| scheme.as_str())
+            )
+        })
+        .into_owned();
+    // A bare scheme word with no authorization key around it is a shape
+    // guess, and `bearer`/`basic`/`token` are also ordinary English words.
+    // "PASS: basic auth creates Authorization header" is a test name, not a
+    // credential; redacting the word after `basic` corrupted it. Only redact
+    // when the following token is not plain prose. Credentials reachable this
+    // way (JWTs, base64, `sk-`/`ghp_` tokens, hex) all fail the prose test.
+    let pattern = Regex::new(r"(?i)\b(bearer|basic|token)\s+([^\s,;]+)")
         .expect("authorization redaction regex is valid");
     let value = pattern
-        .replace_all(value, |captures: &Captures<'_>| {
-            format!("{} {replacement}", &captures[1])
+        .replace_all(&value, |captures: &Captures<'_>| {
+            if looks_like_prose_word(&captures[2]) {
+                captures[0].to_string()
+            } else {
+                format!("{} {replacement}", &captures[1])
+            }
         })
         .into_owned();
     let credentials = Regex::new(r"(?i)\b([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^@/\s]+@")
@@ -337,16 +437,82 @@ fn redact_inline_assignments(value: &str, policy: &RedactionPolicy) -> String {
     pattern
         .replace_all(value, |captures: &Captures<'_>| {
             let key = &captures[1];
-            if normalize_key(key) == "authorization" {
+            // Authorization keys were already handled, scheme name intact.
+            if is_authorization_key(key) {
                 return captures[0].to_string();
             }
-            if policy.is_sensitive_key(key) || policy.is_sensitive_header(key) {
+            // The "key" here was inferred from arbitrary text, so it is held
+            // to the strict credential-key rule instead of the broad
+            // substring rule used for real key positions.
+            if policy.is_credential_key_name(key) {
                 format!("{}{}{}", key, &captures[2], policy.replacement)
             } else {
                 captures[0].to_string()
             }
         })
         .into_owned()
+}
+
+fn is_authorization_key(key: &str) -> bool {
+    let normalized = normalize_key(key);
+    normalized == "authorization" || normalized.ends_with("_authorization")
+}
+
+/// Split a key into lowercase segments, treating `_`, `-`, `.`, `/`, spaces,
+/// and camelCase transitions as boundaries. `X-Api-Key` and `apiKey` both
+/// become `["api", "key"]`.
+fn key_segments(key: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut previous_is_lower_or_digit = false;
+    for character in key.trim().chars() {
+        if matches!(character, '_' | '-' | '.' | '/' | ' ' | ':') {
+            if !current.is_empty() {
+                segments.push(std::mem::take(&mut current));
+            }
+            previous_is_lower_or_digit = false;
+            continue;
+        }
+        if character.is_ascii_uppercase() && previous_is_lower_or_digit && !current.is_empty() {
+            segments.push(std::mem::take(&mut current));
+        }
+        previous_is_lower_or_digit = character.is_ascii_lowercase() || character.is_ascii_digit();
+        current.push(character.to_ascii_lowercase());
+    }
+    if !current.is_empty() {
+        segments.push(current);
+    }
+    segments
+}
+
+/// Whether a token is shaped like an ordinary word rather than a credential.
+/// Deliberately conservative: anything with a digit, punctuation, mixed case,
+/// or more than [`PROSE_WORD_MAX_LEN`] letters is treated as a credential.
+fn looks_like_prose_word(value: &str) -> bool {
+    if value.is_empty() || value.len() > PROSE_WORD_MAX_LEN {
+        return false;
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphabetic())
+    {
+        return false;
+    }
+    let all_lowercase = value
+        .chars()
+        .all(|character| character.is_ascii_lowercase());
+    let all_uppercase = value
+        .chars()
+        .all(|character| character.is_ascii_uppercase());
+    let capitalized = value
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_uppercase())
+        && value
+            .chars()
+            .skip(1)
+            .all(|character| character.is_ascii_lowercase());
+    all_lowercase || capitalized || (all_uppercase && value.len() <= 5)
 }
 
 fn split_once(value: &str, delimiter: char) -> (&str, Option<&str>) {
@@ -406,6 +572,120 @@ mod tests {
             policy.redact_string("token=abc password: hunter2 safe=value"),
             "token=[REDACTED] password: [REDACTED] safe=value"
         );
+    }
+
+    #[test]
+    fn preserves_low_entropy_diagnostic_text_and_failure_counts() {
+        // Verbatim console output from the reproduction in #10521. Every line
+        // here is test output, not a credential: `http-client-proxy-auth-smoke`
+        // merely contains `auth`, and `basic`/`Basic` are English words.
+        let policy = RedactionPolicy::default();
+        let diagnostics = "[1] Standard auth options\n\
+             PASS: basic auth creates Authorization header\n\
+             PASS: bearer auth creates Authorization header\n\
+             [2] Auth ref options\n\
+             FAIL: auth_ref resolves auth options\n\
+             FAIL: auth_ref resolves proxy URL\n\
+             FAIL: auth_ref resolved Basic header is applied\n\
+             === http-client-proxy-auth-smoke: 3 FAIL of 15 ===";
+
+        assert_eq!(policy.redact_string(diagnostics), diagnostics);
+    }
+
+    #[test]
+    fn inferred_keys_only_redact_when_the_head_noun_is_a_credential() {
+        let policy = RedactionPolicy::default();
+
+        for credential_key in [
+            "token",
+            "api_token",
+            "X-Api-Key",
+            "apiKey",
+            "clientSecret",
+            "refresh_token",
+            "session_id",
+            "auth_header",
+            "PASSWORD",
+        ] {
+            assert!(
+                policy.is_credential_key_name(credential_key),
+                "{credential_key} must stay redacted"
+            );
+        }
+
+        for diagnostic_key in [
+            "http-client-proxy-auth-smoke",
+            "auth_ref",
+            "PASS",
+            "monkey",
+            "keyboard",
+            "considered",
+        ] {
+            assert!(
+                !policy.is_credential_key_name(diagnostic_key),
+                "{diagnostic_key} is diagnostic text, not a credential key"
+            );
+        }
+    }
+
+    #[test]
+    fn structured_key_positions_keep_the_broad_fail_closed_rule() {
+        // Narrowing applies only to keys inferred from prose. Real key
+        // positions (env names, JSON keys, headers, query params) still match
+        // on substring so a novel credential name cannot slip through.
+        let policy = RedactionPolicy::default();
+
+        assert!(policy.is_sensitive_key("http-client-proxy-auth-smoke"));
+        assert_eq!(
+            policy.redact_json(&json!({ "proxy_auth_settings": "value" })),
+            json!({ "proxy_auth_settings": "[REDACTED]" })
+        );
+        assert_eq!(
+            policy.redact_url("/path?proxy_auth_settings=value&ok=1"),
+            "/path?proxy_auth_settings=[REDACTED]&ok=1"
+        );
+    }
+
+    #[test]
+    fn redacts_authorization_header_values_without_a_scheme_word() {
+        let policy = RedactionPolicy::default();
+
+        assert_eq!(
+            policy.redact_string("Authorization: opaquecredential"),
+            "Authorization: [REDACTED]"
+        );
+        assert_eq!(
+            policy.redact_string("Proxy-Authorization: Basic secretvalue"),
+            "Proxy-Authorization: Basic [REDACTED]"
+        );
+    }
+
+    #[test]
+    fn bare_scheme_words_still_redact_credential_shaped_tokens() {
+        let policy = RedactionPolicy::default();
+
+        for credential in [
+            "abc.def.ghi",
+            "dXNlcjpzZWNyZXQ=",
+            "ghp_secret",
+            "sk-test-value",
+            "aBcDeFgHiJkL",
+            "0123456789abcdef",
+        ] {
+            let redacted = policy.redact_string(&format!("sent bearer {credential} upstream"));
+            assert_eq!(
+                redacted, "sent bearer [REDACTED] upstream",
+                "bearer {credential} must stay redacted"
+            );
+        }
+    }
+
+    #[test]
+    fn redaction_is_idempotent_over_already_redacted_text() {
+        let policy = RedactionPolicy::default();
+        let once = policy.redact_string("Authorization: Bearer abc.def.ghi token=secret-value");
+
+        assert_eq!(policy.redact_string(&once), once);
     }
 
     #[test]


### PR DESCRIPTION
Closes #10526. Closes #10521.

Two diagnostic-fidelity bugs. Both make Homeboy report a *different failure than the one that happened*, which is the expensive kind: it sends the reader at the wrong subsystem.

---

## Part 1 — #10526: provider SIGTERM collapsed into `provider_empty_stdout`

**Collapse site:** `crates/homeboy-agents/src/agent_task_provider/command_runner.rs:554` on `main` (`if stdout.is_empty()`).

A process killed by a signal and a process that ran to completion emitting nothing both produced `agent_task.provider_empty_stdout` / `provider_error`. "The provider produced no output" points at the provider; the real cause was an external kill (OOM killer, runner/daemon shutdown, operator SIGTERM, CI job cancellation).

Homeboy's own deadline and liveness kills return **earlier** in the wait loop (`killed_for_liveness` → `agent_task.provider_liveness_timeout`, `timed_out` → `execution_deadline_outcome` / `agent_task.provider_timeout`), so a signal observed at the empty-stdout branch was, by construction, initiated **outside** Homeboy. That is now stated as evidence rather than left to inference.

New diagnostic class `agent_task.provider_signal_terminated` records:

| field | why |
| --- | --- |
| `signal`, `signal_name` | `15 (SIGTERM)` instead of a bare number |
| `termination_initiator` | `external_sigkill` / `external_sigterm` / `external_interrupt` / `external_hangup` / `provider_crash` |
| `homeboy_initiated_termination: false` | separates a Homeboy deadline from an external kill — the exact ambiguity in the report |
| `elapsed_ms` | the missing "no elapsed duration" |
| `timeout_ms`, `process_timeout_ms`, `liveness_timeout_ms`, `execution_deadline_unix_ms` | distinguishes *no deadline configured* from *deadline expired*; nulls are explicit |
| `likely_oom_kill` | true for SIGKILL with no output |
| `signal_remediation_hints` | SIGKILL → check `dmesg -T \| grep -i -e oom -e 'killed process'` and cgroup `memory.events`; SIGTERM/SIGINT/SIGHUP → check the supervisor, not the provider |

**Wire enums are deliberately unchanged.** `AgentTaskOutcomeStatus` and `AgentTaskFailureClassification` cross the homeboy/homeboy-extensions boundary and those ship independently, so the status stays `ProviderError` and the classification stays `Provider`. Only the diagnostic class/message/data change — additive at the schema level, no new serde variant for an older consumer to choke on.

`provider_empty_stdout` now means what it says: the executor exited with no independently known termination cause.

**Overlap with #10522 (do not fix):** #10522 wants *reconciliation of external resources* after owner SIGKILL/OOM (containers, temp roots, stale `running` pointers). This PR only fixes *classification of the controller-observed child*. They touch the same SIGKILL/OOM reality from opposite ends and do not conflict: #10522's dead-owner reconciler can consume `termination_initiator` / `likely_oom_kill` as its typed terminal cause instead of re-deriving it.

---

## Part 2 — #10521: redaction erases diagnostic text and failure counts

I pulled the actual artifact from the linked run (`gh run download 30313942537 -R Extra-Chill/data-machine -n homeboy-observations-data-machine-review-test-quality-Linux-node24`) rather than working from the quoted excerpt. **The issue conflates two different redactors, only one of which is Homeboy's.** See the correction comment on #10521.

Homeboy's contribution is the `[REDACTED]` (uppercase, `homeboy-redaction`'s default replacement) edits, applied at `crates/homeboy-core/src/validation_progress.rs:315` — `write_command_artifact` runs `redact_string` over the whole captured console blob:

```
=== http-client-proxy-auth-smoke: 3 FAIL of 15 ===   →   === http-client-proxy-auth-smoke: [REDACTED] FAIL of 15 ===
PASS: basic auth creates Authorization header        →   PASS: basic [REDACTED] creates Authorization header
FAIL: auth_ref resolved Basic header is applied      →   FAIL: auth_ref resolved Basic [REDACTED] is applied
```

### What actually triggers it

Not entropy, not length, not a secret's value. **Two shape heuristics run over free-form prose:**

1. `redact_inline_assignments` (`crates/homeboy-redaction/src/lib.rs:334`) invents a key from *any* word before a `:` or `=`, then tests it with `is_sensitive_key` (`lib.rs:97`), which matches any key that **contains** a sensitive token. `http-client-proxy-auth-smoke` normalizes to `http_client_proxy_auth_smoke`, which contains `auth` → the value `3` was destroyed. Same mechanism destroys anything after `monkey:`, `outside:`, `keyboard:` (`key`, `sid`, `key`).
2. `redact_authorization_schemes` (`lib.rs:317`) matched `\b(bearer|basic|token)\s+[^\s,;]+`. Those are also ordinary English words, so `basic auth`, `Basic header`, `token expires` all lost their next word.

It does **not** run over structured JSON fields in the wrong way here — `redact_json` uses real key context. The corruption is specifically the *free-text* path.

### The fix: narrow **where**, not loosen **how**

- Added `RedactionPolicy::is_credential_key_name` — a strict predicate used **only** by the free-text inline-assignment scan. It requires the sensitive token to be the *head noun* of the key: the final `_`/`-`/`.`/camelCase segment, optionally followed by one generic carrier qualifier (`_id`, `_value`, `_header`, `_b64`, …). `api_key`, `X-Api-Key`, `apiKey`, `clientSecret`, `refresh_token`, `session_id`, `auth_header`, `PASSWORD` all still match. `http-client-proxy-auth-smoke`, `auth_ref`, `PASS`, `monkey`, `keyboard`, `considered` do not.
- **Real key positions are untouched.** JSON object keys, HTTP header names, query parameter names, env var names and CLI flags keep the broad fail-closed `contains` rule via `is_sensitive_key`. There is a test asserting exactly that (`structured_key_positions_keep_the_broad_fail_closed_rule`), because that is where a novel credential name must not slip through.
- A **bare** `bearer`/`basic`/`token` only redacts the next token when it is not plain prose (`looks_like_prose_word`: ≤12 letters, all-lowercase / Capitalized / short all-caps). Every credential shape reachable this way — JWT, base64, `sk-`/`ghp_`, hex, mixed case, >12 letters — fails the prose test and is still redacted.

### I did **not** weaken real secret redaction — and strengthened it in one place

Explicitly confirming: no sensitive key was removed, no entropy floor was added, no value-shape exemption was introduced for credentials, and the *structured* path is byte-for-byte the old behaviour.

The one behaviour change in the credential direction is a **strengthening**: an explicit authorization key now redacts its value unconditionally, preserving the scheme name. Previously `Authorization: opaquevalue` (a header with no scheme word) survived **both** passes — the scheme regex needed `Bearer`/`Basic`/`Token`, and `redact_inline_assignments` deliberately skips `authorization` keys to keep the scheme visible. That was a pre-existing fail-open leak; `redacts_authorization_header_values_without_a_scheme_word` covers it.

The residual narrowing is honest and bounded: in **free prose only**, keys where a sensitive token is *not* the head noun (`token_expiry`, `secret_name`) are no longer redacted. Those name a thing about a credential rather than carrying one, and the same key in any structured position is still caught.

### What I deliberately left alone

`provider_output_redactions` / `redact_sensitive_text` (`command_runner.rs`) is Homeboy's only *value-provenance* redactor: it substring-replaces every secret env value of length ≥ 4 everywhere in provider diagnostics. That matches the issue's "global substring secrets" wording, but it did **not** produce this evidence, and the `len() >= 4` floor is genuinely fail-closed. Raising the bar or requiring word boundaries would be a real weakening to fix a hypothetical, so it stays as-is.

---

## Tests

`crates/homeboy-redaction/src/lib.rs`:
- `preserves_low_entropy_diagnostic_text_and_failure_counts` — the verbatim console block from #10521 must round-trip unchanged, including `3 FAIL of 15`.
- `inferred_keys_only_redact_when_the_head_noun_is_a_credential`
- `structured_key_positions_keep_the_broad_fail_closed_rule`
- `redacts_authorization_header_values_without_a_scheme_word`
- `bare_scheme_words_still_redact_credential_shaped_tokens`
- `redaction_is_idempotent_over_already_redacted_text`

`crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs`: signal-termination classification, and empty-stdout-without-a-signal still classifying as `provider_empty_stdout`.

**No test was found asserting either buggy behaviour** — I checked every `[REDACTED]` assertion in the workspace. The closest call is `diagnostic_text_redacts_sensitive_headers_and_signed_urls` (`gh_cli.rs:1582`), which asserts `Proxy-Authorization: Basic secret` does not leak. `secret` is a prose-shaped word, so the narrowed bare-scheme rule alone would no longer catch it — the new unconditional authorization-key rule is what keeps that test green. Worth knowing if anyone reverts half of this.

## Verification limits

Per host policy this VPS cannot run `cargo build`/`test`/`check`/`clippy` (16 GB shared, OOM risk), so CI is the gate. `cargo fmt` was run and passes. I re-implemented the new matcher in Python and replayed the real artifact plus every pre-existing assertion in the crate and in `gh_cli.rs`/`validation_progress.rs` against it; all pass. No `Cargo.toml`/`Cargo.lock` change, so `--locked` is unaffected.
