### PR TITLE
fix: make release lint baseline-aware

### DIFF
--- a/crates/homeboy-extension/src/lint/run/exit_code.rs
+++ b/crates/homeboy-extension/src/lint/run/exit_code.rs
@@ -42,9 +42,13 @@ pub(super) fn normalize_producer_exit_code(
     }
 }
 
-pub(super) fn effective_lint_exit_code(exit_code: i32, baseline_exit_override: Option<i32>) -> i32 {
+pub(super) fn effective_lint_exit_code(
+    exit_code: i32,
+    baseline_exit_override: Option<i32>,
+    hard_error: bool,
+) -> i32 {
     match baseline_exit_override {
-        Some(0) if exit_code >= 2 => exit_code,
+        Some(0) if hard_error => exit_code.max(1),
         Some(override_code) => override_code,
         None => exit_code,
     }

--- a/crates/homeboy-extension/src/lint/run/scoping.rs
+++ b/crates/homeboy-extension/src/lint/run/scoping.rs
@@ -39,6 +39,7 @@ pub(super) fn resolve_scoped_lint_runs(
             files
         };
 
+        let changed_files = component_relative_changed_files(component, changed_files);
         if changed_files.is_empty() {
             println!("No files in working tree changes");
             return Ok(Some(Vec::new()));
@@ -56,6 +57,7 @@ pub(super) fn resolve_scoped_lint_runs(
             None => git::get_files_changed_since(&component.local_path, git_ref)?,
         };
 
+        let changed_files = component_relative_changed_files(component, changed_files);
         if changed_files.is_empty() {
             println!("No files changed since {}", git_ref);
             return Ok(Some(Vec::new()));
@@ -65,6 +67,21 @@ pub(super) fn resolve_scoped_lint_runs(
     } else {
         Ok(None)
     }
+}
+
+fn component_relative_changed_files(
+    component: &Component,
+    changed_files: Vec<String>,
+) -> Vec<String> {
+    let Some(prefix) = git::get_component_path_prefix(&component.local_path) else {
+        return changed_files;
+    };
+    let prefix = format!("{}/", prefix.trim_end_matches('/'));
+
+    changed_files
+        .into_iter()
+        .filter_map(|file| file.strip_prefix(&prefix).map(str::to_string))
+        .collect()
 }
 
 pub(super) fn build_changed_lint_runs(

--- a/crates/homeboy-extension/src/lint/run/tests/exit_code.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/exit_code.rs
@@ -66,6 +66,8 @@ fn crashed_zero_finding_producer_remains_failure() {
 
 #[test]
 fn baseline_clean_override_honors_known_findings_but_not_infrastructure_errors() {
-    assert_eq!(effective_lint_exit_code(1, Some(0)), 0);
-    assert_eq!(effective_lint_exit_code(2, Some(0)), 2);
+    assert_eq!(effective_lint_exit_code(1, Some(0), false), 0);
+    assert_eq!(effective_lint_exit_code(2, Some(0), true), 2);
+    assert_eq!(effective_lint_exit_code(1, Some(0), true), 1);
+    assert_eq!(effective_lint_exit_code(0, Some(0), true), 1);
 }

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -2,8 +2,10 @@ use super::super::workflow::{
     finish_scoped_lint_run_dir, run_main_lint_workflow, run_self_check_lint_workflow,
 };
 use super::{component, lint_args};
-use homeboy_core::component::{Component, ComponentScriptsConfig};
+use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
 use homeboy_core::engine::run_dir::RunDir;
+use std::collections::HashMap;
+use std::path::Path;
 
 #[test]
 fn test_run_self_check_lint_workflow() {
@@ -58,6 +60,294 @@ fn test_run_main_lint_workflow() {
     assert_eq!(result.status, "passed");
     assert_eq!(result.exit_code, 0);
     assert!(result.findings.is_none());
+}
+
+fn routed_lint_component(home: &Path, source: &Path, script: &str) -> Component {
+    let extension_dir = home.join(".config/homeboy/extensions/routed-lint-fixture");
+    std::fs::create_dir_all(&extension_dir).expect("extension dir");
+    std::fs::write(
+        extension_dir.join("routed-lint-fixture.json"),
+        r#"{
+            "name":"Routed lint fixture",
+            "version":"1.0.0",
+            "lint":{
+                "extension_script":"lint.sh",
+                "changed_file_routes":[
+                    {"extensions":["php"],"step":"php"},
+                    {"extensions":["js"],"step":"js"}
+                ]
+            }
+        }"#,
+    )
+    .expect("extension manifest");
+    std::fs::write(extension_dir.join("lint.sh"), script).expect("lint script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let script_path = extension_dir.join("lint.sh");
+        let mut permissions = std::fs::metadata(&script_path)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(script_path, permissions).expect("executable script");
+    }
+
+    Component {
+        id: "fixture".to_string(),
+        local_path: source.to_string_lossy().to_string(),
+        extensions: Some(HashMap::from([(
+            "routed-lint-fixture".to_string(),
+            ScopedExtensionConfig::default(),
+        )])),
+        ..Default::default()
+    }
+}
+
+fn routed_lint_args() -> super::super::types::LintRunWorkflowArgs {
+    let mut args = lint_args();
+    args.changed_since = Some("v1.0.0".to_string());
+    args.precomputed_changed_files = Some(vec![
+        "legacy.php".to_string(),
+        "assets/app.js".to_string(),
+    ]);
+    args.json_summary = true;
+    args
+}
+
+fn producer_sidecar_paths(
+    workflow: &super::super::types::LintRunWorkflowResult,
+) -> Vec<std::path::PathBuf> {
+    workflow
+        .producer_summaries
+        .iter()
+        .filter_map(|producer| producer.source.as_ref()?.path.as_ref())
+        .map(std::path::PathBuf::from)
+        .collect()
+}
+
+#[test]
+fn multi_route_lint_aggregates_later_route_findings() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+if [ "$HOMEBOY_STEP" = "php" ]; then
+  printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+  exit 0
+fi
+printf '[{"tool":"eslint","message":"later route finding","fingerprint":"later","file":"assets/app.js"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+        );
+        let run_dir = RunDir::create().expect("run dir");
+
+        let workflow = run_main_lint_workflow(
+            &component,
+            source.path(),
+            routed_lint_args(),
+            &run_dir,
+        )
+        .expect("workflow result");
+
+        assert_eq!(workflow.status, "failed");
+        assert_eq!(workflow.exit_code, 1);
+        let findings = workflow.findings.as_ref().expect("findings");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].message, "later route finding");
+        assert_eq!(
+            workflow.producer_summaries[1].step.as_deref(),
+            Some("js")
+        );
+        assert!(producer_sidecar_paths(&workflow)
+            .iter()
+            .all(|path| path.is_file()));
+    });
+}
+
+#[test]
+fn multi_route_failure_retains_later_success_evidence() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+if [ "$HOMEBOY_STEP" = "php" ]; then
+  printf '[{"tool":"phpcs","message":"first route finding","fingerprint":"first","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+  exit 1
+fi
+printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 0
+"#,
+        );
+        let run_dir = RunDir::create().expect("run dir");
+
+        let workflow = run_main_lint_workflow(
+            &component,
+            source.path(),
+            routed_lint_args(),
+            &run_dir,
+        )
+        .expect("workflow result");
+
+        assert_eq!(workflow.status, "failed");
+        assert_eq!(workflow.findings.as_ref().map(Vec::len), Some(1));
+        let paths = producer_sidecar_paths(&workflow);
+        assert_eq!(paths.len(), 2);
+        assert!(paths.iter().all(|path| path.is_file()));
+    });
+}
+
+#[test]
+fn successful_multi_route_lint_cleans_child_route_evidence() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 0
+"#,
+        );
+        let run_dir = RunDir::create().expect("run dir");
+
+        let workflow = run_main_lint_workflow(
+            &component,
+            source.path(),
+            routed_lint_args(),
+            &run_dir,
+        )
+        .expect("workflow result");
+
+        assert_eq!(workflow.status, "passed");
+        let paths = producer_sidecar_paths(&workflow);
+        assert_eq!(paths.len(), 2);
+        assert!(paths[0].is_file(), "primary run evidence remains caller-owned");
+        assert!(!paths[1].exists(), "successful child route must be cleaned");
+    });
+}
+
+#[test]
+fn nested_component_scope_uses_existing_component_relative_file_paths() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let repo = tempfile::tempdir().expect("repo dir");
+        let run_git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo.path())
+                .output()
+                .expect("git command");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run_git(&["init", "-q"]);
+        run_git(&["config", "user.email", "homeboy@example.com"]);
+        run_git(&["config", "user.name", "Homeboy Test"]);
+        let component_path = repo.path().join("packages/fixture");
+        std::fs::create_dir_all(&component_path).expect("component dir");
+        std::fs::write(component_path.join("initial.php"), "<?php\n").expect("initial source");
+        run_git(&["add", "packages/fixture/initial.php"]);
+        run_git(&["commit", "-q", "-m", "initial"]);
+        run_git(&["tag", "fixture-v1.0.0"]);
+        std::fs::write(component_path.join("changed.php"), "<?php echo 1;\n")
+            .expect("changed source");
+        std::fs::write(repo.path().join("outside.php"), "<?php echo 2;\n")
+            .expect("outside source");
+        run_git(&["add", "packages/fixture/changed.php", "outside.php"]);
+        run_git(&["commit", "-q", "-m", "change nested and outside files"]);
+
+        let component = routed_lint_component(
+            home.path(),
+            &component_path,
+            r#"#!/bin/sh
+changed="$(cat "$HOMEBOY_LINT_CHANGED_FILES_FILE")"
+test -f "$HOMEBOY_LINT_GLOB" || exit 2
+printf '[{"tool":"fixture","message":"%s|%s","fingerprint":"scope","file":"changed.php"}]' "$HOMEBOY_LINT_GLOB" "$changed" > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+        );
+        let run_dir = RunDir::create().expect("run dir");
+        let mut args = lint_args();
+        args.changed_since = Some("fixture-v1.0.0".to_string());
+        args.json_summary = true;
+
+        let workflow = run_main_lint_workflow(&component, &component_path, args, &run_dir)
+            .expect("workflow result");
+
+        let expected_glob = component_path.join("changed.php");
+        assert!(expected_glob.is_file());
+        assert_eq!(
+            workflow.findings.as_ref().unwrap()[0].message,
+            format!("{}|changed.php", expected_glob.display())
+        );
+        let manifest = run_dir.step_file(homeboy_core::engine::run_dir::files::LINT_CHANGED_FILES);
+        assert!(manifest.is_file());
+        assert_eq!(std::fs::read_to_string(manifest).unwrap(), "changed.php\n");
+        assert!(!workflow.findings.as_ref().unwrap()[0]
+            .message
+            .contains("packages/fixture/packages/fixture"));
+    });
+}
+
+#[test]
+fn accepted_baseline_does_not_hide_later_route_producer_error() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let mut known = homeboy_core::finding::HomeboyFinding::builder(
+            "eslint",
+            "known finding",
+        )
+        .fingerprint("known")
+        .build();
+        known.location.file = Some("assets/app.js".to_string());
+        crate::lint::baseline::save_baseline(source.path(), "fixture", &[known])
+            .expect("save baseline");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+if [ "$HOMEBOY_STEP" = "php" ]; then
+  printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+  exit 0
+fi
+printf '[{"tool":"eslint","message":"known finding","fingerprint":"known","file":"assets/app.js"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+printf '[{"tool":"eslint","status":"error","finding_count":1}]' > "$HOMEBOY_LINT_PRODUCERS_FILE"
+exit 0
+"#,
+        );
+        let run_dir = RunDir::create().expect("run dir");
+
+        let workflow = run_main_lint_workflow(
+            &component,
+            source.path(),
+            routed_lint_args(),
+            &run_dir,
+        )
+        .expect("workflow result");
+
+        assert_eq!(workflow.status, "failed");
+        assert_eq!(workflow.exit_code, 1);
+        assert_eq!(workflow.findings.as_ref().map(Vec::len), Some(1));
+        assert!(workflow
+            .producer_summaries
+            .iter()
+            .any(|producer| producer.step.as_deref() == Some("js")
+                && producer.status == "error"));
+        assert_eq!(
+            workflow
+                .baseline_comparison
+                .as_ref()
+                .map(|comparison| comparison.new_items.len()),
+            Some(0)
+        );
+    });
 }
 
 #[test]

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -106,10 +106,8 @@ fn routed_lint_component(home: &Path, source: &Path, script: &str) -> Component 
 fn routed_lint_args() -> super::super::types::LintRunWorkflowArgs {
     let mut args = lint_args();
     args.changed_since = Some("v1.0.0".to_string());
-    args.precomputed_changed_files = Some(vec![
-        "legacy.php".to_string(),
-        "assets/app.js".to_string(),
-    ]);
+    args.precomputed_changed_files =
+        Some(vec!["legacy.php".to_string(), "assets/app.js".to_string()]);
     args.json_summary = true;
     args
 }
@@ -143,23 +141,16 @@ exit 1
         );
         let run_dir = RunDir::create().expect("run dir");
 
-        let workflow = run_main_lint_workflow(
-            &component,
-            source.path(),
-            routed_lint_args(),
-            &run_dir,
-        )
-        .expect("workflow result");
+        let workflow =
+            run_main_lint_workflow(&component, source.path(), routed_lint_args(), &run_dir)
+                .expect("workflow result");
 
         assert_eq!(workflow.status, "failed");
         assert_eq!(workflow.exit_code, 1);
         let findings = workflow.findings.as_ref().expect("findings");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].message, "later route finding");
-        assert_eq!(
-            workflow.producer_summaries[1].step.as_deref(),
-            Some("js")
-        );
+        assert_eq!(workflow.producer_summaries[1].step.as_deref(), Some("js"));
         assert!(producer_sidecar_paths(&workflow)
             .iter()
             .all(|path| path.is_file()));
@@ -184,13 +175,9 @@ exit 0
         );
         let run_dir = RunDir::create().expect("run dir");
 
-        let workflow = run_main_lint_workflow(
-            &component,
-            source.path(),
-            routed_lint_args(),
-            &run_dir,
-        )
-        .expect("workflow result");
+        let workflow =
+            run_main_lint_workflow(&component, source.path(), routed_lint_args(), &run_dir)
+                .expect("workflow result");
 
         assert_eq!(workflow.status, "failed");
         assert_eq!(workflow.findings.as_ref().map(Vec::len), Some(1));
@@ -214,18 +201,17 @@ exit 0
         );
         let run_dir = RunDir::create().expect("run dir");
 
-        let workflow = run_main_lint_workflow(
-            &component,
-            source.path(),
-            routed_lint_args(),
-            &run_dir,
-        )
-        .expect("workflow result");
+        let workflow =
+            run_main_lint_workflow(&component, source.path(), routed_lint_args(), &run_dir)
+                .expect("workflow result");
 
         assert_eq!(workflow.status, "passed");
         let paths = producer_sidecar_paths(&workflow);
         assert_eq!(paths.len(), 2);
-        assert!(paths[0].is_file(), "primary run evidence remains caller-owned");
+        assert!(
+            paths[0].is_file(),
+            "primary run evidence remains caller-owned"
+        );
         assert!(!paths[1].exists(), "successful child route must be cleaned");
     });
 }
@@ -258,8 +244,7 @@ fn nested_component_scope_uses_existing_component_relative_file_paths() {
         run_git(&["tag", "fixture-v1.0.0"]);
         std::fs::write(component_path.join("changed.php"), "<?php echo 1;\n")
             .expect("changed source");
-        std::fs::write(repo.path().join("outside.php"), "<?php echo 2;\n")
-            .expect("outside source");
+        std::fs::write(repo.path().join("outside.php"), "<?php echo 2;\n").expect("outside source");
         run_git(&["add", "packages/fixture/changed.php", "outside.php"]);
         run_git(&["commit", "-q", "-m", "change nested and outside files"]);
 
@@ -300,12 +285,9 @@ exit 1
 fn accepted_baseline_does_not_hide_later_route_producer_error() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");
-        let mut known = homeboy_core::finding::HomeboyFinding::builder(
-            "eslint",
-            "known finding",
-        )
-        .fingerprint("known")
-        .build();
+        let mut known = homeboy_core::finding::HomeboyFinding::builder("eslint", "known finding")
+            .fingerprint("known")
+            .build();
         known.location.file = Some("assets/app.js".to_string());
         crate::lint::baseline::save_baseline(source.path(), "fixture", &[known])
             .expect("save baseline");
@@ -324,13 +306,9 @@ exit 0
         );
         let run_dir = RunDir::create().expect("run dir");
 
-        let workflow = run_main_lint_workflow(
-            &component,
-            source.path(),
-            routed_lint_args(),
-            &run_dir,
-        )
-        .expect("workflow result");
+        let workflow =
+            run_main_lint_workflow(&component, source.path(), routed_lint_args(), &run_dir)
+                .expect("workflow result");
 
         assert_eq!(workflow.status, "failed");
         assert_eq!(workflow.exit_code, 1);
@@ -338,8 +316,7 @@ exit 0
         assert!(workflow
             .producer_summaries
             .iter()
-            .any(|producer| producer.step.as_deref() == Some("js")
-                && producer.status == "error"));
+            .any(|producer| producer.step.as_deref() == Some("js") && producer.status == "error"));
         assert_eq!(
             workflow
                 .baseline_comparison

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -140,11 +140,14 @@ pub fn run_main_lint_workflow(
     for evidence in evidence {
         let had_findings = !evidence.findings.is_empty();
         let declared_producers_empty = evidence.declared_producers.is_empty();
-        let scoped_run = evidence.changed_files.as_ref().map(|changed_files| ScopedLintRun {
-            glob: String::new(),
-            step: evidence.step.clone(),
-            changed_files: changed_files.clone(),
-        });
+        let scoped_run = evidence
+            .changed_files
+            .as_ref()
+            .map(|changed_files| ScopedLintRun {
+                glob: String::new(),
+                step: evidence.step.clone(),
+                changed_files: changed_files.clone(),
+            });
         let route_findings = filter_findings_to_scoped_files(
             evidence.findings,
             scoped_run.as_ref().map(std::slice::from_ref),

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -22,6 +22,23 @@ use homeboy_core::finding::HomeboyFinding;
 use homeboy_core::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use std::path::{Path, PathBuf};
 
+struct LintRunEvidence {
+    findings: Vec<HomeboyFinding>,
+    declared_producers: Vec<homeboy_core::finding::FindingProducerSummary>,
+    findings_file: PathBuf,
+    producers_file: PathBuf,
+    changed_files: Option<Vec<String>>,
+    step: Option<String>,
+    success: bool,
+    exit_code: i32,
+}
+
+struct ScopedLintOutput {
+    output: extension::RunnerOutput,
+    evidence: Vec<LintRunEvidence>,
+    child_run_dirs: Vec<RunDir>,
+}
+
 /// Run the main lint workflow.
 ///
 /// Handles changed-file scoping, autofix planning, lint runner execution,
@@ -60,8 +77,9 @@ pub fn run_main_lint_workflow(
     }
 
     // Run lint
-    let output = if let Some(ref runs) = scoped_runs {
-        run_scoped_lint_runs(component, &args, run_dir, runs)?
+    let (output, evidence, child_run_dirs) = if let Some(ref runs) = scoped_runs {
+        let scoped = run_scoped_lint_runs(component, &args, run_dir, runs)?;
+        (scoped.output, scoped.evidence, scoped.child_run_dirs)
     } else {
         let mut progress = ValidationProgressRecorder::new(
             run_dir,
@@ -99,31 +117,61 @@ pub fn run_main_lint_workflow(
         let stdout_artifact = write_command_artifact(run_dir, 0, "stdout", &output.stdout)?;
         let stderr_artifact = write_command_artifact(run_dir, 0, "stderr", &output.stderr)?;
         progress.finish(0, output.exit_code, stdout_artifact, stderr_artifact)?;
-        output
+        let lint_findings_file = run_dir.step_file(run_dir::files::LINT_FINDINGS);
+        if !lint_findings_file.is_file() {
+            return Err(missing_findings_evidence_error(&lint_findings_file));
+        }
+        let lint_producers_file = run_dir.step_file(run_dir::files::LINT_PRODUCERS);
+        let evidence = vec![LintRunEvidence {
+            findings: lint_baseline::parse_findings_file(&lint_findings_file)?,
+            declared_producers: parse_lint_producer_summaries_file(&lint_producers_file)?,
+            findings_file: lint_findings_file,
+            producers_file: lint_producers_file,
+            changed_files: None,
+            step: None,
+            success: output.success,
+            exit_code: output.exit_code,
+        }];
+        (output, evidence, Vec::new())
     };
 
-    let lint_findings_file = run_dir.step_file(run_dir::files::LINT_FINDINGS);
-    let lint_producers_file = run_dir.step_file(run_dir::files::LINT_PRODUCERS);
-    let parsed_lint_findings = lint_baseline::parse_findings_file(&lint_findings_file)?;
-    let scoped_filter_removed_findings = scoped_runs.is_some() && !parsed_lint_findings.is_empty();
-    let raw_lint_findings =
-        filter_findings_to_scoped_files(parsed_lint_findings, scoped_runs.as_deref());
-    let lint_findings = filter_lint_findings(raw_lint_findings, &args);
+    let mut lint_findings = Vec::new();
+    let mut producer_summaries = Vec::new();
+    for evidence in evidence {
+        let had_findings = !evidence.findings.is_empty();
+        let declared_producers_empty = evidence.declared_producers.is_empty();
+        let scoped_run = evidence.changed_files.as_ref().map(|changed_files| ScopedLintRun {
+            glob: String::new(),
+            step: evidence.step.clone(),
+            changed_files: changed_files.clone(),
+        });
+        let route_findings = filter_findings_to_scoped_files(
+            evidence.findings,
+            scoped_run.as_ref().map(std::slice::from_ref),
+        );
+        let route_findings = filter_lint_findings(route_findings, &args);
+        let mut route_producers = build_lint_producer_summaries(
+            &route_findings,
+            &evidence.findings_file,
+            &evidence.producers_file,
+            evidence.declared_producers,
+            evidence.success,
+            evidence.exit_code,
+            evidence.step.as_deref(),
+        );
+        if evidence.changed_files.is_some()
+            && had_findings
+            && route_findings.is_empty()
+            && evidence.exit_code == 1
+            && declared_producers_empty
+        {
+            mark_zero_finding_producers_passed(&mut route_producers);
+        }
+        lint_findings.extend(route_findings);
+        producer_summaries.extend(route_producers);
+    }
     let formatting_findings =
         extract_formatting_findings(&output.stdout, &output.stderr, source_path);
-    let declared_producers = parse_lint_producer_summaries_file(&lint_producers_file)?;
-    let mut producer_summaries = build_lint_producer_summaries(
-        &lint_findings,
-        &lint_findings_file,
-        &lint_producers_file,
-        declared_producers,
-        output.success,
-        output.exit_code,
-        None,
-    );
-    if scoped_filter_removed_findings && lint_findings.is_empty() && output.exit_code == 1 {
-        mark_zero_finding_producers_passed(&mut producer_summaries);
-    }
 
     let mut hints = Vec::new();
 
@@ -139,8 +187,16 @@ pub fn run_main_lint_workflow(
     let (baseline_comparison, baseline_exit_override) =
         process_baseline(source_path, &args, &lint_findings)?;
 
-    let exit_code = effective_lint_exit_code(lint_exit_code, baseline_exit_override);
+    let harness_error = lint_exit_code != 0
+        && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);
+    let hard_error = output.exit_code >= 2
+        || harness_error
+        || producer_summaries
+            .iter()
+            .any(|producer| producer.status == "error");
+    let exit_code = effective_lint_exit_code(lint_exit_code, baseline_exit_override, hard_error);
     let status = if exit_code == 0 { "passed" } else { "failed" }.to_string();
+    finish_scoped_lint_run_dirs(&child_run_dirs, exit_code == 0);
     let lint_clean = lint_findings.is_empty() && exit_code == 0;
 
     // Hint assembly — point to the auto-fix CTA for autofixable findings.
@@ -185,10 +241,6 @@ pub fn run_main_lint_workflow(
 
     // A non-zero exit with zero findings whose runner output shows infra
     // markers is a harness failure, not a real lint failure.
-    let harness_error = exit_code != 0
-        && lint_findings.is_empty()
-        && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);
-
     Ok(LintRunWorkflowResult {
         status,
         component: args.component_label,
@@ -219,12 +271,14 @@ fn run_scoped_lint_runs(
     args: &LintRunWorkflowArgs,
     run_dir: &RunDir,
     runs: &[ScopedLintRun],
-) -> homeboy_core::Result<extension::RunnerOutput> {
+) -> homeboy_core::Result<ScopedLintOutput> {
     let mut success = true;
     let mut exit_code = 0;
     let mut stdout = String::new();
     let mut stderr = String::new();
     let mut extension_phase_timings = Vec::new();
+    let mut evidence = Vec::new();
+    let mut child_run_dirs = Vec::new();
     let mut progress = ValidationProgressRecorder::new(
         run_dir,
         None,
@@ -276,6 +330,31 @@ fn run_scoped_lint_runs(
         let stdout_artifact = write_command_artifact(run_dir, index, "stdout", &output.stdout)?;
         let stderr_artifact = write_command_artifact(run_dir, index, "stderr", &output.stderr)?;
         progress.finish(index, output.exit_code, stdout_artifact, stderr_artifact)?;
+        let findings_file = active_run_dir.step_file(run_dir::files::LINT_FINDINGS);
+        if !findings_file.is_file() {
+            finish_scoped_lint_run_dir(scoped_run_dir.as_ref(), false);
+            return Err(missing_findings_evidence_error(&findings_file));
+        }
+        let producers_file = active_run_dir.step_file(run_dir::files::LINT_PRODUCERS);
+        let parsed_findings = lint_baseline::parse_findings_file(&findings_file);
+        let declared_producers = parse_lint_producer_summaries_file(&producers_file);
+        let (parsed_findings, declared_producers) = match (parsed_findings, declared_producers) {
+            (Ok(findings), Ok(producers)) => (findings, producers),
+            (Err(error), _) | (_, Err(error)) => {
+                finish_scoped_lint_run_dir(scoped_run_dir.as_ref(), false);
+                return Err(error);
+            }
+        };
+        evidence.push(LintRunEvidence {
+            findings: parsed_findings,
+            declared_producers,
+            findings_file,
+            producers_file,
+            changed_files: Some(run.changed_files.clone()),
+            step: run.step.clone(),
+            success: output.success,
+            exit_code: output.exit_code,
+        });
         extension_phase_timings.extend(output.extension_phase_timings);
         if !stdout.is_empty() && !stdout.ends_with('\n') {
             stdout.push('\n');
@@ -288,22 +367,44 @@ fn run_scoped_lint_runs(
 
         if !output.success {
             success = false;
-            if exit_code == 0 {
+            if exit_code == 0 || output.exit_code >= 2 {
                 exit_code = output.exit_code;
             }
         }
-        finish_scoped_lint_run_dir(scoped_run_dir.as_ref(), output.success);
+        if let Some(scoped_run_dir) = scoped_run_dir {
+            child_run_dirs.push(scoped_run_dir);
+        }
     }
 
-    Ok(extension::RunnerOutput {
-        exit_code,
-        success,
-        stdout,
-        stderr,
-        timed_out: false,
-        child_resource: None,
-        extension_phase_timings,
+    Ok(ScopedLintOutput {
+        output: extension::RunnerOutput {
+            exit_code,
+            success,
+            stdout,
+            stderr,
+            timed_out: false,
+            child_resource: None,
+            extension_phase_timings,
+        },
+        evidence,
+        child_run_dirs,
     })
+}
+
+fn finish_scoped_lint_run_dirs(run_dirs: &[RunDir], success: bool) {
+    for run_dir in run_dirs {
+        finish_scoped_lint_run_dir(Some(run_dir), success);
+    }
+}
+
+fn missing_findings_evidence_error(path: &Path) -> homeboy_core::Error {
+    homeboy_core::Error::internal_io(
+        format!(
+            "Lint runner did not produce required findings evidence {}",
+            path.display()
+        ),
+        Some("lint.findings.evidence".to_string()),
+    )
 }
 
 pub(super) fn finish_scoped_lint_run_dir(run_dir: Option<&RunDir>, success: bool) {

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -558,10 +558,7 @@ fn remove_ignored_untracked_composer_lock(component_path: &Path) -> Result<()> {
 fn run_lint_preflight(step: &PlanStep, context: &ReleaseExecutionContext) -> ReleaseStepResult {
     use super::planning_quality::LintQualityOutcome;
 
-    match super::planning_quality::validate_lint_quality(
-        context.component,
-        context.component_id,
-    ) {
+    match super::planning_quality::validate_lint_quality(context.component, context.component_id) {
         LintQualityOutcome::Passed { ran } => successful_quality_result(step, ran),
         LintQualityOutcome::Failed(err) => failed_result(&step.id, &step.kind, err),
     }

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -558,20 +558,12 @@ fn remove_ignored_untracked_composer_lock(component_path: &Path) -> Result<()> {
 fn run_lint_preflight(step: &PlanStep, context: &ReleaseExecutionContext) -> ReleaseStepResult {
     use super::planning_quality::LintQualityOutcome;
 
-    match super::planning_quality::validate_lint_quality(context.component) {
+    match super::planning_quality::validate_lint_quality(
+        context.component,
+        context.component_id,
+    ) {
         LintQualityOutcome::Passed { ran } => successful_quality_result(step, ran),
         LintQualityOutcome::Failed(err) => failed_result(&step.id, &step.kind, err),
-        LintQualityOutcome::HarnessError { message } => {
-            homeboy_core::log_status!("release", "Lint harness warning: {}", message);
-            ReleaseStepResult {
-                id: step.id.clone(),
-                step_type: step.kind.clone(),
-                status: ReleaseStepStatus::Success,
-                warnings: vec![message],
-                data: Some(serde_json::json!({ "ran": true, "harness_error": true })),
-                ..Default::default()
-            }
-        }
     }
 }
 

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -100,14 +100,15 @@ pub(super) fn validate_lint_quality(
         ));
     }
 
-    let lint_context = match homeboy_core::extension_execution::resolve_execution_context_if_available(
-        component,
-        ExtensionCapability::Lint,
-    ) {
-        Ok(Some(context)) => context,
-        Ok(None) => return LintQualityOutcome::Passed { ran: false },
-        Err(error) => return runner_error(error),
-    };
+    let lint_context =
+        match homeboy_core::extension_execution::resolve_execution_context_if_available(
+            component,
+            ExtensionCapability::Lint,
+        ) {
+            Ok(Some(context)) => context,
+            Ok(None) => return LintQualityOutcome::Passed { ran: false },
+            Err(error) => return runner_error(error),
+        };
 
     homeboy_core::log_status!("release", "Running lint ({})...", lint_context.extension_id);
 
@@ -115,15 +116,14 @@ pub(super) fn validate_lint_quality(
         Ok(dir) => dir,
         Err(e) => return LintQualityOutcome::Failed(e),
     };
-    let changed_since = match ReleaseScope::resolve(component, component_id)
-        .and_then(|scope| scope.latest_tag())
-    {
-        Ok(tag) => tag,
-        Err(e) => {
-            release_run_dir.finish(false);
-            return runner_error(e);
-        }
-    };
+    let changed_since =
+        match ReleaseScope::resolve(component, component_id).and_then(|scope| scope.latest_tag()) {
+            Ok(tag) => tag,
+            Err(e) => {
+                release_run_dir.finish(false);
+                return runner_error(e);
+            }
+        };
     let workflow = extension::lint::run_main_lint_workflow(
         component,
         Path::new(&component.local_path),
@@ -416,9 +416,7 @@ mod tests {
         code_quality_failure_message, is_runner_infrastructure_failure, validate_lint_quality,
         validate_test_quality, LintQualityOutcome,
     };
-    use homeboy_core::component::{
-        Component, ComponentScriptsConfig, ScopedExtensionConfig,
-    };
+    use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
     use homeboy_extension::RunnerOutput;
     use std::collections::HashMap;
     use std::fs;
@@ -495,8 +493,7 @@ mod tests {
         if prior_tag {
             run_git(source, &["tag", "v1.0.0"]);
         }
-        fs::write(source.join("changed.php"), "<?php echo 'changed';\n")
-            .expect("changed source");
+        fs::write(source.join("changed.php"), "<?php echo 'changed';\n").expect("changed source");
         run_git(source, &["add", "changed.php"]);
         run_git(source, &["commit", "-q", "-m", "fix: changed file"]);
 
@@ -532,9 +529,7 @@ mod tests {
 
     fn enable_split_lint_routes(home: &Path) {
         fs::write(
-            home.join(
-                ".config/homeboy/extensions/release-lint-fixture/release-lint-fixture.json",
-            ),
+            home.join(".config/homeboy/extensions/release-lint-fixture/release-lint-fixture.json"),
             r#"{
                 "name":"Release lint fixture",
                 "version":"1.0.0",
@@ -585,8 +580,10 @@ mod tests {
 
     #[test]
     fn test_validate_lint_quality() {
-        assert!(!validate_lint_quality(&component_without_quality_runners(), "fixture")
-            .expect_passed_with_value(false));
+        assert!(
+            !validate_lint_quality(&component_without_quality_runners(), "fixture")
+                .expect_passed_with_value(false)
+        );
     }
 
     #[test]
@@ -929,7 +926,10 @@ exit 1
         homeboy_core::test_support::with_isolated_home(|home| {
             let source = tempfile::tempdir().expect("source dir");
             run_git(source.path(), &["init", "-q"]);
-            run_git(source.path(), &["config", "user.email", "homeboy@example.com"]);
+            run_git(
+                source.path(),
+                &["config", "user.email", "homeboy@example.com"],
+            );
             run_git(source.path(), &["config", "user.name", "Homeboy Test"]);
             let component_path = source.path().join("packages/fixture");
             fs::create_dir_all(&component_path).expect("component dir");
@@ -942,8 +942,9 @@ exit 1
             run_git(source.path(), &["add", "packages/fixture/changed.php"]);
             run_git(source.path(), &["commit", "-q", "-m", "fix: package"]);
 
-            let extension_dir =
-                home.path().join(".config/homeboy/extensions/release-lint-fixture");
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions/release-lint-fixture");
             fs::create_dir_all(&extension_dir).expect("extension dir");
             fs::write(
                 extension_dir.join("release-lint-fixture.json"),
@@ -1024,13 +1025,10 @@ exit 0
                 &[known],
             )
             .expect("save accepted baseline");
-            let producer_error =
-                validate_lint_quality(&producer_error, "fixture").expect_failed();
-            assert!(
-                producer_error
-                    .to_string()
-                    .contains("Lint failed (exit code 1,")
-            );
+            let producer_error = validate_lint_quality(&producer_error, "fixture").expect_failed();
+            assert!(producer_error
+                .to_string()
+                .contains("Lint failed (exit code 1,"));
             assert_eq!(
                 producer_error.details["lint_workflow"]["producer_error_count"].as_u64(),
                 Some(1)

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1,9 +1,11 @@
 use homeboy_core::component::Component;
-use homeboy_core::engine::run_dir::{self, RunDir};
+use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::error::{CommandEvidence, Error, Result};
 use homeboy_extension as extension;
 use homeboy_extension::{self, ExtensionCapability};
 use std::path::Path;
+
+use super::scope::ReleaseScope;
 
 /// Maximum captured stdout/stderr bytes retained per stream in command
 /// evidence. Bounds the structured error payload while keeping the tail (where
@@ -51,29 +53,22 @@ fn command_evidence(
 
 /// Outcome of a release lint preflight.
 ///
-/// Distinguishes a genuine lint failure (real findings exist) from a harness /
-/// infrastructure failure (the lint wrapper exited non-zero while reporting
-/// zero findings). The latter must not hard-block a release — the underlying
-/// linter is clean and a broken runner harness should surface as a warning.
 #[derive(Debug)]
 pub(super) enum LintQualityOutcome {
     /// Lint ran and passed, or no lint runner is configured (`ran == false`).
     Passed { ran: bool },
-    /// Lint produced real findings — this is a genuine, hard-blocking failure.
+    /// Lint findings or a lint harness/tool/evidence failure blocked release.
     Failed(Error),
-    /// The lint harness exited non-zero while reporting zero findings.
-    ///
-    /// This is a harness/infra error, not a code-quality failure. The release
-    /// continues with a warning instead of aborting.
-    HarnessError { message: String },
 }
 
 /// Run release lint via the component's extension.
 ///
-/// Returns a [`LintQualityOutcome`] distinguishing real lint findings from a
-/// harness/infrastructure failure. Missing lint support is not a release
-/// blocker because not every extension provides it.
-pub(super) fn validate_lint_quality(component: &Component) -> LintQualityOutcome {
+/// Missing lint support is not a release blocker because not every extension
+/// provides it.
+pub(super) fn validate_lint_quality(
+    component: &Component,
+    component_id: &str,
+) -> LintQualityOutcome {
     // Shared mapping for a lint-runner construction/execution error into the
     // standard hard-blocking outcome, used by both the scripts.lint and the
     // extension-resolved lint paths below.
@@ -99,26 +94,19 @@ pub(super) fn validate_lint_quality(component: &Component) -> LintQualityOutcome
             return LintQualityOutcome::Passed { ran: true };
         }
 
-        // The lint harness exited non-zero. When the underlying linter is clean
-        // and the wrapper/harness itself failed (e.g. the long-standing missing
-        // `runner-steps.sh` environmental issue), surface a non-blocking warning
-        // rather than aborting the release.
-        if workflow.harness_error {
-            return LintQualityOutcome::HarnessError {
-                message: harness_failure_message("Lint", workflow.exit_code),
-            };
-        }
-
         return LintQualityOutcome::Failed(quality_error(
             "lint",
             format!("Lint failed (exit code {})", workflow.exit_code),
         ));
     }
 
-    let lint_context = extension::lint::resolve_lint_command(component);
-
-    let Ok(lint_context) = lint_context else {
-        return LintQualityOutcome::Passed { ran: false };
+    let lint_context = match homeboy_core::extension_execution::resolve_execution_context_if_available(
+        component,
+        ExtensionCapability::Lint,
+    ) {
+        Ok(Some(context)) => context,
+        Ok(None) => return LintQualityOutcome::Passed { ran: false },
+        Err(error) => return runner_error(error),
     };
 
     homeboy_core::log_status!("release", "Running lint ({})...", lint_context.extension_id);
@@ -127,82 +115,101 @@ pub(super) fn validate_lint_quality(component: &Component) -> LintQualityOutcome
         Ok(dir) => dir,
         Err(e) => return LintQualityOutcome::Failed(e),
     };
-    let lint_findings_file = release_run_dir.step_file(run_dir::files::LINT_FINDINGS);
-
-    let output = match extension::lint::build_lint_runner(
-        component,
-        None,
-        &[],
-        false,
-        None,
-        None,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-        &release_run_dir,
-    )
-    .map(|runner| {
-        // The release lint gate is blocking, so a validation dependency resolved
-        // from a stale local checkout must not silently determine the outcome —
-        // fail closed on a behind-upstream dependency (#9643).
-        runner.env(extension::STRICT_VALIDATION_DEPENDENCIES_ENV, "1")
-    })
-    .and_then(|runner| runner.run())
+    let changed_since = match ReleaseScope::resolve(component, component_id)
+        .and_then(|scope| scope.latest_tag())
     {
-        Ok(output) => output,
+        Ok(tag) => tag,
         Err(e) => {
             release_run_dir.finish(false);
             return runner_error(e);
         }
     };
+    let workflow = extension::lint::run_main_lint_workflow(
+        component,
+        Path::new(&component.local_path),
+        extension::lint::LintRunWorkflowArgs {
+            component_label: component_id.to_string(),
+            component_id: component_id.to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            summary: false,
+            file: None,
+            glob: None,
+            changed_only: false,
+            changed_since,
+            precomputed_changed_files: None,
+            sniff_filters: extension::lint::LintSniffFilters::default(),
+            category: None,
+            ci_env: Vec::new(),
+            baseline_flags: Default::default(),
+            json_summary: true,
+        },
+        &release_run_dir,
+    );
+    let workflow = match workflow {
+        Ok(workflow) => workflow,
+        Err(error) => {
+            release_run_dir.finish(false);
+            return runner_error(error);
+        }
+    };
 
-    if output.success {
+    if workflow.status == "passed" && workflow.exit_code == 0 {
         homeboy_core::log_status!("release", "Lint passed");
         release_run_dir.finish(true);
-        return LintQualityOutcome::Passed { ran: true };
-    }
-
-    let source_path = std::path::Path::new(&component.local_path);
-    let findings = homeboy_extension::lint::baseline::parse_findings_file(&lint_findings_file)
-        .unwrap_or_default();
-
-    // A non-zero exit with zero parsed findings is a harness/infra failure, not
-    // a real lint failure — the linter found nothing to report. The underlying
-    // linter is clean, so this must not hard-block the release.
-    if findings.is_empty() {
+        LintQualityOutcome::Passed { ran: true }
+    } else {
         release_run_dir.finish(false);
-        return LintQualityOutcome::HarnessError {
-            message: harness_failure_message("Lint", output.exit_code),
-        };
+        LintQualityOutcome::Failed(lint_workflow_failure(&workflow, &release_run_dir))
     }
+}
 
-    if let Some(baseline) = homeboy_extension::lint::baseline::load_baseline(source_path) {
-        let comparison = homeboy_extension::lint::baseline::compare(&findings, &baseline);
-        if comparison.drift_increased {
-            homeboy_core::log_status!(
-                "release",
-                "Lint baseline drift increased: {} new finding(s)",
-                comparison.new_items.len()
-            );
-        } else {
-            homeboy_core::log_status!(
-                "release",
-                "Lint has known findings but no new drift (baseline honored)"
-            );
-            homeboy_core::log_status!("release", "Lint passed");
-            release_run_dir.finish(true);
-            return LintQualityOutcome::Passed { ran: true };
-        }
+fn lint_workflow_failure(
+    workflow: &extension::lint::LintRunWorkflowResult,
+    run_dir: &RunDir,
+) -> Error {
+    let findings = workflow.findings.as_deref().unwrap_or_default();
+    let producer_errors = workflow
+        .producer_summaries
+        .iter()
+        .filter(|producer| producer.status == "error")
+        .count();
+    let baseline_new = workflow
+        .baseline_comparison
+        .as_ref()
+        .map(|comparison| comparison.new_items.len());
+    let baseline_known = baseline_new.map(|new| findings.len().saturating_sub(new));
+    let message = format!(
+        "Lint failed (exit code {}, {} finding(s), {} producer error(s){}{})",
+        workflow.exit_code,
+        findings.len(),
+        producer_errors,
+        baseline_new
+            .map(|count| format!(", {} baseline-new", count))
+            .unwrap_or_default(),
+        baseline_known
+            .map(|count| format!(", {} baseline-known", count))
+            .unwrap_or_default()
+    );
+    let mut error = quality_error("lint", message);
+    if let Some(details) = error.details.as_object_mut() {
+        details.insert(
+            "lint_workflow".to_string(),
+            serde_json::json!({
+                "exit_code": workflow.exit_code,
+                "finding_count": findings.len(),
+                "findings": findings.iter().take(20).collect::<Vec<_>>(),
+                "producer_error_count": producer_errors,
+                "producer_summaries": workflow.producer_summaries,
+                "baseline_new_count": baseline_new,
+                "baseline_known_count": baseline_known,
+                "harness_error": workflow.harness_error,
+                "hints": workflow.hints,
+                "run_dir": run_dir.path(),
+            }),
+        );
     }
-
-    release_run_dir.finish(false);
-    LintQualityOutcome::Failed(quality_error(
-        "lint",
-        code_quality_failure_message("Lint", &output),
-    ))
+    error
 }
 
 /// Run release tests via the component's extension.
@@ -298,20 +305,6 @@ pub(super) fn validate_test_quality(component: &Component) -> Result<bool> {
             evidence,
         ))
     }
-}
-
-/// Message for a lint/test harness failure (non-zero exit, zero findings).
-///
-/// This is distinct from a real code-quality failure: the underlying tool is
-/// clean and the wrapper/harness itself failed. The release continues with a
-/// warning carrying this message.
-fn harness_failure_message(check: &str, exit_code: i32) -> String {
-    format!(
-        "{} harness exited {} with zero findings — treating as a harness/infra error, not a code-quality failure. \
-Release continues; the underlying linter is clean. To re-run lint in isolation: homeboy lint <component>. \
-To skip only this gate: homeboy release <component> --skip-checks=lint",
-        check, exit_code
-    )
 }
 
 fn quality_error(field: &str, message: String) -> Error {
@@ -420,11 +413,14 @@ fn is_runner_infrastructure_failure(output: &extension::RunnerOutput) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        code_quality_failure_message, harness_failure_message, is_runner_infrastructure_failure,
-        validate_lint_quality, validate_test_quality, LintQualityOutcome,
+        code_quality_failure_message, is_runner_infrastructure_failure, validate_lint_quality,
+        validate_test_quality, LintQualityOutcome,
     };
-    use homeboy_core::component::{Component, ComponentScriptsConfig};
+    use homeboy_core::component::{
+        Component, ComponentScriptsConfig, ScopedExtensionConfig,
+    };
     use homeboy_extension::RunnerOutput;
+    use std::collections::HashMap;
     use std::fs;
     use std::path::Path;
 
@@ -436,13 +432,6 @@ mod tests {
                     ran
                 }
                 other => panic!("expected Passed, got {:?}", other),
-            }
-        }
-
-        fn expect_harness_error(self) -> String {
-            match self {
-                LintQualityOutcome::HarnessError { message } => message,
-                other => panic!("expected HarnessError, got {:?}", other),
             }
         }
 
@@ -475,6 +464,90 @@ mod tests {
             scripts: Some(scripts),
             ..Default::default()
         }
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn extension_lint_component(
+        home: &Path,
+        source: &Path,
+        script: &str,
+        prior_tag: bool,
+    ) -> Component {
+        run_git(source, &["init", "-q"]);
+        run_git(source, &["config", "user.email", "homeboy@example.com"]);
+        run_git(source, &["config", "user.name", "Homeboy Test"]);
+        fs::write(source.join("legacy.php"), "<?php\n").expect("legacy source");
+        run_git(source, &["add", "legacy.php"]);
+        run_git(source, &["commit", "-q", "-m", "chore: initial"]);
+        if prior_tag {
+            run_git(source, &["tag", "v1.0.0"]);
+        }
+        fs::write(source.join("changed.php"), "<?php echo 'changed';\n")
+            .expect("changed source");
+        run_git(source, &["add", "changed.php"]);
+        run_git(source, &["commit", "-q", "-m", "fix: changed file"]);
+
+        let extension_dir = home.join(".config/homeboy/extensions/release-lint-fixture");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("release-lint-fixture.json"),
+            r#"{"name":"Release lint fixture","version":"1.0.0","lint":{"extension_script":"lint.sh"}}"#,
+        )
+        .expect("extension manifest");
+        fs::write(extension_dir.join("lint.sh"), script).expect("extension script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(extension_dir.join("lint.sh"))
+                .expect("script metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(extension_dir.join("lint.sh"), permissions)
+                .expect("executable script");
+        }
+
+        Component {
+            id: "fixture".to_string(),
+            local_path: source.to_string_lossy().to_string(),
+            extensions: Some(HashMap::from([(
+                "release-lint-fixture".to_string(),
+                ScopedExtensionConfig::default(),
+            )])),
+            ..Default::default()
+        }
+    }
+
+    fn enable_split_lint_routes(home: &Path) {
+        fs::write(
+            home.join(
+                ".config/homeboy/extensions/release-lint-fixture/release-lint-fixture.json",
+            ),
+            r#"{
+                "name":"Release lint fixture",
+                "version":"1.0.0",
+                "lint":{
+                    "extension_script":"lint.sh",
+                    "changed_file_routes":[
+                        {"extensions":["php"],"step":"php"},
+                        {"extensions":["js"],"step":"js"}
+                    ]
+                }
+            }"#,
+        )
+        .expect("split route manifest");
     }
 
     fn runner_output(exit_code: i32, stdout: &str, stderr: &str) -> RunnerOutput {
@@ -512,7 +585,7 @@ mod tests {
 
     #[test]
     fn test_validate_lint_quality() {
-        assert!(!validate_lint_quality(&component_without_quality_runners())
+        assert!(!validate_lint_quality(&component_without_quality_runners(), "fixture")
             .expect_passed_with_value(false));
     }
 
@@ -539,7 +612,7 @@ mod tests {
             },
         );
 
-        assert!(validate_lint_quality(&component).expect_passed_with_value(true));
+        assert!(validate_lint_quality(&component, "fixture").expect_passed_with_value(true));
     }
 
     #[test]
@@ -668,17 +741,13 @@ mod tests {
             },
         );
 
-        let err = validate_lint_quality(&component).expect_failed();
+        let err = validate_lint_quality(&component, "fixture").expect_failed();
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.to_string().contains("Lint failed (exit code 1)"));
     }
 
     #[test]
-    fn validate_lint_quality_warns_on_missing_runner_steps_harness() {
-        // Reproduces issue #4586: the lint harness exits non-zero (1) while the
-        // underlying linter is clean. The missing runner-steps.sh marker in the
-        // output identifies this as a harness/infra failure that must NOT
-        // hard-block the release.
+    fn validate_lint_quality_blocks_missing_runner_steps_harness() {
         let dir = tempfile::tempdir().expect("temp dir");
         write_script(
             dir.path(),
@@ -694,23 +763,12 @@ mod tests {
             },
         );
 
-        let message = validate_lint_quality(&component).expect_harness_error();
-        assert!(
-            message.contains("harness exited 1 with zero findings"),
-            "harness error message should mention zero findings: {}",
-            message
-        );
-        assert!(
-            message.contains("--skip-checks=lint"),
-            "harness error message should mention granular skip: {}",
-            message
-        );
+        let error = validate_lint_quality(&component, "fixture").expect_failed();
+        assert!(error.to_string().contains("Lint failed (exit code 1)"));
     }
 
     #[test]
-    fn validate_lint_quality_warns_on_high_exit_code() {
-        // Exit codes >= 2 conventionally indicate tooling/internal errors, not
-        // real lint findings — treated as a harness failure (warning).
+    fn validate_lint_quality_blocks_high_exit_code() {
         let dir = tempfile::tempdir().expect("temp dir");
         write_script(dir.path(), "lint.sh", "exit 7\n");
 
@@ -722,16 +780,270 @@ mod tests {
             },
         );
 
-        let message = validate_lint_quality(&component).expect_harness_error();
-        assert!(message.contains("harness exited 7"));
+        let error = validate_lint_quality(&component, "fixture").expect_failed();
+        assert!(error.to_string().contains("Lint failed (exit code 7)"));
     }
 
     #[test]
-    fn harness_failure_message_mentions_granular_skip() {
-        let message = harness_failure_message("Lint", 1);
-        assert!(message.contains("harness exited 1 with zero findings"));
-        assert!(message.contains("homeboy lint <component>"));
-        assert!(message.contains("--skip-checks=lint"));
+    fn extension_release_lint_blocks_extension_bootstrap_failure() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: "/tmp/fixture".to_string(),
+                extensions: Some(HashMap::from([(
+                    "missing-lint-extension".to_string(),
+                    ScopedExtensionConfig::default(),
+                )])),
+                ..Default::default()
+            };
+
+            let error = validate_lint_quality(&component, "fixture").expect_failed();
+            assert!(error.to_string().contains("Lint runner error"));
+        });
+    }
+
+    #[test]
+    fn extension_release_lint_rejects_invalid_explicit_lint_ownership() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/unsupported");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("unsupported.json"),
+                r#"{"name":"Unsupported","version":"1.0.0"}"#,
+            )
+            .expect("extension manifest");
+            let mut component = Component {
+                id: "fixture".to_string(),
+                local_path: "/tmp/fixture".to_string(),
+                extensions: Some(HashMap::from([(
+                    "unsupported".to_string(),
+                    ScopedExtensionConfig::default(),
+                )])),
+                ..Default::default()
+            };
+            assert!(!validate_lint_quality(&component, "fixture").expect_passed_with_value(false));
+            component
+                .capability_extensions
+                .insert("lint".to_string(), "unsupported".to_string());
+
+            let error = validate_lint_quality(&component, "fixture").expect_failed();
+            assert!(error.to_string().contains("Lint runner error"));
+        });
+    }
+
+    #[test]
+    fn extension_release_lint_blocks_finding_in_file_changed_since_prior_tag() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            let component = extension_lint_component(
+                home.path(),
+                source.path(),
+                r#"#!/bin/sh
+printf '[{"tool":"phpstan","message":"changed finding","fingerprint":"changed","file":"changed.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+                true,
+            );
+
+            let error = validate_lint_quality(&component, "fixture").expect_failed();
+            assert!(error.to_string().contains("Lint failed (exit code 1,"));
+        });
+    }
+
+    #[test]
+    fn extension_release_lint_includes_later_route_finding_in_failure_details() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            let component = extension_lint_component(
+                home.path(),
+                source.path(),
+                r#"#!/bin/sh
+if [ "$HOMEBOY_STEP" = "php" ]; then
+  printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+  exit 0
+fi
+printf '[{"tool":"eslint","message":"second route release finding","fingerprint":"second","file":"assets/app.js"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+                true,
+            );
+            enable_split_lint_routes(home.path());
+            fs::create_dir_all(source.path().join("assets")).expect("assets dir");
+            fs::write(source.path().join("assets/app.js"), "broken();\n").expect("js source");
+            run_git(source.path(), &["add", "assets/app.js"]);
+            run_git(source.path(), &["commit", "-q", "-m", "fix: js route"]);
+
+            let error = validate_lint_quality(&component, "fixture").expect_failed();
+            assert_eq!(
+                error.details["lint_workflow"]["finding_count"].as_u64(),
+                Some(1)
+            );
+            assert_eq!(
+                error.details["lint_workflow"]["findings"][0]["message"].as_str(),
+                Some("second route release finding")
+            );
+            assert!(error.details["lint_workflow"]["run_dir"].is_string());
+            assert!(error.details["lint_workflow"]["hints"].is_array());
+        });
+    }
+
+    #[test]
+    fn extension_release_lint_ignores_legacy_finding_outside_prior_tag_scope() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            let component = extension_lint_component(
+                home.path(),
+                source.path(),
+                r#"#!/bin/sh
+printf '[{"tool":"phpstan","message":"legacy finding","fingerprint":"legacy","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+                true,
+            );
+
+            assert!(validate_lint_quality(&component, "fixture").expect_passed_with_value(true));
+        });
+    }
+
+    #[test]
+    fn first_extension_release_retains_full_lint() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            let component = extension_lint_component(
+                home.path(),
+                source.path(),
+                r#"#!/bin/sh
+printf '[{"tool":"phpstan","message":"legacy finding","fingerprint":"legacy","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+                false,
+            );
+
+            let error = validate_lint_quality(&component, "fixture").expect_failed();
+            assert!(error.to_string().contains("Lint failed (exit code 1,"));
+        });
+    }
+
+    #[test]
+    fn extension_release_lint_uses_component_prefixed_release_tag() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            run_git(source.path(), &["init", "-q"]);
+            run_git(source.path(), &["config", "user.email", "homeboy@example.com"]);
+            run_git(source.path(), &["config", "user.name", "Homeboy Test"]);
+            let component_path = source.path().join("packages/fixture");
+            fs::create_dir_all(&component_path).expect("component dir");
+            fs::write(component_path.join("legacy.php"), "<?php\n").expect("legacy source");
+            run_git(source.path(), &["add", "packages/fixture/legacy.php"]);
+            run_git(source.path(), &["commit", "-q", "-m", "chore: initial"]);
+            run_git(source.path(), &["tag", "fixture-v1.0.0"]);
+            fs::write(component_path.join("changed.php"), "<?php echo 1;\n")
+                .expect("changed source");
+            run_git(source.path(), &["add", "packages/fixture/changed.php"]);
+            run_git(source.path(), &["commit", "-q", "-m", "fix: package"]);
+
+            let extension_dir =
+                home.path().join(".config/homeboy/extensions/release-lint-fixture");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("release-lint-fixture.json"),
+                r#"{"name":"Release lint fixture","version":"1.0.0","lint":{"extension_script":"lint.sh"}}"#,
+            )
+            .expect("extension manifest");
+            fs::write(
+                extension_dir.join("lint.sh"),
+                r#"#!/bin/sh
+printf '[{"tool":"phpstan","message":"legacy","fingerprint":"legacy","file":"packages/fixture/legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+            )
+            .expect("lint script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let script = extension_dir.join("lint.sh");
+                let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+                permissions.set_mode(0o755);
+                fs::set_permissions(script, permissions).expect("executable script");
+            }
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: component_path.to_string_lossy().to_string(),
+                extensions: Some(HashMap::from([(
+                    "release-lint-fixture".to_string(),
+                    ScopedExtensionConfig::default(),
+                )])),
+                ..Default::default()
+            };
+
+            assert!(validate_lint_quality(&component, "fixture").expect_passed_with_value(true));
+        });
+    }
+
+    #[test]
+    fn extension_release_lint_blocks_malformed_missing_and_producer_error_evidence() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let malformed_source = tempfile::tempdir().expect("malformed source dir");
+            let malformed = extension_lint_component(
+                home.path(),
+                malformed_source.path(),
+                "#!/bin/sh\nprintf '{' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nexit 1\n",
+                true,
+            );
+            let malformed_error = validate_lint_quality(&malformed, "fixture").expect_failed();
+            assert!(malformed_error.to_string().contains("Lint runner error"));
+
+            let missing_source = tempfile::tempdir().expect("missing source dir");
+            let missing = extension_lint_component(
+                home.path(),
+                missing_source.path(),
+                "#!/bin/sh\nexit 0\n",
+                true,
+            );
+            let missing_error = validate_lint_quality(&missing, "fixture").expect_failed();
+            assert!(missing_error.to_string().contains("Lint runner error"));
+
+            let producer_source = tempfile::tempdir().expect("producer error source dir");
+            let producer_error = extension_lint_component(
+                home.path(),
+                producer_source.path(),
+                r#"#!/bin/sh
+printf '[{"tool":"phpstan","message":"known","fingerprint":"known","file":"changed.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+printf '[{"tool":"phpstan","status":"error","finding_count":1}]' > "$HOMEBOY_LINT_PRODUCERS_FILE"
+exit 0
+"#,
+                true,
+            );
+            let mut known = homeboy_core::finding::HomeboyFinding::builder("phpstan", "known")
+                .fingerprint("known")
+                .build();
+            known.location.file = Some("changed.php".to_string());
+            homeboy_extension::lint::baseline::save_baseline(
+                producer_source.path(),
+                "fixture",
+                &[known],
+            )
+            .expect("save accepted baseline");
+            let producer_error =
+                validate_lint_quality(&producer_error, "fixture").expect_failed();
+            assert!(
+                producer_error
+                    .to_string()
+                    .contains("Lint failed (exit code 1,")
+            );
+            assert_eq!(
+                producer_error.details["lint_workflow"]["producer_error_count"].as_u64(),
+                Some(1)
+            );
+            assert_eq!(
+                producer_error.details["lint_workflow"]["baseline_new_count"].as_u64(),
+                Some(0)
+            );
+            assert_eq!(
+                producer_error.details["lint_workflow"]["baseline_known_count"].as_u64(),
+                Some(1)
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- scope extension-backed release lint to files changed since the latest component-aware release tag
- aggregate findings and producer evidence across multi-route lint runs while preserving failed evidence
- keep harness, producer, malformed-sidecar, and tool failures fail-closed even with an accepted baseline
- normalize nested monorepo changed paths and improve release failure diagnostics

## Why
`homeboy release extrachill-events` was blocked by 491 pre-existing PHPStan findings despite having no adopted PHPStan baseline. Release bypassed Homeboy's canonical changed-since lint workflow, and the shared workflow could also omit later route findings or let baseline handling hide producer errors.

Closes #6854.

## Verification
- `cargo test -p homeboy-extension lint::run::tests --no-fail-fast` (37 passed)
- `cargo test -p homeboy-release planning_quality --no-fail-fast` (24 passed)
- `cargo check -p homeboy-extension -p homeboy-release`
- `git diff --check`

`cargo fmt --check` was unavailable because the installed Rust toolchain lacks the `rustfmt` component.