### PR TITLE
fix(release): attach verified immutable main checkout

### DIFF
--- a/.github/attach-release-branch.sh
+++ b/.github/attach-release-branch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT_BRANCH="${1:?event branch is required}"
+EVENT_SHA="${2:?event SHA is required}"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+if [ "${EVENT_BRANCH}" != "main" ] || [ "${HEAD_SHA}" != "${EVENT_SHA}" ]; then
+  echo "Refusing release identity branch=${EVENT_BRANCH} event=${EVENT_SHA} checkout=${HEAD_SHA}" >&2
+  exit 1
+fi
+
+git switch --force-create "${EVENT_BRANCH}" "${EVENT_SHA}"
+test "$(git branch --show-current)" = "${EVENT_BRANCH}"
+test "$(git rev-parse HEAD)" = "${EVENT_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,13 @@ jobs:
           ref: ${{ inputs.release_tag || github.sha }}
           fetch-depth: 0
 
+      - name: Attach verified immutable release branch
+        if: inputs.release_tag == ''
+        env:
+          EVENT_BRANCH: ${{ github.ref_name }}
+          EVENT_SHA: ${{ github.sha }}
+        run: bash .github/attach-release-branch.sh "${EVENT_BRANCH}" "${EVENT_SHA}"
+
       - name: Restore failed release marker
         id: failure-cache
         if: inputs.release_tag == ''

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -34,6 +34,26 @@ fn release_quality_policy(
         .expect("release quality policy should run")
 }
 
+fn git(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git should run")
+}
+
+fn release_branch_script(dir: &std::path::Path, branch: &str, sha: &str) -> std::process::Output {
+    std::process::Command::new("bash")
+        .arg(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/.github/attach-release-branch.sh"
+        ))
+        .args([branch, sha])
+        .current_dir(dir)
+        .output()
+        .expect("release branch script should run")
+}
+
 fn job_section<'a>(workflow: &'a str, job: &str) -> &'a str {
     let marker = format!("  {job}:\n");
     let start = workflow
@@ -234,9 +254,62 @@ fn automatic_release_uses_the_immutable_push_sha_for_every_preparation_checkout(
     assert!(workflow.contains(
         "ref: ${{ inputs.release_tag || (needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag']) || github.sha }}"
     ));
+    let check = job_section(workflow, "check");
+    assert!(check.contains("name: Attach verified immutable release branch"));
+    assert!(check.contains(
+        "run: bash .github/attach-release-branch.sh \"${EVENT_BRANCH}\" \"${EVENT_SHA}\""
+    ));
     assert!(
         !workflow.contains("ref: ${{ inputs.release_tag || github.ref }}"),
         "a rolling main branch must not replace the push event's release candidate"
+    );
+}
+
+#[test]
+fn immutable_release_branch_attachment_verifies_identity_before_attaching_main() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path();
+    assert!(git(repo, &["init", "-q", "--initial-branch", "main"])
+        .status
+        .success());
+    assert!(git(repo, &["config", "user.email", "test@example.com"])
+        .status
+        .success());
+    assert!(git(repo, &["config", "user.name", "Test"]).status.success());
+    std::fs::write(repo.join("README.md"), "fixture\n").expect("write fixture");
+    assert!(git(repo, &["add", "."]).status.success());
+    assert!(git(repo, &["commit", "-q", "-m", "fixture"])
+        .status
+        .success());
+    let sha =
+        String::from_utf8(git(repo, &["rev-parse", "HEAD"]).stdout).expect("SHA should be utf-8");
+    let sha = sha.trim();
+    assert!(git(repo, &["checkout", "-q", "--detach", sha])
+        .status
+        .success());
+
+    assert!(release_branch_script(repo, "main", sha).status.success());
+    assert_eq!(
+        String::from_utf8(git(repo, &["branch", "--show-current"]).stdout)
+            .expect("branch should be utf-8")
+            .trim(),
+        "main"
+    );
+
+    assert!(git(repo, &["checkout", "-q", "--detach", sha])
+        .status
+        .success());
+    assert!(!release_branch_script(repo, "feature", sha).status.success());
+    assert!(
+        !release_branch_script(repo, "main", "0000000000000000000000000000000000000000")
+            .status
+            .success()
+    );
+    assert!(
+        String::from_utf8(git(repo, &["branch", "--show-current"]).stdout)
+            .expect("branch should be utf-8")
+            .trim()
+            .is_empty()
     );
 }
 


### PR DESCRIPTION
## Summary

- verify the push event branch and SHA against the detached checkout before release planning
- attach the verified immutable commit to local `main` so released Homeboy versions recognize the default branch
- preserve fail-closed behavior for non-main and mismatched-SHA identities

Closes #10702.

## Verification

- `cargo fmt --check`
- `bash -n .github/attach-release-branch.sh`
- `cargo test --test release_workflow_test` (32 passed)
- `cargo test -p homeboy-release` exercised 764 tests; 759 passed and 5 existing environment/baseline-sensitive tests failed outside this workflow-only diff

## AI assistance

OpenCode with `openai/gpt-5.6-terra` drafted the initial investigation candidate. OpenCode with `openai/gpt-5.6-sol` identified the bootstrap flaw, reduced the change to the workflow-owned repair, added behavioral coverage, and ran verification. Chris Huber remains responsible for the final change.