### PR TITLE
test(agents): pin that shell gate commands infer no toolchain

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1929,8 +1929,13 @@ mod tests {
         assert_eq!(report.environment.inherited[0].value, "kept");
     }
 
+    /// Toolchain preflight is declared, never inferred. A gate command is a
+    /// shell program: its first token can be a builtin, a provider-owned alias,
+    /// or part of a compound expression, so probing it as an executable would
+    /// change what the gate means. `c3462d472` made preflight opt-in for that
+    /// reason and this test tracked the removed inference until #10658.
     #[test]
-    fn existing_gate_commands_are_automatic_toolchain_requirements() {
+    fn only_declared_gate_toolchains_are_preflight_requirements() {
         let options = VerifyGateOptions {
             verify: vec!["cargo test --lib".to_string()],
             private_verify: vec!["npm test".to_string()],
@@ -1943,17 +1948,27 @@ mod tests {
 
         assert_eq!(
             options.required_toolchains(),
-            vec![
-                AgentTaskGateToolchainRequirement {
-                    command: "cargo".to_string(),
-                    probe_arguments: vec!["metadata".to_string()],
-                },
-                AgentTaskGateToolchainRequirement {
-                    command: "npm".to_string(),
-                    probe_arguments: vec!["--version".to_string()],
-                },
-            ]
+            vec![AgentTaskGateToolchainRequirement {
+                command: "cargo".to_string(),
+                probe_arguments: vec!["metadata".to_string()],
+            }]
         );
+    }
+
+    /// A gate command whose first token is a shell builtin or a compound
+    /// expression declares no toolchain at all. Nothing is probed for it.
+    #[test]
+    fn shell_gate_commands_contribute_no_inferred_toolchain() {
+        let options = VerifyGateOptions {
+            verify: vec![
+                "test -f Cargo.toml && cargo test --lib".to_string(),
+                "[ -d target ]".to_string(),
+            ],
+            private_verify: vec!["npm test".to_string()],
+            ..VerifyGateOptions::default()
+        };
+
+        assert!(options.required_toolchains().is_empty());
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1955,6 +1955,24 @@ mod tests {
         );
     }
 
+    /// A gate command whose first token is a shell builtin or part of a
+    /// compound expression declares no toolchain at all. `c3462d472` made
+    /// preflight opt-in precisely because a gate command is a shell program,
+    /// so its first token is not necessarily an executable to probe.
+    #[test]
+    fn shell_gate_commands_contribute_no_inferred_toolchain() {
+        let options = VerifyGateOptions {
+            verify: vec![
+                "test -f Cargo.toml && cargo test --lib".to_string(),
+                "[ -d target ]".to_string(),
+            ],
+            private_verify: vec!["npm test".to_string()],
+            ..VerifyGateOptions::default()
+        };
+
+        assert!(options.required_toolchains().is_empty());
+    }
+
     #[cfg(unix)]
     #[test]
     fn toolchain_preflight_preserves_only_declared_homes_for_cargo_on_path() {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -178,12 +178,41 @@ mod tests {
             .run_id
     }
 
-    fn controller_admission_stamped(run_id: &str) -> bool {
+    /// A value no reconciling read can produce, planted in the metadata key
+    /// that `status()` rewrites on every record it refreshes.
+    const UNREFRESHED_SENTINEL: &str = "homeboy/test/unrefreshed-admission";
+
+    /// Mark a durable record as not-yet-refreshed.
+    ///
+    /// The presence of `controller_admission` is *not* evidence that a read
+    /// refreshed a record: `submit_plan` stamps that key when the record is
+    /// created (`b9618df8b`), so it is already there the moment `seed_record`
+    /// returns. That invalidated the original witness and made these two tests
+    /// fail from the day they landed (#10658).
+    ///
+    /// Overwriting the key with a sentinel restores the intended evidence:
+    /// `status()` replaces it unconditionally, so the sentinel surviving means
+    /// no refreshing — and therefore no writing — pass touched the record.
+    fn mark_unrefreshed(run_id: &str) {
+        crate::agent_task_lifecycle::lifecycle_store::mutate_record(run_id, |record| {
+            record.metadata["controller_admission"] = Value::String(UNREFRESHED_SENTINEL.into());
+            true
+        })
+        .expect("stamp unrefreshed sentinel")
+        .expect("durable record");
+        assert!(
+            is_unrefreshed(run_id),
+            "sentinel must be durable before it can witness anything"
+        );
+    }
+
+    fn is_unrefreshed(run_id: &str) -> bool {
         agent_task_lifecycle::exact_record(run_id)
             .expect("durable record")
             .metadata
             .get("controller_admission")
-            .is_some()
+            .and_then(Value::as_str)
+            == Some(UNREFRESHED_SENTINEL)
     }
 
     #[test]
@@ -200,14 +229,15 @@ mod tests {
     fn probe_by_id_resolves_one_record_without_scanning_or_writing() {
         // #10308: resolving a single agent-task id must be an indexed read, not
         // a full-corpus refresh. The scanning path refreshes every record
-        // through `status()`, which stamps `controller_admission` on each one —
-        // so the absence of that stamp is durable evidence that neither the
-        // probed record nor its siblings were scanned or written.
+        // through `status()`, which rewrites `controller_admission` on each one
+        // — so a sentinel planted in that key surviving the probe is durable
+        // evidence that neither the probed record nor its siblings were scanned
+        // or written.
         with_isolated_home(|_| {
             let target = seed_record("run-probe-target");
             let sibling = seed_record("run-probe-sibling");
-            assert!(!controller_admission_stamped(&target));
-            assert!(!controller_admission_stamped(&sibling));
+            mark_unrefreshed(&target);
+            mark_unrefreshed(&sibling);
 
             let item = AgentTaskActivityProvider
                 .probe_by_id(&target)
@@ -221,14 +251,16 @@ mod tests {
                 item.refs.agent_task_run_id.as_deref(),
                 Some(target.as_str())
             );
-            assert!(!controller_admission_stamped(&target));
-            assert!(!controller_admission_stamped(&sibling));
+            assert!(is_unrefreshed(&target));
+            assert!(is_unrefreshed(&sibling));
 
             // Control: the scanning path the probe replaces does refresh — and
             // therefore write — every record, which is the cost being avoided.
+            // Without this the assertions above would also hold for a witness
+            // that simply never changes.
             agent_task_lifecycle::list_records().expect("records listed");
-            assert!(controller_admission_stamped(&target));
-            assert!(controller_admission_stamped(&sibling));
+            assert!(!is_unrefreshed(&target));
+            assert!(!is_unrefreshed(&sibling));
         });
     }
 
@@ -284,13 +316,14 @@ mod tests {
         with_isolated_home(|_| {
             register();
             let run_id = seed_record("run-show-probe");
+            mark_unrefreshed(&run_id);
 
             let report = homeboy_core::activity::show_activity(&run_id).expect("show activity");
 
             assert_eq!(report.items.len(), 1);
             assert_eq!(report.items[0].id, run_id);
             assert_eq!(report.items[0].source_store, "agent-task.lifecycle");
-            assert!(!controller_admission_stamped(&run_id));
+            assert!(is_unrefreshed(&run_id));
         });
     }
 }


### PR DESCRIPTION
Refs #10658 (closed by #10689).

**Rescoped to a single added test.** This branch originally fixed three of the seven red `homeboy-agents` tests, but **#10689 landed first and fixed all seven** — and reached the same conclusions independently:

- it renamed the toolchain test to `gate_toolchain_requirements_are_explicit`, matching my cook's "declared, never inferred" finding
- for the two `activity_provider` tests it asserts `exact_record == before`, which is a **better** fix than my cook's sentinel approach — it proves directly that no write occurred

So all of that is dropped rather than merged. What remains is one negative case #10689 does not cover: a gate command whose first token is a shell builtin or part of a compound expression (`test -f Cargo.toml && cargo test --lib`, `[ -d target ]`) must contribute **no** toolchain requirement.

That is precisely why `c3462d472` made preflight opt-in. Without this case, someone restoring inference would leave the explicit-declaration test green and reintroduce the bug.