### PR TITLE
Configure worktree provider lookup bounds

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -94,6 +94,8 @@ fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
                         provider.path().display().to_string(),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -186,6 +186,8 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
             enabled: true,
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![
                     provider_path.display().to_string(),
@@ -285,6 +287,8 @@ fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination
             enabled: true,
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![
                     provider.path().display().to_string(),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -182,6 +182,8 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
             enabled: true,
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![
                     provider_path.display().to_string(),

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -245,6 +245,8 @@ fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
                 enabled: true,
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![
                         provider.display().to_string(),
@@ -351,6 +353,8 @@ fn cook_resolves_existing_provider_destination_without_creation_metadata() {
                 enabled: true,
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
                     ..Default::default()
@@ -419,6 +423,8 @@ fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_meta
                 enabled: true,
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "resolve".to_string()]),
                     ensure: Some(vec![provider.display().to_string(), "ensure".to_string()]),

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -472,6 +472,8 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 enabled: true,
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![
                         provider.display().to_string(),

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1816,6 +1816,8 @@ fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
                 enabled: true,
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
                     ensure: Some(vec![provider.display().to_string(), "{handle}".to_string()]),

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -1602,6 +1602,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_preview: Some(vec![script, "dry_run".to_string()]),
                     ..Default::default()
@@ -1661,6 +1663,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script, "apply".to_string()]),
                     ..Default::default()

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -302,10 +302,91 @@ pub struct WorktreeProviderConfig {
     pub apply_enabled: bool,
     #[serde(default)]
     pub commands: WorktreeProviderCommands,
+    /// Maximum time allowed for a provider's read-only `list` or `resolve`
+    /// command. This is intentionally separate from mutating provider actions.
+    #[serde(
+        default = "default_worktree_provider_lookup_timeout_ms",
+        deserialize_with = "deserialize_worktree_provider_lookup_timeout_ms"
+    )]
+    pub lookup_timeout_ms: u64,
+    /// Maximum output retained from a provider's read-only `list` or `resolve`
+    /// command. The configured result mapping receives the complete JSON payload.
+    #[serde(
+        default = "default_worktree_provider_lookup_output_limit_bytes",
+        deserialize_with = "deserialize_worktree_provider_lookup_output_limit_bytes"
+    )]
+    pub lookup_output_limit_bytes: usize,
     /// Explicit projection of a command provider's list result into Homeboy's
     /// generic worktree safety contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub list_result_mapping: Option<WorktreeProviderListResultMapping>,
+}
+
+const DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS: u64 = 10_000;
+const MIN_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS: u64 = 1;
+const MAX_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS: u64 = 300_000;
+const DEFAULT_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES: usize = 64 * 1024;
+const MIN_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES: usize = 1;
+const MAX_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+
+fn default_worktree_provider_lookup_timeout_ms() -> u64 {
+    DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS
+}
+
+fn default_worktree_provider_lookup_output_limit_bytes() -> usize {
+    DEFAULT_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES
+}
+
+fn deserialize_worktree_provider_lookup_timeout_ms<'de, D>(
+    deserializer: D,
+) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let timeout_ms = u64::deserialize(deserializer)?;
+    validate_worktree_provider_lookup_timeout_ms(timeout_ms).map_err(serde::de::Error::custom)?;
+    Ok(timeout_ms)
+}
+
+pub fn validate_worktree_provider_lookup_timeout_ms(
+    timeout_ms: u64,
+) -> std::result::Result<(), String> {
+    if (MIN_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS..=MAX_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS)
+        .contains(&timeout_ms)
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "lookup_timeout_ms must be between {MIN_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS} and {MAX_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS} milliseconds"
+        ))
+    }
+}
+
+fn deserialize_worktree_provider_lookup_output_limit_bytes<'de, D>(
+    deserializer: D,
+) -> std::result::Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let output_limit_bytes = usize::deserialize(deserializer)?;
+    validate_worktree_provider_lookup_output_limit_bytes(output_limit_bytes)
+        .map_err(serde::de::Error::custom)?;
+    Ok(output_limit_bytes)
+}
+
+pub fn validate_worktree_provider_lookup_output_limit_bytes(
+    output_limit_bytes: usize,
+) -> std::result::Result<(), String> {
+    if (MIN_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES
+        ..=MAX_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES)
+        .contains(&output_limit_bytes)
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "lookup_output_limit_bytes must be between {MIN_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES} and {MAX_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES} bytes"
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -595,6 +676,58 @@ mod tests {
             20 * 1024 * 1024 * 1024
         );
         assert_eq!(config.retention.shared_store_lease_seconds, 6 * 60 * 60);
+    }
+
+    #[test]
+    fn worktree_provider_lookup_timeout_defaults_and_validates() {
+        let config: HomeboyConfig = serde_json::from_str(
+            r#"{"worktree_providers":{"fixture":{"commands":{"list":["provider"]}}}}"#,
+        )
+        .expect("existing provider config remains valid");
+        assert_eq!(
+            config.worktree_providers["fixture"].lookup_timeout_ms,
+            DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS
+        );
+        assert_eq!(
+            config.worktree_providers["fixture"].lookup_output_limit_bytes,
+            DEFAULT_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES
+        );
+        assert_eq!(
+            serde_json::to_value(&config)
+                .expect("config serializes")
+                .pointer("/worktree_providers/fixture/lookup_timeout_ms"),
+            Some(&serde_json::json!(
+                DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS
+            ))
+        );
+        assert_eq!(
+            serde_json::to_value(&config)
+                .expect("config serializes")
+                .pointer("/worktree_providers/fixture/lookup_output_limit_bytes"),
+            Some(&serde_json::json!(
+                DEFAULT_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES
+            ))
+        );
+
+        for timeout_ms in [0, MAX_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS + 1] {
+            let error = serde_json::from_value::<HomeboyConfig>(serde_json::json!({
+                "worktree_providers": {"fixture": {"lookup_timeout_ms": timeout_ms}}
+            }))
+            .expect_err("out-of-range lookup timeout is invalid");
+            assert!(error
+                .to_string()
+                .contains("lookup_timeout_ms must be between"));
+        }
+
+        for output_limit_bytes in [0, MAX_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES + 1] {
+            let error = serde_json::from_value::<HomeboyConfig>(serde_json::json!({
+                "worktree_providers": {"fixture": {"lookup_output_limit_bytes": output_limit_bytes}}
+            }))
+            .expect_err("out-of-range lookup output limit is invalid");
+            assert!(error
+                .to_string()
+                .contains("lookup_output_limit_bytes must be between"));
+        }
     }
 
     #[test]

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -420,8 +420,13 @@ pub struct WorktreeProviderCommands {
     /// requested handle. The result uses `list_result_mapping` and may contain one item.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolve: Option<Vec<String>>,
-    /// Provider-native resolve exit statuses that mean the requested handle is
-    /// absent. All other non-zero statuses remain lookup failures.
+    /// Targeted canonical-path lookup. Each `{path}` argument is replaced with
+    /// the requested canonical path. The result uses `list_result_mapping` and
+    /// may contain one item.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolve_path: Option<Vec<String>>,
+    /// Provider-native targeted lookup exit statuses that mean the requested
+    /// handle or path is absent. All other non-zero statuses remain failures.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub resolve_not_found_exit_codes: Vec<i32>,
     /// Discovery command and compatibility fallback for providers without

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -21,10 +21,6 @@ const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_secs(5);
 const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_millis(100);
 const PROVIDER_CLEANUP_OUTPUT_LIMIT: usize = 64 * 1024;
 #[cfg(not(test))]
-const PROVIDER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(10);
-#[cfg(test)]
-const PROVIDER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(1);
-#[cfg(not(test))]
 const PROVIDER_ENSURE_TIMEOUT: Duration = Duration::from_secs(30);
 #[cfg(test)]
 const PROVIDER_ENSURE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -606,6 +602,8 @@ fn run_provider_lookup_command(
     operation: &str,
     not_found_exit_codes: &[i32],
 ) -> Result<Vec<WorktreeProviderHandle>> {
+    let timeout = provider_lookup_timeout(provider)?;
+    let output_limit = provider_lookup_output_limit(provider)?;
     let (program, args) = command
         .split_first()
         .filter(|(program, _)| !program.trim().is_empty())
@@ -635,10 +633,11 @@ fn run_provider_lookup_command(
             None,
         )
     })?;
+    let started = std::time::Instant::now();
     let output = crate::engine::command::wait_with_bounded_output_supervised(
         &mut child,
-        PROVIDER_LOOKUP_OUTPUT_LIMIT,
-        PROVIDER_LOOKUP_TIMEOUT,
+        output_limit,
+        timeout,
         Duration::from_millis(100),
         || false,
         |_, _| Ok(()),
@@ -651,12 +650,13 @@ fn run_provider_lookup_command(
             None,
         )
     })?;
+    let elapsed_ms = started.elapsed().as_millis();
     if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
             format!(
-                "worktree provider `{provider_id}` {operation} command timed out after {} ms",
-                PROVIDER_LOOKUP_TIMEOUT.as_millis()
+                "worktree provider `{provider_id}` {operation} command timed out after {elapsed_ms} ms (configured lookup_timeout_ms: {})",
+                timeout.as_millis()
             ),
             Some(provider_id.to_string()),
             Some(vec![
@@ -665,7 +665,21 @@ fn run_provider_lookup_command(
             ]),
         ));
     }
-    let output = output.output.into_output();
+    let output = output.output;
+    if output.capture.stdout.truncated {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` {operation} command output exceeded configured lookup_output_limit_bytes: {output_limit} (received {} bytes)",
+                output.capture.stdout.bytes_seen
+            ),
+            Some(provider_id.to_string()),
+            Some(vec![
+                "Increase the provider lookup_output_limit_bytes within its configured bound, then retry the operation.".to_string(),
+            ]),
+        ));
+    }
+    let output = output.into_output();
     if !output.status.success() {
         if output
             .status
@@ -710,6 +724,35 @@ fn run_provider_lookup_command(
         )
     })?;
     map_provider_list_result(provider_id, mapping, &value)
+}
+
+fn provider_lookup_timeout(provider: &WorktreeProviderConfig) -> Result<Duration> {
+    defaults::validate_worktree_provider_lookup_timeout_ms(provider.lookup_timeout_ms).map_err(
+        |message| {
+            Error::validation_invalid_argument(
+                "worktree_providers.lookup_timeout_ms",
+                message,
+                Some(provider.lookup_timeout_ms.to_string()),
+                None,
+            )
+        },
+    )?;
+    Ok(Duration::from_millis(provider.lookup_timeout_ms))
+}
+
+fn provider_lookup_output_limit(provider: &WorktreeProviderConfig) -> Result<usize> {
+    defaults::validate_worktree_provider_lookup_output_limit_bytes(
+        provider.lookup_output_limit_bytes,
+    )
+    .map_err(|message| {
+        Error::validation_invalid_argument(
+            "worktree_providers.lookup_output_limit_bytes",
+            message,
+            Some(provider.lookup_output_limit_bytes.to_string()),
+            None,
+        )
+    })?;
+    Ok(provider.lookup_output_limit_bytes)
 }
 
 fn provider_command_evidence(command: &[String], output: &std::process::Output) -> CommandEvidence {
@@ -1792,6 +1835,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
                         script.display().to_string(),
@@ -1880,6 +1925,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
                         script.display().to_string(),
@@ -1971,6 +2018,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
                         script.display().to_string(),
@@ -2016,6 +2065,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_preview: Some(vec![script, "preview".to_string()]),
                     cleanup_apply: None,
@@ -2045,6 +2096,8 @@ mod tests {
             enabled: true,
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 cleanup_preview: Some(vec![script]),
                 ..Default::default()
@@ -2116,6 +2169,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script, "apply".to_string()]),
                     ..Default::default()
@@ -2147,6 +2202,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script, "apply".to_string()]),
                     ..Default::default()
@@ -2182,6 +2239,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![script, "{handle}".to_string()]),
                     ..Default::default()
@@ -2212,6 +2271,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script]),
                     ..Default::default()
@@ -2242,6 +2303,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script]),
                     ..Default::default()
@@ -2265,8 +2328,11 @@ mod tests {
         let workspace = tempfile::tempdir().expect("workspace");
         let dir = unique_fixture_script_dir();
         let script = dir.join("provider");
-        fs::write(&script, "#!/bin/sh\nsleep 2\nprintf '{\"worktrees\":[]}'\n")
-            .expect("write provider");
+        fs::write(
+            &script,
+            "#!/bin/sh\nsleep 0.2\nprintf '{\"worktrees\":[]}'\n",
+        )
+        .expect("write provider");
         make_executable(&script);
 
         let error = resolve_worktree_provider_path_from_config(
@@ -2275,6 +2341,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 25,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script.to_string_lossy().to_string()]),
                     ..Default::default()
@@ -2285,6 +2353,70 @@ mod tests {
         .expect_err("a hung provider must be bounded");
 
         assert!(error.message.contains("timed out"));
+        assert!(error.message.contains("configured lookup_timeout_ms: 25"));
+    }
+
+    #[test]
+    fn configured_lookup_timeout_allows_a_slow_provider_response() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let script = fake_provider_script_body(&format!(
+            "sleep 0.1\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@cook-target\",\"path\":\"{}\",\"branch\":\"cook-target\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+            workspace.path().display()
+        ));
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: false,
+            lookup_timeout_ms: 1_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![script, "{handle}".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        };
+
+        let resolved = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(provider),
+        )
+        .expect("configured timeout allows provider response");
+        assert_eq!(resolved.path, workspace.path().display().to_string());
+    }
+
+    #[test]
+    fn configured_lookup_output_limit_accepts_large_provider_json() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let script = fake_list_provider_script(serde_json::json!({
+            "worktrees": [{
+                "handle": "fixture@cook-target",
+                "path": workspace.path(),
+                "branch": "cook-target",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }],
+            "padding": "x".repeat(70 * 1024),
+        }));
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: false,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 128 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![script, "{handle}".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        };
+
+        let resolved = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(provider),
+        )
+        .expect("configured output limit retains complete provider JSON");
+        assert_eq!(resolved.path, workspace.path().display().to_string());
     }
 
     #[test]
@@ -2323,6 +2455,8 @@ mod tests {
                     enabled: false,
                     kind: WorktreeProviderKind::Command,
                     apply_enabled: false,
+                    lookup_timeout_ms: 10_000,
+                    lookup_output_limit_bytes: 64 * 1024,
                     commands: WorktreeProviderCommands::default(),
                     list_result_mapping: None,
                 },
@@ -2363,6 +2497,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![resolve, "{handle}".to_string()]),
                     list: Some(vec![list]),
@@ -2412,6 +2548,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![script, "{handle}".to_string()]),
                     ..Default::default()
@@ -2451,6 +2589,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script]),
                     ..Default::default()
@@ -2608,6 +2748,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
                         script.display().to_string(),
@@ -2907,6 +3049,8 @@ mod tests {
                 enabled: true,
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script]),
                     ..Default::default()
@@ -2963,6 +3107,8 @@ mod tests {
             enabled: true,
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 list: Some(vec![script]),
                 ..Default::default()

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -198,13 +198,26 @@ pub fn resolve_worktree_provider_path_from_config(
         if !provider.enabled {
             continue;
         }
-        let Some(command) = provider.commands.list.as_ref() else {
-            continue;
+        let worktree = if let Some(command) = provider.commands.resolve_path.as_ref() {
+            let worktrees = run_provider_resolve_path_command(
+                &provider_id,
+                provider,
+                command,
+                requested.as_path(),
+            )?;
+            targeted_path_result(&provider_id, worktrees, requested.as_path())?
+        } else {
+            let Some(command) = provider.commands.list.as_ref() else {
+                continue;
+            };
+            run_provider_list_command(&provider_id, provider, command)?
+                .into_iter()
+                .find(|worktree| {
+                    std::fs::canonicalize(&worktree.path).ok().as_deref()
+                        == Some(requested.as_path())
+                })
         };
-        let worktrees = run_provider_list_command(&provider_id, provider, command)?;
-        let Some(worktree) = worktrees.into_iter().find(|worktree| {
-            std::fs::canonicalize(&worktree.path).ok().as_deref() == Some(requested.as_path())
-        }) else {
+        let Some(worktree) = worktree else {
             continue;
         };
         validate_provider_handle(&provider_id, &worktree, None, None)?;
@@ -585,6 +598,51 @@ fn run_provider_resolve_command(
         "resolve",
         &provider.commands.resolve_not_found_exit_codes,
     )
+}
+
+fn run_provider_resolve_path_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+    path: &std::path::Path,
+) -> Result<Vec<WorktreeProviderHandle>> {
+    let path = path.display().to_string();
+    let command = command
+        .iter()
+        .map(|argument| argument.replace("{path}", &path))
+        .collect::<Vec<_>>();
+    run_provider_lookup_command(
+        provider_id,
+        provider,
+        &command,
+        "resolve_path",
+        &provider.commands.resolve_not_found_exit_codes,
+    )
+}
+
+fn targeted_path_result(
+    provider_id: &str,
+    worktrees: Vec<WorktreeProviderHandle>,
+    requested: &std::path::Path,
+) -> Result<Option<WorktreeProviderHandle>> {
+    if worktrees.is_empty() {
+        return Ok(None);
+    }
+    if let Some(worktree) = worktrees
+        .into_iter()
+        .find(|worktree| std::fs::canonicalize(&worktree.path).ok().as_deref() == Some(requested))
+    {
+        return Ok(Some(worktree));
+    }
+    Err(Error::validation_invalid_argument(
+        "to_worktree",
+        format!(
+            "worktree provider `{provider_id}` resolve_path command did not return the requested canonical path {}",
+            requested.display()
+        ),
+        Some(provider_id.to_string()),
+        None,
+    ))
 }
 
 fn run_provider_list_command(
@@ -2287,7 +2345,7 @@ mod tests {
     }
 
     #[test]
-    fn path_resolution_accepts_an_explicit_provider_worktree_identity() {
+    fn path_resolution_falls_back_to_list_when_resolve_path_is_absent() {
         let workspace = tempfile::tempdir().expect("workspace");
         git_init(workspace.path(), "fix/10251");
         let script = fake_list_provider_script(json!({ "worktrees": [{
@@ -2321,6 +2379,113 @@ mod tests {
             resolution.worktree.path,
             workspace.path().display().to_string()
         );
+    }
+
+    #[test]
+    fn path_resolution_prefers_resolve_path_and_expands_the_canonical_path() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let requested = std::fs::canonicalize(workspace.path()).expect("canonical workspace");
+        let script = fake_provider_script_body(&format!(
+            "if [ \"$1\" != \"{}\" ]; then exit 44; fi\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@cook-target\",\"path\":\"{}\",\"branch\":\"cook-target\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+            requested.display(),
+            requested.display(),
+        ));
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: false,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve_path: Some(vec![script, "{path}".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        };
+
+        let resolution = resolve_worktree_provider_path_from_config(
+            workspace.path(),
+            &config_with_provider(provider),
+        )
+        .expect("path lookup succeeds")
+        .expect("provider owns requested path");
+        assert_eq!(resolution.worktree.path, requested.display().to_string());
+    }
+
+    #[test]
+    fn path_resolution_resolve_path_not_found_does_not_fall_back_to_list() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let marker = workspace.path().join("list-invoked");
+        let list =
+            fake_list_provider_script_with_marker(serde_json::json!({ "worktrees": [] }), &marker);
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: false,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve_path: Some(vec![
+                    fake_provider_script_body("exit 42\n"),
+                    "{path}".to_string(),
+                ]),
+                resolve_not_found_exit_codes: vec![42],
+                list: Some(vec![list]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        };
+
+        assert!(resolve_worktree_provider_path_from_config(
+            workspace.path(),
+            &config_with_provider(provider)
+        )
+        .expect("not found is not an error")
+        .is_none());
+        assert!(!marker.exists(), "list fallback must not run");
+    }
+
+    #[test]
+    fn path_resolution_resolve_path_rejects_malformed_or_mismatched_results() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let other = tempfile::tempdir().expect("other workspace");
+        git_init(other.path(), "cook-target");
+        let mismatched = fake_list_provider_script(serde_json::json!({
+            "worktrees": [{
+                "handle": "fixture@other",
+                "path": other.path(),
+                "branch": "cook-target",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }]
+        }));
+        for (script, expected) in [
+            (
+                fake_provider_script_body("printf '{'\n"),
+                "returned invalid JSON",
+            ),
+            (mismatched, "did not return the requested canonical path"),
+        ] {
+            let provider = WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve_path: Some(vec![script, "{path}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            };
+            let error = resolve_worktree_provider_path_from_config(
+                workspace.path(),
+                &config_with_provider(provider),
+            )
+            .expect_err("invalid targeted path result must fail closed");
+            assert!(error.message.contains(expected), "{}", error.message);
+        }
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -121,6 +121,8 @@ mod lab_source_path_tests {
                     enabled: true,
                     kind: defaults::WorktreeProviderKind::Command,
                     apply_enabled: false,
+                    lookup_timeout_ms: 10_000,
+                    lookup_output_limit_bytes: 64 * 1024,
                     commands: defaults::WorktreeProviderCommands {
                         list: Some(vec![script.display().to_string()]),
                         ..Default::default()


### PR DESCRIPTION
## Summary
- add bounded per-provider `lookup_timeout_ms` and `lookup_output_limit_bytes` for read-only provider lookups
- add optional targeted `commands.resolve_path` with exact `{path}` expansion, preferring it over exhaustive list discovery
- retain `list` as a backward-compatible path-resolution fallback when no targeted command is configured
- preserve existing 10s/64 KiB defaults, validate configured ranges, and expose effective values through config serialization
- report measured timeout duration and explicit truncation evidence

Addresses the timeout, bounded-output, and targeted path-resolution portions of #10567. Capability/readiness negotiation remains follow-up scope.

## Production evidence
- DMC list measured above the former hardcoded 10-second deadline
- candidate honored a 30-second configured deadline and reported 30,213ms elapsed
- candidate then exposed the independent 64 KiB truncation failure rather than misattributing it after the output-budget change
- a final 300-second bounded attempt terminated DMC cleanly at 300,287ms
- targeted path resolution now provides the generic route needed to avoid that exhaustive provider list entirely

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core configured_lookup_timeout -- --nocapture`
- `cargo test -p homeboy-core lookup_output_limit -- --nocapture`
- `cargo test -p homeboy-core worktree_provider_lookup_timeout -- --nocapture`
- `cargo test -p homeboy-core path_resolution -- --nocapture`
- `cargo check -p homeboy-core`
- `cargo test -p homeboy-cli --no-run`
- `cargo test -p homeboy-lab-runner --no-run`
- `cargo build --release --bin homeboy`
- `git diff --check`

Existing repository warnings remain unchanged.

## AI assistance
- Model: OpenAI `openai/gpt-5.6-sol`
- Tool: OpenCode
- Used for: production reproduction, source inspection, implementation, tests, and live candidate verification. Chris Huber reviewed and remains responsible for every line.