### PR TITLE
feat(deploy): lower extension deployment providers

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/config.rs
+++ b/crates/contracts/homeboy-component-contract/src/config.rs
@@ -432,6 +432,14 @@ pub struct ComponentDeployConfig<'a> {
     pub cleanup_artifacts: &'a [CleanupArtifactDeclaration],
 }
 
+/// A repository-owned contract executed by an extension-declared deployment provider.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeploymentProviderAttachment {
+    pub extension: String,
+    pub provider: String,
+    pub contract: String,
+}
+
 impl ComponentDeployConfig<'_> {
     pub fn is_git_deploy(&self) -> bool {
         self.deploy_strategy == Some("git")

--- a/crates/contracts/homeboy-component-contract/src/lib.rs
+++ b/crates/contracts/homeboy-component-contract/src/lib.rs
@@ -18,8 +18,8 @@ pub mod model;
 pub use config::{
     ArtifactInput, CleanupArtifactDeclaration, CommandScopeConfig, ComponentDeployConfig,
     ComponentGithubReleaseConfig, ComponentOverrideConfig, ComponentReleaseConfig,
-    ComponentScriptsConfig, DependencyStackEdge, GitDeployConfig, GithubConfig, GithubHostConfig,
-    GithubReleaseOwner, PackageCoverageArtifactMatch, PackageCoverageConfig, ScopeConfig,
-    ScopedExtensionConfig, VersionTarget,
+    ComponentScriptsConfig, DependencyStackEdge, DeploymentProviderAttachment, GitDeployConfig,
+    GithubConfig, GithubHostConfig, GithubReleaseOwner, PackageCoverageArtifactMatch,
+    PackageCoverageConfig, ScopeConfig, ScopedExtensionConfig, VersionTarget,
 };
 pub use model::{render_remote_path_template, Component, ComponentLifecycle};

--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -3,8 +3,9 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::config::{
     is_default_github_config, ArtifactInput, CleanupArtifactDeclaration, ComponentDeployConfig,
-    ComponentReleaseConfig, ComponentScriptsConfig, DependencyStackEdge, GitDeployConfig,
-    GithubConfig, ScopeConfig, ScopedExtensionConfig, VersionTarget,
+    ComponentReleaseConfig, ComponentScriptsConfig, DependencyStackEdge,
+    DeploymentProviderAttachment, GitDeployConfig, GithubConfig, ScopeConfig,
+    ScopedExtensionConfig, VersionTarget,
 };
 use homeboy_audit_contract::AuditConfig;
 use homeboy_engine_primitives::canonical_json::canonical_json;
@@ -102,6 +103,8 @@ pub struct Component {
     pub remote_owner: Option<String>,
     pub deploy_strategy: Option<String>,
     pub git_deploy: Option<GitDeployConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment_provider: Option<DeploymentProviderAttachment>,
     /// Git remote URL for the component's source repository (e.g., GitHub URL).
     /// Used by deploy to download release artifacts or initialize server-side git repos.
     pub remote_url: Option<String>,
@@ -221,6 +224,8 @@ struct RawComponent {
     deploy_strategy: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     git_deploy: Option<GitDeployConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    deployment_provider: Option<DeploymentProviderAttachment>,
     #[serde(skip_serializing_if = "Option::is_none")]
     remote_url: Option<String>,
     #[serde(default, skip_serializing_if = "is_default_github_config")]
@@ -288,6 +293,7 @@ impl From<RawComponent> for Component {
             remote_owner: raw.remote_owner,
             deploy_strategy: raw.deploy_strategy,
             git_deploy: raw.git_deploy,
+            deployment_provider: raw.deployment_provider,
             remote_url: raw.remote_url,
             github: raw.github,
             release: raw.release,
@@ -336,6 +342,7 @@ impl From<Component> for RawComponent {
             remote_owner: c.remote_owner,
             deploy_strategy: c.deploy_strategy,
             git_deploy: c.git_deploy,
+            deployment_provider: c.deployment_provider,
             remote_url: c.remote_url,
             github: c.github,
             release: c.release,
@@ -415,6 +422,7 @@ impl Component {
             remote_owner: None,
             deploy_strategy: None,
             git_deploy: None,
+            deployment_provider: None,
             remote_url: None,
             github: GithubConfig::default(),
             release: ComponentReleaseConfig::default(),

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -40,9 +40,9 @@ pub use audit::{
 pub use config::{
     ArtifactInput, CleanupArtifactDeclaration, CommandScopeConfig, ComponentDeployConfig,
     ComponentGithubReleaseConfig, ComponentOverrideConfig, ComponentReleaseConfig,
-    ComponentScriptsConfig, DependencyStackEdge, GitDeployConfig, GithubConfig, GithubHostConfig,
-    GithubReleaseOwner, PackageCoverageArtifactMatch, PackageCoverageConfig, ScopeConfig,
-    ScopedExtensionConfig, VersionTarget,
+    ComponentScriptsConfig, DependencyStackEdge, DeploymentProviderAttachment, GitDeployConfig,
+    GithubConfig, GithubHostConfig, GithubReleaseOwner, PackageCoverageArtifactMatch,
+    PackageCoverageConfig, ScopeConfig, ScopedExtensionConfig, VersionTarget,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,

--- a/crates/homeboy-core/src/project/component/attachments.rs
+++ b/crates/homeboy-core/src/project/component/attachments.rs
@@ -145,6 +145,7 @@ fn attach_component_path_unlocked(
             id: component_id.to_string(),
             local_path: local_path.to_string(),
             remote_path: None,
+            deployment_provider: None,
         });
     }
 

--- a/crates/homeboy-core/src/project/component/resolution.rs
+++ b/crates/homeboy-core/src/project/component/resolution.rs
@@ -18,11 +18,15 @@ pub fn resolve_project_component_with_standalone_snapshot(
     component_id: &str,
     standalone_snapshot: Option<&StandaloneComponentConfigSnapshot>,
 ) -> Result<crate::component::Component> {
-    let (mut component, attachment_local_path, attachment_remote_path) = if let Some(attachment) =
-        project
-            .components
-            .iter()
-            .find(|component| component.id == component_id)
+    let (
+        mut component,
+        attachment_local_path,
+        attachment_remote_path,
+        attachment_deployment_provider,
+    ) = if let Some(attachment) = project
+        .components
+        .iter()
+        .find(|component| component.id == component_id)
     {
         super::super::validate_component_local_path(project, component_id)?;
         crate::component::resolution::validate_duplicate_portable_component_ids(
@@ -44,6 +48,7 @@ pub fn resolve_project_component_with_standalone_snapshot(
             })?,
             attachment.local_path.clone(),
             attachment.remote_path.clone(),
+            attachment.deployment_provider.clone(),
         )
     } else {
         return Err(Error::validation_invalid_argument(
@@ -61,6 +66,9 @@ pub fn resolve_project_component_with_standalone_snapshot(
         if !remote_path.trim().is_empty() {
             component.remote_path = remote_path;
         }
+    }
+    if attachment_deployment_provider.is_some() {
+        component.deployment_provider = attachment_deployment_provider;
     }
 
     apply_standalone_component_fallbacks(&mut component, standalone_snapshot);

--- a/crates/homeboy-core/src/project/types/component.rs
+++ b/crates/homeboy-core/src/project/types/component.rs
@@ -12,6 +12,8 @@ pub struct ProjectComponentAttachment {
     /// rewriting the repo-tracked `remote_path` for each environment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_provider: Option<crate::component::DeploymentProviderAttachment>,
 }
 
 pub type ProjectComponentOverrides = crate::component::ComponentOverrideConfig;

--- a/crates/homeboy-extension/src/capability.rs
+++ b/crates/homeboy-extension/src/capability.rs
@@ -134,6 +134,7 @@ mod tests {
                     id: "consumer".to_string(),
                     local_path: component_dir.path().to_string_lossy().to_string(),
                     remote_path: None,
+                    deployment_provider: None,
                 }],
                 ..Default::default()
             };

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -210,6 +210,83 @@ pub fn run_extension(
     })
 }
 
+/// Run an extension-owned deployment provider command and retain its structured
+/// stdout for the deploy result. Provider-specific validation and mutation stay
+/// entirely inside the extension command.
+pub fn run_deployment_provider(
+    extension_id: &str,
+    provider_id: &str,
+    project_id: &str,
+    component_id: &str,
+    contract: &std::path::Path,
+) -> Result<ExtensionRunResult> {
+    let extension = load_extension(extension_id)?;
+    let provider = super::deployment_providers(&extension)
+        .into_iter()
+        .find(|provider| provider.id == provider_id)
+        .ok_or_else(|| Error::validation_invalid_argument(
+            "deployment_provider.provider",
+            format!("Extension '{extension_id}' does not declare deployment provider '{provider_id}'"),
+            None,
+            None,
+        ))?;
+    let readiness = extension_ready_status(&extension);
+    if !readiness.ready {
+        return Err(Error::validation_invalid_argument(
+            "deployment_provider.extension",
+            format!("Deployment extension '{extension_id}' is not ready"),
+            readiness.detail.or(readiness.reason),
+            None,
+        ));
+    }
+    let extension_path = validation::require(
+        extension.extension_path.as_ref(),
+        "extension",
+        "extension_path not set",
+    )?;
+    let contract = contract.to_str().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "deployment_provider.contract",
+            "Contract path is not valid UTF-8",
+            None,
+            None,
+        )
+    })?;
+    let quoted_contract = shell_quote(contract);
+    let command = template::render(
+        &provider.command,
+        &[
+            ("extension_path", extension_path),
+            ("payload.contract", &quoted_contract),
+        ],
+    );
+    let execution = execute_extension_command(
+        &command,
+        &[],
+        Some(extension_path),
+        &build_exec_env(
+            extension_id,
+            Some(project_id),
+            Some(component_id),
+            "{}",
+            Some(extension_path),
+            None,
+            None,
+            None,
+        ),
+        ExtensionExecutionMode::Captured,
+    )?;
+    Ok(ExtensionRunResult {
+        exit_code: execution.exit_code,
+        project_id: Some(project_id.to_string()),
+        output: Some(execution.output),
+    })
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 /// Execute a extension action (API call).
 pub fn run_action(
     extension_id: &str,
@@ -895,6 +972,7 @@ mod tests {
                     id: "fixture".to_string(),
                     local_path: attachment.path().to_string_lossy().to_string(),
                     remote_path: None,
+                    deployment_provider: None,
                 }],
                 ..Default::default()
             })

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -70,8 +70,9 @@ pub(crate) use execution::build_settings_json_from_manifest;
 pub use execution::execute_action;
 pub use execution::{
     extension_ready_status, extension_ready_status_with, is_extension_compatible, run_action,
-    run_extension, run_setup, ExtensionExecutionMode, ExtensionReadinessMode, ExtensionReadyStatus,
-    ExtensionRunResult, ExtensionSetupResult, ExtensionStepFilter,
+    run_deployment_provider, run_extension, run_setup, ExtensionExecutionMode,
+    ExtensionReadinessMode, ExtensionReadyStatus, ExtensionRunResult, ExtensionSetupResult,
+    ExtensionStepFilter,
 };
 pub use fingerprint::{
     run_fingerprint_script, AggregateConstructionSeam, AggregateDefinitionFact, AggregateFieldFact,
@@ -104,13 +105,14 @@ pub use lifecycle::{
 };
 pub use maintenance::{exec_tool, update_all};
 pub use manifest::{
-    structured_sidecar_schema_version, structured_sidecars, ActionConfig, ActionType,
-    AgentRuntimeManifestConfig, AuditCapability, AutofixVerifyConfig, BehaviorScenarioNames,
-    BenchConfig, BuildConfig, CiCapability, CiJobFidelity, CiJobMapping, CiJobSpec, CiLocalContext,
-    CiProfileSpec, CliAutoFlag, CliAutoFlagCondition, CliConfig, CliHelpConfig, ComponentEnvConfig,
-    DatabaseCliConfig, DatabaseConfig, DeployCapability, DeployOverride, DeployOwnerHint,
-    DeployVerification, DepsConfig, DiscoveryConfig, DiscoveryMarkerConfig, DocTarget,
-    ExecutableCapability, ExtensionContractProducer, ExtensionContractProducerInvocation,
+    deployment_providers, structured_sidecar_schema_version, structured_sidecars, ActionConfig,
+    ActionType, AgentRuntimeManifestConfig, AuditCapability, AutofixVerifyConfig,
+    BehaviorScenarioNames, BenchConfig, BuildConfig, CiCapability, CiJobFidelity, CiJobMapping,
+    CiJobSpec, CiLocalContext, CiProfileSpec, CliAutoFlag, CliAutoFlagCondition, CliConfig,
+    CliHelpConfig, ComponentEnvConfig, DatabaseCliConfig, DatabaseConfig, DeployCapability,
+    DeployOverride, DeployOwnerHint, DeployVerification, DeploymentProviderManifest, DepsConfig,
+    DiscoveryConfig, DiscoveryMarkerConfig, DocTarget, ExecutableCapability,
+    ExtensionContractProducer, ExtensionContractProducerInvocation,
     ExtensionContractProducerOutput, ExtensionContractProducerOutputKind,
     ExtensionContractProducerPhase, ExtensionDiagnosticsConfig, ExtensionManifest,
     ExtensionMaterializationHelperManifestRef, ExtensionMaterializationSourceContract,

--- a/crates/homeboy-extension/src/manifest.rs
+++ b/crates/homeboy-extension/src/manifest.rs
@@ -71,6 +71,46 @@ pub use homeboy_extension_contract::notification_transport_config::{
 
 pub use homeboy_extension_contract::ExtensionManifest;
 
+/// Generic provider metadata owned by an extension manifest.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct DeploymentProviderManifest {
+    pub id: String,
+    pub command: String,
+}
+
+/// Extension manifests retain provider descriptors as extension-owned data until
+/// the shared manifest contract publishes this capability.
+pub fn deployment_providers(manifest: &ExtensionManifest) -> Vec<DeploymentProviderManifest> {
+    manifest
+        .extra
+        .get("deployment_providers")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod deployment_provider_tests {
+    use super::*;
+
+    #[test]
+    fn reads_multiple_generic_provider_descriptors() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "fixture", "version": "1.0.0",
+            "deployment_providers": [
+                { "id": "fixture.alpha", "command": "fixture-alpha --contract {{payload.contract}}" },
+                { "id": "fixture.beta", "command": "fixture-beta --contract {{payload.contract}}" }
+            ]
+        }))
+        .expect("fixture manifest");
+
+        let providers = deployment_providers(&manifest);
+        assert_eq!(providers.len(), 2);
+        assert_eq!(providers[0].id, "fixture.alpha");
+        assert_eq!(providers[1].id, "fixture.beta");
+    }
+}
+
 // Sidecar-declaration helpers depend on core run-dir constants, so they stay
 // in core as free functions rather than moving with the manifest data model.
 /// Structured sidecars this extension explicitly declares.

--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -13,6 +13,7 @@ mod planning;
 mod policy;
 pub(crate) mod preparation;
 pub(crate) mod provenance;
+mod provider;
 mod receipt;
 mod safety_and_artifact;
 mod smoke;
@@ -81,6 +82,9 @@ fn run_with_release_artifacts(
     release_artifacts: &mut homeboy_core::git::release_download::ReleaseArtifactStore,
 ) -> Result<DeployOrchestrationResult> {
     let project = project::load(project_id)?;
+    if let Some(result) = provider::run_if_configured(project_id, &project, config)? {
+        return Ok(result);
+    }
     // A version-pinned release asset is resolved remotely before orchestration;
     // requiring its configured checkout to exist would reintroduce a mutable
     // source gate. Other modes retain the existing early local-path validation.
@@ -558,6 +562,7 @@ mod tests {
                     id: "plugin".to_string(),
                     local_path: "/tmp/homeboy-missing-component-path".to_string(),
                     remote_path: Some("wp-content/plugins/plugin".to_string()),
+                    deployment_provider: None,
                 }],
                 ..Project::default()
             })

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -1076,6 +1076,7 @@ mod tests {
                     id: (*id).to_string(),
                     local_path: path.to_string_lossy().to_string(),
                     remote_path: None,
+                    deployment_provider: None,
                 })
                 .collect(),
             ..Default::default()

--- a/crates/homeboy-release/src/deploy/planning.rs
+++ b/crates/homeboy-release/src/deploy/planning.rs
@@ -1049,11 +1049,13 @@ mod tests {
                     id: "a".to_string(),
                     local_path: "/stale/a".to_string(),
                     remote_path: Some("plugins/a".to_string()),
+                    deployment_provider: None,
                 },
                 homeboy_core::project::ProjectComponentAttachment {
                     id: "b".to_string(),
                     local_path: "/stale/b".to_string(),
                     remote_path: Some("plugins/b".to_string()),
+                    deployment_provider: None,
                 },
             ],
             ..Default::default()
@@ -1546,6 +1548,7 @@ mod tests {
                 id: id.to_string(),
                 local_path: dir.to_string_lossy().to_string(),
                 remote_path: None,
+                deployment_provider: None,
             };
 
             let project = Project {

--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -1,0 +1,147 @@
+use std::path::PathBuf;
+
+use homeboy_core::component::Component;
+use homeboy_core::error::{Error, Result};
+use homeboy_core::project::Project;
+
+use super::types::{ComponentDeployResult, DeployConfig, DeployOrchestrationResult, DeploySummary};
+
+pub(super) fn run_if_configured(
+    project_id: &str,
+    project: &Project,
+    config: &DeployConfig,
+) -> Result<Option<DeployOrchestrationResult>> {
+    if config.component_ids.is_empty() {
+        return Ok(None);
+    }
+    let components = config
+        .component_ids
+        .iter()
+        .map(|id| homeboy_core::project::resolve_project_component(project, id))
+        .collect::<Result<Vec<_>>>()?;
+    if components
+        .iter()
+        .all(|component| component.deployment_provider.is_some())
+    {
+        let results = components
+            .iter()
+            .map(|component| run_component(project_id, component, config))
+            .collect::<Result<Vec<_>>>()?;
+        let failed = results
+            .iter()
+            .filter(|result| result.status == "failed")
+            .count() as u32;
+        let total = results.len() as u32;
+        return Ok(Some(DeployOrchestrationResult {
+            results,
+            summary: DeploySummary {
+                total,
+                succeeded: total - failed,
+                failed,
+                skipped: 0,
+            },
+        }));
+    }
+    Ok(None)
+}
+
+fn run_component(
+    project_id: &str,
+    component: &Component,
+    config: &DeployConfig,
+) -> Result<ComponentDeployResult> {
+    let attachment = component
+        .deployment_provider
+        .as_ref()
+        .expect("checked by caller");
+    let contract = repository_contract(component, &attachment.contract)?;
+    if config.dry_run || config.check {
+        // A provider command is allowed to mutate even when its contract has a
+        // preflight capability. Until its manifest declares a separate dry-run
+        // command, Homeboy fails closed rather than treating a preview as safe.
+        return Err(Error::validation_invalid_argument(
+            "deployment_provider",
+            format!("Provider '{}' requires an extension-owned dry-run command", attachment.provider),
+            None,
+            Some(vec![format!(
+                "Add a dry-run command to provider '{}' and rerun homeboy deploy {} --project {} --dry-run",
+                attachment.provider, component.id, project_id
+            )]),
+        ));
+    }
+    let run = homeboy_extension::run_deployment_provider(
+        &attachment.extension,
+        &attachment.provider,
+        project_id,
+        &component.id,
+        &contract,
+    )?;
+    let evidence = run.output.unwrap_or_default();
+    let output = format!("{}{}", evidence.stdout, evidence.stderr);
+    let provider_result = serde_json::from_str::<serde_json::Value>(&evidence.stdout)
+        .unwrap_or_else(|_| serde_json::json!({ "status": "unstructured", "output": output }));
+    let status = if run.exit_code == 0 {
+        "deployed"
+    } else {
+        "failed"
+    };
+    let mut result = ComponentDeployResult::new(component, "").with_status(status);
+    result.deploy_exit_code = Some(run.exit_code);
+    result.error = (run.exit_code != 0).then(|| output);
+    result.deployment_provider = Some(provider_result);
+    Ok(result)
+}
+
+fn repository_contract(component: &Component, contract: &str) -> Result<PathBuf> {
+    let root = std::fs::canonicalize(&component.local_path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "deployment_provider.contract",
+            format!("Component source is unavailable: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let path = root.join(contract);
+    let path = std::fs::canonicalize(&path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "deployment_provider.contract",
+            format!("Contract '{contract}' is unavailable: {error}"),
+            None,
+            None,
+        )
+    })?;
+    if !path.starts_with(&root) || !path.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "deployment_provider.contract",
+            "Contract must be a repository-contained file",
+            None,
+            None,
+        ));
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::repository_contract;
+    use homeboy_core::component::Component;
+
+    #[test]
+    fn requires_a_repository_contained_contract_file() {
+        let repository = tempfile::tempdir().expect("repository");
+        let contract = repository.path().join("deploy-contract.json");
+        std::fs::write(&contract, "{}").expect("contract");
+        let component = Component::new(
+            "fixture".to_string(),
+            repository.path().display().to_string(),
+            String::new(),
+            None,
+        );
+
+        assert_eq!(
+            repository_contract(&component, "deploy-contract.json").expect("contained contract"),
+            std::fs::canonicalize(&contract).expect("canonical contract")
+        );
+        assert!(repository_contract(&component, "../deploy-contract.json").is_err());
+    }
+}

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -503,6 +503,10 @@ pub struct ComponentDeployResult {
     /// Project policy proof that authorized this component's source.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployment_provenance: Option<DeploymentProvenanceEvidence>,
+    /// Extension-owned structured provider result (version, gates, rollback,
+    /// and remediation evidence). Core preserves it without interpreting it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_provider: Option<serde_json::Value>,
 }
 
 impl ComponentDeployResult {
@@ -539,6 +543,7 @@ impl ComponentDeployResult {
             build_provenance: None,
             prepared_artifact: None,
             deployment_provenance: None,
+            deployment_provider: None,
         }
     }
 

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -1002,6 +1002,7 @@ mod tests {
                             .display()
                             .to_string(),
                         remote_path: Some(format!("plugins/{id}")),
+                        deployment_provider: None,
                     }],
                     ..Project::default()
                 })


### PR DESCRIPTION
## Summary
- add generic component/project deployment-provider attachments with repository-contained contracts
- resolve declared extension `deployment_providers`, gate readiness, execute the declared command, and preserve structured provider evidence in deploy results
- fail dry-runs closed when a provider has not declared a distinct non-mutating command

Fixes #10772

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-extension deployment_provider_tests --lib`
- `cargo test -p homeboy-release deploy::provider::tests --lib`
- `git diff --check`

## AI Assistance
OpenCode using OpenAI GPT-5.6 Sol inspected the existing deploy and extension contracts, implemented the provider-agnostic lowering, and added focused deterministic tests. Chris Huber reviewed and owns the change.