### PR TITLE
fix: unify workspace prune classification

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -2789,18 +2789,29 @@ fn prune_candidate_reason(
         }
     }
 
+    Ok(prune_candidate_reason_after_ttl(
+        runner,
+        metadata,
+        path,
+        source_path,
+    ))
+}
+
+fn prune_candidate_reason_after_ttl(
+    runner: &super::super::Runner,
+    metadata: &serde_json::Value,
+    path: &Path,
+    source_path: &str,
+) -> Option<String> {
     if has_terminal_delete_on_success_lifecycle_with(metadata, |run_id| {
         workspace_run_authority(runner, metadata, path, run_id)
     }) {
-        return Ok(Some(TERMINAL_RESOURCE_LIFECYCLE_REASON.to_string()));
+        return Some(TERMINAL_RESOURCE_LIFECYCLE_REASON.to_string());
     }
     if is_stale_materialized_workspace_lifecycle(metadata, path) {
-        return Ok(Some(STALE_MATERIALIZED_WORKSPACE_REASON.to_string()));
+        return Some(STALE_MATERIALIZED_WORKSPACE_REASON.to_string());
     }
-    if !Path::new(source_path).exists() {
-        return Ok(Some("source_path_missing".to_string()));
-    }
-    Ok(None)
+    (!Path::new(source_path).exists()).then(|| "source_path_missing".to_string())
 }
 
 fn is_stale_materialized_workspace_lifecycle(metadata: &serde_json::Value, path: &Path) -> bool {
@@ -3445,16 +3456,7 @@ fn prune_candidate_reason_from_decoded_metadata(
     let source_path = metadata
         .get("local_path")
         .and_then(|value| value.as_str())?;
-    if !Path::new(source_path).exists() {
-        return Some("source_path_missing".to_string());
-    }
-    if has_terminal_delete_on_success_lifecycle_with(metadata, |run_id| {
-        workspace_run_authority(runner, metadata, path, run_id)
-    }) {
-        return Some(TERMINAL_RESOURCE_LIFECYCLE_REASON.to_string());
-    }
-    is_stale_materialized_workspace_lifecycle(metadata, path)
-        .then(|| STALE_MATERIALIZED_WORKSPACE_REASON.to_string())
+    prune_candidate_reason_after_ttl(runner, metadata, path, source_path)
 }
 
 pub(crate) fn prune_scan_command(


### PR DESCRIPTION
## Summary
- share post-TTL workspace candidate classification between local and decoded SSH metadata
- preserve terminal-lifecycle and stale-materialized precedence over generic missing-source classification
- prevent local and SSH cleanup safety behavior from diverging again

## Live evidence
The first #10708 repair corrected local classification, but the shipped `homeboy-lab` apply still removed 0 bytes because SSH inventory retained a duplicate classifier with the old precedence. All candidates remained fail-closed as `active_resource_lifecycle_lease`; no raw deletion occurred.

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-lab-runner`
- `env -u TMPDIR cargo test -p homeboy-lab-runner workspace::tests::prune -- --test-threads=1` (27 passed)
- `git diff --check origin/main...HEAD`

Closes #10708.

## AI assistance
OpenAI `gpt-5.6-sol` through OpenCode diagnosed the local/SSH duplicate-classifier divergence, drafted the shared classifier, and ran verification. Chris Huber reviewed and remains responsible for the change.