### PR TITLE
Retain workspace authority through cleanup

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -51,6 +51,7 @@ mod private_attachment;
 mod records;
 pub mod runner_continuation;
 mod runner_exec;
+mod workspace_authority;
 
 pub use artifact_materialization::*;
 pub use cancellation::*;
@@ -76,6 +77,7 @@ pub use runner_continuation::{
     register_runner_continuation_provider, RunnerContinuationProvider, RunnerJobReconciliation,
 };
 pub use runner_exec::*;
+pub use workspace_authority::*;
 
 pub(crate) use conversion::*;
 pub(crate) use lifecycle_record_ops::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -40,19 +40,25 @@ pub fn accepted_lab_runner_job_identity(
     run_id: &str,
 ) -> Result<Option<homeboy_core::lab_contract::RunnerJobIdentity>> {
     let record = store::read_record(&sanitize_run_id(run_id))?;
+    Ok(accepted_lab_runner_job_identity_from_record(&record))
+}
+
+pub(crate) fn accepted_lab_runner_job_identity_from_record(
+    record: &AgentTaskRunRecord,
+) -> Option<homeboy_core::lab_contract::RunnerJobIdentity> {
     let Some(handoff) = record.lab_handoff.as_ref().filter(|handoff| {
         handoff.validation_error().is_none()
             && handoff.state == AgentTaskLabHandoffState::Accepted
             && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
     }) else {
-        return Ok(None);
+        return None;
     };
     let identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
         &record.run_id,
         &handoff.runner_id,
         handoff.runner_job_id.clone().unwrap_or_default(),
     );
-    Ok(identity.is_complete().then_some(identity))
+    identity.is_complete().then_some(identity)
 }
 
 /// Metadata `kind` marker for a generic runner-execution run. It distinguishes

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -1340,6 +1340,15 @@ fn runner_terminal_reconciliation_is_idempotent_and_preserves_execution_owner() 
             &[],
         );
         store::write_record(&record).expect("terminal record");
+        let receipt = resolve_workspace_terminal_authority(
+            "agent-task-terminal-proxy",
+            "homeboy-lab",
+            "/runner/workspace/repo",
+            Some("job-456"),
+        )
+        .expect("resolve terminal workspace authority")
+        .expect("terminal workspace authority persisted");
+        assert_eq!(receipt.runner_job_id, "job-456");
 
         let retry = record_detached_lab_run(DetachedLabRunRecord {
             run_id: "agent-task-terminal-proxy",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
@@ -1,0 +1,442 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::*;
+
+const WORKSPACE_TERMINAL_AUTHORITY_SCHEMA: &str = "homeboy/workspace-terminal-authority/v1";
+const WORKSPACE_TERMINAL_AUTHORITY_RELEASE_SCHEMA: &str =
+    "homeboy/workspace-terminal-authority-release/v1";
+
+/// Terminal authority retained independently from compactable run records until
+/// the runner workspace that it protects has been durably removed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceTerminalAuthorityReceipt {
+    pub schema: String,
+    pub run_id: String,
+    pub runner_id: String,
+    pub runner_job_id: String,
+    pub remote_workspace: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct WorkspaceTerminalAuthorityRelease {
+    schema: String,
+    run_id: String,
+    runner_id: String,
+    remote_workspace: String,
+    state: String,
+}
+
+fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(run_id.as_bytes());
+    digest.update([0]);
+    digest.update(runner_id.as_bytes());
+    digest.update([0]);
+    digest.update(remote_workspace.as_bytes());
+    format!("{:x}", digest.finalize())
+}
+
+fn receipt_path(run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("workspace-terminal-authority")
+        .join(format!(
+            "{}.json",
+            authority_digest(run_id, runner_id, remote_workspace)
+        )))
+}
+
+fn release_path(run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("workspace-terminal-authority")
+        .join(format!(
+            "{}.release.json",
+            authority_digest(run_id, runner_id, remote_workspace)
+        )))
+}
+
+pub(crate) fn persist_terminal_from_record(record: &AgentTaskRunRecord) -> Result<()> {
+    if !record.state.is_terminal() {
+        return Ok(());
+    }
+    let Some(identity) = accepted_lab_runner_job_identity_from_record(record) else {
+        return Ok(());
+    };
+    let Some(remote_workspace) = record
+        .metadata
+        .get("remote_workspace")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(());
+    };
+    let receipt = WorkspaceTerminalAuthorityReceipt {
+        schema: WORKSPACE_TERMINAL_AUTHORITY_SCHEMA.to_string(),
+        run_id: record.run_id.clone(),
+        runner_id: identity.runner_id,
+        runner_job_id: identity.runner_job_id,
+        remote_workspace: remote_workspace.to_string(),
+    };
+    persist_workspace_terminal_authority(receipt)
+}
+
+fn persist_workspace_terminal_authority(receipt: WorkspaceTerminalAuthorityReceipt) -> Result<()> {
+    let path = receipt_path(
+        &receipt.run_id,
+        &receipt.runner_id,
+        &receipt.remote_workspace,
+    )?;
+    let release_path = release_path(
+        &receipt.run_id,
+        &receipt.runner_id,
+        &receipt.remote_workspace,
+    )?;
+    homeboy_core::config::with_config_lock(|| {
+        if release_path.exists() {
+            read_release(
+                &release_path,
+                &receipt.run_id,
+                &receipt.runner_id,
+                &receipt.remote_workspace,
+            )?;
+            return Ok(());
+        }
+        if path.exists() {
+            let existing: WorkspaceTerminalAuthorityReceipt =
+                serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?)
+                .map_err(|error| {
+                    Error::internal_json(error.to_string(), Some(path.display().to_string()))
+                })?;
+            if existing == receipt {
+                return Ok(());
+            }
+            return Err(Error::validation_invalid_argument(
+                "workspace_terminal_authority",
+                "workspace terminal authority receipt conflicts with existing immutable receipt",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+        homeboy_core::engine::local_files::write_json_file_owner_only(&path, &receipt)
+    })
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub fn persist_workspace_terminal_authority_for_test(
+    run_id: &str,
+    runner_id: &str,
+    runner_job_id: &str,
+    remote_workspace: &str,
+) -> Result<()> {
+    persist_workspace_terminal_authority(WorkspaceTerminalAuthorityReceipt {
+        schema: WORKSPACE_TERMINAL_AUTHORITY_SCHEMA.to_string(),
+        run_id: run_id.to_string(),
+        runner_id: runner_id.to_string(),
+        runner_job_id: runner_job_id.to_string(),
+        remote_workspace: remote_workspace.to_string(),
+    })
+}
+
+pub fn resolve_workspace_terminal_authority(
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+    job_id: Option<&str>,
+) -> Result<Option<WorkspaceTerminalAuthorityReceipt>> {
+    let path = receipt_path(run_id, runner_id, remote_workspace)?;
+    let release_path = release_path(run_id, runner_id, remote_workspace)?;
+    if release_path.exists() {
+        let release = read_release(&release_path, run_id, runner_id, remote_workspace)?;
+        return match release.state.as_str() {
+            "pending" | "released" => Err(Error::validation_invalid_argument(
+                "workspace_terminal_authority",
+                format!("workspace terminal authority release is {}", release.state),
+                Some(release_path.display().to_string()),
+                None,
+            )),
+            _ => Err(invalid_release_error(&release_path)),
+        };
+    }
+    if !path.exists() {
+        return Ok(None);
+    }
+    let receipt: WorkspaceTerminalAuthorityReceipt =
+        serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?)
+        .map_err(|error| {
+            Error::internal_json(error.to_string(), Some(path.display().to_string()))
+        })?;
+    let valid = receipt.schema == WORKSPACE_TERMINAL_AUTHORITY_SCHEMA
+        && receipt.run_id == run_id
+        && receipt.runner_id == runner_id
+        && receipt.remote_workspace == remote_workspace
+        && !receipt.runner_job_id.is_empty()
+        && job_id.is_none_or(|job_id| job_id == receipt.runner_job_id);
+    valid.then_some(receipt).map(Some).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_terminal_authority",
+            "workspace terminal authority receipt is malformed or contradicts workspace ownership",
+            Some(path.display().to_string()),
+            None,
+        )
+    })
+}
+
+pub fn workspace_terminal_authority_release_is_pending(
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+) -> Result<bool> {
+    let path = release_path(run_id, runner_id, remote_workspace)?;
+    if !path.exists() {
+        return Ok(false);
+    }
+    Ok(read_release(&path, run_id, runner_id, remote_workspace)?.state == "pending")
+}
+
+pub fn begin_workspace_terminal_authority_release(
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+) -> Result<()> {
+    let path = release_path(run_id, runner_id, remote_workspace)?;
+    homeboy_core::config::with_config_lock(|| {
+        if path.exists() {
+            let release = read_release(&path, run_id, runner_id, remote_workspace)?;
+            return match release.state.as_str() {
+                "pending" => Ok(()),
+                "released" => Err(Error::validation_invalid_argument(
+                    "workspace_terminal_authority",
+                    "workspace terminal authority was already released",
+                    Some(path.display().to_string()),
+                    None,
+                )),
+                _ => Err(invalid_release_error(&path)),
+            };
+        }
+        write_release(&path, run_id, runner_id, remote_workspace, "pending")
+    })
+}
+
+pub fn abort_workspace_terminal_authority_release(
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+) -> Result<()> {
+    let path = release_path(run_id, runner_id, remote_workspace)?;
+    homeboy_core::config::with_config_lock(|| {
+        if !path.exists() {
+            return Ok(());
+        }
+        let release = read_release(&path, run_id, runner_id, remote_workspace)?;
+        if release.state != "pending" {
+            return Err(invalid_release_error(&path));
+        }
+        std::fs::remove_file(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })
+    })
+}
+
+pub fn remove_workspace_terminal_authority(
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+) -> Result<()> {
+    let path = receipt_path(run_id, runner_id, remote_workspace)?;
+    let release_path = release_path(run_id, runner_id, remote_workspace)?;
+    homeboy_core::config::with_config_lock(|| {
+        write_release(
+            &release_path,
+            run_id,
+            runner_id,
+            remote_workspace,
+            "released",
+        )?;
+        if path.exists() {
+            std::fs::remove_file(&path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(path.display().to_string()))
+            })?;
+        }
+        Ok(())
+    })
+}
+
+fn write_release(
+    path: &std::path::Path,
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+    state: &str,
+) -> Result<()> {
+    homeboy_core::engine::local_files::write_json_file_owner_only(
+        path,
+        &WorkspaceTerminalAuthorityRelease {
+            schema: WORKSPACE_TERMINAL_AUTHORITY_RELEASE_SCHEMA.to_string(),
+            run_id: run_id.to_string(),
+            runner_id: runner_id.to_string(),
+            remote_workspace: remote_workspace.to_string(),
+            state: state.to_string(),
+        },
+    )
+}
+
+fn read_release(
+    path: &std::path::Path,
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+) -> Result<WorkspaceTerminalAuthorityRelease> {
+    let release: WorkspaceTerminalAuthorityRelease =
+        serde_json::from_slice(&std::fs::read(path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?)
+        .map_err(|error| {
+            Error::internal_json(error.to_string(), Some(path.display().to_string()))
+        })?;
+    (release.schema == WORKSPACE_TERMINAL_AUTHORITY_RELEASE_SCHEMA
+        && release.run_id == run_id
+        && release.runner_id == runner_id
+        && release.remote_workspace == remote_workspace
+        && matches!(release.state.as_str(), "pending" | "released"))
+    .then_some(release)
+    .ok_or_else(|| invalid_release_error(path))
+}
+
+fn invalid_release_error(path: &std::path::Path) -> Error {
+    Error::validation_invalid_argument(
+        "workspace_terminal_authority",
+        "workspace terminal authority release marker is malformed or contradicts workspace ownership",
+        Some(path.display().to_string()),
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipt_survives_run_record_compaction_and_requires_exact_binding() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let receipt = WorkspaceTerminalAuthorityReceipt {
+                schema: WORKSPACE_TERMINAL_AUTHORITY_SCHEMA.to_string(),
+                run_id: "run-1".to_string(),
+                runner_id: "reverse-or-direct".to_string(),
+                runner_job_id: "job-1".to_string(),
+                remote_workspace: "/runner/_lab_workspaces/workspace-1".to_string(),
+            };
+            persist_workspace_terminal_authority(receipt.clone()).expect("persist receipt");
+            persist_workspace_terminal_authority(receipt)
+                .expect("terminal progression is idempotent");
+
+            assert!(resolve_workspace_terminal_authority(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+                Some("job-1")
+            )
+            .expect("resolve after lifecycle compaction")
+            .is_some());
+            assert!(resolve_workspace_terminal_authority(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+                Some("other-job")
+            )
+            .is_err());
+            begin_workspace_terminal_authority_release(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+            )
+            .expect("begin workspace cleanup");
+            assert!(resolve_workspace_terminal_authority(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+                Some("job-1")
+            )
+            .is_err());
+            assert!(workspace_terminal_authority_release_is_pending(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+            )
+            .expect("pending cleanup authority"));
+            abort_workspace_terminal_authority_release(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+            )
+            .expect("abort failed workspace cleanup");
+            assert!(resolve_workspace_terminal_authority(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+                Some("job-1")
+            )
+            .expect("authority restored after cleanup abort")
+            .is_some());
+            remove_workspace_terminal_authority(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+            )
+            .expect("remove after workspace cleanup");
+            assert!(resolve_workspace_terminal_authority(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+                Some("job-1")
+            )
+            .is_err());
+            persist_workspace_terminal_authority_for_test(
+                "run-1",
+                "reverse-or-direct",
+                "job-1",
+                "/runner/_lab_workspaces/workspace-1",
+            )
+            .expect("late terminal projection is suppressed");
+            assert!(resolve_workspace_terminal_authority(
+                "run-1",
+                "reverse-or-direct",
+                "/runner/_lab_workspaces/workspace-1",
+                Some("job-1")
+            )
+            .is_err());
+        });
+    }
+
+    #[test]
+    fn malformed_or_mixed_version_receipts_fail_closed() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let path =
+                receipt_path("run-1", "runner-1", "/runner/workspace").expect("receipt path");
+            homeboy_core::engine::local_files::write_json_file_owner_only(
+                &path,
+                &serde_json::json!({
+                    "schema": "homeboy/workspace-terminal-authority/v2",
+                    "run_id": "run-1",
+                    "runner_id": "runner-1",
+                    "runner_job_id": "job-1",
+                    "remote_workspace": "/runner/workspace"
+                }),
+            )
+            .expect("persist unsupported receipt");
+
+            assert!(resolve_workspace_terminal_authority(
+                "run-1",
+                "runner-1",
+                "/runner/workspace",
+                Some("job-1")
+            )
+            .is_err());
+        });
+    }
+}

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -198,7 +198,14 @@ fn write_record_with_aggregate(
         git_sha: None,
         rig_id: None,
         metadata_json,
-    })
+    })?;
+    let committed = store.get_run(&record.run_id)?.ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "committed agent-task run record is unavailable: {}",
+            record.run_id
+        ))
+    })?;
+    super::workspace_authority::persist_terminal_from_record(&record_from_run(&committed)?)
 }
 
 pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {

--- a/crates/homeboy-lab-runner/Cargo.toml
+++ b/crates/homeboy-lab-runner/Cargo.toml
@@ -41,4 +41,4 @@ uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
 [dev-dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
 homeboy-rig = { version = "0.1.0", path = "../homeboy-rig" }
-homeboy-agents = { version = "0.1.0", path = "../homeboy-agents" }
+homeboy-agents = { version = "0.1.0", path = "../homeboy-agents", features = ["test-support"] }

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -39,10 +39,10 @@ use super::types::{
     canonical_workspace_path, ByteFileCounts, LocalGitState, RunnerWorkspaceCurrentSummary,
     RunnerWorkspaceLivenessEvidence, RunnerWorkspaceMaterializationPlan, RunnerWorkspaceMetadata,
     RunnerWorkspacePruneEntry, RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput,
-    RunnerWorkspacePruneSkippedEntry, RunnerWorkspaceSnapshotEntry, RunnerWorkspaceSnapshotFilters,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
-    RunnerWorkspaceTerminalEvidence, RunnerWorkspaceUpdateOptions, RunnerWorkspaceUpdateOutput,
-    DEFAULT_EXCLUDES,
+    RunnerWorkspacePruneSkippedEntry, RunnerWorkspacePruneWithheldReason,
+    RunnerWorkspaceSnapshotEntry, RunnerWorkspaceSnapshotFilters, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput, RunnerWorkspaceTerminalEvidence,
+    RunnerWorkspaceUpdateOptions, RunnerWorkspaceUpdateOutput, DEFAULT_EXCLUDES,
 };
 use super::util::{
     deterministic_remote_path, git_output, parent_remote_path, ssh_client_for_runner,
@@ -1173,6 +1173,7 @@ pub fn prune_workspaces(
     let mut skipped = Vec::new();
     let mut skipped_live_count = 0;
     let mut skipped_unknown_count = 0;
+    let mut withheld_workspaces = std::collections::BTreeMap::<String, (String, u64)>::new();
     let mut stop_commands = Vec::new();
     let mut candidate_entries = Vec::new();
     let mut total_candidate_count = 0;
@@ -1212,6 +1213,13 @@ pub fn prune_workspaces(
                         )
                     }),
             );
+            let reason = withheld
+                .liveness
+                .observations
+                .first()
+                .cloned()
+                .unwrap_or_else(|| withheld.liveness.state.clone());
+            withheld_workspaces.insert(withheld.remote_path.clone(), (reason, withheld.bytes));
             skipped.push(RunnerWorkspacePruneSkippedEntry {
                 remote_path: withheld.remote_path,
                 reason: format!(
@@ -1239,30 +1247,57 @@ pub fn prune_workspaces(
             // The scan is only a snapshot. Recheck ownership at the destructive boundary.
             match revalidate_candidate_liveness(&runner, &candidate) {
                 Ok(liveness) if revalidated_candidate_is_deletable(&liveness) => {
+                    begin_workspace_terminal_authority_release(&runner, &candidate)?;
                     match remove_prune_candidate(&runner, &lab_workspaces_root, &candidate) {
-                        Ok(None) => removed.push(candidate),
-                        Ok(Some(liveness)) => skipped.push(RunnerWorkspacePruneSkippedEntry {
-                            remote_path: candidate.remote_path,
-                            reason: format!(
-                                "workspace liveness changed to {}; {}",
-                                liveness.state,
-                                liveness.observations.join(", ")
-                            ),
-                        }),
+                        Ok(None) => {
+                            remove_workspace_terminal_authority_receipt(&runner, &candidate)?;
+                            withheld_workspaces.remove(&candidate.remote_path);
+                            removed.push(candidate)
+                        }
+                        Ok(Some(liveness)) => {
+                            abort_workspace_terminal_authority_release(&runner, &candidate)?;
+                            record_withheld_liveness(
+                                &mut withheld_workspaces,
+                                &mut skipped_live_count,
+                                &mut skipped_unknown_count,
+                                &candidate,
+                                &liveness,
+                            );
+                            skipped.push(RunnerWorkspacePruneSkippedEntry {
+                                remote_path: candidate.remote_path,
+                                reason: format!(
+                                    "workspace liveness changed to {}; {}",
+                                    liveness.state,
+                                    liveness.observations.join(", ")
+                                ),
+                            })
+                        }
+                        // Transport errors cannot prove that a remote delete did
+                        // not complete. Keep the pending marker so a late terminal
+                        // projection cannot recreate authority for a removed path.
                         Err(err) => skipped.push(RunnerWorkspacePruneSkippedEntry {
                             remote_path: candidate.remote_path,
                             reason: err.to_string(),
                         }),
                     }
                 }
-                Ok(liveness) => skipped.push(RunnerWorkspacePruneSkippedEntry {
-                    remote_path: candidate.remote_path,
-                    reason: format!(
-                        "workspace liveness changed to {}; {}",
-                        liveness.state,
-                        liveness.observations.join(", ")
-                    ),
-                }),
+                Ok(liveness) => {
+                    record_withheld_liveness(
+                        &mut withheld_workspaces,
+                        &mut skipped_live_count,
+                        &mut skipped_unknown_count,
+                        &candidate,
+                        &liveness,
+                    );
+                    skipped.push(RunnerWorkspacePruneSkippedEntry {
+                        remote_path: candidate.remote_path,
+                        reason: format!(
+                            "workspace liveness changed to {}; {}",
+                            liveness.state,
+                            liveness.observations.join(", ")
+                        ),
+                    })
+                }
                 Err(err) => skipped.push(RunnerWorkspacePruneSkippedEntry {
                     remote_path: candidate.remote_path,
                     reason: err.to_string(),
@@ -1317,6 +1352,26 @@ pub fn prune_workspaces(
             skipped,
             skipped_live_count,
             skipped_unknown_count,
+            withheld_by_liveness_reason: withheld_workspaces
+                .into_values()
+                .fold(
+                    std::collections::BTreeMap::<String, (usize, u64)>::new(),
+                    |mut grouped, (reason, bytes)| {
+                        let entry = grouped.entry(reason).or_default();
+                        entry.0 += 1;
+                        entry.1 += bytes;
+                        grouped
+                    },
+                )
+                .into_iter()
+                .map(
+                    |(reason, (workspace_count, bytes))| RunnerWorkspacePruneWithheldReason {
+                        reason,
+                        workspace_count,
+                        bytes,
+                    },
+                )
+                .collect(),
             inspect_command: format!("homeboy runner status {runner_arg}"),
             stop_command: stop_commands.into_iter().next().unwrap_or_else(|| {
                 format!("homeboy runner doctor {runner_arg} --scope lab-offload --repair")
@@ -1336,6 +1391,26 @@ pub fn prune_workspaces(
         },
         0,
     ))
+}
+
+fn record_withheld_liveness(
+    withheld: &mut std::collections::BTreeMap<String, (String, u64)>,
+    live_count: &mut usize,
+    unknown_count: &mut usize,
+    candidate: &RunnerWorkspacePruneEntry,
+    liveness: &RunnerWorkspaceLivenessEvidence,
+) {
+    if liveness.state == "live" {
+        *live_count += 1;
+    } else {
+        *unknown_count += 1;
+    }
+    let reason = liveness
+        .observations
+        .first()
+        .cloned()
+        .unwrap_or_else(|| liveness.state.clone());
+    withheld.insert(candidate.remote_path.clone(), (reason, candidate.bytes));
 }
 
 fn prune_candidates_for_runner(
@@ -1400,7 +1475,22 @@ pub fn reap_run_workspace(
     })?;
     validate_absolute_path("workspace_root", workspace_root)?;
     let lab_workspaces_root = format!("{}/_lab_workspaces", workspace_root.trim_end_matches('/'));
-    remove_workspace(&runner, &lab_workspaces_root, remote_path)?;
+    validate_workspace_removal_path(Path::new(&lab_workspaces_root), Path::new(remote_path))?;
+    // Capture the immutable receipt key before removal; the receipt is released
+    // only after the workspace deletion has durably completed.
+    let run_id = workspace_metadata_run_id(&runner, remote_path)?;
+    if let Some(run_id) = run_id.as_deref() {
+        homeboy_agents::agent_task_lifecycle::begin_workspace_terminal_authority_release(
+            run_id,
+            &runner.id,
+            remote_path,
+        )?;
+    }
+    if let Err(error) = remove_workspace(&runner, &lab_workspaces_root, remote_path) {
+        // The remote side may have completed deletion before transport failed.
+        // Retain pending authority so either outcome remains safe and resumable.
+        return Err(error);
+    }
     // The sibling Homeboy artifact directory (`<checkout>-homeboy-artifacts`)
     // also lives under `_lab_workspaces`, so it passes the same containment
     // guard. It only exists when the run requested `--output`, so a
@@ -1409,7 +1499,45 @@ pub fn reap_run_workspace(
     if let Some(artifact_dir) = artifact_dir {
         let _ = remove_workspace(&runner, &lab_workspaces_root, artifact_dir);
     }
+    if let Some(run_id) = run_id {
+        homeboy_agents::agent_task_lifecycle::remove_workspace_terminal_authority(
+            &run_id,
+            &runner.id,
+            remote_path,
+        )?;
+    }
     Ok(())
+}
+
+fn workspace_metadata_run_id(
+    runner: &super::super::Runner,
+    remote_path: &str,
+) -> Result<Option<String>> {
+    let metadata_path = format!(
+        "{}/{}",
+        remote_path.trim_end_matches('/'),
+        WORKSPACE_METADATA_FILE
+    );
+    let content = match runner.kind {
+        RunnerKind::Local => fs::read_to_string(&metadata_path)
+            .map_err(|error| Error::internal_io(error.to_string(), Some(metadata_path.clone())))?,
+        RunnerKind::Ssh => {
+            let (_, client) = ssh_client_for_runner(runner)?;
+            let output = client.execute_with_timeout(
+                &format!("cat {}", shell::quote_arg(&metadata_path)),
+                WORKSPACE_METADATA_TIMEOUT,
+            );
+            if !output.success {
+                return Err(workspace_metadata_ssh_error(&output));
+            }
+            output.stdout
+        }
+    };
+    Ok(serde_json::from_str::<serde_json::Value>(&content)
+        .map_err(|error| Error::internal_json(error.to_string(), Some(metadata_path.clone())))?
+        .get("run_id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string))
 }
 
 fn workspace_metadata(
@@ -2597,7 +2725,7 @@ fn classify_local_candidate(
     let Some(source_path) = metadata.get("local_path").and_then(|value| value.as_str()) else {
         return Ok(None);
     };
-    let reason = prune_candidate_reason(&metadata, path, source_path)?;
+    let reason = prune_candidate_reason(runner, &metadata, path, source_path)?;
     let Some(reason) = reason else {
         return Ok(None);
     };
@@ -2631,6 +2759,7 @@ fn classify_local_candidate(
 }
 
 fn prune_candidate_reason(
+    runner: &super::super::Runner,
     metadata: &serde_json::Value,
     path: &Path,
     source_path: &str,
@@ -2663,7 +2792,9 @@ fn prune_candidate_reason(
     if !Path::new(source_path).exists() {
         return Ok(Some("source_path_missing".to_string()));
     }
-    if has_terminal_delete_on_success_lifecycle(metadata) {
+    if has_terminal_delete_on_success_lifecycle_with(metadata, |run_id| {
+        workspace_run_authority(runner, metadata, path, run_id)
+    }) {
         return Ok(Some(TERMINAL_RESOURCE_LIFECYCLE_REASON.to_string()));
     }
     if is_stale_materialized_workspace_lifecycle(metadata, path) {
@@ -2706,16 +2837,6 @@ fn is_stale_materialized_workspace_lifecycle(metadata: &serde_json::Value, path:
             == Some("delete_on_success")
         && resource.get("status").and_then(|value| value.as_str()) == Some("active")
         && resource.get("path").and_then(|value| value.as_str()) == path.to_str()
-}
-
-fn has_terminal_delete_on_success_lifecycle(metadata: &serde_json::Value) -> bool {
-    has_terminal_delete_on_success_lifecycle_with(metadata, |run_id| {
-        match homeboy_agents::agent_task_lifecycle::exact_record(run_id) {
-            Ok(record) if record.state.is_terminal() => RunAuthority::Terminal,
-            Ok(_) => RunAuthority::Active,
-            Err(_) => RunAuthority::Unavailable,
-        }
-    })
 }
 
 pub(crate) fn has_terminal_delete_on_success_lifecycle_with(
@@ -2765,11 +2886,7 @@ fn workspace_liveness(
         .and_then(|value| value.as_str())
         .filter(|id| !id.trim().is_empty());
     match active_resource_lifecycle_liveness(metadata, |run_id| {
-        match homeboy_agents::agent_task_lifecycle::exact_record(run_id) {
-            Ok(record) if record.state.is_terminal() => RunAuthority::Terminal,
-            Ok(_) => RunAuthority::Active,
-            Err(_) => RunAuthority::Unavailable,
-        }
+        workspace_run_authority(runner, metadata, path, run_id)
     }) {
         ActiveResourceLifecycleLiveness::Terminal(_)
         | ActiveResourceLifecycleLiveness::NotActive => {}
@@ -2792,6 +2909,84 @@ fn workspace_liveness(
         RunnerKind::Local => local_process_liveness(path),
         RunnerKind::Ssh => ssh_process_liveness(runner, &path.display().to_string()),
     }
+}
+
+/// A compacted lifecycle record is not enough to make an active lease stale.
+/// Only the immutable receipt written with the exact accepted runner binding can
+/// supersede it after ordinary controller retention.
+fn workspace_run_authority(
+    runner: &super::super::Runner,
+    metadata: &serde_json::Value,
+    path: &Path,
+    run_id: &str,
+) -> RunAuthority {
+    let job_id = metadata.get("job_id").and_then(|value| value.as_str());
+    match homeboy_agents::agent_task_lifecycle::resolve_workspace_terminal_authority(
+        run_id,
+        &runner.id,
+        &path.display().to_string(),
+        job_id,
+    ) {
+        Ok(Some(_)) => RunAuthority::Terminal,
+        Err(_)
+            if homeboy_agents::agent_task_lifecycle::workspace_terminal_authority_release_is_pending(
+                run_id,
+                &runner.id,
+                &path.display().to_string(),
+            )
+            .unwrap_or(false) =>
+        {
+            RunAuthority::Terminal
+        }
+        Err(_) => RunAuthority::Unavailable,
+        Ok(None) => match homeboy_agents::agent_task_lifecycle::exact_record(run_id) {
+            Ok(record) if record.state.is_terminal() => RunAuthority::Terminal,
+            Ok(_) => RunAuthority::Active,
+            Err(_) => RunAuthority::Unavailable,
+        },
+    }
+}
+
+fn remove_workspace_terminal_authority_receipt(
+    runner: &super::super::Runner,
+    candidate: &RunnerWorkspacePruneEntry,
+) -> Result<()> {
+    let Some(run_id) = candidate.run_id.as_deref() else {
+        return Ok(());
+    };
+    homeboy_agents::agent_task_lifecycle::remove_workspace_terminal_authority(
+        run_id,
+        &runner.id,
+        &candidate.remote_path,
+    )
+}
+
+fn begin_workspace_terminal_authority_release(
+    runner: &super::super::Runner,
+    candidate: &RunnerWorkspacePruneEntry,
+) -> Result<()> {
+    let Some(run_id) = candidate.run_id.as_deref() else {
+        return Ok(());
+    };
+    homeboy_agents::agent_task_lifecycle::begin_workspace_terminal_authority_release(
+        run_id,
+        &runner.id,
+        &candidate.remote_path,
+    )
+}
+
+fn abort_workspace_terminal_authority_release(
+    runner: &super::super::Runner,
+    candidate: &RunnerWorkspacePruneEntry,
+) -> Result<()> {
+    let Some(run_id) = candidate.run_id.as_deref() else {
+        return Ok(());
+    };
+    homeboy_agents::agent_task_lifecycle::abort_workspace_terminal_authority_release(
+        run_id,
+        &runner.id,
+        &candidate.remote_path,
+    )
 }
 
 pub(crate) fn workspace_liveness_with_size_observation(
@@ -3160,6 +3355,7 @@ fn prune_candidates_ssh(
             continue;
         };
         let reason = prune_candidate_reason_from_decoded_metadata(
+            runner,
             &metadata,
             age_seconds,
             Path::new(&parts[2]),
@@ -3225,6 +3421,7 @@ fn prune_candidates_ssh(
 }
 
 fn prune_candidate_reason_from_decoded_metadata(
+    runner: &super::super::Runner,
     metadata: &serde_json::Value,
     age_seconds: u64,
     path: &Path,
@@ -3251,7 +3448,9 @@ fn prune_candidate_reason_from_decoded_metadata(
     if !Path::new(source_path).exists() {
         return Some("source_path_missing".to_string());
     }
-    if has_terminal_delete_on_success_lifecycle(metadata) {
+    if has_terminal_delete_on_success_lifecycle_with(metadata, |run_id| {
+        workspace_run_authority(runner, metadata, path, run_id)
+    }) {
         return Some(TERMINAL_RESOURCE_LIFECYCLE_REASON.to_string());
     }
     is_stale_materialized_workspace_lifecycle(metadata, path)
@@ -3374,14 +3573,10 @@ fn remove_ssh_prune_candidate(
         );
         return parse_ssh_prune_delete_output(output);
     } else {
-        let terminal_owner_run_id = candidate.run_id.as_deref().filter(|run_id| {
-            homeboy_agents::agent_task_lifecycle::exact_record(run_id)
-                .is_ok_and(|record| record.state.is_terminal())
-        });
         ssh_prune_delete_command_with_terminal_authority(
             root,
             &candidate.remote_path,
-            terminal_owner_run_id,
+            candidate.run_id.as_deref(),
             candidate.job_id.as_deref(),
         )
     };
@@ -3478,14 +3673,7 @@ pub(crate) fn ssh_prune_delete_materialized_workspace_command(
 fn remove_workspace(runner: &super::super::Runner, root: &str, remote_path: &str) -> Result<()> {
     let root_path = Path::new(root);
     let path = Path::new(remote_path);
-    if !path.starts_with(root_path) || path == root_path || remote_path.trim().is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "remote_path",
-            "refusing to remove runner workspace outside _lab_workspaces root",
-            Some(remote_path.to_string()),
-            None,
-        ));
-    }
+    validate_workspace_removal_path(root_path, path)?;
     match runner.kind {
         RunnerKind::Local => remove_local_workspace_with_lifecycle(root_path, path),
         RunnerKind::Ssh => {
@@ -3507,6 +3695,18 @@ fn remove_workspace(runner: &super::super::Runner, root: &str, remote_path: &str
             }
         }
     }
+}
+
+fn validate_workspace_removal_path(root_path: &Path, path: &Path) -> Result<()> {
+    if !path.starts_with(root_path) || path == root_path || path.as_os_str().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "remote_path",
+            "refusing to remove runner workspace outside _lab_workspaces root",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn remove_local_workspace_with_lifecycle(root: &Path, path: &Path) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -192,6 +192,7 @@ fn prune_preserves_job_lifecycle_lease_when_authority_is_unavailable() {
         let mut metadata: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&metadata_path).expect("metadata"))
                 .expect("metadata json");
+        metadata["run_id"] = serde_json::json!("active-job");
         metadata["job_id"] = serde_json::json!("active-job");
         metadata["resource_lifecycle"] = serde_json::json!({
             "owner": "runner.workspace",
@@ -232,7 +233,96 @@ fn prune_preserves_job_lifecycle_lease_when_authority_is_unavailable() {
         assert_eq!(exit_code, 0);
         assert!(output.removed.is_empty());
         assert_eq!(output.skipped_unknown_count, 1);
+        assert_eq!(output.withheld_by_liveness_reason.len(), 1);
+        assert_eq!(
+            output.withheld_by_liveness_reason[0].reason,
+            "active_resource_lifecycle_authority_unavailable"
+        );
+        assert_eq!(output.withheld_by_liveness_reason[0].workspace_count, 1);
+        assert!(output.withheld_by_liveness_reason[0].bytes > 0);
         assert!(workspace.exists());
+    });
+}
+
+#[test]
+fn retained_terminal_receipt_reclassifies_and_releases_compacted_workspace() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_id = "lab-local-prune-terminal-receipt";
+        let run_id = "compacted-terminal-run";
+        let job_id = "job-from-prior-runner-generation";
+        let source_parent = tempfile::tempdir().expect("source parent");
+        let source = source_parent.path().join("retained-source");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let workspace = runner_root.path().join("_lab_workspaces/retained-terminal");
+        fs::create_dir_all(&source).expect("source dir");
+        fs::write(source.join("file.txt"), "source\n").expect("source file");
+        write_terminal_workspace(&workspace, &source, runner_root.path(), run_id);
+        crate::create(
+            &format!(
+                r#"{{"id":"{runner_id}","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        homeboy_agents::agent_task_lifecycle::persist_workspace_terminal_authority_for_test(
+            run_id,
+            runner_id,
+            job_id,
+            &workspace.display().to_string(),
+        )
+        .expect("persist retained terminal authority");
+
+        let (preview, _) = prune_workspaces(
+            runner_id,
+            RunnerWorkspacePruneOptions {
+                apply: false,
+                min_age_hours: 0,
+                limit: 10,
+                passes: 1,
+                cursor: None,
+            },
+        )
+        .expect("preview receipt-authorized workspace");
+        assert_eq!(preview.candidates.len(), 1);
+        assert_eq!(preview.candidates[0].reason, "terminal_resource_lifecycle");
+        assert!(preview.withheld_by_liveness_reason.is_empty());
+        homeboy_agents::agent_task_lifecycle::begin_workspace_terminal_authority_release(
+            run_id,
+            runner_id,
+            &workspace.display().to_string(),
+        )
+        .expect("simulate interruption before workspace deletion");
+
+        let (applied, _) = prune_workspaces(
+            runner_id,
+            RunnerWorkspacePruneOptions {
+                apply: true,
+                min_age_hours: 0,
+                limit: 10,
+                passes: 1,
+                cursor: None,
+            },
+        )
+        .expect("remove receipt-authorized workspace");
+        assert_eq!(applied.removed.len(), 1);
+        assert!(!workspace.exists());
+        homeboy_agents::agent_task_lifecycle::persist_workspace_terminal_authority_for_test(
+            run_id,
+            runner_id,
+            job_id,
+            &workspace.display().to_string(),
+        )
+        .expect("late terminal projection is suppressed after deletion");
+        assert!(
+            homeboy_agents::agent_task_lifecycle::resolve_workspace_terminal_authority(
+                run_id,
+                runner_id,
+                &workspace.display().to_string(),
+                Some(job_id),
+            )
+            .is_err()
+        );
     });
 }
 
@@ -1356,6 +1446,36 @@ fn write_orphan_workspace(path: &Path) {
         serde_json::json!({
             "schema": "homeboy/runner-workspace/v1",
             "local_path": path.join("missing-source").display().to_string(),
+        })
+        .to_string(),
+    )
+    .expect("workspace metadata");
+}
+
+fn write_terminal_workspace(path: &Path, source: &Path, runner_root: &Path, run_id: &str) {
+    fs::create_dir_all(path.join(".homeboy")).expect("workspace metadata dir");
+    fs::write(path.join("file.txt"), "retained\n").expect("workspace file");
+    fs::write(
+        path.join(WORKSPACE_METADATA_FILE),
+        serde_json::json!({
+            "schema": "homeboy/runner-workspace/v1",
+            "run_id": run_id,
+            "local_path": source.display().to_string(),
+            "remote_path": path.display().to_string(),
+            "resource_lifecycle": {
+                "owner": "runner.workspace",
+                "run_id": run_id,
+                "runner_id": null,
+                "path": path.display().to_string(),
+                "root_bound": runner_root.join("_lab_workspaces").display().to_string(),
+                "kind": "runner_workspace",
+                "ttl": null,
+                "cleanup_policy": "delete_on_success",
+                "evidence_retention": "metadata",
+                "cleanup_intent": "dry_run",
+                "cleanup_command": null,
+                "status": "active"
+            }
         })
         .to_string(),
     )

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -347,6 +347,8 @@ pub struct RunnerWorkspacePruneOutput {
     pub skipped_live_count: usize,
     /// Candidates withheld because Homeboy could not prove their liveness state.
     pub skipped_unknown_count: usize,
+    /// Capacity withheld by liveness evidence, grouped by its exact reason.
+    pub withheld_by_liveness_reason: Vec<RunnerWorkspacePruneWithheldReason>,
     pub inspect_command: String,
     pub stop_command: String,
     pub reconcile_command: String,
@@ -400,6 +402,13 @@ pub struct RunnerWorkspaceLivenessEvidence {
 pub struct RunnerWorkspacePruneSkippedEntry {
     pub remote_path: String,
     pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerWorkspacePruneWithheldReason {
+    pub reason: String,
+    pub workspace_count: usize,
+    pub bytes: u64,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Summary
- persist immutable terminal run/runner/job/workspace receipts outside compactable lifecycle records
- couple receipt release to workspace deletion with resumable pending markers that close transport and process-crash races
- recover exact authority during prune while preserving fail-closed behavior for malformed, contradictory, released, or unavailable evidence
- report withheld workspace count and bytes grouped by liveness reason

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-agents -p homeboy-lab-runner`
- `cargo test -p homeboy-agents workspace_authority`
- `cargo test -p homeboy-agents runner_terminal_reconciliation_is_idempotent_and_preserves_execution_owner`
- `cargo test -p homeboy-lab-runner workspace::tests::prune` (26 passed)
- `cargo test -p homeboy-lab-runner workspace::tests::reap` (13 passed)

Closes #10629

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reviewed and repaired the initial candidate, designed the durable receipt/release-marker lifecycle, added deterministic tests, and ran verification. Chris Huber reviewed and owns every line.