### PR TITLE
perf(controller-runtime): stop re-hashing the controller binary seven times per cook

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -88,9 +88,47 @@ static TEST_ADMISSION_OWNER_CAS_REPLACEMENT: OnceLock<Mutex<Option<Value>>> = On
 static TEST_CONTROLLER_FIXTURE_DIGESTS: OnceLock<
     Mutex<BTreeMap<TestExecutableFileIdentity, String>>,
 > = OnceLock::new();
+/// Digests this process has already computed, keyed by observed file identity.
+///
+/// Sealing a cook into an immutable runtime hashes the same bytes repeatedly:
+/// `pin_executable` hashes its source, `publish_pin` hashes the staged copy or
+/// an existing destination, `validate_pin` hashes the destination, and
+/// `admit_current_for` then validates the resulting pin a second time -- before
+/// the re-exec'd child repeats the whole sequence against the pin it is already
+/// executing. Each of those is a full SHA-256 of the controller binary, which
+/// for an unoptimized build is a multi-hundred-megabyte read costing tens of
+/// seconds.
+///
+/// Memoizing is sound because the key is the file's observed identity, not its
+/// path alone: writing to a file moves its modification and change times, and
+/// replacing it moves its inode. A hit therefore means nothing has touched
+/// those bytes since this process hashed them. The memo is process local and
+/// never persisted, so it cannot outlive the observation it was derived from.
+#[cfg(unix)]
+static EXECUTABLE_DIGESTS: OnceLock<Mutex<BTreeMap<ExecutableFileIdentity, String>>> =
+    OnceLock::new();
+#[cfg(all(test, unix))]
+static EXECUTABLE_DIGEST_COMPUTATIONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 #[cfg(all(test, unix))]
 static TEST_CONTROLLER_FIXTURE_DIGEST_CALLS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
+
+/// One executable file as this process observed it. Inode and change time are
+/// part of the identity so replacing or modifying a path cannot reuse its prior
+/// digest.
+#[cfg(unix)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ExecutableFileIdentity {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+    size: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+}
 
 /// A source fixture is immutable for a hermetic test context. Include inode and
 /// change time so replacing or modifying a path cannot reuse its prior digest.
@@ -2155,13 +2193,86 @@ fn activated_executable_identity(path: &Path) -> Result<String> {
 }
 
 fn executable_digest(path: &Path) -> Result<String> {
-    let bytes = fs::read(path).map_err(|error| {
+    let identity = observed_executable_identity(path);
+    if let Some(digest) = memoized_executable_digest(identity.as_ref()) {
+        return Ok(digest);
+    }
+    // Stream the file. A controller binary is hundreds of megabytes in an
+    // unoptimized build and `fs::read` would hold all of it resident purely to
+    // hash it, in a process that is about to fork a controller runtime.
+    #[cfg(all(test, unix))]
+    EXECUTABLE_DIGEST_COMPUTATIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let digest = content_hash::sha256_file(path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some("hash pinned controller executable".to_string()),
         )
     })?;
-    Ok(content_hash::sha256_hex(&bytes))
+    memoize_executable_digest(identity, &digest);
+    Ok(digest)
+}
+
+#[cfg(unix)]
+fn observed_executable_identity(path: &Path) -> Option<ExecutableFileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = fs::metadata(path).ok()?;
+    Some(ExecutableFileIdentity {
+        path: path.to_path_buf(),
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        size: metadata.size(),
+        modified_seconds: metadata.mtime(),
+        modified_nanoseconds: metadata.mtime_nsec(),
+        changed_seconds: metadata.ctime(),
+        changed_nanoseconds: metadata.ctime_nsec(),
+    })
+}
+
+#[cfg(not(unix))]
+fn observed_executable_identity(_path: &Path) -> Option<()> {
+    None
+}
+
+#[cfg(unix)]
+fn memoized_executable_digest(identity: Option<&ExecutableFileIdentity>) -> Option<String> {
+    EXECUTABLE_DIGESTS
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .expect("controller executable digest memo is not poisoned")
+        .get(identity?)
+        .cloned()
+}
+
+#[cfg(not(unix))]
+fn memoized_executable_digest(_identity: Option<&()>) -> Option<String> {
+    None
+}
+
+#[cfg(unix)]
+fn memoize_executable_digest(identity: Option<ExecutableFileIdentity>, digest: &str) {
+    let Some(identity) = identity else {
+        return;
+    };
+    EXECUTABLE_DIGESTS
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .expect("controller executable digest memo is not poisoned")
+        .insert(identity, digest.to_string());
+}
+
+#[cfg(not(unix))]
+fn memoize_executable_digest(_identity: Option<()>, _digest: &str) {}
+
+/// Record a pin whose bytes this process just verified.
+///
+/// `pin_executable` validates the pin immediately after publishing it, which
+/// would otherwise re-read the file it has just hashed. Observe the destination
+/// once publication has finished mutating it -- sealing its mode and linking it
+/// both move the inode's change time -- so the validation that follows resolves
+/// from the memo instead of from disk.
+fn memoize_published_pin(destination: &Path, digest: &str) {
+    memoize_executable_digest(observed_executable_identity(destination), digest);
 }
 
 fn make_executable_read_only(path: &Path) -> Result<()> {
@@ -2219,6 +2330,7 @@ fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Resu
         let actual = executable_digest(destination)?;
         if actual == expected_digest {
             register_test_fixture_candidate(source, destination, expected_digest);
+            memoize_published_pin(destination, expected_digest);
             return Ok(());
         }
         return Err(Error::validation_invalid_argument(
@@ -2266,6 +2378,7 @@ fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Resu
         Ok(()) => {
             let _ = fs::remove_file(&staging);
             register_test_fixture_candidate(source, destination, expected_digest);
+            memoize_published_pin(destination, expected_digest);
             Ok(())
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -2273,6 +2386,7 @@ fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Resu
             let actual = executable_digest(destination)?;
             if actual == expected_digest {
                 register_test_fixture_candidate(source, destination, expected_digest);
+                memoize_published_pin(destination, expected_digest);
                 Ok(())
             } else {
                 Err(Error::validation_invalid_argument(
@@ -3246,6 +3360,121 @@ mod tests {
                 TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.load(std::sync::atomic::Ordering::Relaxed),
                 4,
                 "replacement misses the cache and rehashes before failing"
+            );
+        });
+    }
+
+    /// Sealing one cook hashes the same controller executable up to seven times
+    /// across two processes. Each of those is a full read of a binary that is
+    /// hundreds of megabytes unoptimized, which measurably dominates a detached
+    /// `agent-task cook`: 75.93s of a 76.92s acceptance run was spent inside the
+    /// Cook CLI while every other phase of that run cost 0.64s combined
+    /// (#10659).
+    #[cfg(unix)]
+    #[test]
+    fn executable_digests_are_memoized_per_observed_file_identity() {
+        use std::os::unix::fs::PermissionsExt;
+
+        crate::test_support::with_isolated_home(|_| {
+            EXECUTABLE_DIGESTS
+                .get_or_init(|| Mutex::new(BTreeMap::new()))
+                .lock()
+                .expect("controller executable digest memo is not poisoned")
+                .clear();
+            EXECUTABLE_DIGEST_COMPUTATIONS.store(0, std::sync::atomic::Ordering::Relaxed);
+
+            let temporary = tempfile::tempdir().expect("temporary executable directory");
+            let executable = temporary.path().join("homeboy");
+            fs::write(&executable, b"controller bytes").expect("write controller");
+            fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))
+                .expect("make controller executable");
+
+            let first = executable_digest(&executable).expect("hash controller");
+            let second = executable_digest(&executable).expect("rehash controller");
+            assert_eq!(first, second);
+            assert_eq!(
+                EXECUTABLE_DIGEST_COMPUTATIONS.load(std::sync::atomic::Ordering::Relaxed),
+                1,
+                "an unchanged executable is read once per process"
+            );
+
+            // A memo that survived a content change would report the previous
+            // digest for different bytes, which is the one failure mode that
+            // matters: it would let a replaced controller validate.
+            fs::write(&executable, b"different controller bytes").expect("mutate controller");
+            let mutated = executable_digest(&executable).expect("hash mutated controller");
+            assert_ne!(
+                mutated, first,
+                "a mutated executable never reuses its prior digest"
+            );
+            assert_eq!(
+                EXECUTABLE_DIGEST_COMPUTATIONS.load(std::sync::atomic::Ordering::Relaxed),
+                2,
+                "mutation misses the memo and rehashes"
+            );
+
+            assert_eq!(
+                executable_digest(&executable).expect("rehash mutated controller"),
+                mutated
+            );
+            assert_eq!(
+                EXECUTABLE_DIGEST_COMPUTATIONS.load(std::sync::atomic::Ordering::Relaxed),
+                2,
+                "the mutated executable is then memoized under its new identity"
+            );
+        });
+    }
+
+    /// Publishing a pin verifies the staged bytes and then validates the
+    /// published pin, which used to read the same file twice more. Sealing the
+    /// pin's mode and linking it both move the inode's change time, so the
+    /// memo has to be seeded from the destination as publication left it.
+    #[cfg(unix)]
+    #[test]
+    fn publishing_a_pin_seeds_the_digest_its_validation_needs() {
+        use std::os::unix::fs::PermissionsExt;
+
+        crate::test_support::with_isolated_home(|_| {
+            EXECUTABLE_DIGESTS
+                .get_or_init(|| Mutex::new(BTreeMap::new()))
+                .lock()
+                .expect("controller executable digest memo is not poisoned")
+                .clear();
+            EXECUTABLE_DIGEST_COMPUTATIONS.store(0, std::sync::atomic::Ordering::Relaxed);
+
+            let temporary = tempfile::tempdir().expect("temporary executable directory");
+            let source = temporary.path().join("homeboy");
+            fs::write(&source, b"controller bytes").expect("write controller");
+            fs::set_permissions(&source, fs::Permissions::from_mode(0o755))
+                .expect("make controller executable");
+
+            let runtime = pin_executable(&source, "homeboy 0.0.0+fixture").expect("pin executable");
+            assert_eq!(
+                EXECUTABLE_DIGEST_COMPUTATIONS.load(std::sync::atomic::Ordering::Relaxed),
+                2,
+                "publication reads the source and the staged copy, and nothing else"
+            );
+
+            validate_pin(&runtime).expect("published pin validates");
+            assert_eq!(
+                EXECUTABLE_DIGEST_COMPUTATIONS.load(std::sync::atomic::Ordering::Relaxed),
+                2,
+                "revalidating a published pin resolves from the memo"
+            );
+
+            // The memo must not survive the pin being replaced underneath it,
+            // which is the whole reason the pin is validated at all.
+            let pinned = runtime
+                .pointer("/originating/pinned_executable")
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+                .expect("pinned executable");
+            fs::set_permissions(&pinned, fs::Permissions::from_mode(0o700))
+                .expect("unseal pinned executable");
+            fs::write(&pinned, b"tampered controller bytes").expect("tamper pinned executable");
+            assert!(
+                validate_pin(&runtime).is_err(),
+                "a tampered pin fails closed rather than reusing its memoized digest"
             );
         });
     }


### PR DESCRIPTION
## The measurement

`#10728` instrumented `detached_cook_accepts_reverse_capacity_queue_and_worker_completes_once` with a phase ledger before `#10729` dropped it. That test ran once with the ledger, in job [90459667599](https://github.com/Extra-Chill/homeboy/actions/runs/30415063936/job/90459667599):

```
phase timings (seconds):
  hermetic_context: 0.00
  git_fixtures: 0.03
  daemon_ready: 0.26
  server_and_runner_configured: 0.35
  detached_cook_cli: 75.93
  TOTAL: 76.92
```

**75.93 of 76.92 seconds was one `homeboy agent-task cook` subprocess.** The daemon, the broker, the git worktree and the hermetic context — the parts #10729 identified as the expense — cost 0.64s combined. The cost was the product, not the fixture.

## Where it goes

`agent-task cook` seals itself into an immutable controller runtime and re-execs it. Publishing and validating that pin reads the controller binary end to end, repeatedly:

| process | call | reads |
|---|---|---|
| parent | `pin_executable` → `controller_executable_digest(source)` | 1 |
| parent | `publish_pin` → `executable_digest(staging)` | 2 |
| parent | `pin_executable` → `validate_pin(destination)` | 3 |
| child | `admit_current_for` → `pin_executable` → digest(source) | 4 |
| child | `publish_pin` → `executable_digest(destination)` | 5 |
| child | `pin_executable` → `validate_pin` | 6 |
| child | `admit_current_for` → `validate_pin` | 7 |

Seven full SHA-256 passes plus one full file copy, before any cook work happens. Unoptimized that binary is hundreds of megabytes. The repo already measured this class of cost once and worked around it for the daemon — `HOMEBOY_TEST_DAEMON_BINARY_SHA` exists because "hashing the multi-hundred-MB debug test binary costs ~20s per daemon-state write". The controller-runtime path had no equivalent.

A released binary is smaller, so this is not a tens-of-seconds tax in production — but it is still six redundant full reads of the running executable on every cook, and it is a straight multiplier on every debug-profile test that cooks.

## The fix

Memoize digests on the file's **observed identity** — device, inode, size, modification time, change time — not on its path. Writing to a file moves its modification and change times; replacing it moves its inode. A hit therefore means nothing has touched those bytes since this process read them.

This is not a new trust model: it is the identity key `TestExecutableFileIdentity` already uses for the hermetic fixture cache, promoted from the `test-support` workaround to the production path it was working around. The memo is process local and never persisted, so it cannot outlive the observation it came from, and the pin's integrity contract is unchanged.

Publication additionally seeds the digest its own validation needs. Sealing the pin's mode and hard-linking it both move the inode's change time, so the destination cannot resolve from the source's entry — observe it once publication has finished mutating it.

Expected reads per cook: **7 → 3** (parent: source + staging; child: the pin it is executing).

Also streams the hash instead of `fs::read`. `content_hash` documents that `sha256_file` exists "so hashing a multi-gigabyte release artifact does not read it into memory"; hashing the controller binary was the caller ignoring that, holding hundreds of megabytes resident in a process about to fork a controller runtime.

## Tests

Two new unit tests in `controller_runtime`, both asserting the *invalidation* as well as the hit, because a memo that survives a content change would let a replaced controller validate:

- `executable_digests_are_memoized_per_observed_file_identity` — an unchanged executable is read once per process; a mutated one never reuses its prior digest.
- `publishing_a_pin_seeds_the_digest_its_validation_needs` — publication performs exactly two reads and its validation performs none; a tampered pin still fails closed rather than resolving from the memo.

The existing `test_fixture_identity_cache_reuses_sealed_candidates_and_invalidates_changes` covers the same invariants for the fixture cache and is unchanged.

## Not verified locally

`cargo build`/`test`/`check` cannot run on the authoring host (OOM). `cargo fmt` clean; correctness is on CI.

Refs #10659, #10655