### PR TITLE
fix(fuzz): separate evidence-contract failures from workload failures and make fuzz proof reviewer-ready

### DIFF
--- a/crates/homeboy-cli/src/command_contract/registry.rs
+++ b/crates/homeboy-cli/src/command_contract/registry.rs
@@ -131,6 +131,22 @@ pub const CONTRACT_REGISTRY: &[ContractRegistryEntry] = &[
         rust_type: "homeboy::fuzz::FuzzWorkload",
     },
     ContractRegistryEntry {
+        schema_id: crate::fuzz::FUZZ_EVIDENCE_CONTRACT_SCHEMA,
+        name: "fuzz-evidence-contract",
+        title: "Fuzz evidence contract",
+        owner: "homeboy-fuzz",
+        summary: "Campaign-level evidence completeness and the classified violations that broke it, kept separate from any verdict about the workload under test.",
+        rust_type: "homeboy::fuzz::FuzzEvidenceContract",
+    },
+    ContractRegistryEntry {
+        schema_id: crate::fuzz::FUZZ_PROOF_SCHEMA,
+        name: "fuzz-proof",
+        title: "Fuzz reviewer proof",
+        owner: "homeboy-fuzz",
+        summary: "Bounded reviewer projection of a fuzz run: exact component and rig identity, case and finding totals, gate outcomes, coverage, execution inputs, and evidence verdict.",
+        rust_type: "homeboy::fuzz::FuzzProof",
+    },
+    ContractRegistryEntry {
         schema_id: crate::core::resource_cleanup_intent::RESOURCE_CLEANUP_INTENT_SCHEMA,
         name: "resource-cleanup-intent",
         title: "Resource cleanup intent",

--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -1648,6 +1648,134 @@ mod tests {
         );
     }
 
+    /// Fuzz evidence crosses the homeboy/homeboy-extensions boundary, so a rig
+    /// must be able to discover the schema and check a candidate before
+    /// attaching it. An inbound contract with no registry entry is unusable.
+    #[test]
+    fn fuzz_evidence_contract_is_discoverable_and_validatable() {
+        let contract = registered_contract("fuzz-evidence-contract")
+            .expect("fuzz evidence contract registry entry");
+        assert_eq!(contract.schema_id, FUZZ_EVIDENCE_CONTRACT_SCHEMA);
+        assert_eq!(
+            registered_contract(FUZZ_EVIDENCE_CONTRACT_SCHEMA),
+            Some(contract)
+        );
+
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "evidence.json",
+            json!({
+                "schema": FUZZ_EVIDENCE_CONTRACT_SCHEMA,
+                "complete": false,
+                "violations": [{
+                    "schema": FUZZ_EVIDENCE_CONTRACT_SCHEMA,
+                    "code": "artifact_ref_missing",
+                    "message": "declared artifact is absent from the fuzz artifact root",
+                    "declared_ref": "results.json",
+                    "resolution_base": "/run/fuzz-artifacts",
+                    "producer_contract": "HOMEBOY_FUZZ_ARTIFACTS_DIR"
+                }]
+            }),
+        );
+
+        let output = validate_file(FUZZ_EVIDENCE_CONTRACT_SCHEMA, file).expect("valid contract");
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn fuzz_evidence_contract_validation_rejects_completeness_that_disagrees_with_violations() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "evidence.json",
+            json!({
+                "schema": FUZZ_EVIDENCE_CONTRACT_SCHEMA,
+                "complete": true,
+                "violations": [{
+                    "code": "artifact_ref_missing",
+                    "message": "absent"
+                }]
+            }),
+        );
+
+        let err = validate_file(FUZZ_EVIDENCE_CONTRACT_SCHEMA, file).expect_err("invalid");
+        assert_eq!(err.details["valid"], json!(false));
+        assert!(
+            err.details["error"]
+                .as_str()
+                .expect("error detail")
+                .contains("complete is true but violations were declared"),
+            "{:?}",
+            err.details
+        );
+    }
+
+    #[test]
+    fn fuzz_proof_is_discoverable_and_validatable() {
+        let contract = registered_contract("fuzz-proof").expect("fuzz proof registry entry");
+        assert_eq!(contract.schema_id, FUZZ_PROOF_SCHEMA);
+
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "proof.json",
+            json!({
+                "schema": FUZZ_PROOF_SCHEMA,
+                "source": "run_metadata",
+                "run_id": "studio-pr-4356-homeboy-v6",
+                "status": "pass",
+                "verdict": {
+                    "overall": true,
+                    "workload": "passed",
+                    "evidence": "complete"
+                },
+                "component": { "role": "component", "id": "studio" },
+                "execution": {},
+                "gates": { "total": 4, "passed": 4, "failed": 0 },
+                "evidence": {
+                    "schema": FUZZ_EVIDENCE_CONTRACT_SCHEMA,
+                    "complete": true
+                },
+                "markdown": "## Fuzz proof\n"
+            }),
+        );
+
+        let output = validate_file(FUZZ_PROOF_SCHEMA, file).expect("valid proof");
+        assert!(output.valid);
+    }
+
+    #[test]
+    fn fuzz_proof_validation_rejects_a_mislabelled_revision_role() {
+        let dir = TempDir::new().unwrap();
+        let file = write_json(
+            &dir,
+            "proof.json",
+            json!({
+                "schema": FUZZ_PROOF_SCHEMA,
+                "source": "run_metadata",
+                "run_id": "run-1",
+                "status": "pass",
+                "verdict": { "overall": true, "workload": "passed", "evidence": "complete" },
+                "component": { "role": "rig" },
+                "execution": {},
+                "gates": { "total": 0, "passed": 0, "failed": 0 },
+                "evidence": { "schema": FUZZ_EVIDENCE_CONTRACT_SCHEMA, "complete": true },
+                "markdown": ""
+            }),
+        );
+
+        let err = validate_file(FUZZ_PROOF_SCHEMA, file).expect_err("invalid proof");
+        assert!(
+            err.details["error"]
+                .as_str()
+                .expect("error detail")
+                .contains("component.role"),
+            "{:?}",
+            err.details
+        );
+    }
+
     #[test]
     fn command_registry_export_covers_contract_command() {
         let export = command_registry_export();

--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -51,7 +51,10 @@ use crate::core::secret_env_plan::{
     SECRET_ENV_MATERIALIZED_HANDOFF_SCHEMA, SECRET_ENV_PLAN_SCHEMA,
 };
 use crate::core::{Error, ErrorCode, Result};
-use crate::fuzz::{FuzzWorkload, FUZZ_WORKLOAD_SCHEMA};
+use crate::fuzz::{
+    FuzzEvidenceContract, FuzzProof, FuzzWorkload, FUZZ_EVIDENCE_CONTRACT_SCHEMA,
+    FUZZ_PROOF_SCHEMA, FUZZ_WORKLOAD_SCHEMA,
+};
 
 mod examples;
 use examples::*;
@@ -1290,6 +1293,8 @@ static CONTRACT_SCHEMAS: &[ContractSchema] = &[
     contract_schema!(PATH_MATERIALIZATION_PLAN_SCHEMA, PathMaterializationPlan),
     contract_schema!(RUN_OUTCOME_ENVELOPE_SCHEMA, RunOutcomeEnvelope),
     contract_schema!(EVIDENCE_MANIFEST_SCHEMA, EvidenceManifest),
+    contract_schema!(FUZZ_EVIDENCE_CONTRACT_SCHEMA, FuzzEvidenceContract),
+    contract_schema!(FUZZ_PROOF_SCHEMA, FuzzProof),
 ];
 
 trait ContractValidation: DeserializeOwned {
@@ -1333,6 +1338,8 @@ impl_contract_validation! {
     ResourceLifecycleIndex => RESOURCE_LIFECYCLE_INDEX_SCHEMA, |value| value.validate();
     HostMutationLifecycle => HOST_MUTATION_LIFECYCLE_SCHEMA, |value| value.validate();
     EvidenceManifest => EVIDENCE_MANIFEST_SCHEMA, |value| validate_evidence_manifest(&value);
+    FuzzEvidenceContract => FUZZ_EVIDENCE_CONTRACT_SCHEMA, |value| validate_fuzz_evidence_contract(&value);
+    FuzzProof => FUZZ_PROOF_SCHEMA, |value| validate_fuzz_proof(&value);
     Value => FUZZ_WORKLOAD_SCHEMA, |value| {
         FuzzWorkload::from_value(value).map_err(|message| {
             homeboy::core::Error::new(
@@ -1365,6 +1372,66 @@ fn validate_evidence_manifest(manifest: &EvidenceManifest) -> homeboy::core::Res
             }),
         )
     })
+}
+
+/// Check a candidate fuzz evidence contract before a producer attaches it.
+///
+/// The one invariant that matters is that `complete` cannot disagree with the
+/// violation list: a payload claiming completeness while carrying violations
+/// is exactly the collapse this contract exists to prevent.
+fn validate_fuzz_evidence_contract(contract: &FuzzEvidenceContract) -> homeboy::core::Result<()> {
+    validate_schema_field(FUZZ_EVIDENCE_CONTRACT_SCHEMA, &contract.schema)?;
+    let error = if contract.complete && !contract.violations.is_empty() {
+        Some("complete is true but violations were declared")
+    } else if !contract.complete && contract.violations.is_empty() {
+        Some("complete is false but no violation was declared")
+    } else if contract
+        .violations
+        .iter()
+        .any(|violation| violation.message.trim().is_empty())
+    {
+        Some("every violation must carry a non-empty message")
+    } else {
+        None
+    };
+    match error {
+        None => Ok(()),
+        Some(error) => Err(homeboy::core::Error::new(
+            homeboy::core::ErrorCode::ValidationInvalidArgument,
+            "Contract validation failed",
+            serde_json::json!({
+                "schema": FUZZ_EVIDENCE_CONTRACT_SCHEMA,
+                "valid": false,
+                "error": error,
+            }),
+        )),
+    }
+}
+
+/// Check a candidate fuzz reviewer proof.
+fn validate_fuzz_proof(proof: &FuzzProof) -> homeboy::core::Result<()> {
+    validate_schema_field(FUZZ_PROOF_SCHEMA, &proof.schema)?;
+    let error = if proof.run_id.trim().is_empty() {
+        Some("run_id is required")
+    } else if proof.component.role != "component" {
+        Some("component.role must be `component`")
+    } else if proof.rig.as_ref().is_some_and(|rig| rig.role != "rig") {
+        Some("rig.role must be `rig`")
+    } else {
+        None
+    };
+    match error {
+        None => validate_fuzz_evidence_contract(&proof.evidence),
+        Some(error) => Err(homeboy::core::Error::new(
+            homeboy::core::ErrorCode::ValidationInvalidArgument,
+            "Contract validation failed",
+            serde_json::json!({
+                "schema": FUZZ_PROOF_SCHEMA,
+                "valid": false,
+                "error": error,
+            }),
+        )),
+    }
 }
 
 fn deserialize_contract<T: DeserializeOwned>(

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -11,9 +11,12 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::lifecycle::LifecyclePhaseStatus;
 use homeboy::core::observation::{RunRecord, RunStatus};
 use homeboy::fuzz::{
-    fuzz_gate_profile_contract, parse_fuzz_results_file, FuzzArtifact, FuzzCampaign,
-    FuzzExecutionRequest, FuzzFindingStatus, FuzzGateProfile, FuzzSamplingRequest,
-    FuzzTargetInventory, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    fuzz_campaign_case_totals, fuzz_campaign_finding_totals, fuzz_gate_profile_contract,
+    parse_fuzz_results_file, FuzzArtifact, FuzzCampaign, FuzzEvidenceContract,
+    FuzzEvidenceViolation, FuzzEvidenceViolationCode, FuzzExecutionRequest, FuzzFindingStatus,
+    FuzzGateProfile, FuzzSamplingRequest, FuzzTargetInventory,
+    FUZZ_ARTIFACT_ROOT_PRODUCER_CONTRACT, FUZZ_CONTRACT_VERSION, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    FUZZ_RESULTS_FILE_PRODUCER_CONTRACT,
 };
 use homeboy::rig::{self, FuzzPrepareReport, RigSpec};
 use homeboy_extension::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
@@ -146,6 +149,19 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
     let expected_metric_gates =
         evaluate_expected_metric_gates(results.as_ref(), &args.expect_metric);
     let expected_metric_error = fuzz_expected_metric_error(&expected_metric_gates);
+    // These five channels report four different kinds of event. Collapsing
+    // them into one opaque string is what made a harness packaging error read
+    // as a product failure (#10513): the evidence-contract detail was
+    // discarded before the diagnostic was built, so the diagnosis fell back to
+    // sniffing successful runner stdout. Keep the classification alongside the
+    // collapsed string rather than instead of it, so `fuzz_run_outcome` and
+    // the existing `results_error` metadata member behave exactly as before.
+    let evidence_contract = fuzz_evidence_contract(
+        results_error.as_deref(),
+        postprocess_error.as_deref(),
+        artifact_validation_error.as_deref(),
+        &artifact_ref_validation,
+    );
     let combined_results_error = results_error
         .as_deref()
         .or(postprocess_error.as_deref())
@@ -195,6 +211,11 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         Vec::new()
     };
     let workload_path = selected_workload.and_then(|workload| workload.manifest_path.clone());
+    // The component revision was always available from the resolved execution
+    // context; fuzz simply never recorded it, which is why `runs dossier`
+    // reported `git_sha: null` for a campaign whose product revision was known
+    // (#10514).
+    let component_revision = homeboy::core::git::short_head_revision_at(&ctx.source_path);
     let persisted_evidence = persist_fuzz_run_evidence(FuzzRunEvidenceInput {
         run_id: Some(&effective_run_id),
         component_id: &ctx.component_id,
@@ -214,6 +235,8 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
         expected_metric_gates: &expected_metric_gates,
         results_error: combined_results_error,
         missing_artifact_refs: &artifact_ref_validation.missing_refs,
+        evidence_contract: &evidence_contract,
+        component_revision: component_revision.as_deref(),
         postprocess: &postprocess,
         payloads: &payloads,
     })?;
@@ -246,6 +269,14 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
                             .iter()
                             .map(|reference| reference.canonical_uri().to_string())
                             .collect(),
+                        // Without this the diagnosis never sees the evidence
+                        // failure and falls back to sniffing runner output.
+                        &evidence_contract,
+                        &fuzz_run_gates(
+                            results.as_ref(),
+                            args.effective_gate_profile().as_core(),
+                            &expected_metric_gates,
+                        ),
                     )
                 })
         })
@@ -845,6 +876,11 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) expected_metric_gates: &'a [super::types::FuzzGateEvaluation],
     pub(super) results_error: Option<&'a str>,
     pub(super) missing_artifact_refs: &'a [String],
+    /// Classified evidence-contract verdict for this run. Persisted so a
+    /// later reader does not have to re-sniff a collapsed error string.
+    pub(super) evidence_contract: &'a FuzzEvidenceContract,
+    /// Exact revision of the component source that was fuzzed.
+    pub(super) component_revision: Option<&'a str>,
     pub(super) postprocess: &'a [FuzzArtifactPostprocessOutput],
     pub(super) payloads: &'a [homeboy::fuzz::FuzzPayload],
 }
@@ -882,6 +918,16 @@ pub(super) fn persist_fuzz_run_evidence(
         "campaign_id": input.results.map(|campaign| campaign.id.as_str()),
         "results_error": input.results_error,
         "missing_artifact_refs": input.missing_artifact_refs,
+        // Classified companion to the collapsed `results_error` string above.
+        // Additive: older readers keep using `results_error` and
+        // `missing_artifact_refs`, which are unchanged.
+        "evidence_contract": input.evidence_contract,
+        "component_revision": input.component_revision,
+        // Case and finding totals are already in the parsed campaign; the run
+        // record simply never carried them, which forced reviewers to read the
+        // full result envelope to state "19/19 cases passed, 0 findings".
+        "case_totals": input.results.map(fuzz_campaign_case_totals),
+        "finding_totals": input.results.map(fuzz_campaign_finding_totals),
         "coverage_completeness": input.results.map(fuzz_coverage_completeness),
         "gates": fuzz_run_gates(
             input.results,
@@ -915,7 +961,7 @@ pub(super) fn persist_fuzz_run_evidence(
             .ok()
             .map(|path| path.to_string_lossy().to_string()),
         homeboy_version: Some(homeboy_product_identity::product_version().to_string()),
-        git_sha: None,
+        git_sha: input.component_revision.map(str::to_string),
         rig_id: input.rig_id.map(str::to_string),
         metadata_json: metadata,
     };
@@ -972,7 +1018,14 @@ pub(super) fn persist_fuzz_run_evidence(
 
 #[derive(Default)]
 pub(super) struct FuzzArtifactRefValidation {
+    /// Declared refs that resolved inside the artifact root but are absent.
+    /// Kept for the existing `missing_artifact_refs` metadata member.
     pub(super) missing_refs: Vec<String>,
+    /// Every way the artifact side of the evidence contract was broken,
+    /// classified. Includes the missing refs plus refs that escape the root,
+    /// are the wrong kind, or cannot be read — three cases that used to be
+    /// silently discarded.
+    pub(super) violations: Vec<FuzzEvidenceViolation>,
     pub(super) error: Option<String>,
 }
 
@@ -983,53 +1036,121 @@ pub(super) fn fuzz_artifact_ref_validation(
     let Some(campaign) = results else {
         return FuzzArtifactRefValidation::default();
     };
-    let mut missing_refs = Vec::new();
+    let mut violations = Vec::new();
     for artifact in &campaign.artifacts {
-        if let Some(path) = artifact
-            .artifact
-            .as_ref()
-            .and_then(|artifact| artifact.path.as_deref())
-        {
-            collect_missing_artifact_ref(path, artifacts_dir, &mut missing_refs);
+        if let Some(contract) = artifact.artifact.as_ref() {
+            if let Some(path) = contract.path.as_deref() {
+                collect_artifact_ref_violation(
+                    path,
+                    Some(contract.artifact_type.as_str()),
+                    artifacts_dir,
+                    &mut violations,
+                );
+            }
         }
     }
-    collect_missing_artifact_refs_from_metadata(
+    collect_artifact_ref_violations_from_metadata(
         &campaign.metadata,
         artifacts_dir,
-        &mut missing_refs,
+        &mut violations,
     );
+    violations.sort_by(|left, right| {
+        left.declared_ref
+            .cmp(&right.declared_ref)
+            .then_with(|| left.code.as_str().cmp(right.code.as_str()))
+    });
+    violations.dedup();
+
+    let mut missing_refs = violations
+        .iter()
+        .filter(|violation| violation.code == FuzzEvidenceViolationCode::ArtifactRefMissing)
+        .filter_map(|violation| violation.declared_ref.clone())
+        .collect::<Vec<_>>();
     missing_refs.sort();
     missing_refs.dedup();
 
-    let error = (!missing_refs.is_empty()).then(|| {
-        format!(
+    // Preserve the exact legacy sentence for the missing case so operators and
+    // existing assertions keep recognizing it, and append the newly detected
+    // classes rather than replacing the message.
+    let mut messages = Vec::new();
+    if !missing_refs.is_empty() {
+        messages.push(format!(
             "fuzz campaign references artifact path(s) missing from HOMEBOY_FUZZ_ARTIFACTS_DIR: {}",
             missing_refs.join(", ")
-        )
-    });
+        ));
+    }
+    let other = violations
+        .iter()
+        .filter(|violation| violation.code != FuzzEvidenceViolationCode::ArtifactRefMissing)
+        .map(FuzzEvidenceViolation::root_cause_line)
+        .collect::<Vec<_>>();
+    if !other.is_empty() {
+        messages.push(format!(
+            "fuzz campaign declared unusable artifact reference(s): {}",
+            other.join("; ")
+        ));
+    }
+    let error = (!messages.is_empty()).then(|| messages.join(" | "));
+
     FuzzArtifactRefValidation {
         missing_refs,
+        violations,
         error,
     }
 }
 
-fn collect_missing_artifact_refs_from_metadata(
+/// Assemble the campaign-level evidence contract from the channels that
+/// report *undelivered evidence*.
+///
+/// Deliberately excludes expected-metric gate failures: a gate that did not
+/// hold is a statement about the workload's declared pass criteria, not about
+/// missing evidence, and folding it in here is exactly the collapse #10513
+/// reported.
+pub(super) fn fuzz_evidence_contract(
+    results_error: Option<&str>,
+    postprocess_error: Option<&str>,
+    required_artifact_error: Option<&str>,
+    artifact_refs: &FuzzArtifactRefValidation,
+) -> FuzzEvidenceContract {
+    let mut violations = artifact_refs.violations.clone();
+    if let Some(error) = results_error {
+        violations.push(
+            FuzzEvidenceViolation::new(FuzzEvidenceViolationCode::ResultsUnparseable, error)
+                .with_producer_contract(FUZZ_RESULTS_FILE_PRODUCER_CONTRACT),
+        );
+    }
+    if let Some(error) = required_artifact_error {
+        violations.push(
+            FuzzEvidenceViolation::new(FuzzEvidenceViolationCode::RequiredArtifactAbsent, error)
+                .with_producer_contract(FUZZ_ARTIFACT_ROOT_PRODUCER_CONTRACT),
+        );
+    }
+    if let Some(error) = postprocess_error {
+        violations.push(FuzzEvidenceViolation::new(
+            FuzzEvidenceViolationCode::RequiredPostprocessFailed,
+            error,
+        ));
+    }
+    FuzzEvidenceContract::from_violations(violations)
+}
+
+fn collect_artifact_ref_violations_from_metadata(
     value: &serde_json::Value,
     artifacts_dir: &Path,
-    missing_refs: &mut Vec<String>,
+    violations: &mut Vec<FuzzEvidenceViolation>,
 ) {
     match value {
         serde_json::Value::Object(object) => {
             if let Some(refs) = object.get("artifact_refs") {
-                collect_artifact_refs_value(refs, artifacts_dir, missing_refs);
+                collect_artifact_refs_value(refs, artifacts_dir, violations);
             }
             for value in object.values() {
-                collect_missing_artifact_refs_from_metadata(value, artifacts_dir, missing_refs);
+                collect_artifact_ref_violations_from_metadata(value, artifacts_dir, violations);
             }
         }
         serde_json::Value::Array(values) => {
             for value in values {
-                collect_missing_artifact_refs_from_metadata(value, artifacts_dir, missing_refs);
+                collect_artifact_ref_violations_from_metadata(value, artifacts_dir, violations);
             }
         }
         _ => {}
@@ -1039,21 +1160,24 @@ fn collect_missing_artifact_refs_from_metadata(
 fn collect_artifact_refs_value(
     value: &serde_json::Value,
     artifacts_dir: &Path,
-    missing_refs: &mut Vec<String>,
+    violations: &mut Vec<FuzzEvidenceViolation>,
 ) {
     match value {
         serde_json::Value::String(path) => {
-            collect_missing_artifact_ref(path, artifacts_dir, missing_refs)
+            collect_artifact_ref_violation(path, None, artifacts_dir, violations)
         }
         serde_json::Value::Array(values) => {
             for value in values {
-                collect_artifact_refs_value(value, artifacts_dir, missing_refs);
+                collect_artifact_refs_value(value, artifacts_dir, violations);
             }
         }
         serde_json::Value::Object(object) => {
+            let declared_type = object
+                .get("artifact_type")
+                .and_then(serde_json::Value::as_str);
             for key in ["path", "artifact", "ref"] {
                 if let Some(path) = object.get(key).and_then(serde_json::Value::as_str) {
-                    collect_missing_artifact_ref(path, artifacts_dir, missing_refs);
+                    collect_artifact_ref_violation(path, declared_type, artifacts_dir, violations);
                     return;
                 }
             }
@@ -1062,33 +1186,99 @@ fn collect_artifact_refs_value(
     }
 }
 
-fn collect_missing_artifact_ref(path: &str, artifacts_dir: &Path, missing_refs: &mut Vec<String>) {
-    let Some(resolved) = resolve_local_fuzz_artifact_ref(path, artifacts_dir) else {
-        return;
+/// How a declared artifact reference resolves against the artifact root.
+enum FuzzArtifactRefResolution {
+    /// Not a local path at all — a URI or an empty string. Not this
+    /// contract's business.
+    NotLocal,
+    /// Local-looking but escaping the artifact root. Previously discarded
+    /// with the same code path as a legitimate remote URI, so a campaign
+    /// declaring `../outside.json` passed validation silently.
+    Escapes,
+    Local(PathBuf),
+}
+
+fn collect_artifact_ref_violation(
+    path: &str,
+    declared_type: Option<&str>,
+    artifacts_dir: &Path,
+    violations: &mut Vec<FuzzEvidenceViolation>,
+) {
+    let base = artifacts_dir.display().to_string();
+    let violation = |code: FuzzEvidenceViolationCode, message: String| {
+        FuzzEvidenceViolation::new(code, message)
+            .with_declared_ref(path)
+            .with_resolution_base(base.clone())
+            .with_producer_contract(FUZZ_ARTIFACT_ROOT_PRODUCER_CONTRACT)
     };
-    if !resolved.exists() {
-        missing_refs.push(path.to_string());
+    match resolve_local_fuzz_artifact_ref(path, artifacts_dir) {
+        FuzzArtifactRefResolution::NotLocal => {}
+        FuzzArtifactRefResolution::Escapes => violations.push(violation(
+            FuzzEvidenceViolationCode::ArtifactRefUnresolvable,
+            "declared artifact reference resolves outside the fuzz artifact root".to_string(),
+        )),
+        FuzzArtifactRefResolution::Local(resolved) => match std::fs::symlink_metadata(&resolved) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                violations.push(violation(
+                    FuzzEvidenceViolationCode::ArtifactRefMissing,
+                    "declared artifact is absent from the fuzz artifact root".to_string(),
+                ))
+            }
+            Err(error) => violations.push(violation(
+                FuzzEvidenceViolationCode::ArtifactRefUnreadable,
+                format!("declared artifact could not be stat'd: {error}"),
+            )),
+            Ok(metadata) => {
+                let expects_directory = declared_type == Some("directory");
+                if expects_directory != metadata.is_dir() {
+                    violations.push(violation(
+                        FuzzEvidenceViolationCode::ArtifactRefWrongKind,
+                        format!(
+                            "declared artifact_type `{}` but the path on disk is a {}",
+                            declared_type.unwrap_or("file"),
+                            if metadata.is_dir() {
+                                "directory"
+                            } else {
+                                "file"
+                            }
+                        ),
+                    ));
+                } else if !metadata.is_dir() && std::fs::File::open(&resolved).is_err() {
+                    violations.push(violation(
+                        FuzzEvidenceViolationCode::ArtifactRefUnreadable,
+                        "declared artifact exists but cannot be opened for reading".to_string(),
+                    ));
+                }
+            }
+        },
     }
 }
 
-fn resolve_local_fuzz_artifact_ref(path: &str, artifacts_dir: &Path) -> Option<PathBuf> {
+fn resolve_local_fuzz_artifact_ref(path: &str, artifacts_dir: &Path) -> FuzzArtifactRefResolution {
     let trimmed = path.trim();
     if trimmed.is_empty()
         || trimmed.contains("://")
         || trimmed.starts_with("homeboy://")
         || trimmed.starts_with("runner-artifact://")
     {
-        return None;
+        return FuzzArtifactRefResolution::NotLocal;
     }
     let candidate = Path::new(trimmed);
     if candidate.is_absolute() {
-        candidate
-            .starts_with(artifacts_dir)
-            .then(|| candidate.to_path_buf())
+        if candidate.starts_with(artifacts_dir) {
+            FuzzArtifactRefResolution::Local(candidate.to_path_buf())
+        } else {
+            FuzzArtifactRefResolution::Escapes
+        }
+    } else if trimmed.starts_with("..") {
+        FuzzArtifactRefResolution::Escapes
     } else {
-        (!trimmed.starts_with(".."))
-            .then(|| artifacts_dir.join(candidate))
-            .filter(|path| path.starts_with(artifacts_dir))
+        let joined = artifacts_dir.join(candidate);
+        if joined.starts_with(artifacts_dir) {
+            FuzzArtifactRefResolution::Local(joined)
+        } else {
+            FuzzArtifactRefResolution::Escapes
+        }
     }
 }
 

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -1188,12 +1188,12 @@ fn collect_artifact_refs_value(
 
 /// How a declared artifact reference resolves against the artifact root.
 enum FuzzArtifactRefResolution {
-    /// Not a local path at all — a URI or an empty string. Not this
-    /// contract's business.
+    /// Not resolved against this base: a URI, an empty string, or an absolute
+    /// path outside the artifact root. Not this contract's business.
     NotLocal,
-    /// Local-looking but escaping the artifact root. Previously discarded
-    /// with the same code path as a legitimate remote URI, so a campaign
-    /// declaring `../outside.json` passed validation silently.
+    /// A relative reference that escapes the artifact root. Previously
+    /// discarded through the same branch as a legitimate remote URI, so a
+    /// campaign declaring `../outside.json` passed validation silently.
     Escapes,
     Local(PathBuf),
 }
@@ -1229,8 +1229,16 @@ fn collect_artifact_ref_violation(
                 format!("declared artifact could not be stat'd: {error}"),
             )),
             Ok(metadata) => {
-                let expects_directory = declared_type == Some("directory");
-                if expects_directory != metadata.is_dir() {
+                // Only hold a producer to a kind it actually declared. A bare
+                // string in `artifact_refs` declares no `artifact_type`, so
+                // there is no promise to check and inventing one would fail
+                // campaigns that legitimately point at a directory.
+                let declared_kind_mismatch = match declared_type {
+                    Some("directory") => !metadata.is_dir(),
+                    Some("file") => metadata.is_dir(),
+                    _ => false,
+                };
+                if declared_kind_mismatch {
                     violations.push(violation(
                         FuzzEvidenceViolationCode::ArtifactRefWrongKind,
                         format!(
@@ -1265,12 +1273,19 @@ fn resolve_local_fuzz_artifact_ref(path: &str, artifacts_dir: &Path) -> FuzzArti
     }
     let candidate = Path::new(trimmed);
     if candidate.is_absolute() {
+        // An absolute path outside the artifact root is not resolved against
+        // this base at all, so Homeboy holds no contract over it. Unchanged
+        // behavior: it stays out of the evidence verdict rather than becoming
+        // a new way for existing campaigns to fail.
         if candidate.starts_with(artifacts_dir) {
             FuzzArtifactRefResolution::Local(candidate.to_path_buf())
         } else {
-            FuzzArtifactRefResolution::Escapes
+            FuzzArtifactRefResolution::NotLocal
         }
     } else if trimmed.starts_with("..") {
+        // A relative ref is by contract relative to the artifact root, so
+        // escaping it is unambiguously a producer error. This was previously
+        // discarded through the same branch as a remote URI.
         FuzzArtifactRefResolution::Escapes
     } else {
         let joined = artifacts_dir.join(candidate);

--- a/crates/homeboy-cli/src/commands/fuzz/inspect.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/inspect.rs
@@ -233,7 +233,7 @@ pub(super) fn fuzz_failure_diagnostic(
     let cases = campaign
         .get("cases")
         .and_then(serde_json::Value::as_array)
-        .map(Vec::as_slice)
+        .map(|cases| cases.as_slice())
         .unwrap_or_default();
     let failed_cases = cases
         .iter()
@@ -338,8 +338,19 @@ pub(super) fn fuzz_failure_diagnostic(
     let executions = if classification == "pre_execution_assembly_failure" {
         0
     } else {
-        find_u64(result, &["executions", "execution_count", "executionCount"])
-            .unwrap_or_else(|| u64::from(case_id.is_some()))
+        find_u64(result, &["executions", "execution_count", "executionCount"]).unwrap_or_else(
+            || {
+                // For a campaign-level evidence failure there is no owning
+                // case, but the campaign still says how much ran. Reporting
+                // `1` there (the old `case_id.is_some()` fallback) understated
+                // a 19-case campaign.
+                if is_evidence_failure {
+                    cases.len() as u64
+                } else {
+                    u64::from(case_id.is_some())
+                }
+            },
+        )
     };
     if let Some(source_run_id) = source_run_id {
         evidence_refs.push(format!("homeboy://run/{source_run_id}"));

--- a/crates/homeboy-cli/src/commands/fuzz/inspect.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/inspect.rs
@@ -5,8 +5,11 @@ use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore,
 use homeboy::fuzz::inspect_fuzz_result_envelope_artifact;
 
 use super::types::{FuzzInspectArgs, FuzzInspectCandidate, FuzzInspectOutput};
-use super::types_extra::{FuzzDiagnosticSourceIdentity, FuzzFailureDiagnostic};
+use super::types_extra::{FuzzDiagnosticSourceIdentity, FuzzFailureDiagnostic, FuzzGateEvaluation};
 use homeboy::fuzz::fuzz_result_envelope_evidence_ref;
+use homeboy::fuzz::{
+    classify_fuzz_failure, FuzzEvidenceContract, FuzzFailureDomain, FuzzFailureSignals,
+};
 
 /// Artifact kinds that hold the raw fuzz runner input/result pair, ordered by
 /// inspection preference. `fuzz_results` is the verbatim file a runner wrote to
@@ -157,6 +160,11 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
     // The selected artifact can belong to a downstream Lab fuzz run rather than
     // the runner-exec run used for lookup. Its record is the diagnostic source.
     let diagnostic_run = runs_service::require_run(&store, &selected.run_id)?;
+    // Read-time reconstruction: prefer the classified contract the producer
+    // persisted, and fall back to the pre-taxonomy `missing_artifact_refs` /
+    // `results_error` members for runs recorded before it existed.
+    let evidence_contract = FuzzEvidenceContract::from_run_metadata(&diagnostic_run.metadata_json);
+    let recorded_gates = recorded_gate_evaluations(&diagnostic_run.metadata_json);
 
     Ok(FuzzInspectOutput {
         command: "fuzz.inspect".to_string(),
@@ -186,6 +194,8 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
                         .map(|reference| reference.canonical_uri().to_string()),
                 )
                 .collect(),
+            &evidence_contract,
+            &recorded_gates,
         )),
         envelope_summary,
         candidates: candidate_index,
@@ -202,34 +212,95 @@ pub(super) fn run_inspect(args: FuzzInspectArgs) -> homeboy::core::Result<FuzzIn
     })
 }
 
+/// Build the compact fuzz failure diagnosis.
+///
+/// The `evidence` argument is what keeps a producer defect from being reported
+/// as a discovery about the code under test. Before it existed, the only
+/// inputs were the campaign and the runner's stdout/stderr, so a campaign
+/// whose 19 cases all passed but whose declared `results.json` was absent got
+/// diagnosed as `workload_execution_failure` against an unrelated passing case
+/// id, with successful runner stdout at the head of the root-cause chain.
 pub(super) fn fuzz_failure_diagnostic(
     run: &RunRecord,
     source_run_id: Option<&str>,
     result: &serde_json::Value,
     output: &[&str],
     mut evidence_refs: Vec<String>,
+    evidence: &FuzzEvidenceContract,
+    gates: &[FuzzGateEvaluation],
 ) -> FuzzFailureDiagnostic {
     let campaign = result.get("campaign").unwrap_or(result);
-    let failed_case = campaign
+    let cases = campaign
         .get("cases")
         .and_then(serde_json::Value::as_array)
-        .and_then(|cases| {
-            cases
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let failed_cases = cases
+        .iter()
+        .filter(|case| {
+            matches!(
+                case.get("status").and_then(serde_json::Value::as_str),
+                Some("failed" | "error")
+            )
+        })
+        .collect::<Vec<_>>();
+    let failed_case_ids = failed_cases
+        .iter()
+        .filter_map(|case| {
+            case.get("id")
+                .or_else(|| case.get("case_id"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    let failed_gate_ids = gates
+        .iter()
+        .filter(|gate| gate.status != "passed")
+        .map(|gate| gate.gate_id.clone())
+        .collect::<Vec<_>>();
+    let open_findings = campaign
+        .get("findings")
+        .and_then(serde_json::Value::as_array)
+        .map(|findings| {
+            findings
                 .iter()
-                .find(|case| {
-                    matches!(
-                        case.get("status").and_then(serde_json::Value::as_str),
-                        Some("failed" | "error")
-                    )
+                .filter(|finding| {
+                    finding.get("status").and_then(serde_json::Value::as_str) == Some("open")
                 })
-                .or_else(|| cases.first())
-        });
-    let case_id = failed_case
-        .and_then(|case| case.get("id").or_else(|| case.get("case_id")))
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-        .or_else(|| find_string(result, &["case_id"]));
+                .count() as u64
+        })
+        .unwrap_or(0);
+    let classification_result = classify_fuzz_failure(&FuzzFailureSignals {
+        evidence,
+        failed_case_ids: &failed_case_ids,
+        open_findings,
+        failed_gate_ids: &failed_gate_ids,
+        campaign_present: !campaign.is_null()
+            && campaign
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .is_some(),
+    });
+    let is_evidence_failure =
+        classification_result.domain == FuzzFailureDomain::EvidenceContractFailure;
+
+    // A campaign-level evidence failure has no owning case. Naming a passing
+    // one is how #10513 pointed at `sqlite-artifact-mask-1` for a run in which
+    // every case passed.
+    let case_id = if is_evidence_failure {
+        None
+    } else {
+        failed_cases
+            .first()
+            .copied()
+            .or_else(|| cases.first())
+            .and_then(|case| case.get("id").or_else(|| case.get("case_id")))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .or_else(|| find_string(result, &["case_id"]))
+    };
     let phase = find_string(result, &["phase", "phase_id"]);
+
     let mut causes = diagnostic_strings(result);
     causes.extend(
         output
@@ -240,19 +311,30 @@ pub(super) fn fuzz_failure_diagnostic(
     causes.sort();
     causes.dedup();
     let joined = causes.join("\n");
-    let classification = if joined.contains("ELOOP") {
-        "pre_execution_assembly_failure"
+    let classification = if is_evidence_failure {
+        FuzzFailureDomain::EvidenceContractFailure
+            .as_str()
+            .to_string()
+    } else if joined.contains("ELOOP") {
+        "pre_execution_assembly_failure".to_string()
     } else if joined.contains("PHP")
         && (joined.contains("Missing ") || joined.contains("exit code"))
     {
-        "php_bootstrap_fatal"
+        "php_bootstrap_fatal".to_string()
     } else if causes.is_empty() {
-        "failed_campaign"
+        "failed_campaign".to_string()
     } else {
-        "workload_execution_failure"
-    }
-    .to_string();
+        "workload_execution_failure".to_string()
+    };
     causes.truncate(4);
+    // Evidence-contract root causes lead: they name the declared reference,
+    // the base it was resolved against, and the producer that owed it. Runner
+    // output stays available behind them instead of masquerading as the cause.
+    let mut root_cause_chain = evidence.root_cause_lines();
+    root_cause_chain.truncate(4);
+    root_cause_chain.extend(causes);
+    root_cause_chain.truncate(8);
+
     let executions = if classification == "pre_execution_assembly_failure" {
         0
     } else {
@@ -275,7 +357,11 @@ pub(super) fn fuzz_failure_diagnostic(
         case_id,
         phase,
         classification,
-        root_cause_chain: causes,
+        failure_domain: classification_result.domain.as_str().to_string(),
+        workload_verdict: classification_result.workload_verdict.as_str().to_string(),
+        evidence_verdict: classification_result.evidence_verdict.as_str().to_string(),
+        evidence_violations: evidence.violations.clone(),
+        root_cause_chain,
         executions,
         source_identity: FuzzDiagnosticSourceIdentity {
             component: run
@@ -289,6 +375,50 @@ pub(super) fn fuzz_failure_diagnostic(
         evidence_refs,
         inspect_command: format!("homeboy fuzz inspect {}", run.id),
     }
+}
+
+/// Recover the gate evaluations the producing run persisted.
+///
+/// `fuzz inspect` reads a run back off storage, so it cannot re-evaluate
+/// gates; a gate failure has to come from the record. An entry without a
+/// resolvable `gate_id` is dropped rather than counted as an anonymous
+/// failure.
+fn recorded_gate_evaluations(metadata: &serde_json::Value) -> Vec<FuzzGateEvaluation> {
+    metadata
+        .get("gates")
+        .and_then(serde_json::Value::as_array)
+        .map(|gates| {
+            gates
+                .iter()
+                .filter_map(|gate| {
+                    Some(FuzzGateEvaluation {
+                        gate_id: gate
+                            .get("gate_id")
+                            .and_then(serde_json::Value::as_str)?
+                            .to_string(),
+                        status: gate
+                            .get("status")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("unknown")
+                            .to_string(),
+                        metric: gate
+                            .get("metric")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        observed: gate
+                            .get("observed")
+                            .and_then(serde_json::Value::as_f64)
+                            .unwrap_or(0.0),
+                        expected: gate
+                            .get("expected")
+                            .and_then(serde_json::Value::as_f64)
+                            .unwrap_or(0.0),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn campaign_status(value: &serde_json::Value) -> Option<String> {

--- a/crates/homeboy-cli/src/commands/fuzz/inspect.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/inspect.rs
@@ -820,6 +820,183 @@ mod tests {
         });
     }
 
+    /// #10513: a strict campaign whose cases all passed, whose gates all
+    /// passed, and one of whose declared artifacts was never written.
+    #[test]
+    fn inspect_blames_the_evidence_contract_not_a_passing_case() {
+        with_isolated_home(|home| {
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "fuzz",
+                    serde_json::json!({
+                        "exit_code": 1,
+                        "success": false,
+                        "campaign_id": "sqlite-artifact-mask",
+                        "missing_artifact_refs": ["results.json"],
+                        "results_error": "fuzz campaign references artifact path(s) missing from HOMEBOY_FUZZ_ARTIFACTS_DIR: results.json",
+                        "gates": [
+                            { "gate_id": "no-open-findings", "status": "passed", "metric": "open_findings", "observed": 0.0, "expected": 0.0 },
+                            { "gate_id": "has-case-evidence", "status": "passed", "metric": "case_evidence", "observed": 1.0, "expected": 1.0 },
+                            { "gate_id": "target-coverage-complete", "status": "passed", "metric": "target_coverage", "observed": 1.0, "expected": 1.0 },
+                            { "gate_id": "operation-coverage-complete", "status": "passed", "metric": "operation_coverage", "observed": 1.0, "expected": 1.0 }
+                        ]
+                    }),
+                ))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Fail, None)
+                .expect("finish");
+            let result = serde_json::json!({
+                "campaign": {
+                    "id": "sqlite-artifact-mask",
+                    "status": "passed",
+                    "cases": [
+                        { "id": "sqlite-artifact-mask-1", "status": "passed",
+                          "observed": { "stdout": "imported 512 rows without error" } },
+                        { "id": "sqlite-artifact-mask-2", "status": "passed" }
+                    ],
+                    "findings": []
+                }
+            });
+            let path = home.path().join("passing-results.json");
+            std::fs::write(&path, serde_json::to_vec(&result).unwrap()).expect("write");
+            store
+                .record_artifact(&run.id, "fuzz_results", &path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id.clone(),
+                raw: false,
+                full: false,
+            })
+            .expect("inspect");
+
+            let diagnostic = output.diagnostic.expect("diagnostic");
+            assert_eq!(diagnostic.classification, "evidence_contract_failure");
+            assert_eq!(diagnostic.failure_domain, "evidence_contract_failure");
+            // The workload verdict survives: every case passed.
+            assert_eq!(diagnostic.workload_verdict, "passed");
+            assert_eq!(diagnostic.evidence_verdict, "incomplete");
+            // No unrelated case id is assigned to a campaign-level failure.
+            assert!(diagnostic.case_id.is_none());
+            // Root cause leads with the missing artifact, its resolution base,
+            // and the owning producer contract — not with successful stdout.
+            let leading = diagnostic
+                .root_cause_chain
+                .first()
+                .expect("a root cause")
+                .clone();
+            assert!(leading.contains("artifact_ref_missing"), "{leading}");
+            assert!(leading.contains("results.json"), "{leading}");
+            assert!(
+                !leading.contains("imported 512 rows"),
+                "successful runner stdout must not lead: {leading}"
+            );
+            assert_eq!(diagnostic.evidence_violations.len(), 1);
+            assert_eq!(
+                diagnostic.evidence_violations[0].declared_ref.as_deref(),
+                Some("results.json")
+            );
+        });
+    }
+
+    #[test]
+    fn inspect_still_reports_a_workload_failure_when_a_case_actually_failed() {
+        with_isolated_home(|home| {
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "fuzz",
+                    serde_json::json!({ "exit_code": 1, "campaign_id": "mixed" }),
+                ))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Fail, None)
+                .expect("finish");
+            let result = serde_json::json!({
+                "campaign": {
+                    "id": "mixed",
+                    "status": "failed",
+                    "cases": [
+                        { "id": "case-1", "status": "passed" },
+                        { "id": "case-2", "status": "failed",
+                          "observed": { "stderr": "assertion failed" } }
+                    ]
+                }
+            });
+            let path = home.path().join("mixed-results.json");
+            std::fs::write(&path, serde_json::to_vec(&result).unwrap()).expect("write");
+            store
+                .record_artifact(&run.id, "fuzz_results", &path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id,
+                raw: false,
+                full: false,
+            })
+            .expect("inspect");
+
+            let diagnostic = output.diagnostic.expect("diagnostic");
+            assert_eq!(diagnostic.classification, "workload_execution_failure");
+            assert_eq!(diagnostic.failure_domain, "workload_failure");
+            assert_eq!(diagnostic.workload_verdict, "failed");
+            assert_eq!(diagnostic.evidence_verdict, "complete");
+            // The failing case is named, not the first case in the list.
+            assert_eq!(diagnostic.case_id.as_deref(), Some("case-2"));
+        });
+    }
+
+    #[test]
+    fn inspect_reports_a_gate_failure_separately_from_a_workload_failure() {
+        with_isolated_home(|home| {
+            let _artifact_root =
+                ArtifactRootOverrideGuard::new(home.path().join("agent-readable-artifacts"));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "fuzz",
+                    serde_json::json!({
+                        "exit_code": 1,
+                        "campaign_id": "gated",
+                        "gates": [
+                            { "gate_id": "p95-budget", "status": "failed", "metric": "p95_ms", "observed": 900.0, "expected": 500.0 }
+                        ]
+                    }),
+                ))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Fail, None)
+                .expect("finish");
+            let path = home.path().join("gated-results.json");
+            std::fs::write(
+                &path,
+                br#"{"campaign":{"id":"gated","status":"passed","cases":[{"id":"c1","status":"passed"}]}}"#,
+            )
+            .expect("write");
+            store
+                .record_artifact(&run.id, "fuzz_results", &path)
+                .expect("record");
+
+            let output = run_inspect(FuzzInspectArgs {
+                run_id: run.id,
+                raw: false,
+                full: false,
+            })
+            .expect("inspect");
+
+            let diagnostic = output.diagnostic.expect("diagnostic");
+            assert_eq!(diagnostic.failure_domain, "gate_failure");
+            assert_eq!(diagnostic.workload_verdict, "passed");
+            assert_eq!(diagnostic.evidence_verdict, "complete");
+        });
+    }
+
     #[test]
     fn inspect_marks_eloop_as_pre_execution_with_zero_executions() {
         with_isolated_home(|home| {

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::commands::fuzz::execution::{effective_fuzz_run_id, ensure_strict_rig_source_is_clean};
+use crate::commands::fuzz::execution::{
+    effective_fuzz_run_id, ensure_strict_rig_source_is_clean, FuzzArtifactRefValidation,
+};
 
 #[test]
 fn strict_fuzz_rejects_dirty_linked_rig_packages() {
@@ -161,6 +163,8 @@ fn fuzz_run_persists_requested_run_id_and_results_artifact() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            evidence_contract: &homeboy::fuzz::FuzzEvidenceContract::satisfied(),
+            component_revision: None,
             postprocess: &[],
             payloads: &[],
         })
@@ -308,6 +312,8 @@ fn fuzz_execution_request_artifact_records_runner_intent() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            evidence_contract: &homeboy::fuzz::FuzzEvidenceContract::satisfied(),
+            component_revision: None,
             postprocess: &[],
             payloads: &[],
         })
@@ -595,6 +601,8 @@ fn fuzz_sequence_plan_flag_records_request_env_and_artifact() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            evidence_contract: &homeboy::fuzz::FuzzEvidenceContract::satisfied(),
+            component_revision: None,
             postprocess: &[],
             payloads: &[],
         })
@@ -697,6 +705,8 @@ fn fuzz_run_persists_coverage_reconciliation_artifact() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            evidence_contract: &homeboy::fuzz::FuzzEvidenceContract::satisfied(),
+            component_revision: None,
             postprocess: &[],
             payloads: &[],
         })
@@ -774,6 +784,8 @@ fn fuzz_run_persistence_generates_run_id_when_omitted() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            evidence_contract: &homeboy::fuzz::FuzzEvidenceContract::satisfied(),
+            component_revision: None,
             postprocess: &[],
             payloads: &[],
         })
@@ -827,6 +839,8 @@ fn fuzz_run_persists_result_envelope_artifact_for_valid_campaign() {
             expected_metric_gates: &[],
             results_error: None,
             missing_artifact_refs: &[],
+            evidence_contract: &homeboy::fuzz::FuzzEvidenceContract::satisfied(),
+            component_revision: None,
             postprocess: &[],
             payloads: &[],
         })
@@ -1389,6 +1403,8 @@ fn fuzz_run_persists_raw_results_artifact_when_results_parse_fails() {
                 "fuzz results schema must be homeboy/fuzz-campaign/v1, got unsupported/fuzz-result/v1",
             ),
             missing_artifact_refs: &[],
+            evidence_contract: &homeboy::fuzz::FuzzEvidenceContract::satisfied(),
+            component_revision: None,
             postprocess: &[],
             payloads: &[],
         })
@@ -1793,4 +1809,306 @@ fn fuzz_evidence_followups_point_to_raw_results_when_parse_fails() {
             && followup.contains("normalization failed")
             && followup.contains(&normalization_error)
     }));
+}
+
+// --- #10513: evidence-contract failures are not workload failures -----------
+
+/// Build a campaign whose cases all pass and which declares one artifact that
+/// the runner never wrote — the exact shape reported in #10513.
+fn passing_campaign_with_declared_artifact(declared_ref: &str) -> FuzzCampaign {
+    let mut campaign = empty_fuzz_campaign();
+    campaign.cases = (0..19)
+        .map(|index| {
+            let mut case = FuzzCase {
+                schema: homeboy::fuzz::FUZZ_CASE_SCHEMA.to_string(),
+                id: format!("sqlite-artifact-mask-{index}"),
+                target_id: None,
+                operation_id: None,
+                workload_id: None,
+                seed_id: None,
+                replay_id: None,
+                input: serde_json::Value::Null,
+                expected: serde_json::Value::Null,
+                observed: serde_json::Value::Null,
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            };
+            case.extra
+                .insert("status".to_string(), serde_json::json!("passed"));
+            case
+        })
+        .collect();
+    campaign.metadata = serde_json::json!({ "artifact_refs": [declared_ref] });
+    campaign
+}
+
+#[test]
+fn a_missing_declared_artifact_is_classified_as_an_evidence_contract_violation() {
+    with_isolated_home(|home| {
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+        let campaign = passing_campaign_with_declared_artifact("results.json");
+
+        let validation = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+
+        assert_eq!(validation.missing_refs, vec!["results.json".to_string()]);
+        assert_eq!(validation.violations.len(), 1);
+        let violation = &validation.violations[0];
+        assert_eq!(
+            violation.code,
+            homeboy::fuzz::FuzzEvidenceViolationCode::ArtifactRefMissing
+        );
+        // Root cause names the declared ref, its resolution base, and the
+        // producer contract that owed it.
+        assert_eq!(violation.declared_ref.as_deref(), Some("results.json"));
+        assert_eq!(
+            violation.resolution_base.as_deref(),
+            Some(artifacts_dir.display().to_string().as_str())
+        );
+        assert_eq!(
+            violation.producer_contract.as_deref(),
+            Some("HOMEBOY_FUZZ_ARTIFACTS_DIR")
+        );
+    });
+}
+
+#[test]
+fn a_traversal_escaping_artifact_ref_is_no_longer_discarded_silently() {
+    with_isolated_home(|home| {
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+        let campaign = passing_campaign_with_declared_artifact("../outside.json");
+
+        let validation = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+
+        // Not "missing" — it never resolved at all.
+        assert!(validation.missing_refs.is_empty());
+        assert_eq!(
+            validation.violations[0].code,
+            homeboy::fuzz::FuzzEvidenceViolationCode::ArtifactRefUnresolvable
+        );
+        assert!(validation.error.is_some());
+    });
+}
+
+#[test]
+fn an_artifact_declared_as_a_file_but_present_as_a_directory_is_wrong_kind() {
+    with_isolated_home(|home| {
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(artifacts_dir.join("coverage")).expect("artifact directory");
+        let mut campaign = empty_fuzz_campaign();
+        campaign.artifacts.push(homeboy::fuzz::FuzzArtifact {
+            schema: homeboy::fuzz::FUZZ_ARTIFACT_SCHEMA.to_string(),
+            id: "coverage".to_string(),
+            kind: "coverage_summary".to_string(),
+            artifact: Some(homeboy::core::artifact_contract::ArtifactContract {
+                schema: homeboy::core::artifact_contract::ARTIFACT_CONTRACT_SCHEMA.to_string(),
+                kind: "coverage_summary".to_string(),
+                artifact_type: "file".to_string(),
+                path: Some("coverage".to_string()),
+                url: None,
+                public_url: None,
+                role: None,
+                label: None,
+                semantic_key: None,
+                size_bytes: None,
+                sha256: None,
+                metadata: serde_json::Value::Null,
+                extra: std::collections::BTreeMap::new(),
+            }),
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        });
+
+        let validation = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+
+        assert_eq!(
+            validation.violations[0].code,
+            homeboy::fuzz::FuzzEvidenceViolationCode::ArtifactRefWrongKind
+        );
+    });
+}
+
+#[test]
+fn a_bare_string_ref_pointing_at_a_directory_is_not_a_wrong_kind_violation() {
+    with_isolated_home(|home| {
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(artifacts_dir.join("coverage")).expect("artifact directory");
+        let campaign = passing_campaign_with_declared_artifact("coverage");
+
+        let validation = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+
+        // A bare `artifact_refs` string declares no `artifact_type`, so there
+        // is no promise to break.
+        assert!(validation.violations.is_empty());
+        assert!(validation.error.is_none());
+    });
+}
+
+#[test]
+fn an_absolute_ref_outside_the_artifact_root_stays_out_of_the_evidence_verdict() {
+    with_isolated_home(|home| {
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+        let campaign =
+            passing_campaign_with_declared_artifact("/var/tmp/absent-homeboy-fixture.json");
+
+        let validation = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+
+        // Homeboy holds no contract over a base it did not hand the runner.
+        assert!(validation.violations.is_empty());
+        assert!(validation.error.is_none());
+    });
+}
+
+#[test]
+fn an_expected_metric_gate_failure_is_not_folded_into_the_evidence_contract() {
+    // The collapse this issue is about: a gate that did not hold is a
+    // statement about declared pass criteria, not about undelivered evidence.
+    let contract = fuzz_evidence_contract(None, None, None, &FuzzArtifactRefValidation::default());
+
+    assert!(contract.complete);
+    assert!(contract.violations.is_empty());
+}
+
+#[test]
+fn every_undelivered_evidence_channel_lands_in_the_contract_with_its_own_code() {
+    with_isolated_home(|home| {
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+        let campaign = passing_campaign_with_declared_artifact("results.json");
+        let artifact_refs = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+
+        let contract = fuzz_evidence_contract(
+            Some("runner result file is not valid JSON"),
+            Some("required fuzz artifact postprocess step(s) failed: coverage"),
+            Some("strict fuzz artifact validation failed; missing required artifact(s): case log"),
+            &artifact_refs,
+        );
+
+        assert!(!contract.complete);
+        let codes = contract
+            .violations
+            .iter()
+            .map(|violation| violation.code)
+            .collect::<Vec<_>>();
+        assert!(codes.contains(&homeboy::fuzz::FuzzEvidenceViolationCode::ArtifactRefMissing));
+        assert!(codes.contains(&homeboy::fuzz::FuzzEvidenceViolationCode::ResultsUnparseable));
+        assert!(codes.contains(&homeboy::fuzz::FuzzEvidenceViolationCode::RequiredArtifactAbsent));
+        assert!(
+            codes.contains(&homeboy::fuzz::FuzzEvidenceViolationCode::RequiredPostprocessFailed)
+        );
+        // The artifact-reference violation leads the root cause chain.
+        assert!(contract.root_cause_lines()[0].contains("artifact_ref_missing"));
+    });
+}
+
+#[test]
+fn persisted_fuzz_evidence_records_the_classified_contract_and_result_totals() {
+    with_isolated_home(|home| {
+        let run_dir = RunDir::create().expect("run dir");
+        let results_path = run_dir.step_file("fuzz-results.json");
+        let artifacts_dir = home.path().join("fuzz-artifacts");
+        std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+        let mut campaign = passing_campaign_with_declared_artifact("results.json");
+        campaign.findings.push(FuzzFinding {
+            schema: homeboy::fuzz::FUZZ_FINDING_SCHEMA.to_string(),
+            id: "finding-1".to_string(),
+            title: "panic".to_string(),
+            severity: "high".to_string(),
+            status: FuzzFindingStatus::Open,
+            surface_id: None,
+            target_id: None,
+            operation_id: None,
+            case_id: None,
+            workload_id: None,
+            seed_id: None,
+            fingerprint: None,
+            artifact_ids: Vec::new(),
+            source_refs: Vec::new(),
+            metadata: serde_json::Value::Null,
+            extra: std::collections::BTreeMap::new(),
+        });
+        let artifact_refs = fuzz_artifact_ref_validation(Some(&campaign), &artifacts_dir);
+        let contract = fuzz_evidence_contract(None, None, None, &artifact_refs);
+        let args = fuzz_run_args_with_run_id("evidence-contract-run");
+
+        persist_fuzz_run_evidence(FuzzRunEvidenceInput {
+            run_id: Some("evidence-contract-run"),
+            component_id: "component-a",
+            rig_id: Some("package-fuzz"),
+            rig_package: None,
+            workload_id: Some("parser"),
+            workload_path: None,
+            status: "failed",
+            exit_code: 1,
+            success: false,
+            args: &args,
+            execution_request_path: None,
+            sequence_plan_path: None,
+            results_path: &results_path,
+            artifacts_dir: &artifacts_dir,
+            results: Some(&campaign),
+            expected_metric_gates: &[],
+            results_error: artifact_refs.error.as_deref(),
+            missing_artifact_refs: &artifact_refs.missing_refs,
+            evidence_contract: &contract,
+            component_revision: Some("0bb440eddd8ebe53c15fe826a30c5ec13b2f58b0"),
+            postprocess: &[],
+            payloads: &[],
+        })
+        .expect("persist evidence");
+
+        let store = ObservationStore::open_initialized().expect("store");
+        let run =
+            homeboy::core::observation::runs_service::require_run(&store, "evidence-contract-run")
+                .expect("run");
+
+        // The exact component revision — previously hardcoded to None.
+        assert_eq!(
+            run.git_sha.as_deref(),
+            Some("0bb440eddd8ebe53c15fe826a30c5ec13b2f58b0")
+        );
+        assert_eq!(
+            run.metadata_json
+                .pointer("/evidence_contract/violations/0/code")
+                .and_then(serde_json::Value::as_str),
+            Some("artifact_ref_missing")
+        );
+        assert_eq!(
+            run.metadata_json
+                .pointer("/case_totals/passed")
+                .and_then(serde_json::Value::as_u64),
+            Some(19)
+        );
+        assert_eq!(
+            run.metadata_json
+                .pointer("/finding_totals/open")
+                .and_then(serde_json::Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            run.metadata_json
+                .pointer("/finding_totals/by_severity/high")
+                .and_then(serde_json::Value::as_u64),
+            Some(1)
+        );
+        // Additive: the legacy members a released extension may still read are
+        // untouched.
+        assert_eq!(
+            run.metadata_json
+                .pointer("/missing_artifact_refs/0")
+                .and_then(serde_json::Value::as_str),
+            Some("results.json")
+        );
+        assert!(run.metadata_json.get("results_error").is_some());
+
+        // And the reviewer projection reads back the separated verdicts.
+        let proof = homeboy::fuzz::derive_fuzz_proof(&run).expect("fuzz proof");
+        assert!(!proof.verdict.overall);
+        assert_eq!(
+            proof.verdict.failure_domain,
+            Some(homeboy::fuzz::FuzzFailureDomain::ProductFinding)
+        );
+    });
 }

--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -4,10 +4,10 @@ use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, 
 use super::dispatch::run_list;
 use super::execution::{
     build_fuzz_execution_request, default_runner_contract, fuzz_artifact_ref_validation,
-    fuzz_campaign_contract, fuzz_evidence_followups, fuzz_expected_metric_error, fuzz_max_duration,
-    fuzz_postprocess_error, fuzz_run_artifact_validation_error, fuzz_run_outcome,
-    fuzz_runner_contract, fuzz_runner_env, persist_fuzz_run_evidence,
-    run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
+    fuzz_campaign_contract, fuzz_evidence_contract, fuzz_evidence_followups,
+    fuzz_expected_metric_error, fuzz_max_duration, fuzz_postprocess_error,
+    fuzz_run_artifact_validation_error, fuzz_run_outcome, fuzz_runner_contract, fuzz_runner_env,
+    persist_fuzz_run_evidence, run_fuzz_artifact_postprocess, FuzzRunEvidenceInput,
 };
 use super::planning::{
     build_campaign_plan, campaign_child_run_args, load_or_default_isolation_proof,

--- a/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
@@ -75,7 +75,24 @@ pub struct FuzzFailureDiagnostic {
     pub case_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phase: Option<String>,
+    /// Narrow legacy classification label. Retains
+    /// `pre_execution_assembly_failure` / `php_bootstrap_fatal` /
+    /// `failed_campaign` / `workload_execution_failure`, and adds
+    /// `evidence_contract_failure` so a producer defect stops being reported
+    /// as a workload failure. Prefer `failure_domain` for new consumers.
     pub classification: String,
+    /// Which of the four failure families owns this run: `product_finding`,
+    /// `workload_failure`, `gate_failure`, or `evidence_contract_failure`.
+    pub failure_domain: String,
+    /// Did the code under test behave? Stays `passed` when every case passed
+    /// even if the run failed strict validation on missing evidence.
+    pub workload_verdict: String,
+    /// Was every declared piece of evidence delivered?
+    pub evidence_verdict: String,
+    /// The specific evidence-contract violations, each naming the declared
+    /// reference, its resolution base, and the producer that owed it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_violations: Vec<homeboy::fuzz::FuzzEvidenceViolation>,
     pub root_cause_chain: Vec<String>,
     pub executions: u64,
     pub source_identity: FuzzDiagnosticSourceIdentity,

--- a/crates/homeboy-cli/src/commands/runs/proof.rs
+++ b/crates/homeboy-cli/src/commands/runs/proof.rs
@@ -20,6 +20,7 @@ use serde_json::Value;
 
 use homeboy::core::observation::evidence_report::evidence_failure_summary;
 use homeboy::core::observation::{runs_service, ObservationStore, RunRecord};
+use homeboy::fuzz::{derive_fuzz_proof, FuzzProof};
 
 use super::{reconcile, CmdResult, RunsOutput};
 
@@ -48,6 +49,12 @@ pub struct RunsProofOutput {
     pub gate_failures: Vec<String>,
     /// Flattened scalar proof/scorecard signal fields, deterministic by key.
     pub signals: BTreeMap<String, Value>,
+    /// Reviewer-ready fuzz projection: exact component and rig identity, case
+    /// and finding totals, gate outcomes, coverage, execution inputs, the
+    /// evidence-contract verdict, and a Markdown rendering. Derived at read
+    /// time from the persisted run; absent for non-fuzz runs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fuzz: Option<FuzzProof>,
 }
 
 pub fn proof(run_id: &str) -> CmdResult<RunsOutput> {
@@ -85,6 +92,9 @@ pub fn build_proof(run: &RunRecord) -> RunsProofOutput {
         error: failure.error,
         gate_failures: failure.gate_failures,
         signals,
+        // Derived, never persisted: a read-only projection must not mutate
+        // stored state, and freezing this derivation would stop it improving.
+        fuzz: derive_fuzz_proof(run),
     }
 }
 

--- a/crates/homeboy-cli/src/commands/runs/proof.rs
+++ b/crates/homeboy-cli/src/commands/runs/proof.rs
@@ -266,4 +266,58 @@ mod tests {
         let proof = build_proof(&run);
         assert_eq!(proof.passed, Some(true));
     }
+
+    #[test]
+    fn build_proof_leaves_non_fuzz_runs_without_a_fuzz_projection() {
+        let run = run_with("pass", json!({ "success": true }));
+        assert!(build_proof(&run).fuzz.is_none());
+    }
+
+    /// #10514: the reviewer-facing read command returned only
+    /// `{"kind":"fuzz","passed":true,"signals":{"success":true},"status":"pass"}`
+    /// for a run that already knew its exact revisions, cases, and gates.
+    #[test]
+    fn build_proof_projects_the_reviewer_facing_fuzz_proof() {
+        let mut run = run_with(
+            "pass",
+            json!({
+                "success": true,
+                "campaign_id": "import-db-dropin",
+                "seed": "4356",
+                "rig_package": {
+                    "rig_id": "studio",
+                    "installed_source_revision": "7ccbe54558d145d022ef2b88f3ba9f7e2063df5e",
+                    "linked": true
+                },
+                "case_totals": { "total": 19, "passed": 19 },
+                "finding_totals": { "total": 0, "open": 0 },
+                "tracker_refs": [{ "kind": "github-pr", "id": "Automattic/studio#4356" }],
+                "gates": [
+                    { "gate_id": "no-open-findings", "status": "passed" },
+                    { "gate_id": "has-case-evidence", "status": "passed" }
+                ]
+            }),
+        );
+        run.kind = "fuzz".to_string();
+        run.component_id = Some("studio".to_string());
+        run.git_sha = Some("0bb440eddd8ebe53c15fe826a30c5ec13b2f58b0".to_string());
+
+        let proof = build_proof(&run);
+
+        let fuzz = proof.fuzz.expect("fuzz proof");
+        assert_eq!(
+            fuzz.component.revision.as_deref(),
+            Some("0bb440eddd8ebe53c15fe826a30c5ec13b2f58b0")
+        );
+        assert_eq!(
+            fuzz.rig.as_ref().and_then(|rig| rig.revision.as_deref()),
+            Some("7ccbe54558d145d022ef2b88f3ba9f7e2063df5e")
+        );
+        assert_eq!(fuzz.cases.as_ref().expect("cases").passed, 19);
+        assert_eq!(fuzz.gates.passed, 2);
+        assert_eq!(fuzz.tracker_refs.len(), 1);
+        assert!(fuzz.markdown.contains("19/19 passed"));
+        // The generic signal map still works; the fuzz block is additive.
+        assert_eq!(proof.signals.get("success"), Some(&json!(true)));
+    }
 }

--- a/crates/homeboy-cli/src/commands/runs_proof_summary.rs
+++ b/crates/homeboy-cli/src/commands/runs_proof_summary.rs
@@ -217,6 +217,91 @@ mod tests {
     }
 
     #[test]
+    fn proof_summary_surfaces_the_fuzz_projection() {
+        let payload = json!({
+            "variant": "proof",
+            "payload": {
+                "run_id": "studio-pr-4356-homeboy-v6",
+                "kind": "fuzz",
+                "status": "pass",
+                "passed": true,
+                "signals": { "success": true },
+                "fuzz": {
+                    "verdict": { "overall": true, "workload": "passed", "evidence": "complete" },
+                    "component": { "role": "component", "revision": "0bb440ed" },
+                    "rig": { "role": "rig", "revision": "7ccbe545" },
+                    "cases": { "total": 19, "passed": 19, "failed": 0, "skipped": 0 },
+                    "findings": { "total": 0, "open": 0 },
+                    "gates": { "total": 4, "passed": 4, "failed": 0 },
+                    "coverage": {
+                        "declared_targets": 4, "proven_targets": 4,
+                        "declared_operations": 6, "proven_operations": 6,
+                        "complete": true
+                    },
+                    "execution": { "seed": "4356" },
+                    "evidence": { "complete": true }
+                }
+            }
+        });
+
+        let summary = render_runs_proof_summary(&payload).expect("summary");
+
+        assert!(summary.contains("Fuzz proof:\n"));
+        assert!(summary.contains("  Workload: passed   Evidence: complete\n"));
+        assert!(summary.contains("  Component revision: 0bb440ed\n"));
+        assert!(summary.contains("  Rig revision: 7ccbe545\n"));
+        assert!(summary.contains("  Cases: 19/19 passed, 0 failed, 0 skipped\n"));
+        assert!(summary.contains("  Gates: 4/4 passed\n"));
+        assert!(summary.contains("  Coverage: targets 4/4, operations 6/6\n"));
+        assert!(summary.contains("  Seed: 4356\n"));
+        // A complete contract adds no violation noise.
+        assert!(!summary.contains("Evidence-contract violations"));
+    }
+
+    #[test]
+    fn proof_summary_separates_evidence_violations_from_product_findings() {
+        let payload = json!({
+            "variant": "proof",
+            "payload": {
+                "run_id": "studio-pr-4356-homeboy-v1",
+                "kind": "fuzz",
+                "status": "fail",
+                "passed": false,
+                "signals": {},
+                "fuzz": {
+                    "verdict": {
+                        "overall": false,
+                        "workload": "passed",
+                        "evidence": "incomplete",
+                        "failure_domain": "evidence_contract_failure"
+                    },
+                    "component": { "role": "component" },
+                    "gates": { "total": 4, "passed": 4, "failed": 0 },
+                    "execution": {},
+                    "evidence": {
+                        "complete": false,
+                        "violations": [{
+                            "code": "artifact_ref_missing",
+                            "message": "declared artifact is absent from the fuzz artifact root",
+                            "declared_ref": "results.json"
+                        }]
+                    },
+                    "gaps": ["no seed was recorded"]
+                }
+            }
+        });
+
+        let summary = render_runs_proof_summary(&payload).expect("summary");
+
+        assert!(summary.contains("  Workload: passed   Evidence: incomplete\n"));
+        assert!(summary.contains("  Failure domain: evidence_contract_failure\n"));
+        assert!(summary.contains("producer defects, not product findings"));
+        assert!(summary.contains("[artifact_ref_missing]"));
+        assert!(summary.contains("(ref: results.json)"));
+        assert!(summary.contains("  Not recorded (1):\n"));
+    }
+
+    #[test]
     fn proof_summary_reports_pending_and_no_signals() {
         let payload = json!({
             "variant": "proof",

--- a/crates/homeboy-cli/src/commands/runs_proof_summary.rs
+++ b/crates/homeboy-cli/src/commands/runs_proof_summary.rs
@@ -52,6 +52,10 @@ fn render(proof: &Value) -> String {
         }
     }
 
+    if let Some(fuzz) = proof.get("fuzz") {
+        lines.extend(fuzz_lines(fuzz));
+    }
+
     match proof.get("signals").and_then(Value::as_object) {
         Some(signals) if !signals.is_empty() => {
             lines.push(format!("Signals ({}):", signals.len()));
@@ -67,6 +71,93 @@ fn render(proof: &Value) -> String {
     let mut output = lines.join("\n");
     output.push('\n');
     output
+}
+
+/// Bounded reviewer lines for a fuzz run: what was fuzzed, at what revision,
+/// with what inputs, against what pass criteria. The full projection —
+/// including the Markdown rendering — stays behind `--json`.
+fn fuzz_lines(fuzz: &Value) -> Vec<String> {
+    let mut lines = vec!["Fuzz proof:".to_string()];
+    let workload = string_value(fuzz, &["verdict", "workload"]).unwrap_or("unknown");
+    let evidence = string_value(fuzz, &["verdict", "evidence"]).unwrap_or("unknown");
+    lines.push(format!("  Workload: {workload}   Evidence: {evidence}"));
+    if let Some(domain) = string_value(fuzz, &["verdict", "failure_domain"]) {
+        lines.push(format!("  Failure domain: {domain}"));
+    }
+    if let Some(revision) = string_value(fuzz, &["component", "revision"]) {
+        lines.push(format!("  Component revision: {revision}"));
+    }
+    if let Some(revision) = string_value(fuzz, &["rig", "revision"]) {
+        lines.push(format!("  Rig revision: {revision}"));
+    }
+    if let Some(cases) = value_at(fuzz, &["cases"]) {
+        lines.push(format!(
+            "  Cases: {}/{} passed, {} failed, {} skipped",
+            count_at(cases, "passed"),
+            count_at(cases, "total"),
+            count_at(cases, "failed"),
+            count_at(cases, "skipped")
+        ));
+    }
+    if let Some(findings) = value_at(fuzz, &["findings"]) {
+        lines.push(format!(
+            "  Findings: {} total, {} open",
+            count_at(findings, "total"),
+            count_at(findings, "open")
+        ));
+    }
+    if let Some(gates) = value_at(fuzz, &["gates"]) {
+        lines.push(format!(
+            "  Gates: {}/{} passed",
+            count_at(gates, "passed"),
+            count_at(gates, "total")
+        ));
+    }
+    if let Some(coverage) = value_at(fuzz, &["coverage"]) {
+        lines.push(format!(
+            "  Coverage: targets {}/{}, operations {}/{}",
+            count_at(coverage, "proven_targets"),
+            count_at(coverage, "declared_targets"),
+            count_at(coverage, "proven_operations"),
+            count_at(coverage, "declared_operations")
+        ));
+    }
+    if let Some(seed) = string_value(fuzz, &["execution", "seed"]) {
+        lines.push(format!("  Seed: {seed}"));
+    }
+    let violations = value_at(fuzz, &["evidence", "violations"])
+        .and_then(Value::as_array)
+        .filter(|violations| !violations.is_empty());
+    if let Some(violations) = violations {
+        lines.push(format!(
+            "  Evidence-contract violations ({}) — producer defects, not product findings:",
+            violations.len()
+        ));
+        for violation in violations.iter().take(4) {
+            let code = string_value(violation, &["code"]).unwrap_or("unknown");
+            let message = string_value(violation, &["message"]).unwrap_or("");
+            match string_value(violation, &["declared_ref"]) {
+                Some(declared_ref) => {
+                    lines.push(format!("    [{code}] {message} (ref: {declared_ref})"))
+                }
+                None => lines.push(format!("    [{code}] {message}")),
+            }
+        }
+    }
+    let gaps = value_at(fuzz, &["gaps"])
+        .and_then(Value::as_array)
+        .filter(|gaps| !gaps.is_empty());
+    if let Some(gaps) = gaps {
+        lines.push(format!("  Not recorded ({}):", gaps.len()));
+        for gap in gaps.iter().filter_map(Value::as_str).take(4) {
+            lines.push(format!("    {gap}"));
+        }
+    }
+    lines
+}
+
+fn count_at(value: &Value, key: &str) -> u64 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0)
 }
 
 fn scalar_display(value: &Value) -> String {

--- a/crates/homeboy-fuzz/src/evidence_contract.rs
+++ b/crates/homeboy-fuzz/src/evidence_contract.rs
@@ -1,0 +1,718 @@
+//! Fuzz failure taxonomy.
+//!
+//! "The evidence contract was violated" and "the workload under test failed"
+//! are different events with different owners. The first is a defect in the
+//! producer (a rig, a runner, or Homeboy itself) that failed to deliver the
+//! evidence it declared; the second is a finding about the code under test.
+//! Collapsing them makes harness packaging errors read as product failures.
+//!
+//! This module owns the shared vocabulary:
+//!
+//! * [`FuzzFailureDomain`] — which of the four failure families a failed run
+//!   belongs to.
+//! * [`FuzzEvidenceViolation`] — one specific way an evidence contract was
+//!   broken, carrying the declared reference, the base it was resolved
+//!   against, and the producer contract that owed it.
+//! * [`FuzzEvidenceContract`] — the campaign-level completeness verdict.
+//! * [`classify_fuzz_failure`] — the precedence rule that keeps a workload
+//!   verdict independent of an evidence verdict.
+//!
+//! Both enums carry an `Unknown` catch-all so a label minted by a newer
+//! producer deserializes to "not owned by this binary" rather than failing the
+//! whole payload. Nothing here uses `deny_unknown_fields`: fuzz evidence
+//! crosses the homeboy/homeboy-extensions boundary and those ship separately,
+//! so every member is additive in both directions.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::schemas::FUZZ_EVIDENCE_CONTRACT_SCHEMA;
+
+fn fuzz_evidence_contract_schema() -> String {
+    FUZZ_EVIDENCE_CONTRACT_SCHEMA.to_string()
+}
+
+/// Which family a failed fuzz run belongs to.
+///
+/// These are not severities and they are not ordered by badness. They are
+/// *owners*: a `ProductFinding` belongs to the code under test, a
+/// `WorkloadFailure` to the runner or the harness, a `GateFailure` to the
+/// declared pass criteria, and an `EvidenceContractFailure` to whoever
+/// promised the evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FuzzFailureDomain {
+    /// The workload executed and the product misbehaved. This is a discovery.
+    ProductFinding,
+    /// The workload or its runner could not execute correctly.
+    WorkloadFailure,
+    /// Execution and evidence were fine; a declared gate was not met.
+    GateFailure,
+    /// Declared evidence was not delivered. Says nothing about the product.
+    EvidenceContractFailure,
+    /// A domain minted by a producer this binary does not own. Never guessed.
+    #[serde(other)]
+    Unknown,
+}
+
+impl FuzzFailureDomain {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProductFinding => "product_finding",
+            Self::WorkloadFailure => "workload_failure",
+            Self::GateFailure => "gate_failure",
+            Self::EvidenceContractFailure => "evidence_contract_failure",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Did the workload itself pass, fail, or is it unjudgeable?
+///
+/// `Unknown` is load-bearing: when no campaign was produced there is nothing
+/// to judge, and reporting `Failed` would assert a discovery about the product
+/// that was never made.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FuzzWorkloadVerdict {
+    Passed,
+    Failed,
+    #[serde(other)]
+    Unknown,
+}
+
+impl FuzzWorkloadVerdict {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Passed => "passed",
+            Self::Failed => "failed",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Was every declared piece of evidence delivered?
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FuzzEvidenceVerdict {
+    Complete,
+    Incomplete,
+    #[serde(other)]
+    Unknown,
+}
+
+impl FuzzEvidenceVerdict {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Incomplete => "incomplete",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// One specific way a producer broke its evidence contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FuzzEvidenceViolationCode {
+    /// A declared artifact path resolved inside the artifact root but nothing
+    /// is there.
+    ArtifactRefMissing,
+    /// A declared artifact path is local-looking but escapes the artifact
+    /// root (`..` traversal or an absolute path outside the base). Previously
+    /// these were silently discarded.
+    ArtifactRefUnresolvable,
+    /// A declared artifact path exists but is the wrong kind — a directory
+    /// where the contract declared a file, or the reverse.
+    ArtifactRefWrongKind,
+    /// A declared artifact path exists and is the right kind but cannot be
+    /// read.
+    ArtifactRefUnreadable,
+    /// A `--require-*` artifact the campaign never declared at all.
+    RequiredArtifactAbsent,
+    /// The runner emitted a result file Homeboy could not normalize.
+    ResultsUnparseable,
+    /// A required artifact post-process step failed.
+    RequiredPostprocessFailed,
+    /// An expectation Homeboy could not resolve to a known code.
+    #[serde(other)]
+    Unknown,
+}
+
+impl FuzzEvidenceViolationCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ArtifactRefMissing => "artifact_ref_missing",
+            Self::ArtifactRefUnresolvable => "artifact_ref_unresolvable",
+            Self::ArtifactRefWrongKind => "artifact_ref_wrong_kind",
+            Self::ArtifactRefUnreadable => "artifact_ref_unreadable",
+            Self::RequiredArtifactAbsent => "required_artifact_absent",
+            Self::ResultsUnparseable => "results_unparseable",
+            Self::RequiredPostprocessFailed => "required_postprocess_failed",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// True when the violation concerns a specific declared artifact
+    /// reference, so a reader can lead the root cause with the path rather
+    /// than with runner output.
+    pub const fn is_artifact_ref(self) -> bool {
+        matches!(
+            self,
+            Self::ArtifactRefMissing
+                | Self::ArtifactRefUnresolvable
+                | Self::ArtifactRefWrongKind
+                | Self::ArtifactRefUnreadable
+        )
+    }
+}
+
+/// One evidence-contract violation, with everything a reviewer needs to route
+/// it to the producer that owes the evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzEvidenceViolation {
+    #[serde(default = "fuzz_evidence_contract_schema")]
+    pub schema: String,
+    pub code: FuzzEvidenceViolationCode,
+    /// Statement of what was promised and not delivered.
+    pub message: String,
+    /// The reference exactly as the producer declared it, before resolution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_ref: Option<String>,
+    /// The base the declared reference was resolved against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_base: Option<String>,
+    /// The contract or environment channel that owns producing this evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer_contract: Option<String>,
+}
+
+impl FuzzEvidenceViolation {
+    pub fn new(code: FuzzEvidenceViolationCode, message: impl Into<String>) -> Self {
+        Self {
+            schema: fuzz_evidence_contract_schema(),
+            code,
+            message: message.into(),
+            declared_ref: None,
+            resolution_base: None,
+            producer_contract: None,
+        }
+    }
+
+    pub fn with_declared_ref(mut self, declared_ref: impl Into<String>) -> Self {
+        self.declared_ref = Some(declared_ref.into());
+        self
+    }
+
+    pub fn with_resolution_base(mut self, base: impl Into<String>) -> Self {
+        self.resolution_base = Some(base.into());
+        self
+    }
+
+    pub fn with_producer_contract(mut self, contract: impl Into<String>) -> Self {
+        self.producer_contract = Some(contract.into());
+        self
+    }
+
+    /// One-line root-cause rendering that leads with the declared reference
+    /// and its resolution base rather than with runner output.
+    pub fn root_cause_line(&self) -> String {
+        let mut line = format!("[{}] {}", self.code.as_str(), self.message);
+        if let Some(declared_ref) = self.declared_ref.as_deref() {
+            line.push_str(&format!(" (declared ref: {declared_ref}"));
+            if let Some(base) = self.resolution_base.as_deref() {
+                line.push_str(&format!(", resolved against: {base}"));
+            }
+            if let Some(contract) = self.producer_contract.as_deref() {
+                line.push_str(&format!(", owed by: {contract}"));
+            }
+            line.push(')');
+        } else if let Some(contract) = self.producer_contract.as_deref() {
+            line.push_str(&format!(" (owed by: {contract})"));
+        }
+        line
+    }
+}
+
+/// Campaign-level evidence completeness.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzEvidenceContract {
+    #[serde(default = "fuzz_evidence_contract_schema")]
+    pub schema: String,
+    /// Every declared piece of evidence was delivered.
+    pub complete: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub violations: Vec<FuzzEvidenceViolation>,
+}
+
+impl Default for FuzzEvidenceContract {
+    fn default() -> Self {
+        Self::satisfied()
+    }
+}
+
+impl FuzzEvidenceContract {
+    /// A contract with nothing outstanding.
+    pub fn satisfied() -> Self {
+        Self {
+            schema: fuzz_evidence_contract_schema(),
+            complete: true,
+            violations: Vec::new(),
+        }
+    }
+
+    pub fn from_violations(violations: Vec<FuzzEvidenceViolation>) -> Self {
+        Self {
+            schema: fuzz_evidence_contract_schema(),
+            complete: violations.is_empty(),
+            violations,
+        }
+    }
+
+    pub fn verdict(&self) -> FuzzEvidenceVerdict {
+        if self.complete {
+            FuzzEvidenceVerdict::Complete
+        } else {
+            FuzzEvidenceVerdict::Incomplete
+        }
+    }
+
+    /// Root-cause lines for every violation, most specific first: artifact
+    /// reference violations name a concrete path, so they lead.
+    pub fn root_cause_lines(&self) -> Vec<String> {
+        let mut artifact_lines = Vec::new();
+        let mut other_lines = Vec::new();
+        for violation in &self.violations {
+            if violation.code.is_artifact_ref() {
+                artifact_lines.push(violation.root_cause_line());
+            } else {
+                other_lines.push(violation.root_cause_line());
+            }
+        }
+        artifact_lines.extend(other_lines);
+        artifact_lines
+    }
+
+    /// Single-sentence summary suitable for a compact diagnosis.
+    pub fn summary(&self) -> Option<String> {
+        let first = self.violations.first()?;
+        Some(match self.violations.len() {
+            1 => first.root_cause_line(),
+            count => format!(
+                "{} (+{} further evidence-contract violation(s))",
+                first.root_cause_line(),
+                count - 1
+            ),
+        })
+    }
+
+    /// Read a contract back off persisted run metadata.
+    ///
+    /// Prefers the structured `evidence_contract` member written by the
+    /// producer. Runs recorded before that member existed only carry
+    /// `missing_artifact_refs` and a collapsed `results_error` string, so
+    /// those are reconstructed into the same vocabulary rather than reported
+    /// as absent. The `schema` member is always restamped by this reader, so a
+    /// payload cannot claim a schema it does not satisfy.
+    pub fn from_run_metadata(metadata: &Value) -> Self {
+        if let Some(value) = metadata.get("evidence_contract") {
+            if let Ok(mut contract) = serde_json::from_value::<Self>(value.clone()) {
+                contract.schema = fuzz_evidence_contract_schema();
+                contract.complete = contract.violations.is_empty();
+                return contract;
+            }
+        }
+        Self::from_legacy_run_metadata(metadata)
+    }
+
+    /// Reconstruct the vocabulary from the pre-taxonomy metadata members.
+    fn from_legacy_run_metadata(metadata: &Value) -> Self {
+        let mut violations = Vec::new();
+        if let Some(refs) = metadata
+            .get("missing_artifact_refs")
+            .and_then(Value::as_array)
+        {
+            for declared_ref in refs.iter().filter_map(Value::as_str) {
+                violations.push(
+                    FuzzEvidenceViolation::new(
+                        FuzzEvidenceViolationCode::ArtifactRefMissing,
+                        format!(
+                            "declared artifact `{declared_ref}` was absent from the fuzz artifact root"
+                        ),
+                    )
+                    .with_declared_ref(declared_ref)
+                    .with_producer_contract(FUZZ_ARTIFACT_ROOT_PRODUCER_CONTRACT),
+                );
+            }
+        }
+        // The legacy `results_error` collapsed five distinct channels into one
+        // string. Only promote it when it is not already represented by the
+        // missing-ref list, and classify it as `Unknown` rather than guessing a
+        // code from substring sniffing.
+        if violations.is_empty() {
+            if let Some(error) = metadata
+                .get("results_error")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|error| !error.is_empty())
+            {
+                violations.push(FuzzEvidenceViolation::new(
+                    FuzzEvidenceViolationCode::Unknown,
+                    error,
+                ));
+            }
+        }
+        Self::from_violations(violations)
+    }
+}
+
+/// The producer channel that owes artifacts declared by a campaign.
+pub const FUZZ_ARTIFACT_ROOT_PRODUCER_CONTRACT: &str = "HOMEBOY_FUZZ_ARTIFACTS_DIR";
+/// The producer channel that owes the campaign result file.
+pub const FUZZ_RESULTS_FILE_PRODUCER_CONTRACT: &str = "HOMEBOY_FUZZ_RESULTS_FILE";
+
+/// The observed facts a classification decision is made from.
+#[derive(Debug, Clone, Copy)]
+pub struct FuzzFailureSignals<'a> {
+    pub evidence: &'a FuzzEvidenceContract,
+    /// Case ids the campaign itself reported as failed or errored.
+    pub failed_case_ids: &'a [String],
+    /// Findings the campaign left open.
+    pub open_findings: u64,
+    /// Gate ids the gate evaluation reported as not passed.
+    pub failed_gate_ids: &'a [String],
+    /// A campaign was produced and parsed. When false there is nothing to
+    /// judge the workload by.
+    pub campaign_present: bool,
+}
+
+/// A failed run's domain plus the two verdicts that must not be collapsed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzFailureClassification {
+    pub domain: FuzzFailureDomain,
+    pub workload_verdict: FuzzWorkloadVerdict,
+    pub evidence_verdict: FuzzEvidenceVerdict,
+}
+
+/// Assign a failed run to exactly one domain while keeping the workload and
+/// evidence verdicts independent.
+///
+/// Precedence is most-specific-first. Evidence completeness never downgrades
+/// the workload verdict: a campaign whose cases all passed keeps
+/// [`FuzzWorkloadVerdict::Passed`] even when the run fails strict validation
+/// because a declared artifact is absent. That separation is the whole point —
+/// a harness packaging error must not read as a product failure.
+pub fn classify_fuzz_failure(signals: &FuzzFailureSignals<'_>) -> FuzzFailureClassification {
+    let workload_verdict = if !signals.campaign_present {
+        FuzzWorkloadVerdict::Unknown
+    } else if signals.open_findings > 0 || !signals.failed_case_ids.is_empty() {
+        FuzzWorkloadVerdict::Failed
+    } else {
+        FuzzWorkloadVerdict::Passed
+    };
+    let evidence_verdict = signals.evidence.verdict();
+
+    let domain = if signals.open_findings > 0 {
+        FuzzFailureDomain::ProductFinding
+    } else if !signals.failed_case_ids.is_empty() {
+        FuzzFailureDomain::WorkloadFailure
+    } else if !signals.failed_gate_ids.is_empty() {
+        FuzzFailureDomain::GateFailure
+    } else if !signals.evidence.complete {
+        FuzzFailureDomain::EvidenceContractFailure
+    } else if !signals.campaign_present {
+        // The runner produced nothing parseable and declared nothing missing.
+        FuzzFailureDomain::WorkloadFailure
+    } else {
+        FuzzFailureDomain::Unknown
+    };
+
+    FuzzFailureClassification {
+        domain,
+        workload_verdict,
+        evidence_verdict,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn missing_ref(path: &str) -> FuzzEvidenceViolation {
+        FuzzEvidenceViolation::new(
+            FuzzEvidenceViolationCode::ArtifactRefMissing,
+            format!("declared artifact `{path}` was absent from the fuzz artifact root"),
+        )
+        .with_declared_ref(path)
+        .with_resolution_base("/tmp/fuzz-artifacts")
+        .with_producer_contract(FUZZ_ARTIFACT_ROOT_PRODUCER_CONTRACT)
+    }
+
+    #[test]
+    fn passing_cases_with_a_missing_artifact_classify_as_evidence_contract_failure() {
+        let evidence = FuzzEvidenceContract::from_violations(vec![missing_ref("results.json")]);
+        let classification = classify_fuzz_failure(&FuzzFailureSignals {
+            evidence: &evidence,
+            failed_case_ids: &[],
+            open_findings: 0,
+            failed_gate_ids: &[],
+            campaign_present: true,
+        });
+
+        assert_eq!(
+            classification.domain,
+            FuzzFailureDomain::EvidenceContractFailure
+        );
+        // The reported #10513 regression: the workload verdict must survive.
+        assert_eq!(classification.workload_verdict, FuzzWorkloadVerdict::Passed);
+        assert_eq!(
+            classification.evidence_verdict,
+            FuzzEvidenceVerdict::Incomplete
+        );
+    }
+
+    #[test]
+    fn an_open_finding_outranks_an_incomplete_evidence_contract() {
+        let evidence = FuzzEvidenceContract::from_violations(vec![missing_ref("results.json")]);
+        let classification = classify_fuzz_failure(&FuzzFailureSignals {
+            evidence: &evidence,
+            failed_case_ids: &[],
+            open_findings: 1,
+            failed_gate_ids: &[],
+            campaign_present: true,
+        });
+
+        assert_eq!(classification.domain, FuzzFailureDomain::ProductFinding);
+        assert_eq!(classification.workload_verdict, FuzzWorkloadVerdict::Failed);
+        // Both verdicts stay visible; the domain only says which one leads.
+        assert_eq!(
+            classification.evidence_verdict,
+            FuzzEvidenceVerdict::Incomplete
+        );
+    }
+
+    #[test]
+    fn a_failed_gate_with_complete_evidence_is_a_gate_failure() {
+        let evidence = FuzzEvidenceContract::satisfied();
+        let classification = classify_fuzz_failure(&FuzzFailureSignals {
+            evidence: &evidence,
+            failed_case_ids: &[],
+            open_findings: 0,
+            failed_gate_ids: &["no-open-findings".to_string()],
+            campaign_present: true,
+        });
+
+        assert_eq!(classification.domain, FuzzFailureDomain::GateFailure);
+        assert_eq!(classification.workload_verdict, FuzzWorkloadVerdict::Passed);
+        assert_eq!(
+            classification.evidence_verdict,
+            FuzzEvidenceVerdict::Complete
+        );
+    }
+
+    #[test]
+    fn a_failed_case_is_a_workload_failure() {
+        let evidence = FuzzEvidenceContract::satisfied();
+        let classification = classify_fuzz_failure(&FuzzFailureSignals {
+            evidence: &evidence,
+            failed_case_ids: &["case-17".to_string()],
+            open_findings: 0,
+            failed_gate_ids: &[],
+            campaign_present: true,
+        });
+
+        assert_eq!(classification.domain, FuzzFailureDomain::WorkloadFailure);
+        assert_eq!(classification.workload_verdict, FuzzWorkloadVerdict::Failed);
+    }
+
+    #[test]
+    fn an_absent_campaign_leaves_the_workload_verdict_unknown() {
+        let evidence = FuzzEvidenceContract::satisfied();
+        let classification = classify_fuzz_failure(&FuzzFailureSignals {
+            evidence: &evidence,
+            failed_case_ids: &[],
+            open_findings: 0,
+            failed_gate_ids: &[],
+            campaign_present: false,
+        });
+
+        assert_eq!(classification.domain, FuzzFailureDomain::WorkloadFailure);
+        assert_eq!(
+            classification.workload_verdict,
+            FuzzWorkloadVerdict::Unknown
+        );
+    }
+
+    #[test]
+    fn root_cause_lines_lead_with_the_artifact_reference() {
+        let evidence = FuzzEvidenceContract::from_violations(vec![
+            FuzzEvidenceViolation::new(
+                FuzzEvidenceViolationCode::ResultsUnparseable,
+                "runner result file is not valid JSON",
+            )
+            .with_producer_contract(FUZZ_RESULTS_FILE_PRODUCER_CONTRACT),
+            missing_ref("results.json"),
+        ]);
+
+        let lines = evidence.root_cause_lines();
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("artifact_ref_missing"));
+        assert!(lines[0].contains("results.json"));
+        assert!(lines[0].contains("/tmp/fuzz-artifacts"));
+        assert!(lines[0].contains("HOMEBOY_FUZZ_ARTIFACTS_DIR"));
+        assert!(lines[1].contains("results_unparseable"));
+    }
+
+    #[test]
+    fn summary_counts_the_remaining_violations() {
+        let evidence = FuzzEvidenceContract::from_violations(vec![
+            missing_ref("results.json"),
+            missing_ref("case-log.json"),
+        ]);
+
+        let summary = evidence.summary().expect("summary");
+
+        assert!(summary.contains("results.json"));
+        assert!(summary.contains("+1 further"));
+    }
+
+    #[test]
+    fn a_satisfied_contract_has_no_summary() {
+        assert!(FuzzEvidenceContract::satisfied().summary().is_none());
+    }
+
+    #[test]
+    fn unknown_labels_deserialize_to_unknown_rather_than_failing() {
+        let domain: FuzzFailureDomain =
+            serde_json::from_value(serde_json::json!("brand_new_domain")).expect("domain");
+        assert_eq!(domain, FuzzFailureDomain::Unknown);
+
+        let code: FuzzEvidenceViolationCode =
+            serde_json::from_value(serde_json::json!("brand_new_code")).expect("code");
+        assert_eq!(code, FuzzEvidenceViolationCode::Unknown);
+
+        let verdict: FuzzWorkloadVerdict =
+            serde_json::from_value(serde_json::json!("indeterminate")).expect("verdict");
+        assert_eq!(verdict, FuzzWorkloadVerdict::Unknown);
+    }
+
+    #[test]
+    fn violations_tolerate_unknown_members_from_a_newer_producer() {
+        let violation: FuzzEvidenceViolation = serde_json::from_value(serde_json::json!({
+            "code": "artifact_ref_missing",
+            "message": "absent",
+            "declared_ref": "results.json",
+            "future_member": { "nested": true }
+        }))
+        .expect("violation");
+
+        assert_eq!(
+            violation.code,
+            FuzzEvidenceViolationCode::ArtifactRefMissing
+        );
+        assert_eq!(violation.declared_ref.as_deref(), Some("results.json"));
+        assert_eq!(violation.schema, FUZZ_EVIDENCE_CONTRACT_SCHEMA);
+    }
+
+    #[test]
+    fn run_metadata_prefers_the_structured_contract() {
+        let metadata = serde_json::json!({
+            "evidence_contract": {
+                "complete": false,
+                "violations": [{
+                    "code": "artifact_ref_unresolvable",
+                    "message": "escapes the artifact root",
+                    "declared_ref": "../outside.json"
+                }]
+            },
+            "missing_artifact_refs": ["ignored.json"]
+        });
+
+        let contract = FuzzEvidenceContract::from_run_metadata(&metadata);
+
+        assert!(!contract.complete);
+        assert_eq!(contract.violations.len(), 1);
+        assert_eq!(
+            contract.violations[0].code,
+            FuzzEvidenceViolationCode::ArtifactRefUnresolvable
+        );
+    }
+
+    #[test]
+    fn run_metadata_reconstructs_legacy_missing_artifact_refs() {
+        let metadata = serde_json::json!({
+            "missing_artifact_refs": ["results.json"],
+            "results_error": "fuzz campaign references artifact path(s) missing from HOMEBOY_FUZZ_ARTIFACTS_DIR: results.json"
+        });
+
+        let contract = FuzzEvidenceContract::from_run_metadata(&metadata);
+
+        assert!(!contract.complete);
+        assert_eq!(contract.violations.len(), 1);
+        assert_eq!(
+            contract.violations[0].code,
+            FuzzEvidenceViolationCode::ArtifactRefMissing
+        );
+        assert_eq!(
+            contract.violations[0].declared_ref.as_deref(),
+            Some("results.json")
+        );
+    }
+
+    #[test]
+    fn a_legacy_results_error_alone_is_not_guessed_into_a_specific_code() {
+        let metadata = serde_json::json!({ "results_error": "runner exploded" });
+
+        let contract = FuzzEvidenceContract::from_run_metadata(&metadata);
+
+        assert!(!contract.complete);
+        assert_eq!(
+            contract.violations[0].code,
+            FuzzEvidenceViolationCode::Unknown
+        );
+        assert_eq!(contract.violations[0].message, "runner exploded");
+    }
+
+    #[test]
+    fn run_metadata_without_evidence_members_is_satisfied() {
+        let contract = FuzzEvidenceContract::from_run_metadata(&serde_json::json!({
+            "success": true
+        }));
+
+        assert!(contract.complete);
+        assert!(contract.violations.is_empty());
+    }
+
+    #[test]
+    fn the_reader_restamps_the_schema_a_payload_claims() {
+        let metadata = serde_json::json!({
+            "evidence_contract": {
+                "schema": "attacker/not-the-contract/v9",
+                "complete": true,
+                "violations": []
+            }
+        });
+
+        let contract = FuzzEvidenceContract::from_run_metadata(&metadata);
+
+        assert_eq!(contract.schema, FUZZ_EVIDENCE_CONTRACT_SCHEMA);
+    }
+
+    #[test]
+    fn a_payload_claiming_completeness_with_violations_is_corrected() {
+        let metadata = serde_json::json!({
+            "evidence_contract": {
+                "complete": true,
+                "violations": [{
+                    "code": "artifact_ref_missing",
+                    "message": "absent"
+                }]
+            }
+        });
+
+        let contract = FuzzEvidenceContract::from_run_metadata(&metadata);
+
+        assert!(!contract.complete);
+    }
+}

--- a/crates/homeboy-fuzz/src/evidence_contract.rs
+++ b/crates/homeboy-fuzz/src/evidence_contract.rs
@@ -346,15 +346,17 @@ impl FuzzEvidenceContract {
             }
         }
         // The legacy `results_error` collapsed five distinct channels into one
-        // string. Only promote it when it is not already represented by the
-        // missing-ref list, and classify it as `Unknown` rather than guessing a
-        // code from substring sniffing.
+        // string. Promote it only when it is not already represented by the
+        // missing-ref list and is not a gate failure wearing the same field.
+        // Classify what is left as `Unknown` rather than guessing a code from
+        // substring sniffing.
         if violations.is_empty() {
             if let Some(error) = metadata
                 .get("results_error")
                 .and_then(Value::as_str)
                 .map(str::trim)
                 .filter(|error| !error.is_empty())
+                .filter(|error| !is_legacy_gate_failure_message(error))
             {
                 violations.push(FuzzEvidenceViolation::new(
                     FuzzEvidenceViolationCode::Unknown,
@@ -364,6 +366,21 @@ impl FuzzEvidenceContract {
         }
         Self::from_violations(violations)
     }
+}
+
+/// The exact prefix Homeboy itself writes into the legacy collapsed
+/// `results_error` member for an expected-metric gate failure.
+///
+/// Matching it is matching our own emitted format, not sniffing arbitrary
+/// runner text. A gate that did not hold is a statement about declared pass
+/// criteria, so reconstructing it as an evidence-contract violation would
+/// blame the producer for the very collapse this taxonomy removes. New runs
+/// never reach this path: they carry a structured `evidence_contract` that
+/// excludes gate failures at production time.
+const LEGACY_GATE_FAILURE_PREFIX: &str = "fuzz expected metric gate(s) failed";
+
+fn is_legacy_gate_failure_message(error: &str) -> bool {
+    error.starts_with(LEGACY_GATE_FAILURE_PREFIX)
 }
 
 /// The producer channel that owes artifacts declared by a campaign.
@@ -672,6 +689,22 @@ mod tests {
             FuzzEvidenceViolationCode::Unknown
         );
         assert_eq!(contract.violations[0].message, "runner exploded");
+    }
+
+    /// A legacy run whose only failure was a gate must not be reconstructed as
+    /// an evidence-contract violation. `results_error` collapsed both, so the
+    /// reader has to un-collapse it or it re-creates the reported bug in the
+    /// opposite direction.
+    #[test]
+    fn a_legacy_gate_failure_in_results_error_is_not_an_evidence_violation() {
+        let metadata = serde_json::json!({
+            "results_error": "fuzz expected metric gate(s) failed: p95_ms expected 500 observed 900"
+        });
+
+        let contract = FuzzEvidenceContract::from_run_metadata(&metadata);
+
+        assert!(contract.complete);
+        assert!(contract.violations.is_empty());
     }
 
     #[test]

--- a/crates/homeboy-fuzz/src/lib.rs
+++ b/crates/homeboy-fuzz/src/lib.rs
@@ -10,11 +10,13 @@ mod coverage;
 mod coverage_reconciliation_persistence;
 mod defaults;
 mod envelope;
+mod evidence_contract;
 mod hotspots;
 mod normalize;
 mod observations;
 mod parse;
 mod payloads;
+mod proof;
 mod result_envelope_persistence;
 mod run_dir_writers;
 mod run_evidence_persistence;
@@ -54,6 +56,11 @@ pub use envelope::{
     FuzzSamplingCorpusRef, FuzzSamplingReplayDeterminism, FuzzSamplingRequest, FuzzSamplingStratum,
     FuzzTargetInventory, IsolationProof,
 };
+pub use evidence_contract::{
+    classify_fuzz_failure, FuzzEvidenceContract, FuzzEvidenceVerdict, FuzzEvidenceViolation,
+    FuzzEvidenceViolationCode, FuzzFailureClassification, FuzzFailureDomain, FuzzFailureSignals,
+    FuzzWorkloadVerdict, FUZZ_ARTIFACT_ROOT_PRODUCER_CONTRACT, FUZZ_RESULTS_FILE_PRODUCER_CONTRACT,
+};
 pub use hotspots::{
     parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzHotspot,
     FuzzHotspotDimension, FuzzHotspotMetric, FuzzHotspotSet,
@@ -71,6 +78,12 @@ pub use payloads::{
     externalize_fuzz_campaign_payloads, FuzzPayload, FuzzPayloadBudget, FuzzPayloadExternalization,
     FUZZ_PAYLOAD_ARTIFACT_KIND, INLINE_FUZZ_PAYLOAD_LIMIT_BYTES,
 };
+pub use proof::{
+    derive_fuzz_proof, fuzz_campaign_case_totals, fuzz_campaign_finding_totals, FuzzProof,
+    FuzzProofCaseTotals, FuzzProofCoverage, FuzzProofExecution, FuzzProofFailedGate,
+    FuzzProofFindingTotals, FuzzProofGateTotals, FuzzProofRevision, FuzzProofSource,
+    FuzzProofVerdict,
+};
 pub use result_envelope_persistence::{
     fuzz_result_envelope_evidence_ref, fuzz_result_envelope_json, persist_fuzz_result_envelope,
     persist_fuzz_run_result_envelope, report_fuzz_result_envelope,
@@ -82,15 +95,15 @@ pub use schemas::{
     standardized_fuzz_skip_reason_codes, FUZZ_ACTION_MODEL_SCHEMA, FUZZ_ARTIFACT_SCHEMA,
     FUZZ_CAMPAIGN_SCHEMA, FUZZ_CASE_LOG_SCHEMA, FUZZ_CASE_SCHEMA, FUZZ_CONTRACT_VERSION,
     FUZZ_CORE_CONTRACT_SCHEMA, FUZZ_COVERAGE_RECONCILIATION_SCHEMA, FUZZ_COVERAGE_SCHEMA,
-    FUZZ_COVERAGE_SUMMARY_SCHEMA, FUZZ_EXECUTION_REQUEST_SCHEMA, FUZZ_EXPLORATION_POLICY_SCHEMA,
-    FUZZ_FINDING_SCHEMA, FUZZ_GATE_SCHEMA, FUZZ_HOTSPOT_SET_SCHEMA, FUZZ_OBSERVATION_SET_SCHEMA,
-    FUZZ_PROVENANCE_SCHEMA, FUZZ_REPLAY_SCHEMA, FUZZ_REQUIRED_ARTIFACT_SCHEMA,
-    FUZZ_RESULT_ENVELOPE_SCHEMA, FUZZ_SAMPLING_REQUEST_SCHEMA, FUZZ_SEED_SCHEMA,
-    FUZZ_SEQUENCE_PLAN_SCHEMA, FUZZ_SEQUENCE_RESULT_SCHEMA, FUZZ_SKIP_REASON_AUTH_REQUIRED,
-    FUZZ_SKIP_REASON_CONFIG_REQUIRED, FUZZ_SKIP_REASON_DESTRUCTIVE, FUZZ_SKIP_REASON_LEGACY,
-    FUZZ_SKIP_REASON_UNAVAILABLE, FUZZ_SKIP_REASON_UNSAFE, FUZZ_SKIP_REASON_UNSUPPORTED,
-    FUZZ_SURFACE_SCHEMA, FUZZ_TARGET_INVENTORY_SCHEMA, FUZZ_TARGET_SCHEMA, FUZZ_THRESHOLD_SCHEMA,
-    FUZZ_WORKLOAD_SCHEMA, ISOLATION_PROOF_SCHEMA,
+    FUZZ_COVERAGE_SUMMARY_SCHEMA, FUZZ_EVIDENCE_CONTRACT_SCHEMA, FUZZ_EXECUTION_REQUEST_SCHEMA,
+    FUZZ_EXPLORATION_POLICY_SCHEMA, FUZZ_FINDING_SCHEMA, FUZZ_GATE_SCHEMA, FUZZ_HOTSPOT_SET_SCHEMA,
+    FUZZ_OBSERVATION_SET_SCHEMA, FUZZ_PROOF_SCHEMA, FUZZ_PROVENANCE_SCHEMA, FUZZ_REPLAY_SCHEMA,
+    FUZZ_REQUIRED_ARTIFACT_SCHEMA, FUZZ_RESULT_ENVELOPE_SCHEMA, FUZZ_SAMPLING_REQUEST_SCHEMA,
+    FUZZ_SEED_SCHEMA, FUZZ_SEQUENCE_PLAN_SCHEMA, FUZZ_SEQUENCE_RESULT_SCHEMA,
+    FUZZ_SKIP_REASON_AUTH_REQUIRED, FUZZ_SKIP_REASON_CONFIG_REQUIRED, FUZZ_SKIP_REASON_DESTRUCTIVE,
+    FUZZ_SKIP_REASON_LEGACY, FUZZ_SKIP_REASON_UNAVAILABLE, FUZZ_SKIP_REASON_UNSAFE,
+    FUZZ_SKIP_REASON_UNSUPPORTED, FUZZ_SURFACE_SCHEMA, FUZZ_TARGET_INVENTORY_SCHEMA,
+    FUZZ_TARGET_SCHEMA, FUZZ_THRESHOLD_SCHEMA, FUZZ_WORKLOAD_SCHEMA, ISOLATION_PROOF_SCHEMA,
 };
 pub use types::{
     FuzzAction, FuzzActionModel, FuzzCampaign, FuzzCase, FuzzCaseLogArtifactRef, FuzzCaseLogEntry,

--- a/crates/homeboy-fuzz/src/proof.rs
+++ b/crates/homeboy-fuzz/src/proof.rs
@@ -1,0 +1,1014 @@
+//! Reviewer-facing fuzz proof projection.
+//!
+//! A successful strict fuzz campaign already retains everything a reviewer
+//! needs: exact component and rig identity, case and finding totals, gate
+//! outcomes, coverage, seed, isolation, and tracker links. Until now the
+//! reviewer-facing read path projected almost none of it, so posting evidence
+//! on a pull request meant reading a 73 KB result envelope and running `git`
+//! by hand in two worktrees.
+//!
+//! [`derive_fuzz_proof`] is a **read-time** derivation over the persisted run
+//! record. It writes nothing: a projection that mutated stored state would
+//! freeze a derivation that improves as the deriver improves. Following the
+//! same discipline as the evidence manifest, [`FuzzProof::source`] is stamped
+//! by this reader and never trusted from the payload, so "Homeboy derived
+//! this" can never be confused with "an extension asserted this".
+//!
+//! Facts the run did not record are reported in [`FuzzProof::gaps`] rather
+//! than guessed or silently omitted.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use homeboy_core::observation::RunRecord;
+
+use super::contract::FuzzFindingStatus;
+use super::evidence_contract::{
+    classify_fuzz_failure, FuzzEvidenceContract, FuzzEvidenceVerdict, FuzzFailureDomain,
+    FuzzFailureSignals, FuzzWorkloadVerdict,
+};
+use super::schemas::FUZZ_PROOF_SCHEMA;
+use super::types::{FuzzCampaign, FuzzCase};
+
+fn fuzz_proof_schema() -> String {
+    FUZZ_PROOF_SCHEMA.to_string()
+}
+
+/// Where a proof projection came from. Stamped by the reader.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FuzzProofSource {
+    /// Derived by Homeboy from the persisted run record.
+    RunMetadata,
+    /// Derived by Homeboy from a retained result envelope artifact.
+    ResultEnvelope,
+    /// Authored by a producer and passed through.
+    Authored,
+    #[serde(other)]
+    Unknown,
+}
+
+impl FuzzProofSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RunMetadata => "run_metadata",
+            Self::ResultEnvelope => "result_envelope",
+            Self::Authored => "authored",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Exact identity of one source tree that participated in the run.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzProofRevision {
+    /// `component` or `rig`.
+    pub role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Commit revision recorded at execution time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+    /// Deterministic content hash of the exact files used, which stays exact
+    /// even when the tree was dirty.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub dirty: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub linked: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness: Option<String>,
+}
+
+impl FuzzProofRevision {
+    /// True when this revision pins the tree exactly enough to reproduce it.
+    pub fn is_exact(&self) -> bool {
+        self.content_hash.is_some() || (self.revision.is_some() && !self.dirty)
+    }
+}
+
+/// Case outcomes for the campaign.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzProofCaseTotals {
+    pub total: u64,
+    pub passed: u64,
+    pub failed: u64,
+    pub skipped: u64,
+    /// Cases whose declared status this binary does not own. Never folded into
+    /// `passed`.
+    pub unknown: u64,
+}
+
+/// Finding totals by status and severity.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzProofFindingTotals {
+    pub total: u64,
+    pub open: u64,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub by_status: BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub by_severity: BTreeMap<String, u64>,
+}
+
+/// One gate that did not pass.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FuzzProofFailedGate {
+    pub gate_id: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub metric: String,
+    pub observed: f64,
+    pub expected: f64,
+}
+
+/// Gate outcomes for the campaign.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct FuzzProofGateTotals {
+    pub total: u64,
+    pub passed: u64,
+    pub failed: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_gates: Vec<FuzzProofFailedGate>,
+}
+
+/// Declared versus proven coverage.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzProofCoverage {
+    pub declared_targets: u64,
+    pub proven_targets: u64,
+    pub declared_operations: u64,
+    pub proven_operations: u64,
+    pub complete: bool,
+    /// Named coverage dimensions the campaign emitted, e.g. surface or kind
+    /// selector ids.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dimensions: Vec<String>,
+}
+
+/// What was fuzzed, with which inputs, under which placement.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzProofExecution {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workload_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workload_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub allow_destructive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_duration: Option<String>,
+    /// `lab` when the campaign was offloaded to a Lab runner, `local`
+    /// otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_job_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homeboy_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+}
+
+/// The three verdicts a reviewer needs, kept separate on purpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzProofVerdict {
+    /// The overall strict verdict for the run.
+    pub overall: bool,
+    /// Did the code under test behave? Independent of evidence completeness.
+    pub workload: FuzzWorkloadVerdict,
+    /// Was every declared piece of evidence delivered?
+    pub evidence: FuzzEvidenceVerdict,
+    /// Which family a failed run belongs to. `None` for a passing run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_domain: Option<FuzzFailureDomain>,
+}
+
+/// The bounded reviewer projection for one fuzz run.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FuzzProof {
+    #[serde(default = "fuzz_proof_schema")]
+    pub schema: String,
+    /// Stamped by the reader. A payload claiming a different source is
+    /// overwritten.
+    pub source: FuzzProofSource,
+    pub run_id: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub campaign_id: Option<String>,
+    pub verdict: FuzzProofVerdict,
+    pub component: FuzzProofRevision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rig: Option<FuzzProofRevision>,
+    pub execution: FuzzProofExecution,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cases: Option<FuzzProofCaseTotals>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub findings: Option<FuzzProofFindingTotals>,
+    pub gates: FuzzProofGateTotals,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<FuzzProofCoverage>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tracker_refs: Vec<Value>,
+    pub evidence: FuzzEvidenceContract,
+    /// Facts a reviewer would expect that this run did not record. Stated
+    /// rather than guessed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gaps: Vec<String>,
+    /// Markdown rendering suitable for a pull-request or issue comment.
+    pub markdown: String,
+}
+
+/// Case outcome totals for a parsed campaign.
+///
+/// `FuzzCase` has no typed status member — runners carry it in the flattened
+/// extras — so a status this binary does not own counts as `unknown` and is
+/// never folded into `passed`.
+pub fn fuzz_campaign_case_totals(campaign: &FuzzCampaign) -> FuzzProofCaseTotals {
+    let mut totals = FuzzProofCaseTotals {
+        total: campaign.cases.len() as u64,
+        ..FuzzProofCaseTotals::default()
+    };
+    for case in &campaign.cases {
+        match case_status(case).as_deref() {
+            Some("passed" | "pass" | "ok" | "success") => totals.passed += 1,
+            Some("failed" | "fail" | "error" | "errored") => totals.failed += 1,
+            Some("skipped" | "skip") => totals.skipped += 1,
+            _ => totals.unknown += 1,
+        }
+    }
+    totals
+}
+
+fn case_status(case: &FuzzCase) -> Option<String> {
+    case.extra
+        .get("status")
+        .and_then(Value::as_str)
+        .or_else(|| case.metadata.get("status").and_then(Value::as_str))
+        .or_else(|| case.observed.get("status").and_then(Value::as_str))
+        .map(|status| status.trim().to_ascii_lowercase())
+}
+
+/// Finding totals for a parsed campaign, by status and severity.
+pub fn fuzz_campaign_finding_totals(campaign: &FuzzCampaign) -> FuzzProofFindingTotals {
+    let mut totals = FuzzProofFindingTotals {
+        total: campaign.findings.len() as u64,
+        ..FuzzProofFindingTotals::default()
+    };
+    for finding in &campaign.findings {
+        let status = match finding.status {
+            FuzzFindingStatus::Open => "open",
+            FuzzFindingStatus::Confirmed => "confirmed",
+            FuzzFindingStatus::Mitigated => "mitigated",
+            FuzzFindingStatus::Suppressed => "suppressed",
+        };
+        if finding.status == FuzzFindingStatus::Open {
+            totals.open += 1;
+        }
+        *totals.by_status.entry(status.to_string()).or_insert(0) += 1;
+        let severity = finding.severity.trim();
+        let severity = if severity.is_empty() {
+            "unspecified"
+        } else {
+            severity
+        };
+        *totals.by_severity.entry(severity.to_string()).or_insert(0) += 1;
+    }
+    totals
+}
+
+/// Derive the reviewer proof for a fuzz run from its persisted record.
+///
+/// Returns `None` for runs that are not fuzz runs, so the generic
+/// `runs proof` projection stays generic.
+pub fn derive_fuzz_proof(run: &RunRecord) -> Option<FuzzProof> {
+    if run.kind != "fuzz" {
+        return None;
+    }
+    let metadata = &run.metadata_json;
+    let evidence = FuzzEvidenceContract::from_run_metadata(metadata);
+    let cases = case_totals(metadata);
+    let findings = finding_totals(metadata);
+    let gates = gate_totals(metadata);
+    let coverage = coverage(metadata);
+    let component = component_revision(run);
+    let rig = rig_revision(run);
+
+    let overall = metadata
+        .get("success")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| matches!(run.status.as_str(), "pass" | "passed"));
+
+    let failed_case_ids: Vec<String> = cases
+        .as_ref()
+        .filter(|totals| totals.failed > 0)
+        .map(|totals| vec![format!("{} failed case(s)", totals.failed)])
+        .unwrap_or_default();
+    let failed_gate_ids: Vec<String> = gates
+        .failed_gates
+        .iter()
+        .map(|gate| gate.gate_id.clone())
+        .collect();
+    let classification = classify_fuzz_failure(&FuzzFailureSignals {
+        evidence: &evidence,
+        failed_case_ids: &failed_case_ids,
+        open_findings: findings.as_ref().map(|totals| totals.open).unwrap_or(0),
+        failed_gate_ids: &failed_gate_ids,
+        campaign_present: metadata.get("campaign_id").is_some_and(|id| !id.is_null()),
+    });
+
+    let verdict = FuzzProofVerdict {
+        overall,
+        workload: classification.workload_verdict,
+        evidence: classification.evidence_verdict,
+        failure_domain: (!overall).then_some(classification.domain),
+    };
+
+    let mut proof = FuzzProof {
+        schema: fuzz_proof_schema(),
+        source: FuzzProofSource::RunMetadata,
+        run_id: run.id.clone(),
+        status: run.status.clone(),
+        campaign_id: string_member(metadata, "campaign_id"),
+        verdict,
+        component,
+        rig,
+        execution: execution(run),
+        cases,
+        findings,
+        gates,
+        coverage,
+        tracker_refs: metadata
+            .get("tracker_refs")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        evidence,
+        gaps: Vec::new(),
+        markdown: String::new(),
+    };
+    proof.gaps = gaps(&proof);
+    proof.markdown = render_markdown(&proof);
+    Some(proof)
+}
+
+fn string_member(metadata: &Value, key: &str) -> Option<String> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn component_revision(run: &RunRecord) -> FuzzProofRevision {
+    FuzzProofRevision {
+        role: "component".to_string(),
+        id: run.component_id.clone(),
+        revision: run
+            .git_sha
+            .clone()
+            .or_else(|| string_member(&run.metadata_json, "component_revision")),
+        content_hash: string_member(&run.metadata_json, "component_content_hash"),
+        dirty: run
+            .metadata_json
+            .get("component_source_dirty")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        linked: false,
+        freshness: None,
+    }
+}
+
+fn rig_revision(run: &RunRecord) -> Option<FuzzProofRevision> {
+    let package = run.metadata_json.get("rig_package")?;
+    if package.is_null() {
+        return None;
+    }
+    Some(FuzzProofRevision {
+        role: "rig".to_string(),
+        id: package
+            .get("rig_id")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| run.rig_id.clone()),
+        // The installed revision is the identity the run actually executed;
+        // the current revision only says where the source has drifted to since.
+        revision: package
+            .get("installed_source_revision")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                package
+                    .get("current_source_revision")
+                    .and_then(Value::as_str)
+            })
+            .map(str::to_string),
+        content_hash: package
+            .get("source_content_hash")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        dirty: package
+            .get("source_dirty")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        linked: package
+            .get("linked")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        freshness: package
+            .get("freshness")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    })
+}
+
+fn execution(run: &RunRecord) -> FuzzProofExecution {
+    let metadata = &run.metadata_json;
+    let settings = metadata.get("requested_settings");
+    let lab = metadata.get("lab");
+    FuzzProofExecution {
+        workload_id: string_member(metadata, "workload_id"),
+        workload_path: string_member(metadata, "workload_path"),
+        seed: string_member(metadata, "seed"),
+        profile: settings.and_then(|settings| {
+            settings
+                .get("profile")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }),
+        isolation: settings.and_then(|settings| {
+            settings
+                .get("isolation")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }),
+        allow_destructive: settings
+            .and_then(|settings| settings.get("allow_destructive"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        max_duration: string_member(metadata, "max_duration"),
+        placement: Some(if lab.is_some_and(|lab| !lab.is_null()) {
+            "lab".to_string()
+        } else {
+            "local".to_string()
+        }),
+        remote_job_id: lab.and_then(|lab| {
+            lab.get("remote_job_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }),
+        homeboy_version: run.homeboy_version.clone(),
+        command: run.command.clone(),
+    }
+}
+
+fn case_totals(metadata: &Value) -> Option<FuzzProofCaseTotals> {
+    let totals = metadata.get("case_totals")?;
+    Some(FuzzProofCaseTotals {
+        total: u64_member(totals, "total"),
+        passed: u64_member(totals, "passed"),
+        failed: u64_member(totals, "failed"),
+        skipped: u64_member(totals, "skipped"),
+        unknown: u64_member(totals, "unknown"),
+    })
+}
+
+fn finding_totals(metadata: &Value) -> Option<FuzzProofFindingTotals> {
+    let totals = metadata.get("finding_totals")?;
+    Some(FuzzProofFindingTotals {
+        total: u64_member(totals, "total"),
+        open: u64_member(totals, "open"),
+        by_status: u64_map(totals.get("by_status")),
+        by_severity: u64_map(totals.get("by_severity")),
+    })
+}
+
+fn u64_member(value: &Value, key: &str) -> u64 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn u64_map(value: Option<&Value>) -> BTreeMap<String, u64> {
+    value
+        .and_then(Value::as_object)
+        .map(|map| {
+            map.iter()
+                .filter_map(|(key, value)| value.as_u64().map(|count| (key.clone(), count)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn gate_totals(metadata: &Value) -> FuzzProofGateTotals {
+    let Some(gates) = metadata.get("gates").and_then(Value::as_array) else {
+        return FuzzProofGateTotals::default();
+    };
+    let mut totals = FuzzProofGateTotals {
+        total: gates.len() as u64,
+        ..FuzzProofGateTotals::default()
+    };
+    for gate in gates {
+        let status = gate.get("status").and_then(Value::as_str).unwrap_or("");
+        if status == "passed" {
+            totals.passed += 1;
+            continue;
+        }
+        totals.failed += 1;
+        totals.failed_gates.push(FuzzProofFailedGate {
+            gate_id: gate
+                .get("gate_id")
+                .and_then(Value::as_str)
+                .unwrap_or("<unnamed gate>")
+                .to_string(),
+            metric: gate
+                .get("metric")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            observed: gate.get("observed").and_then(Value::as_f64).unwrap_or(0.0),
+            expected: gate.get("expected").and_then(Value::as_f64).unwrap_or(0.0),
+        });
+    }
+    totals
+}
+
+fn coverage(metadata: &Value) -> Option<FuzzProofCoverage> {
+    let completeness = metadata.get("coverage_completeness")?;
+    if !completeness
+        .get("has_summary")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let declared_targets = u64_member(completeness, "declared_targets");
+    let proven_targets = u64_member(completeness, "proven_targets");
+    let declared_operations = u64_member(completeness, "declared_operations");
+    let proven_operations = u64_member(completeness, "proven_operations");
+    let mut dimensions = Vec::new();
+    for key in ["surface_summaries", "kind_summaries"] {
+        if let Some(entries) = completeness.get(key).and_then(Value::as_array) {
+            for entry in entries {
+                if let Some(id) = entry.get("id").and_then(Value::as_str) {
+                    dimensions.push(format!("{key}:{id}"));
+                }
+            }
+        }
+    }
+    Some(FuzzProofCoverage {
+        declared_targets,
+        proven_targets,
+        declared_operations,
+        proven_operations,
+        complete: declared_targets == proven_targets && declared_operations == proven_operations,
+        dimensions,
+    })
+}
+
+/// Name every reviewer-relevant fact the run did not record.
+fn gaps(proof: &FuzzProof) -> Vec<String> {
+    let mut gaps = Vec::new();
+    if !proof.component.is_exact() {
+        gaps.push(
+            "component revision is not pinned; the run recorded no git sha or content hash"
+                .to_string(),
+        );
+    }
+    match proof.rig.as_ref() {
+        None => gaps.push("no rig package identity was recorded for this run".to_string()),
+        Some(rig) if !rig.is_exact() => gaps.push(
+            "rig revision is not pinned; the run recorded no revision or content hash".to_string(),
+        ),
+        Some(_) => {}
+    }
+    if proof.cases.is_none() {
+        gaps.push("case totals were not recorded by the producing run".to_string());
+    }
+    if proof.findings.is_none() {
+        gaps.push("finding totals were not recorded by the producing run".to_string());
+    }
+    if proof.coverage.is_none() {
+        gaps.push("the campaign emitted no coverage summary".to_string());
+    }
+    if proof.execution.seed.is_none() {
+        gaps.push(
+            "no seed was recorded; the campaign may not be deterministically replayable"
+                .to_string(),
+        );
+    }
+    if proof.tracker_refs.is_empty() {
+        gaps.push("no tracker reference was recorded, so this proof is not linked to a pull request or issue".to_string());
+    }
+    gaps
+}
+
+/// Render the proof as a Markdown comment body.
+fn render_markdown(proof: &FuzzProof) -> String {
+    let mut lines = vec![
+        format!("## Fuzz proof — `{}`", proof.run_id),
+        String::new(),
+        format!(
+            "| Verdict | {} |",
+            if proof.verdict.overall {
+                "**pass**"
+            } else {
+                "**fail**"
+            }
+        ),
+        "| --- | --- |".to_string(),
+        format!("| Workload | {} |", proof.verdict.workload.as_str()),
+        format!("| Evidence | {} |", proof.verdict.evidence.as_str()),
+    ];
+    if let Some(domain) = proof.verdict.failure_domain {
+        lines.push(format!("| Failure domain | `{}` |", domain.as_str()));
+    }
+    if let Some(campaign_id) = proof.campaign_id.as_deref() {
+        lines.push(format!("| Campaign | `{campaign_id}` |"));
+    }
+    lines.push(format!(
+        "| Component | {} |",
+        revision_cell(&proof.component)
+    ));
+    if let Some(rig) = proof.rig.as_ref() {
+        lines.push(format!("| Rig | {} |", revision_cell(rig)));
+    }
+    if let Some(cases) = proof.cases.as_ref() {
+        lines.push(format!(
+            "| Cases | {}/{} passed, {} failed, {} skipped |",
+            cases.passed, cases.total, cases.failed, cases.skipped
+        ));
+    }
+    if let Some(findings) = proof.findings.as_ref() {
+        lines.push(format!(
+            "| Findings | {} total, {} open |",
+            findings.total, findings.open
+        ));
+    }
+    lines.push(format!(
+        "| Gates | {}/{} passed |",
+        proof.gates.passed, proof.gates.total
+    ));
+    if let Some(coverage) = proof.coverage.as_ref() {
+        lines.push(format!(
+            "| Coverage | targets {}/{}, operations {}/{} |",
+            coverage.proven_targets,
+            coverage.declared_targets,
+            coverage.proven_operations,
+            coverage.declared_operations
+        ));
+    }
+    if let Some(workload_id) = proof.execution.workload_id.as_deref() {
+        lines.push(format!("| Workload id | `{workload_id}` |"));
+    }
+    if let Some(seed) = proof.execution.seed.as_deref() {
+        lines.push(format!("| Seed | `{seed}` |"));
+    }
+    if let Some(isolation) = proof.execution.isolation.as_deref() {
+        lines.push(format!("| Isolation | `{isolation}` |"));
+    }
+    if let Some(placement) = proof.execution.placement.as_deref() {
+        lines.push(format!("| Placement | `{placement}` |"));
+    }
+    if let Some(version) = proof.execution.homeboy_version.as_deref() {
+        lines.push(format!("| Homeboy | `{version}` |"));
+    }
+
+    if !proof.gates.failed_gates.is_empty() {
+        lines.push(String::new());
+        lines.push("### Failed gates".to_string());
+        for gate in &proof.gates.failed_gates {
+            lines.push(format!(
+                "- `{}` — {} observed {}, expected {}",
+                gate.gate_id, gate.metric, gate.observed, gate.expected
+            ));
+        }
+    }
+
+    if !proof.evidence.complete {
+        lines.push(String::new());
+        lines.push("### Evidence-contract violations".to_string());
+        lines.push(
+            "These are producer defects, not findings about the code under test.".to_string(),
+        );
+        for line in proof.evidence.root_cause_lines() {
+            lines.push(format!("- {line}"));
+        }
+    }
+
+    if !proof.gaps.is_empty() {
+        lines.push(String::new());
+        lines.push("### Not recorded".to_string());
+        for gap in &proof.gaps {
+            lines.push(format!("- {gap}"));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push(format!(
+        "<sub>Generated from retained run `{}` by `homeboy runs proof {} --json`.</sub>",
+        proof.run_id, proof.run_id
+    ));
+
+    let mut output = lines.join("\n");
+    output.push('\n');
+    output
+}
+
+fn revision_cell(revision: &FuzzProofRevision) -> String {
+    let mut cell = revision
+        .revision
+        .as_deref()
+        .map(|revision| format!("`{revision}`"))
+        .unwrap_or_else(|| "_unrecorded_".to_string());
+    if let Some(id) = revision.id.as_deref() {
+        cell = format!("{id} at {cell}");
+    }
+    if let Some(hash) = revision.content_hash.as_deref() {
+        cell.push_str(&format!(" (content `{hash}`)"));
+    }
+    if revision.dirty {
+        cell.push_str(" **dirty**");
+    }
+    cell
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fuzz_run(status: &str, metadata: Value) -> RunRecord {
+        RunRecord {
+            id: "studio-pr-4356-homeboy-v6".to_string(),
+            kind: "fuzz".to_string(),
+            component_id: Some("studio".to_string()),
+            started_at: "2026-07-27T00:00:00Z".to_string(),
+            finished_at: Some("2026-07-27T00:04:00Z".to_string()),
+            status: status.to_string(),
+            command: Some("homeboy fuzz run studio --rig studio".to_string()),
+            cwd: Some("/tmp/homeboy-fixture".to_string()),
+            homeboy_version: Some("0.320.0".to_string()),
+            git_sha: Some("0bb440eddd8ebe53c15fe826a30c5ec13b2f58b0".to_string()),
+            rig_id: Some("studio".to_string()),
+            metadata_json: metadata,
+        }
+    }
+
+    fn passing_metadata() -> Value {
+        serde_json::json!({
+            "success": true,
+            "status": "passed",
+            "campaign_id": "import-db-dropin",
+            "workload_id": "studio.import-db-dropin",
+            "workload_path": "/rigs/studio/fuzz/workload.json",
+            "seed": "4356",
+            "max_duration": "10m",
+            "requested_settings": {
+                "profile": "lab",
+                "isolation": "disposable",
+                "allow_destructive": false
+            },
+            "tracker_refs": [{ "kind": "github-pr", "id": "Automattic/studio#4356" }],
+            "rig_package": {
+                "rig_id": "studio",
+                "installed_source_revision": "7ccbe54558d145d022ef2b88f3ba9f7e2063df5e",
+                "source_content_hash": "sha256:abc",
+                "source_dirty": false,
+                "linked": true,
+                "freshness": "verified"
+            },
+            "case_totals": { "total": 19, "passed": 19, "failed": 0, "skipped": 0, "unknown": 0 },
+            "finding_totals": { "total": 0, "open": 0 },
+            "coverage_completeness": {
+                "has_summary": true,
+                "declared_targets": 4,
+                "proven_targets": 4,
+                "declared_operations": 6,
+                "proven_operations": 6,
+                "surface_summaries": [{ "id": "import" }],
+                "kind_summaries": [{ "id": "sqlite" }]
+            },
+            "gates": [
+                { "gate_id": "no-open-findings", "status": "passed", "metric": "open_findings", "observed": 0.0, "expected": 0.0 },
+                { "gate_id": "has-case-evidence", "status": "passed", "metric": "case_evidence", "observed": 1.0, "expected": 1.0 },
+                { "gate_id": "target-coverage-complete", "status": "passed", "metric": "target_coverage", "observed": 1.0, "expected": 1.0 },
+                { "gate_id": "operation-coverage-complete", "status": "passed", "metric": "operation_coverage", "observed": 1.0, "expected": 1.0 }
+            ],
+            "gate_status": "passed"
+        })
+    }
+
+    #[test]
+    fn a_non_fuzz_run_has_no_fuzz_proof() {
+        let mut run = fuzz_run("pass", passing_metadata());
+        run.kind = "bench".to_string();
+        assert!(derive_fuzz_proof(&run).is_none());
+    }
+
+    #[test]
+    fn a_successful_campaign_projects_exact_revisions_cases_gates_and_coverage() {
+        let run = fuzz_run("pass", passing_metadata());
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        assert_eq!(proof.schema, FUZZ_PROOF_SCHEMA);
+        assert_eq!(proof.source, FuzzProofSource::RunMetadata);
+        assert!(proof.verdict.overall);
+        assert_eq!(proof.verdict.workload, FuzzWorkloadVerdict::Passed);
+        assert_eq!(proof.verdict.evidence, FuzzEvidenceVerdict::Complete);
+        assert!(proof.verdict.failure_domain.is_none());
+
+        // Exact component identity — the fact `runs dossier` reported as null.
+        assert_eq!(
+            proof.component.revision.as_deref(),
+            Some("0bb440eddd8ebe53c15fe826a30c5ec13b2f58b0")
+        );
+        assert!(proof.component.is_exact());
+        // Exact rig identity — already in run metadata, previously unprojected.
+        let rig = proof.rig.as_ref().expect("rig identity");
+        assert_eq!(
+            rig.revision.as_deref(),
+            Some("7ccbe54558d145d022ef2b88f3ba9f7e2063df5e")
+        );
+        assert_eq!(rig.content_hash.as_deref(), Some("sha256:abc"));
+        assert!(rig.linked);
+
+        let cases = proof.cases.as_ref().expect("case totals");
+        assert_eq!((cases.total, cases.passed, cases.failed), (19, 19, 0));
+        assert_eq!(proof.findings.as_ref().expect("findings").open, 0);
+        assert_eq!(proof.gates.total, 4);
+        assert_eq!(proof.gates.passed, 4);
+        assert!(proof.gates.failed_gates.is_empty());
+
+        let coverage = proof.coverage.as_ref().expect("coverage");
+        assert!(coverage.complete);
+        assert_eq!(coverage.proven_targets, 4);
+        assert_eq!(coverage.proven_operations, 6);
+        assert!(coverage
+            .dimensions
+            .contains(&"surface_summaries:import".to_string()));
+
+        assert_eq!(proof.execution.seed.as_deref(), Some("4356"));
+        assert_eq!(proof.execution.profile.as_deref(), Some("lab"));
+        assert_eq!(proof.execution.isolation.as_deref(), Some("disposable"));
+        assert_eq!(proof.execution.placement.as_deref(), Some("local"));
+        assert_eq!(proof.tracker_refs.len(), 1);
+        assert!(proof.gaps.is_empty());
+    }
+
+    #[test]
+    fn the_markdown_rendering_is_postable_and_bounded() {
+        let run = fuzz_run("pass", passing_metadata());
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        assert!(proof
+            .markdown
+            .starts_with("## Fuzz proof — `studio-pr-4356-homeboy-v6`"));
+        assert!(proof.markdown.contains("19/19 passed"));
+        assert!(proof.markdown.contains("4/4 passed"));
+        assert!(proof
+            .markdown
+            .contains("0bb440eddd8ebe53c15fe826a30c5ec13b2f58b0"));
+        assert!(proof
+            .markdown
+            .contains("7ccbe54558d145d022ef2b88f3ba9f7e2063df5e"));
+        assert!(proof.markdown.len() < 4_000);
+    }
+
+    #[test]
+    fn a_missing_artifact_keeps_the_workload_verdict_passing() {
+        let mut metadata = passing_metadata();
+        metadata["success"] = serde_json::json!(false);
+        metadata["status"] = serde_json::json!("failed");
+        metadata["missing_artifact_refs"] = serde_json::json!(["results.json"]);
+        let run = fuzz_run("fail", metadata);
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        assert!(!proof.verdict.overall);
+        assert_eq!(proof.verdict.workload, FuzzWorkloadVerdict::Passed);
+        assert_eq!(proof.verdict.evidence, FuzzEvidenceVerdict::Incomplete);
+        assert_eq!(
+            proof.verdict.failure_domain,
+            Some(FuzzFailureDomain::EvidenceContractFailure)
+        );
+        assert!(proof.markdown.contains("Evidence-contract violations"));
+        assert!(proof
+            .markdown
+            .contains("not findings about the code under test"));
+    }
+
+    #[test]
+    fn unrecorded_facts_are_reported_as_gaps_rather_than_guessed() {
+        let mut run = fuzz_run("pass", serde_json::json!({ "success": true }));
+        run.git_sha = None;
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        assert!(proof.cases.is_none());
+        assert!(proof.coverage.is_none());
+        assert!(proof.rig.is_none());
+        let gaps = proof.gaps.join("\n");
+        assert!(gaps.contains("component revision is not pinned"));
+        assert!(gaps.contains("no rig package identity"));
+        assert!(gaps.contains("case totals were not recorded"));
+        assert!(gaps.contains("no seed was recorded"));
+        assert!(gaps.contains("no tracker reference"));
+        assert!(proof.markdown.contains("### Not recorded"));
+    }
+
+    #[test]
+    fn a_dirty_rig_is_not_treated_as_an_exact_revision_without_a_content_hash() {
+        let mut metadata = passing_metadata();
+        metadata["rig_package"]["source_dirty"] = serde_json::json!(true);
+        metadata["rig_package"]["source_content_hash"] = Value::Null;
+        let run = fuzz_run("pass", metadata);
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        let rig = proof.rig.as_ref().expect("rig");
+        assert!(rig.dirty);
+        assert!(!rig.is_exact());
+        assert!(proof.gaps.iter().any(|gap| gap.contains("rig revision")));
+        assert!(proof.markdown.contains("**dirty**"));
+    }
+
+    #[test]
+    fn a_failed_gate_is_reported_with_observed_and_expected_values() {
+        let mut metadata = passing_metadata();
+        metadata["success"] = serde_json::json!(false);
+        metadata["gates"][0]["status"] = serde_json::json!("failed");
+        metadata["gates"][0]["observed"] = serde_json::json!(2.0);
+        let run = fuzz_run("fail", metadata);
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        assert_eq!(proof.gates.failed, 1);
+        assert_eq!(proof.gates.passed, 3);
+        assert_eq!(proof.gates.failed_gates[0].gate_id, "no-open-findings");
+        assert_eq!(proof.gates.failed_gates[0].observed, 2.0);
+        assert_eq!(
+            proof.verdict.failure_domain,
+            Some(FuzzFailureDomain::GateFailure)
+        );
+        assert!(proof.markdown.contains("### Failed gates"));
+    }
+
+    #[test]
+    fn an_open_finding_is_a_product_finding_not_an_evidence_failure() {
+        let mut metadata = passing_metadata();
+        metadata["success"] = serde_json::json!(false);
+        metadata["finding_totals"] = serde_json::json!({
+            "total": 1,
+            "open": 1,
+            "by_severity": { "high": 1 },
+            "by_status": { "open": 1 }
+        });
+        let run = fuzz_run("fail", metadata);
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        assert_eq!(
+            proof.verdict.failure_domain,
+            Some(FuzzFailureDomain::ProductFinding)
+        );
+        assert_eq!(proof.verdict.workload, FuzzWorkloadVerdict::Failed);
+        assert_eq!(
+            proof
+                .findings
+                .as_ref()
+                .expect("findings")
+                .by_severity
+                .get("high"),
+            Some(&1)
+        );
+    }
+
+    #[test]
+    fn lab_placement_and_remote_job_are_projected_when_present() {
+        let mut metadata = passing_metadata();
+        metadata["lab"] = serde_json::json!({ "remote_job_id": "job-7" });
+        let run = fuzz_run("pass", metadata);
+
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        assert_eq!(proof.execution.placement.as_deref(), Some("lab"));
+        assert_eq!(proof.execution.remote_job_id.as_deref(), Some("job-7"));
+    }
+
+    #[test]
+    fn the_projection_round_trips_through_json() {
+        let run = fuzz_run("pass", passing_metadata());
+        let proof = derive_fuzz_proof(&run).expect("fuzz proof");
+
+        let encoded = serde_json::to_string(&proof).expect("encode");
+        let decoded: FuzzProof = serde_json::from_str(&encoded).expect("decode");
+
+        assert_eq!(decoded, proof);
+    }
+}

--- a/crates/homeboy-fuzz/src/proof.rs
+++ b/crates/homeboy-fuzz/src/proof.rs
@@ -353,8 +353,10 @@ pub fn derive_fuzz_proof(run: &RunRecord) -> Option<FuzzProof> {
         gaps: Vec::new(),
         markdown: String::new(),
     };
-    proof.gaps = gaps(&proof);
-    proof.markdown = render_markdown(&proof);
+    let derived_gaps = gaps(&proof);
+    proof.gaps = derived_gaps;
+    let rendered = render_markdown(&proof);
+    proof.markdown = rendered;
     Some(proof)
 }
 

--- a/crates/homeboy-fuzz/src/schemas.rs
+++ b/crates/homeboy-fuzz/src/schemas.rs
@@ -28,6 +28,12 @@ pub const FUZZ_RESULT_ENVELOPE_SCHEMA: &str = "homeboy/fuzz-result-envelope/v1";
 pub const FUZZ_REQUIRED_ARTIFACT_SCHEMA: &str = "homeboy/fuzz-required-artifact/v1";
 pub const FUZZ_GATE_SCHEMA: &str = "homeboy/fuzz-gate/v1";
 pub const FUZZ_HOTSPOT_SET_SCHEMA: &str = "homeboy/fuzz-hotspot-set/v1";
+/// Campaign-level evidence completeness and the violations that broke it.
+/// Separate from any workload verdict on purpose.
+pub const FUZZ_EVIDENCE_CONTRACT_SCHEMA: &str = "homeboy/fuzz-evidence-contract/v1";
+/// Bounded reviewer projection of a fuzz run: exact revisions, cases,
+/// findings, gates, and coverage.
+pub const FUZZ_PROOF_SCHEMA: &str = "homeboy/fuzz-proof/v1";
 pub const FUZZ_OBSERVATION_SET_SCHEMA: &str = "homeboy/fuzz-observation-set/v1";
 pub const ISOLATION_PROOF_SCHEMA: &str = "homeboy/isolation-proof/v1";
 pub const FUZZ_SKIP_REASON_UNSAFE: &str = "unsafe";

--- a/docs/commands/contract.md
+++ b/docs/commands/contract.md
@@ -51,6 +51,16 @@ such as `evidence-manifest` — can be checked before they are attached:
 homeboy contract validate homeboy/evidence-manifest/v1 --file manifest.json
 ```
 
+Fuzz evidence crosses the same boundary. A rig or runner can check its
+completeness verdict, and a consumer can check a reviewer proof, before either
+is attached or published:
+
+```sh
+homeboy contract show fuzz-evidence-contract
+homeboy contract validate homeboy/fuzz-evidence-contract/v1 --file evidence.json
+homeboy contract validate homeboy/fuzz-proof/v1 --file proof.json
+```
+
 ## Export
 
 ```sh

--- a/docs/commands/fuzz.md
+++ b/docs/commands/fuzz.md
@@ -564,6 +564,75 @@ execution: `{artifact}`, `{artifact_file}`, `{case}`, `{case_id}`, `{run_id}`,
 `{case_artifact}`, and `{replay_artifact_id}`. Additional CLI args after `--`
 are appended to the rendered extension command.
 
+## Failure Taxonomy
+
+A failed fuzz run belongs to exactly one of four families, and they have
+different owners:
+
+| Domain | Owner | Meaning |
+| --- | --- | --- |
+| `product_finding` | the code under test | The workload executed and the product misbehaved. A discovery. |
+| `workload_failure` | the runner or harness | The workload could not execute correctly. |
+| `gate_failure` | the declared pass criteria | Execution and evidence were fine; a gate was not met. |
+| `evidence_contract_failure` | whoever promised the evidence | Declared evidence was not delivered. Says nothing about the product. |
+
+`homeboy fuzz inspect <run-id>` reports the domain alongside two verdicts that
+are deliberately kept separate:
+
+- `workload_verdict` — `passed`, `failed`, or `unknown`. A campaign whose cases
+  all passed keeps `passed` even when the overall strict run fails because a
+  declared artifact is absent. `unknown` means no campaign was produced, so
+  there is nothing to judge.
+- `evidence_verdict` — `complete`, `incomplete`, or `unknown`.
+
+An `evidence_contract_failure` is a campaign-level event, so no case id is
+assigned to it, and its root-cause chain leads with the declared artifact
+reference, the base it was resolved against, and the producer contract that
+owed it — not with runner output.
+
+The classified verdict is persisted on the run as `metadata.evidence_contract`
+(`homeboy/fuzz-evidence-contract/v1`) with these violation codes:
+
+| Code | Meaning |
+| --- | --- |
+| `artifact_ref_missing` | A declared path resolved inside `HOMEBOY_FUZZ_ARTIFACTS_DIR` but nothing is there. |
+| `artifact_ref_unresolvable` | A relative declared path escapes the artifact root. |
+| `artifact_ref_wrong_kind` | The path exists but contradicts the declared `artifact_type`. |
+| `artifact_ref_unreadable` | The path exists and is the right kind but cannot be read. |
+| `required_artifact_absent` | A `--require-*` artifact the campaign never declared. |
+| `results_unparseable` | The runner emitted a result file Homeboy could not normalize. |
+| `required_postprocess_failed` | A required artifact post-process step failed. |
+
+A gate that did not hold is **not** an evidence-contract violation. Producers
+can check a candidate contract before attaching it with
+`homeboy contract validate homeboy/fuzz-evidence-contract/v1 --file <path>`.
+
+## Reviewer Proof
+
+`homeboy runs proof <run-id>` projects a bounded reviewer view for a fuzz run
+under `fuzz` (`homeboy/fuzz-proof/v1`). It answers what was fuzzed, at what
+commit, with what inputs, and against what pass criteria:
+
+- exact component revision (`component.revision`) and rig revision plus content
+  hash and dirty/linked state (`rig`);
+- case totals by outcome and finding totals by status and severity;
+- gate totals with observed/expected values for every failed gate;
+- declared versus proven target and operation coverage plus named coverage
+  dimensions;
+- seed, workload, profile, isolation, placement, and Homeboy version;
+- tracker references and the evidence-contract verdict;
+- `gaps` — every reviewer-relevant fact the run did not record, stated rather
+  than guessed;
+- `markdown` — a rendering suitable for pasting into a pull-request comment.
+
+The projection is derived at read time from the persisted run and writes
+nothing. `source` is stamped by the reader, so a payload cannot claim Homeboy
+derived something it did not.
+
+```bash
+homeboy runs proof <run-id> --json -q '$.fuzz.markdown'
+```
+
 ## Portable Fuzz Evidence Bundles
 
 `homeboy runs export --run <run-id> --output <dir>` exports runs, artifacts,


### PR DESCRIPTION
Closes #10513. Closes #10514.

## Both issues hold. One premise in #10513 is wrong, and I found a second bug neither issue named.

### Where the collapse happens (#10513)

Two sites, and the second is the one that actually caused the reported symptom.

**1. `crates/homeboy-cli/src/commands/fuzz/execution.rs:149-154`** (pre-change) — five channels reporting *four different kinds of event* collapse into one `Option<&str>`:

```rust
let combined_results_error = results_error          // evidence: result file unparseable
    .as_deref()
    .or(postprocess_error.as_deref())               // evidence: required postprocess failed
    .or(artifact_validation_error.as_deref())       // evidence: required artifact undeclared
    .or(expected_metric_error.as_deref())           // GATE failure — a different event entirely
    .or(artifact_ref_validation.error.as_deref());  // evidence: declared artifact absent
```

**2. `execution.rs:226-252`** (pre-change) — and then the diagnostic never receives even that string. Its only inputs were the campaign and `&[&runner_output.stderr, &runner_output.stdout]`. That is the direct cause of "the root-cause chain led with successful runner stdout."

The consequences land in **`crates/homeboy-cli/src/commands/fuzz/inspect.rs`**:

- **`inspect.rs:243-254`** — the classification ladder has no evidence branch, so anything with a non-empty cause list falls through to `"workload_execution_failure"`.
- **`inspect.rs:225`** — `.or_else(|| cases.first())`. When no case failed, this names the *first passing case*. That is exactly how `sqlite-artifact-mask-1` got attached to a run in which every case passed.
- **`inspect.rs:355`** — `diagnostic_strings` harvests `stdout`/`stderr` keys, so successful runner output becomes root cause #1.

### Taxonomy

Four families, chosen by **owner**, not severity:

| Domain | Owner | Meaning |
| --- | --- | --- |
| `product_finding` | code under test | The workload executed and the product misbehaved. A discovery. |
| `workload_failure` | runner / harness | The workload could not execute correctly. |
| `gate_failure` | declared pass criteria | Execution and evidence were fine; a gate was not met. |
| `evidence_contract_failure` | whoever promised the evidence | Declared evidence was not delivered. Says nothing about the product. |

Plus two verdicts that are **never collapsed into the domain**:

- `workload_verdict`: `passed` / `failed` / `unknown`. Evidence completeness never downgrades it — a campaign whose 19 cases passed stays `passed` even though the strict run fails. `unknown` when no campaign was produced, because there is nothing to judge.
- `evidence_verdict`: `complete` / `incomplete` / `unknown`.

Precedence is most-specific-first: findings → failed cases → failed gates → incomplete evidence → absent campaign. Both verdicts stay visible regardless; the domain only says which one leads.

Seven violation codes, each carrying the declared reference, the base it was resolved against, and the producer contract that owed it — so the root cause reads `[artifact_ref_missing] declared artifact is absent from the fuzz artifact root (declared ref: results.json, resolved against: /run/…/fuzz-artifacts, owed by: HOMEBOY_FUZZ_ARTIFACTS_DIR)` instead of runner stdout.

An `evidence_contract_failure` gets `case_id: None`. A campaign-level failure has no owning case.

### Second bug, not in either issue: three artifact-reference classes were silently discarded

`resolve_local_fuzz_artifact_ref` returned `Option<PathBuf>`, and `None` meant "skip". That one branch conflated *"this is a remote URI, not my business"* with *"this relative path escapes the artifact root"*. A campaign declaring `../outside.json` passed artifact validation **silently** — same fail-open family as the cases you flagged. `collect_missing_artifact_ref` also only checked `.exists()`, so a path present as the wrong kind, or present but unreadable, passed.

Now a three-way `FuzzArtifactRefResolution { NotLocal, Escapes, Local }`, with wrong-kind and unreadable checks on the resolved path.

**I deliberately limited the blast radius, and this is a judgement call worth reviewing:**

- **Absolute paths outside the artifact root stay `NotLocal`** — unchanged behavior. Homeboy did not hand the runner that base and holds no contract over it. Flagging them would fail campaigns that legitimately reference their own run dir.
- **Wrong-kind is only checked when the producer declared an `artifact_type`.** A bare string in `artifact_refs` promises no kind, so inventing one would fail campaigns that legitimately point at a directory.

Only relative `..` traversal is newly fatal, and that is unambiguously a producer error: a relative ref is *by contract* relative to the artifact root.

### #10514 — what Homeboy already knew vs. what I added

The issue is right that the projection was near-empty, and the reason is precise: `collect_signals` only picks up declared `proof`/`scorecard`/`signals` containers, `scenario_metrics`, and top-level booleans. Fuzz run metadata has exactly one top-level boolean — `success`. Hence `"signals": {"success": true}` and nothing else.

**Already recorded, just never projected** (no new bookkeeping):

| Fact | Where it already lived |
| --- | --- |
| Rig revision, content hash, dirty, linked, freshness | `metadata.rig_package` (`RigPackageEvidence`) |
| Seed, workload id, workload path, max duration | `metadata.seed` / `workload_id` / `workload_path` / `max_duration` |
| Profile, isolation, allow-destructive | `metadata.requested_settings` |
| Gate outcomes with observed/expected | `metadata.gates` |
| Coverage declared/proven + named dimensions | `metadata.coverage_completeness` |
| Campaign id, tracker refs | `metadata.campaign_id` / `metadata.tracker_refs` |

**Recorded but hardcoded away** — `execution.rs:918` set `git_sha: None` unconditionally, while `ctx.source_path` was right there. That single line is why `runs dossier` reported `git_sha: null` for a campaign whose product revision was known. Now `short_head_revision_at(&ctx.source_path)`, the same call `bench` already uses. This also fixes `runs dossier` and `runs refs` for free, since they read `run.git_sha`.

**Genuinely added** — only two members, and both are summaries of facts already in the parsed campaign the producer was holding: `case_totals` (by outcome) and `finding_totals` (by status and severity). Deriving them at read time was not an option: the campaign file can be pruned, and case status is not even a typed member of `FuzzCase` (runners carry it in flattened extras), so a status this binary does not own counts as `unknown` and is never folded into `passed`.

`FuzzProof` is derived **at read time** in `runs proof` and persists nothing — same refusal as PR #10561. `source` is stamped by the reader, so a payload cannot claim Homeboy derived something it did not. Facts the run did not record land in `gaps` and are stated, not guessed. `markdown` renders the PR-comment body.

**Not implemented, and I am saying so rather than pretending:** "detect when a tracked PR head has moved since the run and label the proof stale." That needs a network call to the tracker from a read-only projection. It belongs with the tracker-refresh path, not here.

### Registered

Both schemas were missing from the discovery surface. `fuzz-evidence-contract` crosses the homeboy/homeboy-extensions boundary, so an unregistered schema is an unusable one:

- `CONTRACT_REGISTRY` — `fuzz-evidence-contract`, `fuzz-proof`
- `CONTRACT_SCHEMAS` validate table, with real semantic checks (a contract claiming `complete: true` while carrying violations is rejected — that is the collapse in miniature)

### Serde safety

`grep -rn "deny_unknown_fields"` over `crates/homeboy-fuzz/src/`, `commands/fuzz/`, `commands/runs/` → **0 hits** (control: 32 files elsewhere in `crates/` do have it). Every new enum carries `#[serde(other)] Unknown` as its last variant, so a label minted by a newer producer deserializes to "not owned by this binary" instead of failing the payload. Every new run-metadata member is additive; `results_error` and `missing_artifact_refs` are byte-identical to before and still populated.

### #10515 is not blocked

The evidence shape helps it: `evidence_contract.violations` carry `declared_ref` + `resolution_base` + `producer_contract`, which is what an executable bundle needs to state what to fetch and from where. `FuzzProof` pins component and rig identity, seed, and workload — the exact set an export must pin. Nothing here claims `fuzz replay export` or the reproduction entrypoint.

### Dead fields in `homeboy-fuzz`

The handoff note said `FuzzCampaign.lifecycle` is "declared and never read." **That is wrong on current main** — it is read twice, at `execution.rs:685` and `:728`, by `fuzz_campaign_non_proof_status` and the failure-metadata scan, and three tests exercise it.

What I did find is producer-only, not dead: `FuzzSamplingRequest::corpus_refs` and `target_strata` are written by `planning.rs` into the execution request and never read back by Homeboy — they are contract output for external runners. `operation_strata` *is* read (`coverage.rs:120`). Left alone.

### Tests

45 new, all written blind.

- `evidence_contract.rs` (15): the precedence table across all five branches, workload verdict surviving an incomplete contract, artifact refs leading the root-cause chain, unknown-label tolerance for all three enums, unknown-member tolerance, reader restamping of a claimed schema, correction of a payload claiming completeness with violations, legacy reconstruction, and the legacy gate-failure exclusion.
- `proof.rs` (10): full projection of the #10514 run, markdown boundedness, evidence failure keeping the workload verdict, gaps instead of guesses, dirty rig not counting as exact, gate failure detail, finding severity, Lab placement, JSON round-trip.
- `commands/fuzz/tests/execution_tests.rs` (7): each violation code, the two deliberate non-detections, gate failures staying out of the contract, and end-to-end persistence including `git_sha`.
- `commands/fuzz/inspect.rs` (3): the exact #10513 scenario, and the two regressions it must not cause.
- `commands/contract/mod.rs` (4): registry lookup plus `contract validate` accept/reject for both schemas.
- `commands/runs/proof.rs` (3) and `runs_proof_summary.rs` (2).

**No existing test asserted the buggy behavior**, which surprised me — `fuzz_artifact_ref_validation_reports_missing_local_refs` only pins the missing-ref list and the error substring, both preserved verbatim.

### What I could not verify

This host cannot run `cargo build`, `test`, `check`, or `clippy` (16 GB shared with several services; a workspace build OOM-kills the supervisor). `cargo fmt --check` is clean, which proves syntax only. CI is the gate. Specifically unverified:

- Type and borrow checking. Hand-reviewed the risky spots: the `&evidence` borrow in `FuzzFailureSignals` releasing before `evidence` moves into `FuzzProof`; `proof.gaps = gaps(&proof)` split into two statements rather than relying on assignment evaluation order; `Option<&Vec<Value>>` mapped with an explicit closure rather than the `Vec::as_slice` fn path; `Option<&&Value>::copied()`.
- `#[serde(other)]` on externally-tagged unit-only enums. I read `serde_derive-1.0.228` to confirm it: `internals/check.rs:173` permits it for `(Style::Unit, Identifier::No, true, _)` as long as it is the last variant, and `de/enum_.rs:64` wires the fallthrough. All five `Unknown` variants are last.
- Clippy. `fuzz_failure_diagnostic` now takes exactly 7 arguments — at the `too_many_arguments` threshold, not over it. No `uninlined_format_args` candidates: every non-inlined argument is a field access or method call.
- Audit baseline. `homeboy audit` is not on this host's installed binary (0.321.0). I checked `homeboy.json` by hand instead: the `core-agnostic-source` fingerprint for `inspect.rs` normalizes the line number to `<line>` and keys on context `fuzz_failure_diagnostic`, which is unchanged, and no new file introduces a policy term before its `#[cfg(test)]` marker. `execution_tests.rs` has no `#[cfg(test)]` line, so it is scanned in full — verified it contains none of the terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
