### PR TITLE
fix: stop the release check laundering a detached HEAD into "nothing to release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ env:
   RELEASE_BLOCKING_COMMANDS: ${{ inputs.release_blocking_commands || 'review lint,review test' }}
   HOMEBOY_NO_UPDATE_CHECK: '1'
   RELEASE_MIN_FREE_KB: '5242880'
+  # Must match homeboy-action's `release-branch` input default. The check job
+  # re-attaches HEAD to this branch so the action's branch guard can resolve it.
+  RELEASE_BRANCH: main
 
 # Only one release pipeline at a time. If a push arrives while a release
 # is already running, it queues (never cancels). The queued run starts
@@ -68,6 +71,46 @@ jobs:
         with:
           ref: ${{ inputs.release_tag || github.sha }}
           fetch-depth: 0
+
+      # `actions/checkout` with `ref: <sha>` leaves HEAD DETACHED, so
+      # `git rev-parse --abbrev-ref HEAD` — which is how homeboy-action's
+      # release wrapper identifies the current branch — returns the literal
+      # string "HEAD". Its guard then reads that as "not on main", exits 0
+      # before `homeboy release` ever runs, and writes no release-version.
+      # The decide step below used to read that emptiness as "no releasable
+      # commits", so the pipeline reported success while skipping every job
+      # for 131 commits (#10703).
+      #
+      # Re-attaching HEAD is the honest fix. `--head` (via the action's
+      # `release-head` input) is NOT — that flag means "finish an
+      # already-versioned, already-tagged HEAD" and skips the version and
+      # changelog computation that is the entire purpose of the dry run.
+      #
+      # Attach ONLY when the checked-out commit genuinely IS the release
+      # branch tip, which is the property the guard is actually there to
+      # enforce. If a commit landed between trigger and checkout, or the
+      # workflow was dispatched at an arbitrary SHA, HEAD stays detached,
+      # the guard fires, and the decide step turns that into a hard failure
+      # rather than a silent green.
+      - name: Attach HEAD to the release branch
+        if: inputs.release_tag == ''
+        run: |
+          HEAD_SHA="$(git rev-parse HEAD)"
+          BRANCH_SHA="$(git rev-parse -q --verify "refs/remotes/origin/${RELEASE_BRANCH}" || true)"
+
+          if [ -z "${BRANCH_SHA}" ]; then
+            echo "::warning::No refs/remotes/origin/${RELEASE_BRANCH} in this checkout - leaving HEAD detached"
+            exit 0
+          fi
+
+          if [ "${HEAD_SHA}" != "${BRANCH_SHA}" ]; then
+            echo "::warning::HEAD ${HEAD_SHA:0:8} is not the ${RELEASE_BRANCH} tip ${BRANCH_SHA:0:8} - leaving HEAD detached"
+            exit 0
+          fi
+
+          git checkout -q -B "${RELEASE_BRANCH}" "${HEAD_SHA}"
+          git branch --quiet --set-upstream-to "origin/${RELEASE_BRANCH}" "${RELEASE_BRANCH}" 2>/dev/null || true
+          echo "::notice::HEAD attached to ${RELEASE_BRANCH} at ${HEAD_SHA:0:8}"
 
       - name: Restore failed release marker
         id: failure-cache
@@ -183,8 +226,36 @@ jobs:
           RELEASE_VERSION="${{ steps.recovery.outputs['release-version'] || steps.release-check.outputs['release-version'] }}"
           RELEASE_TAG="${{ steps.recovery.outputs['release-tag'] || steps.release-check.outputs['release-tag'] }}"
           BUMP_TYPE="${{ steps.recovery.outputs['release-bump-type'] || steps.release-check.outputs['release-bump-type'] }}"
+          DRY_RUN_OUTCOME="${{ steps.release-check.outcome }}"
+          SKIPPED_REASON="${{ steps.release-check.outputs['skipped-reason'] }}"
 
           echo "recovery-attempts=${STRANDED_ATTEMPTS:-0}" >> "$GITHUB_OUTPUT"
+
+          # #10685: absence of evidence must never be evidence of success.
+          # An empty release-version has two very different causes, and this
+          # step used to collapse both into "No releasable commits":
+          #
+          #   MEASURED   - `homeboy release --dry-run` evaluated the commit
+          #                range and declined. Core emits exactly three such
+          #                reasons from planning_policy.rs.
+          #   UNMEASURED - the action's wrapper bailed before invoking core,
+          #                so nothing was ever evaluated. `wrong-branch` is
+          #                the one that silently ate 131 commits (#10703);
+          #                `release-output-missing` is the other.
+          #
+          # Only a measured negative may render "nothing to release". Anything
+          # else is UNKNOWN and fails the job loudly, because a release
+          # pipeline that cannot tell whether it has work to do must not
+          # report success while skipping every downstream job.
+          if [ "${DRY_RUN_OUTCOME}" = "success" ] && [ -z "${RELEASE_VERSION}" ]; then
+            case "${SKIPPED_REASON}" in
+              no-releasable-commits|release-already-at-head|major-requires-flag) ;;
+              *)
+                echo "::error::Release check could not determine whether there is anything to release at ${HEAD_SHA:0:8}. The dry run produced no release-version and no measured skip reason (skipped-reason='${SKIPPED_REASON:-<empty>}'). This is an UNKNOWN result, not 'nothing to release', so the pipeline is failing instead of skipping every job and reporting success. If skipped-reason is 'wrong-branch', HEAD was detached and the branch guard fired before any commit range was evaluated — see the 'Attach HEAD to the release branch' step above and issue #10703."
+                exit 1
+                ;;
+            esac
+          fi
 
           if [ -n "${RECOVERY_TAG}" ]; then
             # Explicit workflow_dispatch recovery always wins.
@@ -215,8 +286,12 @@ jobs:
           elif [ "${{ steps.failed-release.outputs.blocked }}" = "true" ]; then
             echo "should-release=false" >> "$GITHUB_OUTPUT"
           elif [ -z "${RELEASE_VERSION}" ]; then
+            # Reached only after the measurement check above accepted the
+            # skip reason, so this really is a measured negative. Report the
+            # reason by name — "no releasable commits" is a lie when core
+            # actually said `major-requires-flag` or `release-already-at-head`.
             echo "should-release=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No releasable commits at HEAD ${HEAD_SHA:0:8}"
+            echo "::notice::Not releasing at HEAD ${HEAD_SHA:0:8} — ${SKIPPED_REASON:-no-releasable-commits}"
           else
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "release-bump-type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -947,3 +947,327 @@ fn release_recovery_records_control_binary_lineage_against_the_release_target() 
         "only git's definitive non-ancestor exit code may block a recovery"
     );
 }
+
+/// Extract the shell body of a `run: |` step so its BEHAVIOUR can be exercised
+/// rather than string-matched. Asserting the effect is the whole point: the
+/// audit gate in #10685 passed for weeks because its test asserted the command
+/// it ran instead of what that command produced.
+fn step_run_script(job: &str, marker_line: &str) -> String {
+    let block = release_step_block(job, marker_line);
+    let start = block
+        .find("run: |\n")
+        .expect("step should have a run block");
+    block[start + "run: |\n".len()..]
+        .lines()
+        .take_while(|line| line.trim().is_empty() || line.starts_with("          "))
+        .map(|line| line.get(10..).unwrap_or("").to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Substitute `${{ ... }}` expressions the way the runner does — by value, as
+/// literal text. `subs` is scanned in order, so the caller controls precedence
+/// when one expression mentions several outputs (the `release-version`
+/// fallback chain mentions both `recovery` and `release-check`). Unmatched
+/// expressions become the empty string, exactly as an unset step output does.
+fn interpolate(script: &str, subs: &[(&str, &str)]) -> String {
+    let mut out = String::new();
+    let mut rest = script;
+
+    while let Some(open) = rest.find("${{") {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 3..];
+        let close = after.find("}}").expect("unterminated ${{ expression");
+        let expr = &after[..close];
+        let value = subs
+            .iter()
+            .find(|(key, _)| expr.contains(key))
+            .map_or("", |(_, value)| *value);
+        out.push_str(value);
+        rest = &after[close + 2..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Run the release `check` job's decide step under the runner's own shell
+/// (`bash -e`) and return (exit code, combined output).
+fn run_decide_step(subs: &[(&str, &str)]) -> (i32, String) {
+    let check = job_section(release_workflow(), "check");
+    let script = interpolate(
+        &step_run_script(check, "name: Decide whether to release"),
+        subs,
+    );
+
+    let dir = std::env::temp_dir().join(format!(
+        "homeboy-decide-{}-{:p}",
+        std::process::id(),
+        &script
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let script_path = dir.join("decide.sh");
+    let output_path = dir.join("github_output");
+    std::fs::write(&script_path, &script).expect("write script");
+    std::fs::write(&output_path, "").expect("write output file");
+
+    let output = std::process::Command::new("bash")
+        .arg("-e")
+        .arg(&script_path)
+        .env("GITHUB_OUTPUT", &output_path)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("decide step should run");
+
+    let combined = format!(
+        "{}{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        std::fs::read_to_string(&output_path).unwrap_or_default()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+    (output.status.code().unwrap_or(-1), combined)
+}
+
+/// Regression for #10703, and the fifth instance of the #10685 invariant.
+///
+/// The `check` job checks out by SHA, which leaves HEAD detached, so
+/// `git rev-parse --abbrev-ref HEAD` — how homeboy-action's release wrapper
+/// identifies the branch — returned the literal string `HEAD`. Its guard read
+/// that as "not on main", exited 0 before `homeboy release` ever ran, and
+/// wrote no `release-version`. The decide step then reported "No releasable
+/// commits" and skipped Build, Audit, Test, Lint, Prepare and Create GitHub
+/// Release while concluding `success` — for 131 commits, 86 of them
+/// conventional `fix:`/`feat:` (run 30410721084).
+///
+/// This asserts the EFFECT: an unmeasured skip reason must FAIL the job, and a
+/// measured one must still skip quietly. If someone reverts the measurement
+/// check, the `wrong-branch` case starts exiting 0 and this test fails.
+#[test]
+fn release_check_never_reports_nothing_to_release_without_measuring() {
+    // Reasons core emits from planning_policy.rs after it evaluated the commit
+    // range. These are measured negatives and must skip quietly, exit 0.
+    for reason in [
+        "no-releasable-commits",
+        "release-already-at-head",
+        "major-requires-flag",
+    ] {
+        let (code, out) = run_decide_step(&[
+            ("steps.release-check.outcome", "success"),
+            ("steps.release-check.outputs['skipped-reason']", reason),
+        ]);
+        assert_eq!(
+            code, 0,
+            "measured skip reason {reason} must not fail the release check: {out}"
+        );
+        assert!(
+            out.contains("should-release=false"),
+            "measured skip reason {reason} must skip the release: {out}"
+        );
+        // The reason must be reported by name. Collapsing every measured
+        // negative into "no releasable commits" is how a deliberate refusal
+        // (major-requires-flag) became indistinguishable from an empty commit
+        // range in the first place.
+        assert!(
+            out.contains(reason),
+            "decide step must name the measured skip reason {reason}: {out}"
+        );
+    }
+
+    // Reasons homeboy-action's wrapper emits BEFORE invoking `homeboy release`
+    // (run-release.sh:122 and :209). Nothing was measured, so "nothing to
+    // release" is unknowable and the job must fail rather than skip green.
+    for reason in ["wrong-branch", "release-output-missing"] {
+        let (code, out) = run_decide_step(&[
+            ("steps.release-check.outcome", "success"),
+            ("steps.release-check.outputs['skipped-reason']", reason),
+        ]);
+        assert_ne!(
+            code, 0,
+            "unmeasured skip reason {reason} must fail the release check, not skip it: {out}"
+        );
+        assert!(
+            !out.contains("should-release=true"),
+            "unmeasured skip reason {reason} must never release: {out}"
+        );
+        assert!(
+            out.contains("::error::"),
+            "unmeasured skip reason {reason} must be loud: {out}"
+        );
+    }
+
+    // An empty reason with no version is equally unknowable — fail closed.
+    let (code, out) = run_decide_step(&[("steps.release-check.outcome", "success")]);
+    assert_ne!(
+        code, 0,
+        "a dry run that produced neither a version nor a reason must fail closed: {out}"
+    );
+
+    // A measured version still releases.
+    let (code, out) = run_decide_step(&[
+        ("steps.release-check.outcome", "success"),
+        ("steps.release-check.outputs['release-version']", "0.322.0"),
+        ("steps.release-check.outputs['release-tag']", "v0.322.0"),
+        ("steps.release-check.outputs['release-bump-type']", "minor"),
+    ]);
+    assert_eq!(code, 0, "a measured version must release: {out}");
+    assert!(
+        out.contains("should-release=true") && out.contains("release-version=0.322.0"),
+        "a measured version must release: {out}"
+    );
+
+    // Paths where the dry run legitimately never ran (stranded recovery, hold)
+    // must not be caught by the measurement check — the dry-run step is
+    // `skipped` there and earlier branches own the decision.
+    let (code, out) = run_decide_step(&[
+        ("steps.release-check.outcome", "skipped"),
+        ("steps.stranded.outputs['stranded-tag']", "v0.322.0"),
+        ("steps.stranded.outputs['stranded-version']", "0.322.0"),
+    ]);
+    assert_eq!(code, 0, "stranded recovery must still work: {out}");
+    assert!(
+        out.contains("recovery-release=true"),
+        "stranded recovery must still publish the prepared tag: {out}"
+    );
+
+    let (code, out) = run_decide_step(&[
+        ("steps.release-check.outcome", "skipped"),
+        ("steps.stranded.outputs['hold-reason']", "in-flight release"),
+    ]);
+    assert_eq!(code, 0, "an in-flight hold must not fail the job: {out}");
+    assert!(
+        out.contains("should-release=false"),
+        "an in-flight hold must not release: {out}"
+    );
+}
+
+/// The branch guard must be satisfied by establishing the branch, NOT by
+/// setting `release-head`.
+///
+/// `release-head: 'true'` makes homeboy-action append `--head`, which means
+/// "finish an already-versioned, already-tagged HEAD" and SKIPS the changelog
+/// and version computation (crates/homeboy-cli/src/commands/release/mod.rs).
+/// The `host` publish job checks out a real tag and legitimately wants that.
+/// The dry run exists to compute a fresh bump, so it must never set it — the
+/// asymmetry between the two steps is correct and must stay.
+#[test]
+fn release_dry_run_establishes_its_branch_instead_of_claiming_release_head() {
+    let check = job_section(release_workflow(), "check");
+    let host = job_section(release_workflow(), "host");
+
+    // The two steps must DISAGREE: publish finishes a tagged HEAD, the dry run
+    // must not claim to.
+    assert!(
+        host.contains("release-head: 'true'"),
+        "the publish step finishes an already-tagged HEAD and must keep release-head"
+    );
+    let dry_run = release_step_block(check, "name: Dry-run release check");
+    assert!(
+        !dry_run.contains("release-head"),
+        "the dry run computes a fresh version bump; --head would skip exactly that"
+    );
+
+    // Because it cannot use release-head, the check job must make the branch
+    // resolvable instead, and only when HEAD really is the branch tip.
+    let attach = step_run_script(check, "name: Attach HEAD to the release branch");
+    assert!(
+        attach.contains("git checkout -q -B \"${RELEASE_BRANCH}\""),
+        "the check job must re-attach HEAD so the action's branch guard can resolve it"
+    );
+    assert!(
+        attach.contains("refs/remotes/origin/${RELEASE_BRANCH}")
+            && attach.contains("[ \"${HEAD_SHA}\" != \"${BRANCH_SHA}\" ]"),
+        "attaching must be guarded on HEAD actually being the release branch tip, \
+         otherwise it would launder an arbitrary SHA into a release"
+    );
+
+    // The guard needs full history to resolve the remote branch ref.
+    assert!(
+        check.contains("fetch-depth: 0"),
+        "resolving origin/<branch> requires unshallowed history"
+    );
+}
+
+/// The attach step's real git behaviour: attach at the tip, refuse otherwise.
+/// Asserting the effect, not the shape of the script.
+#[test]
+fn release_head_attach_refuses_any_commit_that_is_not_the_branch_tip() {
+    let check = job_section(release_workflow(), "check");
+    let script = step_run_script(check, "name: Attach HEAD to the release branch");
+
+    let dir = std::env::temp_dir().join(format!("homeboy-attach-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let script_path = dir.join("attach.sh");
+    std::fs::write(&script_path, &script).expect("write script");
+
+    let git = |args: &[&str], cwd: &std::path::Path| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("git should run")
+    };
+
+    let upstream = dir.join("upstream");
+    std::fs::create_dir_all(&upstream).expect("upstream dir");
+    git(&["init", "-q", "-b", "main", "."], &upstream);
+    git(&["commit", "-q", "--allow-empty", "-m", "c1"], &upstream);
+    git(&["commit", "-q", "--allow-empty", "-m", "c2"], &upstream);
+    git(&["clone", "-q", upstream.to_str().unwrap(), "work"], &dir);
+    let work = dir.join("work");
+
+    let attach = |cwd: &std::path::Path| {
+        std::process::Command::new("bash")
+            .arg("-e")
+            .arg(&script_path)
+            .env("RELEASE_BRANCH", "main")
+            .current_dir(cwd)
+            .output()
+            .expect("attach step should run")
+    };
+    let branch_of = |cwd: &std::path::Path| {
+        String::from_utf8_lossy(&git(&["rev-parse", "--abbrev-ref", "HEAD"], cwd).stdout)
+            .trim()
+            .to_string()
+    };
+
+    // A SHA checkout of the branch tip — exactly what `ref: ${{ github.sha }}`
+    // produces — starts detached and reports the literal string "HEAD".
+    git(&["checkout", "-q", "--detach", "HEAD"], &work);
+    assert_eq!(
+        branch_of(&work),
+        "HEAD",
+        "a detached checkout must reproduce the bug's precondition"
+    );
+    let out = attach(&work);
+    assert!(out.status.success(), "attach should succeed at the tip");
+    assert_eq!(
+        branch_of(&work),
+        "main",
+        "HEAD at the branch tip must be re-attached so the branch guard resolves"
+    );
+
+    // An older commit is NOT the branch tip. Attaching it would let a release
+    // be cut from an arbitrary SHA — the exact thing the guard exists to stop.
+    git(&["checkout", "-q", "--detach", "HEAD~1"], &work);
+    let out = attach(&work);
+    assert!(
+        out.status.success(),
+        "refusing to attach is not an error in this step"
+    );
+    assert_eq!(
+        branch_of(&work),
+        "HEAD",
+        "a commit that is not the branch tip must stay detached"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("::warning::"),
+        "refusing to attach must be visible"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Fixes #10703

`Extra-Chill/homeboy` has not released in **131 commits** (86 conventional `fix:`/`feat:`) since `v0.321.1`. Every scheduled Release run concludes `success` with **every job skipped**.

## What actually happened

Run [30410721084](https://github.com/Extra-Chill/homeboy/actions/runs/30410721084), job `Check for releasable commits` (id `90446396775`):

```
line 3377  ##[notice]Not on main (current: HEAD) - skipping release
line 3463  RELEASE_VERSION=""            <- literal, in the interpolated decide script
line 3539  ##[notice]No releasable commits at HEAD 86c1afc9
```

The `check` job checks out `ref: ${{ inputs.release_tag || github.sha }}`, which leaves HEAD **detached**. homeboy-action's release wrapper identifies the branch with `git rev-parse --abbrev-ref HEAD`, which returns the **literal string `HEAD`** on a detached checkout — the log rendered it verbatim as `(current: HEAD)`. Its guard read that as "not on main", **exited 0 before `homeboy release` ever ran**, and wrote no `release-version`. The decide step interpolated that emptiness and reported "No releasable commits".

The job's only `Set output` calls were `should-release` and `recovery-attempts`. `release-version` was never set.

## `release-head` is not the fix

The obvious patch — set `release-head: 'true'` on the dry run to match the publish step — **is wrong**. `RELEASE_HEAD` does double duty in `run-release.sh`: it bypasses the branch guard *and* appends `--head`, which per `crates/homeboy-cli/src/commands/release/mod.rs:105-109` means:

> Finish the release pipeline for an already-versioned, already-tagged HEAD. **Skips changelog/version/git mutation steps**...

The publish job checks out a real tag and legitimately wants that. The dry run exists to *compute a fresh version bump*, which `--head` skips. **The asymmetry between the two steps is correct.** The branch guard is what is broken.

## Changes

**1. Attach HEAD to the release branch — only when HEAD really is the tip.**
`fetch-depth: 0` means `refs/remotes/origin/main` is present. If HEAD is not the tip (a race, or a dispatch at an arbitrary SHA) it stays detached, and change 2 makes that loud. This preserves the property the guard actually exists to enforce.

**2. Require a measurement before reading the verdict (#10685).**
An empty `release-version` now only means "nothing to release" when the dry run reported a reason proving it evaluated the commit range:

| reason | source | verdict |
|---|---|---|
| `no-releasable-commits` | core `planning_policy.rs` | measured -> skip quietly |
| `release-already-at-head` | core `planning_policy.rs` | measured -> skip quietly |
| `major-requires-flag` | core `planning_policy.rs` | measured -> skip quietly |
| `wrong-branch` | wrapper `run-release.sh:122` | **unmeasured -> fail loudly** |
| `release-output-missing` | wrapper `run-release.sh:209` | **unmeasured -> fail loudly** |
| empty + no version | — | **unknown -> fail closed** |

Measured reasons are now reported **by name** — collapsing `major-requires-flag` into "no releasable commits" was its own small lie.

`skipped-reason` is already a composite-action output (`homeboy-action/action.yml:243`), so this needs no action change.

## Verification

Three tests in `tests/release_workflow_test.rs`, asserting **effects**, not strings — they extract the workflow's own shell and execute it:

- `release_check_never_reports_nothing_to_release_without_measuring` — runs the decide step under `bash -e` across all 9 paths.
- `release_dry_run_establishes_its_branch_instead_of_claiming_release_head` — the dry run and publish step must **disagree** on `release-head`.
- `release_head_attach_refuses_any_commit_that_is_not_the_branch_tip` — builds a real git repo, detaches, and asserts the attach step attaches at the tip and refuses elsewhere.

Executed via a faithful port of the helpers (this host cannot run cargo):

```
measured no-releasable-commits    exit=0 named=True
measured release-already-at-head  exit=0 named=True
measured major-requires-flag      exit=0 named=True
unmeasured wrong-branch           exit=1 loud=True
unmeasured release-output-missing exit=1 loud=True
empty reason+version              exit=1
measured version                  exit=0 releases=True
stranded recovery                 exit=0
hold                              exit=0
detached precondition  branch=[HEAD]
at tip  -> attach      branch=[main] exit=0
not tip -> refuse      branch=[HEAD] exit=0 warned=True
```

**Mutation-tested.** With both changes reverted, `wrong-branch` goes back to `exit=0, loud=False` (the original silent green) and the tests fail; the attach-step test panics on the missing step. The tests are negative-sensitive.

## Not fixed here (deliberate)

`v0.320.0` is a stranded Draft, and that is **correct**. `detect-stranded-release.sh` did not miss it — same job, lines 2890-2891 warn that it "sits below an already-published release, so it will NOT be recovered automatically", with the opt-in `gh workflow run` command and a job-summary row. Rule 4 in the script's header names `v0.320.0` as the motivating example. Publishing it is an operator decision.

## Deployment

**This half takes effect immediately** — it is all workflow-side. The companion durable fix in homeboy-action (Extra-Chill/homeboy-action#TBD) **will not take effect until `v2` is re-pointed**: `v2` is frozen at `66fb512` (v2.8.25) because homeboy-action's own releases v2.8.26/v2.8.27/v2.9.0/v2.9.1 are stranded Drafts. Confirmed the guard is byte-identical between `v2^{commit}` and `origin/main`, so no behaviour here depends on that tag moving.
