### PR TITLE
Add automatic bounded Cargo retention

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -94,16 +94,8 @@ pub enum CleanupCommand {
     /// Explain retained Homeboy storage without deleting or reconciling resources.
     RetainedStorage(CleanupRetainedStorageArgs),
 
-    /// Run one configured, bounded automatic retention pass. Invoke this from a
-    /// scheduler at the configured cadence; it is disabled until explicitly enabled.
-    AutomaticRetention(CleanupAutomaticRetentionArgs),
-}
-
-#[derive(Args)]
-pub struct CleanupAutomaticRetentionArgs {
-    /// Run despite the configured cadence. The explicit enablement gate remains in force.
-    #[arg(long)]
-    pub force: bool,
+    /// Run one configured, bounded retention pass
+    AutomaticRetention,
 }
 
 #[derive(Args)]
@@ -245,18 +237,16 @@ pub fn run(args: CleanupArgs) -> CmdResult<Value> {
                 })
             })
             .map(|output| (output, 0)),
-        Some(CleanupCommand::AutomaticRetention(args)) => {
-            cleanup::run_automatic_cargo_retention(args.force)
-                .and_then(|output| {
-                    serde_json::to_value(output).map_err(|err| {
-                        homeboy::core::Error::internal_json(
-                            err.to_string(),
-                            Some("serialize automatic retention output".to_string()),
-                        )
-                    })
+        Some(CleanupCommand::AutomaticRetention) => cleanup::run_automatic_cargo_retention()
+            .and_then(|output| {
+                serde_json::to_value(output).map_err(|err| {
+                    homeboy::core::Error::internal_json(
+                        err.to_string(),
+                        Some("serialize automatic retention output".to_string()),
+                    )
                 })
-                .map(|output| (output, 0))
-        }
+            })
+            .map(|output| (output, 0)),
         None => cleanup_inventory(args).map(|output| (output, 0)),
     }
 }

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -93,6 +93,17 @@ pub enum CleanupCommand {
 
     /// Explain retained Homeboy storage without deleting or reconciling resources.
     RetainedStorage(CleanupRetainedStorageArgs),
+
+    /// Run one configured, bounded automatic retention pass. Invoke this from a
+    /// scheduler at the configured cadence; it is disabled until explicitly enabled.
+    AutomaticRetention(CleanupAutomaticRetentionArgs),
+}
+
+#[derive(Args)]
+pub struct CleanupAutomaticRetentionArgs {
+    /// Run despite the configured cadence. The explicit enablement gate remains in force.
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Args)]
@@ -234,6 +245,18 @@ pub fn run(args: CleanupArgs) -> CmdResult<Value> {
                 })
             })
             .map(|output| (output, 0)),
+        Some(CleanupCommand::AutomaticRetention(args)) => {
+            cleanup::run_automatic_cargo_retention(args.force)
+                .and_then(|output| {
+                    serde_json::to_value(output).map_err(|err| {
+                        homeboy::core::Error::internal_json(
+                            err.to_string(),
+                            Some("serialize automatic retention output".to_string()),
+                        )
+                    })
+                })
+                .map(|output| (output, 0))
+        }
         None => cleanup_inventory(args).map(|output| (output, 0)),
     }
 }
@@ -1153,6 +1176,7 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
             cursor: args.cursor.clone(),
             now: std::time::SystemTime::now(),
             lease_ttl: policy.shared_store_lease_ttl(),
+            deadline: None,
         })?;
         categories.push(category_from_output(
             SHARED_CARGO_TARGETS_METADATA,

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -104,7 +104,7 @@ pub fn run_command_output(
                 args.command,
                 Some(crate::commands::cleanup::CleanupCommand::Artifacts(_))
                     | Some(crate::commands::cleanup::CleanupCommand::Worktrees(_))
-                    | Some(crate::commands::cleanup::CleanupCommand::AutomaticRetention(_))
+                    | Some(crate::commands::cleanup::CleanupCommand::AutomaticRetention)
             ) && !homeboy::core::lab_routing::is_lab_offload_subprocess();
             command_run_with_summary(dispatch(Commands::Cleanup(args), spec), |payload, _| {
                 summarize

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -104,6 +104,7 @@ pub fn run_command_output(
                 args.command,
                 Some(crate::commands::cleanup::CleanupCommand::Artifacts(_))
                     | Some(crate::commands::cleanup::CleanupCommand::Worktrees(_))
+                    | Some(crate::commands::cleanup::CleanupCommand::AutomaticRetention(_))
             ) && !homeboy::core::lab_routing::is_lab_offload_subprocess();
             command_run_with_summary(dispatch(Commands::Cleanup(args), spec), |payload, _| {
                 summarize

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -19,6 +19,8 @@ pub use cargo_targets::{
     acquire_shared_cargo_target, cleanup_shared_cargo_targets, shared_cargo_target_inventory,
     CargoTargetCleanupOptions, CargoTargetCleanupOutput, SharedCargoTargetLease,
 };
+mod automatic_retention;
+pub use automatic_retention::{run_automatic_cargo_retention, AutomaticRetentionOutput};
 mod extension_declarations;
 mod policy;
 pub use policy::{

--- a/crates/homeboy-core/src/cleanup/automatic_retention.rs
+++ b/crates/homeboy-core/src/cleanup/automatic_retention.rs
@@ -21,8 +21,6 @@ static IN_PROCESS_ADMISSION: OnceLock<Mutex<()>> = OnceLock::new();
 pub struct AutomaticRetentionOutput {
     pub command: &'static str,
     pub status: &'static str,
-    pub enabled: bool,
-    pub cadence_seconds: u64,
     pub max_run_seconds: u64,
     pub row_limit: usize,
     pub state_path: String,
@@ -39,27 +37,20 @@ struct AutomaticRetentionState {
     status: String,
 }
 
-pub fn run_automatic_cargo_retention(force: bool) -> Result<AutomaticRetentionOutput> {
+pub fn run_automatic_cargo_retention() -> Result<AutomaticRetentionOutput> {
     let retention = crate::defaults::load_config().retention;
     let data = homeboy_paths::homeboy_data()?;
-    run_automatic_cargo_retention_in(&retention, &data, None, force, SystemTime::now())
+    run_automatic_cargo_retention_in(&retention, &data, None, SystemTime::now())
 }
 
 fn run_automatic_cargo_retention_in(
     retention: &RetentionConfig,
     data: &Path,
     cargo_root: Option<PathBuf>,
-    force: bool,
     now: SystemTime,
 ) -> Result<AutomaticRetentionOutput> {
     let state_path = data.join(STATE_FILE);
     let base = output_base(retention, &state_path);
-    if !retention.automatic_retention_enabled {
-        return Ok(AutomaticRetentionOutput {
-            status: "disabled",
-            ..base
-        });
-    }
     let admission = IN_PROCESS_ADMISSION
         .get_or_init(|| Mutex::new(()))
         .try_lock();
@@ -85,12 +76,6 @@ fn run_automatic_cargo_retention_in(
     }
 
     let mut state = read_state(&state_path);
-    if !force && !due(&state, retention.automatic_retention_interval_seconds, now) {
-        return Ok(AutomaticRetentionOutput {
-            status: "deferred",
-            ..base
-        });
-    }
     state.last_started_unix_ms = unix_ms(now);
     state.status = "running".to_string();
     write_state(&state_path, &state)?;
@@ -133,23 +118,13 @@ fn run_automatic_cargo_retention_in(
 fn output_base(retention: &RetentionConfig, state_path: &Path) -> AutomaticRetentionOutput {
     AutomaticRetentionOutput {
         command: "cleanup.automatic_retention",
-        status: "disabled",
-        enabled: retention.automatic_retention_enabled,
-        cadence_seconds: retention.automatic_retention_interval_seconds,
+        status: "busy",
         max_run_seconds: retention.automatic_retention_max_run_seconds,
         row_limit: usize::try_from(retention.limit).unwrap_or(0),
         state_path: state_path.display().to_string(),
-        resume_command: "homeboy cleanup automatic-retention --force".to_string(),
+        resume_command: "homeboy cleanup automatic-retention".to_string(),
         cargo_targets: None,
     }
-}
-
-fn due(state: &AutomaticRetentionState, interval_seconds: u64, now: SystemTime) -> bool {
-    state.last_started_unix_ms == 0
-        || now
-            .duration_since(UNIX_EPOCH + Duration::from_millis(state.last_started_unix_ms))
-            .unwrap_or_default()
-            >= Duration::from_secs(interval_seconds)
 }
 
 fn unix_ms(now: SystemTime) -> u64 {
@@ -189,7 +164,6 @@ mod tests {
 
     fn enabled_retention() -> RetentionConfig {
         RetentionConfig {
-            automatic_retention_enabled: true,
             limit: 1,
             shared_store_days: 30,
             shared_store_max_bytes: 4,
@@ -224,7 +198,6 @@ mod tests {
             &config,
             data.path(),
             Some(cargo.path().to_path_buf()),
-            false,
             now,
         )
         .unwrap();
@@ -238,7 +211,6 @@ mod tests {
             &config,
             data.path(),
             Some(cargo.path().to_path_buf()),
-            true,
             now,
         )
         .unwrap();
@@ -262,7 +234,6 @@ mod tests {
             &enabled_retention(),
             data.path(),
             Some(cargo.path().to_path_buf()),
-            false,
             now,
         )
         .unwrap();
@@ -290,7 +261,6 @@ mod tests {
             &enabled_retention(),
             data.path(),
             Some(cargo.path().to_path_buf()),
-            false,
             SystemTime::now(),
         )
         .unwrap();

--- a/crates/homeboy-core/src/cleanup/automatic_retention.rs
+++ b/crates/homeboy-core/src/cleanup/automatic_retention.rs
@@ -1,0 +1,301 @@
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use fs4::fs_std::FileExt;
+use serde::{Deserialize, Serialize};
+
+use super::{cleanup_shared_cargo_targets, CargoTargetCleanupOptions, CargoTargetCleanupOutput};
+use crate::defaults::RetentionConfig;
+use crate::{Error, Result};
+
+const STATE_FILE: &str = "automatic-retention.json";
+const LOCK_FILE: &str = "automatic-retention.lock";
+
+// POSIX advisory locks are process-scoped, so a second thread in this process
+// can otherwise re-enter the file lock. The file lock covers other processes.
+static IN_PROCESS_ADMISSION: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[derive(Debug, Serialize)]
+pub struct AutomaticRetentionOutput {
+    pub command: &'static str,
+    pub status: &'static str,
+    pub enabled: bool,
+    pub cadence_seconds: u64,
+    pub max_run_seconds: u64,
+    pub row_limit: usize,
+    pub state_path: String,
+    pub resume_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cargo_targets: Option<CargoTargetCleanupOutput>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct AutomaticRetentionState {
+    last_started_unix_ms: u64,
+    last_finished_unix_ms: u64,
+    cursor: Option<String>,
+    status: String,
+}
+
+pub fn run_automatic_cargo_retention(force: bool) -> Result<AutomaticRetentionOutput> {
+    let retention = crate::defaults::load_config().retention;
+    let data = homeboy_paths::homeboy_data()?;
+    run_automatic_cargo_retention_in(&retention, &data, None, force, SystemTime::now())
+}
+
+fn run_automatic_cargo_retention_in(
+    retention: &RetentionConfig,
+    data: &Path,
+    cargo_root: Option<PathBuf>,
+    force: bool,
+    now: SystemTime,
+) -> Result<AutomaticRetentionOutput> {
+    let state_path = data.join(STATE_FILE);
+    let base = output_base(retention, &state_path);
+    if !retention.automatic_retention_enabled {
+        return Ok(AutomaticRetentionOutput {
+            status: "disabled",
+            ..base
+        });
+    }
+    let admission = IN_PROCESS_ADMISSION
+        .get_or_init(|| Mutex::new(()))
+        .try_lock();
+    let Ok(_admission) = admission else {
+        return Ok(AutomaticRetentionOutput {
+            status: "busy",
+            ..base
+        });
+    };
+    fs::create_dir_all(data)
+        .map_err(|error| io_error(error, "create retention state directory"))?;
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(data.join(LOCK_FILE))
+        .map_err(|error| io_error(error, "open automatic retention lock"))?;
+    if lock.try_lock_exclusive().is_err() {
+        return Ok(AutomaticRetentionOutput {
+            status: "busy",
+            ..base
+        });
+    }
+
+    let mut state = read_state(&state_path);
+    if !force && !due(&state, retention.automatic_retention_interval_seconds, now) {
+        return Ok(AutomaticRetentionOutput {
+            status: "deferred",
+            ..base
+        });
+    }
+    state.last_started_unix_ms = unix_ms(now);
+    state.status = "running".to_string();
+    write_state(&state_path, &state)?;
+
+    let output = cleanup_shared_cargo_targets(CargoTargetCleanupOptions {
+        root: cargo_root,
+        apply: true,
+        older_than: Duration::from_secs(retention.shared_store_days.saturating_mul(86_400)),
+        lease_ttl: Duration::from_secs(retention.shared_store_lease_seconds),
+        max_bytes: retention.shared_store_max_bytes,
+        limit: usize::try_from(retention.limit).unwrap_or(0),
+        cursor: state.cursor.clone(),
+        now,
+        deadline: now.checked_add(Duration::from_secs(
+            retention.automatic_retention_max_run_seconds,
+        )),
+    })?;
+    state.cursor = output.next_cursor.clone();
+    state.last_finished_unix_ms = unix_ms(SystemTime::now());
+    state.status = if output.applied_count == 0 && output.continuation_required {
+        "no_progress".to_string()
+    } else if output.continuation_required {
+        "partial".to_string()
+    } else {
+        "completed".to_string()
+    };
+    write_state(&state_path, &state)?;
+    let status = match state.status.as_str() {
+        "no_progress" => "no_progress",
+        "partial" => "partial",
+        _ => "completed",
+    };
+    Ok(AutomaticRetentionOutput {
+        status,
+        cargo_targets: Some(output),
+        ..base
+    })
+}
+
+fn output_base(retention: &RetentionConfig, state_path: &Path) -> AutomaticRetentionOutput {
+    AutomaticRetentionOutput {
+        command: "cleanup.automatic_retention",
+        status: "disabled",
+        enabled: retention.automatic_retention_enabled,
+        cadence_seconds: retention.automatic_retention_interval_seconds,
+        max_run_seconds: retention.automatic_retention_max_run_seconds,
+        row_limit: usize::try_from(retention.limit).unwrap_or(0),
+        state_path: state_path.display().to_string(),
+        resume_command: "homeboy cleanup automatic-retention --force".to_string(),
+        cargo_targets: None,
+    }
+}
+
+fn due(state: &AutomaticRetentionState, interval_seconds: u64, now: SystemTime) -> bool {
+    state.last_started_unix_ms == 0
+        || now
+            .duration_since(UNIX_EPOCH + Duration::from_millis(state.last_started_unix_ms))
+            .unwrap_or_default()
+            >= Duration::from_secs(interval_seconds)
+}
+
+fn unix_ms(now: SystemTime) -> u64 {
+    now.duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn read_state(path: &Path) -> AutomaticRetentionState {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn write_state(path: &Path, state: &AutomaticRetentionState) -> Result<()> {
+    let raw = serde_json::to_string_pretty(state).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize retention state".to_string()),
+        )
+    })?;
+    fs::write(path, raw).map_err(|error| io_error(error, "write automatic retention state"))
+}
+
+fn io_error(error: std::io::Error, operation: &str) -> Error {
+    Error::internal_io(error.to_string(), Some(operation.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cleanup::cargo_targets::acquire_shared_cargo_target_in;
+    use tempfile::TempDir;
+
+    static TEST_SERIAL: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn enabled_retention() -> RetentionConfig {
+        RetentionConfig {
+            automatic_retention_enabled: true,
+            limit: 1,
+            shared_store_days: 30,
+            shared_store_max_bytes: 4,
+            shared_store_lease_seconds: 60,
+            ..RetentionConfig::default()
+        }
+    }
+
+    fn store(root: &Path, owner: &str, bytes: usize, now: SystemTime) -> PathBuf {
+        let lease = acquire_shared_cargo_target_in(root, owner, now).unwrap();
+        let path = lease.target_dir().to_path_buf();
+        fs::write(path.join("artifact"), vec![b'x'; bytes]).unwrap();
+        drop(lease);
+        path
+    }
+
+    #[test]
+    fn cargo_budget_converges_across_bounded_resumable_passes() {
+        let _serial = TEST_SERIAL
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let data = TempDir::new().unwrap();
+        let cargo = TempDir::new().unwrap();
+        let now = SystemTime::now();
+        let first = store(cargo.path(), "first", 4, now);
+        let second = store(cargo.path(), "second", 4, now);
+        let mut config = enabled_retention();
+        config.shared_store_max_bytes = 0;
+
+        let first_pass = run_automatic_cargo_retention_in(
+            &config,
+            data.path(),
+            Some(cargo.path().to_path_buf()),
+            false,
+            now,
+        )
+        .unwrap();
+        assert_eq!(first_pass.status, "partial");
+        assert_eq!(
+            first_pass.cargo_targets.as_ref().unwrap().inspected_count,
+            1
+        );
+        assert_ne!(first.exists(), second.exists());
+        let second_pass = run_automatic_cargo_retention_in(
+            &config,
+            data.path(),
+            Some(cargo.path().to_path_buf()),
+            true,
+            now,
+        )
+        .unwrap();
+        assert_eq!(second_pass.status, "completed");
+        assert!(!second.exists());
+    }
+
+    #[test]
+    fn active_lease_is_protected_and_bounded_pass_records_no_progress() {
+        let _serial = TEST_SERIAL
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let data = TempDir::new().unwrap();
+        let cargo = TempDir::new().unwrap();
+        let now = SystemTime::now();
+        let lease = acquire_shared_cargo_target_in(cargo.path(), "active", now).unwrap();
+        fs::write(lease.target_dir().join("artifact"), b"payload").unwrap();
+        let other = store(cargo.path(), "other", 8, now);
+        let output = run_automatic_cargo_retention_in(
+            &enabled_retention(),
+            data.path(),
+            Some(cargo.path().to_path_buf()),
+            false,
+            now,
+        )
+        .unwrap();
+        assert_eq!(output.status, "no_progress");
+        assert_eq!(output.cargo_targets.as_ref().unwrap().inspected_count, 1);
+        assert!(lease.target_dir().exists());
+        assert!(other.exists());
+        assert!(data.path().join(STATE_FILE).exists());
+    }
+
+    #[test]
+    fn concurrent_pass_is_admission_rejected_without_mutating_state() {
+        let _serial = TEST_SERIAL
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let data = TempDir::new().unwrap();
+        let cargo = TempDir::new().unwrap();
+        let _admission = IN_PROCESS_ADMISSION
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+
+        let output = run_automatic_cargo_retention_in(
+            &enabled_retention(),
+            data.path(),
+            Some(cargo.path().to_path_buf()),
+            false,
+            SystemTime::now(),
+        )
+        .unwrap();
+
+        assert_eq!(output.status, "busy");
+        assert!(!data.path().join(STATE_FILE).exists());
+    }
+}

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -25,6 +25,9 @@ pub struct CargoTargetCleanupOptions {
     pub limit: usize,
     pub cursor: Option<String>,
     pub now: SystemTime,
+    /// Cooperative deadline checked between stores. A current store's safe
+    /// revalidation/removal is never interrupted mid-mutation.
+    pub deadline: Option<SystemTime>,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
@@ -34,11 +37,13 @@ pub struct CargoTargetCleanupOutput {
     pub root: String,
     pub inventory_bytes: u64,
     pub inventory_count: usize,
+    pub inspected_count: usize,
     pub candidate_count: usize,
     pub applied_count: usize,
     pub skipped_count: usize,
     pub reclaimed_bytes: u64,
     pub continuation_required: bool,
+    pub time_budget_exhausted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -86,7 +91,7 @@ pub fn acquire_shared_cargo_target(owner: &str) -> Result<SharedCargoTargetLease
     acquire_shared_cargo_target_in(&root, owner, SystemTime::now())
 }
 
-fn acquire_shared_cargo_target_in(
+pub(crate) fn acquire_shared_cargo_target_in(
     root: &Path,
     owner: &str,
     now: SystemTime,
@@ -135,8 +140,25 @@ pub fn cleanup_shared_cargo_targets(
     let mut candidates = Vec::new();
     let mut remaining = inventory_bytes;
     let mut has_more = false;
+    let mut time_budget_exhausted = false;
+    let mut inspected_count = 0;
+    let mut last_inspected = None;
 
     for store in stores.iter().skip(start) {
+        if options
+            .deadline
+            .is_some_and(|deadline| SystemTime::now() >= deadline)
+        {
+            has_more = true;
+            time_budget_exhausted = true;
+            break;
+        }
+        if inspected_count == options.limit {
+            has_more = true;
+            break;
+        }
+        inspected_count += 1;
+        last_inspected = Some(store.path.clone());
         if let Some(reason) = store
             .reasons
             .iter()
@@ -161,10 +183,6 @@ pub fn cleanup_shared_cargo_targets(
                 .entry("within age and size budget".to_string())
                 .or_default() += 1;
             continue;
-        }
-        if candidates.len() == options.limit {
-            has_more = true;
-            break;
         }
         remaining = remaining.saturating_sub(store.size_bytes);
         candidates.push(store.clone());
@@ -194,9 +212,7 @@ pub fn cleanup_shared_cargo_targets(
             }
         }
     }
-    let next_cursor = has_more
-        .then(|| candidates.last().map(|store| store.path.clone()))
-        .flatten();
+    let next_cursor = has_more.then_some(last_inspected).flatten();
     let next_command = next_cursor.as_ref().map(|cursor| {
         let apply = if options.apply { " --apply" } else { "" };
         format!(
@@ -211,11 +227,13 @@ pub fn cleanup_shared_cargo_targets(
         root: root.to_string_lossy().to_string(),
         inventory_bytes,
         inventory_count: stores.len(),
+        inspected_count,
         candidate_count: candidates.len(),
         applied_count,
         skipped_count,
         reclaimed_bytes,
         continuation_required: has_more,
+        time_budget_exhausted,
         next_cursor,
         next_command,
         retained_by_reason,
@@ -546,6 +564,7 @@ mod tests {
             limit: 10,
             cursor: None,
             now,
+            deadline: None,
         }
     }
     fn store(root: &Path, owner: &str, bytes: usize, age: Duration, now: SystemTime) -> PathBuf {

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -212,6 +212,17 @@ pub struct RetentionConfig {
     pub shared_store_max_bytes: u64,
     #[serde(default = "default_shared_store_lease_seconds")]
     pub shared_store_lease_seconds: u64,
+    /// Explicit admission for an external scheduler to run automatic retention.
+    /// Disabled by default because this path mutates local stores unattended.
+    #[serde(default)]
+    pub automatic_retention_enabled: bool,
+    /// Minimum interval between automatic retention passes.
+    #[serde(default = "default_automatic_retention_interval_seconds")]
+    pub automatic_retention_interval_seconds: u64,
+    /// Cooperative wall-clock budget for one automatic pass. Category owners
+    /// finish an in-progress safe mutation before the executor yields.
+    #[serde(default = "default_automatic_retention_max_run_seconds")]
+    pub automatic_retention_max_run_seconds: u64,
 }
 
 impl Default for RetentionConfig {
@@ -227,6 +238,9 @@ impl Default for RetentionConfig {
             shared_store_days: default_shared_store_retention_days(),
             shared_store_max_bytes: default_shared_store_max_bytes(),
             shared_store_lease_seconds: default_shared_store_lease_seconds(),
+            automatic_retention_enabled: false,
+            automatic_retention_interval_seconds: default_automatic_retention_interval_seconds(),
+            automatic_retention_max_run_seconds: default_automatic_retention_max_run_seconds(),
         }
     }
 }
@@ -269,6 +283,14 @@ fn default_shared_store_max_bytes() -> u64 {
 
 fn default_shared_store_lease_seconds() -> u64 {
     6 * 60 * 60
+}
+
+fn default_automatic_retention_interval_seconds() -> u64 {
+    60 * 60
+}
+
+fn default_automatic_retention_max_run_seconds() -> u64 {
+    60
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -212,13 +212,6 @@ pub struct RetentionConfig {
     pub shared_store_max_bytes: u64,
     #[serde(default = "default_shared_store_lease_seconds")]
     pub shared_store_lease_seconds: u64,
-    /// Explicit admission for an external scheduler to run automatic retention.
-    /// Disabled by default because this path mutates local stores unattended.
-    #[serde(default)]
-    pub automatic_retention_enabled: bool,
-    /// Minimum interval between automatic retention passes.
-    #[serde(default = "default_automatic_retention_interval_seconds")]
-    pub automatic_retention_interval_seconds: u64,
     /// Cooperative wall-clock budget for one automatic pass. Category owners
     /// finish an in-progress safe mutation before the executor yields.
     #[serde(default = "default_automatic_retention_max_run_seconds")]
@@ -238,8 +231,6 @@ impl Default for RetentionConfig {
             shared_store_days: default_shared_store_retention_days(),
             shared_store_max_bytes: default_shared_store_max_bytes(),
             shared_store_lease_seconds: default_shared_store_lease_seconds(),
-            automatic_retention_enabled: false,
-            automatic_retention_interval_seconds: default_automatic_retention_interval_seconds(),
             automatic_retention_max_run_seconds: default_automatic_retention_max_run_seconds(),
         }
     }
@@ -283,10 +274,6 @@ fn default_shared_store_max_bytes() -> u64 {
 
 fn default_shared_store_lease_seconds() -> u64 {
     6 * 60 * 60
-}
-
-fn default_automatic_retention_interval_seconds() -> u64 {
-    60 * 60
 }
 
 fn default_automatic_retention_max_run_seconds() -> u64 {

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -67,13 +67,16 @@ homeboy cleanup --include shared-cargo-targets --apply
 
 ## Automatic Retention
 
-An external scheduler can invoke one bounded Cargo-target retention pass:
+Declare the bounded Cargo-target retention pass through Homeboy's scheduler:
 
 ```bash
-homeboy cleanup automatic-retention
+homeboy schedule add automatic-retention \
+  --command "cleanup automatic-retention" \
+  --every 1h \
+  --on-overlap skip
 ```
 
-Set `retention.automatic_retention_enabled` to `true` to admit mutation. The hook remains disabled by default. `retention.automatic_retention_interval_seconds` controls cadence, `retention.limit` caps inspected stores per pass, and the existing Cargo byte budget and active-lease predicate remain authoritative. State, continuation cursor, and the exact forced resume command are written under the Homeboy data directory. Use `--force` only to resume a reported partial or no-progress pass before its next cadence.
+The schedule declaration is the explicit opt-in to unattended mutation. The Homeboy daemon owns cadence, overlap prevention, and stale-run recovery; no external timer is needed. `retention.limit` caps inspected stores per pass, while the existing Cargo byte budget and active-lease predicate remain authoritative. The cleanup command retains its own single-flight lock so a manual invocation cannot overlap a scheduled run. State, continuation cursor, and the exact resume command are written under the Homeboy data directory.
 
 ## Runner Binary Caches
 

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -65,6 +65,16 @@ homeboy cleanup --include shared-cargo-targets --apply
 
 `retention.shared_store_days` defaults to `30`, `retention.shared_store_max_bytes` defaults to `21474836480` (20 GiB), and `retention.shared_store_lease_seconds` defaults to `21600` (6 hours). The age and size budgets select rebuildable stores; the lease window independently protects active workloads. Inventory output is bounded by `retention.limit`; when `next_command` is present, run it to continue from `next_cursor`.
 
+## Automatic Retention
+
+An external scheduler can invoke one bounded Cargo-target retention pass:
+
+```bash
+homeboy cleanup automatic-retention
+```
+
+Set `retention.automatic_retention_enabled` to `true` to admit mutation. The hook remains disabled by default. `retention.automatic_retention_interval_seconds` controls cadence, `retention.limit` caps inspected stores per pass, and the existing Cargo byte budget and active-lease predicate remain authoritative. State, continuation cursor, and the exact forced resume command are written under the Homeboy data directory. Use `--force` only to resume a reported partial or no-progress pass before its next cadence.
+
 ## Runner Binary Caches
 
 Runner refresh and dev-sync create managed Homeboy binary slots below each runner workspace root. Inventory or reclaim stale slots through the aggregate cleanup surface:

--- a/docs/reference/cli/commands/cleanup.md
+++ b/docs/reference/cli/commands/cleanup.md
@@ -35,6 +35,7 @@ Remove declared reconstructable artifacts from managed worktrees
 | `homeboy cleanup artifacts` | Inspect or remove declared reconstructable artifacts across repo worktrees |
 | `homeboy cleanup worktrees` | Aggregate cleanup across configured external worktree providers |
 | `homeboy cleanup retained-storage` | Explain retained Homeboy storage without deleting or reconciling resources |
+| `homeboy cleanup automatic-retention` | Run one configured, bounded retention pass |
 
 ## `homeboy cleanup artifacts`
 
@@ -82,4 +83,12 @@ Explain retained Homeboy storage without deleting or reconciling resources
 | --- | --- | --- |
 | `--limit` | `<LIMIT>` | Maximum largest-byte examples to return. The report always aggregates all inspected sources |
 | `--cursor` | `<CURSOR>` | Continue largest-byte examples after this deterministic reference token |
+
+## `homeboy cleanup automatic-retention`
+
+```sh
+homeboy cleanup automatic-retention
+```
+
+Run one configured, bounded retention pass
 

--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -6,7 +6,7 @@ Hand-written narrative for these commands lives in `docs/commands/`. -->
 
 # Homeboy CLI reference (generated)
 
-`homeboy` exposes 529 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
+`homeboy` exposes 530 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
 
 Hand-written narrative lives in the [commands index](../../../commands/commands-index.md). Global flags are documented in [the root command reference](../homeboy-root-command.md). Machine-readable safety, docs, output, and Lab metadata come from `homeboy contract manifest`.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,6 +77,9 @@ own arguments.
 - `shared_store_days` — Age threshold for shared Cargo target stores.
 - `shared_store_max_bytes` — Byte budget for shared Cargo target stores.
 - `shared_store_lease_seconds` — Lease TTL that keeps an in-use shared Cargo target store alive.
+- `automatic_retention_enabled` — Explicitly permits `homeboy cleanup automatic-retention` to mutate the first automatic category. Defaults to `false`.
+- `automatic_retention_interval_seconds` — Minimum scheduler cadence between automatic passes (default: 3600).
+- `automatic_retention_max_run_seconds` — Cooperative wall-clock budget for one automatic pass (default: 60). The executor yields between stores; a category never interrupts an in-progress safe mutation.
 
 Runner-side age floors are deliberately *not* configuration keys. Both the
 runner Lab-workspace and managed-binary-cache floors live on a remote host whose

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,8 +77,6 @@ own arguments.
 - `shared_store_days` — Age threshold for shared Cargo target stores.
 - `shared_store_max_bytes` — Byte budget for shared Cargo target stores.
 - `shared_store_lease_seconds` — Lease TTL that keeps an in-use shared Cargo target store alive.
-- `automatic_retention_enabled` — Explicitly permits `homeboy cleanup automatic-retention` to mutate the first automatic category. Defaults to `false`.
-- `automatic_retention_interval_seconds` — Minimum scheduler cadence between automatic passes (default: 3600).
 - `automatic_retention_max_run_seconds` — Cooperative wall-clock budget for one automatic pass (default: 60). The executor yields between stores; a category never interrupts an in-progress safe mutation.
 
 Runner-side age floors are deliberately *not* configuration keys. Both the


### PR DESCRIPTION
## Summary

- add one bounded, resumable `homeboy cleanup automatic-retention` pass
- compose the existing Homeboy scheduler for cadence, daemon ticking, overlap policy, and stale-run recovery
- use schedule declaration as the explicit opt-in to unattended mutation
- retain in-process and cross-process single-flight admission for concurrent manual invocation
- compose existing shared Cargo cleanup policy and lease protections
- bound cleanup by rows and cooperative wall-clock budget
- persist cursor and resumable pass evidence

Configure automatic execution through the existing scheduler:

```bash
homeboy schedule add automatic-retention \
  --command "cleanup automatic-retention" \
  --every 1h \
  --on-overlap skip
```

This is the first vertical slice of the automatic retention controller. Controller scratch, persisted artifacts, lifecycle reconciliation, and SQLite ownership remain follow-up scope.

## Testing

- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-cli`
- `cargo test -p homeboy-core cleanup::automatic_retention --lib`
- `cargo test -p homeboy-cli --lib cli_surface::reference_docs`

Part of #10695.

## AI assistance

OpenAI GPT-5.6 Sol using OpenCode drafted the implementation and correction. The correction replaced duplicate cadence and enablement state with Homeboy’s existing scheduler contract, regenerated CLI documentation, and reran targeted checks. Chris Huber remains responsible for the change.