### PR TITLE
fix: propagate force through Cook retry reservation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2007,6 +2007,37 @@ fn retryable_pre_provider_retry_stays_attached_to_its_cook() {
 }
 
 #[test]
+fn retryable_pre_provider_retry_propagates_force_after_terminal_successor() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-forced-terminal-retry", 3);
+        let first_retry =
+            crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+                .expect("reserve second attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            &first_retry.record.run_id,
+            &options.initial_plan,
+            "lab_handoff",
+            &Error::internal_io(
+                "File name too long",
+                Some("finalize staged artifact".to_string()),
+            )
+            .with_retryable(true),
+        )
+        .expect("terminalize second attempt");
+
+        let forced =
+            crate::agent_task_service::retry(&first_retry.record.run_id, None, false, true)
+                .expect("force reserves third attempt");
+
+        assert_eq!(forced.record.metadata["cook_attempt"], 3);
+        assert_eq!(
+            forced.record.metadata["retry_of"],
+            first_retry.record.run_id
+        );
+    });
+}
+
+#[test]
 fn retryable_pre_provider_retry_without_a_recipe_uses_legacy_lifecycle_retry() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = batch_cook_options(

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -428,7 +428,8 @@ pub fn retry(
             // before recipe/index binding, so recovery can prove ownership without
             // adopting an unrelated same-plan run.
             if !retry_exists {
-                retry_run_id = reserve_cook_retry_lifecycle(&source, &cook_retry, &retry_run_id)?;
+                retry_run_id =
+                    reserve_cook_retry_lifecycle(&source, &cook_retry, &retry_run_id, force)?;
             }
             // Recipe and index are one Cook-owned binding boundary. Serialize
             // concurrent claim observers so neither can overwrite the other's
@@ -462,6 +463,7 @@ fn reserve_cook_retry_lifecycle(
     source: &agent_task_lifecycle::AgentTaskRunRecord,
     retry: &CookRetryAttempt,
     retry_run_id: &str,
+    force: bool,
 ) -> Result<String> {
     let operation_key = format!("retry:{}:{}", retry.cook_id, retry.attempt);
     match agent_task_lifecycle::claim_cook_operation(
@@ -473,7 +475,7 @@ fn reserve_cook_retry_lifecycle(
             // The Cook operation claim coordinates recipe/index binding; the
             // lifecycle retry lock also makes the first durable successor
             // idempotent across concurrent controllers and processes.
-            agent_task_lifecycle::retry_with_force(&source.run_id, Some(retry_run_id), false)?;
+            agent_task_lifecycle::retry_with_force(&source.run_id, Some(retry_run_id), force)?;
             let result = json!({ "run_id": retry_run_id });
             if let Err(error) = agent_task_lifecycle::complete_cook_operation(
                 &source.run_id,


### PR DESCRIPTION
## Summary

- propagate the operator-provided `force` flag through Cook-specific lifecycle reservation
- add service-level coverage for reserving a third Cook attempt after a terminal successor
- preserve the default fail-closed behavior covered by existing lifecycle retry tests

Closes #10620.

## Verification

- `cargo test -p homeboy-agents retryable_pre_provider_retry_propagates_force_after_terminal_successor`
- `cargo test -p homeboy-agents retryable_pre_provider_retry_stays_attached_to_its_cook`
- `cargo fmt --all --check`
- `git diff --check`

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode traced the dropped force argument, implemented the focused repair and regression test, and ran verification. Chris Huber reviewed and remains responsible for the change.