### PR TITLE
fix(runner): expose runtime promotion admission waits

### DIFF
--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -27,6 +27,29 @@ const SUBPROCESS_LEASE_ENV: &str = "HOMEBOY_RUNTIME_PROMOTION_LEASE";
 // Give concurrent readers a bounded window to observe that publication.
 const ACQUIRE_DISAPPEARED_LEASE_RETRIES: usize = 20;
 const COMPATIBLE_WAIT_POLL: Duration = Duration::from_millis(50);
+const COMPATIBLE_WAIT_HEARTBEAT: Duration = if cfg!(test) {
+    Duration::from_millis(10)
+} else {
+    Duration::from_secs(5)
+};
+
+/// Observable state for a caller waiting on a compatible runtime mutation.
+///
+/// Runtime promotion is machine-scoped, while `target` keeps unrelated runner
+/// or runtime resources independent. Callers render this event in their own
+/// output protocol rather than making core depend on a CLI format.
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimePromotionWaitEvent {
+    pub schema: &'static str,
+    pub state: &'static str,
+    pub resource_class: &'static str,
+    pub wait_timeout_ms: u128,
+    pub waited_ms: u128,
+    pub owner_pid: u32,
+    pub owner_operation: String,
+    pub target: String,
+    pub owner_generation: String,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimePromotionLeaseRecord {
@@ -153,12 +176,13 @@ pub fn acquire_waiting_for_compatible(
     operation: &str,
     target: impl Into<String>,
     timeout: Duration,
-    mut progress: impl FnMut(&RuntimePromotionLeaseRecord),
+    mut progress: impl FnMut(RuntimePromotionWaitEvent),
 ) -> Result<RuntimePromotionLease> {
     let target = target.into();
     let generation = current_generation();
     let deadline = Instant::now() + timeout;
     let mut last_owner = None;
+    let mut last_progress = None;
 
     loop {
         match acquire(operation, target.clone()) {
@@ -169,9 +193,25 @@ pub fn acquire_waiting_for_compatible(
                     return Err(error);
                 }
                 let owner_identity = format!("{}:{}:{}", owner.pid, owner.operation, owner.target);
-                if last_owner.as_ref() != Some(&owner_identity) {
-                    progress(&owner);
+                if last_owner.as_ref() != Some(&owner_identity)
+                    || last_progress
+                        .is_none_or(|last: Instant| last.elapsed() >= COMPATIBLE_WAIT_HEARTBEAT)
+                {
+                    progress(RuntimePromotionWaitEvent {
+                        schema: "homeboy/runtime-promotion-admission/v1",
+                        state: "queued",
+                        resource_class: "runtime_promotion",
+                        wait_timeout_ms: timeout.as_millis(),
+                        waited_ms: timeout
+                            .saturating_sub(deadline.saturating_duration_since(Instant::now()))
+                            .as_millis(),
+                        owner_pid: owner.pid,
+                        owner_operation: owner.operation.clone(),
+                        target: owner.target.clone(),
+                        owner_generation: owner.generation.clone(),
+                    });
                     last_owner = Some(owner_identity);
+                    last_progress = Some(Instant::now());
                 }
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
@@ -695,13 +735,16 @@ fn wait_timeout_error(owner: &RuntimePromotionLeaseRecord, timeout: Duration) ->
             owner.target
         ),
         serde_json::json!({
+            "schema": "homeboy/runtime-promotion-admission/v1",
             "queue_state": "timed_out_waiting_for_compatible_owner",
+            "resource_class": "runtime_promotion",
+            "state": "busy",
             "wait_timeout_seconds": timeout.as_secs(),
             "target": owner.target,
             "holder_pid": owner.pid,
             "holder_operation": owner.operation,
             "holder_generation": owner.generation,
-            "tried": ["The compatible promotion owner did not finish before the admission deadline."],
+            "tried": ["The compatible promotion owner did not finish before the admission deadline.", "Retry the same command after the owner completes or inspect its runtime-promotion lease."],
         }),
     )
 }
@@ -887,7 +930,7 @@ mod tests {
                             "contender",
                             "lab",
                             Duration::from_secs(1),
-                            |owner| queued.send(owner.pid).expect("report queued owner"),
+                            |event| queued.send(event.owner_pid).expect("report queued owner"),
                         )
                         .map(drop)
                     })
@@ -918,11 +961,12 @@ mod tests {
     fn compatible_wait_timeout_leaves_no_queue_state() {
         crate::test_support::with_isolated_home(|_| {
             let mut owner = compatible_wait_owner();
+            let events = std::sync::Mutex::new(Vec::new());
             let error = acquire_waiting_for_compatible(
                 "cancelled contender",
                 "lab",
                 Duration::from_millis(25),
-                |_| {},
+                |event| events.lock().expect("collect admission events").push(event),
             )
             .expect_err("bounded contender wait times out");
             assert_eq!(error.code, ErrorCode::RuntimePromotionWaitTimeout);
@@ -930,6 +974,26 @@ mod tests {
                 error.details["queue_state"],
                 "timed_out_waiting_for_compatible_owner"
             );
+            assert_eq!(error.details["resource_class"], "runtime_promotion");
+            assert_eq!(error.details["state"], "busy");
+            let events = events
+                .into_inner()
+                .expect("admission events are not poisoned");
+            assert!(
+                events.len() >= 2,
+                "the queued wait must emit an immediate event and a heartbeat"
+            );
+            assert!(events.iter().all(|event| {
+                event.schema == "homeboy/runtime-promotion-admission/v1"
+                    && event.state == "queued"
+                    && event.resource_class == "runtime_promotion"
+                    && event.target == "lab"
+                    && event.owner_pid == owner.id()
+                    && event.wait_timeout_ms == 25
+            }));
+            assert!(events
+                .windows(2)
+                .all(|events| events[1].waited_ms >= events[0].waited_ms));
 
             owner.wait().expect("owner exits");
             acquire("later contender", "lab")

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1487,7 +1487,7 @@ fn recover_dead_direct_tunnel(runner_id: &str, session: Option<&RunnerSession>) 
         "runner direct SSH tunnel recovery",
         runner_id.to_string(),
         DIRECT_TUNNEL_RECOVERY_WAIT,
-        |_| {},
+        super::lab_selection::emit_runtime_promotion_wait,
     )?;
     if read_session_or_live_peer(runner_id)?
         .as_ref()

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -8,6 +8,7 @@ use crate::resolve_lab_runner_hint;
 use homeboy_core::daemon::DaemonRepairStep;
 use homeboy_core::error::{ActionSafety, ExecutableAction};
 use homeboy_core::lab_contract::LabCommandPortability;
+use homeboy_core::runtime_promotion::RuntimePromotionWaitEvent;
 use homeboy_core::{Error, ErrorCode, Result};
 
 use super::{
@@ -262,12 +263,7 @@ fn connect_runner_for_offload(
         "Lab runner handoff",
         runner_id.to_string(),
         HANDOFF_ADMISSION_TIMEOUT,
-        |owner| {
-            eprintln!(
-                "Lab runner handoff: queued behind runtime promotion owner pid {} operation `{}` target `{}`; waiting for a compatible ready generation.",
-                owner.pid, owner.operation, owner.target
-            );
-        },
+        emit_runtime_promotion_wait,
     )?;
     if let Ok(report) = status(runner_id) {
         if report.connected {
@@ -340,6 +336,17 @@ fn connect_runner_for_offload(
         },
         exit_code,
     ))
+}
+
+/// Emit queue admission separately from the terminal command envelope so a
+/// human and a streaming caller see progress before the bounded wait ends.
+pub(super) fn emit_runtime_promotion_wait(event: RuntimePromotionWaitEvent) {
+    eprintln!(
+        "{}",
+        serde_json::to_string(&event).unwrap_or_else(|_| {
+            "{\"schema\":\"homeboy/runtime-promotion-admission/v1\",\"state\":\"queued\",\"resource_class\":\"runtime_promotion\"}".to_string()
+        })
+    );
 }
 
 pub(super) fn wait_for_live_session<Session>(


### PR DESCRIPTION
## Summary
- emit immediate structured runtime-promotion queue events and periodic heartbeats for compatible bounded waits
- report structured busy timeout details with resource class and retry guidance
- route direct tunnel recovery and Lab runner handoff through the same observable output contract

Fixes #10770.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core runtime_promotion::tests --lib`
- `cargo check -p homeboy-lab-runner`
- `git diff --check`

## AI assistance
OpenCode using OpenAI GPT-5.6 Sol investigated the contention path, implemented the runtime-promotion admission visibility contract, and added deterministic concurrency coverage. Chris Huber remains responsible for every line.