### PR TITLE
Expose result writer helper to extension test runners

### DIFF
--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -345,6 +345,7 @@ fn run_main_test_workflow_inner(
         .is_some();
     let no_tests_evidence_file = run_dir.step_file(run_dir::files::NO_TESTS_APPLICABLE);
     let no_tests_nonce = uuid::Uuid::new_v4().to_string();
+    let write_results_helper = write_test_results_helper(run_dir)?;
 
     let runner = build_test_runner(
         component,
@@ -365,6 +366,10 @@ fn run_main_test_workflow_inner(
         .env(
             "HOMEBOY_TEST_RESULTS_FILE",
             results_file.to_string_lossy().as_ref(),
+        )
+        .env(
+            crate::runtime_helper::WRITE_TEST_RESULTS_ENV,
+            write_results_helper.to_string_lossy().as_ref(),
         )
         .env_if(
             no_tests_policy_enabled,
@@ -1013,14 +1018,9 @@ fn run_declared_result_parser(
         settings_json,
         &run_dir.legacy_env_vars(),
     )?;
-    let write_results_helper = run_dir.path().join("write-test-results.sh");
-    local_files::write_file_atomic(
-        &write_results_helper,
-        include_str!("../runtime/write-test-results.sh"),
-        "write parser runtime helper",
-    )?;
+    let write_results_helper = write_test_results_helper(run_dir)?;
     env_vars.push((
-        "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS".to_string(),
+        crate::runtime_helper::WRITE_TEST_RESULTS_ENV.to_string(),
         write_results_helper.to_string_lossy().to_string(),
     ));
     env_vars.push((
@@ -1100,6 +1100,16 @@ fn run_declared_result_parser(
     }
 
     Ok(())
+}
+
+fn write_test_results_helper(run_dir: &RunDir) -> homeboy_core::Result<std::path::PathBuf> {
+    let helper = run_dir.path().join("write-test-results.sh");
+    local_files::write_file_atomic(
+        &helper,
+        include_str!("../runtime/write-test-results.sh"),
+        "write test results runtime helper",
+    )?;
+    Ok(helper)
 }
 
 fn declared_result_parser_error(

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -419,8 +419,9 @@ fn full_extension_test_supplies_canonical_result_sidecar() {
             r#"#!/bin/sh
 set -eu
 test -n "$HOMEBOY_TEST_RESULTS_FILE"
-mkdir -p "$(dirname "$HOMEBOY_TEST_RESULTS_FILE")"
-printf '{"schema":"fixture/test-results/v1","total":2,"passed":2,"failed":0,"skipped":0}\n' > "$HOMEBOY_TEST_RESULTS_FILE"
+test -f "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS"
+source "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS"
+homeboy_write_test_results 2 2 0 0
 "#,
         )
         .expect("extension script should be written");
@@ -431,7 +432,6 @@ printf '{"schema":"fixture/test-results/v1","total":2,"passed":2,"failed":0,"ski
 set -eu
 test "$1" = "$HOMEBOY_TEST_RESULTS_FILE"
 test "${2:-}" = "fixture-json"
-grep -q 'fixture/test-results/v1' "$1"
 source "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS"
 homeboy_write_test_results 2 2 0 0
 "#,


### PR DESCRIPTION
## Summary
- materialize the canonical test-result writer before the extension runner starts
- export `HOMEBOY_RUNTIME_WRITE_TEST_RESULTS` with `HOMEBOY_TEST_RESULTS_FILE`
- reuse the same run-scoped helper for the declared post-run parser
- require the integration fixture runner to write counts through the canonical helper

## Production evidence
Static Site Importer run https://github.com/Automattic/static-site-importer/actions/runs/30409101468 has identical PHP 8.1-8.4 failures: the WP Codebox command exits 0, but no structured sidecar is written and Homeboy fails closed with null counts. The WordPress parser requires this helper to call `homeboy_write_test_results`.

Closes #10528.

## Verification
- `cargo test -p homeboy-cli full_extension_test_supplies_canonical_result_sidecar -- --nocapture`
- `cargo test -p homeboy-cli component_script_test -- --nocapture` (16 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode diagnosed the production evidence, implemented the focused runner contract fix, and drafted the regression test update. Chris Huber reviewed and remains responsible for the change.