### PR TITLE
Preserve release lint infrastructure diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -776,7 +776,8 @@ fn release_failure_digest(data: &Value) -> Option<CommandFailureDigest> {
         None => cause.to_string(),
     };
 
-    let mut next_actions = release_repair_actions(step_data);
+    let mut next_actions = release_error_actions(step_data);
+    next_actions.extend(release_repair_actions(step_data));
     if next_actions.is_empty() {
         next_actions.push(release_gate_repro_action(step_id, step_type, component_id));
     }
@@ -792,6 +793,21 @@ fn release_failure_digest(data: &Value) -> Option<CommandFailureDigest> {
         next_actions,
         retryable: None,
     })
+}
+
+/// Preserve explicit typed-error actions emitted by a release step. These are
+/// more specific than the generic gate fallback and may declare that a command
+/// is a fresh diagnostic rather than an exact reproduction.
+fn release_error_actions(step_data: Option<&Value>) -> Vec<CommandNextAction> {
+    step_data
+        .and_then(|data| data.get("error_details"))
+        .and_then(|details| details.get(ACTIONS_DETAILS_KEY))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|value| serde_json::from_value::<ExecutableAction>(value.clone()).ok())
+        .map(CommandNextAction::from_action)
+        .collect()
 }
 
 /// Lift a failed release step's own `repair` block into executable next
@@ -1295,6 +1311,56 @@ mod tests {
                 "{step} must not recommend a plan-only dry run"
             );
         }
+    }
+
+    #[test]
+    fn release_failure_prefers_explicit_fresh_diagnostic_action() {
+        let mut payload = release_failure_payload("preflight.lint", "preflight.lint");
+        payload["result"]["run"]["result"]["steps"][0]["data"] = json!({
+            "error_code": "internal.io_error",
+            "error_details": {
+                "error": "No such file or directory (os error 2)",
+                "context": "read lint evidence /tmp/run/findings.json",
+                "_homeboy_actions": [{
+                    "id": "release.lint.fresh_diagnostic",
+                    "label": "run a fresh local lint diagnostic with the release lint scope",
+                    "program": "homeboy",
+                    "args": ["--placement", "local", "lint", "fixture", "--path", "/workspace/fixture", "--extension", "rust", "--changed-since", "v1.2.3"],
+                    "safety": "read_only",
+                    "evidence": {
+                        "kind": "fresh_diagnostic",
+                        "source_path": "/workspace/fixture",
+                        "extension_id": "rust",
+                        "changed_since": "v1.2.3",
+                        "settings": {}
+                    }
+                }]
+            }
+        });
+
+        let digest = release_failure_digest(&payload).expect("release digest");
+        let action = digest.next_actions.first().expect("explicit action");
+        assert_eq!(
+            action.label,
+            "run a fresh local lint diagnostic with the release lint scope"
+        );
+        assert_eq!(
+            action.command,
+            "homeboy --placement local lint fixture --path /workspace/fixture --extension rust --changed-since v1.2.3"
+        );
+        assert_eq!(
+            action
+                .action
+                .as_ref()
+                .and_then(|action| action.evidence.as_ref())
+                .and_then(|evidence| evidence["source_path"].as_str()),
+            Some("/workspace/fixture")
+        );
+        assert_eq!(
+            digest.next_actions.len(),
+            1,
+            "explicit action must replace the generic purported reproducer"
+        );
     }
 
     /// Steps with no non-mutating reproduction surface still fall back to the

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -685,7 +685,10 @@ fn failed_result(id: &str, step_type: &str, err: Error) -> ReleaseStepResult {
         step_type: step_type.to_string(),
         status: ReleaseStepStatus::Failed,
         hints: err.hints.clone(),
-        data: Some(serde_json::json!({ "error_details": err.details })),
+        data: Some(serde_json::json!({
+            "error_code": err.code.as_str(),
+            "error_details": err.details,
+        })),
         error: Some(err.message),
         ..Default::default()
     }
@@ -2124,13 +2127,23 @@ mod tests {
 
     #[test]
     fn test_failed_result() {
-        let err = homeboy_core::error::Error::internal_unexpected("boom".to_string());
+        let err = homeboy_core::error::Error::internal_io(
+            "No such file or directory (os error 2)",
+            Some("read lint evidence".to_string()),
+        );
 
         let result = super::failed_result("package", "package", err);
 
         assert_eq!(result.id, "package");
         assert_eq!(result.status, ReleaseStepStatus::Failed);
-        assert_eq!(result.error.as_deref(), Some("boom"));
+        assert_eq!(result.error.as_deref(), Some("IO error"));
+        let data = result.data.expect("failed release step has error data");
+        assert_eq!(data["error_code"], "internal.io_error");
+        assert_eq!(
+            data["error_details"]["error"],
+            "No such file or directory (os error 2)"
+        );
+        assert_eq!(data["error_details"]["context"], "read lint evidence");
     }
 
     fn plan_step(step_type: &str) -> PlanStep {

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1,6 +1,6 @@
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::RunDir;
-use homeboy_core::error::{CommandEvidence, Error, Result};
+use homeboy_core::error::{ActionSafety, CommandEvidence, Error, ExecutableAction, Result};
 use homeboy_extension as extension;
 use homeboy_extension::{self, ExtensionCapability};
 use std::path::Path;
@@ -69,11 +69,16 @@ pub(super) fn validate_lint_quality(
     component: &Component,
     component_id: &str,
 ) -> LintQualityOutcome {
-    // Shared mapping for a lint-runner construction/execution error into the
-    // standard hard-blocking outcome, used by both the scripts.lint and the
-    // extension-resolved lint paths below.
-    let runner_error = |e: Error| {
-        LintQualityOutcome::Failed(quality_error("lint", format!("Lint runner error: {}", e)))
+    // Preserve infrastructure errors verbatim. Reclassifying them as invalid
+    // lint arguments discards their typed diagnostics and evidence.
+    let runner_error = |error: Error, extension_id: Option<&str>, changed_since: Option<&str>| {
+        LintQualityOutcome::Failed(lint_runner_error(
+            error,
+            component,
+            component_id,
+            extension_id,
+            changed_since,
+        ))
     };
 
     if component.has_script(ExtensionCapability::Lint) {
@@ -86,7 +91,7 @@ pub(super) fn validate_lint_quality(
             false,
         ) {
             Ok(workflow) => workflow,
-            Err(e) => return runner_error(e),
+            Err(error) => return runner_error(error, None, None),
         };
 
         if workflow.status == "passed" {
@@ -107,7 +112,7 @@ pub(super) fn validate_lint_quality(
         ) {
             Ok(Some(context)) => context,
             Ok(None) => return LintQualityOutcome::Passed { ran: false },
-            Err(error) => return runner_error(error),
+            Err(error) => return runner_error(error, None, None),
         };
 
     homeboy_core::log_status!("release", "Running lint ({})...", lint_context.extension_id);
@@ -121,7 +126,7 @@ pub(super) fn validate_lint_quality(
             Ok(tag) => tag,
             Err(e) => {
                 release_run_dir.finish(false);
-                return runner_error(e);
+                return runner_error(e, Some(&lint_context.extension_id), None);
             }
         };
     let workflow = extension::lint::run_main_lint_workflow(
@@ -136,7 +141,7 @@ pub(super) fn validate_lint_quality(
             file: None,
             glob: None,
             changed_only: false,
-            changed_since,
+            changed_since: changed_since.clone(),
             precomputed_changed_files: None,
             sniff_filters: extension::lint::LintSniffFilters::default(),
             category: None,
@@ -150,7 +155,11 @@ pub(super) fn validate_lint_quality(
         Ok(workflow) => workflow,
         Err(error) => {
             release_run_dir.finish(false);
-            return runner_error(error);
+            return runner_error(
+                error,
+                Some(&lint_context.extension_id),
+                changed_since.as_deref(),
+            );
         }
     };
 
@@ -162,6 +171,52 @@ pub(super) fn validate_lint_quality(
         release_run_dir.finish(false);
         LintQualityOutcome::Failed(lint_workflow_failure(&workflow, &release_run_dir))
     }
+}
+
+/// Attach a diagnostic action without changing the original infrastructure
+/// error's code, message, details, or evidence. The command intentionally says
+/// "fresh" because a new CLI invocation cannot promise the release process's
+/// complete runtime identity.
+fn lint_runner_error(
+    error: Error,
+    component: &Component,
+    component_id: &str,
+    extension_id: Option<&str>,
+    changed_since: Option<&str>,
+) -> Error {
+    let mut args = vec![
+        "--placement".to_string(),
+        "local".to_string(),
+        "lint".to_string(),
+        component_id.to_string(),
+        "--path".to_string(),
+        component.local_path.clone(),
+    ];
+    if let Some(extension_id) = extension_id {
+        args.extend(["--extension".to_string(), extension_id.to_string()]);
+    }
+    if let Some(changed_since) = changed_since {
+        args.extend(["--changed-since".to_string(), changed_since.to_string()]);
+    }
+
+    error.with_action(
+        ExecutableAction::new(
+            "release.lint.fresh_diagnostic",
+            "run a fresh local lint diagnostic with the release lint scope",
+            "homeboy",
+            args,
+            ActionSafety::ReadOnly,
+        )
+        .with_evidence(serde_json::json!({
+            "kind": "fresh_diagnostic",
+            "release_execution_location": "local",
+            "source_path": component.local_path,
+            "component_id": component_id,
+            "extension_id": extension_id,
+            "changed_since": changed_since,
+            "settings": {},
+        })),
+    )
 }
 
 fn lint_workflow_failure(
@@ -417,6 +472,7 @@ mod tests {
         validate_test_quality, LintQualityOutcome,
     };
     use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
+    use homeboy_core::error::Error;
     use homeboy_extension::RunnerOutput;
     use std::collections::HashMap;
     use std::fs;
@@ -584,6 +640,60 @@ mod tests {
             !validate_lint_quality(&component_without_quality_runners(), "fixture")
                 .expect_passed_with_value(false)
         );
+    }
+
+    #[test]
+    fn lint_runner_error_preserves_nested_io_diagnostics_and_emits_fresh_action() {
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: "/workspace/fixture".to_string(),
+            ..Default::default()
+        };
+        let error = super::lint_runner_error(
+            Error::internal_io(
+                "No such file or directory (os error 2)",
+                Some("read lint evidence /tmp/run/findings.json".to_string()),
+            ),
+            &component,
+            "fixture",
+            Some("rust"),
+            Some("v1.2.3"),
+        );
+
+        assert_eq!(error.code.as_str(), "internal.io_error");
+        assert_eq!(
+            error.details["error"].as_str(),
+            Some("No such file or directory (os error 2)")
+        );
+        assert_eq!(
+            error.details["context"].as_str(),
+            Some("read lint evidence /tmp/run/findings.json")
+        );
+
+        let action = &error.details["_homeboy_actions"][0];
+        assert_eq!(action["id"], "release.lint.fresh_diagnostic");
+        assert!(action["label"]
+            .as_str()
+            .is_some_and(|label| label.contains("fresh local lint diagnostic")));
+        assert_eq!(
+            action["args"],
+            serde_json::json!([
+                "--placement",
+                "local",
+                "lint",
+                "fixture",
+                "--path",
+                "/workspace/fixture",
+                "--extension",
+                "rust",
+                "--changed-since",
+                "v1.2.3",
+            ])
+        );
+        assert_eq!(action["evidence"]["source_path"], "/workspace/fixture");
+        assert_eq!(action["evidence"]["extension_id"], "rust");
+        assert_eq!(action["evidence"]["changed_since"], "v1.2.3");
+        assert_eq!(action["evidence"]["settings"], serde_json::json!({}));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve nested lint error codes, details, and evidence through release preflight
- add the error code to failed release-step data
- prefer explicit fresh diagnostic actions over generic reproduction claims

Closes #10713

## Verification
- `cargo test -p homeboy-release lint_runner_error_preserves_nested_io_diagnostics_and_emits_fresh_action --lib`
- `cargo test -p homeboy-release test_failed_result --lib`
- `cargo test -p homeboy-cli release_failure_prefers_explicit_fresh_diagnostic_action --lib`
- `cargo check -p homeboy-release -p homeboy-cli`
- `cargo fmt --all -- --check`

## Compatibility
The failed-step `error_code` field is additive. Existing fallback actions remain for failures without explicit diagnostics.

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode traced the error projection, implemented the patch, and ran focused verification. Chris Huber reviewed and owns the submitted change.