### PR TITLE
Fix release lint evidence for zero-finding runs

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -1323,9 +1323,9 @@ mod tests {
                 "context": "read lint evidence /tmp/run/findings.json",
                 "_homeboy_actions": [{
                     "id": "release.lint.fresh_diagnostic",
-                    "label": "run a fresh local lint diagnostic with the release lint scope",
+                    "label": "run a fresh lint diagnostic with the release lint scope",
                     "program": "homeboy",
-                    "args": ["--placement", "local", "lint", "fixture", "--path", "/workspace/fixture", "--extension", "rust", "--changed-since", "v1.2.3"],
+                    "args": ["--placement", "auto", "review", "lint", "fixture", "--path", "/workspace/fixture", "--extension", "rust", "--changed-since", "v1.2.3"],
                     "safety": "read_only",
                     "evidence": {
                         "kind": "fresh_diagnostic",
@@ -1342,11 +1342,11 @@ mod tests {
         let action = digest.next_actions.first().expect("explicit action");
         assert_eq!(
             action.label,
-            "run a fresh local lint diagnostic with the release lint scope"
+            "run a fresh lint diagnostic with the release lint scope"
         );
         assert_eq!(
             action.command,
-            "homeboy --placement local lint fixture --path /workspace/fixture --extension rust --changed-since v1.2.3"
+            "homeboy --placement auto review lint fixture --path /workspace/fixture --extension rust --changed-since v1.2.3"
         );
         assert_eq!(
             action

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -228,17 +228,10 @@ exit 0
 }
 
 #[test]
-fn successful_multi_route_lint_cleans_child_route_evidence() {
+fn successful_zero_finding_routes_initialize_and_clean_evidence() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");
-        let component = routed_lint_component(
-            home.path(),
-            source.path(),
-            r#"#!/bin/sh
-printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
-exit 0
-"#,
-        );
+        let component = routed_lint_component(home.path(), source.path(), "#!/bin/sh\nexit 0\n");
         let run_dir = RunDir::create().expect("run dir");
 
         let workflow =

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -289,6 +289,10 @@ impl ExtensionRunner {
             &extra_env_vars,
         )?;
 
+        if let Some(run_dir_path) = &self.run_dir_path {
+            initialize_structured_sidecars(run_dir_path, self.execution_context.capability)?;
+        }
+
         let output = self.execute_script(
             &prepared.execution.extension_path,
             &env_vars,
@@ -470,6 +474,23 @@ fn write_structured_failure_sidecar(
         ExtensionCapability::Test => write_test_failure_sidecar(run_dir_path, command, output),
         _ => Ok(()),
     }
+}
+
+fn initialize_structured_sidecars(
+    run_dir_path: &Path,
+    capability: ExtensionCapability,
+) -> Result<()> {
+    if capability == ExtensionCapability::Lint {
+        write_json_sidecar(
+            &run_dir_path.join(run_dir::files::LINT_FINDINGS),
+            &json!([]),
+        )?;
+        write_json_sidecar(
+            &run_dir_path.join(run_dir::files::LINT_PRODUCERS),
+            &json!([]),
+        )?;
+    }
+    Ok(())
 }
 
 fn write_lint_failure_sidecar(
@@ -846,6 +867,29 @@ mod tests {
         assert_eq!(producers[0]["status"], "error");
         assert_eq!(producers[0]["finding_count"], 0);
         assert_eq!(producers[0]["metadata"]["failure"]["exit_code"], 127);
+
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn initializes_empty_lint_sidecars_for_successful_zero_finding_runs() {
+        let run_dir = RunDir::create().expect("run dir");
+
+        initialize_structured_sidecars(run_dir.path(), ExtensionCapability::Lint)
+            .expect("initialize lint evidence");
+
+        let findings: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(run_dir.step_file(run_dir::files::LINT_FINDINGS))
+                .expect("findings file"),
+        )
+        .expect("findings json");
+        let producers: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(run_dir.step_file(run_dir::files::LINT_PRODUCERS))
+                .expect("producers file"),
+        )
+        .expect("producers json");
+        assert_eq!(findings, json!([]));
+        assert_eq!(producers, json!([]));
 
         run_dir.cleanup();
     }

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -176,7 +176,8 @@ pub(super) fn validate_lint_quality(
 /// Attach a diagnostic action without changing the original infrastructure
 /// error's code, message, details, or evidence. The command intentionally says
 /// "fresh" because a new CLI invocation cannot promise the release process's
-/// complete runtime identity.
+/// complete runtime identity, and uses automatic placement so configured
+/// release-gate routing remains authoritative.
 fn lint_runner_error(
     error: Error,
     component: &Component,
@@ -186,7 +187,8 @@ fn lint_runner_error(
 ) -> Error {
     let mut args = vec![
         "--placement".to_string(),
-        "local".to_string(),
+        "auto".to_string(),
+        "review".to_string(),
         "lint".to_string(),
         component_id.to_string(),
         "--path".to_string(),
@@ -202,7 +204,7 @@ fn lint_runner_error(
     error.with_action(
         ExecutableAction::new(
             "release.lint.fresh_diagnostic",
-            "run a fresh local lint diagnostic with the release lint scope",
+            "run a fresh lint diagnostic with the release lint scope",
             "homeboy",
             args,
             ActionSafety::ReadOnly,
@@ -711,12 +713,13 @@ mod tests {
         assert_eq!(action["id"], "release.lint.fresh_diagnostic");
         assert!(action["label"]
             .as_str()
-            .is_some_and(|label| label.contains("fresh local lint diagnostic")));
+            .is_some_and(|label| label.contains("fresh lint diagnostic")));
         assert_eq!(
             action["args"],
             serde_json::json!([
                 "--placement",
-                "local",
+                "auto",
+                "review",
                 "lint",
                 "fixture",
                 "--path",


### PR DESCRIPTION
## Summary

- initialize lint findings and producer sidecars before every extension lint execution
- preserve failure normalization by replacing empty sidecars with infrastructure evidence
- generate a valid `homeboy --placement auto review lint ...` recovery action
- cover zero-finding routed execution and response rendering

Closes #10758.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-extension successful_zero_finding_routes_initialize_and_clean_evidence`
- `cargo test -p homeboy-extension runner::tests::`
- `cargo test -p homeboy-release lint_runner_error_preserves_nested_io_diagnostics_and_emits_fresh_action`
- `cargo test -p homeboy-cli release_failure_prefers_explicit_fresh_diagnostic_action`
- exact release-scoped lint passed against the clean `0.322.1` checkout with zero findings; evidence run `6df4135c-5245-4f26-9f09-f8d9372910b8`

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode diagnosed the release failure, drafted the implementation and tests, and ran the verification. Chris Huber reviewed and remains responsible for the change.