### PR TITLE
fix: route nested singular test directories

### DIFF
--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -998,6 +998,7 @@ fn is_direct_changed_test_path(file: &str) -> bool {
         || path_lower.starts_with("test/")
         || path_lower.starts_with("__tests__/")
         || path_lower.contains("/tests/")
+        || path_lower.contains("/test/")
         || path_lower.contains("/__tests__/")
     {
         return true;
@@ -1085,11 +1086,19 @@ mod tests {
         );
         assert_eq!(
             changed_test_file_for_path("src/core/extension/test/mod.rs"),
-            None
+            Some("src/core/extension/test/mod.rs".to_string())
         );
         assert_eq!(
             changed_test_file_for_path("src/core/audit_test.rs"),
             Some("src/core/audit_test.rs".to_string())
+        );
+        assert_eq!(
+            changed_test_file_for_path("crates/homeboy-extension/src/test/report.rs"),
+            Some("crates/homeboy-extension/src/test/report.rs".to_string())
+        );
+        assert_eq!(
+            changed_test_file_for_path("crates/homeboy-extension/src/test/run.rs"),
+            Some("crates/homeboy-extension/src/test/run.rs".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- recognize nested singular `test/` directories as direct changed-test paths
- cover the exact `homeboy-extension/src/test/report.rs` and `run.rs` paths rejected by the release gate
- preserve support-only Rust module behavior through the existing full-suite fallback

## Verification
- `cargo test -p homeboy-extension changed_scope_maps_contract_fixtures_to_regression_tests --lib`
- `cargo test -p homeboy-extension test::tests --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #10656

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode diagnosed the path-classification mismatch, drafted the focused code/test change, and ran the listed verification. Chris Huber remains responsible for the final change.