### PR TITLE
Fix non-main promotion recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -140,6 +140,10 @@ pub fn resume_promoted_patch(
                 None,
             )
         })?;
+    let verified_base = match verified_base {
+        Some(verified_base) => Some(verified_base),
+        None => capture_declared_base(target_path, options.base_ref.as_deref())?,
+    };
     let expected_candidate = previous
         .pointer("/provenance/candidate")
         .filter(|candidate| !candidate.is_null())
@@ -290,7 +294,10 @@ fn validate_resume_candidate(
     let recorded_inputs = previous
         .pointer("/provenance/resume_contract/inputs")
         .or_else(|| previous.pointer("/provenance/resume_inputs"));
-    if recorded_inputs.is_some_and(|recorded| recorded != &expected_inputs) {
+    if recorded_inputs.is_some_and(|recorded| {
+        recorded != &expected_inputs
+            && !legacy_base_correction_matches(previous, recorded, &expected_inputs)
+    }) {
         return Err(Error::validation_invalid_argument(
             "promotion",
             "promotion resume base or candidate input does not match the durable post-apply promotion",
@@ -369,6 +376,29 @@ fn validate_resume_candidate(
         }
     }
     Ok(())
+}
+
+/// #9400 checkpoints persisted after applying a patch but before the declared
+/// base was validated. Permit exactly that historical base correction only;
+/// artifact, target, and candidate authentication remain mandatory below.
+fn legacy_base_correction_matches(previous: &Value, recorded: &Value, requested: &Value) -> bool {
+    if previous.get("status").and_then(Value::as_str) != Some("verification_pending")
+        || previous.pointer("/provenance/post_apply") != Some(&Value::Bool(true))
+        || previous
+            .get("verified_base")
+            .is_some_and(|base| !base.is_null())
+    {
+        return false;
+    }
+    let mut recorded = recorded.clone();
+    let Some(recorded_inputs) = recorded.as_object_mut() else {
+        return false;
+    };
+    recorded_inputs.insert(
+        "base_ref".to_string(),
+        requested.get("base_ref").cloned().unwrap_or(Value::Null),
+    );
+    &recorded == requested
 }
 
 fn verify_patch_is_present(
@@ -1235,6 +1265,23 @@ fn promote_committed_changes(
         ));
     }
     let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
+    // Keep committed-change promotion on the same atomic base-validation
+    // boundary as artifact promotion: no apply or checkpoint may precede a
+    // failed declared base lookup.
+    let pre_apply_verified_base = if !options.dry_run {
+        match resolve_promotion_target_path(&options.to_worktree)? {
+            Some(target_path) => capture_declared_base(&target_path, options.base_ref.as_deref())?,
+            None => None,
+        }
+    } else {
+        None
+    };
+    let base_verified_before_apply = pre_apply_verified_base.is_some()
+        || options
+            .base_ref
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty);
     let provider_patch = write_normalized_patch(&normalized_patch.content)?;
     let gate_feedback_baseline = bind_gate_feedback_baseline(
         artifact
@@ -1285,7 +1332,7 @@ fn promote_committed_changes(
             artifact
                 .map(|artifact| artifact.metadata.clone())
                 .unwrap_or(Value::Null),
-            None,
+            pre_apply_verified_base.clone(),
         )?;
         checkpoint(&report)?;
         Some(report)
@@ -1293,7 +1340,11 @@ fn promote_committed_changes(
         None
     };
     let verified_base = if let Some(path) = applied_worktree_path.as_deref() {
-        let verified_base = capture_declared_base(path, options.base_ref.as_deref())?;
+        let verified_base = if base_verified_before_apply {
+            pre_apply_verified_base
+        } else {
+            capture_declared_base(path, options.base_ref.as_deref())?
+        };
         (
             run_promotion_gates(
                 options,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1038,6 +1038,87 @@ fn resume_promoted_patch_rebuilds_green_proof_from_pending_post_apply_checkpoint
 }
 
 #[test]
+fn legacy_post_apply_checkpoint_recovers_only_with_corrected_non_main_base() {
+    // #9400 regression sequence: review selected a Cook artifact for a trunk
+    // repository, a legacy generated promote command defaulted to main after
+    // applying it, then the corrected review command resumes the exact target.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let remote = temp.path().join("origin.git");
+    let target = temp.path().join("target");
+    git(
+        temp.path(),
+        &[
+            "init",
+            "--bare",
+            "--initial-branch=trunk",
+            remote.to_str().unwrap(),
+        ],
+    );
+    std::fs::create_dir(&target).expect("target");
+    git(&target, &["init", "--initial-branch=trunk"]);
+    git(&target, &["config", "user.email", "test@example.com"]);
+    git(&target, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(target.join("src")).expect("src");
+    std::fs::write(target.join("src/lib.rs"), "old\n").expect("base");
+    git(&target, &["add", "."]);
+    git(&target, &["commit", "-m", "base"]);
+    git(
+        &target,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&target, &["push", "-u", "origin", "trunk"]);
+    std::fs::write(target.join("src/lib.rs"), "new\n").expect("legacy applied patch");
+    let candidate = crate::agent_task_promotion::candidate_fingerprint(target.to_str().unwrap())
+        .expect("legacy candidate");
+    let (source_path, source) = write_patch_source(&temp);
+    let options = AgentTaskPromotionOptions {
+        source,
+        source_run_id: Some("cook-9400-attempt-1".to_string()),
+        source_path: Some(source_path),
+        source_worktree_path: None,
+        base_ref: Some("trunk".to_string()),
+        task_base_sha: None,
+        candidate_ref: None,
+        to_worktree: "fixture@target".to_string(),
+        task_id: None,
+        artifact_id: None,
+        dry_run: false,
+        gates: VerifyGateOptions::default(),
+        provider_command: None,
+        provider_invocation: None,
+    };
+    let checkpoint = serde_json::json!({
+        "schema": "homeboy/agent-task-promotion-report/v1",
+        "status": "verification_pending",
+        "source_run_id": "cook-9400-attempt-1",
+        "source": { "task_id": "task-1" },
+        "to_worktree": "fixture@target",
+        "target": { "worktree": "fixture@target", "path": target },
+        "patch_artifact": { "id": "patch", "kind": "patch", "sha256": sha256_hex(VALID_PATCH) },
+        "provenance": {
+            "post_apply": true,
+            "candidate": candidate,
+            "resume_contract": {
+                "inputs": { "base_ref": "main", "task_base_sha": null, "candidate_ref": null },
+                "gates": serde_json::to_value(&options.gates).expect("gate contract"),
+            },
+        },
+    });
+
+    let resumed = resume_promoted_patch(options.clone(), &target, &checkpoint)
+        .expect("corrected trunk command resumes the legacy checkpoint");
+    assert_eq!(resumed.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(resumed.verified_base.expect("corrected base").base, "trunk");
+
+    std::fs::write(target.join("unrelated.rs"), "conflict\n").expect("conflicting edit");
+    let error = resume_promoted_patch(options, &target, &checkpoint)
+        .expect_err("conflicting target edits fail closed");
+    assert!(error
+        .message
+        .contains("differs from the exact checkpointed"));
+}
+
+#[test]
 fn resume_applied_promotion_reruns_gates_for_exact_dirty_candidate() {
     let temp = tempfile::tempdir().expect("tempdir");
     let target = temp.path().join("target");

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -202,6 +202,24 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
             &serde_json::to_value(&record).unwrap_or(Value::Null),
         )
     });
+    let cook_base = agent_task_service::load_recipe_for_attempt(&record.run_id)?
+        .map(|recipe| {
+            recipe
+                .finalization
+                .get("base")
+                .and_then(Value::as_str)
+                .filter(|base| !base.trim().is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    homeboy::core::Error::validation_invalid_argument(
+                        "cook_recipe.finalization.base",
+                        "durable Cook recipe is missing its declared promotion base",
+                        Some(recipe.cook_id),
+                        None,
+                    )
+                })
+        })
+        .transpose()?;
     let promotion_candidates = aggregate_review
         .as_ref()
         .map(|review| {
@@ -212,6 +230,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
                         Some(&record.run_id),
                         aggregate_source.as_ref().map(|(_, path)| path.as_str()),
                         args.to_worktree.as_deref(),
+                        cook_base.as_deref(),
                         args.provider_command.as_deref(),
                         &args.provider_argv,
                         record.metadata.get("latest_promotion"),
@@ -1179,6 +1198,7 @@ fn promotion_candidates(
     source_run_id: Option<&str>,
     aggregate_path: Option<&str>,
     to_worktree: Option<&str>,
+    cook_base: Option<&str>,
     provider_command: Option<&str>,
     provider_argv: &[String],
     latest_promotion: Option<&Value>,
@@ -1262,6 +1282,8 @@ fn promotion_candidates(
                     .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
                 {
                     append_resume_contract(&mut command, contract);
+                } else if let Some(base) = cook_base {
+                    command.extend(["--base".to_string(), base.to_string()]);
                 }
                 if let Some(provider_command) = provider_command {
                     command.push("--provider-command".to_string());
@@ -1634,6 +1656,7 @@ mod tests {
             None,
             Some("fixture@target"),
             None,
+            None,
             &[
                 "homeboy".to_string(),
                 "agent-task".to_string(),
@@ -1662,6 +1685,64 @@ mod tests {
                 "--provider-argv=agent-task",
                 "--provider-argv=promotion-provider",
                 "--provider-argv=--workspace=/tmp/target",
+            ])
+        );
+    }
+
+    #[test]
+    fn promotion_candidates_preserve_the_declared_cook_base() {
+        let review = AgentTaskAggregateReport {
+            schema: "homeboy/agent-task-aggregate-report/v1".to_string(),
+            summary: AgentTaskAggregateSummary::default(),
+            tasks: Vec::new(),
+            artifact_inventory: Vec::new(),
+            apply_candidates: vec![AgentTaskDecisionRef {
+                task_id: "task-1".to_string(),
+                decision: AgentTaskReconciliationDecision::ApplyCandidate,
+                reason: "patch available".to_string(),
+                artifact_ids: vec!["patch-1".to_string()],
+            }],
+            issue_report_candidates: Vec::new(),
+            retry_plan: Vec::new(),
+            review_candidates: Vec::new(),
+            matrix: Vec::new(),
+        };
+        let aggregate: AgentTaskAggregate = serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/agent-task-aggregate/v1",
+            "plan_id": "test",
+            "status": "succeeded",
+            "totals": { "skipped": 0 },
+        }))
+        .expect("aggregate");
+
+        let candidates = promotion_candidates(
+            "cook-attempt-9400",
+            Some("cook-attempt-9400"),
+            None,
+            Some("fixture@target"),
+            Some("trunk"),
+            None,
+            &[],
+            None,
+            &aggregate,
+            &review,
+        );
+
+        assert_eq!(
+            candidates[0]["command"],
+            serde_json::json!([
+                "homeboy",
+                "agent-task",
+                "promote",
+                "cook-attempt-9400",
+                "--task-id",
+                "task-1",
+                "--artifact-id",
+                "patch-1",
+                "--to-worktree",
+                "fixture@target",
+                "--base",
+                "trunk",
             ])
         );
     }
@@ -1731,6 +1812,7 @@ mod tests {
             None,
             Some("fixture@target"),
             None,
+            None,
             &[],
             None,
             &equivalent_aggregate,
@@ -1748,6 +1830,7 @@ mod tests {
             None,
             None,
             Some("fixture@target"),
+            None,
             None,
             &[],
             None,


### PR DESCRIPTION
## Summary
Preserve a Cook's declared base through review and promotion recovery.

## What changed
- Review commands now carry the durable Cook base; committed promotion validates it before mutation; exact legacy wrong-base checkpoints can recover with a corrected base.

## How to test
1. Run `cargo +stable test -p homeboy-agents legacy_post_apply_checkpoint_recovers_only_with_corrected_non_main_base`; expect Legacy exact checkpoint recovery passes and conflicting edits fail closed..
2. Run `cargo +stable test -p homeboy-cli promotion_candidates_preserve_the_declared_cook_base`; expect Generated command includes the non-main base..

## Compatibility
Existing valid promotion and resume contracts are unchanged; only the proven legacy wrong-base checkpoint shape gains bounded recovery.

## Evidence
- Base unchanged since verification: main remains at 53eb7f3d66c2e77469d0618412a8d37cc090c3a4.
- CI expected: Homeboy CI
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9400
- Verified finalization base: main at 53eb7f3d66c2e77469d0618412a8d37cc090c3a4
- format: passed (cargo +stable fmt --all -- --check) (Passed)
- legacy-checkpoint: passed (exact corrected-base recovery and conflict rejection) (Passed)
- review-command: passed (durable non-main base retained) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the live non-main promotion failure, implemented bounded recovery and command-generation changes, added regression coverage, and compared broad-suite results against current main.

## Source relationships
- Closes #9400
