### PR TITLE
fix: quick-win batch from the 2026-07-29 issue triage (8 issues)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/tests/common.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/common.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+/// Wall-clock budget for provider subprocess tests. Generous on purpose: these
+/// tests spawn real `node` processes, and the suite runs at default parallelism
+/// on shared machines where a tight window turns a correct terminal status into
+/// a spurious `Timeout` (#7739).
+pub(super) const PROVIDER_TEST_TIMEOUT_MS: u64 = 60_000;
+
 pub(super) fn script(body: &str) -> String {
     let path = std::env::temp_dir().join(format!(
         "homeboy-agent-task-provider-{}-{}.js",
@@ -68,7 +74,19 @@ pub(super) fn request(
         workspace: AgentTaskWorkspace::default(),
         component_contracts: Vec::new(),
         policy: AgentTaskPolicy::default(),
-        limits: AgentTaskLimits::default(),
+        // Pin an explicit, generous wall-clock timeout instead of inheriting the
+        // process-global default. `provider_default_timeout_returns_structured_
+        // outcome_without_explicit_timeout` sets the test default to 50ms through
+        // a process-wide env var, so any sibling test that relied on the default
+        // observed 50ms whenever the two ran concurrently and reported `Timeout`
+        // instead of its real terminal status. Being explicit also makes these
+        // subprocess-spawning tests tolerant of CPU contention on a loaded box
+        // (#7739). Tests that specifically exercise timeout behaviour override
+        // `limits.timeout_ms` themselves.
+        limits: AgentTaskLimits {
+            timeout_ms: Some(PROVIDER_TEST_TIMEOUT_MS),
+            ..AgentTaskLimits::default()
+        },
         expected_artifacts: Vec::new(),
         artifact_declarations: Vec::new(),
         output_declarations: Vec::new(),

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -623,17 +623,37 @@ fn expired_execution_deadline_returns_typed_outcome_without_spawning_provider() 
     assert_eq!(outcome.diagnostics[0].data["remaining_budget_ms"], 0);
 }
 
+/// Restores the process-global test timeout override on drop, including on
+/// panic. Without this a failing assertion left the 50ms override set for every
+/// subsequent test in the process (#7739).
+struct DefaultTimeoutOverride;
+
+impl DefaultTimeoutOverride {
+    fn set(value: &str) -> Self {
+        std::env::set_var("HOMEBOY_AGENT_TASK_TEST_DEFAULT_PROVIDER_TIMEOUT_MS", value);
+        Self
+    }
+}
+
+impl Drop for DefaultTimeoutOverride {
+    fn drop(&mut self) {
+        std::env::remove_var("HOMEBOY_AGENT_TASK_TEST_DEFAULT_PROVIDER_TIMEOUT_MS");
+    }
+}
+
 #[test]
 fn provider_default_timeout_returns_structured_outcome_without_explicit_timeout() {
     let _lock = DEFAULT_TIMEOUT_ENV_LOCK
         .lock()
         .expect("default timeout env lock");
-    std::env::set_var("HOMEBOY_AGENT_TASK_TEST_DEFAULT_PROVIDER_TIMEOUT_MS", "50");
+    let _override = DefaultTimeoutOverride::set("50");
     let command = format!("node {}", script("setInterval(() => {}, 1000);"));
-    let (request, provider) = request("task-default-timeout", command);
+    let (mut request, provider) = request("task-default-timeout", command);
+    // This test is specifically about the *default*, so drop the explicit
+    // timeout the shared fixture now pins.
+    request.limits.timeout_ms = None;
 
     let outcome = run_provider_command(&request, &provider, None);
-    std::env::remove_var("HOMEBOY_AGENT_TASK_TEST_DEFAULT_PROVIDER_TIMEOUT_MS");
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Timeout);
     assert_eq!(

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2359,6 +2359,57 @@ mod tests {
         );
     }
 
+    /// One compact-output convention must work across the `review` umbrella and
+    /// every phase subcommand. Before #10428 `review lint --summary` parsed while
+    /// `review test --summary` failed and clap suggested `-- --summary`, which
+    /// would have forwarded the flag to the underlying test runner instead.
+    ///
+    /// `--summary` is the umbrella's own compact-output selector, and
+    /// `review/mod.rs` already maps it onto `json_summary` for the test and audit
+    /// phases and onto `summary` for lint — so accepting it directly on each
+    /// phase makes the phase surface agree with the umbrella that drives it.
+    #[test]
+    fn summary_is_accepted_across_the_review_umbrella_and_every_phase() {
+        let phases: &[&[&str]] = &[
+            &["homeboy", "review", "lint", "homeboy", "--summary"],
+            &["homeboy", "review", "test", "homeboy", "--summary"],
+            &["homeboy", "review", "audit", "homeboy", "--summary"],
+            &["homeboy", "review", "lint", "homeboy", "--json-summary"],
+            &["homeboy", "review", "test", "homeboy", "--json-summary"],
+            &["homeboy", "review", "audit", "homeboy", "--json-summary"],
+        ];
+
+        for args in phases {
+            Cli::try_parse_from(*args)
+                .unwrap_or_else(|err| panic!("{args:?} must parse, got: {err}"));
+        }
+
+        // The umbrella's own canonical spelling keeps working unchanged.
+        Cli::try_parse_from(["homeboy", "review", "homeboy", "--summary"])
+            .expect("review --summary must parse");
+    }
+
+    /// The alias must select Homeboy output formatting, never leak into the
+    /// runner passthrough after `--`.
+    #[test]
+    fn summary_alias_sets_the_same_field_as_json_summary() {
+        for spelling in ["--summary", "--json-summary"] {
+            let cli = Cli::try_parse_from(["homeboy", "review", "test", "homeboy", spelling])
+                .expect("parse review test summary flag");
+            let Commands::Review(review) = cli.command else {
+                panic!("expected a review command");
+            };
+            let Some(crate::commands::review::ReviewCommand::Test(args)) = review.command else {
+                panic!("expected a review test subcommand");
+            };
+            assert!(args.json_summary, "{spelling} must set json_summary");
+            assert!(
+                args.args.is_empty(),
+                "{spelling} must not leak into runner passthrough args"
+            );
+        }
+    }
+
     #[test]
     fn explicit_runner_preserves_lab_routing_for_hot_cook_and_review_commands() {
         let cases: &[(&[&str], &str)] = &[

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -39,7 +39,7 @@ pub struct AgentTaskArgs {
 #[derive(Subcommand, Debug)]
 pub enum AgentTaskCommand {
     Doctor(AgentTaskDoctorArgs),
-    /// Run an agent task end to end and open a pull request.
+    /// Submit an agent task, run its gates, and open a pull request.
     ///
     /// Provide the work with one `--prompt` and optional `--goal` framing, point
     /// `--to-worktree` at the existing worktree to edit (that checkout is
@@ -50,6 +50,20 @@ pub enum AgentTaskCommand {
     /// before opening the PR). Repeatable `--verify` gates all run; the run
     /// retries up to `--max-attempts` times. Use `agent-task fanout cook-batch`
     /// for independent task waves.
+    ///
+    /// WAIT POLICY: Cook always persists a durable run id before materialization,
+    /// so a returned command is not by itself proof of a completed cook.
+    ///
+    /// `--wait` observes until the lifecycle is terminal and returns the terminal
+    /// Cook report. This is the default when neither flag is passed.
+    ///
+    /// `--detach-after-handoff` returns once the run is durably accepted. Its
+    /// result describes a submission, not an outcome.
+    ///
+    /// Do not infer the wait policy from client interactivity. An orchestration
+    /// client that needs one predictable contract should pass the flag rather than
+    /// rely on the default, and read the terminal outcome from
+    /// `agent-task status <run-id>` in either case.
     Cook(AgentTaskCookArgs),
     /// Continue a detached Cook from its durable Cook ID or provider attempt ID.
     /// The persisted recipe supplies the original prompt, transport, gates,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -893,19 +893,29 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     let executor = ExtensionProviderAgentTaskExecutor::from_catalog(catalog);
     let all_providers = executor.providers();
     if args.validate_readiness {
-        let backend = args.backend.as_deref().ok_or_else(|| {
+        // Fall back to the configured default backend the same way Cook selection
+        // does, so readiness validation does not demand a flag that policy already
+        // answers. `default_backend_for_component` resolves component, then
+        // extension, then Homeboy config `agent_task.default_backend` (#9651).
+        let resolved_backend = match args.backend.clone() {
+            Some(backend) => Some(backend),
+            None => homeboy::agents::agent_tasks::provider::default_backend_for_component(None)?,
+        };
+        let backend = resolved_backend.ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
                 "backend",
-                "agent-task providers --validate-readiness requires --backend",
+                "agent-task providers --validate-readiness requires --backend because no default backend policy is configured",
                 None,
                 Some(vec![
                     "Pass the same --backend value that the agent-task cook command will use."
+                        .to_string(),
+                    "Or set agent_task.default_backend in component, extension, or Homeboy config policy so Cook and readiness validation agree."
                         .to_string(),
                 ]),
             )
         })?;
         homeboy::agents::agent_tasks::provider::validate_provider_runner_readiness_for_backend(
-            backend,
+            &backend,
             args.selector.as_deref(),
         )?;
     }

--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -56,8 +56,12 @@ pub struct AuditArgs {
     #[arg(skip)]
     pub precomputed_changed_files: Option<Vec<String>>,
 
-    /// Include compact machine-readable summary for CI wrappers
-    #[arg(long)]
+    // The `--summary` alias keeps one compact-output convention working across
+    // the `review` umbrella and every phase subcommand. `review/mod.rs` already
+    // maps its own `--summary` onto this field for the audit phase (#10428).
+    /// Include compact machine-readable summary for CI wrappers.
+    /// Also accepts `--summary`.
+    #[arg(long, alias = "summary")]
     pub json_summary: bool,
 
     /// Include automated-fixability metadata. This can be expensive because it

--- a/crates/homeboy-cli/src/commands/lint.rs
+++ b/crates/homeboy-cli/src/commands/lint.rs
@@ -101,6 +101,9 @@ pub struct LintArgs {
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
 
+    // No `--summary` alias here: lint already declares `--summary` above as its
+    // compact-output selector, and that is the field `review --summary` maps
+    // onto for this phase. Aliasing it again collides in clap (#10428).
     /// Print compact machine-readable summary (for CI wrappers)
     #[arg(long)]
     pub json_summary: bool,

--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -97,8 +97,12 @@ pub struct TestArgs {
     #[arg(last = true)]
     pub args: Vec<String>,
 
-    /// Print compact machine-readable summary (for CI wrappers)
-    #[arg(long)]
+    // The `--summary` alias keeps one compact-output convention working across
+    // the `review` umbrella and every phase subcommand. `review/mod.rs` already
+    // maps its own `--summary` onto this field for the test phase (#10428).
+    /// Print compact machine-readable summary (for CI wrappers).
+    /// Also accepts `--summary`.
+    #[arg(long, alias = "summary")]
     pub json_summary: bool,
 
     #[arg(skip)]

--- a/crates/homeboy-extension/src/lint/report.rs
+++ b/crates/homeboy-extension/src/lint/report.rs
@@ -99,8 +99,24 @@ fn lint_phase_report(
             phase_status_from_exit_code(exit_code)
         },
         exit_code: Some(exit_code),
-        summary: if exit_code == 0 {
+        summary: if exit_code == 0 && finding_count == 0 {
             "lint phase passed with no findings".to_string()
+        } else if exit_code == 0 {
+            // A passing exit code with retained findings is the advisory/warning-only
+            // case. The phase really did pass, but claiming "no findings" contradicts
+            // the structured `findings` and `producer_summaries` in the same envelope.
+            if producer_summaries.is_empty() {
+                format!(
+                    "lint phase passed with {} advisory finding(s)",
+                    finding_count
+                )
+            } else {
+                format!(
+                    "lint phase passed with {} advisory finding(s) across {}",
+                    finding_count,
+                    producer_summary_label(producer_summaries)
+                )
+            }
         } else if infrastructure_failure || exit_code >= 2 {
             format!("lint phase infrastructure failure (exit {})", exit_code)
         } else if !producer_summaries.is_empty() {
@@ -287,6 +303,66 @@ mod tests {
             output.phase.summary,
             "lint phase failed with 2 finding(s) across phpcs passed: 0, eslint failed: 1, phpstan failed: 1"
         );
+    }
+
+    #[test]
+    fn passing_lint_with_advisory_findings_does_not_claim_no_findings() {
+        let result = LintRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "fixture".to_string(),
+            exit_code: 0,
+            harness_error: false,
+            infrastructure_failure: false,
+            autofix: None,
+            hints: None,
+            baseline_comparison: None,
+            formatting_findings: None,
+            findings: Some(vec![HomeboyFinding::builder("phpcs", "phpcs warning")
+                .severity("warning")
+                .build()]),
+            producer_summaries: vec![
+                FindingProducerSummary::new("phpcs", "passed").finding_count(1)
+            ],
+            summary: None,
+            self_check_capture: None,
+            extension_phase_timings: Vec::new(),
+        };
+
+        let (output, exit_code) = from_main_workflow(result);
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.phase.status, crate::PhaseStatus::Passed);
+        assert_eq!(
+            output.phase.summary,
+            "lint phase passed with 1 advisory finding(s) across phpcs passed: 1"
+        );
+    }
+
+    #[test]
+    fn passing_lint_without_findings_still_reports_no_findings() {
+        let result = LintRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "fixture".to_string(),
+            exit_code: 0,
+            harness_error: false,
+            infrastructure_failure: false,
+            autofix: None,
+            hints: None,
+            baseline_comparison: None,
+            formatting_findings: None,
+            findings: Some(Vec::new()),
+            producer_summaries: vec![
+                FindingProducerSummary::new("phpcs", "passed").finding_count(0)
+            ],
+            summary: None,
+            self_check_capture: None,
+            extension_phase_timings: Vec::new(),
+        };
+
+        let (output, exit_code) = from_main_workflow(result);
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.phase.summary, "lint phase passed with no findings");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1412,11 +1412,19 @@ pub fn runner_dev_sync(options: RunnerDevSyncOptions) -> Result<(RunnerDevSyncOu
     let mut binary = None;
     if sync_homeboy_binary {
         let source_path = options.homeboy_source.as_deref().map(expand_path);
+        // Resolve the runner and refuse an impossible cross-architecture source
+        // sync BEFORE compiling. A controller-local build always produces a
+        // controller-native binary, so building first and then rejecting the
+        // Mach-O output costs several minutes to reach a verdict that was
+        // knowable up front (#8963).
+        let runner = load(&options.runner_id)?;
+        if options.homeboy_binary.is_none() {
+            validate_dev_sync_source_build_for_runner(&runner)?;
+        }
         let (local_binary, _target_lease) = match options.homeboy_binary.as_deref() {
             Some(path) => (expand_path(path), None),
             None => build_local_homeboy_binary(source_path.as_deref())?,
         };
-        let runner = load(&options.runner_id)?;
         validate_dev_sync_binary_for_runner(&runner, &local_binary)?;
         let sha256 = sha256_file(&local_binary)?;
         let hash = sha256[..16].to_string();
@@ -2010,6 +2018,35 @@ fn sha256_file(path: &Path) -> Result<String> {
             None,
         )
     })
+}
+
+/// Refuse a controller-local source build that could never satisfy an SSH runner,
+/// before paying for the compile. A Darwin controller can only emit Mach-O, which
+/// [`validate_dev_sync_binary_for_runner`] rejects for SSH runners — so the
+/// verdict is decidable from the controller platform alone (#8963).
+///
+/// This deliberately does not replace the post-build binary guard: an explicitly
+/// supplied `--homeboy-binary` is still inspected by magic bytes, because its
+/// architecture is not implied by the controller platform.
+fn validate_dev_sync_source_build_for_runner(runner: &super::Runner) -> Result<()> {
+    if runner.kind == RunnerKind::Ssh && cfg!(target_os = "macos") {
+        return Err(Error::validation_invalid_argument(
+            "homeboy_source",
+            "runner dev-sync cannot build a Homeboy binary for an SSH runner on a Darwin controller",
+            None,
+            Some(vec![
+                format!(
+                    "Build/select Homeboy on the runner with `homeboy runner refresh-homeboy {} --ref main --reconnect`.",
+                    shell_arg(&runner.id)
+                ),
+                format!(
+                    "For extension-only sync, run `homeboy runner dev-sync {} --extensions <id>=<path>` without --homeboy-binary or --homeboy-source.",
+                    shell_arg(&runner.id)
+                ),
+            ]),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_dev_sync_binary_for_runner(runner: &super::Runner, binary: &Path) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -7,6 +7,49 @@ use crate::{
 use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 use homeboy_core::test_support;
 
+/// Environment variables that redirect Cargo's output directory. A nested Cargo
+/// fixture that asserts a fixture-local `target/` path must not inherit these
+/// from the controller, `homeboy review`, or CI — otherwise the nested build
+/// succeeds while writing somewhere else entirely, and the assertion fails on a
+/// path that was never going to exist (#9846).
+const CARGO_TARGET_DIR_OVERRIDES: [&str; 3] = [
+    "CARGO_TARGET_DIR",
+    "CARGO_BUILD_TARGET_DIR",
+    "HOMEBOY_CARGO_TARGET_DIR",
+];
+
+/// A shell for nested Cargo fixtures, hermetic with respect to shared
+/// target-directory configuration.
+fn fixture_build_shell(script: &str) -> Command {
+    let mut command = Command::new("bash");
+    command.args(["-c", script]);
+    for key in CARGO_TARGET_DIR_OVERRIDES {
+        command.env_remove(key);
+    }
+    command
+}
+
+/// Deterministic coverage for the hermeticity contract itself: the fixture shell
+/// must clear every shared target-directory override regardless of what the
+/// surrounding review/CI environment set. This asserts the command's configured
+/// environment rather than mutating process-global state (#9846).
+#[test]
+fn fixture_build_shell_clears_shared_cargo_target_overrides() {
+    let command = fixture_build_shell("true");
+    let removed: Vec<&str> = command
+        .get_envs()
+        .filter(|(_, value)| value.is_none())
+        .filter_map(|(key, _)| key.to_str())
+        .collect();
+
+    for key in CARGO_TARGET_DIR_OVERRIDES {
+        assert!(
+            removed.contains(&key),
+            "fixture shell must clear {key}; cleared: {removed:?}"
+        );
+    }
+}
+
 fn fixture_commits_are_ancestral(repository: &Path, older: &str, newer: &str) -> Result<bool> {
     let status = Command::new("git")
         .args(["merge-base", "--is-ancestor", older, newer])
@@ -802,8 +845,7 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
             binary_path.to_str().expect("binary path"),
             false,
         );
-        let output = Command::new("bash")
-            .args(["-c", &script])
+        let output = fixture_build_shell(&script)
             .output()
             .expect("run materialize script");
         assert!(

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -317,6 +317,56 @@ fn ssh_dev_sync_rejects_darwin_binary_before_upload() {
     })));
 }
 
+/// A Darwin controller cannot produce a Linux binary, so the refusal must land
+/// before the compile rather than after it (#8963).
+#[test]
+fn ssh_dev_sync_source_build_is_refused_before_compilation_on_darwin() {
+    let runner = super::super::super::Runner {
+        id: "homeboy-lab".to_string(),
+        kind: RunnerKind::Ssh,
+        server_id: Some("lab-server".to_string()),
+        workspace_root: Some("/home/chubes/Developer".to_string()),
+        settings: Default::default(),
+        env: Default::default(),
+        secret_env: Default::default(),
+        resources: Default::default(),
+        policy: Default::default(),
+    };
+
+    let result = validate_dev_sync_source_build_for_runner(&runner);
+
+    if cfg!(target_os = "macos") {
+        let err = result.expect_err("darwin controller source build rejected for an SSH runner");
+        assert!(err.message.contains("Darwin controller"));
+        let tried = err.details["tried"].as_array().expect("tried remediation");
+        assert!(tried.iter().any(|hint| hint.as_str().is_some_and(|hint| {
+            hint.contains("runner refresh-homeboy") && hint.contains("--ref main --reconnect")
+        })));
+    } else {
+        result.expect("a non-Darwin controller can build for an SSH runner");
+    }
+}
+
+/// The preflight is scoped to SSH runners; a local runner runs the controller's
+/// own architecture and must keep building from source.
+#[test]
+fn local_dev_sync_source_build_is_always_allowed() {
+    let runner = super::super::super::Runner {
+        id: "lab-local".to_string(),
+        kind: RunnerKind::Local,
+        server_id: None,
+        workspace_root: Some("/tmp/homeboy".to_string()),
+        settings: Default::default(),
+        env: Default::default(),
+        secret_env: Default::default(),
+        resources: Default::default(),
+        policy: Default::default(),
+    };
+
+    validate_dev_sync_source_build_for_runner(&runner)
+        .expect("local runner accepts a controller-local source build");
+}
+
 #[test]
 fn local_dev_sync_allows_darwin_binary() {
     let dir = tempfile::tempdir().expect("binary dir");

--- a/crates/homeboy-release/src/release/executor/package_preflight.rs
+++ b/crates/homeboy-release/src/release/executor/package_preflight.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use crate::release::types::ReleaseArtifact;
 use homeboy_core::component::{
-    CommandScopeConfig, Component, PackageCoverageArtifactMatch, PackageCoverageConfig,
+    CommandScopeConfig, Component, PackageCoverageArtifactMatch, PackageCoverageConfig, ScopeConfig,
 };
 use homeboy_core::error::{Error, Result};
 
@@ -249,6 +249,7 @@ fn tracked_runtime_files(component: &Component, component_path: &Path) -> Result
         .filter_map(|raw| String::from_utf8(raw.to_vec()).ok())
         .map(|path| normalize_archive_path(&path))
         .filter(|path| runtime_candidate(path))
+        .filter(|path| !homeboy_owned_metadata(path) || explicitly_included(path, &scope))
         .filter(|path| scope_allows(path, &scope))
         .collect())
 }
@@ -299,6 +300,29 @@ fn runtime_candidate(path: &str) -> bool {
             .and_then(|extension| extension.to_str()),
         Some("php" | "inc" | "phtml" | "js" | "mjs" | "cjs" | "css" | "json")
     )
+}
+
+/// Homeboy-owned portable component metadata. These files describe how to
+/// build/release/deploy a component; they are not component runtime content, so
+/// they must not count toward release package completeness by default. Every
+/// component would otherwise have to rediscover and exclude them.
+///
+/// This is deliberately separate from [`runtime_candidate`]: the file extension
+/// is a legitimate runtime extension, and the reason for exclusion is ownership,
+/// not shape. A component with an unusual concrete need can opt the file back
+/// into package coverage with an explicit `scopes.release.include` entry.
+fn homeboy_owned_metadata(path: &str) -> bool {
+    matches!(path, "homeboy.json")
+}
+
+/// Whether an explicit include pattern names this path. Unlike [`scope_allows`],
+/// an empty include list is *not* treated as "includes everything" — opting a
+/// Homeboy-owned metadata file back in requires naming it.
+fn explicitly_included(path: &str, scope: &CommandScopeConfig) -> bool {
+    scope
+        .include
+        .iter()
+        .any(|pattern| path_matches(pattern, path))
 }
 
 fn scope_allows(path: &str, scope: &CommandScopeConfig) -> bool {
@@ -694,6 +718,85 @@ mod tests {
         assert!(!should_validate_package_completeness(true));
         // Default release behavior still enforces completeness.
         assert!(should_validate_package_completeness(false));
+    }
+
+    #[test]
+    fn package_completeness_excludes_homeboy_metadata_by_default() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("source")).expect("source dir");
+        std::fs::write(repo.path().join("source/runtime.php"), "<?php\n").expect("runtime");
+        std::fs::write(repo.path().join("homeboy.json"), "{}\n").expect("homeboy metadata");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "source/runtime.php", "homeboy.json"]);
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("source/runtime.php", "<?php\n")]);
+        let component = test_component(repo.path());
+
+        validate_package_completeness(&component, repo.path(), &zip_artifacts("build/package.zip"))
+            .expect("homeboy.json must not count as a missing runtime file by default");
+    }
+
+    #[test]
+    fn package_completeness_admits_homeboy_metadata_when_explicitly_included() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("source")).expect("source dir");
+        std::fs::write(repo.path().join("source/runtime.php"), "<?php\n").expect("runtime");
+        std::fs::write(repo.path().join("homeboy.json"), "{}\n").expect("homeboy metadata");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "source/runtime.php", "homeboy.json"]);
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("source/runtime.php", "<?php\n")]);
+        let mut component = test_component(repo.path());
+        component.scopes = Some(ScopeConfig {
+            release: Some(CommandScopeConfig {
+                include: vec!["homeboy.json".to_string(), "source/**".to_string()],
+                exclude: Vec::new(),
+            }),
+            ..ScopeConfig::default()
+        });
+
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect_err("an explicit release include must opt homeboy.json back into coverage");
+        assert!(
+            error.message.contains("homeboy.json"),
+            "unexpected message: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn package_completeness_keeps_unrelated_json_fail_closed() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("source")).expect("source dir");
+        std::fs::write(repo.path().join("source/runtime.php"), "<?php\n").expect("runtime");
+        std::fs::write(repo.path().join("source/settings.json"), "{}\n").expect("runtime json");
+        run_git(repo.path(), &["init"]);
+        run_git(
+            repo.path(),
+            &["add", "source/runtime.php", "source/settings.json"],
+        );
+        let artifact_path = repo.path().join("build/package.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("source/runtime.php", "<?php\n")]);
+        let component = test_component(repo.path());
+
+        let error = validate_package_completeness(
+            &component,
+            repo.path(),
+            &zip_artifacts("build/package.zip"),
+        )
+        .expect_err("non-Homeboy runtime json must remain fail-closed");
+        assert!(
+            error.message.contains("source/settings.json"),
+            "unexpected message: {}",
+            error.message
+        );
     }
 
     fn test_component(repo: &Path) -> Component {

--- a/docs/reference/cli/commands/agent-task.md
+++ b/docs/reference/cli/commands/agent-task.md
@@ -23,7 +23,7 @@ Run generic agent task plans
 | Subcommand | Summary |
 | --- | --- |
 | `homeboy agent-task doctor` | _no help text_ |
-| `homeboy agent-task cook` | Run an agent task end to end and open a pull request |
+| `homeboy agent-task cook` | Submit an agent task, run its gates, and open a pull request |
 | `homeboy agent-task cook-continue` | Continue a detached Cook from its durable Cook ID or provider attempt ID. The persisted recipe supplies the original prompt, transport, gates, worktree, and disclosure policy |
 | `homeboy agent-task loop` | _no help text_ |
 | `homeboy agent-task run-plan` | _no help text_ |
@@ -85,9 +85,17 @@ _This command declares no clap help text, so no description can be generated for
 homeboy agent-task cook [OPTIONS]
 ```
 
-Run an agent task end to end and open a pull request.
+Submit an agent task, run its gates, and open a pull request.
 
 Provide the work with one `--prompt` and optional `--goal` framing, point `--to-worktree` at the existing worktree to edit (that checkout is authoritative — the agent's changes, the `--verify` gates, and the PR all operate on it), and give one or more `--verify` commands that must pass in that worktree before promotion. Cook then commits, runs the deterministic gates, and finalizes a `--base`-targeted PR (use `--no-finalize` to stop before opening the PR). Repeatable `--verify` gates all run; the run retries up to `--max-attempts` times. Use `agent-task fanout cook-batch` for independent task waves.
+
+WAIT POLICY: Cook always persists a durable run id before materialization, so a returned command is not by itself proof of a completed cook.
+
+`--wait` observes until the lifecycle is terminal and returns the terminal Cook report. This is the default when neither flag is passed.
+
+`--detach-after-handoff` returns once the run is durably accepted. Its result describes a submission, not an outcome.
+
+Do not infer the wait policy from client interactivity. An orchestration client that needs one predictable contract should pass the flag rather than rely on the default, and read the terminal outcome from `agent-task status <run-id>` in either case.
 
 | Option | Value | Description |
 | --- | --- | --- |

--- a/docs/reference/cli/commands/review.md
+++ b/docs/reference/cli/commands/review.md
@@ -72,7 +72,7 @@ Audit code conventions and detect architectural drift
 | `--ignore-baseline` | flag | Skip baseline comparison for this run |
 | `--ratchet` | flag | Auto-update the baseline when the current run improves on it |
 | `--changed-since` | `<CHANGED_SINCE>` | Only audit files changed since a git ref (branch, tag, or SHA) |
-| `--json-summary` | flag | Include compact machine-readable summary for CI wrappers |
+| `--json-summary` | flag | Include compact machine-readable summary for CI wrappers. Also accepts `--summary` |
 | `--fixability` | flag | Include automated-fixability metadata. This can be expensive because it runs the refactor planner after audit completes |
 
 ## `homeboy review lint`
@@ -143,7 +143,7 @@ Run tests for a component
 | `--settings-json-file` | `<FILE>` | Load typed setting overrides from a JSON object file. Repeatable |
 | `--setting` | `<KEY=VALUE>` | String setting override. Repeatable |
 | `--setting-json` | `<SETTING_JSON>` | Typed-JSON setting override. Repeatable |
-| `--json-summary` | flag | Print compact machine-readable summary (for CI wrappers) |
+| `--json-summary` | flag | Print compact machine-readable summary (for CI wrappers). Also accepts `--summary` |
 
 ## `homeboy review build`
 


### PR DESCRIPTION
Eight verified quick wins from the 2026-07-29 open-issue triage sweep. Each is small, independent, and gets its own commit — they are batched into one PR because they are individually trivial and CI is expensive.

Closes #9638, #10104, #10428, #9651, #10527, #8963, #9846, #7739.

## What's here

| Issue | Change |
|---|---|
| **#9638** | `homeboy.json` no longer counts as a missing runtime file in release package completeness |
| **#10104** | A passing lint with advisory findings stops claiming "passed with no findings" |
| **#10428** | `review test --summary` / `review audit --summary` now parse |
| **#9651** | `agent-task providers --validate-readiness` resolves the configured default backend |
| **#10527** | Cook help states the actual wait policy instead of implying it always waits |
| **#8963** | SSH dev-sync refuses an impossible cross-arch source build *before* compiling |
| **#9846** | The nested Cargo fixture stops inheriting the shared target directory |
| **#7739** | The scheduler-test flake is fixed at its real root cause |

## Notes worth reading

**#10428 — the fix is smaller than the issue suggests.** `LintArgs` already had a `--summary` flag, which is why `review lint --summary` worked. My first attempt added `--summary` as a clap alias on all three phases and hit `long option names must be unique`. Looking at `review/mod.rs`, the umbrella already resolves this: it maps its own `--summary` onto `json_summary` for test/audit and onto `summary` for lint. So the correct change is to accept `--summary` on test and audit only, making the phase surface agree with the umbrella that drives it. Lint is untouched.

**#7739 — this was not a contention flake.** `provider_default_timeout_returns_structured_outcome_without_explicit_timeout` sets the test default provider timeout to **50 ms via a process-wide env var** while holding only a module-local mutex. Any sibling test relying on the default observes 50 ms when the two run concurrently and reports `Timeout` instead of its real terminal status. That accounts for every symptom in the issue: a failing set that shifts run to run, `--test-threads=1` passing deterministically, and each test passing individually. Fixed by pinning an explicit 60 s timeout in the shared request fixture, plus a `Drop` guard so a failed assertion no longer leaves 50 ms set for the rest of the process.

**#8963** preserves the existing post-build magic-bytes guard. The new preflight only covers the source-build path, where the output architecture is implied by the controller platform; an explicitly supplied `--homeboy-binary` still gets inspected, because its architecture is not.

**#9638** deliberately keeps the new `homeboy_owned_metadata` policy separate from `runtime_candidate`. `.json` is a legitimate runtime extension — the reason for exclusion is ownership, not shape. An explicit `scopes.release.include` entry still opts the file back in, and unrelated runtime files stay fail-closed.

## Verification

`cargo fmt`, `cargo check --lib --tests` (exit 0), and `cargo clippy --lib --tests` across all five touched crates (exit 0, no new warnings). Targeted suites:

- `homeboy-extension lint::report::` — 5 passed
- `homeboy-release package_completeness` — 15 passed
- `homeboy-cli` summary filter — 103 passed
- `homeboy-lab-runner` dev-sync + fixture shell — 12 passed
- `homeboy-agents scheduler_tests` — 32 passed, **3 failures → 2**

Per the repo's VPS constraints I did not run the full suite locally; leaving that to CI.

## Pre-existing failures I hit (NOT from this PR)

Both verified red on unmodified `main` with my changes stashed:

1. `homeboy-cli commands::runner::tests::exec::runner_exec_structured_summary_is_independent_of_large_stdout` — fails in isolation with a persisted `run_id` collision (`run '…' already exists as a runner-exec run`). Leaked state between runs; same class as #9774 / #10097.
2. `homeboy-agents scheduler_tests::executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests` and `::provider_attempts_receive_distinct_allocated_runtime_tmpdirs`.

Worth flagging: `scheduler_tests::provider_empty_stdout_captures_bounded_stderr_and_exit_context` is **red on main** — that is the test cited as the evidence that #7397 shipped. It goes green with this PR, but it should not have been red in the first place, and no gate reported it. That is consistent with #10477 (member-crate lib tests compiled but never executed).

## Not included

**#7738** (root-owned cargo registry) was in the quick-win batch but its premise no longer holds on this host: there is no `opencode` user, and `openclaw` has no `.cargo` directory at all — cargo runs as root against `/root/.cargo`. I did not perform a no-op `chown`. Recommend closing it or re-scoping to the current user layout.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
