### PR TITLE
fix(release): preflight head recovery identity

### DIFF
--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -31,6 +31,8 @@ pub(super) fn execute_release_plan_step(
         "preflight.default_branch" => Ok(Some(run_default_branch_preflight(step, context))),
         "preflight.git_identity" => configure_git_identity(step, context).map(Some),
         "preflight.working_tree" => Ok(Some(run_working_tree_preflight(step, context))),
+        "preflight.head_identity" => Ok(Some(run_head_identity_preflight(step, context))),
+        "preflight.recovery_artifacts" => Ok(Some(run_recovery_artifacts_preflight(step, context))),
         "preflight.remote_sync" => Ok(Some(run_remote_sync_preflight(step, context))),
         "preflight.bump_policy" => Ok(Some(run_bump_policy_preflight(step))),
         "preflight.dependencies" => Ok(Some(run_dependencies_preflight(step, context))),
@@ -283,6 +285,8 @@ fn release_step_is_plan_only(step: &PlanStep) -> bool {
         && step.kind != "preflight.default_branch"
         && step.kind != "preflight.git_identity"
         && step.kind != "preflight.working_tree"
+        && step.kind != "preflight.head_identity"
+        && step.kind != "preflight.recovery_artifacts"
         && step.kind != "preflight.remote_sync"
         && step.kind != "preflight.bump_policy"
         && step.kind != "preflight.dependencies"
@@ -349,6 +353,59 @@ fn run_working_tree_preflight(
             ..Default::default()
         },
         Err(err) => failed_result(&step.id, &step.kind, err),
+    }
+}
+
+fn run_head_identity_preflight(
+    step: &PlanStep,
+    context: &ReleaseExecutionContext,
+) -> ReleaseStepResult {
+    ReleaseStepResult {
+        id: step.id.clone(),
+        step_type: step.kind.clone(),
+        status: ReleaseStepStatus::Success,
+        data: Some(serde_json::json!({
+            "tag": context.state.tag,
+            "version": context.state.version,
+        })),
+        ..Default::default()
+    }
+}
+
+fn run_recovery_artifacts_preflight(
+    step: &PlanStep,
+    context: &ReleaseExecutionContext,
+) -> ReleaseStepResult {
+    let dir = context
+        .options
+        .pipeline
+        .from_artifacts
+        .as_deref()
+        .unwrap_or_default();
+    let commit = match git::get_head_commit(&context.component.local_path) {
+        Ok(commit) => commit,
+        Err(error) => return failed_result(&step.id, &step.kind, error),
+    };
+    let tag = context.state.tag.as_deref().unwrap_or_default();
+    let version = context.state.version.as_deref().unwrap_or_default();
+    let recovery_context = executor::artifacts::PackageRecoveryContext {
+        component_id: context.component_id,
+        tag,
+        version,
+        commit: &commit,
+    };
+    let mut state = ReleaseState::default();
+
+    match executor::artifacts::run_artifact_inventory(&mut state, dir, &recovery_context) {
+        Ok(result) => ReleaseStepResult {
+            id: step.id.clone(),
+            step_type: step.kind.clone(),
+            status: result.status,
+            data: result.data,
+            warnings: result.warnings,
+            ..Default::default()
+        },
+        Err(error) => failed_result(&step.id, &step.kind, error),
     }
 }
 
@@ -643,6 +700,8 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
         "changelog.finalize"
             | "preflight.default_branch"
             | "preflight.working_tree"
+            | "preflight.head_identity"
+            | "preflight.recovery_artifacts"
             | "preflight.remote_sync"
             | "preflight.bump_policy"
             | "preflight.dependencies"
@@ -655,6 +714,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
             | "release.prepare"
             | "git.commit"
             | "package"
+            | "artifacts.inventory"
             | "artifacts.authority"
             | "git.tag"
             | "git.push"

--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -55,6 +55,8 @@ pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {
         "preflight.default_branch",
         "preflight.git_identity",
         "preflight.working_tree",
+        "preflight.head_identity",
+        "preflight.recovery_artifacts",
         "preflight.remote_sync",
         "preflight.tag_availability",
         "preflight.dependencies",
@@ -181,14 +183,6 @@ fn resolve_head_release(
         ));
     }
 
-    if let Some((tag, version)) = tags
-        .iter()
-        .filter_map(|tag| release_tag_version(tag, tag_prefix).map(|version| (tag, version)))
-        .max_by(|(_, a), (_, b)| a.cmp(b))
-    {
-        return Ok((tag.to_string(), version.to_string()));
-    }
-
     let latest_local = latest_release_tag(local_path, tag_prefix).unwrap_or(None);
     let latest_remote = latest_remote_release_tag(local_path, tag_prefix).unwrap_or(None);
     let latest_known = latest_remote.as_ref().or(latest_local.as_ref());
@@ -300,8 +294,8 @@ fn read_current_release_notes(component: &Component) -> Result<Option<String>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_dry_run_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
-        release_tag_version, resolve_head_release,
+        build_dry_run_preflight_plan, build_initial_preflight_plan, execute_plan_steps,
+        initial_executable_preflight_ids, release_tag_version, resolve_head_release,
     };
     use crate::release::types::{ReleaseOptions, ReleaseStepStatus};
     use homeboy_core::plan::PlanStepStatus;
@@ -401,6 +395,8 @@ mod tests {
                 "preflight.default_branch",
                 "preflight.git_identity",
                 "preflight.working_tree",
+                "preflight.head_identity",
+                "preflight.recovery_artifacts",
                 "preflight.remote_sync",
                 "preflight.tag_availability",
                 "preflight.dependencies",
@@ -482,6 +478,8 @@ mod tests {
                 "preflight.default_branch",
                 "preflight.git_identity",
                 "preflight.working_tree",
+                "preflight.head_identity",
+                "preflight.recovery_artifacts",
                 "preflight.remote_sync",
                 "preflight.dependencies",
                 "preflight.lint",
@@ -570,20 +568,20 @@ mod tests {
     }
 
     #[test]
-    fn head_release_uses_release_tag_pointing_at_head() {
+    fn head_release_rejects_a_different_release_tag_at_head() {
         let (_remote, checkout) = release_repo_with_remote_tag("0.11.10", "v0.11.11");
         run_in(checkout.path(), &["git", "tag", "v0.11.11"]);
 
-        let (tag, version) = resolve_head_release(
+        let error = resolve_head_release(
             checkout.path().to_str().expect("checkout path"),
             "v0.11.10",
             None,
             "fixture",
         )
-        .expect("release tag at HEAD should be used");
+        .expect_err("a tag for another version must not satisfy --head");
 
-        assert_eq!(tag, "v0.11.11");
-        assert_eq!(version, "0.11.11");
+        assert!(error.message.contains("Expected 'v0.11.10'"));
+        assert!(error.message.contains("tags at HEAD: v0.11.11"));
     }
 
     #[test]
@@ -633,6 +631,100 @@ mod tests {
             .as_str()
             .unwrap_or_default()
             .contains("homeboy release fixture --head")));
+    }
+
+    #[test]
+    fn missing_expected_head_tag_never_invokes_project_scripts_or_creates_source_outputs() {
+        let (_remote, checkout) = release_repo_with_remote_tag("0.11.10", "v0.11.11");
+        let options = ReleaseOptions {
+            bump_type: "head".to_string(),
+            path_override: Some(checkout.path().to_string_lossy().to_string()),
+            pipeline: crate::release::types::ReleasePipelineOptions {
+                head: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let plan = build_initial_preflight_plan("fixture", &options);
+        let mut results = Vec::new();
+
+        let error = execute_plan_steps(
+            &plan.plan.steps,
+            "fixture",
+            &options,
+            &mut results,
+            &HashSet::new(),
+        )
+        .expect_err("a mismatched release tag must fail before project scripts run");
+
+        assert!(error
+            .message
+            .contains("--head requires a release tag at HEAD"));
+        assert_project_scripts_were_not_invoked(checkout.path());
+    }
+
+    #[test]
+    fn wrong_version_tag_at_head_never_invokes_project_scripts_or_creates_source_outputs() {
+        let (_remote, checkout) = release_repo_with_remote_tag("0.11.10", "v0.11.11");
+        run_in(checkout.path(), &["git", "tag", "v0.11.11"]);
+
+        assert_invalid_head_identity_has_no_project_side_effects(checkout.path());
+    }
+
+    #[test]
+    fn expected_tag_away_from_head_never_invokes_project_scripts_or_creates_source_outputs() {
+        let (_remote, checkout) = release_repo_with_remote_tag("0.11.10", "v0.11.10");
+        std::fs::write(checkout.path().join("README.md"), "later commit\n").expect("write commit");
+        run_in(checkout.path(), &["git", "add", "README.md"]);
+        run_in(
+            checkout.path(),
+            &["git", "commit", "-q", "-m", "fix: later change"],
+        );
+
+        assert_invalid_head_identity_has_no_project_side_effects(checkout.path());
+    }
+
+    #[test]
+    fn invalid_recovery_manifest_never_invokes_project_scripts_or_creates_source_outputs() {
+        let (_remote, checkout) = release_repo_with_remote_tag("0.11.10", "v0.11.10");
+        run_in(checkout.path(), &["git", "tag", "v0.11.10"]);
+        let artifacts = tempfile::tempdir().expect("artifact tempdir");
+        std::fs::write(
+            artifacts.path().join("manifest.json"),
+            r#"{"schema":"homeboy.package-recovery"}"#,
+        )
+        .expect("write malformed manifest");
+        let options = ReleaseOptions {
+            bump_type: "head".to_string(),
+            path_override: Some(checkout.path().to_string_lossy().to_string()),
+            pipeline: crate::release::types::ReleasePipelineOptions {
+                head: true,
+                from_artifacts: Some(artifacts.path().to_string_lossy().to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let plan = build_initial_preflight_plan("fixture", &options);
+        let mut results = Vec::new();
+
+        let stopped = execute_plan_steps(
+            &plan.plan.steps,
+            "fixture",
+            &options,
+            &mut results,
+            &HashSet::new(),
+        )
+        .expect("manifest validation is reported as a failed preflight");
+
+        assert!(
+            stopped,
+            "invalid manifest must stop before dependency hydration"
+        );
+        assert!(results.iter().any(|result| {
+            result.id == "preflight.recovery_artifacts"
+                && result.status == ReleaseStepStatus::Failed
+        }));
+        assert_project_scripts_were_not_invoked(checkout.path());
     }
 
     #[test]
@@ -691,6 +783,11 @@ mod tests {
             checkout.path().join("homeboy.json"),
             r#"{
                 "id": "fixture",
+                "scripts": {
+                    "lint": ["sh -c 'printf lint >> .preflight-scripts; touch generated-by-script'"],
+                    "test": ["sh -c 'printf test >> .preflight-scripts; touch generated-by-script'"],
+                    "build": ["sh -c 'printf build >> .preflight-scripts; touch generated-by-script'"]
+                },
                 "version_targets": [
                     {"file": "plugin.php", "pattern": "(?m)^Version:\\s*([0-9.]+)"}
                 ]
@@ -708,6 +805,49 @@ mod tests {
         run_in(checkout.path(), &["git", "tag", "-d", tag]);
 
         (remote, checkout)
+    }
+
+    fn assert_project_scripts_were_not_invoked(checkout: &Path) {
+        let invocations = checkout.join(".preflight-scripts");
+        let count = std::fs::read_to_string(&invocations)
+            .map(|contents| contents.lines().count())
+            .unwrap_or(0);
+        assert_eq!(
+            count, 0,
+            "invalid recovery must invoke zero project scripts"
+        );
+        assert!(
+            !checkout.join("generated-by-script").exists(),
+            "invalid recovery must not create project source outputs"
+        );
+    }
+
+    fn assert_invalid_head_identity_has_no_project_side_effects(checkout: &Path) {
+        let options = ReleaseOptions {
+            bump_type: "head".to_string(),
+            path_override: Some(checkout.to_string_lossy().to_string()),
+            pipeline: crate::release::types::ReleasePipelineOptions {
+                head: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let plan = build_initial_preflight_plan("fixture", &options);
+        let mut results = Vec::new();
+
+        let error = execute_plan_steps(
+            &plan.plan.steps,
+            "fixture",
+            &options,
+            &mut results,
+            &HashSet::new(),
+        )
+        .expect_err("invalid --head identity must fail before project scripts run");
+
+        assert!(error
+            .message
+            .contains("--head requires a release tag at HEAD"));
+        assert_project_scripts_were_not_invoked(checkout);
     }
 
     fn run_in(dir: &Path, args: &[&str]) {

--- a/crates/homeboy-release/src/release/plan_steps/preflight.rs
+++ b/crates/homeboy-release/src/release/plan_steps/preflight.rs
@@ -43,15 +43,57 @@ pub(in crate::release) fn build_preflight_steps(
             StepConfig::new(),
         )
     };
+    let head_identity_step = if options.pipeline.head {
+        ready_step(
+            "preflight.head_identity",
+            "preflight.head_identity",
+            "Validate release identity at HEAD",
+            vec!["preflight.working_tree".to_string()],
+            StepConfig::new(),
+        )
+    } else {
+        disabled_step(
+            "preflight.head_identity",
+            "preflight.head_identity",
+            "Validate release identity at HEAD",
+            string_config("reason", "not-head-release"),
+        )
+    };
+    let recovery_artifacts_step =
+        if options.pipeline.head && options.pipeline.from_artifacts.is_some() {
+            ready_step(
+                "preflight.recovery_artifacts",
+                "preflight.recovery_artifacts",
+                "Validate recovery artifact manifest",
+                vec!["preflight.head_identity".to_string()],
+                StepConfig::new(),
+            )
+        } else {
+            disabled_step(
+                "preflight.recovery_artifacts",
+                "preflight.recovery_artifacts",
+                "Validate recovery artifact manifest",
+                string_config("reason", "not-head-release-artifacts"),
+            )
+        };
+    let remote_sync_needs = if options.pipeline.head && options.pipeline.from_artifacts.is_some() {
+        vec!["preflight.recovery_artifacts".to_string()]
+    } else if options.pipeline.head {
+        vec!["preflight.head_identity".to_string()]
+    } else {
+        vec!["preflight.working_tree".to_string()]
+    };
 
     let mut steps = vec![
         default_branch_step,
         working_tree_step,
+        head_identity_step,
+        recovery_artifacts_step,
         ready_step(
             "preflight.remote_sync",
             "preflight.remote_sync",
             "Validate remote sync",
-            vec!["preflight.working_tree".to_string()],
+            remote_sync_needs,
             StepConfig::new(),
         ),
         build_bump_policy_step(options, semver_recommendation),

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -269,7 +269,7 @@ fn build_head_release_steps(
     warnings: &mut Vec<String>,
 ) -> Result<Vec<PlanStep>> {
     let mut steps = Vec::new();
-    let mut artifact_need = "preflight.remote_sync".to_string();
+    let mut artifact_need = "preflight.head_identity".to_string();
     let package_step_needed = options.pipeline.from_artifacts.is_none()
         && head_package_step_needed(component, extensions, publish_targets, options);
 

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -26,6 +26,8 @@ fn test_build_preflight_steps() {
             "preflight.default_branch",
             "preflight.git_identity",
             "preflight.working_tree",
+            "preflight.head_identity",
+            "preflight.recovery_artifacts",
             "preflight.remote_sync",
             "preflight.bump_policy",
             "preflight.dependencies",
@@ -38,6 +40,8 @@ fn test_build_preflight_steps() {
     assert_eq!(steps[0].status, PlanStepStatus::Ready);
     assert_eq!(steps[1].status, PlanStepStatus::Disabled);
     assert_eq!(steps[2].needs, vec!["preflight.git_identity"]);
+    assert_eq!(steps[3].status, PlanStepStatus::Disabled);
+    assert_eq!(steps[4].status, PlanStepStatus::Disabled);
 }
 
 #[test]
@@ -921,6 +925,50 @@ fn head_release_plan_skips_mutation_steps_and_uses_existing_artifacts() {
     assert_eq!(steps[1].needs, vec!["artifacts.inventory"]);
     assert_eq!(steps[2].needs, vec!["artifacts.authority"]);
     assert_eq!(steps[3].needs, vec!["artifacts.authority"]);
+}
+
+#[test]
+fn head_artifact_recovery_validates_identity_and_manifest_before_remote_sync() {
+    let options = ReleaseOptions {
+        bump_type: "head".to_string(),
+        pipeline: ReleasePipelineOptions {
+            head: true,
+            from_artifacts: Some("artifacts".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let steps = build_preflight_steps(&options, None, &[]);
+    let identity = steps
+        .iter()
+        .position(|step| step.id == "preflight.head_identity")
+        .expect("head identity preflight");
+    let artifacts = steps
+        .iter()
+        .position(|step| step.id == "preflight.recovery_artifacts")
+        .expect("recovery artifact preflight");
+    let remote = steps
+        .iter()
+        .position(|step| step.id == "preflight.remote_sync")
+        .expect("remote sync preflight");
+    let dependencies = steps
+        .iter()
+        .position(|step| step.id == "preflight.dependencies")
+        .expect("dependency preflight");
+    let lint = steps
+        .iter()
+        .position(|step| step.id == "preflight.lint")
+        .expect("lint preflight");
+    let test = steps
+        .iter()
+        .position(|step| step.id == "preflight.test")
+        .expect("test preflight");
+
+    assert!(identity < artifacts && artifacts < remote && remote < dependencies);
+    assert!(artifacts < lint && artifacts < test);
+    assert_eq!(steps[artifacts].needs, vec!["preflight.head_identity"]);
+    assert_eq!(steps[remote].needs, vec!["preflight.recovery_artifacts"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- require `--head` to match the source version's exact release tag at `HEAD`
- validate recovery manifests before remote sync, dependency hydration, quality gates, packages, or remote mutation
- stop failed artifact inventory and cover missing, wrong-version, off-HEAD, and malformed-artifact recovery paths with project-script/output sentinels

Fixes #10771.

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-release`
- `cargo test -p homeboy-release release::plan_steps::tests --lib`
- focused head-identity and recovery-manifest execution-plan tests
- `git diff --check`

## AI Assistance
OpenCode using OpenAI GPT-5.6 Sol traced the release preflight ordering, implemented the strict identity and recovery-manifest validation, and drafted the tests. Chris Huber reviewed and owns every line.