### PR TITLE
fix(cli): three CLI-surface bugs — refresh-plan --output collision, git error leak, extension readiness gating (#10566, #10525, #10517)

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/global_flag_surface_tests.rs
+++ b/crates/homeboy-cli/src/cli_surface/global_flag_surface_tests.rs
@@ -1,4 +1,5 @@
-//! Pins the globally-propagated clap argument surface.
+//! Pins the globally-propagated clap argument surface, and asserts the whole
+//! command tree is a legal clap definition.
 //!
 //! Lives beside `cli_surface/mod.rs` rather than inside its `mod tests` block
 //! because that file sits 7 lines under the audit's 1500-line `god_file`
@@ -52,4 +53,27 @@ fn root_global_flag_surface_is_pinned() {
         "the globally-propagated flag surface changed; update remote \
          capability negotiation and docs before accepting this",
     );
+}
+
+/// `Command::build()` is the only thing that runs clap's `debug_assert` suite
+/// over *every* node at once. Nothing in normal operation does: `get_matches`
+/// builds the root and then only the subcommands argv actually descends into,
+/// so a malformed definition on a rarely-parsed command ships silently — clap's
+/// assertions are compiled out of a release binary. That is exactly how
+/// `runner refresh-plan` shipped a local `--output` that collided with the
+/// propagated global `--output` all the way into 0.321.0 (#10566).
+///
+/// This is the canary #10563 deferred. It deliberately does not live next to
+/// the reference-doc generator: that module reads the derived tree *without*
+/// building, so a definition defect reports as a definition defect here instead
+/// of masquerading as stale documentation.
+///
+/// A failure here is a real defect in a `#[derive(Args)]`/`#[derive(Subcommand)]`
+/// declaration. The panic message names the offending command and option.
+#[test]
+fn the_whole_command_tree_is_a_legal_clap_definition() {
+    // `build()` propagates every global into all ~530 nodes and asserts the
+    // result; the built tree itself is not otherwise needed here.
+    let mut command = Cli::command();
+    command.build();
 }

--- a/crates/homeboy-cli/src/cli_surface/reference_docs.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs.rs
@@ -35,11 +35,12 @@
 //! all ~500 nodes, which this module strips again anyway; and it runs clap's
 //! `debug_assert` suite over the whole tree, which turns any pre-existing
 //! definition defect anywhere in the CLI into a *docs* test failure. That is not
-//! hypothetical: `runner refresh-plan` declares a local `--output` that collides
-//! with the propagated global `--output`, and building trips
-//! `Long option names must be unique for each argument`. Once that is fixed, a
-//! deliberate `build()`-based assertion canary would be a good separate guard;
-//! it should not be smuggled in as a side effect of generating docs.
+//! hypothetical: `runner refresh-plan` used to declare a local `--output` that
+//! collided with the propagated global `--output`, and building tripped
+//! `Long option names must be unique for each argument`. That defect is fixed
+//! (#10566, the flag is now `--produces`) and the deliberate `build()`-based
+//! canary lives in `global_flag_surface_tests`, where a definition defect
+//! reports as a definition defect instead of as stale documentation.
 //!
 //! # Why it does not overwrite `docs/commands/`
 //!

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -10,8 +10,8 @@ use homeboy::core::project::{self, Project};
 use homeboy::core::server::{self, SshClient};
 use homeboy::runner::runners::{self, RunnerKind};
 use homeboy_extension::{
-    self, extension_ready_status, is_extension_linked, load_extension, run_setup, ExtensionSummary,
-    UpdateEntry,
+    self, extension_ready_status_with, is_extension_linked, load_extension, run_setup,
+    ExtensionReadinessMode, ExtensionSummary, UpdateEntry,
 };
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -33,6 +33,10 @@ enum ExtensionCommand {
         /// Project ID to filter compatible extensions
         #[arg(short, long)]
         project: Option<String>,
+        /// Report installed metadata only. Skips each extension's ready_check,
+        /// so `ready_reason` is `ready_check_skipped` instead of a live answer
+        #[arg(long)]
+        skip_ready_check: bool,
     },
     /// Compare installed extension revisions with their current checkout HEADs
     DiffInstalled {
@@ -46,6 +50,10 @@ enum ExtensionCommand {
     Show {
         /// Extension ID
         extension_id: String,
+        /// Report installed metadata only. Skips the extension's ready_check,
+        /// so `ready_reason` is `ready_check_skipped` instead of a live answer
+        #[arg(long)]
+        skip_ready_check: bool,
     },
     /// Execute a extension
     Run {
@@ -194,12 +202,18 @@ enum ExtensionCommand {
 
 pub fn run(args: ExtensionArgs) -> CmdResult<ExtensionOutput> {
     match args.command {
-        ExtensionCommand::List { project } => list(project),
+        ExtensionCommand::List {
+            project,
+            skip_ready_check,
+        } => list(project, readiness_mode(skip_ready_check)),
         ExtensionCommand::DiffInstalled {
             extension_id,
             runner,
         } => diff_installed(extension_id.as_deref(), runner.as_deref()),
-        ExtensionCommand::Show { extension_id } => show_extension(&extension_id),
+        ExtensionCommand::Show {
+            extension_id,
+            skip_ready_check,
+        } => show_extension(&extension_id, readiness_mode(skip_ready_check)),
         ExtensionCommand::Run {
             extension_id,
             project,
@@ -581,9 +595,19 @@ pub struct InstalledExtensionDiff {
     pub next_command: String,
 }
 
-fn list(project: Option<String>) -> CmdResult<ExtensionOutput> {
+/// Inventory commands answer "what is installed"; readiness is a separate,
+/// expensive question that `--skip-ready-check` opts out of (#10517).
+fn readiness_mode(skip_ready_check: bool) -> ExtensionReadinessMode {
+    if skip_ready_check {
+        ExtensionReadinessMode::Skip
+    } else {
+        ExtensionReadinessMode::Probe
+    }
+}
+
+fn list(project: Option<String>, readiness: ExtensionReadinessMode) -> CmdResult<ExtensionOutput> {
     let project_config: Option<Project> = project.as_ref().and_then(|id| project::load(id).ok());
-    let summaries = extension::list_summaries(project_config.as_ref());
+    let summaries = extension::list_summaries_with(project_config.as_ref(), readiness);
 
     Ok((
         ExtensionOutput::List {
@@ -854,9 +878,12 @@ fn installed_extension_diff_next_command(summary: &ExtensionSummary, status: &st
     }
 }
 
-fn show_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
+fn show_extension(
+    extension_id: &str,
+    readiness: ExtensionReadinessMode,
+) -> CmdResult<ExtensionOutput> {
     let extension = load_extension(extension_id)?;
-    let ready_status = extension_ready_status(&extension);
+    let ready_status = extension_ready_status_with(&extension, readiness);
     let linked = is_extension_linked(&extension.id);
 
     let has_setup = extension
@@ -1376,6 +1403,88 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
 
+    /// Installs an extension whose `ready_check` leaves a sentinel behind, so a
+    /// test can prove whether the probe ran rather than trusting the reported
+    /// reason string.
+    #[cfg(unix)]
+    fn write_extension_with_observable_ready_check(home: &Path, id: &str, sentinel: &Path) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::to_string(&serde_json::json!({
+                "name": "Readiness fixture",
+                "version": "1.0.0",
+                "executable": {
+                    "runtime": {
+                        "ready_check": format!("touch {}", sentinel.display())
+                    }
+                }
+            }))
+            .expect("manifest json"),
+        )
+        .expect("extension manifest");
+    }
+
+    /// #10517: inventory must not be gated on an operator-authored shell
+    /// command. The sentinel is the evidence — a reason string alone could be
+    /// produced by a probe that ran anyway.
+    #[cfg(unix)]
+    #[test]
+    fn extension_list_with_skip_ready_check_never_spawns_the_ready_check() {
+        with_isolated_home(|home| {
+            let sentinel = home.path().join("ready-check-ran");
+            write_extension_with_observable_ready_check(home.path(), "readiness", &sentinel);
+
+            let (output, exit_code) =
+                list(None, ExtensionReadinessMode::Skip).expect("extension list");
+
+            assert_eq!(exit_code, 0);
+            assert!(
+                !sentinel.exists(),
+                "metadata-only inventory must not execute the ready_check"
+            );
+            let ExtensionOutput::List { extensions, .. } = output else {
+                panic!("expected extension list output");
+            };
+            let entry = extensions
+                .iter()
+                .find(|summary| summary.id == "readiness")
+                .expect("fixture extension");
+            assert_eq!(entry.ready_reason.as_deref(), Some("ready_check_skipped"));
+            // Metadata is the whole point of the fast path; it must still be here.
+            assert_eq!(entry.version, "1.0.0");
+            assert_eq!(entry.has_ready_check, Some(true));
+        });
+    }
+
+    /// The default is deliberately unchanged: dropping readiness from the
+    /// default answer would be a silent, user-visible contract change.
+    #[cfg(unix)]
+    #[test]
+    fn extension_list_still_probes_readiness_by_default() {
+        with_isolated_home(|home| {
+            let sentinel = home.path().join("ready-check-ran");
+            write_extension_with_observable_ready_check(home.path(), "readiness", &sentinel);
+
+            let (output, _) = list(None, ExtensionReadinessMode::Probe).expect("extension list");
+
+            assert!(
+                sentinel.exists(),
+                "the default inventory answer still reports live readiness"
+            );
+            let ExtensionOutput::List { extensions, .. } = output else {
+                panic!("expected extension list output");
+            };
+            let entry = extensions
+                .iter()
+                .find(|summary| summary.id == "readiness")
+                .expect("fixture extension");
+            assert!(entry.ready);
+            assert_eq!(entry.ready_reason, None);
+        });
+    }
+
     #[test]
     fn extension_runtime_diagnostics_reports_generic_materialization_guidance() {
         with_isolated_home(|home| {
@@ -1466,7 +1575,8 @@ mod tests {
             )
             .expect("extension manifest");
 
-            let (output, exit_code) = show_extension(extension_id).expect("show extension");
+            let (output, exit_code) = show_extension(extension_id, ExtensionReadinessMode::Probe)
+                .expect("show extension");
             assert_eq!(exit_code, 0);
             let ExtensionOutput::Show { extension } = output else {
                 panic!("expected extension show output");
@@ -1521,7 +1631,8 @@ mod tests {
             )
             .expect("extension manifest");
 
-            let (output, exit_code) = show_extension(extension_id).expect("show extension");
+            let (output, exit_code) = show_extension(extension_id, ExtensionReadinessMode::Probe)
+                .expect("show extension");
             assert_eq!(exit_code, 0);
             let ExtensionOutput::Show { extension } = output else {
                 panic!("expected extension show output");
@@ -1565,7 +1676,8 @@ mod tests {
             )
             .expect("sidecar revision");
 
-            let (output, exit_code) = show_extension(extension_id).expect("show extension");
+            let (output, exit_code) = show_extension(extension_id, ExtensionReadinessMode::Probe)
+                .expect("show extension");
 
             assert_eq!(exit_code, 0);
             let ExtensionOutput::Show { extension } = output else {

--- a/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
+++ b/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
@@ -1,0 +1,226 @@
+//! Controller-side git ancestry probe for runner recovery guidance (#10525).
+//!
+//! `runner status` prefers a verified newer runner build over an older
+//! controller revision when regenerating a `refresh-homeboy` command, and it
+//! decides that with `git merge-base --is-ancestor`. That probe reads the
+//! caller's *ambient* working directory: it is meaningful when the controller
+//! runs inside a Homeboy checkout and meaningless everywhere else.
+//!
+//! Two things were wrong with running it as a bare `Command::status()`:
+//!
+//! 1. The child inherited stderr, so invoking `homeboy runner status <id> --full`
+//!    from a non-checkout printed `fatal: not a git repository (or any of the
+//!    parent directories): .git` — twice — *before* the structured
+//!    `homeboy/command-result/v3` envelope on stdout. An orchestration client
+//!    then has to separate real runner failure from unrelated ambient noise.
+//! 2. `.is_ok_and(|status| status.success())` collapsed "not an ancestor",
+//!    "not a checkout", and "git is not installed" into one `false`. Homeboy has
+//!    repeatedly lost diagnostics that way (see #10576, where a release failure
+//!    reported only "Unknown error"), so the cause must survive even though the
+//!    answer is the same fallback in every case.
+//!
+//! This module captures the child's streams and reports an unusable probe as a
+//! bounded typed degradation on the existing read-only probe ledger, which
+//! `runner status` already drains into `probe_degradations`. A plain
+//! non-ancestor answer — exit 1 with no stderr — is a real answer and records
+//! nothing.
+
+use std::process::Command;
+
+use homeboy::runner::readonly_probe::{self, ReadOnlyProbeDegradation, REASON_PROBE_UNAVAILABLE};
+
+/// Stable probe label reported in `probe_degradations`.
+const PROBE: &str = "controller_git_ancestry";
+
+/// Upper bound on how much of git's stderr is echoed into the degradation.
+/// The diagnostic must stay a bounded field in a machine-readable envelope, not
+/// an unbounded subprocess transcript.
+const MAX_DETAIL_CHARS: usize = 400;
+
+/// Is `older` an ancestor of `newer` in the controller's ambient checkout?
+///
+/// Returns `false` when the question cannot be answered, which is the same
+/// conservative answer as "no": the caller falls back to the controller's own
+/// refresh ref. When the probe could not run at all, the reason is recorded as
+/// a degradation rather than printed or discarded.
+pub(super) fn commits_are_ancestral(older: &str, newer: &str) -> bool {
+    // `output()` captures both child streams. `status()` would inherit them and
+    // print git's `fatal:` line straight past the structured envelope.
+    ancestry_from_probe(
+        Command::new("git")
+            .args(["merge-base", "--is-ancestor", older, newer])
+            .output(),
+    )
+}
+
+/// Classify a completed probe. Split from the spawn so the "answered false"
+/// versus "could not answer" distinction is deterministically testable without
+/// depending on the machine's git or working directory.
+fn ancestry_from_probe(probe: std::io::Result<std::process::Output>) -> bool {
+    match probe {
+        Ok(output) if output.status.success() => true,
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr.trim();
+            // A non-zero exit with nothing on stderr is git answering the
+            // question: `older` is not an ancestor of `newer`. Only a
+            // diagnostic on stderr means the probe itself could not run.
+            if !stderr.is_empty() {
+                record_unavailable(stderr);
+            }
+            false
+        }
+        Err(error) => {
+            record_unavailable(&format!("git could not be executed: {error}"));
+            false
+        }
+    }
+}
+
+fn record_unavailable(git_diagnostic: &str) {
+    readonly_probe::record_degradation(ReadOnlyProbeDegradation {
+        probe: PROBE.to_string(),
+        runner_id: None,
+        reason_code: REASON_PROBE_UNAVAILABLE,
+        timeout_seconds: 0,
+        detail: unavailable_detail(git_diagnostic),
+    });
+}
+
+/// Split from [`record_unavailable`] so the operator-facing wording is
+/// assertable without spawning git or touching the thread-local ledger.
+fn unavailable_detail(git_diagnostic: &str) -> String {
+    format!(
+        "controller git ancestry probe could not run in the current directory, \
+         so runner recovery guidance falls back to the controller's own build \
+         ref instead of preferring a verified newer runner build. Run from a \
+         Homeboy checkout to restore it. git reported: {}",
+        bounded(git_diagnostic)
+    )
+}
+
+fn bounded(text: &str) -> String {
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= MAX_DETAIL_CHARS {
+        return collapsed;
+    }
+    let truncated: String = collapsed.chars().take(MAX_DETAIL_CHARS).collect();
+    format!("{truncated}… (truncated)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Output;
+
+    #[cfg(unix)]
+    fn exit(code: i32) -> std::process::ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(not(unix))]
+    fn exit(code: i32) -> std::process::ExitStatus {
+        use std::os::windows::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(code as u32)
+    }
+
+    fn probe(code: i32, stderr: &str) -> std::io::Result<Output> {
+        Ok(Output {
+            status: exit(code),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        })
+    }
+
+    /// The exact shape reported in #10525: `runner status --full` invoked from a
+    /// directory that is not a checkout. The answer is the conservative
+    /// fallback, git's line never reaches a stream, and the cause survives as a
+    /// typed degradation on the read-only probe ledger.
+    #[test]
+    fn a_non_checkout_working_directory_reports_a_bounded_degradation_not_raw_git_stderr() {
+        readonly_probe::take_degradations();
+
+        let answer = ancestry_from_probe(probe(
+            128,
+            "fatal: not a git repository (or any of the parent directories): .git\n",
+        ));
+
+        assert!(
+            !answer,
+            "an unanswerable ancestry probe must not claim ancestry"
+        );
+        let degradations = readonly_probe::take_degradations();
+        assert_eq!(degradations.len(), 1);
+        assert_eq!(degradations[0].probe, PROBE);
+        assert_eq!(degradations[0].reason_code, REASON_PROBE_UNAVAILABLE);
+        assert!(
+            degradations[0]
+                .detail
+                .contains("fatal: not a git repository"),
+            "the underlying git diagnostic must survive: {}",
+            degradations[0].detail
+        );
+    }
+
+    /// `git merge-base --is-ancestor` reports a plain "no" as exit 1 with no
+    /// stderr. That is an answer, not a degradation, and must not pollute the
+    /// ledger of a healthy status call.
+    #[test]
+    fn a_plain_non_ancestor_answer_records_nothing() {
+        readonly_probe::take_degradations();
+
+        assert!(!ancestry_from_probe(probe(1, "")));
+        assert!(readonly_probe::take_degradations().is_empty());
+
+        assert!(ancestry_from_probe(probe(0, "")));
+        assert!(readonly_probe::take_degradations().is_empty());
+    }
+
+    #[test]
+    fn a_missing_git_binary_is_reported_rather_than_swallowed() {
+        readonly_probe::take_degradations();
+
+        assert!(!ancestry_from_probe(Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no such file or directory",
+        ))));
+
+        let degradations = readonly_probe::take_degradations();
+        assert_eq!(degradations.len(), 1);
+        assert!(degradations[0].detail.contains("git could not be executed"));
+    }
+
+    #[test]
+    fn the_reported_detail_stays_bounded() {
+        let long = unavailable_detail(&"x".repeat(MAX_DETAIL_CHARS * 3));
+
+        assert!(long.contains("(truncated)"));
+        assert!(long.chars().count() < MAX_DETAIL_CHARS * 2);
+    }
+
+    /// Structural guard for the leak itself: `status()` inherits the parent's
+    /// stdout/stderr, which is how git's `fatal:` line got in front of the
+    /// `homeboy/command-result/v3` envelope. This probe must always capture.
+    #[test]
+    fn the_probe_never_inherits_the_parent_streams() {
+        let source = include_str!("controller_ancestry.rs");
+        let start = source
+            .find("pub(super) fn commits_are_ancestral")
+            .expect("probe entry point");
+        let end = source[start..]
+            .find("fn ancestry_from_probe")
+            .expect("next item")
+            + start;
+        let spawn = &source[start..end];
+        // Composed rather than written literally so this assertion does not
+        // match itself when it scans its own file.
+        let inheriting_spawn = format!(".{}()", "status");
+
+        assert!(spawn.contains(".output()"));
+        assert!(
+            !spawn.contains(&inheriting_spawn),
+            "the ancestry probe must capture git's streams, never inherit them"
+        );
+    }
+}

--- a/crates/homeboy-cli/src/commands/runner/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/mod.rs
@@ -11,6 +11,7 @@ mod workspace;
 
 mod broker;
 mod cli;
+mod controller_ancestry;
 mod dispatch;
 mod env;
 mod exec;

--- a/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
+++ b/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
@@ -32,8 +32,13 @@ pub struct RefreshPlanArgs {
     #[arg(long = "run-id")]
     run_id: String,
 
+    // Spelled `--produces`, not `--output`: the process-wide global
+    // `--output <PATH>` already means "write the JSON result envelope here", and
+    // declaring a second `--output` on this command made both unreachable in a
+    // clap-defined order and tripped `Long option names must be unique for each
+    // argument` under debug assertions (#10566).
     /// Produced output directory or file. Relative paths are resolved from --runner-cwd.
-    #[arg(long = "output", value_name = "PATH")]
+    #[arg(long = "produces", value_name = "PATH")]
     outputs: Vec<String>,
 
     /// Produced summary directory or file. Relative paths are resolved from --runner-cwd.
@@ -198,7 +203,7 @@ pub fn refresh_plan(args: RefreshPlanArgs) -> homeboy::core::Result<LabRefreshPl
             "refresh-plan requires a command after --",
             None,
             Some(vec![
-                "Example: homeboy runner refresh-plan --runner lab --workspace . --runner-cwd /workspace/app --run-id run-1 --output artifacts/review -- npm test".to_string(),
+                "Example: homeboy runner refresh-plan --runner lab --workspace . --runner-cwd /workspace/app --run-id run-1 --produces artifacts/review -- npm test".to_string(),
             ]),
         ));
     }

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -183,10 +183,9 @@ fn probe_degradation_hints() -> Vec<String> {
     readonly_probe::degradations()
         .into_iter()
         .map(|degradation| {
-            // `PARTIAL STATUS` is documented as "the runner did not answer in
-            // time". A probe that could not run in the *controller's* own
-            // environment says nothing about the runner, so it gets its own
-            // label rather than raising a false wedged-Lab alarm (#10525).
+            // `PARTIAL STATUS` means "the runner did not answer in time". A
+            // probe that failed in the *controller's* own environment says
+            // nothing about the runner: label it apart (#10525).
             let label = if degradation.reason_code == readonly_probe::REASON_PROBE_UNAVAILABLE {
                 "DEGRADED PROBE"
             } else {

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::process::Command;
 
 use homeboy::core::agent_runtime_manifest::{
     discover_agent_runtime_catalog, AgentRuntimeDiagnosticFollowup,
@@ -15,6 +14,7 @@ use homeboy::runner::runners::{
 };
 
 use super::super::CmdResult;
+use super::controller_ancestry::commits_are_ancestral;
 use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
     RunnerConnectionOutput, RunnerExecutableRequirementDiagnostics, RunnerExtra,
@@ -183,8 +183,17 @@ fn probe_degradation_hints() -> Vec<String> {
     readonly_probe::degradations()
         .into_iter()
         .map(|degradation| {
+            // `PARTIAL STATUS` is documented as "the runner did not answer in
+            // time". A probe that could not run in the *controller's* own
+            // environment says nothing about the runner, so it gets its own
+            // label rather than raising a false wedged-Lab alarm (#10525).
+            let label = if degradation.reason_code == readonly_probe::REASON_PROBE_UNAVAILABLE {
+                "DEGRADED PROBE"
+            } else {
+                "PARTIAL STATUS"
+            };
             format!(
-                "PARTIAL STATUS ({}): {}",
+                "{label} ({}): {}",
                 degradation.reason_code, degradation.detail
             )
         })
@@ -1051,13 +1060,6 @@ fn recovery_refresh_ref_with(
         }
         _ => controller_ref.to_string(),
     }
-}
-
-fn commits_are_ancestral(older: &str, newer: &str) -> bool {
-    Command::new("git")
-        .args(["merge-base", "--is-ancestor", older, newer])
-        .status()
-        .is_ok_and(|status| status.success())
 }
 
 pub(crate) fn declared_run_followups(

--- a/crates/homeboy-core/src/extension_readiness.rs
+++ b/crates/homeboy-core/src/extension_readiness.rs
@@ -21,11 +21,11 @@ pub struct ExtensionReadyStatus {
 /// Whether a caller wants readiness actually probed, or only the metadata that
 /// costs nothing to read.
 ///
-/// A `ready_check` is an arbitrary operator-authored shell command — a WordPress
-/// doctor, an npm install probe, a Codebox health script. Inventory commands
-/// (`extension list`, `extension show`) exist to answer "what is installed,
-/// from where, at which revision", and that question must not be gated behind
-/// someone else's PHP (#10517).
+/// A `ready_check` is an arbitrary operator-authored shell command declared by
+/// the extension; core neither knows nor bounds what it does. Inventory
+/// commands (`extension list`, `extension show`) exist to answer "what is
+/// installed, from where, at which revision", and that question must not be
+/// gated behind an unrelated toolchain's health script (#10517).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExtensionReadinessMode {
     /// Run the declared `ready_check`, bounded by [`ready_check_timeout`].

--- a/crates/homeboy-core/src/extension_readiness.rs
+++ b/crates/homeboy-core/src/extension_readiness.rs
@@ -1,7 +1,9 @@
+use std::time::Duration;
+
 use serde::Serialize;
 
 use crate::project::Project;
-use crate::server::execute_local_command_in_dir;
+use crate::server::execute_local_command_in_dir_with_timeout;
 use homeboy_engine_primitives::template;
 
 use crate::extension_store::load_extension;
@@ -16,6 +18,48 @@ pub struct ExtensionReadyStatus {
     pub detail: Option<String>,
 }
 
+/// Whether a caller wants readiness actually probed, or only the metadata that
+/// costs nothing to read.
+///
+/// A `ready_check` is an arbitrary operator-authored shell command — a WordPress
+/// doctor, an npm install probe, a Codebox health script. Inventory commands
+/// (`extension list`, `extension show`) exist to answer "what is installed,
+/// from where, at which revision", and that question must not be gated behind
+/// someone else's PHP (#10517).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtensionReadinessMode {
+    /// Run the declared `ready_check`, bounded by [`ready_check_timeout`].
+    Probe,
+    /// Do not spawn anything; report the probe as deliberately not run.
+    Skip,
+}
+
+/// Wall-clock bound applied to a single `ready_check`.
+///
+/// Deliberately generous — a `ready_check` may legitimately compile or install
+/// something — but never unbounded. #10517 reported `extension list` blowing
+/// past a 120s operator bound and a readiness child eventually dying to
+/// SIGTERM, which is the failure mode a bound exists to convert into an answer.
+pub const DEFAULT_READY_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Environment override for [`ready_check_timeout`], in whole seconds.
+pub const READY_CHECK_TIMEOUT_ENV: &str = "HOMEBOY_EXTENSION_READY_CHECK_TIMEOUT_SECONDS";
+
+/// The bound applied to each `ready_check` invocation.
+pub fn ready_check_timeout() -> Duration {
+    ready_check_timeout_from(std::env::var(READY_CHECK_TIMEOUT_ENV).ok().as_deref())
+}
+
+/// Resolve the bound from a raw override. Split from the environment read so
+/// the "never unbounded" contract is deterministically testable. A zero or
+/// unparseable override is ignored rather than reinstating the hang.
+fn ready_check_timeout_from(raw: Option<&str>) -> Duration {
+    raw.and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_READY_CHECK_TIMEOUT)
+}
+
 /// Environment sentinel set while a `ready_check` runs. A `ready_check` command
 /// can invoke `homeboy` (e.g. `homeboy component show <id>`), which would in turn
 /// re-evaluate readiness and re-run the same `ready_check` — an unbounded
@@ -23,7 +67,20 @@ pub struct ExtensionReadyStatus {
 /// detect that it is already inside a `ready_check` and skip re-running it.
 const READY_CHECK_ACTIVE_ENV: &str = "HOMEBOY_EXTENSION_READY_CHECK_ACTIVE";
 
+/// `ready_reason` reported when a caller asked for metadata only.
+pub const READY_CHECK_SKIPPED_REASON: &str = "ready_check_skipped";
+
+/// `ready_reason` reported when a `ready_check` hit its wall-clock bound.
+pub const READY_CHECK_TIMEOUT_REASON: &str = "ready_check_timeout";
+
 pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadyStatus {
+    extension_ready_status_with(extension, ExtensionReadinessMode::Probe)
+}
+
+pub fn extension_ready_status_with(
+    extension: &ExtensionManifest,
+    mode: ExtensionReadinessMode,
+) -> ExtensionReadyStatus {
     let Some(runtime) = extension.runtime() else {
         return ExtensionReadyStatus {
             ready: true,
@@ -39,6 +96,19 @@ pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadySt
             detail: None,
         };
     };
+
+    // The caller asked for metadata only. Mirror the re-entrant case below: the
+    // check did not run, the reason says so, and the answer does not pretend to
+    // be a failed probe. (#10517)
+    if matches!(mode, ExtensionReadinessMode::Skip) {
+        return ExtensionReadyStatus {
+            ready: true,
+            reason: Some(READY_CHECK_SKIPPED_REASON.to_string()),
+            detail: Some(
+                "ready_check not run: this command was asked for metadata only. Run `homeboy extension show <id>` without --skip-ready-check for live readiness.".to_string(),
+            ),
+        };
+    }
 
     // Re-entry guard: if we are already inside a `ready_check`, do not run it
     // again. A `ready_check` that shells back into `homeboy` (component/extension
@@ -68,12 +138,14 @@ pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadySt
         ("entrypoint", entrypoint.as_str()),
     ];
     let command = template::render(ready_check, &vars);
+    let timeout = ready_check_timeout();
     // Mark the child (and anything it spawns) as running inside a ready_check so
     // a re-entrant `homeboy` invocation trips the guard above.
-    let output = execute_local_command_in_dir(
+    let output = execute_local_command_in_dir_with_timeout(
         &command,
         Some(extension_path),
         Some(&[(READY_CHECK_ACTIVE_ENV, "1")]),
+        timeout,
     );
 
     if output.success {
@@ -81,6 +153,24 @@ pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadySt
             ready: true,
             reason: None,
             detail: None,
+        };
+    }
+
+    // A probe that ran out of wall clock is not the same answer as a probe that
+    // ran and said no. Naming it keeps "the doctor is slow" distinguishable from
+    // "the extension is broken", and keeps the surrounding metadata usable.
+    if output.timed_out {
+        return ExtensionReadyStatus {
+            ready: false,
+            reason: Some(READY_CHECK_TIMEOUT_REASON.to_string()),
+            detail: Some(format!(
+                "ready_check '{}' exceeded its {}s bound and its process group was terminated; \
+                 extension metadata is unaffected. Set {} to change the bound, or pass \
+                 --skip-ready-check to inventory commands.",
+                command,
+                timeout.as_secs(),
+                READY_CHECK_TIMEOUT_ENV
+            )),
         };
     }
 
@@ -194,5 +284,75 @@ mod tests {
 
         assert!(status.ready, "a passing ready_check reports ready");
         assert_eq!(status.reason, None);
+    }
+
+    /// Metadata inspection must not spawn an operator-authored shell command.
+    /// The `ready_check` here fails instantly if it ever runs, and the sentinel
+    /// is explicitly absent so the re-entry guard cannot mask the result.
+    #[test]
+    fn a_skipped_ready_check_never_runs_the_command() {
+        let manifest = manifest_with_ready_check("/tmp", "exit 1");
+        let prior = std::env::var_os(READY_CHECK_ACTIVE_ENV);
+        std::env::remove_var(READY_CHECK_ACTIVE_ENV);
+
+        let status = extension_ready_status_with(&manifest, ExtensionReadinessMode::Skip);
+
+        if let Some(value) = prior {
+            std::env::set_var(READY_CHECK_ACTIVE_ENV, value);
+        }
+
+        assert_eq!(status.reason.as_deref(), Some(READY_CHECK_SKIPPED_REASON));
+        assert!(
+            status.ready,
+            "a skipped probe reports 'not evaluated', not 'not ready'"
+        );
+        assert!(status.detail.unwrap_or_default().contains("metadata only"));
+    }
+
+    /// A `ready_check` that outlives its budget must produce an answer rather
+    /// than hanging the inventory command that asked for it (#10517). Uses a
+    /// one-second override so the test costs a second, not the 30s default.
+    #[test]
+    fn a_ready_check_that_outlives_its_bound_reports_a_timeout_instead_of_hanging() {
+        let manifest = manifest_with_ready_check("/tmp", "sleep 30");
+        let prior_active = std::env::var_os(READY_CHECK_ACTIVE_ENV);
+        let prior_timeout = std::env::var_os(READY_CHECK_TIMEOUT_ENV);
+        std::env::remove_var(READY_CHECK_ACTIVE_ENV);
+        std::env::set_var(READY_CHECK_TIMEOUT_ENV, "1");
+
+        let status = extension_ready_status(&manifest);
+
+        match prior_active {
+            Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
+            None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
+        }
+        match prior_timeout {
+            Some(value) => std::env::set_var(READY_CHECK_TIMEOUT_ENV, value),
+            None => std::env::remove_var(READY_CHECK_TIMEOUT_ENV),
+        }
+
+        assert!(!status.ready);
+        assert_eq!(status.reason.as_deref(), Some(READY_CHECK_TIMEOUT_REASON));
+        let detail = status.detail.unwrap_or_default();
+        assert!(detail.contains("exceeded its 1s bound"), "{detail}");
+        assert!(detail.contains("metadata is unaffected"), "{detail}");
+    }
+
+    #[test]
+    fn the_ready_check_bound_is_never_unbounded_and_honors_a_positive_override() {
+        assert_eq!(ready_check_timeout_from(None), DEFAULT_READY_CHECK_TIMEOUT);
+        // "0" would reintroduce the unbounded probe this bound exists to prevent.
+        assert_eq!(
+            ready_check_timeout_from(Some("0")),
+            DEFAULT_READY_CHECK_TIMEOUT
+        );
+        assert_eq!(
+            ready_check_timeout_from(Some("not-a-number")),
+            DEFAULT_READY_CHECK_TIMEOUT
+        );
+        assert_eq!(
+            ready_check_timeout_from(Some(" 3 ")),
+            Duration::from_secs(3)
+        );
     }
 }

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -30,7 +30,8 @@ use homeboy_core::extension_update_check::read_source_revision;
 
 pub use action::execute_action;
 pub use homeboy_core::extension_readiness::{
-    extension_ready_status, is_extension_compatible, ExtensionReadyStatus,
+    extension_ready_status, extension_ready_status_with, is_extension_compatible,
+    ExtensionReadinessMode, ExtensionReadyStatus,
 };
 use settings::serialize_settings;
 pub(crate) use settings::{build_settings_json_from_manifest, load_extension_manifest_from_dir};

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -69,9 +69,9 @@ pub use env_provider::{
 pub(crate) use execution::build_settings_json_from_manifest;
 pub use execution::execute_action;
 pub use execution::{
-    extension_ready_status, is_extension_compatible, run_action, run_extension, run_setup,
-    ExtensionExecutionMode, ExtensionReadyStatus, ExtensionRunResult, ExtensionSetupResult,
-    ExtensionStepFilter,
+    extension_ready_status, extension_ready_status_with, is_extension_compatible, run_action,
+    run_extension, run_setup, ExtensionExecutionMode, ExtensionReadinessMode, ExtensionReadyStatus,
+    ExtensionRunResult, ExtensionSetupResult, ExtensionStepFilter,
 };
 pub use fingerprint::{
     run_fingerprint_script, AggregateConstructionSeam, AggregateDefinitionFact, AggregateFieldFact,
@@ -140,7 +140,7 @@ pub use runtime_helper::{
     BASH_PREFLIGHT_ENV, COMMAND_CAPTURE_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV,
     RUNTIME_SETTINGS_HELPER_ENV, RUNTIME_SETTINGS_HELPER_ID,
 };
-pub use summary::{list_summaries, ActionSummary, ExtensionSummary};
+pub use summary::{list_summaries, list_summaries_with, ActionSummary, ExtensionSummary};
 pub use validation::{
     extension_provides_build, validate_extension_requirements, validate_required_extensions,
 };

--- a/crates/homeboy-extension/src/summary.rs
+++ b/crates/homeboy-extension/src/summary.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
 
-use super::execution::{extension_ready_status, is_extension_compatible};
+use super::execution::{
+    extension_ready_status_with, is_extension_compatible, ExtensionReadinessMode,
+};
 use super::manifest::ActionType;
 use super::{evaluate_core_compatibility, CoreCompatibilityReport};
 use homeboy_core::extension_store::{
@@ -57,12 +59,25 @@ pub struct ActionSummary {
 /// Aggregates ready status, compatibility, linked status, CLI info, actions,
 /// and runtime details into a single summary per extension.
 pub fn list_summaries(project: Option<&homeboy_core::project::Project>) -> Vec<ExtensionSummary> {
+    list_summaries_with(project, ExtensionReadinessMode::Probe)
+}
+
+/// [`list_summaries`], with control over whether readiness is actually probed.
+///
+/// Every field except `ready`/`ready_reason`/`ready_detail` is read from the
+/// installed manifest and costs nothing. Readiness is the only part that spawns
+/// an operator-authored shell command, so it is the only part a caller should
+/// ever have to opt out of (#10517).
+pub fn list_summaries_with(
+    project: Option<&homeboy_core::project::Project>,
+    readiness: ExtensionReadinessMode,
+) -> Vec<ExtensionSummary> {
     let extensions = load_all_extensions().unwrap_or_default();
 
     let mut summaries: Vec<ExtensionSummary> = extensions
         .iter()
         .map(|ext| {
-            let ready_status = extension_ready_status(ext);
+            let ready_status = extension_ready_status_with(ext, readiness);
             let compatible = is_extension_compatible(ext, project);
             let linked = is_extension_linked(&ext.id);
 

--- a/crates/homeboy-lab-runner/src/readonly_probe.rs
+++ b/crates/homeboy-lab-runner/src/readonly_probe.rs
@@ -59,7 +59,9 @@ pub struct ReadOnlyProbeDegradation {
     pub runner_id: Option<String>,
     /// Machine-readable classification of the degradation.
     pub reason_code: &'static str,
-    /// The bound that fired, in seconds.
+    /// The bound that fired, in seconds. `0` when the probe never reached its
+    /// bound because it could not run at all
+    /// (see [`REASON_PROBE_UNAVAILABLE`]).
     pub timeout_seconds: u64,
     /// Operator-facing explanation of what is missing from the result.
     pub detail: String,
@@ -69,6 +71,13 @@ pub struct ReadOnlyProbeDegradation {
 pub const REASON_PROBE_TIMEOUT: &str = "readonly_probe.timeout";
 /// Probe was cut short because the caller cancelled (SIGINT/SIGTERM).
 pub const REASON_PROBE_INTERRUPTED: &str = "readonly_probe.interrupted";
+/// Probe could not run at all in the caller's environment — a required tool is
+/// missing, or the ambient context it reads (a git checkout, say) is absent.
+/// Distinct from a timeout: no bound ever applied, so `timeout_seconds` is `0`.
+/// The subprocess diagnostic that explains it belongs in `detail`, so a
+/// read-only command can drop the ambient failure from its *streams* without
+/// dropping it from its *answer* (#10525).
+pub const REASON_PROBE_UNAVAILABLE: &str = "readonly_probe.unavailable";
 
 // Per-thread ledger, mirroring the existing `ACTIVE_PROBE_LIMITS` design in
 // `homeboy-core`'s SSH client. Inspection commands probe and drain on the same

--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -11,16 +11,39 @@ homeboy extension <COMMAND>
 ### `list`
 
 ```sh
-homeboy extension list [-p|--project <project_id>]
+homeboy extension list [-p|--project <project_id>] [--skip-ready-check]
 ```
 
 ### `show`
 
 ```sh
-homeboy extension show <extension_id>
+homeboy extension show <extension_id> [--skip-ready-check]
 ```
 
 Print detailed manifest, runtime, capability, and readiness information for one installed extension.
+
+### Readiness is the expensive part of inventory
+
+Everything `list`/`show` report except `ready`, `ready_reason`, and
+`ready_detail` is read from the installed manifest. `ready` comes from running
+the extension's `ready_check`, an arbitrary operator-authored shell command —
+a WordPress doctor, an npm probe, a Codebox health script. Both commands still
+probe by default, so their output is unchanged; two things bound the cost:
+
+- **`--skip-ready-check`** answers "what is installed, from where, at which
+  revision" without spawning anything. `ready_reason` is then
+  `ready_check_skipped` and `ready` carries no live signal — the same shape the
+  re-entrancy guard has always used, so the JSON contract does not change.
+- **Every `ready_check` is bounded** at 30s, overridable with
+  `HOMEBOY_EXTENSION_READY_CHECK_TIMEOUT_SECONDS`. A probe that hits the bound
+  has its process group terminated and reports
+  `ready_reason: "ready_check_timeout"`; the surrounding metadata is still
+  returned. Before this, a slow doctor could hang inventory indefinitely
+  (#10517).
+
+The bound is per extension, not aggregate: `list` over *n* extensions is bounded
+by *n* × the per-check budget. Use `--skip-ready-check` when only metadata is
+wanted.
 
 ### `run`
 
@@ -202,7 +225,7 @@ Executable extensions define their runtime behavior in their extension manifest 
 
 - `run_command`: Shell command to execute the extension. Template variables: `{{extensionPath}}`, `{{entrypoint}}`, `{{args}}`, plus project context vars.
 - `setup_command`: Optional shell command to set up the extension (run during install/update).
-- `ready_check`: Optional shell command to check if extension is ready (exit 0 = ready).
+- `ready_check`: Optional shell command to check if extension is ready (exit 0 = ready). Bounded at 30s per invocation; override with `HOMEBOY_EXTENSION_READY_CHECK_TIMEOUT_SECONDS`.
 - `env`: Optional environment variables to set when running.
 
 ## Release Configuration
@@ -233,7 +256,9 @@ Extension entry (`extensions[]`):
 - `id`, `name`, `version`, `description`
 - `runtime`: `executable` (has runtime config) or `platform` (no runtime config)
 - `compatible` (with optional `--project`)
-- `ready` (runtime readiness based on `ready_check`)
+- `ready` (runtime readiness based on `ready_check`; see `ready_reason` for
+  `ready_check_skipped` / `ready_check_timeout` / `ready_check_reentrant_skipped`,
+  each of which means the check did not produce a live pass/fail)
 - `linked`: whether the extension is symlinked
 - `path`: extension directory path (may be empty if unknown)
 - Optional fields include `ready_reason`, `ready_detail`, `error`, `symlink_target`, `source_revision`, `cli_tool`, `cli_display_name`, `actions`, `has_setup`, and `has_ready_check`.

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -329,7 +329,7 @@ Lab offload selection.
 ### `refresh-plan`
 
 ```sh
-homeboy runner refresh-plan --runner <runner-id> --workspace . --runner-cwd /runner/workspaces/app --run-id matrix-refresh-1 --output artifacts/review --summary artifacts/review/summary.json -- npm test
+homeboy runner refresh-plan --runner <runner-id> --workspace . --runner-cwd /runner/workspaces/app --run-id matrix-refresh-1 --produces artifacts/review --summary artifacts/review/summary.json -- npm test
 ```
 
 Plans a runner-backed refresh loop before dispatching matrix-style work, without
@@ -341,6 +341,13 @@ declared evidence/artifact paths, and the ordered `next_commands` to verify the
 runner, sync the workspace, run the refresh, and inspect the produced evidence.
 Source and fixture paths passed with `--source`/`--fixture` must exist before the
 plan is emitted; `--sync-mode` accepts `snapshot`, `snapshot-git`, or `git`.
+
+Declared produced evidence uses `--produces` and `--summary`. `--produces` was
+spelled `--output` through 0.321.0, which collided with the process-wide global
+`--output <PATH>` ("write the JSON result envelope to this file") and left both
+meanings unreachable in a clap-defined order (#10566). On this command `--output`
+now unambiguously means the global envelope path; use `--produces` to declare a
+produced artifact.
 
 ### `connect`
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -999,6 +999,16 @@ entry in `operator_hints`. A non-empty `probe_degradations` list means the answe
 is **partial** — the runner did not respond in time — which is how an operator
 distinguishes "the Lab is wedged" from "there is nothing to report".
 
+The same ledger carries `readonly_probe.unavailable`, which is *not* a remote
+timeout: a probe that reads the controller's own ambient environment could not
+run there at all. Its `timeout_seconds` is `0` and its hint is labelled
+`DEGRADED PROBE (...)` so it cannot be mistaken for a wedged runner. The
+controller-side git ancestry probe (`controller_git_ancestry`) reports this way
+when `runner status --full` runs outside a Homeboy checkout: recovery guidance
+falls back to the controller's own build ref, git's `fatal: not a git
+repository` is captured into `detail` instead of being printed in front of the
+result envelope, and the runner answer itself is unaffected (#10525).
+
 `runs list --include-active-runner-jobs` deliberately reads the latency-bounded
 indexed active-job snapshot rather than the full status report: it does not
 reconcile the daemon generation ledger, so a wedged Lab cannot block a listing.

--- a/docs/reference/cli/commands/extension.md
+++ b/docs/reference/cli/commands/extension.md
@@ -49,6 +49,7 @@ Show available extensions with compatibility status
 | Option | Value | Description |
 | --- | --- | --- |
 | `-p`, `--project` | `<PROJECT>` | Project ID to filter compatible extensions |
+| `--skip-ready-check` | flag | Report installed metadata only. Skips each extension's ready_check, so `ready_reason` is `ready_check_skipped` instead of a live answer |
 
 ## `homeboy extension diff-installed`
 
@@ -69,7 +70,7 @@ Compare installed extension revisions with their current checkout HEADs
 ## `homeboy extension show`
 
 ```sh
-homeboy extension show <EXTENSION_ID>
+homeboy extension show [OPTIONS] <EXTENSION_ID>
 ```
 
 Show detailed information about a extension
@@ -77,6 +78,10 @@ Show detailed information about a extension
 | Argument | Required | Description |
 | --- | --- | --- |
 | `<EXTENSION_ID>` | yes | Extension ID |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--skip-ready-check` | flag | Report installed metadata only. Skips the extension's ready_check, so `ready_reason` is `ready_check_skipped` instead of a live answer |
 
 ## `homeboy extension run`
 

--- a/docs/reference/cli/commands/runner.md
+++ b/docs/reference/cli/commands/runner.md
@@ -651,7 +651,7 @@ Plan a runner-backed refresh loop before dispatching matrix-style work
 | `--workspace` | `<WORKSPACE>` | Controller-side workspace or worktree to sync to the runner |
 | `--runner-cwd` | `<RUNNER_CWD>` | Runner-side cwd for the eventual runner exec command |
 | `--run-id` | `<RUN_ID>` | Stable run id to use for the produced evidence |
-| `--output` | `<PATH>` | Produced output directory or file. Relative paths are resolved from --runner-cwd |
+| `--produces` | `<PATH>` | Produced output directory or file. Relative paths are resolved from --runner-cwd |
 | `--summary` | `<PATH>` | Produced summary directory or file. Relative paths are resolved from --runner-cwd |
 | `--source` | `<PATH>` | Source path that must exist before the refresh is dispatched. Repeat for multiple paths |
 | `--fixture` | `<PATH>` | Fixture path that must exist before the refresh is dispatched. Repeat for multiple paths |


### PR DESCRIPTION
Closes #10566. Closes #10525. Closes #10517 (partially — see below).

One PR, four commits, one per concern. They are grouped because they share the CLI/output layer and all three are small; each commit stands alone and can be dropped without touching the others.

## Verdict on the three issues

| Issue | Verdict |
|---|---|
| #10566 — `refresh-plan --output` collides with the global `--output` | **Correct on every load-bearing point.** Fixed. |
| #10525 — `runner status --full` emits raw Git errors | **Correct.** Root cause is one `Command::status()` call. Fixed. |
| #10517 — extension list/show gate metadata on readiness | **Correct on the defect, oversized on the remedy, and wrong about one piece of evidence.** Core layering bug fixed; the caching subsystem in the acceptance criteria is not built. |

None of the three was already fixed. One new issue found and filed: **#10616**.

---

## #10566 — `runner refresh-plan --output` → `--produces`

Both definitions are exactly where the issue says. The intended meaning is the local one (`refresh_plan.rs:201` advertises it, `refresh_plan.rs:564` consumes `args.outputs`), so the *global* is what would have to lose — but the global is a pinned protocol surface. Renamed the local flag instead.

**Why `--produces` and not the issue's other suggestions.** `--artifact` collides visually with the propagated global `--artifact-root <DIR>`, already in the same rendered help block; `--output-path` collides the same way with `--output <PATH>`. Both swap one confusable pair for another. `--produces` is a verb — it declares what the *workload* produces — and collides with nothing.

**No deprecation alias.** An alias spelled `--output` would reintroduce the collision, and there is no stable behaviour to preserve: which argument won was clap-internal and undefined.

**Follow-up guard, also in this PR** (separate commit, droppable): `the_whole_command_tree_is_a_legal_clap_definition` calls `Command::build()`, the only thing that runs clap's debug assertions over every node at once. This matters more than it looks. `get_matches` builds the root and then only the subcommands argv descends into, so a malformed definition on a rarely-parsed command is never asserted even in a debug test run — and release builds compile the assertions out entirely. That is the complete explanation for how this reached 0.321.0. Deliberately not next to the docs generator, so a definition defect reports as a definition defect rather than as stale documentation.

## #10525 — raw Git errors from `runner status --full`

`status.rs:1056` used `Command::status()`, which **inherits** the parent's streams. Two `fatal:` lines, exactly as reported, because `recovery_refresh_ref` is reached twice on the `--full` path (`status.rs:925` and `status.rs:955`).

Moved to `commands/runner/controller_ancestry.rs`:

- `.output()` instead of `.status()` — nothing reaches a stream.
- **The cause is kept, not swallowed.** `.is_ok_and(success)` collapsed "not an ancestor", "not a checkout" and "git is not installed" into one `false`. The last two now record a new `readonly_probe.unavailable` degradation on the existing read-only probe ledger, carrying git's own diagnostic in a bounded `detail`; `runner status` already drains that ledger into `probe_degradations`. A plain non-ancestor answer (exit 1, empty stderr) is a real answer and records nothing. This was a hard constraint — #10576 is what happens when homeboy drops a subprocess cause.
- The hint is labelled `DEGRADED PROBE`, not `PARTIAL STATUS`. `PARTIAL STATUS` is documented as "the runner did not answer in time"; a probe that failed in the *controller's* environment says nothing about the runner and must not raise a false wedged-Lab alarm.

**Not fully met:** "runner inspection is independent of the caller CWD". The CWD still influences which refresh ref is suggested, because the ancestry question has no other input. What changed is that a non-checkout is handled as a normal absent context — quiet, typed, explained, fallback named. Making the checkout an explicit declared input is a larger change and deserves its own issue.

## #10517 — extension inventory vs. readiness

Two corrections to the issue, posted in full on the issue itself:

1. **Six of seven acceptance criteria describe a readiness caching subsystem** (cached readiness with timestamp/revision/invalidation reason, aggregate timeouts, phase/progress output). Real design, not this defect. Not built. Per-criterion status is in the issue comment.
2. **`extension diff-installed` is not the fast path the issue believes.** It calls the same `list_summaries(None)` and runs the same probes (`extension.rs:605`). Its apparent speed was the doctor's mood, not a different code path.

Shipped:

- `ExtensionReadinessMode::{Probe,Skip}` in `homeboy-core::extension_readiness`, threaded through a new `list_summaries_with`.
- `--skip-ready-check` on `extension list` and `extension show`.
- Every `ready_check` bounded at 30s (`HOMEBOY_EXTENSION_READY_CHECK_TIMEOUT_SECONDS`) with process-group termination and `ready_reason: ready_check_timeout`. Metadata survives a probe that does not.

**Default output is deliberately unchanged.** Both commands still probe unless told not to. Removing readiness from the default answer would be a silent contract change, and `extension show` readiness is consumed by `validate_runner_extension_ready` in runner extension-parity checks (that path builds its own remote command and never passes the flag).

When skipped, `ready` is `true` with `ready_reason: "ready_check_skipped"` — the shape the #8115 re-entrancy guard already established, keeping `ready` a required bool so `remote_extension_ready_status` keeps parsing. **The reason field, not the boolean, says the answer is not live**; now documented. Making `ready` nullable is a wider breaking change and was not made implicitly.

The test asserts on a sentinel file the `ready_check` would leave behind, so "the probe did not run" is proven rather than inferred from the reason string under test.

## New issue found: #10616

**`homeboy --help` spawns every installed extension's `ready_check`.** The root-help fast path (`cli_runtime.rs:79`) builds the augmented command → `collect_extension_cli_info()` → `list_summaries(None)` → an unbounded probe per extension. Same for the augmented-parse fallback (`cli_runtime.rs:331`), i.e. every extension-provided command (`homeboy rust ...`, `homeboy wp ...`, `homeboy cargo ...`). Built-in commands are safe — the static parse succeeds first.

Pure waste on the help path: the result only feeds `ExtensionCommandManifest.health`, which never appears in rendered help.

Not fixed here because making discovery metadata-only changes `extension.health.status`/`.ready` in `homeboy contract manifest` for every extension-provided command, with a test pinning it (`augmented_manifest_includes_extension_command_contract_and_health`). The 30s bound in this PR contains it (*n* × 30s instead of unbounded).

---

## `--help` handshake: not broken

`negotiate_leaseless_recovery_contract` parses the rendered `Options:` block of `daemon reconcile-leaseless-orphans --help`, and `declared_long_options` only accepts bare options — #10536 found that adding a doc comment to a flag on that command emptied the advertised contract.

- **No command on that path is touched.** The changes are `runner refresh-plan`, `runner status`, `extension list`, `extension show`. `daemon reconcile-leaseless-orphans` is untouched.
- **No `global = true` argument is added, removed, renamed or re-documented.** `root_global_flag_surface_is_pinned` is unmodified and its 14-entry list is unchanged.
- The two new arguments (`--produces`, `--skip-ready-check`) are local to their commands. Renaming a duplicate long name can only reduce ambiguity in any rendering.

## Generated CLI docs

Yes, regeneration was required — the command surface moved on three commands. `docs/reference/cli/commands/{runner,extension}.md` updated: one renamed option cell, one added option row, one added option table, one synopsis gaining `[OPTIONS]`.

I cannot run `cargo` on this host, so these were hand-derived from `reference_docs.rs`'s rendering rules and then **verified by CI**: the CLI Reference Docs gate regenerates in write mode and fails on `git diff --exit-code`. It passed on both `170842746` (#10566 + #10525) and `24d2411d1` (+ #10517). That gate compiles `homeboy-cli` lib + tests, so it also confirms the crate builds.

## What I could not verify locally

`cargo build`/`test`/`check`/`clippy` are all barred on this host (16GB shared, the workspace OOM-kills the supervisor). `cargo fmt` is the only cargo command I ran; it parses every file, so syntax is confirmed. Everything else rides on CI:

- Full compilation of `homeboy-core`, `homeboy-extension`, `homeboy-lab-runner` (only `homeboy-cli` is proven so far, by the docs gate).
- All new tests actually passing.
- The `Command::build()` canary. **This one is a deliberate risk**: if any *other* clap definition defect exists anywhere in the ~530-node tree, this test fails and names it. That is the point — it is the only way to verify the #10566 fix without a local toolchain — but if it surfaces an unrelated defect, drop commit `d5a2ad10c` and I will file the defect separately.
- The 1-second-override timeout test: real wall clock, so mildly timing-dependent. `sleep 30` against a 1s bound is a 30× margin.
