### PR TITLE
fix: report an exhausted test budget as a timeout, not a harness failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,57 @@ jobs:
             title: Audit
             section_key: audit
             section_title: Audit
+            # Audit and Lint are nowhere near their budget; leave them at the
+            # action defaults so raising the Test gate cannot mask a genuine
+            # hang in either of them.
+            execution_timeout_seconds: '1800'
+            test_timeout_seconds: '1500'
           - command: review lint
             title: Lint
             section_key: lint
             section_title: Lint
+            execution_timeout_seconds: '1800'
+            test_timeout_seconds: '1500'
           - command: review test
             title: Test
             section_key: test
             section_title: Test
+            # See #10639. Two budgets bound this gate, and the *inner* one is
+            # the binding constraint that produced 17 false-red runs on
+            # 2026-07-28:
+            #
+            #   test_timeout_seconds      -> HOMEBOY_TEST_TIMEOUT_SECONDS,
+            #     enforced by Homeboy itself around the test child
+            #     (DEFAULT_TEST_TIMEOUT_SECONDS = 25*60 in
+            #     crates/homeboy-extension/src/test/run.rs). This is what
+            #     actually fired at 1500s; the action's 1800s never got the
+            #     chance.
+            #   execution_timeout_seconds -> the action's outer wrapper.
+            #
+            # These are deliberately ordered inner < outer, with 300s of
+            # margin. The inner path returns Homeboy's structured evidence
+            # (counts, findings, retained output); the outer path SIGKILLs the
+            # process group and loses it. The inner timeout must always win the
+            # race, so the outer one is a backstop for a genuinely wedged
+            # process rather than the normal exit.
+            #
+            # 2700s is 1.8x the ceiling that was being hit and roughly 2.3x a
+            # median successful phase (~17-20 min once ~10 min of setup is
+            # subtracted from the job). Worst case is 2 phases (candidate +
+            # differential baseline) x 45 min + setup ~= 100 min, well inside
+            # GitHub's 360-minute job cap.
+            #
+            # This raises the budget for *this* repository only. It is set here
+            # rather than by changing the action's global default so other
+            # homeboy-action consumers keep their existing bounds.
+            execution_timeout_seconds: '3000'
+            test_timeout_seconds: '2700'
+    # Job-level env reaches the composite action's `run:` steps, and therefore
+    # the `homeboy` child process, without needing an action input or an
+    # action release. (Callers of the *reusable workflow* have no such path --
+    # that gap is Extra-Chill/homeboy-action#303.)
+    env:
+      HOMEBOY_TEST_TIMEOUT_SECONDS: ${{ matrix.test_timeout_seconds }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -124,6 +167,7 @@ jobs:
           # lands a bot commit mid-review and supersedes in-flight CI runs,
           # which reads as a spurious failure (see #3819). Require manual fixes.
           autofix: 'false'
+          execution-timeout-seconds: ${{ matrix.execution_timeout_seconds }}
           app-token: ${{ steps.app-token.outputs.token || github.token }}
           comment-section-key: ${{ matrix.section_key }}
           comment-section-title: ${{ matrix.section_title }}

--- a/crates/homeboy-extension/src/test/report.rs
+++ b/crates/homeboy-extension/src/test/report.rs
@@ -19,8 +19,38 @@ use homeboy_refactor_contract::AppliedRefactor;
 use serde::Serialize;
 use serde_json::Value;
 
-use super::run::{RawTestOutput, TestRunWorkflowResult};
+use super::run::{test_timeout, RawTestOutput, TestRunWorkflowResult};
 use super::workflow::{AutoFixDriftOutput, AutoFixDriftWorkflowResult, DriftWorkflowResult};
+
+/// Exit status Homeboy assigns when it terminates a child that exhausted its
+/// execution budget (`timed_out_exit_code` in `homeboy-core`).
+///
+/// A timeout is neither a test failure nor a broken harness: the suite is
+/// *incomplete*. Classifying it as either discards the distinction between
+/// "your change broke tests" and "the clock ran out", which is the only thing
+/// a reviewer needs in order to know whether to act. It must therefore be
+/// matched before any count-based branch, because a killed child usually never
+/// writes its results sidecar and so arrives with absent or partial counts.
+const TIMEOUT_EXIT_CODE: i32 = 124;
+
+/// Render a timeout as a timeout, naming the budget that was exhausted and
+/// whatever partial progress survived.
+///
+/// The budget is read back through the same `test_timeout()` accessor the run
+/// path used to arm the child, so the number reported is always the number
+/// actually enforced rather than a duplicated constant that can drift.
+fn test_timeout_summary(counts: Option<&TestCounts>) -> String {
+    let budget_seconds = test_timeout().as_secs();
+    match counts {
+        Some(counts) if counts.passed + counts.failed > 0 => format!(
+            "test phase timed out after {}s: {} passed, {} failed before termination, suite incomplete",
+            budget_seconds, counts.passed, counts.failed
+        ),
+        _ => format!(
+            "test phase timed out after {budget_seconds}s before reporting test counts, suite incomplete"
+        ),
+    }
+}
 
 /// Build output from a main test workflow result.
 pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, i32) {
@@ -185,6 +215,8 @@ fn test_phase_report(
             } else {
                 "test phase passed".to_string()
             }
+        } else if exit_code == TIMEOUT_EXIT_CODE {
+            test_timeout_summary(counts)
         } else if counts.map(|counts| counts.total == 0).unwrap_or(false) {
             "test runner reported zero executed tests".to_string()
         } else if has_findings {
@@ -215,6 +247,20 @@ fn test_phase_failure(
     counts: Option<&TestCounts>,
     has_findings: bool,
 ) -> PhaseFailure {
+    // Checked before `has_findings`: a suite killed mid-run can still have
+    // parsed a few structured failures, but partial findings from an aborted
+    // run are not a verdict. Classifying that as `Findings` would report "N
+    // test failure(s) detected" for a run that never finished. The findings
+    // themselves stay in the output envelope, so nothing is discarded here —
+    // only the phase label is corrected.
+    if exit_code == TIMEOUT_EXIT_CODE {
+        return PhaseFailure {
+            phase: VerificationPhase::Test,
+            summary: test_timeout_summary(counts),
+            category: PhaseFailureCategory::Infrastructure,
+        };
+    }
+
     let category = if has_findings {
         PhaseFailureCategory::Findings
     } else if exit_code != 0 && counts.map(|counts| counts.total == 0).unwrap_or(false) {
@@ -341,6 +387,105 @@ mod tests {
         assert_eq!(json["findings"][0]["file"], "tests/fails.rs");
         assert_eq!(json["findings"][0]["line"], 42);
         assert_eq!(json["failure"]["category"], "findings");
+    }
+
+    /// Recorded from job 90334340546 of run 30376771886: `homeboy review test`
+    /// exhausted its 1500s budget, the child was killed before writing its
+    /// results sidecar, and the phase was reported as
+    /// "test harness infrastructure failure (exit 124)" with zero counts.
+    fn timed_out_workflow_result(counts: Option<TestCounts>) -> TestRunWorkflowResult {
+        let mut result = workflow_result(None);
+        result.exit_code = 124;
+        result.test_counts = counts;
+        result
+    }
+
+    #[test]
+    fn a_timed_out_test_phase_is_not_reported_as_a_test_failure() {
+        let (output, exit_code) = from_main_workflow(timed_out_workflow_result(None));
+        let json = serde_json::to_value(output).expect("serialize test command output");
+
+        assert_eq!(exit_code, 124);
+
+        // The effect that matters: a reviewer must be able to tell a timeout
+        // apart from "your change broke tests" and from a broken harness.
+        let failure_summary = json["failure"]["summary"].as_str().expect("summary");
+        let phase_summary = json["phase"]["summary"].as_str().expect("phase summary");
+        for summary in [failure_summary, phase_summary] {
+            assert!(
+                summary.contains("timed out"),
+                "timeout must be named as a timeout, got: {summary}"
+            );
+            assert!(
+                summary.contains("suite incomplete"),
+                "timeout must state the suite did not finish, got: {summary}"
+            );
+            assert!(
+                !summary.contains("infrastructure failure"),
+                "a timeout is not a harness infrastructure failure, got: {summary}"
+            );
+            assert!(
+                !summary.contains("failure(s) detected"),
+                "a timeout is not a set of test failures, got: {summary}"
+            );
+        }
+
+        // `findings` remains the only category meaning "tests reported
+        // problems"; a timeout must never borrow it.
+        assert_ne!(json["failure"]["category"], "findings");
+    }
+
+    #[test]
+    fn a_timed_out_test_phase_reports_the_budget_and_partial_progress() {
+        let (output, _) = from_main_workflow(timed_out_workflow_result(Some(TestCounts::new(
+            412, 410, 2, 0,
+        ))));
+        let json = serde_json::to_value(output).expect("serialize test command output");
+        let summary = json["failure"]["summary"].as_str().expect("summary");
+
+        // The budget reported is the budget enforced, read back through the
+        // same accessor the run path arms the child with.
+        let budget = super::test_timeout().as_secs();
+        assert!(
+            summary.contains(&format!("after {budget}s")),
+            "timeout must name the budget it exhausted, got: {summary}"
+        );
+        assert!(
+            summary.contains("410 passed"),
+            "work completed before termination must survive, got: {summary}"
+        );
+        assert!(
+            summary.contains("suite incomplete"),
+            "partial counts must not read as a final verdict, got: {summary}"
+        );
+    }
+
+    #[test]
+    fn partial_findings_from_an_aborted_run_do_not_become_a_test_failure_verdict() {
+        // A suite killed mid-run can still have parsed a few failures. That is
+        // not a verdict, and the phase must not be labelled as one -- but the
+        // findings themselves must still reach the reader.
+        let mut result = timed_out_workflow_result(Some(TestCounts::new(9, 8, 1, 0)));
+        result.findings = Some(vec![HomeboyFinding::builder("test", "assertion failed")
+            .rule("AssertionFailed")
+            .severity("error")
+            .build()]);
+
+        let (output, _) = from_main_workflow(result);
+        let json = serde_json::to_value(output).expect("serialize test command output");
+
+        assert_ne!(
+            json["failure"]["category"], "findings",
+            "an incomplete run cannot deliver a findings verdict"
+        );
+        assert!(json["failure"]["summary"]
+            .as_str()
+            .expect("summary")
+            .contains("timed out"));
+        assert_eq!(
+            json["findings"][0]["message"], "assertion failed",
+            "evidence must be preserved even though the label changes"
+        );
     }
 
     #[test]

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -56,7 +56,7 @@ const NO_TESTS_APPLICABLE_EXTENSION_ENV: &str = "HOMEBOY_NO_TESTS_APPLICABLE_EXT
 const NO_TESTS_APPLICABLE_STEP: &str = "test";
 const DEFAULT_TEST_TIMEOUT_SECONDS: u64 = 25 * 60;
 
-fn test_timeout() -> Duration {
+pub(crate) fn test_timeout() -> Duration {
     std::env::var("HOMEBOY_TEST_TIMEOUT_SECONDS")
         .ok()
         .and_then(|value| value.parse::<u64>().ok())


### PR DESCRIPTION
Fixes #10639.

## The framing was wrong in two ways — evidence first

**1. The binding timeout is not `execution-timeout-seconds`.**

The Test gate does not time out at the action's 1800 s. It times out at Homeboy's own:

```rust
// crates/homeboy-extension/src/test/run.rs:57
const DEFAULT_TEST_TIMEOUT_SECONDS: u64 = 25 * 60;   // 1500
```

Phase boundaries from job 90334340546 of [run 30376771886](https://github.com/Extra-Chill/homeboy/actions/runs/30376771886):

| phase | start | end | elapsed |
|---|---|---|---|
| candidate `review test` | 16:18:12 | 16:43:14 | **1502 s** |
| baseline (differential gating) | 16:43:16 | 17:08:17 | **1501 s** |

`differential-gating: true` runs the suite twice, so an exhausted Test job is `2 × 1500 s ≈ 60 min` — exactly the 17 failures today clustered at **59.3–60.4 min**. The action's 1800 s never gets a chance to fire. **Raising only `execution-timeout-seconds` would have changed nothing.**

**2. PR #10551 did not cause this.** Median `homeboy / Test` job duration, successes only:

```
07-27T18   25.3      07-28T04   43.8  <-- step change here
07-28T01   25.4      07-28T05   44.2
07-28T02   25.6      07-28T06   40.1
07-28T03   32.3      --- #10551 merged 10:12 ---
                     07-28T10   43.6
                     07-28T13   50.8
```

The 25 → 44 min step lands between **03:20 and 04:34 UTC**, about **six hours before #10551 merged at 10:12**. Across the merge boundary the median is flat (40.1 → 43.6). The hypothesis does not hold; the regression window worth investigating is 03:20–04:34, with a second escalation near 13:00. That is left open in #10639 rather than guessed at here.

**Not a hang.** Phases complete inside the budget throughout, and runs at 16:28–16:49 return to ~26 min. The suite is doing real work and finishing — it has outgrown a budget nobody revisited.

## The dishonest classification

On timeout `local_exec.rs` returns exit 124. `test_phase_failure` had **no branch for it**, so it fell through to `phase_failure_category_from_exit_code`, which returns `Infrastructure` for any `exit_code >= 2`:

```json
"failure": { "category": "infrastructure",
             "summary": "test harness infrastructure failure (exit 124)" },
"summary": { "failed": 0, "passed": 0, "total": 0 }
```

Zero counts — while 729 KB of retained stdout held thousands of `... ok` lines **and three genuine `FAILED` tests**. The timeout destroyed signal in both directions. Three PRs (#10607, #10608, #10617) merged against this red gate.

## Changes

**Classify exit 124 explicitly**, in both `test_phase_report` and `test_phase_failure`, ahead of every count-based and findings-based branch:

- *Before the count branches*, because a killed child rarely writes its results sidecar, so counts arrive absent or partial.
- *Before `has_findings`*, because a suite killed mid-run may have parsed a few failures, and partial findings from an aborted run are not a verdict. The findings themselves stay in the output envelope — **only the label changes, no evidence is discarded**.

The budget in the message is read back through the same `test_timeout()` accessor the run path arms the child with, so the number reported can never drift from the number enforced.

```
before:  test harness infrastructure failure (exit 124)
after:   test phase timed out after 2700s: 410 passed, 2 failed before termination, suite incomplete
         test phase timed out after 2700s before reporting test counts, suite incomplete
```

**Raise the budget**, scoped to this repository's Test matrix entry:

| | inner `HOMEBOY_TEST_TIMEOUT_SECONDS` | outer `execution-timeout-seconds` |
|---|---|---|
| Audit / Lint | 1500 (unchanged) | 1800 (unchanged) |
| Test | **2700** | **3000** |

Audit and Lint stay at the defaults so raising Test cannot mask a genuine hang in either.

**How 2700 was chosen.** The enforced ceiling was 1500 s and 17 runs hit it exactly. Subtracting ~10 min of setup from job totals puts a median successful phase at ~17–20 min, with the worst ≥ 25 min. 2700 s is **1.8× the ceiling being hit and ~2.3× the median phase**. Worst case is 2 phases × 45 min + setup ≈ 100 min, well inside GitHub's 360-minute job cap. Generous is the right bias: the cost of a false red is reviewers learning to ignore the gate, which already happened three times today.

**Why inner < outer, by 300 s.** The inner path returns Homeboy's structured evidence — counts, findings, retained output. The outer path SIGKILLs the process group and loses it. The inner timeout must always win the race; the outer one is a backstop for a genuinely wedged process, not the normal exit. That ordering, not the specific numbers, is the durable part.

## No action release required

Set through job-level `env:`, which reaches the composite action's `run:` steps and therefore the `homeboy` child **without any action change**. This lands against the unchanged `v2` tag and the false reds stop on merge.

The companion Extra-Chill/homeboy-action#305 fixes the differential gate's handling of timeouts and **does** need `v2` re-pointed to take effect. Cutting that release is an operator action; I have not done it. Extra-Chill/homeboy-action#303 (reusable-workflow callers cannot set the inner budget at all) remains open.

## Reported, deliberately not fixed here

`tests/reverse_cook_queue_acceptance.rs::detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once` runs **424 s** as the sole test in its binary — ~28% of the entire old budget in one test. Next slowest binaries are 75 s and 73 s. The Test phase also runs `cargo fmt` and a full workspace `cargo clippy` before any test executes, sharing the same budget.

I could **not** attribute how much of the 1500 s clippy consumed: intra-phase timestamps in the job log are all flushed when the retained log is `cat`ed at phase end, so they are unusable for that. Claiming otherwise would have been a guess. Suite duration is tracked in #10639.

## Verification I could not do

No cargo on this host — `cargo build`/`test`/`check`/`clippy` are all barred here. `cargo fmt --all` passes, which parses both edited files, so the changes are syntactically valid; type-checking and the new unit tests are CI's job. The changed Rust is confined to two functions plus a visibility widening (`fn test_timeout` → `pub(crate)`, called from a sibling module in the same crate). `PhaseFailureCategory` was deliberately **not** given a new variant: it has 13 match sites, and an exhaustiveness break I cannot compile-check is not worth it. A dedicated `Timeout` category is the right follow-up once someone can build.

Three unit tests pin the classification: a timeout is never labelled a test failure or a harness failure, it reports the budget and partial progress, and partial findings from an aborted run do not become a findings verdict while the findings themselves still reach the reader.

## AI assistance

- Agent: chubes-bot (Claude Code)
- Used for: correlating job-level durations across 100 CI runs against the #10551 merge boundary, extracting phase timings and retained result JSON from job 90334340546, and tracing the timeout path through `local_exec.rs` → `test/run.rs` → `test/report.rs`.
