### PR TITLE
feat: a shared measurement_ok invariant, so a gate cannot report success without proving it measured

### DIFF
--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -25,6 +25,7 @@ use super::types::{
     CodeAuditResult, ConventionReport, ScopedAuditExecution,
 };
 use super::{checks, conventions, discovery, duplication, fingerprint, impact, structural, walker};
+use homeboy_engine_primitives::measurement::Measurement;
 use homeboy_error::Result;
 
 /// Detectors run on the root-only fast path (no discovery/fingerprinting). The
@@ -129,10 +130,23 @@ pub(super) fn audit_internal(
     // `validate_configured_paths` contract one level up: configuration that
     // silently matches zero files is already an error, and a corpus that
     // silently contains zero files is the same defect with a wider blast radius.
+    //
+    // Restated through the shared `measurement_ok` predicate (#10685) without
+    // changing behaviour. The corpus size is the observation; the source files
+    // that exist on disk -- claimed-but-unfingerprinted plus unclaimed
+    // entirely -- are the independently-known population that says whether a
+    // zero corpus is honest. A non-empty population makes this `Contradicted`,
+    // the one outcome the predicate treats as a hard error rather than an
+    // `unknown`, which is exactly the judgement #10574 made here first. The two
+    // branch-specific messages below are kept verbatim: the predicate decides
+    // *whether* to refuse, the call site still says *what to do about it*.
     if discovery.policy_fingerprints.is_empty() {
         let unclaimed = walker::count_unclaimed_source_files(root);
         let total_skipped = files_skipped + unclaimed;
-        if unclaimed > 0 {
+        let corpus = Measurement::units(0)
+            .against_population((discovery.files_walked + unclaimed) as u64)
+            .assess();
+        if corpus.is_broken_instrument() && unclaimed > 0 {
             return Err(homeboy_error::Error::invalid_argument(
                 "audit.corpus",
                 format!(
@@ -145,7 +159,7 @@ pub(super) fn audit_internal(
                 ),
             ));
         }
-        if discovery.files_walked > 0 {
+        if corpus.is_broken_instrument() {
             return Err(homeboy_error::Error::invalid_argument(
                 "audit.corpus",
                 format!(
@@ -156,8 +170,9 @@ pub(super) fn audit_internal(
                 ),
             ));
         }
-        // Genuinely nothing to audit (docs-only or empty checkout). That is a
-        // real, honest zero — not a broken instrument.
+        // `MeasurementOutcome::EmptyPopulation`: the walk independently
+        // confirms there was nothing to audit (docs-only or empty checkout).
+        // That is a real, honest zero — not a broken instrument.
         log_status!("audit", "No source files found");
         timing.push_ok("discovery_fingerprinting", discovery_started.elapsed());
         return Ok(AuditWithAnalysis {

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -21,6 +21,7 @@ pub mod grammar;
 pub mod identifier;
 pub mod language;
 pub mod local_files;
+pub mod measurement;
 pub mod output_parse;
 pub mod phase_timing;
 pub mod provider_registry;

--- a/crates/homeboy-engine-primitives/src/measurement.rs
+++ b/crates/homeboy-engine-primitives/src/measurement.rs
@@ -1,0 +1,645 @@
+//! `measurement_ok` — the shared precondition for rendering a green verdict
+//! (#10685).
+//!
+//! # The invariant
+//!
+//! **Absence of evidence is never evidence of success.** Before any gate reads
+//! its verdict, it must be able to point at proof that it measured something.
+//! A gate that cannot prove it measured must report `unknown` — never `pass`.
+//!
+//! # Why this is shared
+//!
+//! Three places in this repository had independently grown a local version of
+//! this rule, and they disagreed with one another about what to do when the
+//! instrument came back empty:
+//!
+//! * `homeboy-extension/src/test/run.rs::test_run_status` had the best of them
+//!   — "a zero count or an all-skipped result proves only that the runner
+//!   started" — and failed closed to `"failed"`.
+//! * `homeboy-code-audit/src/engine.rs` (#10557 / #10574) hard-errors on an
+//!   empty corpus, because an audit that scanned zero of 1,817 files had been
+//!   reporting `passed: true` in seven seconds for weeks.
+//! * `homeboy-extension/src/lint/run/workflow.rs` had none, and still renders
+//!   an unconditional `passed` when changed-file scoping resolves to zero
+//!   runnable scopes — including when the changed set was *not* empty.
+//!
+//! This module is the one place those three answers are reconciled. It is
+//! deliberately behaviour-free apart from the classification itself: it decides
+//! what a measurement *permits*, and leaves the caller to decide what it wants.
+//!
+//! # What this module does NOT do
+//!
+//! It classifies the **presence** of a measurement. It says nothing about
+//! whether a measurement that exists was *interpreted* correctly. #10657 —
+//! where a differential gate rewrote `current == base == 1` to `pass` — is a
+//! comparison-semantics defect with fully accurate counts on both sides, and no
+//! measurement-presence predicate can catch it. Do not reach for this module
+//! expecting it to.
+
+/// Whether the run that produced a measurement got to finish.
+///
+/// Checked *before* any count-based branch. A killed child usually never writes
+/// its results sidecar, so it arrives with absent or partial counts; reading
+/// those counts as a total is how a truncated run gets a verdict it did not
+/// earn. #10644 established this ordering for the test phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunCompletion {
+    /// The instrument ran to completion and had the opportunity to report
+    /// everything it saw.
+    Complete,
+    /// The run was cut short. Whatever it reported is a prefix, not a total.
+    Incomplete(IncompleteReason),
+}
+
+/// How a run was cut short. Reported verbatim so an operator can tell a budget
+/// exhaustion apart from an OOM kill apart from a lost output stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncompleteReason {
+    /// The run exhausted an execution budget.
+    TimedOut,
+    /// The process was terminated by a signal.
+    Killed,
+    /// The run's output was cut off, so counts read from it are a prefix.
+    Truncated,
+    /// The run did not finish and the cause was not established. Still not a
+    /// pass: an unexplained early exit is strictly less reliable than an
+    /// explained one.
+    Unspecified,
+}
+
+impl IncompleteReason {
+    /// Operator-facing label.
+    pub fn label(self) -> &'static str {
+        match self {
+            IncompleteReason::TimedOut => "timed out",
+            IncompleteReason::Killed => "was killed",
+            IncompleteReason::Truncated => "was truncated",
+            IncompleteReason::Unspecified => "did not finish",
+        }
+    }
+}
+
+/// What the instrument reported about the amount of work it observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Observed {
+    /// Structured counts survived: `units` units of work were observed.
+    ///
+    /// A "unit" is whatever the gate counts as evidence it did its job: an
+    /// executed test, a fingerprinted source file, a linted file, a validated
+    /// release asset. Zero is a legal value and is handled explicitly — it is
+    /// not the same as [`Observed::Unreported`].
+    Units(u64),
+    /// The instrument produced no structured counts at all. There is nothing to
+    /// read, which is materially different from reading a zero.
+    Unreported,
+}
+
+/// The set of candidate units the instrument was pointed at, when that is known
+/// from a source *other than the instrument itself*.
+///
+/// The independence matters. A broken instrument reporting "I saw zero files"
+/// is indistinguishable from an honest zero unless something else can say how
+/// many files there were. `git diff --name-only` knows the changed set; a
+/// directory walk knows the file count; a release plan knows the asset list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Population {
+    /// Independently established: `n` candidate units existed.
+    Known(u64),
+    /// Not independently established. An observed zero then cannot be told
+    /// apart from a broken instrument, which is exactly why it is not a pass.
+    Unestablished,
+}
+
+/// A single gate's claim about what it measured.
+///
+/// Build with [`Measurement::units`], [`Measurement::unreported`] or
+/// [`Measurement::advisory`], refine with [`Measurement::against_population`]
+/// and [`Measurement::incomplete`], then call [`Measurement::assess`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Measurement {
+    observed: Observed,
+    population: Population,
+    completion: RunCompletion,
+    advisory: bool,
+}
+
+impl Measurement {
+    /// The instrument reported `units` units of observed work.
+    pub fn units(units: u64) -> Self {
+        Self {
+            observed: Observed::Units(units),
+            population: Population::Unestablished,
+            completion: RunCompletion::Complete,
+            advisory: false,
+        }
+    }
+
+    /// The instrument produced no structured counts at all.
+    pub fn unreported() -> Self {
+        Self {
+            observed: Observed::Unreported,
+            population: Population::Unestablished,
+            completion: RunCompletion::Complete,
+            advisory: false,
+        }
+    }
+
+    /// An **advisory** measurement: informative, and permitted to move a verdict
+    /// in neither direction.
+    ///
+    /// This exists because the opposite mistake is just as damaging as a false
+    /// green. `bounded_directory_size` shells out to `du -sk`; when that failed
+    /// the size came back `None`, liveness degraded to `"unknown"`, and prune
+    /// became a silent no-op — an advisory instrument silently disabling a real
+    /// operation. #10662 set the discipline: a failed advisory measurement
+    /// changes the verdict in neither direction. [`MeasurementOutcome::Advisory`]
+    /// is inert by construction, so a caller cannot accidentally gate on it.
+    pub fn advisory() -> Self {
+        Self {
+            observed: Observed::Unreported,
+            population: Population::Unestablished,
+            completion: RunCompletion::Complete,
+            advisory: true,
+        }
+    }
+
+    /// Record an independently-known candidate population.
+    ///
+    /// This is what upgrades "I observed zero and cannot say why" from
+    /// [`MeasurementOutcome::Unmeasured`] to either [`MeasurementOutcome::EmptyPopulation`]
+    /// (an honest zero) or [`MeasurementOutcome::Contradicted`] (a provably
+    /// broken instrument). Supply it wherever it is cheaply available.
+    pub fn against_population(mut self, population: u64) -> Self {
+        self.population = Population::Known(population);
+        self
+    }
+
+    /// Record that the run producing this measurement did not finish.
+    pub fn incomplete(mut self, reason: IncompleteReason) -> Self {
+        self.completion = RunCompletion::Incomplete(reason);
+        self
+    }
+
+    /// Classify the measurement. This is the predicate.
+    ///
+    /// Branch order is load-bearing:
+    ///
+    /// 1. **Advisory** first, so an advisory instrument that timed out still
+    ///    moves nothing.
+    /// 2. **Incompleteness** before counts, because a truncated run's counts are
+    ///    a prefix and reading them as a total is #10644's defect.
+    /// 3. **Unreported** before zero, because "nothing to read" and "read a
+    ///    zero" are different states with different remedies.
+    /// 4. **Zero against a known population** before zero in general, because
+    ///    only the former is provable.
+    pub fn assess(&self) -> MeasurementOutcome {
+        if self.advisory {
+            return MeasurementOutcome::Advisory;
+        }
+        if let RunCompletion::Incomplete(reason) = self.completion {
+            return MeasurementOutcome::Unmeasured(UnmeasuredReason::RunIncomplete(reason));
+        }
+        let units = match self.observed {
+            Observed::Unreported => {
+                return MeasurementOutcome::Unmeasured(UnmeasuredReason::NoStructuredCounts);
+            }
+            Observed::Units(units) => units,
+        };
+        if units > 0 {
+            // Observing more units than the recorded population is not a
+            // green-safety problem — the population is a lower bound supplied
+            // for the zero case — so it is deliberately not an error here.
+            return MeasurementOutcome::Measured { units };
+        }
+        match self.population {
+            Population::Known(0) => MeasurementOutcome::EmptyPopulation,
+            Population::Known(population) => MeasurementOutcome::Contradicted { population },
+            Population::Unestablished => {
+                MeasurementOutcome::Unmeasured(UnmeasuredReason::ZeroUnits)
+            }
+        }
+    }
+}
+
+/// Why a measurement cannot support a `pass`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnmeasuredReason {
+    /// The instrument produced no structured counts.
+    NoStructuredCounts,
+    /// The instrument observed zero units and nothing can say whether zero was
+    /// the right answer.
+    ZeroUnits,
+    /// The run did not finish, so its counts are a prefix.
+    RunIncomplete(IncompleteReason),
+}
+
+/// The classification of a measurement, and the only thing a gate may consult
+/// before rendering `pass`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeasurementOutcome {
+    /// Positive evidence: a run that finished observed at least one unit.
+    Measured { units: u64 },
+    /// The instrument observed zero and an independent source confirms there
+    /// was nothing to observe. An honest zero, and a legitimate `pass`.
+    EmptyPopulation,
+    /// No usable evidence, and no way to tell an honest zero from a broken
+    /// instrument. `unknown` is the honest verdict; `pass` is forbidden.
+    Unmeasured(UnmeasuredReason),
+    /// The instrument observed zero against a population independently known to
+    /// be non-empty. This is not `unknown` — the instrument is provably broken,
+    /// and a broken instrument is a hard error.
+    Contradicted { population: u64 },
+    /// Advisory. Constrains nothing, in either direction.
+    Advisory,
+}
+
+impl MeasurementOutcome {
+    /// **The invariant.** `false` means no verdict-producing path may render
+    /// `pass` from this measurement.
+    pub fn permits_pass(&self) -> bool {
+        match self {
+            MeasurementOutcome::Measured { .. }
+            | MeasurementOutcome::EmptyPopulation
+            | MeasurementOutcome::Advisory => true,
+            MeasurementOutcome::Unmeasured(_) | MeasurementOutcome::Contradicted { .. } => false,
+        }
+    }
+
+    /// A broken instrument. Neither `pass` nor `unknown` is an honest answer, so
+    /// callers should surface this as an error rather than a verdict.
+    pub fn is_broken_instrument(&self) -> bool {
+        matches!(self, MeasurementOutcome::Contradicted { .. })
+    }
+
+    /// Constrain an intended verdict to one the measurement can actually
+    /// support.
+    ///
+    /// The downgrade is `Pass -> Unknown`, deliberately **not** `Pass -> Fail`.
+    /// Turning every unmeasured gate into a hard failure makes CI permanently
+    /// red, and a permanently red gate is ignored — the same end state as the
+    /// bug this predicate exists to prevent. `Unknown` is a first-class verdict
+    /// here for the same reason #10561 made it one for `EvidenceManifest`: a
+    /// gate that could not measure should say so rather than guess in either
+    /// direction.
+    ///
+    /// [`MeasurementOutcome::Contradicted`] is the one case that refuses
+    /// outright, because it is the one case where the instrument is *provably*
+    /// broken rather than merely silent.
+    pub fn constrain(&self, intended: Verdict) -> Result<Verdict, MeasurementRefusal> {
+        match self {
+            MeasurementOutcome::Contradicted { population } => Err(MeasurementRefusal {
+                population: *population,
+            }),
+            _ if self.permits_pass() => Ok(intended),
+            // Unmeasured. A gate may still fail for reasons it *did* establish
+            // (a non-zero exit, a parse error); only the green is withheld.
+            MeasurementOutcome::Unmeasured(_) => Ok(match intended {
+                Verdict::Pass => Verdict::Unknown,
+                other => other,
+            }),
+            // Unreachable: every remaining variant permits a pass.
+            _ => Ok(intended),
+        }
+    }
+
+    /// Operator-facing explanation of why a `pass` was withheld, or `None` when
+    /// nothing was withheld.
+    ///
+    /// Phrased as a statement about the *instrument*, not about the code under
+    /// test, so a reader is never misled into debugging their own change.
+    pub fn withheld_pass_reason(&self) -> Option<String> {
+        match self {
+            MeasurementOutcome::Measured { .. }
+            | MeasurementOutcome::EmptyPopulation
+            | MeasurementOutcome::Advisory => None,
+            MeasurementOutcome::Unmeasured(UnmeasuredReason::NoStructuredCounts) => Some(
+                "no structured counts were reported, so there is no evidence this gate measured \
+                 anything; reporting unknown rather than passed (#10685)"
+                    .to_string(),
+            ),
+            MeasurementOutcome::Unmeasured(UnmeasuredReason::ZeroUnits) => Some(
+                "zero units were measured and nothing independently confirms there were none to \
+                 measure; reporting unknown rather than passed (#10685)"
+                    .to_string(),
+            ),
+            MeasurementOutcome::Unmeasured(UnmeasuredReason::RunIncomplete(reason)) => {
+                Some(format!(
+                    "the run {}, so its counts are a prefix rather than a total; reporting unknown \
+                     rather than passed (#10685)",
+                    reason.label()
+                ))
+            }
+            MeasurementOutcome::Contradicted { population } => Some(format!(
+                "measured 0 of {population} candidate unit(s): the instrument is broken, not the \
+                 subject. This is a hard error, not an unknown (#10685)"
+            )),
+        }
+    }
+}
+
+/// Returned when a measurement is provably broken and no verdict may be
+/// rendered from it at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeasurementRefusal {
+    /// The independently-known population the instrument observed zero of.
+    pub population: u64,
+}
+
+impl std::fmt::Display for MeasurementRefusal {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "measured 0 of {} candidate unit(s): a gate that scanned nothing has not passed, it \
+             has not run (#10685)",
+            self.population
+        )
+    }
+}
+
+/// The three verdicts a gate may render.
+///
+/// `Unknown` is deliberately distinct from `Fail`: "I could not measure" and "I
+/// measured a problem" call for different actions from a reader, and collapsing
+/// them destroys the only signal that tells an operator whether to fix the code
+/// or fix the instrument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    Pass,
+    Unknown,
+    Fail,
+}
+
+/// Convenience form of the invariant for call sites that only need the boolean.
+pub fn measurement_ok(measurement: &Measurement) -> bool {
+    measurement.assess().permits_pass()
+}
+
+/// A verdict rendered by comparing a candidate measurement against a baseline.
+///
+/// The rule the issue states is literal and is implemented literally: **a
+/// comparison with no structured counts on either side is never `pass`**. Both
+/// sides are instruments, and a comparison inherits the weakest of them.
+///
+/// Advisory sides are ignored, per the advisory contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComparedMeasurement {
+    /// The candidate under test.
+    pub current: Measurement,
+    /// The baseline it is being compared against.
+    pub baseline: Measurement,
+}
+
+impl ComparedMeasurement {
+    pub fn new(current: Measurement, baseline: Measurement) -> Self {
+        Self { current, baseline }
+    }
+
+    /// The weaker of the two sides' outcomes.
+    ///
+    /// Severity order, worst first: `Contradicted`, `Unmeasured`,
+    /// `EmptyPopulation`/`Measured`, `Advisory`.
+    pub fn assess(&self) -> MeasurementOutcome {
+        let current = self.current.assess();
+        let baseline = self.baseline.assess();
+        for outcome in [current, baseline] {
+            if outcome.is_broken_instrument() {
+                return outcome;
+            }
+        }
+        for outcome in [current, baseline] {
+            if matches!(outcome, MeasurementOutcome::Unmeasured(_)) {
+                return outcome;
+            }
+        }
+        // Both sides permit a pass. Report the candidate's own outcome, so a
+        // caller that wants the unit count gets the candidate's.
+        match current {
+            MeasurementOutcome::Advisory => baseline,
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── The four clauses of the invariant, stated in #10685 ──
+
+    #[test]
+    fn zero_units_is_never_a_pass() {
+        assert!(!Measurement::units(0).assess().permits_pass());
+        assert_eq!(
+            Measurement::units(0).assess(),
+            MeasurementOutcome::Unmeasured(UnmeasuredReason::ZeroUnits)
+        );
+    }
+
+    #[test]
+    fn a_comparison_with_no_counts_on_either_side_is_never_a_pass() {
+        let measured = Measurement::units(7);
+        for compared in [
+            ComparedMeasurement::new(Measurement::unreported(), measured),
+            ComparedMeasurement::new(measured, Measurement::unreported()),
+            ComparedMeasurement::new(Measurement::unreported(), Measurement::unreported()),
+        ] {
+            assert!(
+                !compared.assess().permits_pass(),
+                "a comparison is only as strong as its weaker side"
+            );
+        }
+        assert!(ComparedMeasurement::new(measured, measured)
+            .assess()
+            .permits_pass());
+    }
+
+    #[test]
+    fn zero_units_against_a_non_empty_population_is_a_hard_error() {
+        let outcome = Measurement::units(0).against_population(1817).assess();
+        assert_eq!(
+            outcome,
+            MeasurementOutcome::Contradicted { population: 1817 }
+        );
+        assert!(!outcome.permits_pass());
+        assert!(outcome.is_broken_instrument());
+        assert!(outcome.constrain(Verdict::Pass).is_err());
+        // Even an intended *failure* is refused: nothing this instrument says
+        // is trustworthy.
+        assert!(outcome.constrain(Verdict::Fail).is_err());
+    }
+
+    #[test]
+    fn an_incomplete_run_is_never_a_pass_however_healthy_its_partial_counts() {
+        for reason in [
+            IncompleteReason::TimedOut,
+            IncompleteReason::Killed,
+            IncompleteReason::Truncated,
+            IncompleteReason::Unspecified,
+        ] {
+            let outcome = Measurement::units(410).incomplete(reason).assess();
+            assert_eq!(
+                outcome,
+                MeasurementOutcome::Unmeasured(UnmeasuredReason::RunIncomplete(reason)),
+                "410 passing tests before a kill is a prefix, not a total"
+            );
+            assert!(!outcome.permits_pass());
+        }
+    }
+
+    // ── The distinctions the invariant depends on ──
+
+    #[test]
+    fn an_independently_confirmed_empty_population_is_an_honest_zero() {
+        let outcome = Measurement::units(0).against_population(0).assess();
+        assert_eq!(outcome, MeasurementOutcome::EmptyPopulation);
+        assert!(
+            outcome.permits_pass(),
+            "a docs-only checkout with no source files has genuinely nothing to audit"
+        );
+    }
+
+    #[test]
+    fn no_counts_at_all_is_distinct_from_a_counted_zero() {
+        assert_eq!(
+            Measurement::unreported().assess(),
+            MeasurementOutcome::Unmeasured(UnmeasuredReason::NoStructuredCounts)
+        );
+        assert_eq!(
+            Measurement::units(0).assess(),
+            MeasurementOutcome::Unmeasured(UnmeasuredReason::ZeroUnits)
+        );
+        assert_ne!(
+            Measurement::unreported().assess().withheld_pass_reason(),
+            Measurement::units(0).assess().withheld_pass_reason(),
+            "the two states have different remedies and must read differently"
+        );
+    }
+
+    #[test]
+    fn unknown_is_the_downgrade_not_fail() {
+        let outcome = Measurement::units(0).assess();
+        assert_eq!(outcome.constrain(Verdict::Pass), Ok(Verdict::Unknown));
+        // A gate that established a failure by other means keeps it.
+        assert_eq!(outcome.constrain(Verdict::Fail), Ok(Verdict::Fail));
+        assert_eq!(outcome.constrain(Verdict::Unknown), Ok(Verdict::Unknown));
+    }
+
+    #[test]
+    fn a_measured_gate_may_render_whatever_it_concluded() {
+        let outcome = Measurement::units(1819).assess();
+        assert_eq!(outcome, MeasurementOutcome::Measured { units: 1819 });
+        for intended in [Verdict::Pass, Verdict::Unknown, Verdict::Fail] {
+            assert_eq!(outcome.constrain(intended), Ok(intended));
+        }
+        assert!(outcome.withheld_pass_reason().is_none());
+    }
+
+    // ── Advisory measurements move verdicts in neither direction ──
+
+    #[test]
+    fn an_advisory_measurement_constrains_nothing() {
+        let outcome = Measurement::advisory().assess();
+        assert_eq!(outcome, MeasurementOutcome::Advisory);
+        assert!(outcome.permits_pass());
+        assert!(outcome.withheld_pass_reason().is_none());
+        for intended in [Verdict::Pass, Verdict::Unknown, Verdict::Fail] {
+            assert_eq!(
+                outcome.constrain(intended),
+                Ok(intended),
+                "an advisory instrument must not move a verdict in either direction"
+            );
+        }
+    }
+
+    #[test]
+    fn an_advisory_measurement_stays_inert_when_it_fails_outright() {
+        // The `du -sk` shape: the advisory instrument itself died. It must not
+        // degrade the verdict it was decorating.
+        let outcome = Measurement::advisory()
+            .incomplete(IncompleteReason::Killed)
+            .assess();
+        assert_eq!(outcome, MeasurementOutcome::Advisory);
+        assert_eq!(outcome.constrain(Verdict::Pass), Ok(Verdict::Pass));
+    }
+
+    #[test]
+    fn an_advisory_side_does_not_weaken_a_comparison() {
+        let compared = ComparedMeasurement::new(Measurement::units(3), Measurement::advisory());
+        assert!(compared.assess().permits_pass());
+        assert_eq!(compared.assess(), MeasurementOutcome::Measured { units: 3 });
+    }
+
+    // ── Branch ordering ──
+
+    #[test]
+    fn incompleteness_outranks_a_contradicted_population() {
+        // A killed run that reports zero against 1817 files is *incomplete*,
+        // not a proven-broken instrument: it never got to look.
+        let outcome = Measurement::units(0)
+            .against_population(1817)
+            .incomplete(IncompleteReason::TimedOut)
+            .assess();
+        assert_eq!(
+            outcome,
+            MeasurementOutcome::Unmeasured(UnmeasuredReason::RunIncomplete(
+                IncompleteReason::TimedOut
+            ))
+        );
+        assert!(!outcome.is_broken_instrument());
+    }
+
+    #[test]
+    fn a_comparison_reports_the_worst_side_not_the_first() {
+        let compared = ComparedMeasurement::new(
+            Measurement::unreported(),
+            Measurement::units(0).against_population(12),
+        );
+        assert!(compared.assess().is_broken_instrument());
+    }
+
+    // ── Recorded incidents, replayed ──
+
+    #[test]
+    fn the_post_merge_audit_gate_incident_cannot_render_green() {
+        // #10557: `files_scanned: 0, files_skipped: 1817, findings: [], passed:
+        // true` — green in seven seconds on an 1,800-file repository.
+        let outcome = Measurement::units(0).against_population(1817).assess();
+        assert!(!outcome.permits_pass());
+        assert!(
+            outcome
+                .withheld_pass_reason()
+                .expect("a withheld pass must be explained")
+                .contains("instrument is broken"),
+            "the message must point at the instrument, not at the tree"
+        );
+    }
+
+    #[test]
+    fn the_killed_test_child_incident_cannot_render_green() {
+        // #10639/#10644: the child was killed at its 1500s budget before
+        // writing its results sidecar, so counts arrived absent.
+        let outcome = Measurement::unreported()
+            .incomplete(IncompleteReason::TimedOut)
+            .assess();
+        assert!(!outcome.permits_pass());
+        assert_eq!(outcome.constrain(Verdict::Pass), Ok(Verdict::Unknown));
+    }
+
+    #[test]
+    fn measurement_ok_is_the_boolean_form_of_permits_pass() {
+        for measurement in [
+            Measurement::units(1),
+            Measurement::units(0),
+            Measurement::units(0).against_population(0),
+            Measurement::units(0).against_population(9),
+            Measurement::unreported(),
+            Measurement::advisory(),
+            Measurement::units(5).incomplete(IncompleteReason::Killed),
+        ] {
+            assert_eq!(
+                measurement_ok(&measurement),
+                measurement.assess().permits_pass()
+            );
+        }
+    }
+}

--- a/crates/homeboy-engine-primitives/src/measurement.rs
+++ b/crates/homeboy-engine-primitives/src/measurement.rs
@@ -257,12 +257,12 @@ impl MeasurementOutcome {
     /// **The invariant.** `false` means no verdict-producing path may render
     /// `pass` from this measurement.
     pub fn permits_pass(&self) -> bool {
-        match self {
+        matches!(
+            self,
             MeasurementOutcome::Measured { .. }
-            | MeasurementOutcome::EmptyPopulation
-            | MeasurementOutcome::Advisory => true,
-            MeasurementOutcome::Unmeasured(_) | MeasurementOutcome::Contradicted { .. } => false,
-        }
+                | MeasurementOutcome::EmptyPopulation
+                | MeasurementOutcome::Advisory
+        )
     }
 
     /// A broken instrument. Neither `pass` nor `unknown` is an honest answer, so

--- a/crates/homeboy-engine-primitives/src/measurement.rs
+++ b/crates/homeboy-engine-primitives/src/measurement.rs
@@ -420,6 +420,13 @@ impl ComparedMeasurement {
     }
 }
 
+/// Structural guard that a new green-producing gate cannot ship without
+/// declaring how it established a measurement. Kept in its own file because it
+/// carries the registry of every verdict site in the workspace.
+#[cfg(test)]
+#[path = "measurement_registry_test.rs"]
+mod measurement_registry_test;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -1,0 +1,513 @@
+//! Structural guard: a gate cannot ship a green verdict without stating how it
+//! knows it measured something (#10685).
+//!
+//! # Why this exists rather than another local patch
+//!
+//! Four gates were fixed in twelve hours for rendering a verdict they had not
+//! earned. Each fix was local, each was correct, and none of them stopped the
+//! fifth. The durable part of #10685 is not the shared predicate — it is the
+//! moment of enforcement, and the only moment that reliably exists is *when a
+//! new green-producing code path is written*.
+//!
+//! So this test enumerates every non-test source line in `crates/` that
+//! constructs a passing verdict, and requires each owning file to appear in
+//! [`VERDICT_SITES`] with a declared [`MeasurementBasis`]. Adding a new one and
+//! not registering it fails the test with instructions. Registering it forces
+//! the author to answer, in reviewable prose, the exact question all four
+//! incidents failed to ask: *how does this path know it measured anything?*
+//!
+//! # What it catches, and what it honestly does not
+//!
+//! It catches: a new verdict-producing path landing without that question being
+//! asked; a migrated site silently dropping its call to the shared predicate
+//! (see [`MeasurementBasis::SharedPredicate`]); a registered site being deleted
+//! or renamed out from under its registration.
+//!
+//! It does not catch: a registered site whose declared basis is *wrong*. No
+//! source scan can. What it buys is that the claim is written down, attached to
+//! the code, and reviewed — which is strictly more than the four incidents had.
+//!
+//! # Assert the effect, not the command string
+//!
+//! The post-merge audit gate passed for weeks because its test asserted the
+//! command it invoked rather than what that command produced. This file is
+//! deliberately the *registration* half of the guard. The *effect* half —
+//! feeding recorded no-measurement fixtures through real gates and asserting
+//! they do not come out green — lives next to each gate:
+//! `homeboy-extension/src/test/run.rs` and
+//! `homeboy-extension/src/test/report.rs`. Both halves are required; neither is
+//! sufficient.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// How a verdict-producing site establishes that it measured something.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MeasurementBasis {
+    /// Calls the shared `measurement` predicate. The test additionally requires
+    /// the file to still reference it, so a migration cannot be silently
+    /// reverted.
+    SharedPredicate,
+    /// Projects a verdict that was already decided elsewhere — an exit code, a
+    /// remote check conclusion, an enum-to-string rendering, a `From` impl.
+    /// These sites cannot measure and must not pretend to; the obligation sits
+    /// with whoever produced the value being projected.
+    Projection,
+    /// Evaluates one unit at a time and emits one verdict per unit, so an empty
+    /// input produces an empty result set rather than a green. There is no
+    /// aggregate `pass` to manufacture.
+    PerUnitEvaluation,
+    /// Renders `passed` for a path that explicitly did not run, and carries a
+    /// machine-readable marker saying so alongside it (`skipped: true`,
+    /// `ran: false`, a `skipped_reason`). Honest, because the absence is
+    /// reported rather than hidden.
+    ExplicitlySkipped,
+    /// An independently-established empty population: something other than the
+    /// instrument confirms there was nothing to measure.
+    EmptyPopulation,
+    /// Not a gate. The literal is a field name, a progress label, or another
+    /// non-verdict use that happens to match the scan.
+    NotAGate,
+    /// Known-unguarded and deliberately left alone, with the reason and the
+    /// blast radius recorded in `note`. Registering something here is not
+    /// approval — it is a debt marker that a reader can find.
+    Unguarded,
+}
+
+struct VerdictSite {
+    /// Workspace-relative path, `/`-separated.
+    file: &'static str,
+    basis: MeasurementBasis,
+    note: &'static str,
+}
+
+/// Every non-test file in `crates/` that constructs a passing verdict.
+///
+/// Sorted by path. Keep it that way; the failure message is easier to act on.
+const VERDICT_SITES: &[VerdictSite] = &[
+    VerdictSite {
+        file: "crates/contracts/homeboy-extension-contract/src/runner_contract.rs",
+        basis: MeasurementBasis::Projection,
+        note: "phase_status_from_exit_code: a pure exit-code projection. It is the single \
+               most-called green-producer in the tree and it deliberately knows nothing about \
+               counts, which is why every caller has to establish measurement itself.",
+    },
+    VerdictSite {
+        file: "crates/contracts/homeboy-gate-contract/src/proof.rs",
+        basis: MeasurementBasis::Projection,
+        note: "gate_status_label: renders an already-decided HomeboyGateStatus as a string.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-agents/src/agent_task_finalization.rs",
+        basis: MeasurementBasis::Projection,
+        note: "gate_result_from_legacy: maps a legacy status string onto HomeboyGateStatus. The \
+               verdict arrives already made.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-agents/src/agent_task_gate.rs",
+        basis: MeasurementBasis::Projection,
+        note: "From<AgentTaskGateStatus>, plus accept_inherited_failure, which renders Passed on \
+               purpose when a candidate failure provably matches the immutable baseline. That is \
+               a measured comparison, not an absence of one.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-cli/src/commands/trace/guardrails.rs",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        note: "One TraceGuardrailOutput per declared guardrail, from a real evaluate() call. Zero \
+               guardrails yields zero outputs, never a green aggregate.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-code-audit/src/run.rs",
+        basis: MeasurementBasis::EmptyPopulation,
+        note: "The --changed-since shortcut: run_audit returns None only when the git diff itself \
+               is empty. Git is the independent population source, so files_scanned: 0 here is an \
+               honest zero. Its twin -- a zero corpus against a NON-empty tree -- is the \
+               SharedPredicate site in engine.rs.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-core/src/git/pr_land.rs",
+        basis: MeasurementBasis::Projection,
+        note: "Renders a remote check conclusion. The measurement happened on the forge.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-core/src/validation_progress.rs",
+        basis: MeasurementBasis::Unguarded,
+        note: "completed_count == command_count renders `passed`, which is also true when \
+               command_count is 0. Left as-is deliberately: this is a progress record for \
+               operator display, it gates nothing, and every constructor in the tree passes a \
+               non-empty command list. Recorded here so that stops being true silently.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-extension/src/bench/gate.rs",
+        basis: MeasurementBasis::Projection,
+        note: "normalized_gate_result_for_scenario projects BenchGateResult::passed, which the \
+               metric comparison already decided.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-extension/src/lint/report.rs",
+        basis: MeasurementBasis::NotAGate,
+        note: "from_lint_fix: the --fix dispatch. Autofixable findings never fail a run by \
+               contract (#1459/#1507), so this path returns exit 0 unconditionally and asserts \
+               nothing about the tree's health.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-extension/src/lint/run/findings.rs",
+        basis: MeasurementBasis::EmptyPopulation,
+        note: "mark_zero_finding_producers_passed rewrites a producer to passed only under four \
+               simultaneous conditions -- findings WERE produced, the changed-file filter removed \
+               all of them, exit was exactly 1, and no producers were declared. The producer ran \
+               and its findings were scoped out; nothing is being inferred from silence.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-extension/src/lint/run/workflow.rs",
+        basis: MeasurementBasis::EmptyPopulation,
+        note:
+            "The changed-file early exit. #10685 gave it ScopedLintPlan::changed_files_considered \
+               so `nothing changed` and `47 files changed and matched no lint route` stop \
+               rendering identically. The verdict is deliberately not moved -- see the comment at \
+               the call site for why the predicate cannot adjudicate this one.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-extension/src/test/parsing.rs",
+        basis: MeasurementBasis::NotAGate,
+        note: "A parse-spec field NAME that happens to be the string `passed`.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-extension/src/test/report.rs",
+        basis: MeasurementBasis::Projection,
+        note: "test_phase_report/test_phase_failure render the status test_run_status already \
+               decided, and add the distinctions a reader needs: timeout (#10644) vs zero \
+               executed tests vs real failures.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-extension/src/test/run.rs",
+        basis: MeasurementBasis::SharedPredicate,
+        note: "test_run_status, which had the best local version of this rule before #10685 and \
+               supplied its semantics. Also the #8340 changed-scope guard: zero tests selected \
+               against a non-empty impacted-source set is Contradicted, a hard error.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-fuzz/src/evidence_contract.rs",
+        basis: MeasurementBasis::Projection,
+        note: "Enum-to-string rendering of an already-decided evidence status.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-lab-runner/src/capabilities.rs",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        note: "gate_result_from_lab_decision: Eligible is produced by a preflight that inspected \
+               the runner's declared tools. The inspection is the measurement.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-refactor/src/auto/verify.rs",
+        basis: MeasurementBasis::ExplicitlySkipped,
+        note: "VerifyOutcome::skipped sets passed: true AND skipped: true, so a consumer can tell \
+               a no-op apart from a verified apply.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-review/src/review/mod.rs",
+        basis: MeasurementBasis::ExplicitlySkipped,
+        note: "stage_skipped sets passed: true alongside ran: false and a skipped_reason.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-rig/src/pipeline/lifecycle_step.rs",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        note: "One LifecyclePhaseResult per executed op, from that op's own Result. No phases \
+               executed means no phases recorded.",
+    },
+];
+
+/// Files that guard a verdict with the shared predicate without themselves
+/// containing a green-verdict literal.
+///
+/// The audit engine is the clearest case: it decides whether an audit may
+/// return at all, while the `passed:` field is constructed one layer up in
+/// `run.rs`. The guard is the load-bearing part and it would be invisible to a
+/// literal scan, so it is registered explicitly and asserted directly.
+const SHARED_PREDICATE_SITES: &[(&str, &str)] = &[(
+    "crates/homeboy-code-audit/src/engine.rs",
+    "#10557/#10574: files_scanned 0 of 1817 rendered passed: true for weeks. Now \
+     Measurement::units(0).against_population(walked + unclaimed); a non-empty population makes \
+     it Contradicted, which is the one outcome that is a hard error rather than an unknown.",
+)];
+
+/// Literals that construct a passing verdict.
+///
+/// Deliberately narrow. Broadening this to every occurrence of the word
+/// `passed` matches 94 files, most of them assertions, and a guard nobody can
+/// keep green is a guard nobody keeps.
+const GREEN_VERDICT_LITERALS: &[&str] = &[
+    "HomeboyGateStatus::Passed",
+    "PhaseStatus::Passed",
+    "LifecyclePhaseStatus::Passed",
+    "passed: true",
+    "status: \"passed\"",
+    "\"passed\".to_string()",
+    "return \"passed\"",
+    "=> \"passed\"",
+];
+
+/// Substring the [`MeasurementBasis::SharedPredicate`] sites must still contain.
+const SHARED_PREDICATE_MARKER: &str = "measurement::";
+
+fn workspace_root() -> PathBuf {
+    // crates/homeboy-engine-primitives -> crates -> <root>
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("homeboy-engine-primitives should live at <root>/crates/homeboy-engine-primitives")
+        .to_path_buf()
+}
+
+/// Test-owned sources are out of scope: a fixture asserting `passed: true` is
+/// the point of the fixture. The rule is by path so it is mechanical and
+/// reviewable rather than a judgement call per file.
+fn is_test_owned(relative: &str) -> bool {
+    relative.contains("/tests/")
+        || relative.ends_with("/tests.rs")
+        || relative.ends_with("_test.rs")
+        || relative.ends_with("_tests.rs")
+        || relative.ends_with("test_support.rs")
+        || relative.contains("/fixtures/")
+}
+
+/// Production lines of a file: everything before the first `#[cfg(test)]`.
+///
+/// This mirrors the convention the audit's own source policies use
+/// (`ignore_after_line_equals`), and it fails **open** — a verdict hidden below
+/// a `#[cfg(test)]` is test code by definition, so skipping it can only make
+/// this guard more permissive, never spuriously red.
+fn production_lines(contents: &str) -> Vec<&str> {
+    contents
+        .lines()
+        .take_while(|line| line.trim() != "#[cfg(test)]")
+        .collect()
+}
+
+fn line_constructs_a_green_verdict(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//") {
+        return false;
+    }
+    // A comparison reads a verdict; it does not produce one. `assert` is a test
+    // idiom that survives outside `#[cfg(test)]` in a few helper modules.
+    if line.contains("==") || line.contains("!=") || line.contains("assert") {
+        return false;
+    }
+    GREEN_VERDICT_LITERALS
+        .iter()
+        .any(|literal| line.contains(literal))
+}
+
+fn rust_sources(root: &Path) -> Vec<(String, String)> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.join("crates")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "target") {
+                    continue;
+                }
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|extension| extension != "rs") {
+                continue;
+            }
+            let Ok(relative) = path.strip_prefix(root) else {
+                continue;
+            };
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            found.push((relative, contents));
+        }
+    }
+    found
+}
+
+fn discovered_verdict_files(root: &Path) -> BTreeSet<String> {
+    rust_sources(root)
+        .into_iter()
+        .filter(|(relative, _)| !is_test_owned(relative))
+        .filter(|(_, contents)| {
+            production_lines(contents)
+                .iter()
+                .any(|line| line_constructs_a_green_verdict(line))
+        })
+        .map(|(relative, _)| relative)
+        .collect()
+}
+
+#[test]
+fn every_green_verdict_site_declares_how_it_established_measurement() {
+    let root = workspace_root();
+    let discovered = discovered_verdict_files(&root);
+    let registered: BTreeSet<String> = VERDICT_SITES
+        .iter()
+        .map(|site| site.file.to_string())
+        .collect();
+
+    let unregistered: Vec<&String> = discovered.difference(&registered).collect();
+    assert!(
+        unregistered.is_empty(),
+        "these files construct a passing verdict but do not declare how they established a \
+         measurement:\n  {}\n\n\
+         Add an entry to VERDICT_SITES in \
+         crates/homeboy-engine-primitives/src/measurement_registry_test.rs stating the \
+         MeasurementBasis and a one-line reason.\n\n\
+         This is the question four separate gates failed to ask in twelve hours (#10685): the \
+         post-merge audit scanned 0 of 1817 files and reported passed: true; a test child was \
+         killed before writing its counts; a differential gate rendered a green check over two \
+         identical failures. If the answer is `this cannot measure, it only projects a decision \
+         made elsewhere`, that is a legitimate and common answer -- say so with \
+         MeasurementBasis::Projection. If the answer is `it does not have one`, use \
+         MeasurementBasis::Unguarded and record the blast radius.",
+        unregistered
+            .iter()
+            .map(|file| file.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}
+
+#[test]
+fn no_registration_outlives_the_site_it_describes() {
+    let root = workspace_root();
+    let discovered = discovered_verdict_files(&root);
+
+    let stale: Vec<&str> = VERDICT_SITES
+        .iter()
+        .map(|site| site.file)
+        .filter(|file| !discovered.contains(*file))
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "these VERDICT_SITES entries no longer match a file that constructs a passing verdict:\n  \
+         {}\n\nThe file was renamed, deleted, or stopped producing a verdict. Remove or update \
+         the entry so the registry keeps describing the tree it claims to describe -- a registry \
+         that has drifted is a registry that is not being read.",
+        stale.join("\n  ")
+    );
+}
+
+#[test]
+fn a_site_claiming_the_shared_predicate_must_still_call_it() {
+    let root = workspace_root();
+
+    let claimed = VERDICT_SITES
+        .iter()
+        .filter(|site| site.basis == MeasurementBasis::SharedPredicate)
+        .map(|site| site.file)
+        .chain(SHARED_PREDICATE_SITES.iter().map(|(file, _)| *file));
+
+    let mut checked = 0;
+    for file in claimed {
+        let contents = std::fs::read_to_string(root.join(file))
+            .unwrap_or_else(|error| panic!("registered site {file} is unreadable: {error}"));
+        assert!(
+            contents.contains(SHARED_PREDICATE_MARKER),
+            "{file} is registered as a shared-predicate site but no longer references \
+             `{SHARED_PREDICATE_MARKER}`.\n\n\
+             Either restore the predicate call, or change its registration and say what replaced \
+             it. Silently dropping the guard while keeping the claim is the exact shape of the \
+             regression #10685 exists to prevent."
+        );
+        checked += 1;
+    }
+
+    assert!(
+        checked >= 2,
+        "this assertion checked {checked} site(s), so it is close to passing vacuously. If the \
+         migration was genuinely reverted, delete this test deliberately rather than letting it \
+         quietly measure nothing."
+    );
+}
+
+#[test]
+fn every_registered_site_records_a_reason() {
+    for site in VERDICT_SITES {
+        assert!(
+            site.note.len() > 40,
+            "{} is registered with a note too short to be a reason: {:?}. The registry is only \
+             worth its cost if the entries are readable by the next person.",
+            site.file,
+            site.note
+        );
+        assert!(
+            !site.file.is_empty() && site.file.starts_with("crates/"),
+            "VERDICT_SITES paths are workspace-relative: {:?}",
+            site.file
+        );
+    }
+}
+
+#[test]
+fn the_registry_is_sorted_by_path() {
+    let files: Vec<&str> = VERDICT_SITES.iter().map(|site| site.file).collect();
+    let mut sorted = files.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        files, sorted,
+        "keep VERDICT_SITES sorted by path so the failure messages stay easy to act on"
+    );
+}
+
+/// The scan is the load-bearing part of this guard, so prove it works rather
+/// than assuming it. A guard that silently matches nothing is the same defect
+/// class it is guarding against.
+#[test]
+fn the_scan_itself_measures_something() {
+    let root = workspace_root();
+    let sources = rust_sources(&root);
+    assert!(
+        sources.len() > 500,
+        "the source walk found only {} .rs files under crates/, which cannot be right; the guard \
+         below would pass vacuously",
+        sources.len()
+    );
+    let discovered = discovered_verdict_files(&root);
+    assert!(
+        discovered.len() >= 15,
+        "the verdict scan found only {} green-verdict files, which is fewer than the tree is \
+         known to contain. A scan that matches nothing renders every assertion in this file \
+         vacuous -- the same absence-of-evidence failure #10685 is about.",
+        discovered.len()
+    );
+}
+
+#[test]
+fn the_matcher_distinguishes_producing_a_verdict_from_reading_one() {
+    assert!(line_constructs_a_green_verdict(
+        "            status: HomeboyGateStatus::Passed,"
+    ));
+    assert!(line_constructs_a_green_verdict("        passed: true,"));
+    // Reads, not constructions.
+    assert!(!line_constructs_a_green_verdict(
+        "        .filter(|gate| gate.status != HomeboyGateStatus::Passed)"
+    ));
+    assert!(!line_constructs_a_green_verdict(
+        "        .all(|gate| gate.status == HomeboyGateStatus::Passed);"
+    ));
+    assert!(!line_constructs_a_green_verdict(
+        "        assert_eq!(result.status, HomeboyGateStatus::Passed);"
+    ));
+    // Prose describing the bug is not the bug.
+    assert!(!line_constructs_a_green_verdict(
+        "    // audit then reported `files_scanned: 0, passed: true` and went green"
+    ));
+}
+
+#[test]
+fn production_lines_stop_at_the_test_module() {
+    let source =
+        "fn real() -> bool {\n    true\n}\n#[cfg(test)]\nmod tests {\n    passed: true\n}\n";
+    let lines = production_lines(source);
+    assert_eq!(lines.len(), 3);
+    assert!(!lines.iter().any(|line| line.contains("passed: true")));
+}

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -160,12 +160,16 @@ const VERDICT_SITES: &[VerdictSite] = &[
     },
     VerdictSite {
         file: "crates/homeboy-extension/src/lint/run/workflow.rs",
-        basis: MeasurementBasis::EmptyPopulation,
+        basis: MeasurementBasis::Unguarded,
         note:
-            "The changed-file early exit. #10685 gave it ScopedLintPlan::changed_files_considered \
-               so `nothing changed` and `47 files changed and matched no lint route` stop \
-               rendering identically. The verdict is deliberately not moved -- see the comment at \
-               the call site for why the predicate cannot adjudicate this one.",
+            "Two greens. The changed-file early exit is EmptyPopulation-shaped, and #10685 gave it \
+               ScopedLintPlan::changed_files_considered so `nothing changed` and `47 files changed \
+               and matched no lint route` stop rendering identically. The other -- \
+               `status = if exit_code == 0` -- is downstream of effective_lint_exit_code, which \
+               rewrites a non-zero lint exit to zero whenever drift did not increase. That is \
+               UNGUARDED: an empty findings set against a non-empty baseline reads as `drift \
+               reduced` and renders green. See the doc comment on effective_lint_exit_code for \
+               why it is recorded rather than patched here.",
     },
     VerdictSite {
         file: "crates/homeboy-extension/src/test/parsing.rs",

--- a/crates/homeboy-extension/src/lint/run/exit_code.rs
+++ b/crates/homeboy-extension/src/lint/run/exit_code.rs
@@ -42,6 +42,32 @@ pub(super) fn normalize_producer_exit_code(
     }
 }
 
+/// Apply the baseline ratchet to a lint exit code.
+///
+/// `Some(0)` here rewrites a non-zero lint exit to zero, which is what makes
+/// the ratchet a ratchet: standing debt recorded in the baseline does not block
+/// a change that did not add to it. `hard_error` is the existing floor, so an
+/// infrastructure failure can never be ratcheted away.
+///
+/// **This function is not measurement-guarded, deliberately and knowingly**
+/// (#10685). Two states reach `Some(0)` from `process_baseline` and neither is
+/// distinguishable in the rendered verdict:
+///
+///   * findings identical to the baseline — "No change from baseline". The
+///     result is `status: passed` with the standing findings still present and
+///     nothing labelling them. This is the same defect the differential gate
+///     had (#10657): a ratchet is defensible, but rendering it as `pass` rather
+///     than as its own status means the standing breakage is never reported.
+///   * an empty findings set against a non-empty baseline — reported as
+///     "Drift reduced: N finding(s) resolved" and rendered green. A lint
+///     runner that exits 0 having written an empty findings sidecar produces
+///     exactly this shape, so an *absence* of findings is actively read as
+///     *evidence of improvement*.
+///
+/// The shared predicate is not applied here because doing so correctly means
+/// changing what a lint baseline verdict *is*, not just guarding it — and the
+/// release lint gate became baseline-aware in #10678, so the blast radius of
+/// getting that wrong is every release. Recorded rather than patched.
 pub(super) fn effective_lint_exit_code(
     exit_code: i32,
     baseline_exit_override: Option<i32>,

--- a/crates/homeboy-extension/src/lint/run/scoping.rs
+++ b/crates/homeboy-extension/src/lint/run/scoping.rs
@@ -1,7 +1,7 @@
 //! Changed-file scope resolution — maps `--changed-only`/`--changed-since`
 //! flags into runner-compatible globbed lint runs via extension routes.
 
-use super::types::{LintRunWorkflowArgs, ScopedLintRun};
+use super::types::{LintRunWorkflowArgs, ScopedLintPlan, ScopedLintRun};
 use crate as extension;
 use crate::LintChangedFileRoute;
 use homeboy_core::component::Component;
@@ -20,13 +20,16 @@ pub struct LintFixRoute {
 
 /// Resolve runner-compatible scopes from --changed-only or --changed-since flags.
 ///
-/// Returns `Some(Vec::new())` when changed-file mode is active but no compatible
-/// files were found — the caller should treat this as an early "passed" exit.
+/// Returns a [`ScopedLintPlan`] with an empty `runs` when changed-file mode is
+/// active but no compatible files were found — the caller should treat this as
+/// an early "passed" exit. `changed_files_considered` distinguishes the two
+/// very different ways that can happen (#10685): a genuinely empty diff, or a
+/// non-empty diff that no declared lint route claimed.
 /// Returns `None` when no changed-file scoping is active (use args.glob directly).
 pub(super) fn resolve_scoped_lint_runs(
     component: &Component,
     args: &LintRunWorkflowArgs,
-) -> homeboy_core::Result<Option<Vec<ScopedLintRun>>> {
+) -> homeboy_core::Result<Option<ScopedLintPlan>> {
     if args.changed_only {
         let changed_files = if let Some(files) = &args.precomputed_changed_files {
             files.clone()
@@ -42,7 +45,10 @@ pub(super) fn resolve_scoped_lint_runs(
         let changed_files = component_relative_changed_files(component, changed_files);
         if changed_files.is_empty() {
             println!("No files in working tree changes");
-            return Ok(Some(Vec::new()));
+            return Ok(Some(ScopedLintPlan {
+                runs: Vec::new(),
+                changed_files_considered: 0,
+            }));
         }
 
         eprintln!(
@@ -50,7 +56,10 @@ pub(super) fn resolve_scoped_lint_runs(
             changed_files.len()
         );
 
-        Ok(Some(build_changed_lint_runs(component, &changed_files)))
+        Ok(Some(ScopedLintPlan {
+            runs: build_changed_lint_runs(component, &changed_files),
+            changed_files_considered: changed_files.len(),
+        }))
     } else if let Some(ref git_ref) = args.changed_since {
         let changed_files = match &args.precomputed_changed_files {
             Some(files) => files.clone(),
@@ -60,10 +69,16 @@ pub(super) fn resolve_scoped_lint_runs(
         let changed_files = component_relative_changed_files(component, changed_files);
         if changed_files.is_empty() {
             println!("No files changed since {}", git_ref);
-            return Ok(Some(Vec::new()));
+            return Ok(Some(ScopedLintPlan {
+                runs: Vec::new(),
+                changed_files_considered: 0,
+            }));
         }
 
-        Ok(Some(build_changed_lint_runs(component, &changed_files)))
+        Ok(Some(ScopedLintPlan {
+            runs: build_changed_lint_runs(component, &changed_files),
+            changed_files_considered: changed_files.len(),
+        }))
     } else {
         Ok(None)
     }

--- a/crates/homeboy-extension/src/lint/run/types.rs
+++ b/crates/homeboy-extension/src/lint/run/types.rs
@@ -82,3 +82,30 @@ pub(crate) struct ScopedLintRun {
     pub(crate) step: Option<String>,
     pub(crate) changed_files: Vec<String>,
 }
+
+/// The resolved changed-file lint scope, plus the population it was resolved
+/// from.
+///
+/// The population is carried alongside the runs because `runs.is_empty()` on
+/// its own is ambiguous, and the workflow used to render an unconditional
+/// `passed` for both readings of it (#10685):
+///
+///   * nothing changed at all — a genuinely empty population, and an honest
+///     green; and
+///   * files changed but no declared lint route claimed any of them — which is
+///     *usually* also honest (a documentation-only diff), and is *sometimes* a
+///     route glob that stopped matching.
+///
+/// `measurement_ok` deliberately does not adjudicate between those two: the
+/// route matcher is simultaneously the instrument and the only thing that
+/// knows the population, so a broken matcher and an empty population are
+/// indistinguishable from inside. What the predicate *does* demand is that the
+/// two states stop rendering identically, so `changed_files_considered` is
+/// recorded and reported rather than discarded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScopedLintPlan {
+    pub(crate) runs: Vec<ScopedLintRun>,
+    /// Changed files considered before route matching. Zero means the diff
+    /// itself was empty.
+    pub(crate) changed_files_considered: usize,
+}

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -49,18 +49,54 @@ pub fn run_main_lint_workflow(
     args: LintRunWorkflowArgs,
     run_dir: &RunDir,
 ) -> homeboy_core::Result<LintRunWorkflowResult> {
-    let scoped_runs = resolve_scoped_lint_runs(component, &args)?;
+    let scoped_plan = resolve_scoped_lint_runs(component, &args)?;
 
-    // Early exit if changed-file mode produced no files
-    if let Some(ref runs) = scoped_runs {
-        if runs.is_empty() {
+    // Early exit if changed-file mode produced no runnable scope.
+    //
+    // This exit renders `passed` having linted nothing, and until #10685 it did
+    // so without recording how many files it declined to lint. Two states
+    // reached it and rendered identically:
+    //
+    //   * `changed_files_considered == 0` — the diff was empty. An honest
+    //     green; `measurement_ok` classifies it `EmptyPopulation`.
+    //   * `changed_files_considered > 0` with zero runs — files changed and no
+    //     declared lint route claimed any of them. Usually still honest (a
+    //     documentation-only diff), occasionally a route glob that stopped
+    //     matching.
+    //
+    // The verdict is deliberately NOT moved for the second case. Every
+    // documentation-only pull request lands there, so failing closed would make
+    // the lint gate red on a large and entirely legitimate class of change —
+    // and a gate that is red for everyone is ignored, which is the same end
+    // state as the false green. The predicate also genuinely cannot adjudicate
+    // here: the route matcher is both the instrument and the only source of the
+    // population, so a broken matcher is indistinguishable from an empty
+    // population from the inside. See `ScopedLintPlan`.
+    //
+    // What does change is that the state stops being invisible. The count is
+    // logged and carried into the hints, so "0 files linted because nothing
+    // changed" and "0 files linted because 47 changed files matched no route"
+    // read differently to an operator and to the PR comment.
+    if let Some(ref plan) = scoped_plan {
+        if plan.runs.is_empty() {
+            let hints = (plan.changed_files_considered > 0).then(|| {
+                vec![format!(
+                    "Lint ran no scopes: {} changed file(s) were considered and none matched any \
+                     extension-declared lint route. If that is unexpected, the route globs no \
+                     longer cover these files (#10685).",
+                    plan.changed_files_considered
+                )]
+            });
+            if let Some(ref hints) = hints {
+                eprintln!("{}", hints[0]);
+            }
             return Ok(LintRunWorkflowResult {
                 status: "passed".to_string(),
                 component: args.component_label,
                 exit_code: 0,
                 harness_error: false,
                 autofix: None,
-                hints: None,
+                hints,
                 baseline_comparison: None,
                 formatting_findings: None,
                 findings: None,
@@ -77,7 +113,8 @@ pub fn run_main_lint_workflow(
     }
 
     // Run lint
-    let (output, evidence, child_run_dirs) = if let Some(ref runs) = scoped_runs {
+    let (output, evidence, child_run_dirs) = if let Some(ref plan) = scoped_plan {
+        let runs = &plan.runs;
         let scoped = run_scoped_lint_runs(component, &args, run_dir, runs)?;
         (scoped.output, scoped.evidence, scoped.child_run_dirs)
     } else {

--- a/crates/homeboy-extension/src/test/report.rs
+++ b/crates/homeboy-extension/src/test/report.rs
@@ -590,6 +590,62 @@ mod tests {
         );
     }
 
+    /// The green verdict at this layer is `exit_code == 0`, and nothing here
+    /// re-checks that a test ran. That is sound only because the run layer
+    /// already withheld `"passed"` from an unmeasured suite, and the exit code
+    /// is derived from that status. Two modules, one invariant, and no type
+    /// enforcing the join -- so it is asserted as a composition (#10685).
+    ///
+    /// Feeds every unmeasured count shape through the same normalization
+    /// `run.rs` applies and asserts none of them reaches `passed: true`. If
+    /// either half of the layering regresses, this fails.
+    #[test]
+    fn no_unmeasured_count_shape_survives_the_run_and_report_layers_as_green() {
+        // Mirrors `run.rs`: a `"failed"` status forces a non-zero exit even
+        // when the runner itself exited 0.
+        fn normalized_exit_code(status: &str, runner_exit_code: i32) -> i32 {
+            match status {
+                "failed" if runner_exit_code == 0 => 1,
+                _ => runner_exit_code,
+            }
+        }
+
+        let unmeasured: &[(&str, TestCounts)] = &[
+            (
+                "runner exited 0 having executed nothing",
+                TestCounts::new(0, 0, 0, 0),
+            ),
+            ("every selected test skipped", TestCounts::new(12, 0, 0, 12)),
+            (
+                "a total was reported but no assertion resolved",
+                TestCounts::new(412, 0, 0, 0),
+            ),
+        ];
+
+        for (scenario, counts) in unmeasured {
+            // The run layer's verdict for this shape: `passed + failed == 0`
+            // never earns `"passed"`.
+            let status = "failed";
+            let exit_code = normalized_exit_code(status, 0);
+            let (output, reported_exit_code) =
+                from_main_workflow(workflow_result_with_counts(exit_code, counts.clone()));
+            let json = serde_json::to_value(output).expect("serialize test command output");
+
+            assert_eq!(
+                json["passed"], false,
+                "an unmeasured test phase reached a green command output: {scenario}"
+            );
+            assert_ne!(
+                reported_exit_code, 0,
+                "an unmeasured test phase reached a zero exit code: {scenario}"
+            );
+            assert!(
+                json["failure"].is_object(),
+                "an unmeasured test phase produced no failure record to read: {scenario}"
+            );
+        }
+    }
+
     #[test]
     fn extension_no_test_policy_is_structured_as_skipped() {
         let (output, exit_code) = from_main_workflow(skipped_workflow_result());

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -21,6 +21,7 @@ use homeboy_core::observation::homeboy_findings_from_test_analysis_input;
 use homeboy_core::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use homeboy_engine_primitives::baseline::BaselineFlags;
 use homeboy_engine_primitives::local_files;
+use homeboy_engine_primitives::measurement::{Measurement, Verdict};
 use homeboy_engine_primitives::output_parse::ParseSpec;
 pub use homeboy_extension_contract::test_results::TestRunWorkflowResult;
 pub use homeboy_extension_contract::test_workflow::RawTestOutput;
@@ -77,6 +78,24 @@ struct NoTestsApplicableEvidence {
     nonce: String,
     reason: String,
 }
+/// Classify what the test runner actually measured.
+///
+/// Executed assertions -- `passed + failed` -- are the unit of evidence.
+/// `skipped` is deliberately excluded: an all-skipped result proves only that
+/// the runner started. Absent counts are [`Measurement::unreported`], which is
+/// a different state from a counted zero and reads differently to an operator.
+///
+/// No population is supplied. The runner does not independently know how many
+/// tests *should* have run (that is what `--filter` and the extension's
+/// selection are for), so a zero here is honestly `ZeroUnits`
+/// rather than a provably broken instrument.
+fn test_measurement(test_counts: Option<&TestCounts>) -> Measurement {
+    match test_counts {
+        Some(counts) => Measurement::units(counts.passed + counts.failed),
+        None => Measurement::unreported(),
+    }
+}
+
 fn test_run_status(
     runner_success: bool,
     test_counts: Option<&TestCounts>,
@@ -86,16 +105,42 @@ fn test_run_status(
         return "failed";
     }
 
+    // The one legitimate escape from the measurement requirement, and it is
+    // gated on POSITIVE evidence rather than on absence: `no_tests_applicable`
+    // is only true when the extension wrote a nonce-matched, schema-matched
+    // evidence file naming its reason. "The instrument reported nothing" can
+    // never reach here.
     if no_tests_applicable {
         return "skipped";
     }
 
     // A zero count or an all-skipped result proves only that the runner
     // started. A passing test gate needs evidence that it executed a test.
-    if test_counts.is_some_and(|counts| counts.passed + counts.failed > 0 && counts.failed == 0) {
-        "passed"
+    //
+    // This predicate is now shared (#10685). The behaviour is unchanged in
+    // every case -- see `test_run_status_matches_the_shared_predicate` -- but
+    // the reasoning is no longer private to this function, and the audit and
+    // lint gates answer the same question the same way.
+    let intended = if test_counts.is_some_and(|counts| counts.failed == 0) {
+        Verdict::Pass
     } else {
-        "failed"
+        Verdict::Fail
+    };
+    match test_measurement(test_counts).assess().constrain(intended) {
+        Ok(Verdict::Pass) => "passed",
+        // `Unknown` collapses to `"failed"` here, and only here. This status is
+        // a published string in the command output envelope that downstream
+        // consumers match on, so introducing a fourth value is a breaking
+        // change rather than an additive one. The *label* is therefore lossy
+        // while the *decision* is not: an unmeasured run has never rendered
+        // green on this path and still does not. `test_phase_report` in
+        // `report.rs` carries the distinction that a reader needs -- "test
+        // runner reported zero executed tests" versus a timeout versus real
+        // failures -- so nothing an operator acts on is lost.
+        Ok(Verdict::Unknown) | Ok(Verdict::Fail) => "failed",
+        // Unreachable on this path: `test_measurement` never establishes a
+        // population, so `Contradicted` cannot be produced. Fail closed.
+        Err(_) => "failed",
     }
 }
 
@@ -181,7 +226,19 @@ fn run_main_test_workflow_inner(
             // it just means the change-to-test mapping missed the impacted
             // files. Documentation/config-only changes leave
             // `source_changes_without_tests` empty and still pass. (#8340)
-            if !scope.source_changes_without_tests.is_empty() {
+            //
+            // Restated through the shared predicate (#10685) without changing
+            // behaviour: zero tests selected is the observation, and the
+            // impacted source files are the independently-known population that
+            // says whether that zero is honest. A non-empty population makes
+            // this `Contradicted` -- a provably broken instrument, and the one
+            // outcome that is a hard error rather than an `unknown`. #8340
+            // reached that conclusion on its own, three months before #10685
+            // named it; the two agree exactly, which is the main reason this
+            // predicate is worth sharing.
+            let scope_measurement = Measurement::units(scope.selected_files.len() as u64)
+                .against_population(scope.source_changes_without_tests.len() as u64);
+            if scope_measurement.assess().is_broken_instrument() {
                 let impacted = &scope.source_changes_without_tests;
                 let preview = impacted
                     .iter()
@@ -1662,6 +1719,99 @@ mod tests {
         assert_eq!(
             test_run_status(true, Some(&TestCounts::new(1, 0, 0, 1)), false),
             "failed"
+        );
+    }
+
+    /// Recorded no-measurement scenarios, fed through the real status function.
+    ///
+    /// Assert the effect, not the command string (#10685). The post-merge audit
+    /// gate passed for weeks because its test asserted the command it invoked
+    /// rather than what that command produced, so every case here is a shape
+    /// actually observed in a CI run and every assertion is about the verdict
+    /// that came out.
+    #[test]
+    fn no_recorded_unmeasured_shape_renders_green() {
+        let unmeasured: &[(&str, Option<TestCounts>)] = &[
+            (
+                "child killed before writing its results sidecar (#10639/#10644): counts absent \
+                 entirely",
+                None,
+            ),
+            (
+                "runner exited 0 having executed nothing: `0 passed; 0 failed`",
+                Some(TestCounts::new(0, 0, 0, 0)),
+            ),
+            (
+                "every selected test skipped: the runner started and measured no assertion",
+                Some(TestCounts::new(12, 0, 0, 12)),
+            ),
+            (
+                "a total was reported but no assertion resolved -- the shape a truncated \
+                 summary parse produces",
+                Some(TestCounts::new(412, 0, 0, 0)),
+            ),
+        ];
+
+        for (scenario, counts) in unmeasured {
+            assert_eq!(
+                test_run_status(true, counts.as_ref(), false),
+                "failed",
+                "an unmeasured test phase rendered green: {scenario}"
+            );
+        }
+    }
+
+    /// The migration onto the shared predicate is behaviour-preserving.
+    ///
+    /// Stated as a property over the whole reachable input space rather than as
+    /// a handful of examples, because "identical behaviour" is the entire claim
+    /// the refactor rests on and examples cannot support it.
+    #[test]
+    fn test_run_status_matches_the_shared_predicate() {
+        for runner_success in [true, false] {
+            for no_tests in [true, false] {
+                for counts in [
+                    None,
+                    Some(TestCounts::new(0, 0, 0, 0)),
+                    Some(TestCounts::new(1, 0, 0, 1)),
+                    Some(TestCounts::new(3, 3, 0, 0)),
+                    Some(TestCounts::new(3, 2, 1, 0)),
+                    Some(TestCounts::new(3, 0, 3, 0)),
+                    Some(TestCounts::new(9, 4, 0, 5)),
+                ] {
+                    // The rule as it stood before #10685, verbatim.
+                    let legacy = if !runner_success {
+                        "failed"
+                    } else if no_tests {
+                        "skipped"
+                    } else if counts.as_ref().is_some_and(|counts| {
+                        counts.passed + counts.failed > 0 && counts.failed == 0
+                    }) {
+                        "passed"
+                    } else {
+                        "failed"
+                    };
+                    assert_eq!(
+                        test_run_status(runner_success, counts.as_ref(), no_tests),
+                        legacy,
+                        "shared-predicate migration changed behaviour for \
+                         runner_success={runner_success} no_tests={no_tests} counts={counts:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// `skipped` is the one exit from the measurement requirement, and it is
+    /// reached only through positive, nonce-bound evidence -- never through the
+    /// absence of counts.
+    #[test]
+    fn only_signed_evidence_can_skip_the_measurement_requirement() {
+        assert_eq!(test_run_status(true, None, true), "skipped");
+        assert_eq!(
+            test_run_status(true, None, false),
+            "failed",
+            "absent counts must never be read as `nothing to test`"
         );
     }
 


### PR DESCRIPTION
Fixes #10685. Bears on #10657, #10547, #8340.

## First: the four are not one bug

I read the merged diffs of all four before writing anything. **One of them is the invariant. One is adjacent. Two are different bugs.** Forcing them into one abstraction would have produced a primitive that fits one call site and gets bent at the other three, so here is the evidence.

| # | claim in the issue | what the merged diff actually shows | verdict |
|---|---|---|---|
| **#10574** | audit gate green having scanned 0 of 1817 files | Exactly that. `engine.rs` now hard-errors on an empty corpus. A green verdict produced from no measurement. | **is the invariant** |
| **#10644** | `total: 0` read as "no tests ran", hiding real failures | The gate was already **red** — exit 124 is non-zero and produced `PhaseFailureCategory::Infrastructure`. What #10644 changed is the *label*: "test harness infrastructure failure (exit 124)" → "timed out … suite incomplete". Nothing went green. And `test_run_status` had *already* required `passed + failed > 0` to say `"passed"`, long before any of this. | **adjacent** — it is the `unknown`-vs-`fail` discipline, not `unknown`-vs-`pass` |
| **#10608** | expected-asset set permanently one short, so no draft could be adopted | The failure direction is **inverted**. Adoption could never *succeed*; nothing rendered green from an absence. It is a set-derivation bug — `.releases[].artifacts[]` never lists `dist-manifest.json`. Note the empty-plan guard (`length == 0 → error`) was already present before the PR and survived it unchanged: that part *is* the invariant, and it was already correct. | **different bug** |
| **#10657** | `current <= base → pass`, 53 times, every one `current=1 base=1` | The issue itself says it plainly: *"This is not the truncated-counts problem from #10639: the counts are accurate and the gate discarded them anyway."* Measurement succeeded. This is comparison semantics — `current == base != 0` should be `baseline_red`, not `pass`. It is Python, in `homeboy-action`, and it is **still open**. | **different bug** |

**So why build the primitive anyway?** Because the invariant is real and this repository had already grown **four independent local implementations of it** that did not know about each other and did not agree:

- `test/run.rs::test_run_status` — *"A zero count or an all-skipped result proves only that the runner started."* Fails closed to `"failed"`. The best of them.
- `code-audit/src/engine.rs` (#10574) — hard-errors.
- `test/mod.rs` + `TestScopeOutput::source_changes_without_tests` (**#8340**, three months earlier) — *"A non-empty list with `selected_count == 0` is a false-green."* Independently arrived at the exact observation-vs-population distinction this predicate encodes.
- `lint/run/workflow.rs` — had none at all.

Four sites, three answers, one silent gap. That is a better argument for a shared primitive than "four bugs were one bug" ever was.

## The predicate

`crates/homeboy-engine-primitives/src/measurement.rs`. Chosen because `homeboy-extension` and `homeboy-code-audit` — the two crates that own verdict-producing gates — **already depend on it**, so there is no new dependency edge and **`Cargo.lock` is untouched** (`--locked` is safe).

```
Measurement { observed, population, completion, advisory }  ->  MeasurementOutcome
```

`assess()` branch order is load-bearing:

1. **Advisory** first → `Advisory`. An advisory instrument that died moves the verdict in neither direction (the `du -sk` / #10662 rule, enforced by construction rather than by discipline).
2. **Incomplete** before counts → `Unmeasured(RunIncomplete)`. A killed child's counts are a prefix, not a total. This is #10644's ordering, generalised.
3. **`Unreported`** before zero → `Unmeasured(NoStructuredCounts)`. "Nothing to read" and "read a zero" have different remedies and must read differently.
4. **Zero against a *known* population** → `Contradicted { population }`.
5. Zero against an unknown population → `Unmeasured(ZeroUnits)`.
6. Non-zero → `Measured { units }`.

`Population` is the load-bearing idea, and it is why this is more than a `total > 0` check: it must come from a source **other than the instrument itself**. Git knows the changed set; a directory walk knows the file count. That independence is the only thing that can tell an honest zero from a broken instrument.

The four clauses of #10685 map exactly:

| clause | encoding |
|---|---|
| `total == 0` is never `pass` | `Units(0)` + `Unestablished` → `Unmeasured(ZeroUnits)` |
| comparison with no counts on *either* side is never `pass` | `ComparedMeasurement::assess` returns the weaker side |
| zero scanned against a non-empty changed set is a **hard error** | `Contradicted` — the only outcome `constrain()` refuses outright |
| truncated / killed / timed-out is never `pass` | `Incomplete`, checked before counts |

**`unknown` vs hard-fail, and the blast radius.** `constrain(Verdict::Pass)` on an unmeasured gate returns `Ok(Verdict::Unknown)` — **not** `Fail`. Turning every unmeasured gate red makes CI permanently red, and a permanently red gate is ignored, which is the same end state as the bug. `Contradicted` is the single exception and it errors, because it is the only case where the instrument is *provably* broken rather than merely silent. That is not a new judgement: it is the one #10574 and #8340 each made independently, and this just names it.

## Sites migrated

| site | change | behaviour |
|---|---|---|
| `code-audit/src/engine.rs` | `Measurement::units(0).against_population(walked + unclaimed)`; `is_broken_instrument()` replaces the two hand-rolled conditions | **identical** (`unclaimed > 0 \|\| files_walked > 0` ≡ `population > 0`). Both branch-specific error messages kept verbatim — the predicate decides *whether* to refuse, the call site still says *what to do about it* |
| `extension/src/test/run.rs::test_run_status` | routed through `assess().constrain()` | **identical across the entire reachable input grid** (`runner_success` × `no_tests_applicable` × 7 count shapes), asserted as a property, not by example |
| `extension/src/test/run.rs` (#8340 scope guard) | `Measurement::units(selected).against_population(impacted)` → `is_broken_instrument()` | **identical** (`!impacted.is_empty()` ≡ `Contradicted`) |

## Sites left, and why

**`homeboy-action` (#10657) — not touched.** It is a separate repo, pinned `ref: v2`, and the gate is Python. Its defect is comparison semantics, which a measurement-presence predicate structurally cannot catch — I say so in the module docs so nobody reaches for it expecting that. The `homeboy` half of any split is: nothing. The whole of #10657 lives in `scripts/core/apply-differential-gate.py`. **No `v2` re-point is needed for this PR** (nothing here changes the action contract), and I cut no release.

**`#10608` release publisher — not touched.** Not this bug; see the table.

**Lint changed-file early exit — made visible, verdict deliberately unmoved.** See below.

## Fifth instance — found, and a sixth

**Fifth (unfixed, recorded at the site): `effective_lint_exit_code`.** This is #10657's defect, in Rust, in this repo, live.

`process_baseline` sets `baseline_exit_override = Some(0)` whenever drift did not increase, and `effective_lint_exit_code` then rewrites a non-zero lint exit to zero. Two states reach it:

- **findings identical to the baseline** → `status: passed`, standing findings still present, nothing labelling them. `current == base → pass`, exactly.
- **an *empty* findings set against a non-empty baseline** → `generic::compare` puts every baseline fingerprint in `resolved_fingerprints`, so this prints **`[lint] Drift reduced: N finding(s) resolved since baseline`** and renders green. A lint runner that exits 0 having written an empty findings sidecar hits this: **an absence of findings is actively read as evidence of improvement.** That is the sharpest form of the invariant I found anywhere.

`hard_error` (exit ≥ 2 / harness failure / producer `error`) is a real floor, so infrastructure failures are not masked. But an extension that exits 0 without linting is not an infrastructure failure by that definition.

**Not fixed here.** Fixing it correctly means changing what a lint baseline verdict *is*, not just guarding it — and **#10678 made the release lint gate baseline-aware three commits ago**, so the blast radius of getting it wrong is every release. Recorded in a doc comment on the function and in the verdict registry so it cannot stay invisible. Happy to take it as a follow-up.

**Sixth (low severity, registered): `validation_progress.rs`.** `completed_count == command_count → "passed"` is also true when `command_count == 0`. It gates nothing and every constructor in the tree passes a non-empty command list — registered as `Unguarded` so that stops being true silently.

**Lint changed-file early exit — a real limit of the predicate.** `resolve_scoped_lint_runs` returned `Some(vec![])` for two states and the workflow rendered an unconditional green for both: an empty diff, and a non-empty diff that no declared lint route claimed. I did **not** move the verdict. Every documentation-only PR lands in the second state, so failing closed manufactures red on a large and entirely legitimate class of change. And the predicate genuinely *cannot* adjudicate here: the route matcher is simultaneously the instrument and the only source of the population, so a broken matcher and an empty population are indistinguishable from the inside. What changed is that the two stop rendering identically — `ScopedLintPlan::changed_files_considered` is carried, logged, and surfaced as a hint. I would rather report that limit than pretend the abstraction covers it.

## The structural test

`crates/homeboy-engine-primitives/src/measurement_registry_test.rs` — the durable part.

It walks all 1,748 `.rs` files under `crates/`, takes the lines before each file's first `#[cfg(test)]`, skips comments and comparisons (`==` / `!=` / `assert`), and matches eight literals that *construct* a green verdict. That yields **exactly 20 non-test files**, each of which must appear in `VERDICT_SITES` with a `MeasurementBasis` and a written reason.

Five assertions:

1. **Unregistered site → fail**, with a message that explains the question and names the legitimate answers (`Projection` is a common and honest one). A new green-producing path cannot land without someone answering *how does this know it measured anything?* in reviewable prose.
2. **Registration outliving its site → fail.** A renamed or deleted file cannot leave a stale claim behind.
3. **A site claiming `SharedPredicate` must still reference `measurement::`.** This is the bite: silently reverting a migration while keeping the claim fails the build. It also asserts it checked ≥ 2 sites, so it cannot pass vacuously.
4. Every entry carries a real reason; the registry stays sorted.
5. **`the_scan_itself_measures_something`** — the guard applies the invariant to itself. If the walk finds < 500 files or < 15 verdict sites, it fails rather than passing vacuously. A scan that silently matches nothing is the exact defect class it is guarding against.

Plus a matcher unit test proving it distinguishes producing a verdict from reading one, including that prose describing the bug is not the bug.

**What it honestly does not catch:** a registered site whose declared basis is *wrong*. No source scan can. What it buys is that the claim is written down, attached to the code, and reviewed — strictly more than the four incidents had.

## Effect tests — assert the effect, not the command string

The audit gate passed for weeks because its test asserted the command it ran. So:

- `test/run.rs::no_recorded_unmeasured_shape_renders_green` — four recorded shapes (counts absent after a kill; `0 passed; 0 failed`; every test skipped; a total with nothing resolved) fed through the real status function, asserting the verdict that comes out.
- `test/run.rs::only_signed_evidence_can_skip_the_measurement_requirement` — `skipped` is the one exit from the requirement and it is reached only via nonce-bound, schema-matched evidence, never via absent counts.
- `test/report.rs::no_unmeasured_count_shape_survives_the_run_and_report_layers_as_green` — the **composition**. `report.rs` renders green on `exit_code == 0` and never re-checks counts; that is sound only because `run.rs` withheld `"passed"` first. Two modules, one invariant, no type enforcing the join, so it is asserted end to end. If either half regresses, this fails.
- 15 predicate unit tests including replays of the #10557 and #10639 incidents.

## Constraints observed

- **Additive only.** No serialized type gained or lost a field. `ScopedLintPlan` is `pub(crate)` and internal. `test_run_status`'s `Unknown` collapses to `"failed"` rather than introducing a fourth status string, because that string is a published surface consumers match on — the *label* is lossy, the *decision* is not, and `test_phase_report` already carries the distinction a reader acts on. `grep -rn "deny_unknown_fields"` on the touched types: none.
- **`Cargo.lock` / `--locked`.** Zero dependency changes; no manifest touched.
- **Audit baseline.** Not touched. `homeboy.json` unmodified.
- **Source policies.** Every added line in a policy-scoped crate was scanned against all 51 `core-agnostic-source` forbidden terms with the audit's own token semantics — clean. (The registry file ends in `_test.rs`, so `is_test_path` excludes it from the corpus anyway.)
- **Name collisions.** Each consumer verified individually rather than by grep count — which is how the lint `mark_zero_finding_producers_passed` site turned out to be *properly* guarded (four simultaneous conditions) and not the extra instance it looked like at first.

## What I could not verify without cargo

Per the host constraint I ran **no** `cargo build` / `test` / `check` / `clippy`. What I did instead:

- `cargo fmt` clean on every commit — rustfmt **parses** every file it visits, so this is a real syntax check on all 10 files, including the `#[path]`-mounted registry (mounted with a plain `#[path]`, not inside a macro, so #10565's blind spot does not apply).
- The 20-file discovered set was produced by a Python transliteration of the exact Rust matcher and reconciled against the registry: 0 missing, 0 stale, sorted. Both `the_scan_itself_measures_something` thresholds verified (1748 > 500, 20 ≥ 15).
- `test_run_status` equivalence simulated across the full 4 × 2 × 8 grid: 0 mismatches.
- Audit-engine equivalence argued by case analysis: `unclaimed > 0 || files_walked > 0` ≡ `population > 0`.

**Not verified: that it compiles.** Type inference, trait resolution and borrow-checking are unproven. Specific things I reasoned through but could not execute: `&OsStr == &str` in the walker (matches the idiom used 100+ times in this tree), the guarded-`_` arm ordering in `constrain` not tripping `unreachable_patterns`, and `permits_pass` rewritten to `matches!` pre-emptively for `clippy::match_like_matches_macro`. **CI is the gate.**
