### PR TITLE
Keep gate feedback out of mutation startup

### DIFF
--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -18,6 +18,13 @@ pub fn classify(args: &[String]) -> CommandCapability {
         return CommandCapability::ReadOnly;
     }
 
+    if args
+        .windows(2)
+        .any(|args| args == ["agent-task", "gate-feedback"])
+    {
+        return CommandCapability::ReadOnly;
+    }
+
     match args {
         [flag] if flag == "--version" || flag == "-V" => CommandCapability::ReadOnly,
         [command, subcommand]
@@ -50,6 +57,15 @@ mod tests {
             args(&["homeboy", "self", "status"]),
             args(&["homeboy", "status"]),
             args(&["homeboy", "agent-task", "retry", "--help"]),
+            args(&[
+                "homeboy",
+                "agent-task",
+                "gate-feedback",
+                "--promotion",
+                "{}",
+                "--source-task",
+                "{}",
+            ]),
         ] {
             assert_eq!(classify(&command), CommandCapability::ReadOnly);
         }

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -53,7 +53,6 @@ pub(super) fn agent_task_resource_behavior(
         | agent_task::AgentTaskCommand::Adopt(_)
         | agent_task::AgentTaskCommand::PromotionProvider(_)
         | agent_task::AgentTaskCommand::FinalizePr(_)
-        | agent_task::AgentTaskCommand::GateFeedback(_)
         | agent_task::AgentTaskCommand::Tool(_) => AgentTaskResourceBehavior::AdmittedWorkload,
         agent_task::AgentTaskCommand::Retry(retry) if retry.run => {
             AgentTaskResourceBehavior::AdmittedWorkload
@@ -66,6 +65,7 @@ pub(super) fn agent_task_resource_behavior(
         | agent_task::AgentTaskCommand::Artifacts(_)
         | agent_task::AgentTaskCommand::Evidence(_)
         | agent_task::AgentTaskCommand::Diagnose(_)
+        | agent_task::AgentTaskCommand::GateFeedback(_)
         // Provider discovery reads controller-local extension and runtime
         // manifests under bounded probes. Classifying it as an admitted
         // workload put it behind resource admission, which captured a

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -741,6 +741,16 @@ mod tests {
             ["homeboy", "agent-task", "list"].as_slice(),
             ["homeboy", "agent-task", "active"].as_slice(),
             ["homeboy", "agent-task", "latest"].as_slice(),
+            [
+                "homeboy",
+                "agent-task",
+                "gate-feedback",
+                "--promotion",
+                "{}",
+                "--source-task",
+                "{}",
+            ]
+            .as_slice(),
             ["homeboy", "agent-task", "fanout", "status", "batch-123"].as_slice(),
             ["homeboy", "agent-task", "fanout", "artifacts", "batch-123"].as_slice(),
             ["homeboy", "agent-task", "loop", "status", "loop-123"].as_slice(),


### PR DESCRIPTION
Closes #10707

## Summary
- classify the pure `agent-task gate-feedback` route read-only before runtime startup
- skip mutation-only terminal runner reconciliation for that route
- treat parsed gate-feedback as bounded controller-local computation instead of an admitted workload

## Verification
- `cargo test -p homeboy-cli classifies_runtime_safe_diagnostics_without_parsing_runtime_state -- --nocapture`
- `cargo test -p homeboy-cli bounded_agent_task_metadata_reads_bypass_hot_admission_for_all_runner_states -- --nocapture`
- `cargo check -p homeboy-cli`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
GPT-5.6-sol via OpenCode sampled the blocked process, identified the startup classification defect, and drafted the implementation and regression coverage. Chris Huber remains responsible for every line.