### PR TITLE
fix(release): complete assets after draft publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1091,8 +1091,27 @@ jobs:
         run: |
           rm -f artifacts/*-dist-manifest.json
 
+      - name: Create authoritative recovery manifest
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs['release-version'] }}
+          EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
+        run: |
+          set -euo pipefail
+          COMMIT="$(git rev-parse "${RELEASE_TAG}^{}")"
+          jq -n \
+            --arg schema homeboy.package-recovery \
+            --argjson schema_version 1 \
+            --arg component_id homeboy \
+            --arg tag "${RELEASE_TAG}" \
+            --arg version "${RELEASE_VERSION}" \
+            --arg commit "${COMMIT}" \
+            --argjson expected_assets "${EXPECTED_ASSETS}" \
+            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, artifacts: [$expected_assets[] | {path: ("artifacts/" + .)}]}' > artifacts/manifest.json
+
       - name: Create remote draft adoption manifest
-        if: needs.prepare.outputs.recovery-release == 'true'
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true'
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           RELEASE_VERSION: ${{ needs.prepare.outputs['release-version'] }}
@@ -1162,7 +1181,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           CONTROL_SHA: ${{ github.sha }}
-          ADOPTION_SOURCE: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}
+          ADOPTION_SOURCE: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}
           ARTIFACT_ORIGIN: ${{ needs.plan.outputs.draft-complete == 'true' && 'pre-existing draft assets (rebuild skipped)' || 'rebuilt and re-uploaded by this run' }}
         run: |
           set -euo pipefail
@@ -1199,7 +1218,7 @@ jobs:
           commands: release
           binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}
           release-head: 'true'
-          release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}
+          release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}
           release-skip-publish: 'true'
 
   # ── Step 5b: Fail loudly if a prepared release did not publish ──

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -317,9 +317,11 @@ fn reconcile_release_publications_with(
         if verify_release_publication(publication, remote, verify_digestless)? {
             existing.push(publication.clone());
         } else {
+            let observed = canonical_remote_digest(remote)?
+                .unwrap_or_else(|| "downloaded bytes with no reported digest".to_string());
             return Err(format!(
-                "GitHub Release asset '{}' conflicts with the canonical publication bytes",
-                publication.target_name
+                "GitHub Release asset '{}' conflicts with the canonical publication bytes (expected sha256:{}, found {})",
+                publication.target_name, publication.sha256, observed
             ));
         }
     }
@@ -2453,7 +2455,7 @@ mod tests {
     }
 
     #[test]
-    fn partial_reupload_reuses_verified_asset_and_uploads_only_missing_asset() {
+    fn draft_published_during_build_reuses_verified_asset_and_uploads_only_missing_asset() {
         let dir = tempfile::tempdir().expect("tempdir");
         let first = dir.path().join("first.zip");
         let second = dir.path().join("second.zip");
@@ -2464,20 +2466,88 @@ mod tests {
             artifact(&second, None),
         ]))
         .expect("publication identities");
-
-        let (uploads, existing) = reconcile_release_publications_with(
-            &publications,
-            &[remote_asset(
+        let planned = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: Vec::new(),
+        };
+        assert!(planned.is_draft, "planning observed the matching draft");
+        let finalizing = GitHubReleaseMetadata {
+            tag_name: planned.tag_name.clone(),
+            is_draft: false,
+            assets: vec![remote_asset(
                 "first.zip",
                 publications[0].size,
                 Some(format!("sha256:{}", publications[0].sha256)),
             )],
+        };
+
+        let (uploads, existing) = reconcile_release_publications_with(
+            &publications,
+            &finalizing.assets,
             &mut unexpected_download,
         )
         .expect("partial recovery");
 
+        assert_eq!(finalizing.tag_name, planned.tag_name);
+        assert!(!finalizing.is_draft, "finalization observed publication");
         assert_eq!(existing, vec![publications[0].clone()]);
         assert_eq!(uploads, vec![publications[1].clone()]);
+
+        let mut completed_assets = finalizing.assets;
+        completed_assets.push(remote_asset(
+            "second.zip",
+            publications[1].size,
+            Some(format!("sha256:{}", publications[1].sha256)),
+        ));
+        verify_release_publications_with(
+            &publications,
+            &completed_assets,
+            &mut unexpected_download,
+        )
+        .expect("the missing authoritative upload completes the published release");
+    }
+
+    #[test]
+    fn draft_published_during_build_rejects_conflicting_existing_bytes() {
+        let publication = ReleaseAssetPublication {
+            target_name: "component.zip".to_string(),
+            sha256: "a".repeat(64),
+            size: 15,
+            source_path: "component.zip".to_string(),
+        };
+        let planned = GitHubReleaseMetadata {
+            tag_name: "v1.2.3".to_string(),
+            is_draft: true,
+            assets: Vec::new(),
+        };
+        let finalizing = GitHubReleaseMetadata {
+            tag_name: planned.tag_name.clone(),
+            is_draft: false,
+            assets: vec![remote_asset(
+                "component.zip",
+                publication.size,
+                Some(format!("sha256:{}", "b".repeat(64))),
+            )],
+        };
+
+        let error = reconcile_release_publications_with(
+            &[publication],
+            &finalizing.assets,
+            &mut unexpected_download,
+        )
+        .expect_err("published conflicting bytes must fail closed");
+
+        assert_eq!(finalizing.tag_name, planned.tag_name);
+        assert!(!finalizing.is_draft);
+        assert_eq!(
+            error,
+            format!(
+                "GitHub Release asset 'component.zip' conflicts with the canonical publication bytes (expected sha256:{}, found sha256:{})",
+                "a".repeat(64),
+                "b".repeat(64)
+            )
+        );
     }
 
     #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -637,7 +637,7 @@ fn release_finish_head_pipeline_uses_homeboy_action_head_inputs() {
     assert!(host.contains("expected_assets: $expected_assets"));
     assert!(host.contains("Download current Homeboy finalizer"));
     assert!(host.contains("binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}"));
-    assert!(host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}"));
+    assert!(host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}"));
 }
 
 #[test]
@@ -855,9 +855,34 @@ fn release_recovery_skips_the_artifact_rebuild_when_the_draft_is_already_complet
         "verified draft adoption must run on the fast path — it is the whole point of taking it"
     );
     assert!(
-        adoption.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && 'draft-adoption' || 'artifacts' }}"),
+        adoption.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}"),
         "the fast path must still hand the finalizer the remote-adoption manifest"
     );
+}
+
+/// Issue #10733: the release can become published while the artifact matrix is
+/// still building. cargo-dist then reports a successful upload without filling
+/// the published release, so finalization must retain the rebuilt byte authority
+/// instead of replacing it with the remote-only draft-adoption contract.
+#[test]
+fn incomplete_recovery_delivers_identity_bound_artifacts_to_the_finalizer() {
+    let host = job_section(release_workflow(), "host");
+    let recovery = release_step_block(host, "name: Create authoritative recovery manifest");
+    let adoption = release_step_block(host, "name: Create remote draft adoption manifest");
+
+    assert!(recovery.contains(
+        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'"
+    ));
+    assert!(recovery.contains("--arg schema homeboy.package-recovery"));
+    assert!(recovery.contains("--arg tag \"${RELEASE_TAG}\""));
+    assert!(recovery.contains("--arg commit \"${COMMIT}\""));
+    assert!(recovery.contains("artifacts: [$expected_assets[] | {path: (\"artifacts/\" + .)}]"));
+    assert!(adoption.contains(
+        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true'"
+    ));
+    assert!(host.contains(
+        "needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts'"
+    ));
 }
 
 /// The fast path is an optimisation, never a relaxation. Skipping the rebuild


### PR DESCRIPTION
## Summary

- keep rebuilt recovery assets as finalizer publication authority when the planned draft was incomplete
- retain remote-only draft adoption for complete drafts and existing complete-published idempotency
- report canonical and observed SHA-256 identities when an existing named asset conflicts

Closes #10733.

## Evidence

- Source relationship: direct fix for #10733, reproduced by recovery run https://github.com/Extra-Chill/homeboy/actions/runs/30414880669.
- Observed identity: `v0.322.0` / `3a94fad401418550e76d378bcc9ced33632da36c`; the release became published at `2026-07-29T02:14:40Z` while the matrix was still building.
- Observed inventory: the authoritative plan required 13 assets, while finalization still saw the seven pre-existing valid assets and lacked `dist-manifest.json`, both aarch64 archives/sidecars, and the x86_64 macOS archive/sidecar.
- Change kind: workflow delivery-contract correction plus generic conflict diagnostics and deterministic regression coverage.
- Verification capability: tests model `draft=true` during planning and the same tag at `draft=false` during finalization, proving verified reuse, missing-only completion, and fail-closed conflicting bytes.
- Scope boundary: no broader release lifecycle predicate was added. Incomplete recovery now feeds the existing identity-bound package-recovery and canonical reconciliation implementation; the existing complete-draft adoption path and published no-artifact no-op remain unchanged.
- Safety: this PR did not publish, deploy, or modify the existing `v0.322.0` release.

## Verification

- `cargo test -p homeboy-release release::executor::github_release` (90 passed)
- `cargo test --test release_workflow_test` (36 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance

OpenCode using `openai/gpt-5.6-sol` traced the GitHub metadata, run timeline, draft-adoption handoff, and existing asset-authority predicates; implemented the bounded workflow and diagnostic changes; and authored and ran the deterministic tests. The PR diff and evidence remain subject to maintainer review.