### PR TITLE
fix(release): skip a superseded push instead of failing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
       # the guard fires, and the decide step turns that into a hard failure
       # rather than a silent green.
       - name: Attach HEAD to the release branch
+        id: attach
         if: inputs.release_tag == ''
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
@@ -103,8 +104,18 @@ jobs:
             exit 0
           fi
 
+          # A newer commit reached the branch tip between this push and this
+          # checkout. That is not an unknown: we measured it right here, and it
+          # names the exact commit whose own run owns the release. Record it so
+          # the decide step can skip on evidence instead of failing on mystery.
+          #
+          # Superseding is expected at this repo's merge rate, and no work is
+          # lost: `homeboy release` computes its range from the last tag, so the
+          # newest tip's run covers this commit too.
           if [ "${HEAD_SHA}" != "${BRANCH_SHA}" ]; then
-            echo "::warning::HEAD ${HEAD_SHA:0:8} is not the ${RELEASE_BRANCH} tip ${BRANCH_SHA:0:8} - leaving HEAD detached"
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+            echo "branch-tip=${BRANCH_SHA}" >> "$GITHUB_OUTPUT"
+            echo "::notice::HEAD ${HEAD_SHA:0:8} is not the ${RELEASE_BRANCH} tip ${BRANCH_SHA:0:8} - superseded, the newer tip's run owns this release"
             exit 0
           fi
 
@@ -228,8 +239,33 @@ jobs:
           BUMP_TYPE="${{ steps.recovery.outputs['release-bump-type'] || steps.release-check.outputs['release-bump-type'] }}"
           DRY_RUN_OUTCOME="${{ steps.release-check.outcome }}"
           SKIPPED_REASON="${{ steps.release-check.outputs['skipped-reason'] }}"
+          SUPERSEDED="${{ steps.attach.outputs.superseded }}"
+          BRANCH_TIP="${{ steps.attach.outputs['branch-tip'] }}"
 
           echo "recovery-attempts=${STRANDED_ATTEMPTS:-0}" >> "$GITHUB_OUTPUT"
+
+          # A superseded push is a MEASURED negative, and the only one this job
+          # measures itself rather than reading back from the dry run.
+          #
+          # The attach step compared this commit against the branch tip and
+          # found a newer one, so `wrong-branch` here is the branch guard
+          # working correctly, not the #10703 laundering bug. Failing it turns
+          # every merge that is overtaken by the next merge into a red run.
+          #
+          # This deliberately does NOT widen the #10685 hole: the reason is
+          # only accepted when THIS job proved the supersession and recorded
+          # the winning tip. If HEAD really is the tip, `superseded` is empty,
+          # `wrong-branch` stays unmeasured, and the hard failure below still
+          # fires — which is exactly the #10703 regression signal.
+          if [ "${SUPERSEDED}" = "true" ] && [ -z "${RELEASE_VERSION}" ]; then
+            case "${SKIPPED_REASON}" in
+              wrong-branch|'')
+                echo "should-release=false" >> "$GITHUB_OUTPUT"
+                echo "::notice::Superseded: ${HEAD_SHA:0:8} is behind the ${RELEASE_BRANCH} tip ${BRANCH_TIP:0:8}, whose own run owns this release. Skipping (skipped-reason='${SKIPPED_REASON:-<empty>}')."
+                exit 0
+                ;;
+            esac
+          fi
 
           # #10685: absence of evidence must never be evidence of success.
           # An empty release-version has two very different causes, and this

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1220,15 +1220,19 @@ fn release_head_attach_refuses_any_commit_that_is_not_the_branch_tip() {
     git(&["clone", "-q", upstream.to_str().unwrap(), "work"], &dir);
     let work = dir.join("work");
 
+    let step_output = dir.join("attach_output");
     let attach = |cwd: &std::path::Path| {
+        std::fs::write(&step_output, "").expect("reset step output");
         std::process::Command::new("bash")
             .arg("-e")
             .arg(&script_path)
             .env("RELEASE_BRANCH", "main")
+            .env("GITHUB_OUTPUT", &step_output)
             .current_dir(cwd)
             .output()
             .expect("attach step should run")
     };
+    let recorded = || std::fs::read_to_string(&step_output).unwrap_or_default();
     let branch_of = |cwd: &std::path::Path| {
         String::from_utf8_lossy(&git(&["rev-parse", "--abbrev-ref", "HEAD"], cwd).stdout)
             .trim()
@@ -1250,6 +1254,13 @@ fn release_head_attach_refuses_any_commit_that_is_not_the_branch_tip() {
         "main",
         "HEAD at the branch tip must be re-attached so the branch guard resolves"
     );
+    // The tip is not superseded. This is what keeps the #10703 hard failure
+    // armed: without this output, `wrong-branch` must stay unmeasured.
+    assert!(
+        !recorded().contains("superseded=true"),
+        "the branch tip must never be recorded as superseded: {}",
+        recorded()
+    );
 
     // An older commit is NOT the branch tip. Attaching it would let a release
     // be cut from an arbitrary SHA — the exact thing the guard exists to stop.
@@ -1265,9 +1276,100 @@ fn release_head_attach_refuses_any_commit_that_is_not_the_branch_tip() {
         "a commit that is not the branch tip must stay detached"
     );
     assert!(
-        String::from_utf8_lossy(&out.stdout).contains("::warning::"),
+        String::from_utf8_lossy(&out.stdout).contains("::notice::"),
         "refusing to attach must be visible"
+    );
+    // Refusal must leave EVIDENCE, not just a log line. The decide step keys
+    // its measured skip off these outputs; without them a superseded push is
+    // indistinguishable from the #10703 laundering bug and fails the run.
+    let recorded_refusal = recorded();
+    assert!(
+        recorded_refusal.contains("superseded=true"),
+        "a superseded commit must record that it was superseded: {recorded_refusal}"
+    );
+    let tip = String::from_utf8_lossy(&git(&["rev-parse", "origin/main"], &work).stdout)
+        .trim()
+        .to_string();
+    assert!(
+        recorded_refusal.contains(&format!("branch-tip={tip}")),
+        "a superseded commit must name the tip that beat it: {recorded_refusal}"
     );
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A push that is overtaken by the next merge must skip quietly, and ONLY when
+/// this job proved the supersession itself.
+///
+/// #10706 made an unmeasured `wrong-branch` fail loudly, which was right for
+/// #10703 (HEAD *was* the tip and the guard misread a detached checkout). But
+/// at this repo's merge rate a push is routinely overtaken before its check job
+/// starts, and that is a measured, benign skip — the newer tip's run cuts the
+/// release, covering this commit's range too. Failing it turns a healthy merge
+/// train red.
+#[test]
+fn release_check_skips_a_superseded_push_but_still_fails_an_unmeasured_one() {
+    // Superseded: the attach step measured it and named the winning tip.
+    for reason in ["wrong-branch", ""] {
+        let (code, out) = run_decide_step(&[
+            ("steps.release-check.outcome", "success"),
+            ("steps.release-check.outputs['skipped-reason']", reason),
+            ("steps.attach.outputs.superseded", "true"),
+            ("steps.attach.outputs['branch-tip']", "0123456789abcdef"),
+        ]);
+        assert_eq!(
+            code, 0,
+            "a superseded push must not fail the release check (reason {reason:?}): {out}"
+        );
+        assert!(
+            out.contains("should-release=false"),
+            "a superseded push must skip the release (reason {reason:?}): {out}"
+        );
+        assert!(
+            !out.contains("should-release=true"),
+            "a superseded push must never release (reason {reason:?}): {out}"
+        );
+        assert!(
+            out.contains("Superseded"),
+            "the skip must name supersession as the reason (reason {reason:?}): {out}"
+        );
+        assert!(
+            out.contains("01234567"),
+            "the skip must name the tip that owns the release (reason {reason:?}): {out}"
+        );
+    }
+
+    // NOT superseded — HEAD really was the tip. This is #10703 itself, and it
+    // must still fail closed. This is the assertion that stops the fix above
+    // from being widened into a blanket `wrong-branch` amnesty.
+    let (code, out) = run_decide_step(&[
+        ("steps.release-check.outcome", "success"),
+        (
+            "steps.release-check.outputs['skipped-reason']",
+            "wrong-branch",
+        ),
+    ]);
+    assert_ne!(
+        code, 0,
+        "wrong-branch without a proven supersession must still fail: {out}"
+    );
+    assert!(
+        out.contains("::error::"),
+        "an unmeasured wrong-branch must still be loud: {out}"
+    );
+
+    // Supersession must not rescue a genuinely unmeasured reason either.
+    let (code, out) = run_decide_step(&[
+        ("steps.release-check.outcome", "success"),
+        (
+            "steps.release-check.outputs['skipped-reason']",
+            "release-output-missing",
+        ),
+        ("steps.attach.outputs.superseded", "true"),
+        ("steps.attach.outputs['branch-tip']", "0123456789abcdef"),
+    ]);
+    assert_ne!(
+        code, 0,
+        "release-output-missing is unmeasured even when superseded: {out}"
+    );
 }


### PR DESCRIPTION
## Symptom

`Check for releasable commits` is failing on `main` on every merge, so **every downstream job is skipped and the run is red**. Runs [30414110514](https://github.com/Extra-Chill/homeboy/actions/runs/30414110514) and [30414450306](https://github.com/Extra-Chill/homeboy/actions/runs/30414450306):

```
##[warning]HEAD 086f1c32 is not the main tip 3a94fad4 - leaving HEAD detached
##[error]Release check could not determine whether there is anything to release
at 086f1c32 ... skipped-reason='wrong-branch'
```

## Root cause

At this repo's merge rate a push is routinely overtaken before its `check` job starts. Then:

1. `Attach HEAD to the release branch` correctly refuses — `086f1c32` is not the tip, and attaching an arbitrary SHA is exactly what that guard exists to prevent. It exits 0 leaving HEAD detached.
2. homeboy-action's wrapper reads `git rev-parse --abbrev-ref HEAD` → literal `HEAD`, and emits `skipped-reason=wrong-branch`.
3. #10706's measurement check classifies `wrong-branch` as **UNMEASURED** and fails the job.

Step 3 is the bug. #10706 was right for #10703 — where HEAD *was* the tip and the guard misread a detached checkout — but a superseded push is a **measured** negative, and it is the one negative this job measures *itself*: the attach step compared the commit against `refs/remotes/origin/main` and found a newer tip.

**No work is lost.** `homeboy release` computes its range from the last tag, so the newer tip's run covers this commit too.

## Fix

The attach step records what it measured (`superseded=true`, `branch-tip=<sha>`); the decide step skips on that evidence.

### This does not widen the #10685 hole

The amnesty is deliberately narrow, and the tests pin all three edges:

| case | result |
|---|---|
| `wrong-branch` **+ proven supersession** | quiet skip, names the winning tip |
| `wrong-branch` **without** supersession (= #10703 itself) | **still hard-fails** |
| `release-output-missing` even when superseded | **still hard-fails** |

If HEAD really is the tip, `superseded` is empty and the #10703 regression signal stays armed. The attach step explicitly asserts it never records the tip as superseded.

## Verification

Per this VPS's no-heavy-cargo rule I did not run the suite locally; instead I replicated `run_decide_step`'s harness (`job_section` → `step_run_script` → `interpolate` → `bash -e`) and the attach step's git fixture exactly, and ran every scenario against the real workflow file.

Decide step — 8/8, including every pre-existing invariant:
```
PASS superseded + reason='wrong-branch' -> quiet skip (exit=0)
PASS superseded + reason='' -> quiet skip (exit=0)
PASS NOT superseded + wrong-branch -> hard fail (exit=1)
PASS superseded + release-output-missing -> hard fail (exit=1)
PASS measured no-releasable-commits -> quiet skip (exit=0)
PASS measured release-already-at-head -> quiet skip (exit=0)
PASS measured major-requires-flag -> quiet skip (exit=0)
PASS empty reason, not superseded -> hard fail (exit=1)
```

Attach step against a real two-commit repo — 9/9:
```
PASS attach succeeds at tip / HEAD re-attached to main
PASS tip NOT recorded superseded (keeps #10703 armed)
PASS non-tip stays detached, refusal is not an error
PASS refusal records superseded=true and names the winning tip
```

`cargo fmt --check` clean, `git diff --check` clean, workflow parses as valid YAML.

The new Rust test `release_check_skips_a_superseded_push_but_still_fails_an_unmeasured_one` mirrors these cases; CI runs the real suite.

## Note on the existing attach test

`release_head_attach_refuses_any_commit_that_is_not_the_branch_tip` asserted `::warning::` on refusal. Refusal is now a `::notice::` (it is expected, not anomalous), and the test asserts the **evidence** — `superseded=true` plus the winning tip — rather than the log level. It also now supplies `GITHUB_OUTPUT`, which the step needs.

## AI Assistance

Investigated and drafted with Claude via opencode; verified against the real workflow file and live CI logs. Chris Huber remains responsible for the change.