### PR TITLE
fix(lab): project a terminal reverse result after the worker exits (#10659)

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/daemon_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon_api.rs
@@ -130,10 +130,36 @@ pub fn daemon_api_post(runner_id: &str, path: &str) -> Result<Value> {
     daemon_api_request(runner_id, path, "POST")
 }
 
+/// A reverse runner's broker is a controller-reachable durable rendezvous, not
+/// the runner machine. A detached Cook's worker exits as soon as it publishes
+/// its terminal result, so its controller-session heartbeat necessarily ages
+/// out past `REVERSE_RUNNER_HEARTBEAT_TTL` — but the result it already wrote to
+/// the broker stays readable and must stay projectable
+/// (Extra-Chill/homeboy#10659). Observation of durable broker state therefore
+/// requires only a recorded reverse session that names its broker endpoint.
+/// Mutations still assert an intent that a live worker has to honor, so they
+/// keep the liveness gate, as does every direct-daemon transport.
+fn reverse_broker_read_without_live_worker(session: Option<&RunnerSession>, method: &str) -> bool {
+    method == "GET"
+        && session.is_some_and(|session| {
+            session.mode == RunnerTunnelMode::Reverse
+                && session.local_url.is_none()
+                && session
+                    .broker_url
+                    .as_deref()
+                    .is_some_and(|url| !url.trim().is_empty())
+        })
+}
+
 pub(super) fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> Result<Value> {
     let runner = load(runner_id)?;
     let connected = status(runner_id)?;
-    let Some(legacy_session) = connected.session.filter(|_| connected.connected) else {
+    let recorded_broker_read =
+        reverse_broker_read_without_live_worker(connected.session.as_ref(), method);
+    let Some(legacy_session) = connected
+        .session
+        .filter(|_| connected.connected || recorded_broker_read)
+    else {
         return Err(Error::validation_invalid_argument(
             "runner",
             "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` first",
@@ -143,7 +169,14 @@ pub(super) fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> R
             ]),
         ));
     };
-    let session = daemon_api_session_for_path(runner_id, path, legacy_session)?;
+    // Generation routing resolves which *live* direct-daemon endpoint owns a
+    // job. A recorded-only reverse session has no generation to reconcile, so
+    // read it through the broker endpoint it recorded.
+    let session = if connected.connected {
+        daemon_api_session_for_path(runner_id, path, legacy_session)?
+    } else {
+        legacy_session
+    };
     let client = Client::builder()
         .no_proxy()
         .timeout(Duration::from_secs(10))
@@ -288,6 +321,67 @@ mod tests {
         let data = reverse_broker_daemon_data(json!({ "job": { "id": "job-1" } }));
         let body = canonical_daemon_body(&data, "reverse broker job").expect("canonical body");
         assert_eq!(body["job"]["id"], "job-1");
+    }
+
+    fn reverse_session() -> RunnerSession {
+        let mut session = session("lease-reverse", "unused");
+        session.mode = RunnerTunnelMode::Reverse;
+        session.broker_url = Some("http://127.0.0.1:9000".to_string());
+        session.local_url = None;
+        session.local_port = None;
+        session.remote_daemon_address = None;
+        session
+    }
+
+    #[test]
+    fn recorded_reverse_session_still_serves_broker_reads_after_its_worker_exits() {
+        // A detached Cook's worker exits the moment it publishes its terminal
+        // result, so its session heartbeat is always stale by the time the
+        // controller projects. The broker is durable and controller-reachable,
+        // so the read must not depend on worker liveness
+        // (Extra-Chill/homeboy#10659).
+        assert!(reverse_broker_read_without_live_worker(
+            Some(&reverse_session()),
+            "GET"
+        ));
+    }
+
+    #[test]
+    fn recorded_reverse_session_still_gates_mutations_and_direct_transports() {
+        // A mutation asserts an intent a live worker has to honor.
+        assert!(!reverse_broker_read_without_live_worker(
+            Some(&reverse_session()),
+            "POST"
+        ));
+        // Direct-SSH transport reads the runner machine itself, so liveness
+        // remains the correct gate.
+        assert!(!reverse_broker_read_without_live_worker(
+            Some(&session("lease-a", "daemon-a")),
+            "GET"
+        ));
+        // A reverse session that never recorded a broker endpoint has nothing
+        // durable to read.
+        let mut without_broker = reverse_session();
+        without_broker.broker_url = None;
+        assert!(!reverse_broker_read_without_live_worker(
+            Some(&without_broker),
+            "GET"
+        ));
+        let mut blank_broker = reverse_session();
+        blank_broker.broker_url = Some("   ".to_string());
+        assert!(!reverse_broker_read_without_live_worker(
+            Some(&blank_broker),
+            "GET"
+        ));
+        // A reverse session pinned to a local daemon endpoint would route
+        // direct, and that endpoint really is dead once the worker exits.
+        let mut with_local = reverse_session();
+        with_local.local_url = Some("http://127.0.0.1:4100".to_string());
+        assert!(!reverse_broker_read_without_live_worker(
+            Some(&with_local),
+            "GET"
+        ));
+        assert!(!reverse_broker_read_without_live_worker(None, "GET"));
     }
 }
 

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -267,7 +267,7 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
 
     let mut cook_command = context.command(TestBinary::HomeboyFixture);
     cook_command
-        .env("PATH", path)
+        .env("PATH", &path)
         .env("HOMEBOY_CONTROLLER_ID", "fixture-controller")
         .args([
             "--runner",
@@ -329,6 +329,7 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
             let run_id = accepted["latest_run_id"].as_str().unwrap_or("unknown");
             let status = context
                 .command(TestBinary::HomeboyFixture)
+                .env("PATH", &path)
                 .args(["agent-task", "status", run_id])
                 .output()
                 .expect("inspect stalled controller parent");
@@ -460,6 +461,10 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
     let terminal = loop {
         let status = context
             .command(TestBinary::HomeboyFixture)
+            // A recorded-only reverse session makes `runner status` reach for
+            // its SSH recovery probe. Keep that on the fixture shim rather than
+            // letting a real `ssh` escape the hermetic context.
+            .env("PATH", &path)
             .args(["agent-task", "status", run_id])
             .output()
             .expect("read terminal parent status");

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -1,8 +1,89 @@
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use homeboy::core::api_jobs::{JobEventKind, JobStatus};
 use homeboy_core::test_support::{HermeticTestContext, ReverseBrokerFixture, TestBinary};
+
+/// A live reverse worker republishes its controller session heartbeat while it
+/// is connected; the recorded `last_seen_at` is only as old as its last beat.
+/// The fixture used to fake that with a single timestamp five minutes in the
+/// future, which `reverse_controller_session_is_live` accepts because a
+/// negative age fails `Duration::try_from` and falls open. That gave the test a
+/// fixed ~390 s liveness window (300 s of future skew plus the 90 s heartbeat
+/// TTL) while the test itself runs 430–590 s, so whether it passed depended on
+/// where that wall-clock cliff landed. Beat the session honestly instead.
+struct ReverseSessionHeartbeat {
+    path: PathBuf,
+    session: serde_json::Value,
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ReverseSessionHeartbeat {
+    fn start(path: &Path, mut session: serde_json::Value) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        session["last_seen_at"] = serde_json::json!(chrono::Utc::now().to_rfc3339());
+        Self::write(path, &session);
+        let handle = {
+            let path = path.to_path_buf();
+            let session = session.clone();
+            let stop = stop.clone();
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(500));
+                    if stop.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let mut beat = session.clone();
+                    beat["last_seen_at"] = serde_json::json!(chrono::Utc::now().to_rfc3339());
+                    Self::write(&path, &beat);
+                }
+            })
+        };
+        Self {
+            path: path.to_path_buf(),
+            session,
+            stop,
+            handle: Some(handle),
+        }
+    }
+
+    /// Stop beating and record the session a worker that has already exited
+    /// leaves behind: a real `last_seen_at` older than the reverse heartbeat
+    /// TTL. The controller must still project the terminal result the worker
+    /// published to the broker before it exited.
+    fn expire(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("reverse session heartbeat thread");
+        }
+        let mut expired = self.session.clone();
+        expired["last_seen_at"] =
+            serde_json::json!((chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339());
+        Self::write(&self.path, &expired);
+    }
+
+    /// Publish through a same-directory rename. A truncating rewrite would let
+    /// a controller read observe an empty session file mid-beat and report the
+    /// runner disconnected for reasons that have nothing to do with liveness.
+    fn write(path: &Path, session: &serde_json::Value) {
+        let staged = path.with_extension("beat");
+        std::fs::write(&staged, session.to_string()).expect("stage reverse controller session");
+        std::fs::rename(&staged, path).expect("publish reverse controller session");
+    }
+}
+
+impl Drop for ReverseSessionHeartbeat {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
 
 fn output(command: &mut Command) -> std::process::Output {
     let output = command.output().expect("run homeboy fixture command");
@@ -163,8 +244,10 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         .join("runner-sessions/lab/fixture-controller.json");
     std::fs::create_dir_all(session_path.parent().expect("session parent"))
         .expect("create session directory");
-    std::fs::write(
-        session_path,
+    // Beat the session for as long as the fixture worker is "connected", the
+    // way `homeboy runner work` does, instead of pinning one future timestamp.
+    let mut session_heartbeat = ReverseSessionHeartbeat::start(
+        &session_path,
         serde_json::json!({
             "runner_id": "lab",
             "mode": "reverse",
@@ -179,11 +262,8 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
             "connected_at": "2026-01-01T00:00:00Z",
             "worker_identity": "fixture-worker",
             "worker_pid": 1,
-            "last_seen_at": (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339()
-        })
-        .to_string(),
-    )
-    .expect("write reverse controller session");
+        }),
+    );
 
     let mut cook_command = context.command(TestBinary::HomeboyFixture);
     cook_command
@@ -366,6 +446,12 @@ fn detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once() {
         })
         .expect("duplicate worker wake");
     assert_eq!(duplicate_code, 0);
+    // Both worker waves have returned, so the reverse worker is gone and its
+    // controller-session heartbeat stops. That is the steady state of a
+    // detached Cook, not an edge case: the worker exits the moment it publishes
+    // its terminal result. Record it explicitly so terminal projection is
+    // proven against a genuinely expired session instead of racing one.
+    session_heartbeat.expire();
     // The controller must project the broker result after the worker exits.
     // `daemon serve` is intentionally un-tokenized, so terminate the test-owned
     // foreground child only after that durable parent lifecycle is terminal.


### PR DESCRIPTION
## Summary

`detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once` is red because **the production code is wrong**, and the test is right — it just only ever proved it by accident of wall-clock timing.

A detached Cook's reverse worker exits the moment it publishes its terminal result to the broker. Its controller-session heartbeat therefore *necessarily* ages out past `REVERSE_RUNNER_HEARTBEAT_TTL` (90 s). But `daemon_api_request` gated **every** reverse read on that liveness:

```rust
let Some(legacy_session) = connected.session.filter(|_| connected.connected) else {
    return Err(... "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` first");
};
```

So `runner_job_log_snapshot` → `fetch_daemon_job` → `daemon_api_get` hard-failed, `reconcile_runner_job` fell to `UnconfirmedAbsence`, `is_runner_connected` returned false, the run got annotated `runner_disconnected`, and the durable parent could never reach a terminal state. That is *exactly* what this acceptance test asserts is impossible:

> The controller must project the broker result after the worker exits.

The broker is a controller-reachable durable rendezvous, not the runner machine. Its readability has nothing to do with whether a worker is currently connected.

## The fix

- `crates/homeboy-lab-runner/src/execution/daemon_api.rs` — serve **reverse broker reads** from a *recorded* session that names its broker endpoint, without requiring a live worker. Mutations still assert an intent a live worker has to honor, and every direct-daemon transport reads the runner machine itself, so both keep the liveness gate. Generation routing (a live direct-daemon concern) is skipped on the recorded-only path.
- Unit coverage for the policy, so the production fix is locked in by a millisecond-scale test rather than by an 8-minute acceptance test.

## Why the test was flaky rather than simply red

The fixture pinned `last_seen_at` **five minutes in the future**. `reverse_controller_session_is_live` accepts that, because a negative age fails `Duration::try_from` and the match arm falls open:

```rust
match age.to_std() {
    Ok(age) => age <= REVERSE_RUNNER_HEARTBEAT_TTL,
    Err(_) => true,
}
```

That handed the test a fixed **~390 s** liveness window (300 s of future skew + the 90 s TTL) while the test itself runs **430–590 s**. Whether it passed depended on whether terminal projection completed before that cliff — pure scheduling and load.

The fixture now beats the session honestly while the fixture worker is connected (which is what `homeboy runner work` does), and then records the **expired** session a departed worker actually leaves behind before asserting terminal projection. The assertion is now deterministic and strictly stronger: it proves projection survives worker exit instead of racing a fake liveness window.

Beats are published through a same-directory rename so a controller read can never observe a truncated session file mid-beat.

## Corrections to the issue's framing

`#10659` says the test "panics on the 10 s deadline" when the suite is small and "takes 431.81 s and passes" when it is large. The timing half of that is not what the logs show. In run [30364158677](https://github.com/Extra-Chill/homeboy/actions/runs/30364158677) (job `90291061000`), **both phases of the same job** ran the test to completion:

| phase | line | outcome | duration |
|---|---|---|---|
| candidate | 15421 | FAILED | **438.59 s** |
| baseline | 25872 | ok | **442.12 s** |

The failing run is not fast. The 10 s deadline sits at the end of a ~440 s test; it is the last 2 % of the runtime, and it is not the defect. The issue's *conclusion* — that the outcome turns on scheduling and load rather than on a commit difference — is right; the mechanism it names is not.

The `missing field `exit_code`` warning quoted in the issue was a genuine second defect (`mirror_reverse_broker_evidence` deserializing `RemoteRunnerJobResult` from `{}` on a **not-yet-terminal** job), but it was already fixed on `main` by #10666 (`classify_terminal_result` → `TerminalResultAvailability::Pending`). This PR does not touch it.

## What this PR does not fix

- **The 470 s runtime (#10655) is untouched.** I could not establish where it goes from CI logs alone: per-test duration is captured, per-phase is not, and libtest hides captured output on success. The dominant cost is inside the first `run_reverse_worker`, which executes a full runner-side `homeboy agent-task` cook as a debug-build subprocess; the 424 → 442 → 473 → 586 s spread across runs is load-proportional, not a fixed timeout, which argues for real work rather than a wall-clock wait. That needs a measurement pass, not a guess. It is a separate defect from this one and the test should **not** be deleted or `#[ignore]`d for it — it is the only coverage of detached Cook + reverse capacity queue.
- **`reverse_controller_session_is_live` still falls open on a future `last_seen_at`.** Clock skew or a crafted session makes a session immortal. Nothing depends on it after this PR, but it is still a fail-open and deserves its own issue.

## Verification

- `cargo fmt --all`
- `git diff --check`
- Cargo build/check/test were **not** run locally: this host shares 16 GB with other services and a homeboy workspace build OOM-kills the agent supervisor. Compilation and both tests are verified by PR CI.

Refs #10659

## AI Assistance

- Agent: chubes-bot (Claude Code)
- Used for: harvesting the failing CI Test-job logs via the raw jobs-logs API, tracing the reverse-read liveness gate, and drafting the fix and its coverage. Chris Huber remains responsible for the final change.
