### PR TITLE
Fix adoption cancellation process-group race

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -36,17 +36,6 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
                 },
             )? {
                 homeboy_core::process::terminate_isolated_process_group(process_group)?;
-                if homeboy_core::process::isolated_process_group_is_running(process_group).map_err(
-                    |error| {
-                        Error::internal_unexpected(format!(
-                            "verify adoption gate process group termination: {error}"
-                        ))
-                    },
-                )? {
-                    return Err(Error::internal_unexpected(format!(
-                        "adoption gate process group {process_group} remains alive after cancellation"
-                    )));
-                }
             }
         }
         let now = now_timestamp();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -415,7 +415,7 @@ fn candidate_adoption_cancellation_persists_request_before_group_termination() {
         let run_id = record.run_id.clone();
         let cancellation = std::thread::spawn(move || cancel_run(&run_id, Some("operator cancel")));
         let observed_request = (0..100).any(|_| {
-            let state = status(&record.run_id)
+            let state = exact_record(&record.run_id)
                 .expect("read adoption")
                 .candidate_adoption
                 .expect("adoption")


### PR DESCRIPTION
## Summary
- treat successful isolated process-group termination as sufficient before persisting terminal cancellation
- observe the durable cancellation request with an exact record read rather than reconciliation

Closes #10693

## Root Cause
On macOS, `kill(-pgid, 0)` continues to report a SIGKILLed group leader while it is a zombie awaiting its owner's `wait()`. `cancel_run()` performed that immediate liveness check before returning, while the owner waited only after cancellation returned, so a successfully killed gate was reported as a cancellation failure.

## Verification
- cancellation persistence race passed three consecutive focused runs
- all four lifecycle failures from #10693 pass independently
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode reproduced the release failure, diagnosed the process-group zombie race, drafted the minimal runtime and test changes, and ran focused verification. Chris Huber remains responsible for the submitted changes.