### PR TITLE
Fix finalized artifact media type projection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -216,6 +216,7 @@ fn staged_file(
     validate_token("artifact.id", &artifact.id)?;
     validate_token("artifact.kind", &artifact.kind)?;
     let declared = Path::new(declared);
+    let mime = homeboy_core::artifact_metadata::content_type_from_path(declared);
     let candidate = if declared.is_absolute() {
         declared.to_path_buf()
     } else {
@@ -359,12 +360,7 @@ fn staged_file(
             ))
         }
     }
-    Ok((
-        destination.clone(),
-        size,
-        sha256,
-        homeboy_core::artifact_metadata::content_type_from_path(&destination),
-    ))
+    Ok((destination.clone(), size, sha256, mime))
 }
 
 #[cfg(windows)]
@@ -728,6 +724,7 @@ mod tests {
                 b"verified patch bytes"
             );
             assert_eq!(artifact.size_bytes, Some(20));
+            assert_eq!(artifact.mime.as_deref(), Some("text/x-patch"));
             assert_eq!(
                 artifact.sha256,
                 Some(

--- a/crates/homeboy-core/src/artifact_metadata.rs
+++ b/crates/homeboy-core/src/artifact_metadata.rs
@@ -19,6 +19,8 @@ pub fn content_type_from_path(path: &Path) -> Option<String> {
         "css" => "text/css",
         "js" | "mjs" => "text/javascript",
         "txt" | "log" => "text/plain",
+        "patch" => "text/x-patch",
+        "diff" => "text/x-diff",
         "csv" => "text/csv",
         "xml" => "application/xml",
         "zip" => "application/zip",
@@ -33,4 +35,26 @@ pub fn content_type_from_path(path: &Path) -> Option<String> {
         _ => return None,
     };
     Some(mime.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn executor_artifact_extensions_have_stable_content_types() {
+        for (path, expected) in [
+            ("change.patch", "text/x-patch"),
+            ("change.diff", "text/x-diff"),
+            ("transcript.txt", "text/plain"),
+            ("result.json", "application/json"),
+            ("runtime.log", "text/plain"),
+        ] {
+            assert_eq!(
+                content_type_from_path(Path::new(path)).as_deref(),
+                Some(expected)
+            );
+        }
+        assert_eq!(content_type_from_path(Path::new("artifact.unknown")), None);
+    }
 }

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -1217,6 +1217,19 @@ where
                 ),
             ));
         }
+        if artifact.mime.as_deref().is_none_or(str::is_empty) {
+            return Err(artifact_projection_error(
+                runner,
+                job,
+                &run.id,
+                Error::validation_invalid_argument(
+                    "artifact.mime",
+                    "terminal artifact is missing controller media type metadata",
+                    Some(artifact.id.clone()),
+                    None,
+                ),
+            ));
+        }
         let mut file = tempfile::NamedTempFile::new().map_err(|error| {
             artifact_projection_error(
                 runner,
@@ -1437,6 +1450,7 @@ fn permanent_artifact_provenance_error(error: &Error) -> bool {
             Some("artifact.provenance")
                 | Some("artifact.size_bytes")
                 | Some("artifact.sha256")
+                | Some("artifact.mime")
                 | Some("artifact.content_base64")
         )
 }

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -1789,6 +1789,51 @@ fn terminal_artifacts_missing_integrity_are_permanent_provenance_errors() {
 }
 
 #[test]
+fn terminal_artifact_missing_mime_is_a_permanent_provenance_error() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let mut job = terminal_runner_job();
+        let bytes = b"typed terminal artifact";
+        job.artifacts = vec![JobArtifactMetadata {
+            id: "missing-mime".to_string(),
+            name: Some("artifact.unknown".to_string()),
+            path: Some("/runner/artifact.unknown".to_string()),
+            url: None,
+            mime: None,
+            size_bytes: Some(bytes.len() as u64),
+            sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+            content_base64: None,
+            metadata: None,
+        }];
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/runner",
+            &[],
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        )
+        .expect("synthetic run");
+
+        let error = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |_| {
+            Ok(bytes.to_vec())
+        })
+        .expect_err("missing media type is rejected");
+
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(
+            error.details["source_error"]["details"]["field"],
+            "artifact.mime"
+        );
+        assert!(!error.retryable.unwrap_or(true));
+        assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
+    });
+}
+
+#[test]
 fn terminal_artifact_download_failure_rolls_back_every_artifact_and_retry_is_idempotent() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let store = ObservationStore::open_initialized().expect("store");
@@ -1802,7 +1847,7 @@ fn terminal_artifact_download_failure_rolls_back_every_artifact_and_retry_is_ide
                 name: None,
                 path: None,
                 url: None,
-                mime: None,
+                mime: Some("application/octet-stream".to_string()),
                 size_bytes: Some(bytes.len() as u64),
                 sha256: Some(format!("{:x}", Sha256::digest(bytes))),
                 content_base64: None,


### PR DESCRIPTION
## Summary

- infer finalized executor artifact MIME from its declared source path before extensionless publication
- define stable `.patch` and `.diff` MIME mappings in the shared artifact metadata contract
- reject untyped terminal runner artifacts before controller import and classify malformed MIME provenance as permanent

Closes #10627

## Verification

- `cargo test -p homeboy-core executor_artifact_extensions_have_stable_content_types`
- `cargo test -p homeboy-agents finalization_persists_opened_bytes_in_canonical_store_with_hash_parity`
- `cargo test -p homeboy-lab-runner terminal_artifact`
- `cargo fmt --all`
- `git diff --check`

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode traced the production artifact projection failure, implemented the source-path MIME inference and strict mirror validation, and wrote the focused regressions. Chris Huber directed the repair and is responsible for the change.