### PR TITLE
Prune terminal-owned runner workspaces

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -67,6 +67,7 @@ const WORKSPACE_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_METADATA_OUTPUT_LIMIT: usize = 4 * 1024;
 const WORKSPACE_PRUNE_TIMEOUT: Duration = Duration::from_secs(30);
 const STALE_MATERIALIZED_WORKSPACE_REASON: &str = "stale_materialized_workspace_lifecycle";
+const TERMINAL_RESOURCE_LIFECYCLE_REASON: &str = "terminal_resource_lifecycle";
 // A page must leave time for its transport timeout and advance past a directory
 // whose size cannot be measured. Size is advisory, never a deletion proof.
 const WORKSPACE_PRUNE_SCAN_BUDGET: Duration = Duration::from_secs(20);
@@ -2662,6 +2663,9 @@ fn prune_candidate_reason(
     if !Path::new(source_path).exists() {
         return Ok(Some("source_path_missing".to_string()));
     }
+    if has_terminal_delete_on_success_lifecycle(metadata) {
+        return Ok(Some(TERMINAL_RESOURCE_LIFECYCLE_REASON.to_string()));
+    }
     if is_stale_materialized_workspace_lifecycle(metadata, path) {
         return Ok(Some(STALE_MATERIALIZED_WORKSPACE_REASON.to_string()));
     }
@@ -2684,7 +2688,10 @@ fn is_stale_materialized_workspace_lifecycle(metadata: &serde_json::Value, path:
 
     absent_owner("run_id")
         && absent_owner("job_id")
-        && metadata.get("sync_mode").and_then(|value| value.as_str()) == Some("snapshot")
+        && matches!(
+            metadata.get("sync_mode").and_then(|value| value.as_str()),
+            Some("snapshot" | "snapshot-git")
+        )
         && metadata
             .get("snapshot_identity")
             .and_then(|value| value.as_str())
@@ -2699,6 +2706,42 @@ fn is_stale_materialized_workspace_lifecycle(metadata: &serde_json::Value, path:
             == Some("delete_on_success")
         && resource.get("status").and_then(|value| value.as_str()) == Some("active")
         && resource.get("path").and_then(|value| value.as_str()) == path.to_str()
+}
+
+fn has_terminal_delete_on_success_lifecycle(metadata: &serde_json::Value) -> bool {
+    has_terminal_delete_on_success_lifecycle_with(metadata, |run_id| {
+        match homeboy_agents::agent_task_lifecycle::exact_record(run_id) {
+            Ok(record) if record.state.is_terminal() => RunAuthority::Terminal,
+            Ok(_) => RunAuthority::Active,
+            Err(_) => RunAuthority::Unavailable,
+        }
+    })
+}
+
+pub(crate) fn has_terminal_delete_on_success_lifecycle_with(
+    metadata: &serde_json::Value,
+    authority: impl FnOnce(&str) -> RunAuthority,
+) -> bool {
+    let Some(run_id) = metadata
+        .get("run_id")
+        .and_then(|value| value.as_str())
+        .filter(|run_id| !run_id.trim().is_empty())
+    else {
+        return false;
+    };
+    let Some(resource) = metadata
+        .get("resource_lifecycle")
+        .and_then(|value| value.as_object())
+    else {
+        return false;
+    };
+    resource.get("run_id").and_then(|value| value.as_str()) == Some(run_id)
+        && resource.get("status").and_then(|value| value.as_str()) == Some("active")
+        && resource
+            .get("cleanup_policy")
+            .and_then(|value| value.as_str())
+            == Some("delete_on_success")
+        && matches!(authority(run_id), RunAuthority::Terminal)
 }
 
 pub(crate) fn encoded_materialized_workspace_metadata_is_valid(encoded: &str, path: &Path) -> bool {
@@ -3207,6 +3250,9 @@ fn prune_candidate_reason_from_decoded_metadata(
         .and_then(|value| value.as_str())?;
     if !Path::new(source_path).exists() {
         return Some("source_path_missing".to_string());
+    }
+    if has_terminal_delete_on_success_lifecycle(metadata) {
+        return Some(TERMINAL_RESOURCE_LIFECYCLE_REASON.to_string());
     }
     is_stale_materialized_workspace_lifecycle(metadata, path)
         .then(|| STALE_MATERIALIZED_WORKSPACE_REASON.to_string())

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -8,10 +8,11 @@ use base64::Engine;
 
 use crate::workspace::sync::{
     active_resource_lifecycle_liveness, encoded_materialized_workspace_metadata_is_valid,
-    prune_scan_command, prune_workspaces, revalidated_candidate_is_deletable,
-    runner_job_liveness_with, ssh_process_liveness_command, ssh_prune_delete_command,
-    ssh_prune_delete_command_with_terminal_owner, ssh_prune_delete_materialized_workspace_command,
-    sync_workspace, update_workspace_resource_lifecycle, workspace_liveness_with_size_observation,
+    has_terminal_delete_on_success_lifecycle_with, prune_scan_command, prune_workspaces,
+    revalidated_candidate_is_deletable, runner_job_liveness_with, ssh_process_liveness_command,
+    ssh_prune_delete_command, ssh_prune_delete_command_with_terminal_owner,
+    ssh_prune_delete_materialized_workspace_command, sync_workspace,
+    update_workspace_resource_lifecycle, workspace_liveness_with_size_observation,
     ActiveResourceLifecycleLiveness, RunAuthority, WORKSPACE_METADATA_FILE,
 };
 use crate::workspace::types::{
@@ -270,6 +271,31 @@ fn active_lifecycle_lease_requires_unambiguous_terminal_run_authority() {
     assert!(matches!(
         active_resource_lifecycle_liveness(&ambiguous, |_| RunAuthority::Terminal),
         ActiveResourceLifecycleLiveness::Unknown("active_resource_lifecycle_owner_ambiguous")
+    ));
+}
+
+#[test]
+fn terminal_delete_on_success_lifecycle_requires_exact_durable_authority() {
+    let mut metadata = active_lifecycle_metadata("run-terminal", "run-terminal");
+    metadata["resource_lifecycle"]["cleanup_policy"] = serde_json::json!("delete_on_success");
+    assert!(has_terminal_delete_on_success_lifecycle_with(
+        &metadata,
+        |_| RunAuthority::Terminal,
+    ));
+    assert!(!has_terminal_delete_on_success_lifecycle_with(
+        &metadata,
+        |_| RunAuthority::Active,
+    ));
+    assert!(!has_terminal_delete_on_success_lifecycle_with(
+        &metadata,
+        |_| RunAuthority::Unavailable,
+    ));
+
+    let mut ambiguous = active_lifecycle_metadata("run-terminal", "other-run");
+    ambiguous["resource_lifecycle"]["cleanup_policy"] = serde_json::json!("delete_on_success");
+    assert!(!has_terminal_delete_on_success_lifecycle_with(
+        &ambiguous,
+        |_| RunAuthority::Terminal,
     ));
 }
 
@@ -1204,6 +1230,24 @@ fn ssh_materialized_workspace_delete_requires_exact_inactive_lifecycle() {
     assert!(output.status.success(), "{output:?}");
     assert_ne!(String::from_utf8_lossy(&output.stdout), "removed");
     assert!(process_owned.exists());
+}
+
+#[test]
+fn snapshot_git_materialized_workspace_uses_the_same_bounded_lifecycle_contract() {
+    let root = tempfile::tempdir().expect("workspace root");
+    let workspace = root.path().join("_lab_workspaces/snapshot-git");
+    write_materialized_workspace(&workspace);
+    let metadata_path = workspace.join(WORKSPACE_METADATA_FILE);
+    let mut metadata: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&metadata_path).expect("metadata"))
+            .expect("metadata json");
+    metadata["sync_mode"] = serde_json::json!("snapshot-git");
+    fs::write(&metadata_path, metadata.to_string()).expect("write snapshot-git metadata");
+
+    assert!(encoded_materialized_workspace_metadata_is_valid(
+        &encoded_workspace_metadata(&workspace),
+        &workspace,
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- admit active `delete_on_success` workspaces when their exact durable run is terminal, even while the controller source path exists
- apply the bounded ownerless materialization lifecycle contract to both `snapshot` and `snapshot-git` workspaces
- preserve repeated exact authority, runner-job, metadata, and process-ownership checks immediately before deletion

## Production evidence
On `homeboy-lab`, ordinary fail-closed pruning reclaimed another 10.40 GB but filesystem use remained about 1.551 TB. Large terminal-owned and ownerless `snapshot-git` workspaces remain stranded because candidate classification never reaches the existing liveness checks.

The fresh scan retained 108 authority-unknown and five live workspaces, demonstrating the existing revalidation boundary remains fail-closed.

## Verification
- `cargo test -p homeboy-lab-runner workspace::tests::prune` (25 passed)
- `cargo fmt --check`
- `git diff --check`

Closes #10559.

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode analyzed production Lab prune evidence, implemented the focused lifecycle classification repair, and added deterministic terminal-authority and `snapshot-git` coverage. Chris Huber reviewed and owns every line.