### PR TITLE
Prefer durable local evidence for runs show

### DIFF
--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -6,23 +6,33 @@ pub fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> 
     if let Some(run) = store.get_run(run_id)? {
         return Ok(run);
     }
+    // Resolve durable local aliases before consulting the runner. A runner
+    // probe can reconcile generations and hydrate artifacts, so it must not
+    // delay metadata already indexed in the observation store.
+    if let Some(run) = resolve_local_run_label(store, run_id)? {
+        return Ok(run);
+    }
     if let Ok(Some(run)) =
         runner_evidence::with_runner_evidence(|p| p.mirror_connected_runner_run(run_id))
     {
         return Ok(run);
     }
-    if let Some(run) = resolve_run_label(store, run_id)? {
+    if let Some(run) = resolve_remote_run_label(run_id)? {
         return Ok(run);
     }
     Err(missing_run_error(run_id))
 }
 
-fn resolve_run_label(store: &ObservationStore, label: &str) -> Result<Option<RunRecord>> {
+fn resolve_local_run_label(store: &ObservationStore, label: &str) -> Result<Option<RunRecord>> {
     let runs = store.list_runs(RunListFilter {
         limit: Some(1000),
         ..Default::default()
     })?;
-    let mut matches = matching_run_labels(&runs, label);
+    resolve_run_label_matches(label, matching_run_labels(&runs, label))
+}
+
+fn resolve_remote_run_label(label: &str) -> Result<Option<RunRecord>> {
+    let mut matches = Vec::new();
     let connected_runners: Vec<RunnerConnectionInfo> = runner_evidence::with_runner_evidence(|p| {
         p.statuses().into_iter().filter(|r| r.connected).collect()
     });
@@ -63,19 +73,21 @@ fn canonicalize_lab_run_label_matches(matches: Vec<RunRecord>) -> Vec<RunRecord>
 /// logical execution (`run_lookup` disambiguation; `runs list` dedup #9629).
 /// Returns `None` for local runs with no Lab lineage.
 pub fn lab_run_lineage(run: &RunRecord) -> Option<(String, String)> {
-    runner_evidence::with_runner_evidence(|provider| provider.mirrored_runner_job_identity(run))
-        .or_else(|| {
-            let lab = run.metadata_json.get("lab")?;
-            let runner_id = lab
-                .pointer("/runner/id")
-                .or_else(|| lab.get("runner_id"))
-                .and_then(Value::as_str)?;
-            let job_id = lab
-                .pointer("/remote_job/id")
-                .or_else(|| lab.get("remote_job_id"))
-                .and_then(Value::as_str)?;
-            Some((runner_id.to_string(), job_id.to_string()))
-        })
+    let local = || {
+        let lab = run.metadata_json.get("lab")?;
+        let runner_id = lab
+            .pointer("/runner/id")
+            .or_else(|| lab.get("runner_id"))
+            .and_then(Value::as_str)?;
+        let job_id = lab
+            .pointer("/remote_job/id")
+            .or_else(|| lab.get("remote_job_id"))
+            .and_then(Value::as_str)?;
+        Some((runner_id.to_string(), job_id.to_string()))
+    };
+    local().or_else(|| {
+        runner_evidence::with_runner_evidence(|provider| provider.mirrored_runner_job_identity(run))
+    })
 }
 
 /// Outcome of collapsing a run list to one canonical row per logical execution.

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -259,16 +259,29 @@ pub fn has_runner_evidence_provider() -> bool {
 }
 
 #[cfg(test)]
+pub(crate) fn clear_runner_evidence_provider() {
+    provider_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take();
+}
+
+#[cfg(test)]
+pub(crate) fn runner_evidence_test_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex, OnceLock};
+    use std::sync::{Arc, Mutex};
 
     use crate::observation::{ObservationStore, RunStatus};
     use crate::test_support::with_isolated_home;
 
     fn provider_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        super::runner_evidence_test_lock()
     }
 
     fn run(id: &str) -> RunRecord {

--- a/crates/homeboy-core/src/observation/runs_service/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/tests.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::observation::NewRunRecord;
 use crate::test_support::with_isolated_home;
 use serde_json::Value;
+use std::sync::{mpsc, Mutex};
 
 struct XdgGuard(Option<String>);
 
@@ -595,6 +596,126 @@ fn require_run_resolves_requested_run_id_metadata_alias() {
             resolve_run_id_or_label(&store, "proof-label").expect("alias id"),
             run.id
         );
+    });
+}
+
+#[test]
+fn require_run_reads_terminal_lab_review_alias_while_runner_probe_is_stalled() {
+    struct StalledProvider {
+        entered: mpsc::Sender<()>,
+        release: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl RunnerEvidenceProvider for StalledProvider {
+        fn mirror_connected_runner_run(&self, _run_id: &str) -> Result<Option<RunRecord>> {
+            self.entered.send(()).expect("signal stalled probe");
+            self.release
+                .lock()
+                .expect("release lock")
+                .recv()
+                .expect("release stalled probe");
+            Ok(None)
+        }
+
+        fn statuses(&self) -> Vec<RunnerConnectionInfo> {
+            Vec::new()
+        }
+
+        fn daemon_api_get(&self, _runner_id: &str, _path: &str) -> Result<Value> {
+            unreachable!("local lookup must not query the daemon")
+        }
+
+        fn runner_artifact_content(
+            &self,
+            _runner_id: &str,
+            _job_id: &str,
+            _artifact_id: &str,
+        ) -> Result<Value> {
+            unreachable!("local lookup must not hydrate artifacts")
+        }
+
+        fn runner_job_cancel(
+            &self,
+            _runner_id: &str,
+            _job_id: &str,
+        ) -> Result<(crate::api_jobs::Job, Vec<crate::api_jobs::JobEvent>)> {
+            unreachable!("local lookup must not mutate runner jobs")
+        }
+
+        fn refresh_mirrored_daemon_evidence(
+            &self,
+            _run_id: &str,
+        ) -> Result<Option<Vec<RunRecord>>> {
+            unreachable!("local lookup must not reconcile runner evidence")
+        }
+
+        fn mirrored_runner_job_identity(&self, _run: &RunRecord) -> Option<(String, String)> {
+            None
+        }
+
+        fn download_remote_artifact(
+            &self,
+            _path: &str,
+            _output: Option<std::path::PathBuf>,
+        ) -> Result<RemoteArtifactDownloadInfo> {
+            unreachable!("local lookup must not hydrate artifacts")
+        }
+    }
+
+    let _provider_lock = runner_evidence::runner_evidence_test_lock()
+        .lock()
+        .expect("provider test lock");
+
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let label = "runner-exec-review-homeboy-lab-terminal-job";
+        let run = RunRecord {
+            id: "terminal-lab-review-mirror".to_string(),
+            kind: "runner-exec".to_string(),
+            started_at: "2026-07-28T00:00:00Z".to_string(),
+            finished_at: Some("2026-07-28T00:01:00Z".to_string()),
+            status: RunStatus::Fail.as_str().to_string(),
+            metadata_json: serde_json::json!({
+                "requested_run_id": label,
+                "lab": {
+                    "runner": { "id": "homeboy-lab" },
+                    "remote_job": { "id": "terminal-job" }
+                }
+            }),
+            ..Default::default()
+        };
+        store
+            .import_run(&run)
+            .expect("persist terminal Lab review run");
+
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        runner_evidence::register_runner_evidence_provider(Box::new(StalledProvider {
+            entered: entered_tx,
+            release: Mutex::new(release_rx),
+        }));
+        let stalled = std::thread::spawn(|| {
+            runner_evidence::with_runner_evidence(|provider| {
+                provider.mirror_connected_runner_run("unrelated-run")
+            })
+        });
+        entered_rx.recv().expect("secondary probe is stalled");
+
+        let resolved = require_run(&store, label).expect("durable local terminal record");
+        assert_eq!(resolved.id, run.id);
+        assert_eq!(resolved.status, RunStatus::Fail.as_str());
+        assert!(
+            !stalled.is_finished(),
+            "lookup completed before probe release"
+        );
+
+        release_tx.send(()).expect("release secondary probe");
+        stalled
+            .join()
+            .expect("secondary probe joined")
+            .expect("secondary probe result");
+        runner_evidence::clear_runner_evidence_provider();
     });
 }
 


### PR DESCRIPTION
## Summary
- resolve local run aliases before remote runner mirroring
- read persisted Lab lineage before consulting secondary runner evidence
- preserve remote discovery only as the absent-local-record fallback

Closes #10715

## Verification
- `cargo test -p homeboy-core require_run_reads_terminal_lab_review_alias_while_runner_probe_is_stalled --lib`
- `cargo check -p homeboy-core`
- `cargo fmt --all -- --check`
- broader runs-service module: 73 passed, one independent stale expected-guidance assertion tracked in #10719

## Compatibility
No output or persisted schema changes. Durable local evidence gains precedence; remote-only discovery remains intact.

## Dependency
#10719 restores the independently red runs-service baseline.

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode traced the blocking lookup path, implemented local-first resolution, and added stalled-provider coverage. Chris Huber reviewed and owns the submitted change.