### PR TITLE
fix(release): preserve published bytes during recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1091,6 +1091,41 @@ jobs:
         run: |
           rm -f artifacts/*-dist-manifest.json
 
+      - name: Preserve existing published asset bytes
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${RELEASE_TAG}" --json isDraft,assets > existing-release.json; then
+            exit 0
+          fi
+          if [ "$(jq -r '.isDraft' existing-release.json)" != "false" ]; then
+            exit 0
+          fi
+
+          mkdir -p existing-assets
+          gh release download "${RELEASE_TAG}" --dir existing-assets
+          while IFS= read -r name; do
+            path="existing-assets/${name}"
+            if [ ! -f "${path}" ]; then
+              continue
+            fi
+            test -s "${path}"
+            remote_digest="$(jq -r --arg name "${name}" '.assets[] | select(.name == $name) | .digest // empty' existing-release.json)"
+            if [[ "${remote_digest}" != sha256:* ]]; then
+              echo "::error::GitHub metadata did not provide a SHA-256 digest for existing asset ${name}"
+              exit 1
+            fi
+            actual_digest="sha256:$(sha256sum "${path}" | cut -d' ' -f1)"
+            if [ "${actual_digest}" != "${remote_digest}" ]; then
+              echo "::error::Downloaded ${name} digest ${actual_digest} does not match GitHub metadata ${remote_digest}"
+              exit 1
+            fi
+            cp "${path}" "artifacts/${name}"
+          done < <(jq -r '.[]' <<< "${EXPECTED_ASSETS}")
+
       - name: Create authoritative recovery manifest
         if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
         env:

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -867,9 +867,17 @@ fn release_recovery_skips_the_artifact_rebuild_when_the_draft_is_already_complet
 #[test]
 fn incomplete_recovery_delivers_identity_bound_artifacts_to_the_finalizer() {
     let host = job_section(release_workflow(), "host");
+    let preserve = release_step_block(host, "name: Preserve existing published asset bytes");
     let recovery = release_step_block(host, "name: Create authoritative recovery manifest");
     let adoption = release_step_block(host, "name: Create remote draft adoption manifest");
 
+    assert!(preserve.contains(
+        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'"
+    ));
+    assert!(preserve.contains(".isDraft' existing-release.json)\" != \"false\""));
+    assert!(preserve.contains("done < <(jq -r '.[]' <<< \"${EXPECTED_ASSETS}\")"));
+    assert!(preserve.contains("actual_digest=\"sha256:$(sha256sum"));
+    assert!(preserve.contains("cp \"${path}\" \"artifacts/${name}\""));
     assert!(recovery.contains(
         "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'"
     ));


### PR DESCRIPTION
## Summary

- preserve already-published bytes for names in the authoritative cargo-dist plan
- verify every downloaded asset against GitHub's SHA-256 metadata before overlaying rebuilt artifacts
- keep rebuilt bytes authoritative only for missing names and retain Homeboy's conflict checks

Closes #10752.

## Evidence

Recovery run https://github.com/Extra-Chill/homeboy/actions/runs/30428262530 rebuilt all 13 assets for `v0.322.0`, then correctly failed closed because the rebuilt Linux x86_64 archive did not match the existing published archive. The existing release bytes came from the same tagged release pipeline but cargo-dist archives are not byte-reproducible across rebuilds.

This workflow repair downloads the existing published release, overlays only names already present in `expected-assets`, and validates each downloaded file against GitHub's `sha256:` digest before the identity-bound `homeboy.package-recovery` manifest is generated. Missing names remain supplied by the new matrix build. Draft recovery and the generic Homeboy finalizer are unchanged.

## Verification

- `cargo test --test release_workflow_test` (36 passed)
- `actionlint -ignore SC2129 -ignore SC2086 .github/workflows/release.yml`
- `git diff --check`

## AI Assistance

OpenCode using `openai/gpt-5.6-sol` diagnosed the failed tagged recovery, implemented the workflow artifact-overlay repair, and added the regression assertions. Chris remains responsible for the final change.