### PR TITLE
fix(lifecycle): persist terminal authority outside config lock

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -811,6 +811,18 @@ fn expired_or_cancelled_pending_submission_binds_and_cancels_the_accepted_job() 
                 assert_eq!(record.state, AgentTaskRunState::Cancelled);
                 let job_id = job.id.to_string();
                 assert_eq!(record.runner_job_id(), Some(job_id.as_str()));
+                assert_eq!(
+                    crate::agent_task_lifecycle::workspace_authority::resolve_workspace_terminal_authority(
+                        run_id,
+                        "homeboy-lab",
+                        "/runner/workspace/homeboy",
+                        Some(&job_id),
+                    )
+                    .expect("terminal authority resolves")
+                    .expect("terminal authority persisted")
+                    .runner_job_id,
+                    job_id,
+                );
             }
         }
         record_lab_offload_planned(LabOffloadProxyPlan {

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -128,14 +128,23 @@ pub(super) fn mutate_record(
     run_id: &str,
     mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
 ) -> Result<Option<AgentTaskRunRecord>> {
-    homeboy_core::config::with_config_lock(|| {
+    let record = homeboy_core::config::with_config_lock(|| {
         let mut record = read_record(run_id)?;
         if !mutate(&mut record) {
             return Ok(None);
         }
-        write_record(&record)?;
-        Ok(Some(record))
-    })
+        let committed = write_record_with_aggregate_without_workspace_authority(
+            &record,
+            read_mirrored_aggregate(&record.run_id)?,
+        )?;
+        Ok(Some(committed))
+    })?;
+    if let Some(record) = record.as_ref() {
+        // Terminal authority has its own config lock. Persist it after releasing
+        // the record mutation lock so a terminal update cannot self-deadlock.
+        super::workspace_authority::persist_terminal_from_record(record)?;
+    }
+    Ok(record)
 }
 
 /// Commit the controller projection and child aggregate in one observation row.
@@ -170,6 +179,14 @@ fn write_record_with_aggregate(
     record: &AgentTaskRunRecord,
     aggregate: Option<AgentTaskAggregate>,
 ) -> Result<()> {
+    let committed = write_record_with_aggregate_without_workspace_authority(record, aggregate)?;
+    super::workspace_authority::persist_terminal_from_record(&committed)
+}
+
+fn write_record_with_aggregate_without_workspace_authority(
+    record: &AgentTaskRunRecord,
+    aggregate: Option<AgentTaskAggregate>,
+) -> Result<AgentTaskRunRecord> {
     #[cfg(test)]
     if FAIL_NEXT_RECORD_WRITE.swap(false, Ordering::SeqCst) {
         return Err(Error::internal_io(
@@ -205,7 +222,7 @@ fn write_record_with_aggregate(
             record.run_id
         ))
     })?;
-    super::workspace_authority::persist_terminal_from_record(&record_from_run(&committed)?)
+    record_from_run(&committed)
 }
 
 pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {


### PR DESCRIPTION
## Summary

- release the lifecycle mutation config lock before persisting terminal workspace authority
- retain the existing committed record and aggregate projection behavior
- assert that the accepted cancelled runner job still persists terminal authority

Closes #10751.

## Root Cause

`mutate_record` held `config.lock` while `write_record` called terminal workspace-authority persistence. That persistence path acquires the same filesystem lock, causing a self-deadlock when a mutation becomes terminal. CI then consumed the full differential test budgets rather than surfacing an assertion.

## Verification

- `cargo test -p homeboy-agents expired_or_cancelled_pending_submission_binds_and_cancels_the_accepted_job -- --nocapture` (passed in 7.74s)
- `cargo fmt --all -- --check`
- `git diff --check`

The broader `status_and_recovery` module still has the unrelated `malformed_typed_pending_handoff_is_health_malformed_and_unreconciled` failure reproduced on clean current main; it is not introduced by this change.

## AI Assistance

OpenCode using `openai/gpt-5.6-sol` traced the nested filesystem lock, implemented the lock-order repair, and added and ran the terminal-authority regression assertion. Chris remains responsible for the final change.