### PR TITLE
fix(release): bind qualification repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,7 @@ jobs:
         id: proof
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           CANDIDATE_SHA: ${{ github.sha }}
           DRY_RUN: ${{ inputs.dry-run || 'false' }}
         run: |

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -219,6 +219,7 @@ fn release_reuses_or_awaits_an_exact_main_guard_qualification() {
     let qualification = job_section(workflow, "release-qualification");
 
     assert!(qualification.contains("CANDIDATE_SHA: ${{ github.sha }}"));
+    assert!(qualification.contains("GH_REPO: ${{ github.repository }}"));
     assert!(qualification.contains("gh run list --workflow audit-debt.yml"));
     assert!(qualification.contains("--commit \"$CANDIDATE_SHA\""));
     assert!(qualification.contains(


### PR DESCRIPTION
## Summary
- bind checkout-free release qualification GitHub CLI calls through `GH_REPO`
- add workflow contract coverage for the repository-context invariant

## Root Cause
Release run [30393696553](https://github.com/Extra-Chill/homeboy/actions/runs/30393696553) invoked `gh run list` from a job without a checkout or explicit repository, causing GitHub CLI to fail before exact Main Guard proof discovery.

## Verification
- `cargo test --test release_workflow_test release_reuses_or_awaits_an_exact_main_guard_qualification -- --exact`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #10672

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode diagnosed the checkout-free GitHub CLI context failure, drafted the focused workflow and contract-test change, and ran the listed verification. Chris Huber remains responsible for the final change.