### PR TITLE
Fix read-only status creating deferred workload state

### DIFF
--- a/crates/homeboy-core/src/deferred_workload.rs
+++ b/crates/homeboy-core/src/deferred_workload.rs
@@ -286,7 +286,7 @@ pub fn defer_claim(id: &str, owner: &str) -> Result<()> {
 }
 
 pub fn records() -> Result<Vec<DeferredWorkload>> {
-    update(|records| Ok(records.clone()))
+    read_store(&store_path()?)
 }
 
 pub fn worker_lock() -> Result<File> {
@@ -577,6 +577,20 @@ mod tests {
             assert!(claim(&input(), "other-lab", "second-owner")
                 .expect("idempotent claim")
                 .is_none());
+        });
+    }
+
+    #[test]
+    fn reading_an_absent_store_does_not_create_runtime_state() {
+        crate::test_support::with_isolated_home(|_| {
+            let path = store_path().expect("store path");
+
+            assert!(records().expect("read absent store").is_empty());
+            assert!(!path.exists(), "read created deferred workload store");
+            assert!(
+                !path.with_extension("lock").exists(),
+                "read created deferred workload lock"
+            );
         });
     }
 


### PR DESCRIPTION
## Summary
- make deferred workload inspection read the store without invoking the mutating update path
- preserve an absent store as absent during CLI startup
- add focused coverage for store and lock non-creation

Fixes #10621.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-core deferred_workload::tests --lib`
- `cargo test --test readonly_cli_lock_test read_only_cli_commands_complete_while_runtime_promotion_is_held -- --exact`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced the release-gate failure, drafted the minimal code and regression test, and ran the listed verification. Chris Huber remains responsible for the change.