### PR TITLE
fix(release): bound recovery control-binary lineage to the release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -986,10 +986,42 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           RELEASE_VERSION: ${{ needs.prepare.outputs['release-version'] }}
           EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
+          CONTROL_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           mkdir -p draft-adoption
           COMMIT="$(git rev-parse "${RELEASE_TAG}^{}")"
+
+          # ── Control-binary lineage (issue #10519) ──
+          # This checkout is the RELEASE TARGET (the tag). The binary that will
+          # publish it was built from CONTROL_SHA. Recovery is meant to run code
+          # NEWER than the tag it repairs — that is how a publisher fix merged
+          # after the tag reaches the stranded release at all. The inverse is
+          # not safe: a control binary from a tree that never contained the tag
+          # would apply a release contract this tag was never planned under.
+          # Record the relationship so the publisher can enforce that boundary.
+          #
+          # Every unresolvable path emits `null`, never `false`: an ambiguous
+          # answer must degrade to "unverified", not brick an already-stranded
+          # release. Only a definitive "not an ancestor" blocks recovery.
+          CONTAINS_TARGET=null
+          if ! git cat-file -e "${CONTROL_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "${CONTROL_SHA}" 2>/dev/null || true
+          fi
+          if git cat-file -e "${CONTROL_SHA}^{commit}" 2>/dev/null; then
+            set +e
+            git merge-base --is-ancestor "${COMMIT}" "${CONTROL_SHA}" 2>/dev/null
+            ANCESTRY_STATUS=$?
+            set -e
+            case "${ANCESTRY_STATUS}" in
+              0) CONTAINS_TARGET=true ;;
+              1) CONTAINS_TARGET=false ;;
+              *) echo "::warning::git merge-base --is-ancestor exited ${ANCESTRY_STATUS}; recovery control lineage reported as unverified." ;;
+            esac
+          else
+            echo "::warning::Control commit ${CONTROL_SHA} is not present in this checkout; recovery control lineage reported as unverified."
+          fi
+
           jq -n \
             --arg schema homeboy.draft-adoption \
             --argjson schema_version 1 \
@@ -998,7 +1030,10 @@ jobs:
             --arg version "${RELEASE_VERSION}" \
             --arg commit "${COMMIT}" \
             --argjson expected_assets "${EXPECTED_ASSETS}" \
-            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, expected_assets: $expected_assets}' > draft-adoption/manifest.json
+            --arg control_commit "${CONTROL_SHA}" \
+            --argjson contains_target "${CONTAINS_TARGET}" \
+            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, expected_assets: $expected_assets, control: {commit: $control_commit, contains_target: $contains_target}}' > draft-adoption/manifest.json
+          echo "::notice::Recovery control lineage: control ${CONTROL_SHA} vs target ${COMMIT} (contains_target=${CONTAINS_TARGET})"
 
       - name: Download current Homeboy finalizer
         if: needs.prepare.outputs.recovery-release == 'true'

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -32,6 +32,80 @@ struct DraftAdoptionManifest {
     version: String,
     commit: String,
     expected_assets: Vec<String>,
+    /// Provenance of the binary performing the recovery, as opposed to the
+    /// release target it repairs (issue #10519). Optional so a manifest
+    /// written before this field existed still adopts instead of failing
+    /// closed on a pipeline that is already stranded.
+    #[serde(default)]
+    control: Option<DraftAdoptionControl>,
+}
+
+#[derive(Deserialize)]
+struct DraftAdoptionControl {
+    /// Commit the control binary was built from.
+    commit: String,
+    /// Whether the control binary's history contains the release target
+    /// commit. `None` when CI could not resolve the relationship, which must
+    /// degrade to "unverified", never to "blocked".
+    #[serde(default)]
+    contains_target: Option<bool>,
+}
+
+/// How the control binary performing a recovery relates to the release it is
+/// repairing.
+///
+/// Recovery deliberately runs a binary built from the current default branch
+/// rather than from the stranded tag, so that a publisher fix merged *after*
+/// the tag can be applied to it (#10519). That freedom has an inverse hazard:
+/// a control binary from a tree that never contained the tag would apply a
+/// release contract this tag was never planned under. This classification is
+/// the boundary between the two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecoveryLineage {
+    /// Control binary strictly descends from the release target: it contains
+    /// everything the tag contained, plus any publisher fix merged since.
+    /// This is the bootstrap working as intended.
+    Bootstrapped,
+    /// Control binary *is* the release target commit. Legitimate for a tag
+    /// pushed moments ago, but a publisher fix merged after the tag cannot be
+    /// bootstrapped by this run.
+    Pinned,
+    /// Control binary's history does not contain the release target commit.
+    Divergent,
+    /// CI could not establish the relationship.
+    Unknown,
+}
+
+impl RecoveryLineage {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Bootstrapped => "bootstrapped",
+            Self::Pinned => "pinned",
+            Self::Divergent => "divergent",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Classify control-binary lineage from the two commits and CI's ancestry
+/// answer. Pure so the policy is testable without a repository.
+fn classify_recovery_lineage(
+    control_commit: &str,
+    target_commit: &str,
+    contains_target: Option<bool>,
+) -> RecoveryLineage {
+    if control_commit.is_empty() || target_commit.is_empty() {
+        return RecoveryLineage::Unknown;
+    }
+    // A commit always contains itself, so equality outranks CI's answer.
+    if control_commit.eq_ignore_ascii_case(target_commit) {
+        return RecoveryLineage::Pinned;
+    }
+    match contains_target {
+        Some(true) => RecoveryLineage::Bootstrapped,
+        Some(false) => RecoveryLineage::Divergent,
+        None => RecoveryLineage::Unknown,
+    }
 }
 
 pub(crate) struct PackageRecoveryContext<'a> {
@@ -61,14 +135,23 @@ pub(crate) fn run_artifact_inventory(
 
     let manifest_path = dir.join(PACKAGE_RECOVERY_MANIFEST);
     if manifest_path.is_file() && is_draft_adoption_manifest(&manifest_path) {
-        let intent = inventory_draft_adoption_manifest(&manifest_path, recovery_context)?;
+        let (intent, lineage) =
+            inventory_draft_adoption_manifest(&manifest_path, recovery_context)?;
         let count = intent.expected_assets.len();
         state.draft_adoption = Some(intent);
+        if lineage == RecoveryLineage::Pinned {
+            homeboy_core::log_status!(
+                "release",
+                "! recovery control binary is the release target commit {}; a publisher fix merged after {} cannot be applied by this run",
+                recovery_context.commit,
+                recovery_context.tag
+            );
+        }
         return Ok(step_success(
             "artifacts.inventory",
             "artifacts.inventory",
             Some(
-                serde_json::json!({ "dir": artifact_dir, "artifact_count": 0, "adoption_asset_count": count }),
+                serde_json::json!({ "dir": artifact_dir, "artifact_count": 0, "adoption_asset_count": count, "control_lineage": lineage.as_str() }),
             ),
             Vec::new(),
         ));
@@ -241,7 +324,7 @@ fn is_draft_adoption_manifest(manifest_path: &std::path::Path) -> bool {
 fn inventory_draft_adoption_manifest(
     manifest_path: &std::path::Path,
     context: &PackageRecoveryContext,
-) -> Result<DraftAdoptionIntent> {
+) -> Result<(DraftAdoptionIntent, RecoveryLineage)> {
     let contents = std::fs::read_to_string(manifest_path).map_err(|error| {
         Error::internal_io(
             format!(
@@ -270,6 +353,7 @@ fn inventory_draft_adoption_manifest(
             None,
         ));
     }
+    let target_commit = manifest.commit.clone();
     let identity = PackageRecoveryManifest {
         schema: manifest.schema,
         schema_version: 1,
@@ -280,6 +364,38 @@ fn inventory_draft_adoption_manifest(
         artifacts: Vec::new(),
     };
     validate_recovery_identity(&identity, manifest_path, context)?;
+
+    // Recovery is allowed — required, even — to be NEWER than the release it
+    // repairs; that is the whole point of building the control binary from the
+    // default branch instead of the stranded tag. It must never be OLDER or
+    // sideways: a control binary whose history lacks the tag cannot be shown
+    // to carry the publisher fix recovery exists to apply, and would impose a
+    // release contract this tag was never planned under.
+    let lineage = match manifest.control.as_ref() {
+        Some(control) => {
+            classify_recovery_lineage(&control.commit, &target_commit, control.contains_target)
+        }
+        None => RecoveryLineage::Unknown,
+    };
+    if lineage == RecoveryLineage::Divergent {
+        let control_commit = manifest
+            .control
+            .as_ref()
+            .map(|control| control.commit.as_str())
+            .unwrap_or_default();
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Draft adoption control binary was built from commit '{}', whose history does not contain release target '{}' ({}). Recovery may run code newer than the tag it repairs, but not code from a tree that never contained it. Re-dispatch the release workflow from a ref that contains {}.",
+                control_commit,
+                target_commit,
+                identity.tag,
+                identity.tag
+            ),
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
     if manifest.expected_assets.is_empty()
         || manifest
             .expected_assets
@@ -303,9 +419,12 @@ fn inventory_draft_adoption_manifest(
             None,
         ));
     }
-    Ok(DraftAdoptionIntent {
-        expected_assets: names,
-    })
+    Ok((
+        DraftAdoptionIntent {
+            expected_assets: names,
+        },
+        lineage,
+    ))
 }
 
 fn valid_asset_name(name: &str) -> bool {
@@ -538,7 +657,8 @@ fn validate_recovery_artifact(
 #[cfg(test)]
 mod tests {
     use super::{
-        establish_publication_authority, run_artifact_inventory, PackageRecoveryContext,
+        classify_recovery_lineage, establish_publication_authority, run_artifact_inventory,
+        PackageRecoveryContext, RecoveryLineage, ReleaseStepResult, Result,
         PACKAGE_RECOVERY_MANIFEST, PACKAGE_RECOVERY_MANIFEST_SCHEMA,
         PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
     };
@@ -979,5 +1099,129 @@ mod tests {
             sha256: None,
             publication_authority: false,
         }
+    }
+
+    // ── Recovery control-binary lineage (issue #10519) ──
+
+    #[test]
+    fn recovery_lineage_allows_newer_control_binaries_and_rejects_only_divergent_history() {
+        // The bootstrap: control binary descends from the tag, so it can carry
+        // a publisher fix merged after the tag was cut.
+        assert_eq!(
+            classify_recovery_lineage("newsha", "abc123", Some(true)),
+            RecoveryLineage::Bootstrapped
+        );
+        // The trap #10519 names: control binary IS the stranded tag.
+        assert_eq!(
+            classify_recovery_lineage("abc123", "abc123", None),
+            RecoveryLineage::Pinned
+        );
+        // A commit always contains itself; equality outranks a bogus CI answer.
+        assert_eq!(
+            classify_recovery_lineage("ABC123", "abc123", Some(false)),
+            RecoveryLineage::Pinned
+        );
+        // The inverse hazard: control binary from a tree without the tag.
+        assert_eq!(
+            classify_recovery_lineage("othersha", "abc123", Some(false)),
+            RecoveryLineage::Divergent
+        );
+        // Unresolvable ancestry degrades to "unverified", never to "blocked".
+        assert_eq!(
+            classify_recovery_lineage("othersha", "abc123", None),
+            RecoveryLineage::Unknown
+        );
+        assert_eq!(
+            classify_recovery_lineage("", "abc123", Some(false)),
+            RecoveryLineage::Unknown
+        );
+    }
+
+    fn adoption_manifest_with_control(control: Option<serde_json::Value>) -> serde_json::Value {
+        let mut manifest = serde_json::json!({
+            "schema": "homeboy.draft-adoption",
+            "schema_version": 1,
+            "component_id": "plugin",
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "commit": "abc123",
+            "expected_assets": ["plugin.zip", "plugin.zip.sha256"],
+        });
+        if let Some(control) = control {
+            manifest
+                .as_object_mut()
+                .expect("object")
+                .insert("control".to_string(), control);
+        }
+        manifest
+    }
+
+    fn adopt(control: Option<serde_json::Value>) -> Result<ReleaseStepResult> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            adoption_manifest_with_control(control).to_string(),
+        )
+        .unwrap();
+        run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &recovery_context(),
+        )
+    }
+
+    #[test]
+    fn draft_adoption_accepts_a_control_binary_newer_than_the_release_it_repairs() {
+        let result = adopt(Some(serde_json::json!({
+            "commit": "deadbeefnewer",
+            "contains_target": true,
+        })))
+        .expect("newer control binary must be allowed to recover an older tag");
+        assert_eq!(
+            result.data.as_ref().and_then(|d| d.get("control_lineage")),
+            Some(&serde_json::json!("bootstrapped"))
+        );
+    }
+
+    #[test]
+    fn draft_adoption_rejects_a_control_binary_whose_history_lacks_the_release_target() {
+        let error = adopt(Some(serde_json::json!({
+            "commit": "deadbeefsideways",
+            "contains_target": false,
+        })))
+        .expect_err("divergent control binary must not adopt a draft");
+        let rendered = format!("{error}");
+        assert!(
+            rendered.contains("deadbeefsideways") && rendered.contains("abc123"),
+            "error must name both provenances, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn draft_adoption_records_but_permits_a_control_binary_pinned_to_the_release_target() {
+        // A tag pushed moments ago is legitimately still HEAD. Refusing here
+        // would block ordinary same-commit recoveries, so this is evidence
+        // only — but it must be visible, because in this shape a publisher fix
+        // merged after the tag cannot be bootstrapped.
+        let result = adopt(Some(serde_json::json!({
+            "commit": "abc123",
+            "contains_target": true,
+        })))
+        .expect("same-commit recovery stays legal");
+        assert_eq!(
+            result.data.as_ref().and_then(|d| d.get("control_lineage")),
+            Some(&serde_json::json!("pinned"))
+        );
+    }
+
+    #[test]
+    fn draft_adoption_without_control_provenance_still_adopts_as_unverified() {
+        // Fail-safe: the guard must never be a new way for an already-stranded
+        // release to become unrecoverable.
+        let result = adopt(None).expect("absent control provenance must not block recovery");
+        assert_eq!(
+            result.data.as_ref().and_then(|d| d.get("control_lineage")),
+            Some(&serde_json::json!("unknown"))
+        );
     }
 }

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -876,3 +876,47 @@ fn release_fast_path_keeps_every_publication_verification() {
         "recovery evidence must record whether the published bytes were rebuilt or pre-existing"
     );
 }
+
+/// Recovery is allowed — required — to run a control binary NEWER than the tag
+/// it repairs; that is the bootstrap #10519 asks for, and #10560 built it by
+/// pinning `gate-build` to `github.sha`. The inverse was never bounded: a
+/// control binary from a tree that never contained the tag cannot be shown to
+/// carry the publisher fix recovery exists to apply, and would impose a release
+/// contract the tag was never planned under.
+///
+/// The workflow is the only place that relationship can be established, because
+/// only it holds both the control commit and the release target's git history.
+/// The publisher enforces it, so the manifest must carry it.
+#[test]
+fn release_recovery_records_control_binary_lineage_against_the_release_target() {
+    let workflow = release_workflow();
+    let host = job_section(workflow, "host");
+    let adoption = release_step_block(host, "name: Create remote draft adoption manifest");
+
+    assert!(
+        adoption.contains("CONTROL_SHA: ${{ github.sha }}"),
+        "the adoption manifest must record which commit the control binary was built from"
+    );
+    assert!(
+        adoption.contains("git merge-base --is-ancestor"),
+        "control lineage must be read out of git history, never assumed"
+    );
+    assert!(
+        adoption.contains("contains_target: $contains_target"),
+        "the publisher can only enforce the lineage boundary if the manifest carries it"
+    );
+
+    // Fail-safe direction. An already-stranded release must never become
+    // unrecoverable because ancestry could not be resolved, so only a
+    // definitive "not an ancestor" (git exit code 1) may produce `false`;
+    // every other path leaves the answer null, which the publisher treats as
+    // unverified-but-permitted.
+    assert!(
+        adoption.contains("CONTAINS_TARGET=null"),
+        "unresolvable ancestry must default to unverified, never to a blocking answer"
+    );
+    assert!(
+        adoption.contains("1) CONTAINS_TARGET=false ;;"),
+        "only git's definitive non-ancestor exit code may block a recovery"
+    );
+}


### PR DESCRIPTION
Closes part of #10519 (acceptance criterion 3 — version skew).

## What was already true, verified independently

The headline defect of #10519 — "recovery executes the stranded tag's binary" — **is already fixed on `main`**, and I am not re-fixing it. Verified at `45e609c87`:

| what | where |
| --- | --- |
| control binary is built from the dispatching commit, not the tag | `release.yml:249` — `gate-build` checks out `ref: ${{ github.sha }}` |
| it is uploaded as an artifact | `release.yml:270` — `name: homeboy-binary` |
| recovery downloads it | `release.yml:1003-1007` — `Download current Homeboy finalizer` |
| recovery **executes** it | `release.yml:1054` — `binary-path: ...recovery-release == 'true' && '.homeboy-bin/homeboy'` |
| the release target tree stays pinned to the tag | `release.yml:915` — `ref: ${{ needs.prepare.outputs['release-tag'] }}` |

`binary-path` is a real, load-bearing input: `Extra-Chill/homeboy-action`'s `action.yml` documents `version` as *"Ignored when source or binary-path is set."* Both auto-detected recovery (`release.yml:210`) and operator `workflow_dispatch` recovery (`release.yml:195`) set `recovery-release=true`, so both paths get the fresh binary.

## What was not bounded, and is what this PR fixes

Recovery is *allowed* to run code newer than the tag it repairs — that is the entire point. **Nothing bounded the inverse.** A control binary built from a tree that never contained the tag would:

- be unable to carry the publisher fix recovery exists to apply, and
- impose a release contract the tag was never planned under.

That is reachable today: `gh workflow run release.yml --ref <stale-or-divergent-branch> -f release_tag=v0.321.1` builds `gate-build` from that ref's `github.sha` and hands it the draft. Nothing checks the relationship.

### The fix

The draft-adoption manifest now carries the control binary's provenance, and the publisher enforces a boundary on it:

| lineage | meaning | action |
| --- | --- | --- |
| `bootstrapped` | control commit strictly descends from the tag | **allowed** — the bootstrap working |
| `pinned` | control commit *is* the tag commit | allowed, recorded — a post-tag fix cannot be applied in this shape |
| `divergent` | control history does not contain the tag | **rejected** |
| `unknown` | ancestry unresolvable | allowed, recorded |

Ancestry is read out of git (`git merge-base --is-ancestor`) in the workflow, which is the only place holding both the control commit and the target's history. The publisher classifies and enforces it in `artifacts.rs`, before any GitHub mutation.

### Fail-safe by construction

This pipeline is stranded right now, so a new guard must not be a new way to strand it. Only git's **definitive** non-ancestor answer (exit code 1) yields `false`. A missing object, a fetch failure, or any other exit code emits `null`, which classifies as `unknown` and permits adoption. The `control` block itself is optional, so a manifest without it still adopts.

**No currently-stranded draft is affected.** `v0.320.0` (`f8b96e0d`), `v0.321.0` (`192964f6`) and `v0.321.1` (`9b9bb931`) are all ancestors of `main`, so recovery from `main` classifies `bootstrapped`.

## Composition with #10608 / #10611

Orthogonal and complementary. #10608 fixed *which assets* are expected (cargo-dist's unlisted `dist-manifest.json`); #10611 skips the rebuild when the draft is already complete. Both concern **what** gets adopted. This PR concerns **who** is allowed to adopt it. The guard runs in `artifacts.inventory`, strictly before `validate_draft_adoption`, so a divergent control binary is rejected before the fast path or the asset comparison is reached.

## Tests

- `artifacts.rs` — four tests: the pure classifier across all six input shapes; newer-control accepted; divergent-control rejected *and the error names both provenances*; pinned recorded; absent-provenance still adopts.
- `tests/release_workflow_test.rs` — **I did touch this file** (noted as recently edited by #10607). I added one new test function appended at the end; I modified no existing test. It is the only place that can assert the YAML emits the lineage facts, including the fail-safe direction. My branch is cut from current `main`, which already contains #10607 and #10611.

## Not verified

No cargo on the authoring host (16GB shared, OOM risk) — compilation and tests are CI's to prove. I verified the shell/jq logic empirically in a scratch git repo across all four lineage cases (ancestor / self / orphan / absent object) and confirmed the emitted JSON shape, and I simulated the workflow-test helpers against the real YAML. End-to-end proof still needs a Release run to complete, which has not happened since `v0.321.0`.

## Out of scope, reported

- **#10487** (recovery misidentifies canonical asset digests) — overlaps the same `validate_draft_adoption` call site but concerns digest authority, not control provenance. Untouched.
- The `check` job's `Dry-run release check` (`release.yml:145-150`) passes neither `source` nor `binary-path`, so it resolves `version: latest` and runs the **last published** binary (v0.321.0, 137 commits stale). That is the same chicken-and-egg one job earlier, on the gate that decides whether anything releases at all. It does not affect recovery (the step is skipped when a stranded tag or `release_tag` is present), and fixing it means `gate-build` can no longer depend on `check` — a build on every push, which worsens the current cancellation starvation. Operator trade-off; deserves its own issue.
- Release runs are currently dying to `cancelled` under `cancel-in-progress: false`, not to code. No fix here changes that.

---
**AI assistance** — Model: Claude Sonnet 4.6. Tool: opencode + Data Machine. Used for: independent verification of the existing bootstrap, the lineage guard, and tests. Chris Huber reviews and owns.