### PR TITLE
Run Homeboy-owned retention stores automatically

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, HashSet};
+use std::fs::{self, OpenOptions};
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 
 use clap::{Args, Subcommand, ValueEnum};
+use fs4::fs_std::FileExt;
 use homeboy::core::cleanup::{
     self, ArtifactCleanupOptions, ArtifactCleanupSort, CleanupPolicy, CleanupPolicyOverrides,
     ResourceCleanupOptions,
@@ -63,6 +66,23 @@ pub struct CleanupArgs {
 
     #[command(subcommand)]
     pub command: Option<CleanupCommand>,
+}
+
+const AUTOMATIC_RETENTION_LOCK_FILE: &str = "automatic-retention-controller.lock";
+const AUTOMATIC_RETENTION_STATE_FILE: &str = "automatic-retention-controller.json";
+
+// Advisory file locks are process-scoped on POSIX. Keep the process-local gate
+// so a manual invocation cannot overlap a scheduled pass in this process.
+static AUTOMATIC_RETENTION_ADMISSION: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[derive(Serialize)]
+struct AutomaticRetentionControllerOutput {
+    command: &'static str,
+    status: &'static str,
+    state_path: String,
+    resume_command: &'static str,
+    reconciliation: homeboy::agents::agent_task_service::AgentTaskReconcileReport,
+    cleanup: Value,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -237,16 +257,7 @@ pub fn run(args: CleanupArgs) -> CmdResult<Value> {
                 })
             })
             .map(|output| (output, 0)),
-        Some(CleanupCommand::AutomaticRetention) => cleanup::run_automatic_cargo_retention()
-            .and_then(|output| {
-                serde_json::to_value(output).map_err(|err| {
-                    homeboy::core::Error::internal_json(
-                        err.to_string(),
-                        Some("serialize automatic retention output".to_string()),
-                    )
-                })
-            })
-            .map(|output| (output, 0)),
+        Some(CleanupCommand::AutomaticRetention) => automatic_retention(),
         None => cleanup_inventory(args).map(|output| (output, 0)),
     }
 }
@@ -917,6 +928,114 @@ const CONTROLLER_RUNTIMES_METADATA: CleanupInventoryCategoryMetadata =
         dry_run_command: "homeboy runtime controller-prune",
         apply_command: "homeboy runtime controller-prune --apply",
     };
+
+fn automatic_retention() -> CmdResult<Value> {
+    let data = homeboy::core::paths::homeboy_data()?;
+    fs::create_dir_all(&data).map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("create automatic retention state directory".to_string()),
+        )
+    })?;
+    let state_path = data.join(AUTOMATIC_RETENTION_STATE_FILE);
+    let admission = AUTOMATIC_RETENTION_ADMISSION
+        .get_or_init(|| Mutex::new(()))
+        .try_lock();
+    let Ok(_admission) = admission else {
+        return Ok((
+            serde_json::json!({
+                "command": "cleanup.automatic_retention",
+                "status": "busy",
+                "state_path": state_path,
+                "resume_command": "homeboy cleanup automatic-retention",
+            }),
+            0,
+        ));
+    };
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(data.join(AUTOMATIC_RETENTION_LOCK_FILE))
+        .map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some("open automatic retention lock".to_string()),
+            )
+        })?;
+    if lock.try_lock_exclusive().is_err() {
+        return Ok((
+            serde_json::json!({
+                "command": "cleanup.automatic_retention",
+                "status": "busy",
+                "state_path": state_path,
+                "resume_command": "homeboy cleanup automatic-retention",
+            }),
+            0,
+        ));
+    }
+
+    fs::write(&state_path, r#"{"status":"running"}"#).map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("write automatic retention state".to_string()),
+        )
+    })?;
+    let reconciliation = homeboy::agents::agent_task_service::reconcile_stale_active_runs(false)?;
+    let cleanup = cleanup_inventory(CleanupArgs {
+        apply: true,
+        include: vec![
+            CleanupCategoryArg::TerminalRuns,
+            CleanupCategoryArg::PersistedRunArtifacts,
+            CleanupCategoryArg::OrphanedArtifactBytes,
+            CleanupCategoryArg::RuntimeTmp,
+            CleanupCategoryArg::ControllerScratch,
+            CleanupCategoryArg::ControllerRuntimes,
+        ],
+        exclude: Vec::new(),
+        older_than_days: None,
+        limit: None,
+        full: false,
+        cursor: None,
+        command: None,
+    })?;
+    let cargo_targets = cleanup::run_automatic_cargo_retention()?;
+    let status = cargo_targets.status;
+    let output = AutomaticRetentionControllerOutput {
+        command: "cleanup.automatic_retention",
+        status,
+        state_path: state_path.display().to_string(),
+        resume_command: "homeboy cleanup automatic-retention",
+        reconciliation,
+        cleanup: serde_json::json!({
+            "categories": cleanup,
+            "cargo_targets": cargo_targets,
+        }),
+    };
+    let value = serde_json::to_value(&output).map_err(|error| {
+        homeboy::core::Error::internal_json(
+            error.to_string(),
+            Some("serialize automatic retention output".to_string()),
+        )
+    })?;
+    fs::write(
+        &state_path,
+        serde_json::to_vec_pretty(&value).map_err(|error| {
+            homeboy::core::Error::internal_json(
+                error.to_string(),
+                Some("serialize automatic retention state".to_string()),
+            )
+        })?,
+    )
+    .map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("write automatic retention state".to_string()),
+        )
+    })?;
+    Ok((value, 0))
+}
 
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     let selected = CleanupCategorySelection::new(args.include, args.exclude);

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -67,7 +67,7 @@ homeboy cleanup --include shared-cargo-targets --apply
 
 ## Automatic Retention
 
-Declare the bounded Cargo-target retention pass through Homeboy's scheduler:
+Declare the bounded retention pass through Homeboy's scheduler:
 
 ```bash
 homeboy schedule add automatic-retention \
@@ -76,7 +76,7 @@ homeboy schedule add automatic-retention \
   --on-overlap skip
 ```
 
-The schedule declaration is the explicit opt-in to unattended mutation. The Homeboy daemon owns cadence, overlap prevention, and stale-run recovery; no external timer is needed. `retention.limit` caps inspected stores per pass, while the existing Cargo byte budget and active-lease predicate remain authoritative. The cleanup command retains its own single-flight lock so a manual invocation cannot overlap a scheduled run. State, continuation cursor, and the exact resume command are written under the Homeboy data directory.
+The schedule declaration is the explicit opt-in to unattended mutation. The Homeboy daemon owns cadence, overlap prevention, and stale-run recovery; no external timer is needed. Each pass first reconciles stale agent-task records, then applies the existing terminal-run, persisted-artifact, orphaned-byte, runtime-temp, controller-scratch, controller-runtime, and shared-Cargo cleanup policies. Runner downloads, worktrees, and external providers remain outside unattended scope. `retention.limit` caps each category; Cargo retains its configured aggregate byte budget and active-lease predicate. The controller has a process and cross-process single-flight lock, writes combined pass evidence under the Homeboy data directory, and returns `homeboy cleanup automatic-retention` as the exact resume command.
 
 ## Runner Binary Caches
 


### PR DESCRIPTION
## Summary

- make `homeboy cleanup automatic-retention` reconcile stale agent-task lifecycle records before applying existing safe cleanup owners
- converge terminal runs, persisted artifacts, orphaned bytes, runtime temp, controller scratch, controller runtimes, and the existing bounded Cargo target executor in one scheduled pass
- add process-local and cross-process single-flight admission plus durable combined pass evidence and an exact resume command

The existing Homeboy scheduler remains the explicit opt-in: declare `homeboy schedule add automatic-retention --command "cleanup automatic-retention" --every 1h --on-overlap skip`. No schedule is created by default. External worktrees/providers and operator-requested runner downloads remain outside unattended mutation. Existing category-level lease, lifecycle, Git, containment, and evidence protections remain authoritative.

Closes #10695.

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-core cleanup::automatic_retention --lib`
- `cargo test -p homeboy-cli --lib cli_surface::reference_docs`
- `cargo clippy -p homeboy-cli --no-deps`

`cargo clippy` completes with pre-existing workspace warnings.

## AI assistance

OpenAI GPT-5.6 Sol, using OpenCode, was used for implementation and tests. Chris remains responsible for every line.