### PR TITLE
fix(release): reconcile published recovery assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1092,7 +1092,7 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
 
       - name: Create remote draft adoption manifest
-        if: needs.prepare.outputs.recovery-release == 'true'
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true'
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           RELEASE_VERSION: ${{ needs.prepare.outputs['release-version'] }}
@@ -1162,7 +1162,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           CONTROL_SHA: ${{ github.sha }}
-          ADOPTION_SOURCE: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}
+          ADOPTION_SOURCE: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}
           ARTIFACT_ORIGIN: ${{ needs.plan.outputs.draft-complete == 'true' && 'pre-existing draft assets (rebuild skipped)' || 'rebuilt and re-uploaded by this run' }}
         run: |
           set -euo pipefail
@@ -1199,7 +1199,7 @@ jobs:
           commands: release
           binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}
           release-head: 'true'
-          release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}
+          release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}
           release-skip-publish: 'true'
 
   # ── Step 5b: Fail loudly if a prepared release did not publish ──
@@ -1233,6 +1233,16 @@ jobs:
           fi
 
           gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > release.json
+          if ! jq -e '.draft == false' release.json >/dev/null; then
+            echo "::error::Release ${RELEASE_TAG} still resolves to an unpublished draft."
+            exit 1
+          fi
+          expected_inventory="$(jq -c 'sort' <<< "${EXPECTED_ASSETS}")"
+          actual_inventory="$(jq -c '[.assets[].name] | sort' release.json)"
+          if [ "${actual_inventory}" != "${expected_inventory}" ]; then
+            echo "::error::Release ${RELEASE_TAG} asset inventory is not exactly authoritative. Expected ${expected_inventory}; found ${actual_inventory}."
+            exit 1
+          fi
           missing=()
           invalid=()
           while IFS= read -r asset; do

--- a/crates/homeboy-release/src/release/executor/github_release/delivery.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/delivery.rs
@@ -58,3 +58,9 @@ pub(crate) fn existing_release_action(
     }
     ExistingReleaseAction::PublishDraft
 }
+
+/// Adoption revalidates the remote inventory immediately before this decision.
+/// A concurrent publisher may have completed the same release in that window.
+pub(crate) fn adopted_release_needs_publish(is_draft: bool) -> bool {
+    is_draft
+}

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -297,6 +297,7 @@ fn reconcile_release_publications_with(
     remote_assets: &[GitHubReleaseAsset],
     verify_digestless: &mut impl FnMut(&GitHubReleaseAsset, u64) -> Result<(u64, String), String>,
 ) -> Result<(Vec<ReleaseAssetPublication>, Vec<ReleaseAssetPublication>), String> {
+    validate_remote_publication_inventory(publications, remote_assets)?;
     let mut upload = Vec::new();
     let mut existing = Vec::new();
     for publication in publications {
@@ -317,9 +318,11 @@ fn reconcile_release_publications_with(
         if verify_release_publication(publication, remote, verify_digestless)? {
             existing.push(publication.clone());
         } else {
+            let remote_digest = canonical_remote_digest(remote)?
+                .unwrap_or_else(|| "unavailable (downloaded bytes differed)".to_string());
             return Err(format!(
-                "GitHub Release asset '{}' conflicts with the canonical publication bytes",
-                publication.target_name
+                "GitHub Release asset '{}' conflicts with the canonical publication bytes (remote digest: {}; authoritative digest: sha256:{})",
+                publication.target_name, remote_digest, publication.sha256
             ));
         }
     }
@@ -626,6 +629,7 @@ fn verify_release_publications_with(
     assets: &[GitHubReleaseAsset],
     verify_digestless: &mut impl FnMut(&GitHubReleaseAsset, u64) -> Result<(u64, String), String>,
 ) -> Result<(), String> {
+    validate_remote_publication_inventory(publications, assets)?;
     for publication in publications {
         let matches = assets
             .iter()
@@ -649,6 +653,40 @@ fn verify_release_publications_with(
                 publication.target_name
             ));
         }
+    }
+    Ok(())
+}
+
+fn validate_remote_publication_inventory(
+    publications: &[ReleaseAssetPublication],
+    assets: &[GitHubReleaseAsset],
+) -> Result<(), String> {
+    let expected = publications
+        .iter()
+        .map(|publication| publication.target_name.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let actual = assets
+        .iter()
+        .map(|asset| asset.name.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut seen = std::collections::BTreeSet::new();
+    let duplicated = assets
+        .iter()
+        .filter(|asset| !seen.insert(asset.name.as_str()))
+        .map(|asset| asset.name.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    if !duplicated.is_empty() {
+        return Err(format!(
+            "GitHub Release has multiple assets named {}; canonical publication ownership is ambiguous",
+            duplicated.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+    }
+    let unexpected = actual.difference(&expected).copied().collect::<Vec<_>>();
+    if !unexpected.is_empty() {
+        return Err(format!(
+            "GitHub Release has assets outside the authoritative publication inventory: {}",
+            unexpected.join(", ")
+        ));
     }
     Ok(())
 }
@@ -1074,8 +1112,8 @@ pub(crate) fn validate_draft_adoption(
     metadata: &GitHubReleaseMetadata,
     sidecars: &BTreeMap<String, String>,
 ) -> Result<(), String> {
-    if !metadata.is_draft || metadata.tag_name != tag {
-        return Err("draft adoption requires the matching unpublished GitHub Release".to_string());
+    if metadata.tag_name != tag {
+        return Err("draft adoption requires the matching GitHub Release".to_string());
     }
     let expected = expected_names
         .iter()
@@ -1673,6 +1711,11 @@ mod tests {
         let mut sidecars = BTreeMap::new();
         sidecars.insert("app.zip.sha256".to_string(), format!("{digest}  app.zip\n"));
         validate_draft_adoption("v1.2.3", &expected, &metadata, &sidecars).expect("valid adoption");
+
+        let mut published = metadata.clone();
+        published.is_draft = false;
+        validate_draft_adoption("v1.2.3", &expected, &published, &sidecars)
+            .expect("the same verified release may become published before finalization");
 
         let mut extra = metadata.clone();
         extra
@@ -2453,7 +2496,7 @@ mod tests {
     }
 
     #[test]
-    fn partial_reupload_reuses_verified_asset_and_uploads_only_missing_asset() {
+    fn draft_to_published_recovery_reuses_verified_asset_and_uploads_only_missing_asset() {
         let dir = tempfile::tempdir().expect("tempdir");
         let first = dir.path().join("first.zip");
         let second = dir.path().join("second.zip");
@@ -2465,16 +2508,23 @@ mod tests {
         ]))
         .expect("publication identities");
 
-        let (uploads, existing) = reconcile_release_publications_with(
-            &publications,
-            &[remote_asset(
+        let mut metadata = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: vec![remote_asset(
                 "first.zip",
                 publications[0].size,
                 Some(format!("sha256:{}", publications[0].sha256)),
             )],
+        };
+        metadata.is_draft = false;
+
+        let (uploads, existing) = reconcile_release_publications_with(
+            &publications,
+            &metadata.assets,
             &mut unexpected_download,
         )
-        .expect("partial recovery");
+        .expect("reconcile after publication");
 
         assert_eq!(existing, vec![publications[0].clone()]);
         assert_eq!(uploads, vec![publications[1].clone()]);
@@ -2516,7 +2566,7 @@ mod tests {
     }
 
     #[test]
-    fn conflicting_preexisting_canonical_asset_is_rejected() {
+    fn draft_to_published_recovery_rejects_conflicting_existing_asset() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("component.zip");
         std::fs::write(&path, b"component bytes").expect("write zip");
@@ -2524,17 +2574,30 @@ mod tests {
             github_release_publications(&release_state_with_artifacts(vec![artifact(&path, None)]))
                 .expect("publication identity");
 
-        let error = reconcile_release_publications_with(
-            &publications,
-            &[remote_asset(
+        let remote_digest = format!("sha256:{}", "f".repeat(64));
+        let mut metadata = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: vec![remote_asset(
                 "component.zip",
                 publications[0].size,
-                Some(format!("sha256:{}", "f".repeat(64))),
+                Some(remote_digest.clone()),
             )],
+        };
+        metadata.is_draft = false;
+
+        let error = reconcile_release_publications_with(
+            &publications,
+            &metadata.assets,
             &mut unexpected_download,
         )
         .expect_err("conflicting bytes must fail");
-        assert!(error.contains("conflicts with the canonical publication bytes"));
+        assert!(error.contains("asset 'component.zip' conflicts"));
+        assert!(error.contains(&format!("remote digest: {remote_digest}")));
+        assert!(error.contains(&format!(
+            "authoritative digest: sha256:{}",
+            publications[0].sha256
+        )));
     }
 
     #[test]
@@ -2616,6 +2679,29 @@ mod tests {
         .expect_err("duplicate canonical names must fail closed");
 
         assert!(error.contains("canonical publication ownership is ambiguous"));
+    }
+
+    #[test]
+    fn remote_asset_outside_authoritative_inventory_is_rejected() {
+        let publication = ReleaseAssetPublication {
+            target_name: "component.zip".to_string(),
+            sha256: "a".repeat(64),
+            size: 15,
+            source_path: "component.zip".to_string(),
+        };
+        let error = reconcile_release_publications_with(
+            &[publication],
+            &[remote_asset(
+                "unrelated.zip",
+                15,
+                Some(format!("sha256:{}", "b".repeat(64))),
+            )],
+            &mut unexpected_download,
+        )
+        .expect_err("unrelated remote asset must fail closed");
+
+        assert!(error.contains("outside the authoritative publication inventory"));
+        assert!(error.contains("unrelated.zip"));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -5,7 +5,9 @@ use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 
 use super::super::step_success;
-use super::delivery::{existing_release_action, ExistingReleaseAction};
+use super::delivery::{
+    adopted_release_needs_publish, existing_release_action, ExistingReleaseAction,
+};
 use super::gh_cli::{
     gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
     github_release_publications,
@@ -244,6 +246,20 @@ pub(crate) fn run_github_release(
                 .map_err(|error| {
                 Error::validation_invalid_argument("release assets", error, None, None)
             })?;
+            if !adopted_release_needs_publish(current.is_draft) {
+                homeboy_core::log_status!(
+                    "release",
+                    "GitHub Release {} became published for {} after adoption planning — skipping publish (idempotent)",
+                    tag,
+                    repo_flag
+                );
+                return Ok(skipped_result(
+                    &tag,
+                    &github,
+                    "release-already-published",
+                    None,
+                ));
+            }
             let output = run_gh_command(
                 gh_command(
                     &github,

--- a/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
@@ -15,6 +15,7 @@
 //! them whenever the run carried no artifacts of its own, so the pipeline
 //! reported a delivered release over an undeliverable tag.
 
+use super::super::delivery::adopted_release_needs_publish;
 use super::super::{existing_release_action, ExistingReleaseAction};
 
 #[test]
@@ -23,6 +24,12 @@ fn published_release_with_nothing_to_attach_is_an_idempotent_no_op() {
         existing_release_action(false, false, 13, true),
         ExistingReleaseAction::AlreadyPublished
     );
+}
+
+#[test]
+fn adoption_does_not_republish_after_the_release_becomes_published() {
+    assert!(adopted_release_needs_publish(true));
+    assert!(!adopted_release_needs_publish(false));
 }
 
 #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -637,7 +637,7 @@ fn release_finish_head_pipeline_uses_homeboy_action_head_inputs() {
     assert!(host.contains("expected_assets: $expected_assets"));
     assert!(host.contains("Download current Homeboy finalizer"));
     assert!(host.contains("binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}"));
-    assert!(host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}"));
+    assert!(host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}"));
 }
 
 #[test]
@@ -846,17 +846,15 @@ fn release_recovery_skips_the_artifact_rebuild_when_the_draft_is_already_complet
         );
     }
 
-    // ...and the adoption phase is not, or the fast path would publish nothing.
-    let adoption = &host[host
-        .find("- name: Create remote draft adoption manifest")
-        .expect("host must build the draft adoption manifest")..];
+    // ...and remote-only adoption is reserved for that complete fast path.
+    let adoption = release_step_block(host, "name: Create remote draft adoption manifest");
     assert!(
-        !adoption.contains("draft-complete != 'true'"),
-        "verified draft adoption must run on the fast path — it is the whole point of taking it"
+        adoption.contains("needs.plan.outputs.draft-complete == 'true'"),
+        "verified draft adoption must run only on the complete remote fast path"
     );
     assert!(
-        adoption.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}"),
-        "the fast path must still hand the finalizer the remote-adoption manifest"
+        host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}"),
+        "only the complete fast path may hand the finalizer the remote-adoption manifest; rebuilt recovery must retain local artifact authority"
     );
 }
 
@@ -880,6 +878,15 @@ fn release_fast_path_keeps_every_publication_verification() {
     assert!(
         verify.contains("HOST_RESULT: ${{ needs.host.result }}"),
         "verification must still require the publishing job to have succeeded"
+    );
+    assert!(
+        verify.contains("jq -e '.draft == false' release.json"),
+        "verification must require the final release to be published"
+    );
+    assert!(
+        verify.contains("[.assets[].name] | sort")
+            && verify.contains("jq -c 'sort' <<< \"${EXPECTED_ASSETS}\""),
+        "verification must require the remote inventory to exactly match the authoritative plan"
     );
 
     // The control binary that performs adoption is still the one built from the


### PR DESCRIPTION
Closes #10733

## Summary
- keep rebuilt recovery artifacts as the authoritative finalizer input, even when the probed draft becomes published while matrices run
- reconcile the matching release by exact canonical name, size, and SHA-256; reuse matching bytes, upload only missing publications, and reject conflicts, duplicate names, or assets outside the authoritative inventory
- make complete remote-only adoption lifecycle-tolerant while preserving exact tag/inventory checks, and skip `--draft=false` when the final reread is already published
- require final workflow verification to observe a published release with the exact planned asset-name inventory

## Source relationship and scope
- Source evidence: recovery run https://github.com/Extra-Chill/homeboy/actions/runs/30414880669 for `v0.322.0` / `3a94fad401418550e76d378bcc9ced33632da36c`, where planning expected 13 assets and finalization observed the matching published release with 7 valid assets after the draft-to-published transition.
- Change kind: bounded workflow routing, release-delivery validation, and deterministic regression tests based on the existing draft-adoption and canonical-publication implementation families.
- Verification capability: local tests model metadata changing from draft to published and prove verified reuse plus missing upload, conflict diagnostics with both digests, duplicate/unexpected-name refusal, complete-adoption idempotency, and no republish decision. No live release mutation was used.
- Runtime breadth: incomplete recovery is routed into the pre-existing authoritative local-artifact reconciler; complete adoption only relaxes publication lifecycle state after retaining exact tag, asset, digest, upload-state, and checksum validation. Inventory validation is tightened only to enforce the manifest-owned publication set evidenced by this incident.

The missing inventory in the source run was `dist-manifest.json`, both aarch64 archives and sidecars, and the x86_64 macOS archive and sidecar. This change does not modify or dispatch recovery for the existing `v0.322.0` release.

## Verification
- `cargo test -p homeboy-release --lib release::executor::github_release` (111 passed)
- `cargo test --test release_workflow_test` (35 passed)
- `cargo test --test release_expected_assets_test` (5 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

Existing workspace warnings remain unchanged.

## AI assistance
OpenCode with `openai/gpt-5.6-sol` traced the GitHub release metadata and draft-adoption delivery flow, implemented the bounded runtime and test changes, ran focused verification, and performed a second-pass review. Chris Huber reviews and owns the change.