### PR TITLE
fix: prefer stale materialized workspace cleanup

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -2789,9 +2789,6 @@ fn prune_candidate_reason(
         }
     }
 
-    if !Path::new(source_path).exists() {
-        return Ok(Some("source_path_missing".to_string()));
-    }
     if has_terminal_delete_on_success_lifecycle_with(metadata, |run_id| {
         workspace_run_authority(runner, metadata, path, run_id)
     }) {
@@ -2799,6 +2796,9 @@ fn prune_candidate_reason(
     }
     if is_stale_materialized_workspace_lifecycle(metadata, path) {
         return Ok(Some(STALE_MATERIALIZED_WORKSPACE_REASON.to_string()));
+    }
+    if !Path::new(source_path).exists() {
+        return Ok(Some("source_path_missing".to_string()));
     }
     Ok(None)
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -67,7 +67,10 @@ fn prune_workspaces_previews_orphans_without_deleting_by_default() {
         assert!(output.next_command.is_none());
         assert!(output.drain_command.contains("--apply --min-age-hours 0"));
         assert_eq!(output.candidates[0].remote_path, synced.remote_path);
-        assert_eq!(output.candidates[0].reason, "source_path_missing");
+        assert_eq!(
+            output.candidates[0].reason,
+            "stale_materialized_workspace_lifecycle"
+        );
         assert!(Path::new(&synced.remote_path).exists());
     });
 }
@@ -558,6 +561,51 @@ fn prune_workspaces_reaps_stale_materialized_workspace_with_live_source() {
         );
         assert!(!Path::new(&synced.remote_path).exists());
         assert!(source.exists());
+    });
+}
+
+#[test]
+fn prune_workspaces_prefers_stale_materialized_lifecycle_when_source_is_missing() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source_parent = tempfile::tempdir().expect("source parent");
+        let source = source_parent.path().join("removed-source");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        fs::create_dir_all(&source).expect("source dir");
+        fs::write(source.join("file.txt"), "removed\n").expect("source file");
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-local-prune-materialized-missing","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let (synced, _) = sync_workspace(
+            "lab-local-prune-materialized-missing",
+            sync_options(source.display().to_string()),
+        )
+        .expect("sync workspace");
+        fs::remove_dir_all(&source).expect("remove source");
+
+        let (output, exit_code) = prune_workspaces(
+            "lab-local-prune-materialized-missing",
+            RunnerWorkspacePruneOptions {
+                apply: true,
+                min_age_hours: 0,
+                limit: 10,
+                passes: 1,
+                cursor: None,
+            },
+        )
+        .expect("prune stale materialized workspace with missing source");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.removed.len(), 1);
+        assert_eq!(
+            output.removed[0].reason,
+            "stale_materialized_workspace_lifecycle"
+        );
+        assert!(!Path::new(&synced.remote_path).exists());
     });
 }
 


### PR DESCRIPTION
## Summary
- classify canonical stale materialized lifecycle records before generic missing-source candidates
- route those candidates through the existing exact-metadata SSH deletion guard
- cover missing-source materialized workspaces while preserving process/open-file and metadata-change safety checks

## Live evidence
After #10698 restored authoritative generation health, a `homeboy-lab` dry run exposed 45 inactive candidates totaling 1,355,079,680 bytes. Apply removed zero because `source_path_missing` bypassed the dedicated materialized-workspace deletion path and the generic guard correctly retained the active synthetic lease. One inspected candidate had the canonical `materialized-workspace` lifecycle shape and no run/job owner.

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-lab-runner`
- `env -u TMPDIR cargo test -p homeboy-lab-runner workspace::tests::prune -- --test-threads=1` (27 passed)
- `git diff --check origin/main...HEAD`

Closes #10708.

## AI assistance
OpenAI `gpt-5.6-sol` through OpenCode diagnosed the live classification/deletion mismatch, drafted the reason-precedence repair and regression coverage, and ran verification. Chris Huber reviewed and remains responsible for the change.