### PR TITLE
Fix retained storage filesystem reconciliation

### DIFF
--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -114,7 +114,7 @@ fn allocate_attempt_at_index(
     attempt: u32,
     index_path: PathBuf,
 ) -> Result<ControllerScratchAllocation> {
-    let root = paths::homeboy_data()?.join("controller-scratch/attempts");
+    let root = paths::controller_scratch_store()?.join("attempts");
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -1697,7 +1697,7 @@ fn path_size(path: &Path) -> Result<u64> {
 }
 
 fn index_path() -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?.join("controller-scratch/resources.json"))
+    Ok(paths::controller_scratch_store()?.join("resources.json"))
 }
 
 fn with_index_lock<T>(index_path: &Path, operation: impl FnOnce() -> Result<T>) -> Result<T> {

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Args, Subcommand, ValueEnum};
 use homeboy::core::cleanup::{
@@ -297,6 +297,9 @@ struct RetainedStorageReport {
     continuation: Option<String>,
     safe_next_commands: Vec<String>,
     sqlite: RetainedStorageSqlite,
+    /// Added in #9824. Existing lifecycle aggregates above retain their
+    /// historical meaning; this is the direct filesystem reconciliation view.
+    filesystem: RetainedStorageFilesystem,
 }
 
 #[derive(Debug, Serialize)]
@@ -306,6 +309,43 @@ struct RetainedStorageSqlite {
     size_bytes: u64,
     status_command: &'static str,
     compaction: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct RetainedStorageFilesystem {
+    root: RetainedStorageFilesystemUsage,
+    top_level: Vec<RetainedStorageFilesystemEntry>,
+    reconciliation: RetainedStorageReconciliation,
+    accounting_notes: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct RetainedStorageFilesystemUsage {
+    path: String,
+    exists: bool,
+    apparent_bytes: u64,
+    physical_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct RetainedStorageFilesystemEntry {
+    path: String,
+    category: &'static str,
+    classification: &'static str,
+    apparent_bytes: u64,
+    physical_bytes: u64,
+    cleanup_or_status_command: &'static str,
+    largest_examples: Vec<RetainedStorageFilesystemUsage>,
+}
+
+#[derive(Debug, Serialize)]
+struct RetainedStorageReconciliation {
+    top_level_apparent_bytes: u64,
+    top_level_physical_bytes: u64,
+    apparent_difference_bytes: u64,
+    physical_difference_bytes: u64,
+    apparent_difference_direction: &'static str,
+    physical_difference_direction: &'static str,
 }
 
 fn retained_storage_report(
@@ -471,12 +511,242 @@ fn retained_storage_report(
         });
     }
 
+    let filesystem = retained_storage_filesystem_inventory()?;
     Ok(build_retained_storage_report(
         records,
         args.limit,
         args.cursor.as_deref(),
         sqlite,
+        filesystem,
     ))
+}
+
+fn retained_storage_filesystem_inventory() -> homeboy::core::Result<RetainedStorageFilesystem> {
+    let root = homeboy::core::paths::homeboy_data()?;
+    let root_usage = filesystem_usage(&root)?;
+    let mut top_level = Vec::new();
+    if root.exists() {
+        for entry in std::fs::read_dir(&root).map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(format!("read Homeboy storage root {}", root.display())),
+            )
+        })? {
+            let entry = entry.map_err(|error| {
+                homeboy::core::Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read Homeboy storage root {}", root.display())),
+                )
+            })?;
+            top_level.push(filesystem_entry(entry.path())?);
+        }
+    }
+
+    // An explicit artifact root can live on a separate volume. It is still a
+    // Homeboy store, but cannot be reconciled into the data-root totals.
+    let artifact_root = homeboy::core::artifacts::root()?;
+    if !artifact_root.starts_with(&root) {
+        top_level.push(filesystem_entry_with_category(
+            artifact_root,
+            "artifacts",
+            "managed/external",
+            "homeboy cleanup --include persisted-run-artifacts",
+        )?);
+    }
+    top_level.sort_by_key(|entry| std::cmp::Reverse(entry.physical_bytes));
+
+    let apparent_total = top_level
+        .iter()
+        .filter(|entry| entry.classification != "managed/external")
+        .map(|entry| entry.apparent_bytes)
+        .sum();
+    let physical_total = top_level
+        .iter()
+        .filter(|entry| entry.classification != "managed/external")
+        .map(|entry| entry.physical_bytes)
+        .sum();
+    Ok(RetainedStorageFilesystem {
+        root: RetainedStorageFilesystemUsage {
+            path: root.display().to_string(),
+            exists: root.exists(),
+            apparent_bytes: root_usage.apparent_bytes,
+            physical_bytes: root_usage.physical_bytes,
+        },
+        top_level,
+        reconciliation: RetainedStorageReconciliation {
+            top_level_apparent_bytes: apparent_total,
+            top_level_physical_bytes: physical_total,
+            apparent_difference_bytes: root_usage.apparent_bytes.abs_diff(apparent_total),
+            physical_difference_bytes: root_usage.physical_bytes.abs_diff(physical_total),
+            apparent_difference_direction: difference_direction(root_usage.apparent_bytes, apparent_total),
+            physical_difference_direction: difference_direction(root_usage.physical_bytes, physical_total),
+        },
+        accounting_notes: vec![
+            "Apparent bytes sum file lengths; physical bytes sum allocated filesystem blocks.",
+            "Sparse files can have greater apparent than physical bytes.",
+            "Root totals de-duplicate hard-linked inodes; independently measured top-level stores can count a cross-store hard link more than once.",
+            "The root directory's own metadata and filesystem allocation granularity can leave a small reconciliation difference.",
+            "Symlinks are measured as links and are not followed.",
+        ],
+    })
+}
+
+fn difference_direction(root: u64, top_level: u64) -> &'static str {
+    match root.cmp(&top_level) {
+        std::cmp::Ordering::Equal => "equal",
+        std::cmp::Ordering::Greater => "root_greater",
+        std::cmp::Ordering::Less => "top_level_greater",
+    }
+}
+
+fn filesystem_entry(path: PathBuf) -> homeboy::core::Result<RetainedStorageFilesystemEntry> {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let (category, classification, command) = match name {
+        "artifacts" => (
+            "artifacts",
+            "managed",
+            "homeboy cleanup --include persisted-run-artifacts",
+        ),
+        homeboy::core::paths::CARGO_TARGETS_STORE => (
+            "shared_cargo_targets",
+            "managed/shared",
+            "homeboy cleanup --include shared-cargo-targets",
+        ),
+        homeboy::core::paths::CONTROLLER_RUNTIMES_STORE => (
+            "controller_runtimes",
+            "managed",
+            "homeboy cleanup --include controller-runtimes",
+        ),
+        homeboy::core::paths::CONTROLLER_SCRATCH_STORE => (
+            "controller_scratch",
+            "managed",
+            "homeboy cleanup --include controller-scratch",
+        ),
+        "homeboy.sqlite" => ("sqlite_observation_store", "managed", "homeboy db status"),
+        _ => (
+            "unknown_storage",
+            "unknown/unmanaged",
+            "inspect path ownership before removal",
+        ),
+    };
+    filesystem_entry_with_category(path, category, classification, command)
+}
+
+fn filesystem_entry_with_category(
+    path: PathBuf,
+    category: &'static str,
+    classification: &'static str,
+    command: &'static str,
+) -> homeboy::core::Result<RetainedStorageFilesystemEntry> {
+    let usage = filesystem_usage(&path)?;
+    Ok(RetainedStorageFilesystemEntry {
+        path: path.display().to_string(),
+        category,
+        classification,
+        apparent_bytes: usage.apparent_bytes,
+        physical_bytes: usage.physical_bytes,
+        cleanup_or_status_command: command,
+        largest_examples: largest_children(&path)?,
+    })
+}
+
+#[derive(Default)]
+struct FilesystemUsage {
+    apparent_bytes: u64,
+    physical_bytes: u64,
+}
+
+fn filesystem_usage(path: &Path) -> homeboy::core::Result<FilesystemUsage> {
+    let mut seen = HashSet::new();
+    let mut usage = FilesystemUsage::default();
+    accumulate_filesystem_usage(path, &mut seen, &mut usage)?;
+    Ok(usage)
+}
+
+fn accumulate_filesystem_usage(
+    path: &Path,
+    seen: &mut HashSet<(u64, u64)>,
+    usage: &mut FilesystemUsage,
+) -> homeboy::core::Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(format!("measure Homeboy storage path {}", path.display())),
+            ))
+        }
+    };
+    #[cfg(unix)]
+    let identity = {
+        use std::os::unix::fs::MetadataExt;
+        (metadata.dev(), metadata.ino())
+    };
+    #[cfg(not(unix))]
+    let identity = (0, 0);
+    if seen.insert(identity) {
+        usage.apparent_bytes = usage.apparent_bytes.saturating_add(metadata.len());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            usage.physical_bytes = usage
+                .physical_bytes
+                .saturating_add(metadata.blocks().saturating_mul(512));
+        }
+        #[cfg(not(unix))]
+        {
+            usage.physical_bytes = usage.physical_bytes.saturating_add(metadata.len());
+        }
+    }
+    if metadata.file_type().is_dir() {
+        for entry in std::fs::read_dir(path).map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(format!("read Homeboy storage path {}", path.display())),
+            )
+        })? {
+            let entry = entry.map_err(|error| {
+                homeboy::core::Error::internal_io(
+                    error.to_string(),
+                    Some(format!("read Homeboy storage path {}", path.display())),
+                )
+            })?;
+            accumulate_filesystem_usage(&entry.path(), seen, usage)?;
+        }
+    }
+    Ok(())
+}
+
+fn largest_children(path: &Path) -> homeboy::core::Result<Vec<RetainedStorageFilesystemUsage>> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(homeboy::core::Error::internal_io(error.to_string(), None)),
+    };
+    if !metadata.file_type().is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut children = Vec::new();
+    for entry in std::fs::read_dir(path)
+        .map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?
+    {
+        let entry =
+            entry.map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?;
+        let usage = filesystem_usage(&entry.path())?;
+        children.push(RetainedStorageFilesystemUsage {
+            path: entry.path().display().to_string(),
+            exists: true,
+            apparent_bytes: usage.apparent_bytes,
+            physical_bytes: usage.physical_bytes,
+        });
+    }
+    children.sort_by_key(|entry| std::cmp::Reverse(entry.physical_bytes));
+    children.truncate(10);
+    Ok(children)
 }
 
 /// Account for the artifact root — the product's primary output store.
@@ -632,6 +902,7 @@ fn build_retained_storage_report(
     limit: usize,
     cursor: Option<&str>,
     sqlite: RetainedStorageSqlite,
+    filesystem: RetainedStorageFilesystem,
 ) -> RetainedStorageReport {
     records.sort_by(|left, right| {
         right
@@ -691,6 +962,7 @@ fn build_retained_storage_report(
             "homeboy db status".to_string(),
         ],
         sqlite,
+        filesystem,
     }
 }
 
@@ -2166,6 +2438,7 @@ mod tests {
                 status_command: "homeboy db status",
                 compaction: "delegated",
             },
+            test_filesystem(),
         );
 
         assert_eq!(report.retained_count, 3);
@@ -2205,6 +2478,7 @@ mod tests {
                 status_command: "homeboy db status",
                 compaction: "delegated",
             },
+            test_filesystem(),
         );
         assert_eq!(continuation.largest_examples[0].reference, "runtime-a");
         assert_eq!(age_bucket(3_600), "under_1d");
@@ -2238,6 +2512,93 @@ mod tests {
         }
     }
 
+    fn test_filesystem() -> RetainedStorageFilesystem {
+        RetainedStorageFilesystem {
+            root: RetainedStorageFilesystemUsage {
+                path: "/homeboy".to_string(),
+                exists: true,
+                apparent_bytes: 0,
+                physical_bytes: 0,
+            },
+            top_level: Vec::new(),
+            reconciliation: RetainedStorageReconciliation {
+                top_level_apparent_bytes: 0,
+                top_level_physical_bytes: 0,
+                apparent_difference_bytes: 0,
+                physical_difference_bytes: 0,
+                apparent_difference_direction: "equal",
+                physical_difference_direction: "equal",
+            },
+            accounting_notes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn filesystem_inventory_exposes_large_cargo_children_and_unknown_storage() {
+        let root = TempDir::new().expect("storage root");
+        let cargo = root.path().join(homeboy::core::paths::CARGO_TARGETS_STORE);
+        let target = cargo.join("homeboy-b706ed1ffed4");
+        std::fs::create_dir_all(&target).expect("cargo target");
+        let debug = target.join("debug");
+        std::fs::File::create(&debug)
+            .expect("debug artifact")
+            .set_len(42 * 1024 * 1024 * 1024)
+            .expect("sparse 42 GiB debug artifact");
+        let unknown = root.path().join("left-behind-store");
+        std::fs::create_dir_all(&unknown).expect("unknown store");
+        std::fs::write(unknown.join("data"), b"unmanaged").expect("unknown data");
+
+        let cargo_entry = filesystem_entry(cargo).expect("cargo inventory");
+        assert_eq!(cargo_entry.category, "shared_cargo_targets");
+        assert_eq!(
+            cargo_entry.cleanup_or_status_command,
+            "homeboy cleanup --include shared-cargo-targets"
+        );
+        assert!(
+            cargo_entry.largest_examples[0].apparent_bytes >= 42 * 1024 * 1024 * 1024,
+            "the target directory includes its own metadata beside the debug file"
+        );
+        assert!(cargo_entry.largest_examples[0]
+            .path
+            .ends_with("homeboy-b706ed1ffed4"));
+
+        let unknown_entry = filesystem_entry(unknown).expect("unknown inventory");
+        assert_eq!(unknown_entry.category, "unknown_storage");
+        assert_eq!(unknown_entry.classification, "unknown/unmanaged");
+        assert_eq!(
+            unknown_entry.cleanup_or_status_command,
+            "inspect path ownership before removal"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filesystem_usage_deduplicates_hard_links_in_root_totals() {
+        let root = TempDir::new().expect("storage root");
+        let first = root.path().join("cargo-targets");
+        let second = root.path().join("controller-runtimes");
+        std::fs::create_dir_all(&first).expect("first store");
+        std::fs::create_dir_all(&second).expect("second store");
+        let original = first.join("shared");
+        std::fs::File::create(&original)
+            .expect("shared file")
+            .set_len(1024 * 1024)
+            .expect("shared file length");
+        std::fs::hard_link(&original, second.join("shared")).expect("hard link");
+
+        let root_usage = filesystem_usage(root.path()).expect("root usage");
+        let per_store_apparent = filesystem_usage(&first)
+            .expect("first usage")
+            .apparent_bytes
+            + filesystem_usage(&second)
+                .expect("second usage")
+                .apparent_bytes;
+        assert!(
+            root_usage.apparent_bytes < per_store_apparent,
+            "root accounting must count one shared inode once"
+        );
+    }
+
     #[test]
     fn reclaimable_storage_is_never_summed_into_the_retained_total() {
         // "cleanup cannot free this" and "cleanup has not freed this yet" are
@@ -2252,6 +2613,7 @@ mod tests {
             10,
             None,
             test_sqlite(),
+            test_filesystem(),
         );
 
         assert_eq!(report.inspected_count, 3);
@@ -2269,7 +2631,8 @@ mod tests {
 
     #[test]
     fn retained_storage_names_a_reclaim_command_for_every_artifact_root_category() {
-        let report = build_retained_storage_report(Vec::new(), 1, None, test_sqlite());
+        let report =
+            build_retained_storage_report(Vec::new(), 1, None, test_sqlite(), test_filesystem());
 
         // The report used to accumulate from five sources and never reach the
         // artifact root, so an operator saw bytes it could not name a command

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -121,6 +121,9 @@ pub enum CleanupCommand {
     Worktrees(CleanupWorktreesArgs),
 
     /// Explain retained Homeboy storage without deleting or reconciling resources.
+    ///
+    /// Reports lifecycle aggregates alongside root filesystem accounting, top-level
+    /// stores, largest child paths, ownership classification, and cleanup guidance.
     RetainedStorage(CleanupRetainedStorageArgs),
 
     /// Run one configured, bounded retention pass

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 
 use crate::{Error, Result};
 
-const STORE_ROOT: &str = "cargo-targets";
 const LOCK_FILE: &str = ".homeboy-lock";
 const LEASE_FILE: &str = ".homeboy-lease";
 const OWNER_FILE: &str = ".homeboy-owner";
@@ -87,7 +86,7 @@ impl Drop for SharedCargoTargetLease {
 }
 
 pub fn acquire_shared_cargo_target(owner: &str) -> Result<SharedCargoTargetLease> {
-    let root = homeboy_paths::homeboy_data()?.join(STORE_ROOT);
+    let root = homeboy_paths::cargo_targets_store()?;
     acquire_shared_cargo_target_in(&root, owner, SystemTime::now())
 }
 
@@ -122,7 +121,7 @@ pub fn cleanup_shared_cargo_targets(
 ) -> Result<CargoTargetCleanupOutput> {
     let root = options
         .root
-        .unwrap_or(homeboy_paths::homeboy_data()?.join(STORE_ROOT));
+        .unwrap_or(homeboy_paths::cargo_targets_store()?);
     let mut stores = inventory(&root, options.now, options.older_than, options.lease_ttl)?;
     let inventory_bytes: u64 = stores.iter().map(|store| store.size_bytes).sum();
     stores.sort_by(order_stores);
@@ -249,7 +248,7 @@ pub fn shared_cargo_target_inventory(
     older_than: Duration,
     lease_ttl: Duration,
 ) -> Result<Vec<CargoTargetStore>> {
-    let root = root.unwrap_or(homeboy_paths::homeboy_data()?.join(STORE_ROOT));
+    let root = root.unwrap_or(homeboy_paths::cargo_targets_store()?);
     let mut stores = inventory(&root, now, older_than, lease_ttl)?;
     stores.sort_by(order_stores);
     Ok(stores)

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1047,7 +1047,7 @@ fn recover_pin_unlocked(
 }
 
 fn runtime_root() -> Result<PathBuf> {
-    let root = paths::homeboy_data()?.join("controller-runtimes");
+    let root = paths::controller_runtimes_store()?;
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -5,6 +5,9 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 pub const HOMEBOY_DATA_DIR_ENV: &str = "HOMEBOY_DATA_DIR";
+pub const CARGO_TARGETS_STORE: &str = "cargo-targets";
+pub const CONTROLLER_RUNTIMES_STORE: &str = "controller-runtimes";
+pub const CONTROLLER_SCRATCH_STORE: &str = "controller-scratch";
 
 mod locations;
 mod rigs;
@@ -144,6 +147,26 @@ pub fn observation_db() -> Result<PathBuf> {
     Ok(homeboy_data()?.join("homeboy.sqlite"))
 }
 
+/// Resolve a named store below the Homeboy data root.
+///
+/// Storage owners use this rather than rebuilding paths so reporting and future
+/// placement policy can refer to the same stable store identities.
+pub fn homeboy_data_store(name: &str) -> Result<PathBuf> {
+    Ok(homeboy_data()?.join(name))
+}
+
+pub fn cargo_targets_store() -> Result<PathBuf> {
+    homeboy_data_store(CARGO_TARGETS_STORE)
+}
+
+pub fn controller_runtimes_store() -> Result<PathBuf> {
+    homeboy_data_store(CONTROLLER_RUNTIMES_STORE)
+}
+
+pub fn controller_scratch_store() -> Result<PathBuf> {
+    homeboy_data_store(CONTROLLER_SCRATCH_STORE)
+}
+
 /// Root directory for copied run artifacts.
 ///
 /// Precedence:
@@ -172,7 +195,7 @@ pub fn artifact_root() -> Result<PathBuf> {
         }
     }
 
-    Ok(homeboy_data()?.join("artifacts"))
+    homeboy_data_store("artifacts")
 }
 
 /// Expand a leading tilde in a local path.

--- a/docs/cleanup-retention.md
+++ b/docs/cleanup-retention.md
@@ -172,6 +172,17 @@ Protected persisted artifacts are summarized as one counted record rather than
 one zero-byte row each: only rows classified for removal carry a measured size,
 and an unmeasured size is reported as zero and never inferred.
 
+The additive `filesystem` object is the root-accounting contract. It inventories
+every top-level data-root entry, including `artifacts`, `cargo-targets`,
+`controller-runtimes`, `controller-scratch`, and the SQLite store, and labels
+unrecognized entries `unknown/unmanaged`. It also includes configured artifact
+roots outside the data root as `managed/external`. `apparent_bytes` is the sum
+of file lengths; `physical_bytes` is allocated filesystem blocks. Sparse files,
+hard links shared across top-level stores, directory metadata, and allocation
+granularity can make the top-level sum differ from root physical usage; the
+report states the direction and byte difference rather than hiding it. Existing
+`retained_bytes` and lifecycle aggregates remain unchanged for consumers.
+
 ## Remaining Scope
 
 The following Issue #8648 portions remain independently owned and are not

--- a/docs/reference/cli/commands/cleanup.md
+++ b/docs/reference/cli/commands/cleanup.md
@@ -77,10 +77,9 @@ Aggregate cleanup across configured external worktree providers
 homeboy cleanup retained-storage [OPTIONS]
 ```
 
-Explain retained Homeboy storage without deleting or reconciling resources. The
-output preserves the existing lifecycle aggregates and adds a `filesystem`
-reconciliation view with root apparent/physical totals, every top-level store,
-largest child examples, ownership classification, and cleanup/status guidance.
+Explain retained Homeboy storage without deleting or reconciling resources.
+
+Reports lifecycle aggregates alongside root filesystem accounting, top-level stores, largest child paths, ownership classification, and cleanup guidance.
 
 | Option | Value | Description |
 | --- | --- | --- |
@@ -94,3 +93,4 @@ homeboy cleanup automatic-retention
 ```
 
 Run one configured, bounded retention pass
+

--- a/docs/reference/cli/commands/cleanup.md
+++ b/docs/reference/cli/commands/cleanup.md
@@ -77,7 +77,10 @@ Aggregate cleanup across configured external worktree providers
 homeboy cleanup retained-storage [OPTIONS]
 ```
 
-Explain retained Homeboy storage without deleting or reconciling resources
+Explain retained Homeboy storage without deleting or reconciling resources. The
+output preserves the existing lifecycle aggregates and adds a `filesystem`
+reconciliation view with root apparent/physical totals, every top-level store,
+largest child examples, ownership classification, and cleanup/status guidance.
 
 | Option | Value | Description |
 | --- | --- | --- |
@@ -91,4 +94,3 @@ homeboy cleanup automatic-retention
 ```
 
 Run one configured, bounded retention pass
-


### PR DESCRIPTION
Closes #9824

## Summary
- add an additive filesystem reconciliation view for the Homeboy data root
- classify every top-level store, expose physical/apparent usage, largest children, and owning cleanup/status guidance
- centralize named storage paths for Cargo, controller runtime, and controller scratch so placement policy can reuse stable identities

## Verification
- `cargo test -p homeboy-cli filesystem_inventory_exposes_large_cargo_children_and_unknown_storage --lib -- --test-threads=1`
- `cargo test -p homeboy-cli filesystem_usage_deduplicates_hard_links_in_root_totals --lib -- --test-threads=1`
- `cargo fmt --all --check`
- `cargo check -p homeboy-cli`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode used for implementation and tests; Chris remains responsible.