### PR TITLE
Extend the measurement registry to the shell/YAML gate layer (#10741)

### DIFF
--- a/.github/release-quality-policy.sh
+++ b/.github/release-quality-policy.sh
@@ -1,17 +1,102 @@
 #!/usr/bin/env bash
+#
+# Release-blocking quality policy.
+#
+# Reads the three quality gate results and exits non-zero when a gate that
+# `BLOCKING_COMMANDS` declared release-blocking did not succeed.
+#
+# ── The measurement invariant, ported to shell (#10741 / #10685) ──
+#
+# This script used to render its verdict from a population it never checked for
+# emptiness. `check_command` matched each of `audit`/`lint`/`test` against the
+# configured set; anything that did not match took the "tracked but not
+# release-blocking" branch and left `failed` at 0. If NO command matched, all
+# three took that branch and the policy exited 0 having enforced nothing.
+#
+# Reproduced before the fix:
+#
+#   BLOCKING_COMMANDS="review tests,review lints" \
+#     AUDIT_RESULT=failure LINT_RESULT=failure TEST_RESULT=failure \
+#     bash .github/release-quality-policy.sh   # -> exit 0
+#
+# Blast radius, stated accurately: the *absent* input is already safe, because
+# `release.yml` interpolates
+# `${{ inputs.release_blocking_commands || 'review lint,review test' }}` and
+# GitHub's `||` treats the empty string as falsy, so the automated push path can
+# never reach here with an empty set. The reachable defect is a **malformed
+# non-empty set** — a `workflow_dispatch` typo such as `review tests` — which is
+# exactly the shape below that is now a hard error.
+#
+# The classification mirrors `Measurement::assess` in
+# `crates/homeboy-engine-primitives/src/measurement.rs`, using the same three
+# outcomes and the same vocabulary, so the shell gate layer and the Rust gate
+# layer answer this question the same way. Four divergent local answers to this
+# same question is the disease #10690 was treating; a fifth, in bash, would be
+# more of it.
+#
+#   population - configured blocking entries that canonicalize to a real token.
+#                Known independently of the matcher: it comes from splitting the
+#                input string, not from asking the matcher what it found.
+#   units      - checked commands that the matcher claimed.
+#
+#   units > 0                    -> measured        -> enforce, exit `failed`
+#   units == 0, population == 0  -> empty-population-> honest zero, warn, exit 0
+#   units == 0, population > 0   -> contradicted    -> broken instrument, exit 1
+#
+# `unknown` is deliberately NOT collapsed into `fail` here, and `contradicted`
+# deliberately IS a hard error — the same split `engine.rs` makes. See
+# `assess_measurement` below for why each branch chose what it chose.
+#
+# Env:
+#   BLOCKING_COMMANDS - comma-separated commands that may block release
+#                       preparation (e.g. "review lint,review test")
+#   AUDIT_RESULT      - gate-audit result
+#   LINT_RESULT       - gate-lint result
+#   TEST_RESULT       - gate-test result
 
 set -euo pipefail
 
-is_blocking_command() {
-  local command="$1"
+# Commands this policy is able to check. An entry in BLOCKING_COMMANDS naming
+# anything outside this set declares a blocking requirement that no measurement
+# can ever satisfy, which is why it is refused rather than ignored.
+CHECKABLE_COMMANDS='audit lint test'
+
+# Canonical form of a configured entry: lowercased, whitespace removed, and the
+# `review` verb stripped, so "review lint", "Review Lint" and "lint" are one
+# token. An entry that canonicalizes to the empty string declares nothing and is
+# not counted towards the population.
+canonicalize() {
+  local canonical
+  canonical="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  printf '%s' "${canonical#review}"
+}
+
+configured_tokens=()
+unmatched_tokens=()
+
+read_configured_tokens() {
   local configured
   local canonical
+  local raw=()
 
-  IFS=',' read -r -a configured_commands <<< "${BLOCKING_COMMANDS}"
-  for configured in "${configured_commands[@]}"; do
-    canonical="$(printf '%s' "${configured}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
-    canonical="${canonical#review}"
-    if [ "${canonical}" = "${command}" ]; then
+  IFS=',' read -r -a raw <<< "${BLOCKING_COMMANDS}"
+  for configured in ${raw+"${raw[@]}"}; do
+    canonical="$(canonicalize "${configured}")"
+    [ -n "${canonical}" ] || continue
+    configured_tokens+=("${canonical}")
+    case " ${CHECKABLE_COMMANDS} " in
+      *" ${canonical} "*) ;;
+      *) unmatched_tokens+=("${configured}") ;;
+    esac
+  done
+}
+
+is_blocking_command() {
+  local command="$1"
+  local token
+
+  for token in ${configured_tokens+"${configured_tokens[@]}"}; do
+    if [ "${token}" = "${command}" ]; then
       return 0
     fi
   done
@@ -20,12 +105,14 @@ is_blocking_command() {
 }
 
 failed=0
+measured_units=0
 
 check_command() {
   local command="$1"
   local result="$2"
 
   if is_blocking_command "${command}"; then
+    measured_units=$((measured_units + 1))
     if [ "${result}" = "success" ]; then
       echo "::notice::Release-blocking command ${command} passed"
     else
@@ -37,8 +124,78 @@ check_command() {
   fi
 }
 
+# The predicate. Classifies the matched population BEFORE the exit code is read,
+# and emits one machine-readable provenance line in every branch so a log reader
+# can tell a *measured zero* from *no measurement* without inferring it from the
+# exit code. Absence of this line means the script died before assessing, which
+# is a third state again and is also not a pass.
+assess_measurement() {
+  local population="${#configured_tokens[@]}"
+  local outcome
+
+  if [ "${measured_units}" -gt 0 ]; then
+    outcome='measured'
+  elif [ "${population}" -eq 0 ]; then
+    outcome='empty-population'
+  else
+    outcome='contradicted'
+  fi
+
+  echo "::notice::measurement basis=release-quality-policy population=${population} units=${measured_units} outcome=${outcome}"
+
+  case "${outcome}" in
+    measured)
+      return 0
+      ;;
+    empty-population)
+      # A MEASURED zero. Splitting the configured string is independent of the
+      # matcher, and it says there was genuinely nothing declared blocking, so
+      # zero matches is the right answer rather than a broken matcher. That is
+      # `MeasurementOutcome::EmptyPopulation`, which permits a pass.
+      #
+      # Warned rather than failed on purpose. `release.yml` cannot reach this
+      # branch (the `||` fallback supplies the default set), so hard-failing it
+      # would add red that no current run can produce while breaking any future
+      # deliberate "block on nothing" configuration. Loud is enough.
+      echo "::warning::No release-blocking commands are configured (BLOCKING_COMMANDS='${BLOCKING_COMMANDS}'), so this policy enforced nothing. Gate results are advisory for this run."
+      return 0
+      ;;
+    contradicted)
+      # `MeasurementOutcome::Contradicted`: zero matches against an
+      # independently non-empty population. The matcher is provably broken, not
+      # the gates, so neither `pass` nor `unknown` is honest — this is the one
+      # outcome the shared predicate makes a hard error rather than a verdict.
+      echo "::error::Release-blocking policy matched none of its ${population} configured command(s) (BLOCKING_COMMANDS='${BLOCKING_COMMANDS}'). Every gate fell through to the non-blocking branch, so this policy would have exited 0 while enforcing nothing. Checkable commands are: ${CHECKABLE_COMMANDS}."
+      return 1
+      ;;
+  esac
+}
+
+# A configured entry naming an uncheckable command is a declared blocking
+# requirement no measurement can satisfy. Refused rather than ignored: it is the
+# partial form of the same defect (one typo in "review lint,review tests"
+# silently stops the test gate blocking while the policy still reports
+# `outcome=measured`), and the remedy is a one-character edit to a
+# `workflow_dispatch` input. It cannot fire on the automated push path, whose
+# set is the well-formed default.
+assess_configuration() {
+  if [ "${#unmatched_tokens[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "::error::Release-blocking policy cannot check: ${unmatched_tokens[*]}. These entries of BLOCKING_COMMANDS='${BLOCKING_COMMANDS}' name no command this policy measures, so they declare a release-blocking requirement that is silently never enforced. Checkable commands are: ${CHECKABLE_COMMANDS}."
+  return 1
+}
+
+read_configured_tokens
+
 check_command audit "${AUDIT_RESULT}"
 check_command lint "${LINT_RESULT}"
 check_command test "${TEST_RESULT}"
+
+# The measurement is assessed before the gate verdict is returned, so a broken
+# matcher can never be reported as a clean run.
+assess_measurement || failed=1
+assess_configuration || failed=1
 
 exit "${failed}"

--- a/.github/release-quality-policy.sh
+++ b/.github/release-quality-policy.sh
@@ -39,9 +39,10 @@
 #                input string, not from asking the matcher what it found.
 #   units      - checked commands that the matcher claimed.
 #
-#   units > 0                    -> measured        -> enforce, exit `failed`
-#   units == 0, population == 0  -> empty-population-> honest zero, warn, exit 0
-#   units == 0, population > 0   -> contradicted    -> broken instrument, exit 1
+#   population == 0              -> empty-population -> honest zero, warn, exit 0
+#   units == 0 (population > 0)  -> contradicted     -> broken instrument, exit 1
+#   any entry uncheckable        -> unenforceable    -> silently unenforced, exit 1
+#   otherwise                    -> measured         -> enforce, exit `failed`
 #
 # `unknown` is deliberately NOT collapsed into `fail` here, and `contradicted`
 # deliberately IS a hard error — the same split `engine.rs` makes. See
@@ -124,24 +125,39 @@ check_command() {
   fi
 }
 
-# The predicate. Classifies the matched population BEFORE the exit code is read,
-# and emits one machine-readable provenance line in every branch so a log reader
-# can tell a *measured zero* from *no measurement* without inferring it from the
-# exit code. Absence of this line means the script died before assessing, which
-# is a third state again and is also not a pass.
+# The predicate. ONE function, deliberately.
+#
+# The first draft of this fix had two — `assess_measurement` for the empty
+# matched population and `assess_configuration` for an entry naming an
+# uncheckable command — and mutation testing showed why that was wrong:
+# reverting the `contradicted` branch to a pass changed no observable
+# behaviour, because zero matches against a non-empty population means *every*
+# entry is unmatched, so the second guard always fired first. The load-bearing
+# check was one of the two and the other was decoration that could rot
+# untested. Two functions answering one question is the shape #10690 exists to
+# stop; it does not become acceptable because both of them are mine.
+#
+# Classifies BEFORE the exit code is read, and emits one machine-readable
+# provenance line in every branch so a log reader can tell a *measured zero*
+# from *no measurement* without inferring it from the exit code. Absence of the
+# line means the script died before assessing — a third state again, and also
+# not a pass.
 assess_measurement() {
   local population="${#configured_tokens[@]}"
+  local unmatched="${#unmatched_tokens[@]}"
   local outcome
 
-  if [ "${measured_units}" -gt 0 ]; then
-    outcome='measured'
-  elif [ "${population}" -eq 0 ]; then
+  if [ "${population}" -eq 0 ]; then
     outcome='empty-population'
-  else
+  elif [ "${measured_units}" -eq 0 ]; then
     outcome='contradicted'
+  elif [ "${unmatched}" -gt 0 ]; then
+    outcome='unenforceable'
+  else
+    outcome='measured'
   fi
 
-  echo "::notice::measurement basis=release-quality-policy population=${population} units=${measured_units} outcome=${outcome}"
+  echo "::notice::measurement basis=release-quality-policy population=${population} units=${measured_units} unmatched=${unmatched} outcome=${outcome}"
 
   case "${outcome}" in
     measured)
@@ -165,26 +181,22 @@ assess_measurement() {
       # independently non-empty population. The matcher is provably broken, not
       # the gates, so neither `pass` nor `unknown` is honest — this is the one
       # outcome the shared predicate makes a hard error rather than a verdict.
+      # This is the #10741 defect exactly.
       echo "::error::Release-blocking policy matched none of its ${population} configured command(s) (BLOCKING_COMMANDS='${BLOCKING_COMMANDS}'). Every gate fell through to the non-blocking branch, so this policy would have exited 0 while enforcing nothing. Checkable commands are: ${CHECKABLE_COMMANDS}."
       return 1
       ;;
+    unenforceable)
+      # The partial form of the same defect, and the subtler one: a single typo
+      # in "review lint,review tests" leaves `units` non-zero, so the emptiness
+      # check alone reads it as a healthy measurement while the test gate
+      # silently stops blocking. Refused rather than warned because the remedy
+      # is a one-character edit to a `workflow_dispatch` input, and because the
+      # automated push path — whose set is the well-formed default — cannot
+      # reach it.
+      echo "::error::Release-blocking policy cannot check: ${unmatched_tokens[*]}. These entries of BLOCKING_COMMANDS='${BLOCKING_COMMANDS}' name no command this policy measures, so they declare a release-blocking requirement that is silently never enforced. Checkable commands are: ${CHECKABLE_COMMANDS}."
+      return 1
+      ;;
   esac
-}
-
-# A configured entry naming an uncheckable command is a declared blocking
-# requirement no measurement can satisfy. Refused rather than ignored: it is the
-# partial form of the same defect (one typo in "review lint,review tests"
-# silently stops the test gate blocking while the policy still reports
-# `outcome=measured`), and the remedy is a one-character edit to a
-# `workflow_dispatch` input. It cannot fire on the automated push path, whose
-# set is the well-formed default.
-assess_configuration() {
-  if [ "${#unmatched_tokens[@]}" -eq 0 ]; then
-    return 0
-  fi
-
-  echo "::error::Release-blocking policy cannot check: ${unmatched_tokens[*]}. These entries of BLOCKING_COMMANDS='${BLOCKING_COMMANDS}' name no command this policy measures, so they declare a release-blocking requirement that is silently never enforced. Checkable commands are: ${CHECKABLE_COMMANDS}."
-  return 1
 }
 
 read_configured_tokens
@@ -196,6 +208,5 @@ check_command test "${TEST_RESULT}"
 # The measurement is assessed before the gate verdict is returned, so a broken
 # matcher can never be reported as a clean run.
 assess_measurement || failed=1
-assess_configuration || failed=1
 
 exit "${failed}"

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -460,8 +460,27 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
     },
 ];
 
-/// Directories under `.github/` are the gate layer. Extensions that can carry
-/// verdict logic.
+/// Extensions under `.github/` that can carry verdict logic.
+///
+/// # Why the scan stops at `.github/`
+///
+/// `crates/homeboy-extension/src/runtime/*.sh` is the other body of shell in
+/// this repository, and it was swept for this issue rather than assumed
+/// harmless. Those files are evidence *producers*, not verdict renderers: they
+/// write the counts and findings sidecars that Rust gates then read. Registering
+/// them would add thirteen rows that all say `NotAGate`, burying the eleven that
+/// mean something.
+///
+/// One of them is worth recording anyway. `write-test-results.sh` reads its
+/// counts as `local passed="${2:-0}"`, so an *absent* argument is written to the
+/// sidecar as a measured `0` — the exact measured-zero/no-measurement collapse
+/// this registry is about, at the point where the evidence is created. It does
+/// not become a green: `test_run_status` maps `Some(counts)` to
+/// `Measurement::units(passed + failed)`, and `units(0)` with no population is
+/// `Unmeasured(ZeroUnits)`, which forbids a pass. The consequence is narrower
+/// than a false verdict and real — an operator reading the sidecar cannot tell
+/// "the runner reported zero tests" from "the runner reported nothing" — so it
+/// is recorded here rather than patched under a gate-layer issue.
 const GATE_LAYER_EXTENSIONS: &[&str] = &["yml", "yaml", "sh"];
 
 /// Substring the shell [`MeasurementBasis::SharedPredicate`] sites must still
@@ -646,7 +665,12 @@ fn gate_layer_decision(relative: &str, line: &str) -> Option<String> {
             let needle = format!("={value}\"");
             if let Some(end) = trimmed.find(&needle) {
                 let head = &trimmed[..end];
-                let name_start = head.rfind('"').map(|index| index + 1)?;
+                // `continue`, not `?`: a bare `?` here would abandon the whole
+                // line the moment one of the two values failed to parse, which
+                // would silently stop the scan seeing the other.
+                let Some(name_start) = head.rfind('"').map(|index| index + 1) else {
+                    continue;
+                };
                 let name = &head[name_start..];
                 if !name.is_empty()
                     && name
@@ -941,28 +965,39 @@ fn every_skip_rendering_gate_layer_decision_is_executed_by_a_fixture() {
          ran instead of what that command produced."
     );
 
+    // A skip-rendering decision must either name a fixture or carry the debt
+    // marker. `renders_skip` is the obligation; the marker is the escape hatch,
+    // and it is greppable on purpose.
+    for site in GATE_LAYER_SITES
+        .iter()
+        .filter(|site| site.renders_skip && site.fixture.is_none())
+    {
+        assert!(
+            site.note.starts_with("NO FIXTURE:"),
+            "{} -> {} renders a skip with no fixture, and its note does not open with \
+             `NO FIXTURE:`.\n\nA skip-rendering decision without an executing test is exactly the \
+             state `should-release=false` was in when #10706 laundered a detached HEAD into \
+             `No releasable commits`. If it genuinely cannot be fixtured yet, say so explicitly \
+             so the debt is greppable rather than invisible.",
+            site.file,
+            site.decision
+        );
+    }
+
+    // Every *claimed* fixture must exist. Counted across all sites, not only
+    // the skip-rendering ones: an aspirational fixture name is a false claim
+    // wherever it appears.
     let mut executed = 0;
-    for site in GATE_LAYER_SITES.iter().filter(|site| site.renders_skip) {
+    for site in GATE_LAYER_SITES {
         let Some(fixture) = site.fixture else {
-            assert!(
-                site.note.starts_with("NO FIXTURE:"),
-                "{} -> {} renders a skip with no fixture, and its note does not open with \
-                 `NO FIXTURE:`.\n\nA skip-rendering decision without an executing test is exactly \
-                 the state `should-release=false` was in when #10706 laundered a detached HEAD \
-                 into `No releasable commits`. If it genuinely cannot be fixtured yet, say so \
-                 explicitly so the debt is greppable rather than invisible.",
-                site.file,
-                site.decision
-            );
             continue;
         };
-
         assert!(
             fixtures.contains(&format!("fn {fixture}(")),
             "{} -> {} names fixture `{fixture}`, but no such test exists in \
              {GATE_LAYER_FIXTURE_FILE}.\n\nEither the test was renamed and the registration was \
-             not, or the registration was aspirational. Both leave a skip-rendering decision \
-             unexercised while claiming otherwise.",
+             not, or the registration was aspirational. Both leave a decision unexercised while \
+             claiming otherwise.",
             site.file,
             site.decision
         );
@@ -971,9 +1006,25 @@ fn every_skip_rendering_gate_layer_decision_is_executed_by_a_fixture() {
 
     assert!(
         executed >= 2,
-        "only {executed} skip-rendering gate-layer decision(s) resolved to a real fixture, so \
-         this assertion is close to passing vacuously -- the same absence-of-evidence failure it \
-         exists to prevent."
+        "only {executed} gate-layer decision(s) resolved to a real fixture, so this assertion is \
+         close to passing vacuously -- the same absence-of-evidence failure it exists to prevent."
+    );
+
+    // And the acceptance case specifically. A general floor can drift until it
+    // no longer covers the incident that motivated it; recorded incidents get
+    // replayed by name.
+    let incident = GATE_LAYER_SITES
+        .iter()
+        .find(|site| {
+            site.file == ".github/workflows/release.yml" && site.decision == "should-release=false"
+        })
+        .expect("the #10706 decision must stay registered");
+    let fixture = incident.fixture.expect(
+        "`should-release=false` must keep an executing fixture -- it is the acceptance case",
+    );
+    assert!(
+        fixtures.contains(&format!("fn {fixture}(")),
+        "the #10706 acceptance case names fixture `{fixture}`, which does not exist"
     );
 }
 

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -16,12 +16,40 @@
 //! the author to answer, in reviewable prose, the exact question all four
 //! incidents failed to ask: *how does this path know it measured anything?*
 //!
+//! # The gate layer is not written in Rust (#10741)
+//!
+//! The paragraph above described this registry's original scope — `crates/`,
+//! `.rs` — and that scope was itself the next instance of the bug.
+//!
+//! #10706 merged roughly ninety minutes after this guard landed. It fixed a
+//! textbook instance of the invariant: `git rev-parse --abbrev-ref HEAD`
+//! returns the literal string `HEAD` in a detached checkout, the release
+//! wrapper read that as "not on main" and exited before evaluating anything,
+//! and the workflow laundered the resulting empty `release-version` into
+//! `No releasable commits` — skipping every job, concluding green, over 131
+//! pending commits. It touched `.github/workflows/release.yml` and
+//! `tests/release_workflow_test.rs`. **Zero files under `crates/`.** The guard
+//! could not have seen it.
+//!
+//! So the registry now has two layers, in one file and one vocabulary:
+//!
+//! * [`VERDICT_SITES`] — Rust, `crates/**/*.rs`, keyed by file.
+//! * [`GATE_LAYER_SITES`] — shell and YAML, `.github/**/*.{yml,sh}`, keyed by
+//!   **decision** rather than by file, and additionally requiring an executable
+//!   fixture. See [`GATE_LAYER_SITES`] for why both of those differ.
+//!
+//! Keeping them together is deliberate. #10690 exists because four independent
+//! local implementations of this invariant had grown up and disagreed with each
+//! other; answering the same question a fifth time in a second registry file
+//! would be more of the same disease.
+//!
 //! # What it catches, and what it honestly does not
 //!
 //! It catches: a new verdict-producing path landing without that question being
 //! asked; a migrated site silently dropping its call to the shared predicate
 //! (see [`MeasurementBasis::SharedPredicate`]); a registered site being deleted
-//! or renamed out from under its registration.
+//! or renamed out from under its registration; and, in the gate layer, a
+//! skip-rendering decision that has no test executing its actual shell.
 //!
 //! It does not catch: a registered site whose declared basis is *wrong*. No
 //! source scan can. What it buys is that the claim is written down, attached to
@@ -30,13 +58,23 @@
 //! # Assert the effect, not the command string
 //!
 //! The post-merge audit gate passed for weeks because its test asserted the
-//! command it invoked rather than what that command produced. This file is
-//! deliberately the *registration* half of the guard. The *effect* half —
-//! feeding recorded no-measurement fixtures through real gates and asserting
-//! they do not come out green — lives next to each gate:
+//! command it invoked rather than what that command produced. The Rust half of
+//! this file is deliberately only the *registration* half of the guard. The
+//! *effect* half — feeding recorded no-measurement fixtures through real gates
+//! and asserting they do not come out green — lives next to each gate:
 //! `homeboy-extension/src/test/run.rs` and
 //! `homeboy-extension/src/test/report.rs`. Both halves are required; neither is
 //! sufficient.
+//!
+//! The gate layer does not get that choice. Registration alone provably would
+//! not have caught #10706 — `should-release=false` already existed in
+//! `release.yml`, so a file-keyed or even decision-keyed registration would have
+//! been sitting there, green, while the laundering happened inside it. What was
+//! actually missing was any test that *ran* the decide step; `run_decide_step`
+//! in `tests/release_workflow_test.rs` was added **by** #10706, not before it.
+//! So a gate-layer site that renders a skip must name a fixture, and
+//! [`every_skip_rendering_gate_layer_decision_is_executed_by_a_fixture`]
+//! requires that fixture to exist and to actually spawn a shell.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -253,6 +291,196 @@ const GREEN_VERDICT_LITERALS: &[&str] = &[
 /// Substring the [`MeasurementBasis::SharedPredicate`] sites must still contain.
 const SHARED_PREDICATE_MARKER: &str = "measurement::";
 
+// ─────────────────────────────────────────────────────────────────────────────
+// The shell/YAML gate layer (#10741)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A verdict-producing decision in the shell/YAML gate layer.
+///
+/// Keyed by `(file, decision)` rather than by file, unlike [`VerdictSite`].
+/// `release.yml` is 1,377 lines and contains nine distinct boolean gating
+/// decisions; one registry row covering the whole file would be a row that says
+/// nothing, which is the failure mode this registry exists to prevent.
+struct GateLayerSite {
+    /// Workspace-relative path, `/`-separated.
+    file: &'static str,
+    /// The exact literal the scan matches: a boolean `$GITHUB_OUTPUT` write, or
+    /// a shell script's terminal `exit`.
+    decision: &'static str,
+    basis: MeasurementBasis,
+    /// `true` when this decision renders a **skip** — a value that causes
+    /// downstream jobs not to run while the workflow still concludes green.
+    ///
+    /// This is the #10706 shape, and it is the field that carries the fixture
+    /// obligation. It is keyed on the decision's *value*, not on `basis`, so it
+    /// cannot be dodged by relabelling a site `Projection`.
+    renders_skip: bool,
+    /// A test function that executes this decision's real shell and asserts what
+    /// it produced. `None` is permitted only with a `NO FIXTURE:` note.
+    fixture: Option<&'static str>,
+    note: &'static str,
+}
+
+/// Every boolean gating decision in `.github/`, plus every gate script's exit.
+///
+/// Sorted by `(file, decision)`. Keep it that way.
+const GATE_LAYER_SITES: &[GateLayerSite] = &[
+    GateLayerSite {
+        file: ".github/detect-stranded-release.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::ExplicitlySkipped,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: `finish` is the script's single exit and it always writes all four \
+               outputs, so a crash leaves them unset and release.yml's fallback supplies inert \
+               defaults. The one genuine no-measurement path -- `gh release list` failing -- \
+               already refuses to read its own failure as `nothing is published`, warns, and \
+               finishes empty (line 114). Its remaining soft spot is the empty `git tag --list` \
+               case: a shallow or tagless checkout is indistinguishable from a repo with no \
+               stranded tags, and both render `stranded-tag=`. That degrades to `no recovery`, \
+               never to a false release, so it is recorded rather than patched. Exercising it \
+               needs a fixture git repo plus a `gh` stub, which is why there is no fixture yet.",
+    },
+    GateLayerSite {
+        file: ".github/release-quality-policy.sh",
+        decision: "exit \"${failed}\"",
+        basis: MeasurementBasis::SharedPredicate,
+        renders_skip: false,
+        fixture: Some("release_quality_policy_refuses_a_blocking_set_that_matches_nothing"),
+        note: "#10741, the sixth instance. Three `check_command` calls each fell through to the \
+               non-blocking branch when nothing matched, leaving `failed` at 0, so the policy \
+               exited green having enforced nothing. `assess_measurement` now ports \
+               Measurement::assess to bash: units>0 measured, units==0 with an empty configured \
+               population is an honest zero (warn, pass), units==0 against a non-empty population \
+               is Contradicted and a hard error.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "blocked=false",
+        basis: MeasurementBasis::EmptyPopulation,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: the marker file was read and did not name this HEAD. The filesystem is \
+               the independent population source and a missing marker is a real, honest zero -- \
+               there is no prior failure to find. This is the permissive direction (it lets the \
+               release proceed to real gates), so a defect here cannot manufacture a green skip.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "blocked=true",
+        basis: MeasurementBasis::ExplicitlySkipped,
+        renders_skip: true,
+        fixture: None,
+        note: "NO FIXTURE: skips because the restored cache marker holds this exact HEAD SHA. The \
+               evidence is a positive string equality against a file this job read, not an \
+               absence, so there is no emptiness to launder -- an unreadable or missing marker \
+               falls through to `blocked=false`. Debt: no test executes this step; it needs a \
+               RUNNER_TEMP fixture.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "prepared=true",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: projects the outcome of the `homeboy release` invocation that ran in \
+               the same step. The measurement obligation belongs to core's release planner, not \
+               to this echo.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "recovery-release=false",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: a mode flag, not a verdict. It records that the bump type core \
+               reported was not `recovery`; the release still proceeds through every gate.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "recovery-release=true",
+        basis: MeasurementBasis::Projection,
+        renders_skip: true,
+        fixture: None,
+        note: "NO FIXTURE: recovery legitimately bypasses the quality gates, so this genuinely is \
+               a skip-rendering decision. It is a projection of an already-established fact -- an \
+               explicit dispatch `release_tag`, a stranded tag the detector selected, or core \
+               reporting `bump-type=recovery` -- and each of those three is a positive finding \
+               rather than an absence. Debt: the branch selection is covered by \
+               `release_check_*` string assertions, not by an executing fixture.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "released=true",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: None,
+        note:
+            "NO FIXTURE: projects the result of the release step that just ran in this job. Same \
+               reasoning as `prepared=true`.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "should-release=false",
+        basis: MeasurementBasis::EmptyPopulation,
+        renders_skip: true,
+        fixture: Some("release_check_never_reports_nothing_to_release_without_measuring"),
+        note: "**The #10706 site, and the reason this layer exists.** An empty release-version \
+               used to render this unconditionally, collapsing a measured negative (core \
+               evaluated the commit range and declined) with an unmeasured one (the wrapper bailed \
+               before core ran). #10706 split them: only the three reasons core emits from \
+               planning_policy.rs may skip, plus a supersession this job proved itself; anything \
+               else is UNKNOWN and fails loudly. The population is core's own commit-range \
+               evaluation, which is independent of this step.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "should-release=true",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: Some("release_check_never_reports_nothing_to_release_without_measuring"),
+        note: "Projects a release core already planned, or a tag the recovery/stranded paths \
+               already validated. Registered with a fixture anyway because it shares the decide \
+               step's branch ladder with `should-release=false`: a fixture that only pinned the \
+               skip branch could be satisfied by a step that never releases at all.",
+    },
+    GateLayerSite {
+        file: ".github/workflows/release.yml",
+        decision: "superseded=true",
+        basis: MeasurementBasis::EmptyPopulation,
+        renders_skip: true,
+        fixture: None,
+        note:
+            "NO FIXTURE: the attach step compared HEAD against origin/<release-branch> and found \
+               a newer tip, naming the commit whose own run owns the release. That is a positive \
+               measurement made in this step, which is precisely why the decide step is allowed \
+               to accept `wrong-branch` only when this flag is set -- the narrow exemption that \
+               keeps #10706's hard failure intact. Debt: exercising it needs a fixture git repo \
+               with an origin remote.",
+    },
+];
+
+/// Directories under `.github/` are the gate layer. Extensions that can carry
+/// verdict logic.
+const GATE_LAYER_EXTENSIONS: &[&str] = &["yml", "yaml", "sh"];
+
+/// Substring the shell [`MeasurementBasis::SharedPredicate`] sites must still
+/// contain — the bash counterpart of [`SHARED_PREDICATE_MARKER`].
+///
+/// A shell script cannot `use` the Rust predicate, so the migration is pinned to
+/// the name of the function that ports it. Same anti-silent-revert property:
+/// deleting the port while keeping the registration fails.
+const SHELL_PREDICATE_MARKER: &str = "assess_measurement";
+
+/// The test file that owns gate-layer fixtures.
+const GATE_LAYER_FIXTURE_FILE: &str = "tests/release_workflow_test.rs";
+
+/// Proof that the fixture file executes shells rather than string-matching YAML.
+///
+/// Without this, "has a fixture" degrades into "has a test that greps the
+/// workflow" — which is the exact failure the audit gate shipped for weeks.
+const GATE_LAYER_FIXTURE_EXECUTES_SHELL: &str = "Command::new(\"bash\")";
+
 fn workspace_root() -> PathBuf {
     // crates/homeboy-engine-primitives -> crates -> <root>
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -344,6 +572,121 @@ fn discovered_verdict_files(root: &Path) -> BTreeSet<String> {
                 .any(|line| line_constructs_a_green_verdict(line))
         })
         .map(|(relative, _)| relative)
+        .collect()
+}
+
+// ── Gate-layer scan ──────────────────────────────────────────────────────────
+
+/// Every `.yml`/`.sh` file under `.github/`, workspace-relative.
+fn gate_layer_sources(root: &Path) -> Vec<(String, String)> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.join(".github")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let is_gate_layer = path.extension().is_some_and(|extension| {
+                GATE_LAYER_EXTENSIONS
+                    .iter()
+                    .any(|candidate| extension == *candidate)
+            });
+            if !is_gate_layer {
+                continue;
+            }
+            let Ok(relative) = path.strip_prefix(root) else {
+                continue;
+            };
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            found.push((relative, contents));
+        }
+    }
+    found
+}
+
+/// The gate-layer decision a line makes, if any.
+///
+/// Two rules, both mechanical:
+///
+/// 1. **A boolean `$GITHUB_OUTPUT` write.** `name=true` / `name=false` is a
+///    verdict a downstream `if:` reads; `release-version=0.3.2` is data. Keying
+///    on the boolean-ness is what separates the two without a hand-curated list
+///    of blessed output names, so a *newly invented* gating output is caught.
+/// 2. **A shell script's terminal `exit`.** A `.github/*.sh` file is invoked as
+///    a gate, so its exit status is its verdict.
+///
+/// A step's `exit 0` inside a workflow `run:` block is deliberately *not* a
+/// decision on its own: in YAML the step's verdict is carried by the outputs it
+/// wrote, and every such early exit in this repo is paired with one. Counting
+/// both would double-register the same decision.
+///
+/// **Known blind spot, stated rather than hidden:** a brace group redirected
+/// wholesale (`{ echo "x=true"; } >> "$GITHUB_OUTPUT"`) writes a boolean gating
+/// output on a line that never mentions `$GITHUB_OUTPUT`, so rule 1 misses it.
+/// The one such block in this repo (`release.yml`'s stranded-detector fallback)
+/// writes only empty strings, so nothing is missed today.
+/// [`the_gate_layer_scan_has_no_unseen_boolean_output_blocks`] fails if a
+/// boolean ever appears inside one.
+fn gate_layer_decision(relative: &str, line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if trimmed.starts_with('#') {
+        return None;
+    }
+
+    if trimmed.contains("$GITHUB_OUTPUT") {
+        for value in ["true", "false"] {
+            let needle = format!("={value}\"");
+            if let Some(end) = trimmed.find(&needle) {
+                let head = &trimmed[..end];
+                let name_start = head.rfind('"').map(|index| index + 1)?;
+                let name = &head[name_start..];
+                if !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|character| character.is_ascii_lowercase() || character == '-')
+                {
+                    return Some(format!("{name}={value}"));
+                }
+            }
+        }
+        return None;
+    }
+
+    // Rule 2 applies to gate scripts only. Indentation is not consulted: the
+    // single exit in `detect-stranded-release.sh` lives inside its `finish`
+    // helper, and that is still the script's verdict.
+    if relative.ends_with(".sh") && trimmed.starts_with("exit ") {
+        return Some(trimmed.trim_end_matches(';').to_string());
+    }
+
+    None
+}
+
+/// Discovered `(file, decision)` pairs across the whole gate layer.
+fn discovered_gate_layer_decisions(root: &Path) -> BTreeSet<(String, String)> {
+    let mut found = BTreeSet::new();
+    for (relative, contents) in gate_layer_sources(root) {
+        for line in contents.lines() {
+            if let Some(decision) = gate_layer_decision(&relative, line) {
+                found.insert((relative.clone(), decision));
+            }
+        }
+    }
+    found
+}
+
+fn registered_gate_layer_decisions() -> BTreeSet<(String, String)> {
+    GATE_LAYER_SITES
+        .iter()
+        .map(|site| (site.file.to_string(), site.decision.to_string()))
         .collect()
 }
 
@@ -514,4 +857,348 @@ fn production_lines_stop_at_the_test_module() {
     let lines = production_lines(source);
     assert_eq!(lines.len(), 3);
     assert!(!lines.iter().any(|line| line.contains("passed: true")));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The shell/YAML gate layer (#10741)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn every_gate_layer_decision_declares_how_it_established_measurement() {
+    let root = workspace_root();
+    let discovered = discovered_gate_layer_decisions(&root);
+    let registered = registered_gate_layer_decisions();
+
+    let unregistered: Vec<String> = discovered
+        .difference(&registered)
+        .map(|(file, decision)| format!("{file}  ->  {decision}"))
+        .collect();
+
+    assert!(
+        unregistered.is_empty(),
+        "these gate-layer decisions render a verdict but do not declare how they established a \
+         measurement:\n  {}\n\n\
+         Add an entry to GATE_LAYER_SITES in \
+         crates/homeboy-engine-primitives/src/measurement_registry_test.rs stating the \
+         MeasurementBasis, whether it renders a skip, and a reason.\n\n\
+         A boolean written to $GITHUB_OUTPUT is a verdict: a downstream `if:` reads it and \
+         decides whether an entire job runs. #10706 is what happens when one of those is rendered \
+         from an emptiness nobody checked -- `should-release=false` from an empty release-version \
+         that the release wrapper never actually computed, skipping every job over 131 commits \
+         while the run concluded green (#10703).\n\n\
+         If this decision only projects something already decided elsewhere, say so with \
+         MeasurementBasis::Projection. If it renders a skip, set renders_skip: true and name a \
+         fixture that EXECUTES its shell -- a test that greps the YAML does not count.",
+        unregistered.join("\n  ")
+    );
+}
+
+#[test]
+fn no_gate_layer_registration_outlives_the_decision_it_describes() {
+    let root = workspace_root();
+    let discovered = discovered_gate_layer_decisions(&root);
+
+    let stale: Vec<String> = registered_gate_layer_decisions()
+        .difference(&discovered)
+        .map(|(file, decision)| format!("{file}  ->  {decision}"))
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "these GATE_LAYER_SITES entries no longer match a decision in the tree:\n  {}\n\nThe \
+         workflow step or script was renamed, deleted, or stopped rendering that value. Remove or \
+         update the entry -- a registry that has drifted is a registry that is not being read.",
+        stale.join("\n  ")
+    );
+}
+
+/// **The acceptance bar for #10741.**
+///
+/// Registration on its own provably would not have caught #10706:
+/// `should-release=false` already existed in `release.yml`, so a registry row
+/// for it would have been sitting there, green, while the laundering happened
+/// inside the branch that wrote it. What was actually absent was any test that
+/// *ran* the decide step — `run_decide_step` was added **by** #10706.
+///
+/// So this is the clause with teeth. Every decision that renders a skip must
+/// name a fixture, that fixture must exist, and the file holding it must
+/// actually spawn a shell. Run against the tree as it stood the hour before
+/// #10706, this test fails on `should-release=false`.
+///
+/// `renders_skip` is keyed on the decision's value, not on `basis`, so the
+/// obligation cannot be shed by relabelling a site `Projection`.
+#[test]
+fn every_skip_rendering_gate_layer_decision_is_executed_by_a_fixture() {
+    let root = workspace_root();
+    let fixtures = std::fs::read_to_string(root.join(GATE_LAYER_FIXTURE_FILE))
+        .unwrap_or_else(|error| panic!("{GATE_LAYER_FIXTURE_FILE} is unreadable: {error}"));
+
+    assert!(
+        fixtures.contains(GATE_LAYER_FIXTURE_EXECUTES_SHELL),
+        "{GATE_LAYER_FIXTURE_FILE} no longer spawns a shell ({GATE_LAYER_FIXTURE_EXECUTES_SHELL}), \
+         so every fixture it holds has degraded into a string match against YAML. That is the \
+         precise failure the post-merge audit gate shipped for weeks: it asserted the command it \
+         ran instead of what that command produced."
+    );
+
+    let mut executed = 0;
+    for site in GATE_LAYER_SITES.iter().filter(|site| site.renders_skip) {
+        let Some(fixture) = site.fixture else {
+            assert!(
+                site.note.starts_with("NO FIXTURE:"),
+                "{} -> {} renders a skip with no fixture, and its note does not open with \
+                 `NO FIXTURE:`.\n\nA skip-rendering decision without an executing test is exactly \
+                 the state `should-release=false` was in when #10706 laundered a detached HEAD \
+                 into `No releasable commits`. If it genuinely cannot be fixtured yet, say so \
+                 explicitly so the debt is greppable rather than invisible.",
+                site.file,
+                site.decision
+            );
+            continue;
+        };
+
+        assert!(
+            fixtures.contains(&format!("fn {fixture}(")),
+            "{} -> {} names fixture `{fixture}`, but no such test exists in \
+             {GATE_LAYER_FIXTURE_FILE}.\n\nEither the test was renamed and the registration was \
+             not, or the registration was aspirational. Both leave a skip-rendering decision \
+             unexercised while claiming otherwise.",
+            site.file,
+            site.decision
+        );
+        executed += 1;
+    }
+
+    assert!(
+        executed >= 2,
+        "only {executed} skip-rendering gate-layer decision(s) resolved to a real fixture, so \
+         this assertion is close to passing vacuously -- the same absence-of-evidence failure it \
+         exists to prevent."
+    );
+}
+
+/// The bash port of the shared predicate must still be there.
+///
+/// A shell script cannot `use` the Rust `measurement` module, so the migration
+/// is pinned to the name of the function that ports it. Same property as
+/// [`a_site_claiming_the_shared_predicate_must_still_call_it`]: silently
+/// dropping the guard while keeping the claim is the regression shape itself.
+#[test]
+fn a_gate_layer_site_claiming_the_shared_predicate_must_still_port_it() {
+    let root = workspace_root();
+
+    let mut checked = 0;
+    for site in GATE_LAYER_SITES
+        .iter()
+        .filter(|site| site.basis == MeasurementBasis::SharedPredicate)
+    {
+        let contents = std::fs::read_to_string(root.join(site.file))
+            .unwrap_or_else(|error| panic!("registered site {} is unreadable: {error}", site.file));
+        assert!(
+            contents.contains(SHELL_PREDICATE_MARKER),
+            "{} is registered as a shared-predicate site but no longer defines \
+             `{SHELL_PREDICATE_MARKER}`.\n\nRestore the port, or change the registration and say \
+             what replaced it.",
+            site.file
+        );
+        // The port is worthless if it never classifies an empty population.
+        for outcome in ["empty-population", "contradicted"] {
+            assert!(
+                contents.contains(outcome),
+                "{} ports the shared predicate but never renders `{outcome}`. The whole point is \
+                 that a measured zero and a broken instrument stop being indistinguishable.",
+                site.file
+            );
+        }
+        checked += 1;
+    }
+
+    assert_eq!(
+        checked, 1,
+        "expected exactly one shell shared-predicate site (release-quality-policy.sh); found \
+         {checked}. If another script ported the predicate, register it; if this one stopped, \
+         this assertion has gone vacuous."
+    );
+}
+
+#[test]
+fn every_registered_gate_layer_site_records_a_reason() {
+    for site in GATE_LAYER_SITES {
+        assert!(
+            site.note.len() > 40,
+            "{} -> {} is registered with a note too short to be a reason: {:?}",
+            site.file,
+            site.decision,
+            site.note
+        );
+        assert!(
+            site.file.starts_with(".github/"),
+            "GATE_LAYER_SITES paths are workspace-relative under .github/: {:?}",
+            site.file
+        );
+        assert!(
+            site.fixture.is_some() || site.note.starts_with("NO FIXTURE:"),
+            "{} -> {} has no fixture and does not open its note with `NO FIXTURE:`, so the debt is \
+             invisible to a reader grepping for it",
+            site.file,
+            site.decision
+        );
+    }
+}
+
+#[test]
+fn the_gate_layer_registry_is_sorted() {
+    let keys: Vec<(&str, &str)> = GATE_LAYER_SITES
+        .iter()
+        .map(|site| (site.file, site.decision))
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        keys, sorted,
+        "keep GATE_LAYER_SITES sorted by (file, decision) so failure messages stay easy to act on"
+    );
+}
+
+/// The gate-layer scan is load-bearing, so prove it works rather than assuming
+/// it. A scan that silently matches nothing renders every assertion above
+/// vacuous — the same defect class the whole registry guards against.
+#[test]
+fn the_gate_layer_scan_itself_measures_something() {
+    let root = workspace_root();
+
+    let sources = gate_layer_sources(&root);
+    assert!(
+        sources.len() >= 4,
+        "the gate-layer walk found only {} .yml/.sh files under .github/, which cannot be right",
+        sources.len()
+    );
+    assert!(
+        sources
+            .iter()
+            .any(|(relative, _)| relative == ".github/workflows/release.yml"),
+        "the gate-layer walk did not find release.yml, so it is not walking what it claims to"
+    );
+
+    let discovered = discovered_gate_layer_decisions(&root);
+    assert!(
+        discovered.len() >= 8,
+        "the gate-layer scan found only {} decision(s); the tree is known to contain more",
+        discovered.len()
+    );
+
+    // The #10706 site specifically. Recorded incidents get replayed rather than
+    // trusted to a general rule that could quietly stop covering them.
+    assert!(
+        discovered.contains(&(
+            ".github/workflows/release.yml".to_string(),
+            "should-release=false".to_string()
+        )),
+        "the scan no longer sees release.yml's `should-release=false` -- the decision #10706 was \
+         about. Either it was renamed (update the registry) or the matcher regressed."
+    );
+    let incident = GATE_LAYER_SITES
+        .iter()
+        .find(|site| {
+            site.file == ".github/workflows/release.yml" && site.decision == "should-release=false"
+        })
+        .expect("the #10706 decision must stay registered");
+    assert!(
+        incident.renders_skip,
+        "`should-release=false` skips every downstream job; recording it as anything else \
+         releases it from the fixture obligation that is the whole point of this layer"
+    );
+    assert!(
+        incident.fixture.is_some(),
+        "`should-release=false` must keep an executing fixture -- it is the acceptance case"
+    );
+}
+
+#[test]
+fn the_gate_layer_matcher_distinguishes_a_verdict_from_data() {
+    // Boolean gating outputs are verdicts.
+    assert_eq!(
+        gate_layer_decision(
+            ".github/workflows/release.yml",
+            "            echo \"should-release=false\" >> \"$GITHUB_OUTPUT\""
+        )
+        .as_deref(),
+        Some("should-release=false")
+    );
+    assert_eq!(
+        gate_layer_decision(
+            ".github/workflows/release.yml",
+            "          echo \"superseded=true\" >> \"$GITHUB_OUTPUT\""
+        )
+        .as_deref(),
+        Some("superseded=true")
+    );
+
+    // Non-boolean outputs are data, not verdicts. Registering them would bury
+    // the verdicts in noise.
+    assert!(gate_layer_decision(
+        ".github/workflows/release.yml",
+        "            echo \"release-version=${RELEASE_VERSION}\" >> \"$GITHUB_OUTPUT\""
+    )
+    .is_none());
+    assert!(gate_layer_decision(
+        ".github/workflows/release.yml",
+        "              echo \"stranded-attempts=0\" >> \"$GITHUB_OUTPUT\""
+    )
+    .is_none());
+
+    // Prose describing a decision is not the decision.
+    assert!(gate_layer_decision(
+        ".github/workflows/release.yml",
+        "          # used to write should-release=false into \"$GITHUB_OUTPUT\" unconditionally"
+    )
+    .is_none());
+
+    // Gate scripts declare a verdict by exiting.
+    assert_eq!(
+        gate_layer_decision(".github/release-quality-policy.sh", "exit \"${failed}\"").as_deref(),
+        Some("exit \"${failed}\"")
+    );
+    assert_eq!(
+        gate_layer_decision(".github/detect-stranded-release.sh", "  exit 0").as_deref(),
+        Some("exit 0")
+    );
+    // A workflow step's early exit is carried by the outputs it wrote.
+    assert!(gate_layer_decision(".github/workflows/release.yml", "            exit 0").is_none());
+    // `return` is a function's control flow, not the script's verdict.
+    assert!(gate_layer_decision(".github/release-quality-policy.sh", "  return 0").is_none());
+}
+
+/// The documented blind spot, pinned so it stays a blind spot in theory only.
+///
+/// A brace group redirected wholesale writes gating outputs on lines that never
+/// mention `$GITHUB_OUTPUT`, so the line-oriented matcher cannot see them. The
+/// repo has exactly one such block and it writes only empty strings. If a
+/// boolean ever appears inside one, this fails and the matcher must grow.
+#[test]
+fn the_gate_layer_scan_has_no_unseen_boolean_output_blocks() {
+    let root = workspace_root();
+
+    for (relative, contents) in gate_layer_sources(&root) {
+        let lines: Vec<&str> = contents.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if !line.trim().starts_with('}') || !line.contains("$GITHUB_OUTPUT") {
+                continue;
+            }
+            let start = lines[..index]
+                .iter()
+                .rposition(|candidate| candidate.trim() == "{")
+                .unwrap_or(0);
+            for hidden in &lines[start..index] {
+                assert!(
+                    !hidden.contains("=true\"") && !hidden.contains("=false\""),
+                    "{relative} writes a boolean gating output inside a redirected brace group \
+                     ({}), which the line-oriented gate-layer matcher cannot see. Teach \
+                     gate_layer_decision about brace groups, or write the output with its own \
+                     `>> \"$GITHUB_OUTPUT\"`.",
+                    hidden.trim()
+                );
+            }
+        }
+    }
 }

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -267,7 +267,7 @@ fn release_quality_policy_refuses_a_blocking_set_that_matches_nothing() {
         "the default release path must be unaffected: {normal_output}"
     );
     assert!(
-        normal_output.contains("population=2 units=2 outcome=measured"),
+        normal_output.contains("population=2 units=2 unmatched=0 outcome=measured"),
         "the default path must record that it actually measured both blocking gates: \
          {normal_output}"
     );

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -174,6 +174,105 @@ fn release_quality_policy_blocks_review_test_failures_and_allows_passing_gates()
     assert!(passed.status.success());
 }
 
+/// The fixture that was missing, and the sixth instance of #10685 (#10741).
+///
+/// `release_quality_policy` was called exactly twice before this, both times
+/// with a well-formed `"review lint,review test"`. Nothing exercised a blocking
+/// set that matched *nothing*, so nothing noticed that when no command matched,
+/// all three `check_command` calls took the "tracked but not release-blocking"
+/// branch, `failed` stayed 0, and the policy exited green having enforced
+/// nothing.
+///
+/// The blast radius is narrower than "empty input" and it is worth being exact:
+/// `release.yml` interpolates
+/// `${{ inputs.release_blocking_commands || 'review lint,review test' }}`, and
+/// GitHub treats the empty string as falsy, so the automated push path can
+/// never arrive here with an empty set. What is reachable is a **malformed
+/// non-empty** set — a `workflow_dispatch` typo such as `review tests`.
+///
+/// This asserts the EFFECT by running the real script.
+#[test]
+fn release_quality_policy_refuses_a_blocking_set_that_matches_nothing() {
+    // Contradicted: a non-empty configured population, zero of it matched. The
+    // instrument is provably broken, so this is a hard error rather than an
+    // `unknown` — the same call `homeboy-code-audit`'s engine makes.
+    let contradicted =
+        release_quality_policy("review tests,review lints", "failure", "failure", "failure");
+    let output = String::from_utf8_lossy(&contradicted.stdout).into_owned();
+
+    assert!(
+        !contradicted.status.success(),
+        "a blocking set that matches nothing enforced nothing, and must not exit green: {output}"
+    );
+    assert!(
+        output.contains("outcome=contradicted"),
+        "the refusal must be attributable to the measurement, not just to an exit code: {output}"
+    );
+    assert!(
+        output.contains("::error::"),
+        "a broken policy must be loud: {output}"
+    );
+
+    // A partially-matched set is the same defect wearing one typo instead of
+    // two: `test` silently stops blocking while the policy still reports
+    // `outcome=measured`, so the emptiness check alone would let it through.
+    let partial =
+        release_quality_policy("review lint,review tests", "success", "success", "failure");
+    let partial_output = String::from_utf8_lossy(&partial.stdout).into_owned();
+
+    assert!(
+        !partial.status.success(),
+        "an entry naming a command this policy cannot check declares a requirement that is never \
+         enforced, and must not pass: {partial_output}"
+    );
+    assert!(
+        partial_output.contains("cannot check"),
+        "the unenforceable entry must be named so the typo is fixable from the log: \
+         {partial_output}"
+    );
+
+    // Measured zero vs no measurement. An empty configured set is an honest
+    // zero — splitting the string is independent of the matcher and it says
+    // there was genuinely nothing to match — so it passes, loudly. This branch
+    // is unreachable from `release.yml`; hard-failing it would add red no
+    // current run can produce.
+    let empty = release_quality_policy("", "failure", "failure", "failure");
+    let empty_output = String::from_utf8_lossy(&empty.stdout).into_owned();
+
+    assert!(
+        empty.status.success(),
+        "an independently-confirmed empty population is a legitimate pass: {empty_output}"
+    );
+    assert!(
+        empty_output.contains("outcome=empty-population"),
+        "a measured zero must be distinguishable in the log from a broken matcher: {empty_output}"
+    );
+    assert!(
+        empty_output.contains("::warning::"),
+        "enforcing nothing must never be silent, even when it is honest: {empty_output}"
+    );
+    assert_ne!(
+        empty_output.contains("outcome=contradicted"),
+        empty_output.contains("outcome=empty-population"),
+        "the two zero states must never render identically -- that collapse is the defect"
+    );
+
+    // The default set still measures and still enforces. A guard that made the
+    // normal path red would be the same end state as the bug.
+    let normal = release_quality_policy("review lint,review test", "failure", "success", "success");
+    let normal_output = String::from_utf8_lossy(&normal.stdout).into_owned();
+
+    assert!(
+        normal.status.success(),
+        "the default release path must be unaffected: {normal_output}"
+    );
+    assert!(
+        normal_output.contains("population=2 units=2 outcome=measured"),
+        "the default path must record that it actually measured both blocking gates: \
+         {normal_output}"
+    );
+}
+
 #[test]
 fn release_audit_is_advisory_without_losing_raw_failure_outcome() {
     let gate_audit = job_section(release_workflow(), "gate-audit");


### PR DESCRIPTION
Closes #10741.

## Both claims verified independently against source

**The registry gap is real.** `measurement_registry_test.rs::rust_sources` walks `root.join("crates")` and skips anything without a `.rs` extension. #10706 — a genuine instance of the invariant, fixed ~90 minutes after the guard landed — touched `.github/workflows/release.yml` and `tests/release_workflow_test.rs` and **zero files under `crates/`**. Confirmed by `gh pr diff 10706`.

**The policy hole is real, and reproduced before touching anything:**

```
$ BLOCKING_COMMANDS="review tests,review lints" \
    AUDIT_RESULT=failure LINT_RESULT=failure TEST_RESULT=failure \
    bash .github/release-quality-policy.sh
::notice::Command audit is tracked but not release-blocking (result: failure)
::notice::Command lint is tracked but not release-blocking (result: failure)
::notice::Command test is tracked but not release-blocking (result: failure)
EXIT=0
```

Three failed gates, exit 0. `release_quality_policy(...)` was called exactly twice in the suite (lines 166 and 172), both with a well-formed `"review lint,review test"`.

**One correction to the issue's framing.** #10741 says "an empty matched population is not a pass." Under the shared predicate that is not quite right, and the distinction is load-bearing: `MeasurementOutcome::EmptyPopulation` — zero observed against an *independently confirmed empty* population — **does** permit a pass. What is a hard error is `Contradicted`: zero observed against a population independently known to be non-empty. This PR implements that split rather than the flat rule.

## 1 — Registry extended to the gate layer

Extended **in the same file, same `MeasurementBasis` vocabulary**. A second registry file answering the same question would be the disease #10690 was treating.

Two things differ from the Rust half, both deliberately:

**Keyed by `(file, decision)`, not by file.** `release.yml` is 1,377 lines holding nine distinct boolean gating decisions; one row covering the file would say nothing.

**A decision is discovered, not hand-listed.** Either a boolean `$GITHUB_OUTPUT` write (`name=true`/`name=false` — a value a downstream `if:` reads) or a gate script's `exit`. Keying on boolean-ness rather than on a blessed list of output names is what makes a *newly invented* gating output get caught. Non-boolean writes (`release-version=0.3.2`) are data. The scan finds exactly 11 decisions across 6 files; all 11 are registered.

### Proof it catches a #10706-shaped defect

Registration alone would **not** have caught #10706, and this PR says so in the module docs rather than claiming otherwise: `should-release=false` already existed, so a registry row for it would have been sitting there green while the laundering happened inside the branch that wrote it.

The clause with teeth is that a **skip-rendering decision must name a fixture that executes its shell**, and the guard checks the fixture exists and that the fixture file still spawns `bash`. `run_decide_step` was added **by** #10706 — before it, nothing executed the decide step at all.

Run against the actual pre-#10706 tree (`ced59d2ff`, files pulled with `git show`, this PR's registry dropped in unchanged):

```
RED: should-release=false names fixture `release_check_never_reports_nothing_to_release_without_measuring` which does not exist
RED: only 0 decision(s) resolved to a real fixture (vacuous)
RED: the #10706 acceptance case names fixture `...` which does not exist
```

Both routes are red, which matters: had the entry instead been written `fixture: None`, the guard demands the note open with `NO FIXTURE:` — a greppable written admission that the skip is unexercised. Pre-#10706 had neither. The guard forces one or the other.

## 2 — `release-quality-policy.sh`

`assess_measurement` ports `Measurement::assess` to bash with four outcomes:

| condition | outcome | verdict |
|---|---|---|
| `population == 0` | `empty-population` | **pass**, with `::warning::` |
| `units == 0`, `population > 0` | `contradicted` | **exit 1** |
| any entry names an uncheckable command | `unenforceable` | **exit 1** |
| otherwise | `measured` | enforce |

**Blast radius, stated accurately.** The *absent* input is already safe: `release.yml` interpolates `${{ inputs.release_blocking_commands || 'review lint,review test' }}` and GitHub treats `''` as falsy, so the automated push path can never arrive with an empty set. The reachable defect is a **malformed non-empty** set — a `workflow_dispatch` typo. Neither new hard error can fire on any current automated run; verified by running the default set. This is not manufactured red.

I also refused the **partially**-matched set (`review lint,review tests`), which the issue does not mention and which is subtler: `units` stays non-zero so the emptiness check alone reads it as healthy, while the test gate silently stops blocking.

## 3 — measured-zero vs no-measurement

One provenance line, always, in every branch:

```
::notice::measurement basis=release-quality-policy population=2 units=2 unmatched=0 outcome=measured
```

`outcome=empty-population` is a **measured zero** — splitting the configured string is independent of the matcher, so it can say there was genuinely nothing to match. `outcome=contradicted` is **no measurement** against a known-non-empty population. Absence of the line entirely is a third state (the script died before assessing) and is also not a pass. The fixture asserts the two zero states never render identically.

## 4 — `unknown` vs hard-fail

`empty-population` warns and passes; only `contradicted` and `unenforceable` fail. Rationale: `contradicted` is the one case where the instrument is *provably* broken — the same call `engine.rs` makes. `empty-population` is unreachable from `release.yml`, so hard-failing it would add red no current run can produce while breaking any future deliberate "block on nothing" config.

For the registry, `MeasurementBasis::Unguarded` is used for **zero** gate-layer sites. Every unfixtured skip carries a `NO FIXTURE:` note instead — a debt marker, not a failure. Nothing in this PR turns a currently-green path red.

## 5 — Sweep

- **`ci.yml`, `audit-debt.yml`: no inline verdict shell at all.** Both delegate wholly to `./.homeboy-action`. Their verdict logic lives in homeboy-action, which is pinned at `v2`, frozen at Jul 26 by the stranded-draft releases — so it is out of scope and would not run if changed. Nothing to fix homeboy-side; reporting rather than inventing work.
- **`release.yml`: 9 decisions, all registered, none newly red.** `should-release=false` and `superseded=true` are already correctly guarded post-#10706.
- **`detect-stranded-release.sh`:** already refuses to read a failed `gh release list` as "nothing is published" (line 114). Remaining soft spot recorded in the registry: an empty `git tag --list` from a shallow/tagless checkout is indistinguishable from "no stranded tags". Degrades to *no recovery*, never to a false release, so recorded not patched.
- **`crates/**/runtime/*.sh` (13 files):** swept, not assumed harmless. Evidence producers, not verdict renderers. `write-test-results.sh` reads `local passed="${2:-0}"`, so an absent argument is written as a measured `0` — the collapse, at the point evidence is created. It does not become a green: `test_run_status` maps it to `Measurement::units(0)` → `Unmeasured(ZeroUnits)`. Recorded in the registry docs.
- **No Python in this repo.** The differential-gate Python #10741 mentions is homeboy-action's, i.e. `v2`-gated.

## 6 — Mutation testing

Mutation testing **found two defects in my own first commit**, both now fixed:

1. The first draft had two guards, and reverting the `contradicted` branch to a pass changed **no observable behaviour** — zero matches against a non-empty population means *every* entry is unmatched, so the second guard always fired first. One check was load-bearing and the other was decoration that could rot untested. Collapsed into one predicate.
2. The fixture floor counted only skip-rendering sites, which resolved to exactly **one** on this branch — the assertion would have failed on its own tree.

Every mutation below was verified to turn the new tests red, and the baseline green.

**Shell (8/8 red)** — `M1` revert `contradicted` to a pass *(the original bug)*; `M2` never call the predicate; `M3` make the honest zero an error too *(over-broad fix)*; `M4` drop the provenance line; `M5` stop refusing the partial typo; `M6` derive population from the matcher instead of independently; `M7` swap branch order; `M8` stop counting units.

**Registry (9/9 red)** — `R1` a new boolean gating output lands unregistered; `R2` registry entry deleted while its decision lives; `R3` the #10706 fixture renamed away; `R4` fixture file stops spawning a shell *(degrades to string-matching)*; `R5` the bash predicate port silently removed; `R7` a boolean hidden in a redirected brace group; `R8` a skip drops its `NO FIXTURE:` marker; `R9` registry reordered.

`R7` covers a blind spot I documented rather than hid: a brace group redirected wholesale writes outputs on lines that never mention `$GITHUB_OUTPUT`. The one such block in this repo writes only empty strings; `the_gate_layer_scan_has_no_unseen_boolean_output_blocks` fails if a boolean ever appears in one.

## What I could NOT verify without cargo

Per this host's constraints, no `cargo build/test/check/clippy` was run — only `cargo fmt` (clean).

- **Compilation of the ~750 new lines is unverified.** CI is the gate. Reviewed by hand for the known hazards: `is_some_and`/`is_none_or` are already used in this file so MSRV is unchanged; no new dependencies, so `Cargo.lock`/`--locked` is untouched; no struct field is unused (no `dead_code`); `MeasurementBasis` already derives `PartialEq`. I found and fixed one real bug this way — `gate_layer_decision` used `?` inside the value loop, which would have abandoned the whole line rather than trying the other boolean.
- **The Rust assertions were mutation-tested via a faithful Python replica** that parses `GATE_LAYER_SITES` **out of the Rust source** rather than transcribing it, so the registry under test is the real one. The replica proves the *logic*; it does not prove the Rust compiles.
- The shell half needed no proxy — all 8 mutations ran the real script.
- `shellcheck` is not installed on this host; `bash -n` passes.
- No audit-baseline (`homeboy.json`) change was needed or made.

Nothing here lands in `homeboy-action`, so none of it is gated on the frozen `v2` tag.