### PR TITLE
Preflight extension-declared Lab toolchain readiness

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -95,6 +95,10 @@ pub struct ExtensionManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<RuntimeRequirementsConfig>,
 
+    /// Extension-owned executable/toolchain probes for Lab admission.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub toolchain_readiness: Vec<ToolchainReadinessProbe>,
+
     // Standalone capabilities (already self-contained structs)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cli: Option<CliConfig>,

--- a/crates/contracts/homeboy-extension-contract/src/manifest_toolchain_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest_toolchain_config.rs
@@ -6,6 +6,20 @@ use homeboy_engine_primitives::output_parse::ParseSpec;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
+/// An extension-owned executable readiness probe for portable operations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ToolchainReadinessProbe {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostic_env: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RequirementsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -219,6 +219,16 @@ pub struct RunnerToolCapabilityRequirement {
     pub capabilities: Vec<String>,
 }
 
+/// Extension-owned command that proves a runner toolchain is usable.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunnerToolchainReadinessProbe {
+    pub extension_id: String,
+    pub id: String,
+    pub command: String,
+    pub repair_command: Option<String>,
+    pub diagnostic_env: Vec<String>,
+}
+
 /// A resolved set of capability requirements to preflight before running a
 /// command on a runner.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -227,6 +237,7 @@ pub struct RunnerCapabilityPreflight {
     pub required_tools: Vec<RunnerRequiredTool>,
     pub required_commands: Vec<String>,
     pub required_tool_capabilities: Vec<RunnerToolCapabilityRequirement>,
+    pub required_toolchain_probes: Vec<RunnerToolchainReadinessProbe>,
     pub required_components: Vec<String>,
     pub required_env: Vec<String>,
     pub timeout: Option<std::time::Duration>,
@@ -237,6 +248,7 @@ impl RunnerCapabilityPreflight {
         self.required_tools.is_empty()
             && self.required_commands.is_empty()
             && self.required_tool_capabilities.is_empty()
+            && self.required_toolchain_probes.is_empty()
             && self.required_components.is_empty()
             && self.required_env.is_empty()
     }
@@ -260,6 +272,7 @@ impl From<PreparedLabRunnerCapability> for RunnerCapabilityPreflight {
             required_tools: plan.required_tools,
             required_commands: Vec::new(),
             required_tool_capabilities: Vec::new(),
+            required_toolchain_probes: Vec::new(),
             required_components: Vec::new(),
             required_env: Vec::new(),
             timeout: None,

--- a/crates/homeboy-extension/src/manifest.rs
+++ b/crates/homeboy-extension/src/manifest.rs
@@ -45,7 +45,8 @@ pub use homeboy_extension_contract::manifest_toolchain_config::{
     DepsConfig, DiscoveryConfig, EnvProviderConfig, FileContainsCondition, LintChangedFileRoute,
     LintConfig, PortableEnvConfig, RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig,
     SinceTagConfig, SourceSnapshotConfig, TestChangedFileExclusiveEnv, TestChangedFileRouting,
-    TestChangedFileRoutingStrategy, TestConfig, TestNoTestsApplicablePolicy, VersionPatternConfig,
+    TestChangedFileRoutingStrategy, TestConfig, TestNoTestsApplicablePolicy,
+    ToolchainReadinessProbe, VersionPatternConfig,
 };
 pub use homeboy_extension_contract::DeployArchiveInstallPolicy;
 pub use homeboy_extension_contract::{TestPassthroughFilter, TestPassthroughFilterStrategy};

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -21,6 +21,7 @@ pub use homeboy_lab_runner_contract::RunnerCapabilityPreflight;
 // RunnerToolCapabilityRequirement now lives in the shared runner-contract crate
 // (behavior-free data). Re-exported so existing call sites resolve unchanged.
 pub use homeboy_lab_runner_contract::RunnerToolCapabilityRequirement;
+pub use homeboy_lab_runner_contract::RunnerToolchainReadinessProbe;
 
 pub use homeboy_lab_runner_contract::{
     LabRunnerCapabilityContract, LabRunnerGateDecision, LabRunnerGateMode,
@@ -112,6 +113,8 @@ pub(crate) fn validate_runner_capability_preflight(
         .iter()
         .filter_map(|requirement| missing_tool_capability(requirement, capabilities, request_env))
         .collect::<Vec<_>>();
+    let failed_toolchain_probes =
+        capabilities.failed_toolchain_probes(&preflight.required_toolchain_probes);
     let missing_env = preflight
         .required_env
         .iter()
@@ -127,6 +130,7 @@ pub(crate) fn validate_runner_capability_preflight(
         && missing_components.is_empty()
         && missing_commands.is_empty()
         && missing_tool_capabilities.is_empty()
+        && failed_toolchain_probes.is_empty()
         && missing_env.is_empty()
     {
         return Ok(());
@@ -155,6 +159,12 @@ pub(crate) fn validate_runner_capability_preflight(
             missing_tool_capabilities.join(", ")
         ));
     }
+    if !failed_toolchain_probes.is_empty() {
+        missing.push(format!(
+            "toolchain probes: {}",
+            failed_toolchain_probes.join(", ")
+        ));
+    }
     if !missing_env.is_empty() {
         missing.push(format!("environment: {}", missing_env.join(", ")));
     }
@@ -181,6 +191,24 @@ pub(crate) fn validate_runner_capability_preflight(
             "Refresh or configure the runner tool that provides '{capability}', then retry the evidence run."
         )
     }));
+    remediation.extend(
+        preflight
+            .required_toolchain_probes
+            .iter()
+            .filter_map(|probe| {
+                failed_toolchain_probes
+                    .iter()
+                    .any(|failed| failed.starts_with(&format!("{}:", probe.id)))
+                    .then(|| {
+                        probe.repair_command.clone().unwrap_or_else(|| {
+                            format!(
+                                "Repair extension `{}` toolchain probe `{}` and retry.",
+                                probe.extension_id, probe.id
+                            )
+                        })
+                    })
+            }),
+    );
     remediation.extend(missing_env.iter().map(|name| {
         format!("Set required environment variable '{name}' on the runner or pass it with the runner exec request.")
     }));
@@ -200,11 +228,25 @@ pub(crate) fn validate_runner_capability_preflight(
     ))
 }
 
+/// Run arbitrary extension-owned readiness probes during controller admission,
+/// before source or runtime materialization reserves a Lab slot.
+pub(crate) fn preflight_runner_toolchain_readiness(
+    runner: &Runner,
+    preflight: &RunnerCapabilityPreflight,
+) -> Result<()> {
+    if preflight.required_toolchain_probes.is_empty() {
+        return Ok(());
+    }
+    let capabilities = RunnerCapabilitySnapshot::from_runner_probe(runner, preflight)?;
+    validate_runner_capability_preflight(&runner.id, preflight, &capabilities, &HashMap::new())
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RunnerCapabilitySnapshot {
     tools: BTreeSet<RunnerRequiredTool>,
     commands: BTreeSet<String>,
     tool_capabilities: BTreeSet<String>,
+    failed_toolchain_probes: HashMap<String, String>,
     components: BTreeSet<String>,
 }
 
@@ -246,6 +288,7 @@ impl RunnerCapabilitySnapshot {
                 tools: probe.tools,
                 commands: probe.commands,
                 tool_capabilities: probe.tool_capabilities,
+                failed_toolchain_probes: probe.failed_toolchain_probes,
                 components: configured_runner_components(runner),
             });
         }
@@ -257,6 +300,7 @@ impl RunnerCapabilitySnapshot {
             tools: probe.tools,
             commands: probe.commands,
             tool_capabilities: probe.tool_capabilities,
+            failed_toolchain_probes: probe.failed_toolchain_probes,
             components: configured_runner_components(runner),
         })
     }
@@ -271,6 +315,17 @@ impl RunnerCapabilitySnapshot {
 
     fn has_tool_capability(&self, capability: &str) -> bool {
         self.tool_capabilities.contains(capability.trim())
+    }
+
+    fn failed_toolchain_probes(&self, probes: &[RunnerToolchainReadinessProbe]) -> Vec<String> {
+        probes
+            .iter()
+            .filter_map(|probe| {
+                self.failed_toolchain_probes
+                    .get(&probe.id)
+                    .map(|detail| format!("{}: {detail}", probe.id))
+            })
+            .collect()
     }
 
     fn batch_probe(
@@ -293,7 +348,12 @@ impl RunnerCapabilitySnapshot {
             .collect::<Result<Vec<_>>>()?;
         let command_names = normalized_command_names(&preflight.required_commands);
         let capability_probes = normalized_tool_capability_probes(preflight);
-        let script = batch_probe_script(&tool_commands, &command_names, &capability_probes);
+        let script = batch_probe_script(
+            &tool_commands,
+            &command_names,
+            &capability_probes,
+            &preflight.required_toolchain_probes,
+        );
         let output = preflight
             .timeout
             .map(|timeout| client.execute_with_timeout(&script, timeout))
@@ -303,6 +363,7 @@ impl RunnerCapabilitySnapshot {
             &tool_commands,
             &command_names,
             &capability_probes,
+            &preflight.required_toolchain_probes,
         ))
     }
 
@@ -329,7 +390,12 @@ impl RunnerCapabilitySnapshot {
             .collect::<Vec<_>>();
         let command_names = normalized_command_names(&preflight.required_commands);
         let capability_probes = normalized_tool_capability_probes(preflight);
-        let script = batch_probe_script(&tool_commands, &command_names, &capability_probes);
+        let script = batch_probe_script(
+            &tool_commands,
+            &command_names,
+            &capability_probes,
+            &preflight.required_toolchain_probes,
+        );
         let env = runner
             .env
             .iter()
@@ -347,6 +413,7 @@ impl RunnerCapabilitySnapshot {
             &tool_commands,
             &command_names,
             &capability_probes,
+            &preflight.required_toolchain_probes,
         ))
     }
 
@@ -371,6 +438,7 @@ struct RunnerCapabilityProbeResult {
     tools: BTreeSet<RunnerRequiredTool>,
     commands: BTreeSet<String>,
     tool_capabilities: BTreeSet<String>,
+    failed_toolchain_probes: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -385,6 +453,7 @@ fn batch_probe_script(
     tool_commands: &[(RunnerRequiredTool, String)],
     command_names: &[String],
     capability_probes: &[RunnerToolCapabilityProbe],
+    toolchain_probes: &[RunnerToolchainReadinessProbe],
 ) -> String {
     let mut lines = Vec::new();
     lines.push("set +e".to_string());
@@ -402,6 +471,15 @@ fn batch_probe_script(
     }
     for (index, probe) in capability_probes.iter().enumerate() {
         lines.push(tool_capability_probe_script(index, probe));
+    }
+    for (index, probe) in toolchain_probes.iter().enumerate() {
+        let environment = probe
+            .diagnostic_env
+            .iter()
+            .map(|name| format!("{name}=${{{name}:-}}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        lines.push(format!("if ({}) >/dev/null 2>&1; then printf 'R\\t{index}\\t1\\n'; else printf 'R\\t{index}\\t0\\t{}\\n'; fi", probe.command, shell::quote_arg(&environment)));
     }
     lines.push("exit 0".to_string());
     lines.join("\n")
@@ -425,6 +503,7 @@ fn parse_batch_probe_output(
     tool_commands: &[(RunnerRequiredTool, String)],
     command_names: &[String],
     capability_probes: &[RunnerToolCapabilityProbe],
+    toolchain_probes: &[RunnerToolchainReadinessProbe],
 ) -> RunnerCapabilityProbeResult {
     let mut result = RunnerCapabilityProbeResult::default();
     for line in stdout.lines() {
@@ -435,7 +514,8 @@ fn parse_batch_probe_output(
         let Some(index) = fields.next().and_then(|value| value.parse::<usize>().ok()) else {
             continue;
         };
-        if fields.next() != Some("1") {
+        let succeeded = fields.next() == Some("1");
+        if !succeeded && kind != "R" {
             continue;
         }
         match kind {
@@ -452,6 +532,14 @@ fn parse_batch_probe_output(
             "P" => {
                 if let Some(probe) = capability_probes.get(index) {
                     result.tool_capabilities.insert(probe.id.clone());
+                }
+            }
+            "R" if !succeeded => {
+                if let Some(probe) = toolchain_probes.get(index) {
+                    result.failed_toolchain_probes.insert(
+                        probe.id.clone(),
+                        fields.next().unwrap_or("probe failed").to_string(),
+                    );
                 }
             }
             _ => {}
@@ -812,6 +900,7 @@ mod tests {
             .collect(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
+            failed_toolchain_probes: HashMap::new(),
             components: BTreeSet::new(),
         };
 
@@ -840,6 +929,7 @@ mod tests {
             tools: [RunnerRequiredTool::git()].into_iter().collect(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
+            failed_toolchain_probes: HashMap::new(),
             components: BTreeSet::new(),
         };
 
@@ -919,6 +1009,7 @@ mod tests {
             tools: [RunnerRequiredTool::git()].into_iter().collect(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
+            failed_toolchain_probes: HashMap::new(),
             components: BTreeSet::new(),
         };
 
@@ -952,6 +1043,7 @@ mod tests {
             ],
             required_commands: vec!["zip".to_string()],
             required_tool_capabilities: Vec::new(),
+            required_toolchain_probes: Vec::new(),
             required_components: vec!["fixture-a".to_string(), "fixture-b".to_string()],
             required_env: vec!["HOMEBOY_TOKEN".to_string()],
             timeout: None,
@@ -960,6 +1052,7 @@ mod tests {
             tools: [RunnerRequiredTool::git()].into_iter().collect(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
+            failed_toolchain_probes: HashMap::new(),
             components: ["fixture-a".to_string()].into_iter().collect(),
         };
 
@@ -1035,6 +1128,7 @@ mod tests {
                 .collect(),
             commands: BTreeSet::new(),
             tool_capabilities: BTreeSet::new(),
+            failed_toolchain_probes: HashMap::new(),
             components: BTreeSet::new(),
         };
         validate_runner_capability_preflight("lab", &preflight, &capable, &HashMap::new())
@@ -1062,6 +1156,7 @@ mod tests {
             ],
             required_commands: vec!["zip".to_string()],
             required_tool_capabilities: Vec::new(),
+            required_toolchain_probes: Vec::new(),
             required_components: vec!["fixture-a".to_string()],
             required_env: vec!["HOMEBOY_TOKEN".to_string()],
             timeout: None,
@@ -1075,6 +1170,7 @@ mod tests {
             .collect(),
             commands: ["zip".to_string()].into_iter().collect(),
             tool_capabilities: BTreeSet::new(),
+            failed_toolchain_probes: HashMap::new(),
             components: ["fixture-a".to_string()].into_iter().collect(),
         };
         let mut env = HashMap::new();
@@ -1146,6 +1242,51 @@ mod tests {
         assert!(tried.iter().any(|hint| hint
             .as_str()
             .is_some_and(|hint| { hint.contains("Remote execution was not started") })));
+    }
+
+    #[test]
+    fn toolchain_probe_rejects_a_present_command_when_its_usable_probe_fails() {
+        let runner = Runner {
+            id: "local".to_string(),
+            kind: RunnerKind::Local,
+            server_id: None,
+            workspace_root: None,
+            settings: RunnerSettings::default(),
+            env: HashMap::new(),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: RunnerPolicy::default(),
+        };
+        let preflight = RunnerCapabilityPreflight {
+            command: "lint".to_string(),
+            required_commands: vec!["sh".to_string()],
+            required_toolchain_probes: vec![RunnerToolchainReadinessProbe {
+                extension_id: "fixture".to_string(),
+                id: "fixture:usable-toolchain".to_string(),
+                command: "command -v sh >/dev/null && false".to_string(),
+                repair_command: Some("repair-fixture-toolchain".to_string()),
+                diagnostic_env: vec!["PATH".to_string()],
+            }],
+            ..Default::default()
+        };
+
+        let capabilities = runner_capability_snapshot_for_preflight(&runner, &preflight)
+            .expect("snapshot completes even when a readiness probe fails");
+        let error = validate_runner_capability_preflight(
+            "local",
+            &preflight,
+            &capabilities,
+            &HashMap::new(),
+        )
+        .expect_err("a present command without a usable toolchain is rejected");
+
+        assert!(error.message.contains("fixture:usable-toolchain"));
+        assert!(error.message.contains("PATH="));
+        assert!(error.details["tried"]
+            .as_array()
+            .expect("remediation")
+            .iter()
+            .any(|hint| hint.as_str() == Some("repair-fixture-toolchain")));
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1571,7 +1571,19 @@ pub(crate) fn run_lab_offload_inner(
         }
     }
 
-    let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
+    let mut capability_preflight: Option<RunnerCapabilityPreflight> =
+        capability_plan.map(Into::into);
+    if let Some(toolchain_preflight) = toolchain_readiness_preflight(&contract)? {
+        match &mut capability_preflight {
+            Some(preflight) => preflight
+                .required_toolchain_probes
+                .extend(toolchain_preflight.required_toolchain_probes),
+            None => capability_preflight = Some(toolchain_preflight),
+        }
+    }
+    if let Some(preflight) = capability_preflight.as_ref() {
+        preflight_runner_toolchain_readiness(&runner, preflight)?;
+    }
     // Detached agent-task work is controller-owned from this point.
     // It must never fall through to caller-side workspace staging after admission.
     if request.detach_after_handoff

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -55,6 +55,7 @@ use homeboy_core::runner_execution_envelope::PathMaterializationPlan;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use homeboy_core::{Error, ErrorCode, Result};
 
+use super::super::capabilities::preflight_runner_toolchain_readiness;
 use super::super::command_path::{
     preflight_remote_argv_path_translation, preflight_remote_path_bearing_surfaces,
 };
@@ -76,7 +77,9 @@ use super::super::lab_args::{
     remap_provider_config_with_materialization_plan_in_args, rewrite_lab_offload_args,
     rewrite_runner_resident_lab_offload_args, LabAtFileSpec, LabPathRemap,
 };
-use super::super::lab_capabilities::lab_runner_capability_contract;
+use super::super::lab_capabilities::{
+    lab_runner_capability_contract, toolchain_readiness_preflight,
+};
 use super::super::lab_command::lab_offload_command_prefix;
 use super::super::lab_env::{
     build_lab_offload_env_with_passthroughs, forward_declared_dependency_paths_env,

--- a/crates/homeboy-lab-runner/src/lab_capabilities.rs
+++ b/crates/homeboy-lab-runner/src/lab_capabilities.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use super::{LabOffloadCommand, LabRunnerCapabilityContract, RunnerRequiredTool};
+use super::{RunnerCapabilityPreflight, RunnerToolchainReadinessProbe};
 
 pub(super) fn lab_runner_capability_contract(
     command: &LabOffloadCommand,
@@ -28,6 +29,45 @@ pub(super) fn lab_runner_capability_contract(
             .map(|capability| capability.name.clone())
             .collect(),
     })
+}
+
+/// Resolve extension-owned usable-toolchain probes before any Lab workspace is
+/// hydrated. The operation label is generic Homeboy command metadata; extension
+/// manifests own the language, tool, probe, and repair semantics.
+pub(super) fn toolchain_readiness_preflight(
+    command: &LabOffloadCommand,
+) -> homeboy_core::Result<Option<RunnerCapabilityPreflight>> {
+    let operation = command
+        .hot_label
+        .split_whitespace()
+        .last()
+        .unwrap_or_default();
+    let mut probes = Vec::new();
+    for extension_id in &command.required_extensions {
+        let manifest = homeboy_core::extension_store::load_extension(extension_id)?;
+        for probe in &manifest.toolchain_readiness {
+            if !probe.capabilities.is_empty()
+                && !probe
+                    .capabilities
+                    .iter()
+                    .any(|capability| capability == operation)
+            {
+                continue;
+            }
+            probes.push(RunnerToolchainReadinessProbe {
+                extension_id: extension_id.clone(),
+                id: format!("{extension_id}:{}", probe.id),
+                command: probe.command.clone(),
+                repair_command: probe.repair_command.clone(),
+                diagnostic_env: probe.diagnostic_env.clone(),
+            });
+        }
+    }
+    Ok((!probes.is_empty()).then(|| RunnerCapabilityPreflight {
+        command: command.hot_label.to_string(),
+        required_toolchain_probes: probes,
+        ..Default::default()
+    }))
 }
 
 fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {

--- a/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
@@ -412,6 +412,7 @@ pub(super) fn source_cli_workspace_has_package_lock(file_path: &Path) -> bool {
 /// so the runner must expose the declared commands before remote dispatch.
 pub(super) fn source_cli_bootstrap_capability_preflight() -> RunnerCapabilityPreflight {
     RunnerCapabilityPreflight {
+        required_toolchain_probes: Vec::new(),
         command: "lab.source_cli_bootstrap".to_string(),
         required_tools: Vec::new(),
         required_commands: Vec::new(),

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -130,6 +130,7 @@ pub use capabilities::{
     runner_capability_inventory, LabRunnerCapabilityContract, LabRunnerGateDecision,
     LabRunnerGateMode, PreparedLabRunnerCapability, RunnerCapabilityInventory,
     RunnerCapabilityPreflight, RunnerRequiredTool, RunnerToolCapabilityRequirement,
+    RunnerToolchainReadinessProbe,
 };
 pub(crate) use command_path::normalize_runner_command_env_for_homeboy_path;
 pub use command_path::preflight_remote_argv_path_translation;

--- a/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
@@ -24,6 +24,7 @@ use super::super::{
 /// remote run that would otherwise error mid-dispatch (#5285).
 pub(super) fn rig_install_capability_preflight() -> RunnerCapabilityPreflight {
     RunnerCapabilityPreflight {
+        required_toolchain_probes: Vec::new(),
         command: "rig.install".to_string(),
         required_tools: vec![RunnerRequiredTool::homeboy()],
         required_commands: Vec::new(),

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -175,6 +175,7 @@ pub fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecO
 
 pub fn runner_upgrade_capability_plan() -> RunnerCapabilityPreflight {
     RunnerCapabilityPreflight {
+        required_toolchain_probes: Vec::new(),
         command: "homeboy upgrade".to_string(),
         required_tools: vec![RunnerRequiredTool::homeboy()],
         required_commands: Vec::new(),

--- a/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
@@ -113,6 +113,7 @@ pub fn runner_source_checkout_prepare_options(
         source_snapshot: None,
         path_materialization_plan: None,
         capability_preflight: Some(RunnerCapabilityPreflight {
+            required_toolchain_probes: Vec::new(),
             command: "prepare source checkout for homeboy upgrade".to_string(),
             required_tools: vec![RunnerRequiredTool::git()],
             required_commands: Vec::new(),

--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -51,6 +51,7 @@ Extension identity is path-derived: Homeboy derives the extension `id` from the 
 - **`notification_transports`** (array): Declares versioned, extension-owned completion notification transports
 - **`materialization_source`** (object): Declares runner-resolvable source metadata for materializing this extension away from controller-local paths
 - **`contract_producers`** (array): Declares generic producer invocations Homeboy can call at explicit lifecycle phases
+- **`toolchain_readiness`** (array): Declares executable usability probes for portable Lab admission
 - **`fuzz`** (object): Declares fuzz workload metadata, optional runner script, and optional campaign portability metadata
 - **`commands`** (object): Additional CLI commands provided by extension
 - **`actions`** (array): Action definitions for `homeboy extension action`; release actions are normal actions whose IDs start with `release.`
@@ -563,6 +564,29 @@ The CLI contract intentionally omits Desktop-only runtime metadata such as runti
   - Example: `{"MY_VAR": "{{extensionPath}}/data"}`
 
 ## Runtime Requirements
+
+## Toolchain Readiness
+
+Extensions can reject a portable Lab operation before workspace materialization
+when a command is present but not usable in the runner environment.
+
+```json
+{
+  "toolchain_readiness": [{
+    "id": "formatter-toolchain",
+    "capabilities": ["lint"],
+    "command": "tool --verify-toolchain",
+    "repair_command": "toolchain-manager install stable",
+    "diagnostic_env": ["PATH", "TOOLCHAIN_HOME"]
+  }]
+}
+```
+
+`id` is extension-local, `capabilities` contains generic operation labels, and
+`command` runs in the runner's configured environment. A non-zero result fails
+admission before source transfer. `repair_command` and non-secret
+`diagnostic_env` values are returned to the operator. Omitted
+`toolchain_readiness` preserves existing manifests and behavior.
 
 Extension manifests and `component_env.detect_script` output can declare runtime requirements with a generic `runtimes` map:
 


### PR DESCRIPTION
## Summary
- add an additive extension-manifest toolchain readiness contract
- evaluate matching probes during Lab admission before workspace hydration
- return probe identity, non-secret environment diagnostics, and extension-owned repair guidance

Part of #10712. The concrete Rust declaration is staged separately in `homeboy-extensions`.

## Verification
- `cargo test -p homeboy-lab-runner toolchain_probe_rejects_a_present_command_when_its_usable_probe_fails`
- `cargo check -p homeboy-lab-runner`
- `cargo fmt --all -- --check`

## Compatibility
The new manifest array defaults empty, preserving all existing extension behavior. Core remains language and product agnostic.

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode designed and implemented the generic contract and focused regression coverage. Chris Huber reviewed and owns the submitted change.