### PR TITLE
fix: propagate declared test secrets to local children

### DIFF
--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -178,6 +178,7 @@ pub mod schedule;
 pub mod scope;
 pub mod stack_provider;
 pub use homeboy_lab_contract::secret_env_plan;
+pub mod secret_env;
 
 /// Flattened re-export of the lab-contract crate's Lab types (workload, handoff,
 /// typed identifiers, labels). Core consumers import these from here rather than

--- a/crates/homeboy-core/src/secret_env.rs
+++ b/crates/homeboy-core/src/secret_env.rs
@@ -1,0 +1,61 @@
+use crate::error::{Error, Result};
+use crate::secret_env_plan::{resolve_secret_env_names, SecretEnvValueProvider};
+
+/// Resolve secret identities for a local child from Homeboy's authorized
+/// controller sources. Values are returned only for direct child injection;
+/// diagnostics contain names and source guidance, never values.
+pub fn resolve_local_required(
+    names: impl IntoIterator<Item = String>,
+    field: &str,
+    workload: &str,
+) -> Result<Vec<(String, String)>> {
+    resolve_secret_env_names(
+        names,
+        vec![
+            SecretEnvValueProvider::new("process-env", |name| std::env::var(name).ok()),
+            SecretEnvValueProvider::new("homeboy-config", |name| {
+                crate::agent_task_secret_provider::resolve_agent_task_secret_env(&[
+                    name.to_string(),
+                ])
+                .into_iter()
+                .next()
+                .map(|(_, value)| value)
+            }),
+        ],
+        &format!("missing required {workload} secret env"),
+    )
+    .map(|resolution| resolution.env)
+    .map_err(|error| {
+        Error::validation_invalid_argument(
+            field,
+            error.message,
+            None,
+            Some(vec![
+                "Export each declared variable in the controller environment, or configure an authorized Homeboy secret mapping with `homeboy agent-task auth map-env` / `homeboy agent-task auth set-keychain`.".to_string(),
+                "Homeboy resolves declared local child secrets from process environment first, then configured secret mappings; it never reads component settings as secret values.".to_string(),
+            ]),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_declared_local_secret_without_exposing_value_in_errors() {
+        let name = format!("HOMEBOY_LOCAL_CHILD_SECRET_{}", std::process::id());
+        std::env::set_var(&name, "fixture-local-secret");
+
+        let resolved = resolve_local_required([name.clone()], "test.secret_env", "test child")
+            .expect("declared secret resolves");
+
+        assert_eq!(resolved, vec![(name.clone(), "fixture-local-secret".to_string())]);
+        std::env::remove_var(&name);
+
+        let error = resolve_local_required([name.clone()], "test.secret_env", "test child")
+            .expect_err("missing secret fails before child execution");
+        assert!(error.message.contains(&name));
+        assert!(!error.to_string().contains("fixture-local-secret"));
+    }
+}

--- a/crates/homeboy-core/src/secret_env.rs
+++ b/crates/homeboy-core/src/secret_env.rs
@@ -50,7 +50,10 @@ mod tests {
         let resolved = resolve_local_required([name.clone()], "test.secret_env", "test child")
             .expect("declared secret resolves");
 
-        assert_eq!(resolved, vec![(name.clone(), "fixture-local-secret".to_string())]);
+        assert_eq!(
+            resolved,
+            vec![(name.clone(), "fixture-local-secret".to_string())]
+        );
         std::env::remove_var(&name);
 
         let error = resolve_local_required([name.clone()], "test.secret_env", "test child")

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -749,6 +749,7 @@ fn wait_for_child_or_delegated_failure(
 
 const CHILD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 const CHILD_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
+pub const CHILD_SECRET_ENV_NAMES_ENV: &str = "HOMEBOY_CHILD_SECRET_ENV_NAMES";
 static CHILD_SUPERVISION_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
@@ -772,6 +773,7 @@ struct ChildSupervisionRecord {
 struct ChildSupervision {
     path: PathBuf,
     record: ChildSupervisionRecord,
+    redaction_values: Vec<String>,
     last_heartbeat: Instant,
 }
 
@@ -781,13 +783,14 @@ impl ChildSupervision {
             (*key == crate::engine::run_dir::run_dir_env()).then_some(*value)
         })?;
         let now = Utc::now().to_rfc3339();
+        let redaction_values = child_secret_values(env);
         let supervision = Self {
             path: PathBuf::from(run_dir).join(crate::engine::run_dir::files::CHILD_SUPERVISION),
             record: ChildSupervisionRecord {
                 schema: "homeboy.child_supervision.v1",
                 status: "running".to_string(),
                 phase: "child",
-                command: crate::redaction::redact_string(command),
+                command: redact_child_secret_values(command, &redaction_values),
                 child_pid,
                 started_at: now.clone(),
                 heartbeat_at: now,
@@ -798,6 +801,7 @@ impl ChildSupervision {
                 stdout_tail: String::new(),
                 stderr_tail: String::new(),
             },
+            redaction_values,
             last_heartbeat: Instant::now(),
         };
         supervision.persist();
@@ -835,8 +839,8 @@ impl ChildSupervision {
             signal.map(|signal| format!("signal:{signal}"))
         };
         self.record.exit_code = Some(output.exit_code);
-        self.record.stdout_tail = bounded_redacted_tail(&output.stdout);
-        self.record.stderr_tail = bounded_redacted_tail(&output.stderr);
+        self.record.stdout_tail = bounded_redacted_tail(&output.stdout, &self.redaction_values);
+        self.record.stderr_tail = bounded_redacted_tail(&output.stderr, &self.redaction_values);
         self.persist();
     }
 
@@ -870,13 +874,43 @@ impl ChildSupervision {
     }
 }
 
-fn bounded_redacted_tail(output: &str) -> String {
+fn child_secret_values(env: Option<&[(&str, &str)]>) -> Vec<String> {
+    let Some(env) = env else {
+        return Vec::new();
+    };
+    let declared_names = env
+        .iter()
+        .find_map(|(name, value)| (*name == CHILD_SECRET_ENV_NAMES_ENV).then_some(*value))
+        .unwrap_or_default();
+    let mut values = declared_names
+        .lines()
+        .filter_map(|declared| {
+            env.iter()
+                .find_map(|(name, value)| (*name == declared).then_some((*value).to_string()))
+        })
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    values.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    values.dedup();
+    values
+}
+
+fn redact_child_secret_values(output: &str, redaction_values: &[String]) -> String {
+    let redacted = redaction_values
+        .iter()
+        .fold(output.to_string(), |output, secret| {
+            output.replace(secret, "[REDACTED]")
+        });
+    crate::redaction::redact_string(&redacted)
+}
+
+fn bounded_redacted_tail(output: &str, redaction_values: &[String]) -> String {
     let start = output.len().saturating_sub(CHILD_OUTPUT_TAIL_BYTES);
     let start = output
         .char_indices()
         .find_map(|(index, _)| (index >= start).then_some(index))
         .unwrap_or_default();
-    crate::redaction::redact_string(&output[start..])
+    redact_child_secret_values(&output[start..], redaction_values)
 }
 
 #[cfg(test)]
@@ -927,6 +961,29 @@ mod tests {
                 Some(libc::ESRCH)
             );
         }
+    }
+
+    #[test]
+    fn supervision_redacts_values_from_declared_child_secret_env() {
+        let run_dir = tempfile::tempdir().expect("run dir");
+        let run_dir_key = crate::engine::run_dir::run_dir_env();
+        let run_dir_value = run_dir.path().to_string_lossy().to_string();
+        let env = [
+            (run_dir_key.as_str(), run_dir_value.as_str()),
+            (CHILD_SECRET_ENV_NAMES_ENV, "FIXTURE_SECRET"),
+            ("FIXTURE_SECRET", "supervision-fixture-secret"),
+        ];
+
+        let output = execute_local_command_in_dir(
+            "printf 'received=%s\\n' \"$FIXTURE_SECRET\"",
+            None,
+            Some(&env),
+        );
+
+        assert!(output.success, "{}", output.stderr);
+        let supervision = supervision_output(&run_dir).to_string();
+        assert!(supervision.contains("[REDACTED]"));
+        assert!(!supervision.contains("supervision-fixture-secret"));
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/server/client/mod.rs
+++ b/crates/homeboy-core/src/server/client/mod.rs
@@ -17,6 +17,7 @@ pub use host::is_transient_ssh_error;
 pub use local_exec::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_passthrough,
+    CHILD_SECRET_ENV_NAMES_ENV,
 };
 pub use local_exec::{
     execute_local_command_passthrough_with_timeout, execute_local_command_stderr_passthrough,

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -15,7 +15,7 @@ pub use client::DELEGATED_RUN_STATUS_FILE_ENV;
 pub use client::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_passthrough, is_transient_ssh_error,
-    CommandOutput, SshClient,
+    CommandOutput, SshClient, CHILD_SECRET_ENV_NAMES_ENV,
 };
 pub use client::{
     execute_local_command_passthrough_with_timeout, execute_local_command_stderr_passthrough,

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -451,9 +451,11 @@ fn redact_resolved_secret_values(value: &str, secret_env: &[(String, String)]) -
     secrets.sort_by_key(|value| std::cmp::Reverse(value.len()));
     secrets.dedup();
 
-    let redacted = secrets.into_iter().fold(value.to_string(), |output, secret| {
-        output.replace(secret, "[REDACTED]")
-    });
+    let redacted = secrets
+        .into_iter()
+        .fold(value.to_string(), |output, secret| {
+            output.replace(secret, "[REDACTED]")
+        });
     homeboy_core::redaction::redact_string(&redacted)
 }
 

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -45,6 +45,7 @@ pub struct ExtensionRunner {
     /// conflict — strictly more expressive). See SettingArgs docstring.
     settings_json_overrides: Vec<(String, serde_json::Value)>,
     env_vars: Vec<(String, String)>,
+    secret_env_names: Vec<String>,
     env_provider_extensions: Vec<String>,
     script_args: Vec<String>,
     path_override: Option<String>,
@@ -84,6 +85,7 @@ impl ExtensionRunner {
             settings_overrides: Vec::new(),
             settings_json_overrides: Vec::new(),
             env_vars: Vec::new(),
+            secret_env_names: Vec::new(),
             env_provider_extensions: Vec::new(),
             script_args: Vec::new(),
             path_override: None,
@@ -125,6 +127,15 @@ impl ExtensionRunner {
     /// Add an environment variable.
     pub fn env(mut self, key: &str, value: &str) -> Self {
         self.env_vars.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Declare secret identities that Homeboy must resolve for this local
+    /// child. Values are never stored in the runner or command string.
+    pub fn secret_env_names(mut self, names: impl IntoIterator<Item = String>) -> Self {
+        self.secret_env_names.extend(names);
+        self.secret_env_names.sort();
+        self.secret_env_names.dedup();
         self
     }
 
@@ -248,9 +259,25 @@ impl ExtensionRunner {
 
         let project_path = PathBuf::from(&prepared.execution.component.local_path);
         let invocation = self.acquire_invocation_guard()?;
+        let secret_env = homeboy_core::secret_env::resolve_local_required(
+            self.secret_env_names.clone(),
+            "test.secret_env",
+            "extension child",
+        )?;
         let mut extra_env_vars =
             super::component_script::component_env_vars(&prepared.execution.component);
         extra_env_vars.extend(self.env_vars.clone());
+        extra_env_vars.extend(secret_env.iter().cloned());
+        if !secret_env.is_empty() {
+            extra_env_vars.push((
+                homeboy_core::server::CHILD_SECRET_ENV_NAMES_ENV.to_string(),
+                secret_env
+                    .iter()
+                    .map(|(name, _)| name.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            ));
+        }
         if let Some(invocation) = invocation.as_ref() {
             extra_env_vars.extend(invocation.env_vars());
         }
@@ -262,7 +289,12 @@ impl ExtensionRunner {
             &extra_env_vars,
         )?;
 
-        let output = self.execute_script(&prepared.execution.extension_path, &env_vars)?;
+        let output = self.execute_script(
+            &prepared.execution.extension_path,
+            &env_vars,
+            !secret_env.is_empty(),
+        )?;
+        let output = redact_runner_output(output, &secret_env);
         if !output.success {
             if let Some(run_dir_path) = &self.run_dir_path {
                 let command = self.command_string(&prepared.execution.extension_path);
@@ -366,6 +398,7 @@ impl ExtensionRunner {
         &self,
         extension_path: &Path,
         env_vars: &[(String, String)],
+        contains_secrets: bool,
     ) -> Result<CommandOutput> {
         super::execution::execute_capability_script(
             extension_path,
@@ -375,8 +408,11 @@ impl ExtensionRunner {
             self.working_dir.as_deref(),
             self.command_override.as_deref(),
             super::execution::CapabilityScriptOptions {
-                passthrough: self.passthrough,
-                stderr_passthrough: self.stderr_passthrough,
+                // Streaming an arbitrary child stream cannot guarantee exact
+                // value redaction. Secret-bearing children are captured first,
+                // then redacted before any Homeboy evidence is produced.
+                passthrough: self.passthrough && !contains_secrets,
+                stderr_passthrough: self.stderr_passthrough && !contains_secrets,
                 timeout: self.timeout,
             },
         )
@@ -395,6 +431,30 @@ impl ExtensionRunner {
         }
         command
     }
+}
+
+fn redact_runner_output(
+    mut output: CommandOutput,
+    secret_env: &[(String, String)],
+) -> CommandOutput {
+    output.stdout = redact_resolved_secret_values(&output.stdout, secret_env);
+    output.stderr = redact_resolved_secret_values(&output.stderr, secret_env);
+    output
+}
+
+fn redact_resolved_secret_values(value: &str, secret_env: &[(String, String)]) -> String {
+    let mut secrets = secret_env
+        .iter()
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    secrets.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    secrets.dedup();
+
+    let redacted = secrets.into_iter().fold(value.to_string(), |output, secret| {
+        output.replace(secret, "[REDACTED]")
+    });
+    homeboy_core::redaction::redact_string(&redacted)
 }
 
 fn write_structured_failure_sidecar(

--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -131,6 +131,10 @@ pub fn build_test_runner(
 ) -> homeboy_core::Result<ExtensionRunner> {
     let resolved = resolve_test_command(component)?;
     let extension_id = resolved.extension_id.clone();
+    let secret_env_names = crate::load_extension(&extension_id)?
+        .test
+        .map(|test| test.secret_env.into_keys().collect::<Vec<_>>())
+        .unwrap_or_default();
 
     let mut runner = ExtensionRunner::for_context(resolved)
         .component(component.clone())
@@ -138,6 +142,7 @@ pub fn build_test_runner(
         .settings(settings)
         .settings_json(settings_json)
         .with_run_dir(run_dir)
+        .secret_env_names(secret_env_names)
         .env_if(skip_lint, "HOMEBOY_SKIP_LINT", "1")
         .env_if(coverage_enabled, "HOMEBOY_COVERAGE", "1");
 

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -1314,7 +1314,112 @@ fn merge_reported_test_artifact_locators(
 mod tests {
     use super::*;
     use crate::test::TestFailure;
-    use homeboy_core::component::ComponentScriptsConfig;
+    use homeboy_core::component::{ComponentScriptsConfig, ScopedExtensionConfig};
+    use std::collections::HashMap;
+
+    fn assert_artifact_tree_excludes(root: &Path, needle: &str) {
+        for entry in std::fs::read_dir(root).expect("read artifact directory") {
+            let path = entry.expect("artifact entry").path();
+            if path.is_dir() {
+                assert_artifact_tree_excludes(&path, needle);
+            } else if let Ok(contents) = std::fs::read_to_string(&path) {
+                assert!(
+                    !contents.contains(needle),
+                    "artifact {} leaked declared secret",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn review_test_injects_declared_secret_and_redacts_child_evidence() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions/secret-test-fixture");
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            std::fs::write(
+                extension_dir.join("secret-test-fixture.json"),
+                r#"{
+                    "name":"Secret test fixture",
+                    "version":"1.0.0",
+                    "test":{
+                        "extension_script":"test.sh",
+                        "secret_env":{"DECLARED_TEST_SECRET":"DECLARED_TEST_SECRET"}
+                    }
+                }"#,
+            )
+            .expect("extension manifest");
+            std::fs::write(
+                extension_dir.join("test.sh"),
+                "#!/bin/sh\nprintf 'received=%s\\n' \"$DECLARED_TEST_SECRET\"\nexit 1\n",
+            )
+            .expect("extension script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let script = extension_dir.join("test.sh");
+                let mut permissions = std::fs::metadata(&script)
+                    .expect("script metadata")
+                    .permissions();
+                permissions.set_mode(0o755);
+                std::fs::set_permissions(script, permissions).expect("executable script");
+            }
+
+            let component = Component {
+                id: "secret-consumer".to_string(),
+                local_path: source.path().to_string_lossy().to_string(),
+                extensions: Some(HashMap::from([(
+                    "secret-test-fixture".to_string(),
+                    ScopedExtensionConfig::default(),
+                )])),
+                ..Default::default()
+            };
+            let run_dir = RunDir::create().expect("run dir");
+            std::env::set_var("DECLARED_TEST_SECRET", "review-fixture-secret");
+            let result = run_main_test_workflow(
+                &component,
+                source.path(),
+                TestRunWorkflowArgs {
+                    component_label: component.id.clone(),
+                    component_id: component.id.clone(),
+                    path_override: None,
+                    settings: Vec::new(),
+                    settings_json: Vec::new(),
+                    skip_lint: true,
+                    coverage: false,
+                    coverage_min: None,
+                    analyze: false,
+                    baseline_flags: Default::default(),
+                    changed_since: None,
+                    precomputed_changed_files: None,
+                    json_summary: true,
+                    restore_checkout: false,
+                    ci_env: Vec::new(),
+                    passthrough_args: Vec::new(),
+                },
+                &run_dir,
+            )
+            .expect("review workflow reaches secret-bearing child");
+            std::env::remove_var("DECLARED_TEST_SECRET");
+
+            assert_eq!(result.exit_code, 1, "child ran after secret injection");
+            let rendered = serde_json::to_string(&result).expect("review result JSON");
+            assert!(rendered.contains("[REDACTED]"));
+            assert!(!rendered.contains("review-fixture-secret"));
+            let artifact = std::fs::read_to_string(
+                run_dir
+                    .path()
+                    .join("validation-progress/command-1-stdout.log"),
+            )
+            .expect("review stdout artifact");
+            assert!(artifact.contains("[REDACTED]"));
+            assert!(!artifact.contains("review-fixture-secret"));
+            assert_artifact_tree_excludes(run_dir.path(), "review-fixture-secret");
+        });
+    }
 
     /// Two lines of a real cargo test run: one binary that finished and
     /// reported its time, and one that started and never did.

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -795,7 +795,10 @@ mod tests {
                 .expect_err("release preflight must reject missing secret before spawn");
 
             assert!(error.message.contains("DECLARED_RELEASE_SECRET"));
-            assert!(error.details.to_string().contains("agent-task auth map-env"));
+            assert!(error
+                .details
+                .to_string()
+                .contains("agent-task auth map-env"));
             assert!(!marker.exists(), "release test child must not start");
         });
     }

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -338,8 +338,7 @@ pub(super) fn validate_test_quality(component: &Component) -> Result<bool> {
         None,
         &test_run_dir,
     )
-    .and_then(|runner| runner.run())
-    .map_err(|e| quality_error("test", format!("Test runner error: {}", e)))?;
+    .and_then(|runner| runner.run())?;
 
     if output.success {
         homeboy_core::log_status!("release", "Tests passed");
@@ -583,6 +582,44 @@ mod tests {
         }
     }
 
+    fn extension_test_component(home: &Path, source: &Path, script: &str) -> Component {
+        let extension_dir = home.join(".config/homeboy/extensions/release-test-fixture");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("release-test-fixture.json"),
+            r#"{
+                "name":"Release test fixture",
+                "version":"1.0.0",
+                "test":{
+                    "extension_script":"test.sh",
+                    "secret_env":{"DECLARED_RELEASE_SECRET":"DECLARED_RELEASE_SECRET"}
+                }
+            }"#,
+        )
+        .expect("extension manifest");
+        fs::write(extension_dir.join("test.sh"), script).expect("extension script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let script_path = extension_dir.join("test.sh");
+            let mut permissions = fs::metadata(&script_path)
+                .expect("script metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script_path, permissions).expect("executable script");
+        }
+
+        Component {
+            id: "fixture".to_string(),
+            local_path: source.to_string_lossy().to_string(),
+            extensions: Some(HashMap::from([(
+                "release-test-fixture".to_string(),
+                ScopedExtensionConfig::default(),
+            )])),
+            ..Default::default()
+        }
+    }
+
     fn enable_split_lint_routes(home: &Path) {
         fs::write(
             home.join(".config/homeboy/extensions/release-lint-fixture/release-lint-fixture.json"),
@@ -740,6 +777,57 @@ mod tests {
         );
 
         assert!(validate_test_quality(&component).expect("test script should pass"));
+    }
+
+    #[test]
+    fn validate_test_quality_fails_before_child_when_declared_secret_is_missing() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            let marker = source.path().join("child-ran");
+            let component = extension_test_component(
+                home.path(),
+                source.path(),
+                &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            );
+            std::env::remove_var("DECLARED_RELEASE_SECRET");
+
+            let error = validate_test_quality(&component)
+                .expect_err("release preflight must reject missing secret before spawn");
+
+            assert!(error.message.contains("DECLARED_RELEASE_SECRET"));
+            assert!(error.details.to_string().contains("agent-task auth map-env"));
+            assert!(!marker.exists(), "release test child must not start");
+        });
+    }
+
+    #[test]
+    fn validate_test_quality_redacts_injected_secret_from_release_evidence() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source = tempfile::tempdir().expect("source dir");
+            let marker = source.path().join("child-ran");
+            let component = extension_test_component(
+                home.path(),
+                source.path(),
+                &format!(
+                    "#!/bin/sh\ntouch '{}'\nprintf 'received=%s\\n' \"$DECLARED_RELEASE_SECRET\" >&2\nexit 1\n",
+                    marker.display()
+                ),
+            );
+            std::env::set_var("DECLARED_RELEASE_SECRET", "release-fixture-secret");
+
+            let error = validate_test_quality(&component)
+                .expect_err("fixture child intentionally fails after injection");
+            std::env::remove_var("DECLARED_RELEASE_SECRET");
+
+            assert!(marker.exists(), "release test child received declared env");
+            let rendered = format!("{}\n{}", error, error.details);
+            assert!(rendered.contains("[REDACTED]"));
+            assert!(!rendered.contains("release-fixture-secret"));
+            assert!(!error.details["command_evidence"]["command"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("release-fixture-secret"));
+        });
     }
 
     #[test]

--- a/docs/architecture/secret-env-contract.md
+++ b/docs/architecture/secret-env-contract.md
@@ -10,6 +10,7 @@ The contract is intentionally small:
 - Status metadata records only `name`, `configured`, and `source`; it never includes resolved values.
 - Missing required names produce a structured error with normalized missing names and redacted status metadata.
 - Provider command execution receives `HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON`, a serialized `SecretEnvPlan` containing normalized env names, env-name mappings, and redacted configured/missing status metadata. It never contains resolved secret values.
+- Local extension test children resolve only identities declared by `test.secret_env`, using process environment before configured Homeboy secret mappings. Missing identities fail before child execution. Secret-bearing child streams are captured and exact values are redacted before Homeboy creates output, logs, or artifacts.
 
 Value providers remain domain-owned. Core does not know where a secret comes from beyond the provider's source label. Current consumers can provide process env, config, keychain, remote runner, or extension-specific providers without adding domain semantics to the shared contract.
 


### PR DESCRIPTION
## Summary
- resolve manifest-declared `test.secret_env` identities for local extension test children from authorized Homeboy sources
- fail review/release test execution before child spawn when a declared identity is unavailable
- capture secret-bearing child streams and redact exact values from results, supervision records, artifacts, and release command evidence

## Root Cause And Owning Layer
Homeboy already carried the generic `test.secret_env` contract into portable runner dispatch, but the local `ExtensionRunner` path used by `review test` and release `preflight.test` never materialized those declared identities. That propagation gap belongs in Homeboy. Release also replaced the structured resolver error with a generic test-runner error, hiding the available remediation.

The fix remains generic: Homeboy does not name WordPress, WP Codebox, or any vendor-specific environment variable. Extensions declare identities through `test.secret_env`; Homeboy resolves and transports only those declarations.

## Review And Release Behavior
Before:
- local `review test` and release `preflight.test` inherited only ambient process env
- configured Homeboy secret mappings were not materialized for the extension child
- missing values failed later inside the extension adapter

After:
- both paths resolve declared identities before spawning the child
- missing identities return an actionable preflight error and do not start the child
- available identities are injected into the child environment without entering command strings
- release preserves the structured resolver error instead of replacing it

## Secret Source And Redaction Contract
Resolution order is process environment, then configured Homeboy secret mappings backed by the existing agent-task secret provider. Homeboy does not inspect arbitrary component settings for values and does not introduce another secret store.

Secret-bearing children do not stream arbitrary output directly. Captured stdout/stderr is exact-value redacted before workflow results, failure sidecars, validation artifacts, or release evidence are produced. Child-supervision records receive the same declared exact-value redaction. Tests recursively inspect the review run artifact tree and verify release command evidence contains no resolved value.

## Tests
- `cargo test -p homeboy-core secret_env::tests:: --lib` - 1 passed
- `cargo test -p homeboy-core server::client::local_exec::tests:: --lib` - 4 passed
- `cargo test -p homeboy-extension test::run::tests:: --lib` - 30 passed
- `cargo test -p homeboy-release validate_test_quality_ --lib` - 4 passed
- `git diff --check` - passed

The broader `cargo test -p homeboy-release release::planning_quality::tests:: --lib` ran 27 tests: 24 passed and three unrelated existing lint-message assertions failed (`extension_release_lint_blocks_extension_bootstrap_failure`, `extension_release_lint_rejects_invalid_explicit_lint_ownership`, and `extension_release_lint_blocks_malformed_missing_and_producer_error_evidence`). The test-specific release subset above is green. `cargo fmt` could not run because this environment does not have the `cargo-fmt`/`rustfmt` component installed.

## Remaining Dependencies
This PR fixes Homeboy's owning local-propagation gap but intentionally leaves #10402 open. The installed WordPress extension does not yet project the component-selected database-service environment identities into the generic `test.secret_env` contract. Extra-Chill/homeboy-extensions#2458 must declare those identities before WordPress review/release children can request them through this path.

The operator must also make each declared identity available through process env or an authorized Homeboy mapping (`homeboy agent-task auth map-env` / `set-keychain`). This PR does not read production configuration or create a new secret source. Extra-Chill/extrachill-users#305 remains separate component bootstrap/config work.