### PR TITLE
fix: fail fast on unleased daemon conflicts

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -1759,12 +1759,49 @@ fn start_or_return_live_unlocked_with_startup_token(
 ) -> Result<DaemonStartResult> {
     let _repaired_legacy_lease = repair_legacy_lease_for_start()?;
     reattach_exact_live_owner()?;
+    refuse_unleased_process_conflict()?;
     start_or_return_live_with_operations(
         read_status,
         try_acquire_daemon_owner_lock,
         || stop_unlocked().map(|_| ()),
         || spawn_and_wait_for_lease(addr, startup_token),
     )
+}
+
+/// A missing lease cannot authorize replacement when another foreground daemon
+/// may still own this store. Starting a child in this state only delays the
+/// diagnosis until that child fails to acquire `owner.lock`; return the typed
+/// evidence immediately and never signal a process we cannot prove we own.
+fn refuse_unleased_process_conflict() -> Result<()> {
+    let state_path = crate::paths::daemon_state_file()?;
+    if state_path.exists() {
+        return Ok(());
+    }
+    let candidates = daemon_process_candidates(&crate::paths::daemon_jobs_file()?)?
+        .into_iter()
+        .filter(|candidate| {
+            matches!(
+                candidate.ownership,
+                DaemonProcessOwnership::Owning | DaemonProcessOwnership::Ambiguous
+            )
+        })
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return Ok(());
+    }
+
+    let mut error = Error::internal_unexpected(
+        "daemon lease is missing while foreground daemon candidates remain live; refusing replacement without an authoritative lease",
+    );
+    error.details = serde_json::json!({
+        "classification": "daemon_unleased_process_conflict",
+        "state_path": state_path,
+        "candidates": candidates,
+        "safe_next_action": "Run `homeboy daemon status` and reconcile only a daemon whose PID, binary identity, durable-store path, and startup token are all attributable to this state directory.",
+    });
+    Err(error.with_hint(
+        "No process was terminated. Preserve active jobs and inspect the reported candidates before an explicit lease-bound stop or recovery.".to_string(),
+    ))
 }
 
 /// Restore the lease only for one process whose executable and explicit HOME

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -787,16 +787,57 @@ pub fn read_status() -> Result<DaemonStatus> {
         pid_is_running,
     );
     let active_jobs = active_job_recovery_evidence.len();
+    let process_candidates = control::daemon_process_candidates(&jobs_path)?;
+    let mut freshness = freshness_report_from_validation(&validation, active_jobs);
+    let candidate_conflict = validation.stale_reason_code
+        == Some(DaemonStaleReasonCode::LeaseMissing)
+        && process_candidates.iter().any(|candidate| {
+            matches!(
+                candidate.ownership,
+                DaemonProcessOwnership::Owning | DaemonProcessOwnership::Ambiguous
+            )
+        });
+    let stale_reason = if candidate_conflict {
+        let evidence = process_candidates
+            .iter()
+            .filter(|candidate| {
+                matches!(
+                    candidate.ownership,
+                    DaemonProcessOwnership::Owning | DaemonProcessOwnership::Ambiguous
+                )
+            })
+            .map(|candidate| {
+                format!(
+                    "pid={} ownership={:?} endpoint={}",
+                    candidate.pid,
+                    candidate.ownership,
+                    candidate.bind_endpoint.as_deref().unwrap_or("unreported")
+                )
+            })
+            .collect::<Vec<_>>();
+        let message = format!(
+            "daemon lease is missing while foreground daemon candidates remain live: {}; no process was signaled",
+            evidence.join(", ")
+        );
+        freshness.ownership_evidence = Some(message.clone());
+        freshness.repair_plan = vec![DaemonRepairStep {
+            code: "daemon_conflicting_owner_inspect".to_string(),
+            command: "homeboy daemon status".to_string(),
+        }];
+        Some(message)
+    } else {
+        validation.stale_reason.clone()
+    };
     Ok(DaemonStatus {
         running: validation.running && validation.fresh && validation.reachable,
         fresh: validation.fresh,
         reachable: validation.reachable,
-        freshness: freshness_report_from_validation(&validation, active_jobs),
-        stale_reason: validation.stale_reason,
+        freshness,
+        stale_reason,
         state: validation.state,
         state_path,
         state_identity,
-        process_candidates: control::daemon_process_candidates(&jobs_path)?,
+        process_candidates,
         active_job_recovery_evidence,
         termination_evidence: (!validation.running)
             .then(read_termination_evidence)


### PR DESCRIPTION
Closes #10736

## Summary
- Refuse daemon replacement before spawning when the lease is missing but typed foreground process evidence identifies an owning or ambiguous candidate.
- Return structured candidate, state-path, and safe recovery diagnostics without signaling any process or mutating active jobs.
- Surface the same conflict in daemon status freshness evidence and repair planning.

## Reproduction Evidence
- The pre-fix path reattached only one exact owner; multiple live candidates fell through to a child spawn that could not acquire `owner.lock`, then waited through the startup poll.
- The new pre-spawn check terminates that path immediately with `daemon_unleased_process_conflict`, including PID, executable, command line, endpoint, durable-store path, build identity, and ownership classification.
- Existing core tests cover owner-lock exclusion, multiple ambiguous candidates, stale/missing leases, active-job preservation, startup tokens, and bounded lifecycle-lock waiting using isolated homes.

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-core`
- `cargo test -p homeboy-core daemon::daemon_test::status_treats_dead_known_legacy_lease_as_missing_metadata_for_recovery --lib`
- `cargo test -p homeboy-core daemon::daemon_test::test_pid_is_running_rejects_impossible_pid_and_drives_status --lib`
- `cargo test -p homeboy-core daemon --lib` ran 185 tests: 179 passed; six pre-existing parallel-test failures outside this change.
- `cargo clippy -p homeboy-core --lib -- -D warnings` is blocked by two existing warnings promoted to errors in `homeboy-lab-runner-contract`.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested the daemon conflict diagnostics. Chris remains responsible for every line.