### PR TITLE
fix(release): adopt a complete draft without rebuilding, and name inventory mismatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -601,6 +601,7 @@ jobs:
       val: ${{ steps.plan.outputs.manifest }}
       tag-flag: ${{ format('--tag={0}', needs.prepare.outputs['release-tag']) }}
       expected-assets: ${{ steps.plan.outputs.expected-assets }}
+      draft-complete: ${{ steps.draft-probe.outputs.draft-complete }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -650,6 +651,75 @@ jobs:
           echo "planned-artifacts=${PLANNED_ARTIFACTS}" >> "$GITHUB_OUTPUT"
           echo "expected-assets=${EXPECTED_ASSETS}" >> "$GITHUB_OUTPUT"
 
+      # ── Recovery fast path: is the draft already complete? (issue #10519) ──
+      # Recovery rebuilds every platform (~40 minutes) before it can adopt a
+      # draft that frequently already holds every authoritative asset — the
+      # stranded v0.321.1 draft has carried all 13 since 2026-07-27. Probe the
+      # remote inventory so the publish chain can skip straight to adoption.
+      #
+      # This probe deliberately runs AFTER `dist host --steps=create`. Whether
+      # `--steps=create` disturbs an existing draft's assets is undocumented,
+      # and gating the build matrix on a pre-create observation could skip the
+      # very rebuild that restores assets create had just cleared. Observing the
+      # post-create state makes the fast path fail-safe by construction: if
+      # create emptied the draft, the probe sees an incomplete inventory and the
+      # full rebuild runs exactly as it does today.
+      #
+      # This is an optimisation gate only, and is deliberately weaker than the
+      # authority it defers to: `validate_draft_adoption` still re-verifies
+      # every asset's name, size, upload state and SHA-256 digest against the
+      # published checksum sidecars in the `host` finalizer, and `verify-published`
+      # independently re-checks the inventory afterwards. Neither is skipped.
+      - name: Probe existing draft for a complete asset inventory
+        id: draft-probe
+        if: needs.prepare.outputs.recovery-release == 'true'
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          EXPECTED_ASSETS: ${{ steps.plan.outputs.expected-assets }}
+        run: |
+          # A probe that cannot read the inventory must degrade to "rebuild
+          # everything", never to "fail the release". GitHub's default shell is
+          # `bash -e`, so errexit has to be turned off explicitly here — `set
+          # -uo pipefail` alone would leave it on and let a transient jq or gh
+          # failure block the release outright.
+          set +e
+          set -uo pipefail
+          COMPLETE=false
+          REASON=''
+
+          if ! gh release view "${RELEASE_TAG}" --json isDraft,assets > draft.json 2> draft.err; then
+            REASON="the inventory for ${RELEASE_TAG} could not be read"
+            sed 's/^/gh: /' draft.err >&2 || true
+          elif [ "$(jq -r '.isDraft' draft.json)" != "true" ]; then
+            REASON="${RELEASE_TAG} is not an unpublished draft"
+          else
+            WANTED="$(jq -Sc 'unique' <<< "${EXPECTED_ASSETS}")"
+            USABLE="$(jq -Sc '[.assets[] | select(.state == "uploaded" and .size > 0) | .name] | unique' draft.json)"
+            TOTAL="$(jq -r '.assets | length' draft.json)"
+            WANTED_COUNT="$(jq -r 'length' <<< "${WANTED}")"
+            # Exact inventory: every expected asset usable, and nothing else
+            # present. `TOTAL` catches duplicates and strays that `unique`
+            # would otherwise collapse away.
+            if [ "${USABLE}" = "${WANTED}" ] && [ "${TOTAL}" = "${WANTED_COUNT}" ]; then
+              COMPLETE=true
+            else
+              REASON="the inventory differs (expected ${WANTED_COUNT}: ${WANTED}; usable: ${USABLE}; total on release: ${TOTAL})"
+            fi
+          fi
+
+          echo "draft-complete=${COMPLETE}" >> "$GITHUB_OUTPUT"
+          if [ "${COMPLETE}" = "true" ]; then
+            echo "::notice::${RELEASE_TAG} already holds every expected asset; skipping the cross-platform rebuild and re-upload, and going straight to draft adoption (#10519)"
+            {
+              echo "### Release recovery fast path"
+              echo ""
+              echo "\`${RELEASE_TAG}\` already holds every expected asset, so the cross-platform rebuild and re-upload are skipped."
+              echo "The \`host\` finalizer still re-verifies name, size, upload state and SHA-256 digest before publishing."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::notice::Rebuilding every release artifact for ${RELEASE_TAG}: ${REASON}"
+          fi
+
       - name: Upload dist-manifest.json
         uses: actions/upload-artifact@v4
         with:
@@ -661,7 +731,7 @@ jobs:
     needs:
       - prepare
       - plan
-    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && needs.plan.outputs.draft-complete != 'true' && fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
@@ -739,7 +809,7 @@ jobs:
       - prepare
       - plan
       - build-local-artifacts
-    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && (fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && needs.plan.outputs.draft-complete != 'true' && (fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success') }}
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -829,7 +899,10 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && needs.build-global-artifacts.result == 'success' && (fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success') }}
+    # The draft-complete fast path (#10519) skips the artifact matrix entirely,
+    # so `host` must not require builds that were deliberately never run. It
+    # still runs: the adoption finalizer below is what publishes the draft.
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.plan.result == 'success' && (needs.plan.outputs.draft-complete == 'true' || (needs.build-global-artifacts.result == 'success' && (fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include == null || needs.build-local-artifacts.result == 'success'))) }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -844,15 +917,22 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
+      # Everything from here to the adoption manifest exists to rebuild and
+      # re-upload artifacts. When the draft already holds every expected asset
+      # (#10519) there is nothing to upload, so the whole cargo-dist upload
+      # phase is skipped and this job goes straight to verified adoption.
       - name: Install cached dist
+        if: needs.plan.outputs.draft-complete != 'true'
         uses: actions/download-artifact@v4
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
 
-      - run: chmod +x ~/.cargo/bin/dist
+      - if: needs.plan.outputs.draft-complete != 'true'
+        run: chmod +x ~/.cargo/bin/dist
 
       - name: Fetch artifacts
+        if: needs.plan.outputs.draft-complete != 'true'
         uses: actions/download-artifact@v4
         with:
           pattern: artifacts-*
@@ -860,6 +940,7 @@ jobs:
           merge-multiple: true
 
       - id: host
+        if: needs.plan.outputs.draft-complete != 'true'
         shell: bash
         run: |
           if ! grep -Fqx '[package.metadata.dist]' Cargo.toml; then
@@ -876,16 +957,18 @@ jobs:
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
 
       - name: Restore recovery cargo-dist overlay
-        if: needs.prepare.outputs.recovery-release == 'true'
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
         run: git restore --source=HEAD -- Cargo.toml
 
       - name: Upload dist-manifest.json
+        if: needs.plan.outputs.draft-complete != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-dist-manifest
           path: dist-manifest.json
 
       - name: Download GitHub Artifacts
+        if: needs.plan.outputs.draft-complete != 'true'
         uses: actions/download-artifact@v4
         with:
           pattern: artifacts-*
@@ -893,6 +976,7 @@ jobs:
           merge-multiple: true
 
       - name: Cleanup
+        if: needs.plan.outputs.draft-complete != 'true'
         run: |
           rm -f artifacts/*-dist-manifest.json
 
@@ -933,6 +1017,7 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           CONTROL_SHA: ${{ github.sha }}
           ADOPTION_SOURCE: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}
+          ARTIFACT_ORIGIN: ${{ needs.plan.outputs.draft-complete == 'true' && 'pre-existing draft assets (rebuild skipped)' || 'rebuilt and re-uploaded by this run' }}
         run: |
           set -euo pipefail
           chmod +x .homeboy-bin/homeboy
@@ -950,6 +1035,7 @@ jobs:
             echo "| release target tag | \`${RELEASE_TAG}\` |"
             echo "| release target commit | \`${TARGET_SHA}\` |"
             echo "| artifact provenance | \`${ADOPTION_SOURCE}\` |"
+            echo "| artifact bytes | \`${ARTIFACT_ORIGIN}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::notice::Recovery control binary ${CONTROL_IDENTITY} built from ${CONTROL_SHA} is repairing ${RELEASE_TAG} at ${TARGET_SHA} using ${ADOPTION_SOURCE} provenance"
           if [ "${CONTROL_SHA}" = "${TARGET_SHA}" ]; then

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -1087,9 +1087,42 @@ pub(crate) fn validate_draft_adoption(
         .map(|asset| asset.name.clone())
         .collect::<std::collections::BTreeSet<_>>();
     if expected != actual || actual.len() != metadata.assets.len() {
-        return Err(
-            "draft adoption asset inventory does not exactly match the manifest".to_string(),
-        );
+        // Name the difference. Recovery is a ~40 minute rebuild cycle, so an
+        // inventory mismatch reported only as "does not match" costs a full
+        // release cycle per diagnostic guess — that is exactly how #10547
+        // (cargo-dist's unlisted `dist-manifest.json`) stayed hidden across
+        // repeated recovery attempts of v0.321.1.
+        let missing = expected.difference(&actual).cloned().collect::<Vec<_>>();
+        let unexpected = actual.difference(&expected).cloned().collect::<Vec<_>>();
+        let mut seen = std::collections::BTreeSet::new();
+        let duplicated = metadata
+            .assets
+            .iter()
+            .filter(|asset| !seen.insert(asset.name.as_str()))
+            .map(|asset| asset.name.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        let mut detail = Vec::new();
+        if !missing.is_empty() {
+            detail.push(format!("expected but absent: {}", missing.join(", ")));
+        }
+        if !unexpected.is_empty() {
+            detail.push(format!("present but unexpected: {}", unexpected.join(", ")));
+        }
+        if !duplicated.is_empty() {
+            detail.push(format!(
+                "duplicated on the release: {}",
+                duplicated.into_iter().collect::<Vec<_>>().join(", ")
+            ));
+        }
+        if detail.is_empty() {
+            detail.push("inventory differs in multiplicity only".to_string());
+        }
+        return Err(format!(
+            "draft adoption asset inventory does not exactly match the manifest ({} expected, {} on the release): {}",
+            expected.len(),
+            metadata.assets.len(),
+            detail.join("; ")
+        ));
     }
     for asset in &metadata.assets {
         if asset.state != "uploaded" || asset.size == 0 || canonical_remote_digest(asset)?.is_none()
@@ -1113,7 +1146,9 @@ pub(crate) fn validate_draft_adoption(
     let mut references = BTreeMap::new();
     for (sidecar, contents) in sidecars {
         if !expected.contains(sidecar) {
-            return Err("checksum sidecar is not an expected asset".to_string());
+            return Err(format!(
+                "checksum sidecar '{sidecar}' is not an expected asset"
+            ));
         }
         let mut sidecar_references = 0;
         for line in contents.lines().filter(|line| !line.trim().is_empty()) {
@@ -1659,6 +1694,79 @@ mod tests {
             format!("{}  unknown.zip\n", "c".repeat(64)),
         );
         assert!(validate_draft_adoption("v1.2.3", &expected, &metadata, &sidecars).is_err());
+    }
+
+    /// Regression for #10519/#10547: an inventory mismatch must name the
+    /// differing assets. Recovery is a full rebuild cycle, so a bare "does not
+    /// match" forces operators to spend one ~40 minute release run per guess.
+    #[test]
+    fn draft_adoption_inventory_mismatch_names_the_differing_assets() {
+        let digest = "a".repeat(64);
+        let metadata = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: vec![
+                remote_asset("app.zip", 1, Some(format!("sha256:{digest}"))),
+                remote_asset(
+                    "app.zip.sha256",
+                    70,
+                    Some(format!("sha256:{}", "b".repeat(64))),
+                ),
+                // cargo-dist publishes this but never lists it in the plan
+                // manifest's `.releases[].artifacts[]` (#10547).
+                remote_asset(
+                    "dist-manifest.json",
+                    12,
+                    Some(format!("sha256:{}", "c".repeat(64))),
+                ),
+            ],
+        };
+        let expected = vec!["app.zip".to_string(), "app.zip.sha256".to_string()];
+        let mut sidecars = BTreeMap::new();
+        sidecars.insert("app.zip.sha256".to_string(), format!("{digest}  app.zip\n"));
+
+        let error = validate_draft_adoption("v1.2.3", &expected, &metadata, &sidecars)
+            .expect_err("unexpected remote asset must fail adoption");
+        assert!(
+            error.contains("dist-manifest.json"),
+            "mismatch must name the unexpected asset, got: {error}"
+        );
+        assert!(
+            error.contains("present but unexpected"),
+            "mismatch must say which side the asset is on, got: {error}"
+        );
+        assert!(
+            error.contains("2 expected") && error.contains("3 on the release"),
+            "mismatch must report both counts, got: {error}"
+        );
+
+        // The inverse direction: an asset the manifest expects but the draft
+        // never received.
+        let mut short = metadata.clone();
+        short.assets.retain(|asset| asset.name != "app.zip.sha256");
+        let error = validate_draft_adoption("v1.2.3", &expected, &short, &sidecars)
+            .expect_err("missing remote asset must fail adoption");
+        assert!(
+            error.contains("expected but absent") && error.contains("app.zip.sha256"),
+            "mismatch must name the absent asset, got: {error}"
+        );
+
+        // Duplicate names collapse in a set comparison, so multiplicity needs
+        // its own report or the error would be empty of detail.
+        let mut duplicate = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: metadata.assets[..2].to_vec(),
+        };
+        duplicate
+            .assets
+            .push(remote_asset("app.zip", 1, Some(format!("sha256:{digest}"))));
+        let error = validate_draft_adoption("v1.2.3", &expected, &duplicate, &sidecars)
+            .expect_err("duplicated remote asset must fail adoption");
+        assert!(
+            error.contains("duplicated on the release") && error.contains("app.zip"),
+            "mismatch must report duplicates, got: {error}"
+        );
     }
 
     #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -718,3 +718,161 @@ fn release_prepare_and_publish_preflight_runner_disk() {
     assert!(workflow
         .contains("refusing publish before the runner exhausts disk while writing diagnostics"));
 }
+
+/// Isolate a single `steps:` entry so a gate can be asserted on the step it
+/// actually guards rather than merely somewhere in the job.
+fn release_step_block<'a>(job: &'a str, marker_line: &str) -> &'a str {
+    let marker = format!("      - {marker_line}\n");
+    let start = job
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing step '{marker_line}'"));
+    let rest = &job[start + marker.len()..];
+    let end = rest
+        .find("\n      - ")
+        .map_or(rest.len(), |index| index + 1);
+    &rest[..end]
+}
+
+/// Acceptance criteria 3 and 4 of #10519: recovery must not rebuild every
+/// platform before it can adopt a draft that already holds every authoritative
+/// asset. Both stranded drafts on this repo are in exactly that state
+/// (`v0.321.1` with 13 assets, `v0.320.0` with 15 including Windows), yet each
+/// recovery attempt spent ~40 minutes rebuilding them before failing in the
+/// publisher.
+#[test]
+fn release_recovery_skips_the_artifact_rebuild_when_the_draft_is_already_complete() {
+    let workflow = release_workflow();
+    let plan = job_section(workflow, "plan");
+
+    assert!(
+        plan.contains("draft-complete: ${{ steps.draft-probe.outputs.draft-complete }}"),
+        "plan must publish the fast-path decision to downstream jobs"
+    );
+
+    let probe = release_step_block(
+        plan,
+        "name: Probe existing draft for a complete asset inventory",
+    );
+    assert!(
+        probe.contains("if: needs.prepare.outputs.recovery-release == 'true'"),
+        "the fast path is a recovery-only concern; fresh releases have no draft to adopt"
+    );
+    assert!(
+        probe.contains("draft-complete=${COMPLETE}"),
+        "the probe must emit its decision"
+    );
+    assert!(
+        probe.contains("COMPLETE=false"),
+        "the probe must default to rebuilding"
+    );
+
+    // The fail-safe ordering property. Whether `dist host --steps=create`
+    // disturbs an existing draft's assets is undocumented; observing the
+    // inventory *after* create means a create that emptied the draft is seen as
+    // incomplete and the normal rebuild runs. A pre-create probe could skip the
+    // very rebuild that restores those assets.
+    let create = plan
+        .find("dist host --steps=create")
+        .expect("plan must create the GitHub Release with cargo-dist");
+    let probe_at = plan
+        .find("- name: Probe existing draft for a complete asset inventory")
+        .expect("plan must probe the draft");
+    assert!(
+        create < probe_at,
+        "the completeness probe must observe the post-create inventory so an asset-clearing create falls back to the rebuild"
+    );
+
+    // GitHub's default shell is `bash -e`; `set -uo pipefail` alone leaves
+    // errexit on, so a transient `gh`/`jq` failure in an optimisation probe
+    // would fail the whole release.
+    assert!(
+        probe.contains("set +e"),
+        "the probe must not be able to fail a release it only exists to speed up"
+    );
+
+    for job in ["build-local-artifacts", "build-global-artifacts"] {
+        assert!(
+            job_section(workflow, job).contains("needs.plan.outputs.draft-complete != 'true'"),
+            "{job} must be skipped when the draft already holds every expected asset"
+        );
+    }
+
+    let host = job_section(workflow, "host");
+    assert!(
+        host.contains("needs.plan.outputs.draft-complete == 'true' || (needs.build-global-artifacts.result == 'success'"),
+        "host must still run when the artifact matrix was deliberately skipped, or the draft could never be published"
+    );
+
+    // Every cargo-dist upload-phase step is gated...
+    for step in [
+        "name: Install cached dist",
+        "name: Fetch artifacts",
+        "id: host",
+        "name: Upload dist-manifest.json",
+        "name: Download GitHub Artifacts",
+        "name: Cleanup",
+    ] {
+        assert!(
+            release_step_block(host, step)
+                .contains("needs.plan.outputs.draft-complete != 'true'"),
+            "host step '{step}' rebuilds or re-uploads artifacts and must be skipped on the fast path"
+        );
+    }
+
+    // ...and the adoption phase is not, or the fast path would publish nothing.
+    let adoption = &host[host
+        .find("- name: Create remote draft adoption manifest")
+        .expect("host must build the draft adoption manifest")..];
+    assert!(
+        !adoption.contains("draft-complete != 'true'"),
+        "verified draft adoption must run on the fast path — it is the whole point of taking it"
+    );
+    assert!(
+        adoption.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}"),
+        "the fast path must still hand the finalizer the remote-adoption manifest"
+    );
+}
+
+/// The fast path is an optimisation, never a relaxation. Skipping the rebuild
+/// must not skip a single verification: `validate_draft_adoption` still checks
+/// name, size, upload state and SHA-256 digest against the published checksum
+/// sidecars, and `verify-published` still re-reads the release afterwards.
+#[test]
+fn release_fast_path_keeps_every_publication_verification() {
+    let workflow = release_workflow();
+    let verify = job_section(workflow, "verify-published");
+
+    assert!(
+        !verify.contains("draft-complete"),
+        "post-publication verification must be unconditional, including on the fast path"
+    );
+    assert!(
+        verify.contains("EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}"),
+        "verification must re-check the same expected inventory the fast path matched on"
+    );
+    assert!(
+        verify.contains("HOST_RESULT: ${{ needs.host.result }}"),
+        "verification must still require the publishing job to have succeeded"
+    );
+
+    // The control binary that performs adoption is still the one built from the
+    // dispatching commit, not from the stranded tag (#10519's headline defect,
+    // fixed in #10560 — keep it fixed).
+    let host = job_section(workflow, "host");
+    assert!(
+        host.contains("binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}"),
+        "recovery must execute the freshly built control binary, never the stranded tag's"
+    );
+    assert!(
+        job_section(workflow, "gate-build").contains("ref: ${{ github.sha }}"),
+        "the control binary must be built from the dispatching commit"
+    );
+    assert!(
+        host.contains("ref: ${{ needs.prepare.outputs['release-tag'] }}"),
+        "the release target tree must stay pinned to the tag being recovered"
+    );
+    assert!(
+        host.contains("| artifact bytes |"),
+        "recovery evidence must record whether the published bytes were rebuilt or pre-existing"
+    );
+}


### PR DESCRIPTION
Refs #10519.

## Correction first: the headline defect is already fixed

#10519's title — "recovery executes the stranded tag binary" — describes a defect that **#10560 already fixed**, and I verified that independently rather than taking the existing issue comment's word for it:

* **`.github/workflows/release.yml:249`** — `gate-build` checks out `ref: ${{ github.sha }}`, not the tag.
* **`.github/workflows/release.yml:919-924`** — `host` downloads that `homeboy-binary` artifact into `.homeboy-bin/`.
* **`.github/workflows/release.yml:968`** — passes it as `binary-path` on recovery runs, while the `host` checkout stays pinned to `needs.prepare.outputs['release-tag']`.
* **The piece nobody had checked:** an unknown Action input is *silently ignored* by GitHub Actions, so `binary-path` being present in the workflow proves nothing on its own. `Extra-Chill/homeboy-action`'s `action.yml` declares it, and the `Install pre-built binary` step is gated `if: inputs.binary-path != ''` while **every** source-build and release-download step is gated `if: inputs.binary-path == '' && ...`. `binary-path` strictly short-circuits `source`. The fix is real.
* **Empirically**, run `30365955747` (a v0.321.1 self-recovery) reported `BINARY_SOURCE: prebuilt` and `HOMEBOY_CLI_VERSION: homeboy 0.321.1+88b201ab7c19+9b9bb9311` — `88b201ab7c19` is main, not the `9b9bb93115fd` tag commit.

So acceptance criteria 1 and 2 are met. **This PR does criteria 3 and 4**, which were still open, plus a diagnostic defect I hit while tracing it.

## 1. Recovery no longer rebuilds a draft that is already complete

Recovery ran the full `plan` → `build-local-artifacts` → `build-global-artifacts` → `dist host --steps=upload` chain before reaching the adoption finalizer — ~40 minutes per attempt. Both stranded drafts already hold every authoritative asset:

| tag | state | assets | expected at that tag |
| --- | --- | --- | --- |
| `v0.321.1` | Draft | 13 | 12 planned + `dist-manifest.json` = 13 |
| `v0.320.0` | Draft | 15 | 14 planned + `dist-manifest.json` = 15 |

(`v0.320.0` legitimately has two more: `dist-workspace.toml:19` at that tag still targets `x86_64-pc-windows-msvc`. Because `plan` checks out the tag, the expectation is computed per-tag and matches.)

A new `draft-probe` step in `plan` reads the inventory and emits `draft-complete`. When set, the artifact matrix and the whole cargo-dist upload phase are skipped and `host` goes straight to verified adoption.

### How the "is `--steps=create` destructive?" question is resolved

The previous investigation stopped here because it could not determine whether `dist host --steps=create` resets an existing draft's assets — and if it does, skipping the rebuild would destroy the assets recovery is trying to preserve.

**The probe runs *after* `--steps=create`, so the question does not need answering.** If create emptied the draft, the probe observes an incomplete inventory and the normal rebuild runs exactly as it does today. The fast path is fail-safe by construction. This ordering is asserted by a test, with the reasoning in the comment, so it cannot be "tidied" into a pre-create probe later.

### The probe cannot break a release

GitHub's default shell is `bash -e`, so `set -uo pipefail` alone would leave errexit on and let a transient `gh`/`jq` failure fail the whole release. The probe does `set +e` explicitly and defaults `COMPLETE=false`. Any unreadable inventory ⇒ rebuild.

### Nothing is relaxed

The probe is an optimisation gate, deliberately weaker than the authority it defers to. `validate_draft_adoption` still re-verifies name, size, upload state and SHA-256 digest against the published checksum sidecars (twice — once before and once after a re-read, to close the concurrent-edit race), and `verify-published` still independently re-reads the release afterwards. A test asserts the adoption phase carries no `draft-complete` gate.

## 2. Inventory mismatches now name the differing assets

`validate_draft_adoption` reported every mismatch as `draft adoption asset inventory does not exactly match the manifest`. Recovery is a full rebuild cycle, so each diagnostic guess cost one ~40-minute release run — which is precisely how #10547 (cargo-dist publishes `dist-manifest.json` but never lists it in `.releases[].artifacts[]`) survived repeated recovery attempts. Run `30365955747` failed with `adoption_asset_count: 12` against a 13-asset release and said nothing about which asset.

It now reports both counts and the exact assets that are absent, unexpected, or duplicated. Same fail-closed semantics.

## Version skew

Skew is bounded by *what each side owns*, and this PR does not widen it:

* The control binary contributes **publisher logic only** — draft lookup, inventory validation, `gh release edit --draft=false`.
* Every version-bearing input comes from the **tag**: `host` checks out `needs.prepare.outputs['release-tag']`, and the adoption manifest's `tag`, `version` and `commit` are derived there (`git rev-parse "${RELEASE_TAG}^{}"`), not from the binary.
* `expected_assets` is computed by `dist` **at the tag's tree**, so a newer control binary cannot impose a newer target set on an older tag — demonstrated by `v0.320.0` correctly expecting its Windows artifacts.
* Adoption is byte-preserving: it validates and flips the draft bit. It never rewrites artifacts, so a newer publisher cannot retroactively change what an older tag shipped.
* The residual skew — a control binary applying *validation* semantics stricter than the tag's — is fail-closed and visible: it can only refuse adoption, and the provenance table records control identity/commit and target tag/commit as separate rows.

## Composition with #10608

#10608 is already merged; this branch is based on it. It is load-bearing here — the fast path compares the remote inventory to `plan`'s `expected-assets`, so without #10608's `+ ["dist-manifest.json"]` the probe would find every draft one asset short and never fire. Its `release_expected_assets_test.rs` extracts the `PLANNED_ARTIFACTS`/`EXPECTED_ASSETS` jq programs from `release.yml` by name; both lines are untouched and still resolve uniquely.

#10607 is also merged, so `tests/release_workflow_test.rs` no longer has a concurrent editor; my additions append after its content.

## Tests

* `release_recovery_skips_the_artifact_rebuild_when_the_draft_is_already_complete` — probe exists, is recovery-gated, defaults to rebuild, disables errexit, **runs after `--steps=create`**; build jobs and the upload phase are gated; the adoption phase is not.
* `release_fast_path_keeps_every_publication_verification` — verification is unconditional; and the #10560 bootstrap split (`gate-build` at `github.sha`, `binary-path` on recovery, `host` pinned to the tag) is pinned so it cannot silently regress.
* `draft_adoption_inventory_mismatch_names_the_differing_assets` — asserts the absent/unexpected/duplicated cases each name the asset, using cargo-dist's real `dist-manifest.json` shape.

## Verified without cargo, and what I could not verify

Per host constraints I ran no cargo command but `cargo fmt`. To compensate I re-implemented `job_section`, the new `release_step_block`, and **every** assertion — new and pre-existing — in Python against the real workflow text: all 24 new assertions pass, and all pre-existing shape assertions still hold (notably `--allow-dirty` count == 1 per dist phase, opt-in-before-dist ordering, and upload < restore < finalize in `host`). The YAML parses and the probe passes `bash -n`. I also dry-ran the probe's exact logic against the live `v0.321.1` and `v0.320.0` inventories: both return `draft-complete=true`.

Not verifiable here: compilation and the actual test run (CI), and real fast-path behaviour, which needs a recovery run.

## Would the stranded drafts recover now?

* **`v0.321.1`** — yes. It is the newest tag and above the published boundary, so `detect-stranded-release.sh` auto-selects it; with #10608 the expectation is 13 and the draft has 13, so the probe fires and adoption should publish it in minutes instead of 40. **What still blocks it is not code:** the last several Release runs were `cancelled`, displaced by newer merges under `cancel-in-progress: false`. A run has to be allowed to finish.
* **`v0.320.0`** — no, not automatically, and that is by design. `detect-stranded-release.sh:161-173` stops automatic recovery at the first published release; `v0.321.0` published above it, so `v0.320.0` is classified `buried` and only reported. It needs the deliberate `gh workflow run release.yml -f release_tag=v0.320.0`. On that path it now takes the fast path too (expectation 15, draft has 15). Note `MAX_RECOVERY_ATTEMPTS` is 3 per tag.

## Separate finding — reported, not fixed here

**The release *decision* gate has the same bootstrap trap #10519 describes, and it is not fixed.** `check`'s `Dry-run release check` (`release.yml:145-150`) invokes `homeboy-action` with neither `source` nor `binary-path`, so `version` defaults to `latest` and `resolve-homeboy-version.sh` downloads the newest *published stable* release — currently **v0.321.0, 120+ commits stale**. A `release --dry-run` bug shipped in v0.321.0 could block all releases with no way to bootstrap the fix.

I did not fix it here on purpose. The obvious fix (build the control binary before `check`) requires `gate-build` to stop depending on `check`, which means a `cargo build --release` on *every* push to main. Under `concurrency: cancel-in-progress: false` that would lengthen every run in an already-serialised queue and make the documented cancellation starvation worse. That is an operator trade-off, not a cook's call. Suggest a separate issue.

**Overlap with #10487** (recovery misidentifies canonical GitHub asset digests): it concerns `canonical_remote_digest`, which the fast path relies on more heavily, since adoption is now the *only* thing standing between a stranded draft and publication rather than a second check after a fresh upload. Not touched here; the digest logic is unchanged.

## AI assistance
- Model: Claude Sonnet 4.6
- Tool: opencode + Data Machine
- Used for: traced binary provenance through `release.yml` and `homeboy-action`, verified against live release/run state, wrote the fast path, diagnostics and tests. Chris Huber reviews and owns.