### PR TITLE
Classify lint runner failures as infrastructure errors

### DIFF
--- a/crates/homeboy-extension/src/lint/report.rs
+++ b/crates/homeboy-extension/src/lint/report.rs
@@ -47,6 +47,7 @@ pub fn from_main_workflow_with_ci_context(
         &result.status,
         finding_count,
         &result.producer_summaries,
+        result.infrastructure_failure,
     );
     let failure = if exit_code == 0 {
         None
@@ -55,6 +56,7 @@ pub fn from_main_workflow_with_ci_context(
             exit_code,
             finding_count,
             result.formatting_findings.as_ref(),
+            result.infrastructure_failure,
         ))
     };
 
@@ -87,14 +89,19 @@ fn lint_phase_report(
     status: &str,
     finding_count: usize,
     producer_summaries: &[FindingProducerSummary],
+    infrastructure_failure: bool,
 ) -> PhaseReport {
     PhaseReport {
         phase: VerificationPhase::Lint,
-        status: phase_status_from_exit_code(exit_code),
+        status: if infrastructure_failure {
+            crate::PhaseStatus::Error
+        } else {
+            phase_status_from_exit_code(exit_code)
+        },
         exit_code: Some(exit_code),
         summary: if exit_code == 0 {
             "lint phase passed with no findings".to_string()
-        } else if exit_code >= 2 {
+        } else if infrastructure_failure || exit_code >= 2 {
             format!("lint phase infrastructure failure (exit {})", exit_code)
         } else if !producer_summaries.is_empty() {
             format!(
@@ -198,6 +205,7 @@ fn lint_phase_failure(
     exit_code: i32,
     finding_count: usize,
     formatting_findings: Option<&FormattingFindings>,
+    infrastructure_failure: bool,
 ) -> PhaseFailure {
     if let Some(formatting) = formatting_findings {
         let count = formatting.files.len();
@@ -219,7 +227,11 @@ fn lint_phase_failure(
             },
         };
     }
-    let category = phase_failure_category_from_exit_code(exit_code);
+    let category = if infrastructure_failure {
+        PhaseFailureCategory::Infrastructure
+    } else {
+        phase_failure_category_from_exit_code(exit_code)
+    };
     PhaseFailure {
         phase: VerificationPhase::Lint,
         summary: match category {
@@ -249,6 +261,7 @@ mod tests {
             component: "fixture".to_string(),
             exit_code: 1,
             harness_error: false,
+            infrastructure_failure: false,
             autofix: None,
             hints: None,
             baseline_comparison: None,
@@ -283,6 +296,7 @@ mod tests {
             component: "fixture".to_string(),
             exit_code: 1,
             harness_error: false,
+            infrastructure_failure: false,
             autofix: None,
             hints: None,
             baseline_comparison: None,
@@ -307,6 +321,46 @@ mod tests {
         assert_eq!(
             failure.summary,
             "format check found 2 unformatted file(s): src/lib.rs, src/main.rs; run `cargo fmt`"
+        );
+    }
+
+    #[test]
+    fn infrastructure_producer_overrides_exit_one_finding_classification() {
+        let result = LintRunWorkflowResult {
+            status: "error".to_string(),
+            component: "fixture".to_string(),
+            exit_code: 1,
+            harness_error: false,
+            infrastructure_failure: true,
+            autofix: None,
+            hints: None,
+            baseline_comparison: None,
+            formatting_findings: None,
+            findings: Some(Vec::new()),
+            producer_summaries: vec![FindingProducerSummary::new(
+                "homeboy-extension-runner",
+                "error",
+            )
+            .finding_count(0)],
+            summary: None,
+            self_check_capture: None,
+            extension_phase_timings: Vec::new(),
+        };
+
+        let (output, exit_code) = from_main_workflow(result);
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(output.status, "error");
+        assert_eq!(output.phase.status, crate::PhaseStatus::Error);
+        assert_eq!(
+            output.phase.summary,
+            "lint phase infrastructure failure (exit 1)"
+        );
+        let failure = output.failure.expect("infrastructure failure");
+        assert_eq!(failure.category, PhaseFailureCategory::Infrastructure);
+        assert_eq!(
+            failure.summary,
+            "lint runner infrastructure failure (exit 1)"
         );
     }
 }

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -158,6 +158,46 @@ exit 1
 }
 
 #[test]
+fn runner_failure_without_findings_is_an_infrastructure_error_without_autofix() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+printf '%s\n' 'toolchain unavailable' >&2
+exit 127
+"#,
+        );
+        let run_dir = RunDir::create().expect("run dir");
+
+        let workflow =
+            run_main_lint_workflow(&component, source.path(), routed_lint_args(), &run_dir)
+                .expect("runner failure should normalize into a result");
+
+        assert_eq!(workflow.status, "error");
+        assert_eq!(workflow.exit_code, 127);
+        assert!(workflow.infrastructure_failure);
+        assert!(workflow.findings.as_ref().is_some_and(Vec::is_empty));
+        assert_eq!(
+            workflow
+                .summary
+                .as_ref()
+                .map(|summary| summary.total_findings),
+            Some(0)
+        );
+        assert!(workflow
+            .producer_summaries
+            .iter()
+            .all(|summary| summary.finding_count == 0));
+        assert!(!workflow
+            .hints
+            .as_ref()
+            .is_some_and(|hints| hints.iter().any(|hint| hint.starts_with("Auto-fix:"))));
+    });
+}
+
+#[test]
 fn multi_route_failure_retains_later_success_evidence() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");

--- a/crates/homeboy-extension/src/lint/run/types.rs
+++ b/crates/homeboy-extension/src/lint/run/types.rs
@@ -61,6 +61,11 @@ pub struct LintRunWorkflowResult {
     /// non-blocking warning rather than a hard failure.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub harness_error: bool,
+    /// True when the extension runner failed before yielding source findings.
+    /// This is an internal normalization signal used to render the existing
+    /// phase infrastructure status without adding a second public envelope.
+    #[serde(skip)]
+    pub infrastructure_failure: bool,
     pub autofix: Option<AppliedRefactor>,
     pub hints: Option<Vec<String>>,
     pub baseline_comparison: Option<lint_baseline::BaselineComparison>,

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -95,6 +95,7 @@ pub fn run_main_lint_workflow(
                 component: args.component_label,
                 exit_code: 0,
                 harness_error: false,
+                infrastructure_failure: false,
                 autofix: None,
                 hints,
                 baseline_comparison: None,
@@ -229,13 +230,25 @@ pub fn run_main_lint_workflow(
 
     let harness_error = lint_exit_code != 0
         && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);
+    let infrastructure_failure = producer_summaries.iter().any(|producer| {
+        producer.tool == "homeboy-extension-runner"
+            && producer.status == "error"
+            && producer.metadata.contains_key("failure")
+    });
     let hard_error = output.exit_code >= 2
         || harness_error
         || producer_summaries
             .iter()
             .any(|producer| producer.status == "error");
     let exit_code = effective_lint_exit_code(lint_exit_code, baseline_exit_override, hard_error);
-    let status = if exit_code == 0 { "passed" } else { "failed" }.to_string();
+    let status = if exit_code == 0 {
+        "passed"
+    } else if infrastructure_failure {
+        "error"
+    } else {
+        "failed"
+    }
+    .to_string();
     finish_scoped_lint_run_dirs(&child_run_dirs, exit_code == 0);
     let lint_clean = lint_findings.is_empty() && exit_code == 0;
 
@@ -247,7 +260,7 @@ pub fn run_main_lint_workflow(
     // consistent prose. `homeboy review lint --fix` is the ergonomic adapter and is
     // listed first; the canonical `homeboy refactor --from lint --write`
     // invocation follows for users who want the longer form.
-    if !lint_clean {
+    if !lint_clean && !infrastructure_failure {
         hints.push(build_autofix_hint(&args));
         if args.changed_only {
             hints.push(
@@ -286,6 +299,7 @@ pub fn run_main_lint_workflow(
         component: args.component_label,
         exit_code,
         harness_error,
+        infrastructure_failure,
         autofix: None,
         hints,
         baseline_comparison,
@@ -524,6 +538,7 @@ Re-run `homeboy review lint {}` or skip only this gate with `--skip-checks=lint`
         component: component_label,
         exit_code: output.exit_code,
         harness_error,
+        infrastructure_failure: harness_error,
         autofix: None,
         hints,
         baseline_comparison: None,

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -421,14 +421,13 @@ fn write_lint_failure_sidecar(
     }
 
     let failure = failure_payload("lint", command, output);
+    write_json_sidecar(&path, &json!([]))?;
     write_json_sidecar(
-        &path,
+        &run_dir_path.join(run_dir::files::LINT_PRODUCERS),
         &json!([{
             "tool": "homeboy-extension-runner",
-            "category": "infrastructure",
-            "severity": "error",
-            "message": format!("lint runner failed before producing lint findings (exit {})", output.exit_code),
-            "fingerprint": format!("homeboy-extension-runner:lint:{}", output.exit_code),
+            "status": "error",
+            "finding_count": 0,
             "metadata": {
                 "phase": "lint",
                 "failure": failure,
@@ -473,7 +472,7 @@ fn sidecar_has_payload(path: &Path) -> bool {
         Ok(serde_json::Value::Array(items)) => !items.is_empty(),
         Ok(serde_json::Value::Object(fields)) => !fields.is_empty(),
         Ok(_) => true,
-        Err(_) => true,
+        Err(_) => false,
     }
 }
 
@@ -751,7 +750,7 @@ mod tests {
     }
 
     #[test]
-    fn writes_lint_failure_sidecar_as_finding() {
+    fn writes_lint_failure_sidecar_as_infrastructure_producer() {
         let run_dir = RunDir::create().expect("run dir");
         let output = CommandOutput {
             stdout: String::new(),
@@ -775,9 +774,52 @@ mod tests {
                 .expect("findings file"),
         )
         .expect("json");
-        assert_eq!(payload[0]["tool"], "homeboy-extension-runner");
-        assert_eq!(payload[0]["metadata"]["phase"], "lint");
-        assert_eq!(payload[0]["metadata"]["failure"]["exit_code"], 127);
+        assert_eq!(payload, json!([]));
+        let producers: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(run_dir.step_file(run_dir::files::LINT_PRODUCERS))
+                .expect("producers file"),
+        )
+        .expect("json");
+        assert_eq!(producers[0]["tool"], "homeboy-extension-runner");
+        assert_eq!(producers[0]["status"], "error");
+        assert_eq!(producers[0]["finding_count"], 0);
+        assert_eq!(producers[0]["metadata"]["failure"]["exit_code"], 127);
+
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn replaces_malformed_lint_findings_sidecar_with_infrastructure_producer() {
+        let run_dir = RunDir::create().expect("run dir");
+        std::fs::write(
+            run_dir.step_file(run_dir::files::LINT_FINDINGS),
+            "{ malformed",
+        )
+        .expect("malformed findings file");
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: "runner failed".to_string(),
+            success: false,
+            exit_code: 1,
+            timed_out: false,
+            child_resource: None,
+        };
+
+        write_structured_failure_sidecar(
+            run_dir.path(),
+            ExtensionCapability::Lint,
+            "./lint.sh",
+            &output,
+        )
+        .expect("write fallback");
+
+        assert_eq!(
+            std::fs::read_to_string(run_dir.step_file(run_dir::files::LINT_FINDINGS))
+                .expect("findings file")
+                .trim(),
+            "[]"
+        );
+        assert!(run_dir.step_file(run_dir::files::LINT_PRODUCERS).is_file());
 
         run_dir.cleanup();
     }

--- a/docs/architecture/ci-results-contract.md
+++ b/docs/architecture/ci-results-contract.md
@@ -143,18 +143,21 @@ without scraping raw GitHub logs.
 
 Fallback sidecars preserve the existing file roles:
 
-- `lint-findings.json` remains a JSON array of findings. A pre-result lint
-  failure is emitted as a single `homeboy-extension-runner` infrastructure
-  finding with `metadata.failure` containing `phase`, `command`, `exit_code`,
-  `stdout_tail`, `stderr_tail`, truncation flags, and `parsed_detail` when a
-  JSON object can be recovered from runner output.
+- `lint-findings.json` remains a JSON array of source findings and is empty
+  when a runner fails before it can produce one. The accompanying
+  `lint-producers.json` entry records `homeboy-extension-runner` with
+  `status: "error"`, `finding_count: 0`, and `metadata.failure` containing
+  `phase`, `command`, `exit_code`, `stdout_tail`, `stderr_tail`, truncation
+  flags, and `parsed_detail` when a JSON object can be recovered from runner
+  output.
 - `test-results.json` remains a JSON object. A pre-result test failure contains
   `status: "failed"`, `phase`, `command`, `exit_code`, output tails, and a
   nested `failure` object with the same structured fields. It intentionally does
   not invent test counts when no runner produced them.
 
-Runners that already wrote their structured sidecar keep ownership of it; the
-fallback only fills missing/empty sidecar files after a failed runner exit.
+Runners that already wrote a valid structured sidecar keep ownership of it; the
+fallback replaces missing, empty, or malformed sidecars after a failed runner
+exit.
 
 ## Legacy per-command artifacts
 


### PR DESCRIPTION
## Summary
- record runner startup/toolchain failures in producer evidence instead of synthetic source findings
- report infrastructure-only lint failures as error with zero findings
- suppress autofix guidance when no fixable source finding exists

Closes #10714

## Verification
- focused workflow, runner-sidecar, malformed-sidecar, and report-classification tests
- `cargo check -p homeboy-extension`
- `cargo fmt --all -- --check`
- full extension suite reached 650 passing tests; 10 existing environment-sensitive toolchain/provider/trace fixtures remain red outside this lint slice

## Compatibility
No public fields were added or removed. Existing phase and producer-summary infrastructure channels now carry the failure consistently.

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode implemented the normalization and regression coverage. Chris Huber reviewed and owns the submitted change.