### PR TITLE
Fix stale homeboy-agents main test contracts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -825,16 +825,17 @@ mod baseline_tests {
         assert!(report.stderr.contains("was cancelled"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn bounded_baseline_gate_reaps_background_descendants_before_reader_join() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let marker = temp.path().join("descendant-survived");
+        let pid_file = temp.path().join("descendant.pid");
         let report = run_gate_command_with_timeout(
             temp.path(),
             1,
             &format!(
-                "(sleep 0.2; touch '{}') & while :; do sleep 1; done",
-                marker.display()
+                "sh -c 'trap \"\" TERM; while :; do sleep 1; done' & echo $! > '{}'; wait",
+                pid_file.display()
             ),
             AgentTaskGateVisibility::Visible,
             AgentTaskGateRevealPolicy::FullEvidence,
@@ -845,8 +846,12 @@ mod baseline_tests {
         .expect("bounded gate report");
 
         assert_eq!(report.exit_code, 124);
-        std::thread::sleep(Duration::from_millis(300));
-        assert!(!marker.exists(), "background descendant survived timeout");
+        let descendant_pid = std::fs::read_to_string(pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<libc::pid_t>()
+            .expect("numeric descendant pid");
+        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
     }
 }
 
@@ -1930,7 +1935,7 @@ mod tests {
     }
 
     #[test]
-    fn existing_gate_commands_are_automatic_toolchain_requirements() {
+    fn gate_toolchain_requirements_are_explicit() {
         let options = VerifyGateOptions {
             verify: vec!["cargo test --lib".to_string()],
             private_verify: vec!["npm test".to_string()],
@@ -1943,16 +1948,10 @@ mod tests {
 
         assert_eq!(
             options.required_toolchains(),
-            vec![
-                AgentTaskGateToolchainRequirement {
-                    command: "cargo".to_string(),
-                    probe_arguments: vec!["metadata".to_string()],
-                },
-                AgentTaskGateToolchainRequirement {
-                    command: "npm".to_string(),
-                    probe_arguments: vec!["--version".to_string()],
-                },
-            ]
+            vec![AgentTaskGateToolchainRequirement {
+                command: "cargo".to_string(),
+                probe_arguments: vec!["metadata".to_string()],
+            }]
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -178,14 +178,6 @@ mod tests {
             .run_id
     }
 
-    fn controller_admission_stamped(run_id: &str) -> bool {
-        agent_task_lifecycle::exact_record(run_id)
-            .expect("durable record")
-            .metadata
-            .get("controller_admission")
-            .is_some()
-    }
-
     #[test]
     fn runner_backed_actions_execute_on_the_owning_runner() {
         let actions = actions_for_agent_task("run-1", Some("lab-a"), ActivityState::Stale);
@@ -199,15 +191,14 @@ mod tests {
     #[test]
     fn probe_by_id_resolves_one_record_without_scanning_or_writing() {
         // #10308: resolving a single agent-task id must be an indexed read, not
-        // a full-corpus refresh. The scanning path refreshes every record
-        // through `status()`, which stamps `controller_admission` on each one —
-        // so the absence of that stamp is durable evidence that neither the
-        // probed record nor its siblings were scanned or written.
+        // a full-corpus refresh. Preserve the exact durable records to prove
+        // that neither the target nor its sibling was scanned or rewritten.
         with_isolated_home(|_| {
             let target = seed_record("run-probe-target");
             let sibling = seed_record("run-probe-sibling");
-            assert!(!controller_admission_stamped(&target));
-            assert!(!controller_admission_stamped(&sibling));
+            let target_before = agent_task_lifecycle::exact_record(&target).expect("target record");
+            let sibling_before =
+                agent_task_lifecycle::exact_record(&sibling).expect("sibling record");
 
             let item = AgentTaskActivityProvider
                 .probe_by_id(&target)
@@ -221,14 +212,14 @@ mod tests {
                 item.refs.agent_task_run_id.as_deref(),
                 Some(target.as_str())
             );
-            assert!(!controller_admission_stamped(&target));
-            assert!(!controller_admission_stamped(&sibling));
-
-            // Control: the scanning path the probe replaces does refresh — and
-            // therefore write — every record, which is the cost being avoided.
-            agent_task_lifecycle::list_records().expect("records listed");
-            assert!(controller_admission_stamped(&target));
-            assert!(controller_admission_stamped(&sibling));
+            assert_eq!(
+                agent_task_lifecycle::exact_record(&target).expect("target remains readable"),
+                target_before
+            );
+            assert_eq!(
+                agent_task_lifecycle::exact_record(&sibling).expect("sibling remains readable"),
+                sibling_before
+            );
         });
     }
 
@@ -284,13 +275,17 @@ mod tests {
         with_isolated_home(|_| {
             register();
             let run_id = seed_record("run-show-probe");
+            let before = agent_task_lifecycle::exact_record(&run_id).expect("record before show");
 
             let report = homeboy_core::activity::show_activity(&run_id).expect("show activity");
 
             assert_eq!(report.items.len(), 1);
             assert_eq!(report.items[0].id, run_id);
             assert_eq!(report.items[0].source_store, "agent-task.lifecycle");
-            assert!(!controller_admission_stamped(&run_id));
+            assert_eq!(
+                agent_task_lifecycle::exact_record(&run_id).expect("record after show"),
+                before
+            );
         });
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -506,7 +506,7 @@ fn retry_rebuilds_follow_up_candidate_from_durable_promotion() {
 }
 
 #[test]
-fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
+fn controller_proxy_records_pending_handoff_then_binds_runner_child() {
     with_isolated_home(|_| {
         let command = vec![
             "homeboy".to_string(),
@@ -525,7 +525,10 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
         assert_eq!(planned.state, AgentTaskRunState::Queued);
         assert!(planned.metadata.get("runner_job_id").is_none());
         assert_eq!(planned.metadata["lifecycle_store_owner"], "controller");
-        assert!(planned.lab_handoff.is_none());
+        let pending = planned.lab_handoff.as_ref().expect("pending handoff");
+        assert_eq!(pending.state, AgentTaskLabHandoffState::Pending);
+        assert_eq!(pending.runner_id, "homeboy-lab");
+        assert!(pending.runner_job_id.is_none());
         assert!(planned.metadata.get("handoff_acceptance").is_none());
         assert!(load_plan("agent-task-controller-proxy")
             .expect("proxy plan")
@@ -999,7 +1002,10 @@ fn preacceptance_snapshot_binds_planned_runner_job_before_validation() {
             Some(&plan),
         )
         .expect("persist planned controller execution");
-        assert!(record.lab_handoff.is_none());
+        let pending = record.lab_handoff.as_ref().expect("pending handoff");
+        assert_eq!(pending.state, AgentTaskLabHandoffState::Pending);
+        assert_eq!(pending.runner_id, "homeboy-lab");
+        assert!(pending.runner_job_id.is_none());
         assert_eq!(record.metadata["runner_id"], "homeboy-lab");
         let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
         snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1376,7 +1376,7 @@ fn controller_leaves_runner_artifact_projection_pending_when_it_cannot_mirror_by
         aggregate.outcomes[0].artifacts = vec![
             AgentTaskArtifact {
                 schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                id: "patch".to_string(),
+                id: "report".to_string(),
                 kind: "patch".to_string(),
                 name: None,
                 label: None,


### PR DESCRIPTION
## Summary
- align gate toolchain assertions with explicit requirements
- assert indexed activity reads preserve exact durable records
- preserve pending Lab handoff and distinct artifact identity contracts
- verify bounded gate cleanup using actual descendant liveness

Closes #10658

## Verification
- all failures observed in run 30397550280 pass when run directly
- `cargo test -p homeboy-agents --lib agent_task_gate::baseline_tests`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode diagnosed the stale assertions, drafted the test-only changes, and ran the focused verification. Chris Huber remains responsible for the submitted changes.