### PR TITLE
fix: accept runner-bound Cook retry plans

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2038,6 +2038,58 @@ fn retryable_pre_provider_retry_propagates_force_after_terminal_successor() {
 }
 
 #[test]
+fn retryable_pre_provider_retry_accepts_runner_rebound_workspace_identity() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-runner-rebound-retry";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = format!("{cook_id}-attempt-1");
+        options.max_attempts = 3;
+        let controller_identity = serde_json::json!({
+            "canonical_path": "/controller/worktree",
+            "git_representation": "pointer_file",
+        });
+        options.initial_plan.tasks[0].metadata["cook_workspace_identity"] =
+            controller_identity.clone();
+        super::super::persist_initial_recipe(&options).expect("persist Cook recipe");
+        super::super::materialize_initial_cook_attempt(&options)
+            .expect("materialize first attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            &options.initial_run_id,
+            &options.initial_plan,
+            "lab_handoff",
+            &Error::internal_io("projection failed", None).with_retryable(true),
+        )
+        .expect("fail first attempt");
+
+        let second = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect("reserve second attempt");
+        let mut runner_plan = options.initial_plan.clone();
+        runner_plan.tasks[0].metadata["cook_workspace_identity"] = serde_json::json!({
+            "canonical_path": "/runner/worktree",
+            "git_representation": "directory",
+        });
+        runner_plan.tasks[0].metadata["cook_workspace_identity_predecessor"] = controller_identity;
+        agent_task_lifecycle::record_pre_execution_failure(
+            &second.record.run_id,
+            &runner_plan,
+            "lab_handoff",
+            &Error::internal_io("projection failed", None).with_retryable(true),
+        )
+        .expect("fail runner-bound second attempt");
+
+        let third = crate::agent_task_service::retry(&second.record.run_id, None, false, true)
+            .expect("runner-bound plan retains Cook retry ownership");
+        assert_eq!(third.record.metadata["cook_attempt"], 3);
+
+        runner_plan.tasks[0].executor.model = Some("different/model".to_string());
+        assert!(!super::super::execution::cook_retry_plans_match(
+            &options.initial_plan,
+            &runner_plan,
+        ));
+    });
+}
+
+#[test]
 fn retryable_pre_provider_retry_without_a_recipe_uses_legacy_lifecycle_retry() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = batch_cook_options(

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -598,7 +598,10 @@ fn retryable_cook_attempt(
                 None,
             ));
         }
-        if agent_task_lifecycle::load_plan(&recipe_attempt.run_id)? != recipe_attempt.plan {
+        if !cook_retry_plans_match(
+            &recipe_attempt.plan,
+            &agent_task_lifecycle::load_plan(&recipe_attempt.run_id)?,
+        ) {
             return Err(Error::validation_invalid_argument(
                 "cook_recipe.attempts",
                 "pending Cook retry run does not match its durable plan",
@@ -690,7 +693,43 @@ fn is_exact_retry_reservation(
 ) -> Result<bool> {
     let record = agent_task_lifecycle::exact_record(run_id)?;
     Ok(record.metadata["retry_of"] == source.run_id
-        && agent_task_lifecycle::load_plan(run_id)? == *plan)
+        && cook_retry_plans_match(plan, &agent_task_lifecycle::load_plan(run_id)?))
+}
+
+pub(super) fn cook_retry_plans_match(expected: &AgentTaskPlan, observed: &AgentTaskPlan) -> bool {
+    if expected == observed {
+        return true;
+    }
+    if expected.tasks.len() != observed.tasks.len() {
+        return false;
+    }
+
+    let mut normalized = observed.clone();
+    for (expected_task, observed_task) in expected.tasks.iter().zip(&mut normalized.tasks) {
+        let expected_identity = expected_task.metadata.get("cook_workspace_identity");
+        if observed_task.metadata.get("cook_workspace_identity") == expected_identity {
+            continue;
+        }
+        if observed_task
+            .metadata
+            .get("cook_workspace_identity_predecessor")
+            != expected_identity
+        {
+            return false;
+        }
+        let Some(expected_identity) = expected_identity else {
+            return false;
+        };
+        let Some(metadata) = observed_task.metadata.as_object_mut() else {
+            return false;
+        };
+        metadata.insert(
+            "cook_workspace_identity".to_string(),
+            expected_identity.clone(),
+        );
+        metadata.remove("cook_workspace_identity_predecessor");
+    }
+    normalized == *expected
 }
 
 struct CookRetryAttempt {


### PR DESCRIPTION
## Summary

- compare Cook retry plans through one compatibility boundary
- accept only runner-rebound workspace identity when its predecessor exactly matches the recipe identity
- retain full structural equality for every other plan field
- cover the real terminal Lab retry sequence and rejection of unrelated model drift

Closes #10624.

## Verification

- `cargo test -p homeboy-agents retryable_pre_provider_retry_accepts_runner_rebound_workspace_identity`
- `cargo test -p homeboy-agents retryable_pre_provider_retry_propagates_force_after_terminal_successor`
- `cargo test -p homeboy-agents retryable_pre_provider_retry_rejects_a_lifecycle_reservation_collision_without_recipe_mutation`
- `cargo fmt --all --check`
- `git diff --check`

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode reproduced the mixed-runtime failure against the durable Cook lineage, isolated runner attestation rebinding as the semantic difference, implemented the bounded compatibility comparison and behavioral regression, and ran verification. Chris Huber reviewed and remains responsible for the change.