### PR TITLE
fix: quick-win batch wave 2 from the 2026-07-29 issue triage (5 issues)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -13,14 +13,16 @@ use super::super::super::review;
 #[derive(Args, Debug, Clone)]
 pub struct VerifyGateArgs {
     /// Deterministic verification command that must pass before the cook
-    /// promotes its work (e.g. `--verify "cargo fmt --check"`). Runs in the
-    /// destination worktree. Repeat to require multiple gates; every one must
-    /// pass. Its output is included in the review evidence.
+    /// promotes its work (e.g. `--verify "cargo fmt --check"`). Required unless
+    /// `--private-verify` is given — a cook that cannot verify its work cannot
+    /// promote it. Runs in the destination worktree. Repeat to require multiple
+    /// gates; every one must pass. Its output is included in the review evidence.
     #[arg(long = "verify", value_name = "COMMAND")]
     pub verify: Vec<String>,
     /// Like `--verify`, but the command's output is treated as private: only a
     /// pass/fail summary is revealed by default (see `--private-gate-reveal`).
-    /// Use for gates whose logs may contain secrets. Repeatable.
+    /// Satisfies the same mandatory-gate requirement as `--verify`. Use for
+    /// gates whose logs may contain secrets. Repeatable.
     #[arg(long = "private-verify", value_name = "COMMAND")]
     pub private_verify: Vec<String>,
     /// How much of a `--private-verify` gate's output to reveal: `summary-only`

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -10,6 +10,11 @@ pub struct AgentTaskFanoutArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AgentTaskFanoutCommand {
+    /// Cook a wave of independent tasks, one child cook per issue.
+    ///
+    /// Requires at least one deterministic gate: pass `--verify` or
+    /// `--private-verify`. The gate is not optional — a child cook that cannot
+    /// verify its work cannot promote it (#9838).
     CookBatch(AgentTaskFanoutCookBatchArgs),
     Plan(AgentTaskFanoutPlanArgs),
     Submit(AgentTaskFanoutSubmitArgs),

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -370,9 +370,19 @@ fn cook_batch_inner(
     mut args: AgentTaskFanoutCookBatchArgs,
     attempt_dispatcher: Option<&CookAttemptDispatcherFactory>,
 ) -> CmdResult<Value> {
+    // Checked before provider readiness, worktree creation, or any other
+    // expensive preflight, so an operator who followed --help does not discover
+    // the requirement only after discovery succeeds (#9838).
     if !args.gates.has_deterministic_gate() {
-        return Err(invalid_fanout(
-            "agent-task fanout cook-batch requires --verify or --private-verify",
+        return Err(Error::validation_invalid_argument(
+            "verify",
+            "agent-task fanout cook-batch requires at least one deterministic gate: pass --verify or --private-verify",
+            None,
+            Some(vec![
+                "Add a public gate, e.g. --verify 'cargo test --workspace'.".to_string(),
+                "Use --private-verify for a gate whose output may contain secrets.".to_string(),
+                "A child cook that cannot verify its work cannot promote it, so the gate is not optional.".to_string(),
+            ]),
         ));
     }
     apply_provider_profile(&mut args);

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -397,6 +397,9 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     let run_id = args
         .run_id
         .expect("clap requires --run-id without --recover");
+    // Retained for the finalization handoff, which names the exact apply command
+    // after a validated preflight (#9867). `run_id` itself moves into the options.
+    let handoff_run_id = run_id.clone();
     let path = args.path.expect("clap requires --path without --recover");
     let title = args.title.expect("clap requires --title without --recover");
     let commit_message = args
@@ -516,7 +519,11 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     };
 
     let mut value = serde_json::to_value(&report).unwrap_or(Value::Null);
-    value["handoff"] = finalization_handoff(&report.status, report.pr_url.as_deref());
+    value["handoff"] = finalization_handoff(
+        &report.status,
+        report.pr_url.as_deref(),
+        Some(handoff_run_id.as_str()),
+    );
 
     Ok((value, exit_code))
 }
@@ -1467,22 +1474,61 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, _to_worktree: &str) -> V
     })
 }
 
-fn finalization_handoff(status: &str, pr_url: Option<&str>) -> Value {
+/// Render the finalization boundary.
+///
+/// A successful `--preflight` deliberately suppresses publication, so it must
+/// not be described with the same "PR was not opened; inspect … errors" wording
+/// as a failed publication attempt. Reporting a validated safety check as an
+/// apparent failure sent an agent toward error inspection instead of the apply
+/// command it had just earned (#9867).
+fn finalization_handoff(status: &str, pr_url: Option<&str>, run_id: Option<&str>) -> Value {
     let pr_opened = status == "review_ready" && pr_url.is_some();
+    // `validated` is the terminal success status for a non-mutating preflight;
+    // `finalize_pr` never returns it.
+    let publication_validated = status == "validated";
+
+    let boundary = if pr_opened {
+        "pr_opened"
+    } else if publication_validated {
+        "publication_validated_not_executed"
+    } else {
+        "pr_not_opened"
+    };
+
+    let finalize_command =
+        run_id.map(|run_id| format!("homeboy agent-task finalize-pr --recover {run_id}"));
+
+    let next_actions = if pr_opened {
+        vec!["PR opened or updated; continue review in GitHub".to_string()]
+    } else if publication_validated {
+        let mut actions = vec![
+            "Publication validated; no commit, push, or PR mutation occurred by design."
+                .to_string(),
+        ];
+        match finalize_command.as_deref() {
+            Some(command) => actions.push(format!("Run `{command}` to execute the validated publication.")),
+            None => actions.push(
+                "Rerun the same finalize-pr invocation without --preflight to execute the validated publication."
+                    .to_string(),
+            ),
+        }
+        actions
+    } else {
+        vec!["PR was not opened; inspect finalization status and git/PR errors".to_string()]
+    };
+
     serde_json::json!({
         "schema": "homeboy/agent-task-finalization-handoff/v1",
         "states": {
             "patch_artifact_produced": true,
             "patch_promoted": true,
-            "pr_opened": pr_opened
+            "pr_opened": pr_opened,
+            "publication_mutated": !publication_validated && pr_opened
         },
-        "boundary": if pr_opened { "pr_opened" } else { "pr_not_opened" },
+        "boundary": boundary,
         "pr_url": pr_url,
-        "next_actions": if pr_opened {
-            vec!["PR opened or updated; continue review in GitHub".to_string()]
-        } else {
-            vec!["PR was not opened; inspect finalization status and git/PR errors".to_string()]
-        }
+        "finalize_command": if publication_validated { finalize_command.clone() } else { None },
+        "next_actions": next_actions
     })
 }
 
@@ -2061,6 +2107,7 @@ mod tests {
         let handoff = finalization_handoff(
             "review_ready",
             Some("https://github.com/Extra-Chill/homeboy/pull/9999"),
+            Some("agent-task-1234"),
         );
 
         assert_eq!(handoff["states"]["patch_artifact_produced"], true);
@@ -2070,6 +2117,58 @@ mod tests {
         assert_eq!(
             handoff["pr_url"],
             "https://github.com/Extra-Chill/homeboy/pull/9999"
+        );
+        assert!(
+            handoff["finalize_command"].is_null(),
+            "an executed publication has nothing left to apply"
+        );
+    }
+
+    /// A validated preflight suppressed publication on purpose, so it must not
+    /// be rendered with failed-publication wording (#9867).
+    #[test]
+    fn finalization_handoff_distinguishes_validated_preflight_from_failed_publication() {
+        let handoff = finalization_handoff("validated", None, Some("agent-task-9867"));
+
+        assert_eq!(handoff["boundary"], "publication_validated_not_executed");
+        assert_eq!(handoff["states"]["pr_opened"], false);
+        assert_eq!(handoff["states"]["publication_mutated"], false);
+        assert_eq!(
+            handoff["finalize_command"],
+            "homeboy agent-task finalize-pr --recover agent-task-9867"
+        );
+
+        let actions = handoff["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .iter()
+            .filter_map(|action| action.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            actions.contains("no commit, push, or PR mutation occurred by design"),
+            "must state the suppression was intentional: {actions}"
+        );
+        assert!(
+            actions.contains("homeboy agent-task finalize-pr --recover agent-task-9867"),
+            "must name the exact apply command: {actions}"
+        );
+        assert!(
+            !actions.contains("inspect finalization status"),
+            "error-inspection guidance is reserved for real failures: {actions}"
+        );
+    }
+
+    /// A genuinely failed publication keeps the error-inspection guidance.
+    #[test]
+    fn finalization_handoff_keeps_error_guidance_for_failed_publication() {
+        let handoff = finalization_handoff("failed", None, Some("agent-task-9867"));
+
+        assert_eq!(handoff["boundary"], "pr_not_opened");
+        assert!(handoff["finalize_command"].is_null());
+        assert_eq!(
+            handoff["next_actions"][0],
+            "PR was not opened; inspect finalization status and git/PR errors"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1046,9 +1046,18 @@ pub struct CleanupInventoryOutput {
     pub command: &'static str,
     pub mode: &'static str,
     pub category_count: usize,
+    /// Resources selected for removal, summed across categories.
+    ///
+    /// `candidate_count`, `applied_count` and `skipped_count` all count
+    /// *resources*. Category-level execution success is reported separately as
+    /// `applied_category_count`, so an atomic directory-level cleanup can no
+    /// longer be mistaken for a partial one (#9483).
     pub candidate_count: usize,
     pub applied_count: usize,
     pub skipped_count: usize,
+    /// Categories that executed and removed at least one resource. Counted in
+    /// categories, never in resources.
+    pub applied_category_count: usize,
     pub estimated_bytes: u64,
     pub reclaimed_bytes: u64,
     pub retention: CleanupRetentionManifest,
@@ -1487,7 +1496,13 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
         categories.push(category_from_output(
             RUNNER_DOWNLOADS_METADATA,
             apply,
-            output.inspected_count,
+            // `planned_count`, not `inspected_count`: a candidate is a resource
+            // selected for removal, not every entry the sweep walked past. Using
+            // the inspected total reported `candidate_count: 588, applied_count: 1`
+            // for a sweep that removed everything it selected, which reads as a
+            // 587-resource failure (#9483). The full inspected total remains
+            // visible in this category's nested `output`.
+            output.planned_count,
             output.removed_count,
             output.skipped_count,
             output.planned_size_bytes,
@@ -1639,6 +1654,7 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
         .iter()
         .map(|category| category.reclaimed_bytes)
         .sum();
+    let applied_category_count = applied_category_count(&categories);
     let actionable = cleanup_actionable(&categories, apply);
     serde_json::to_value(CleanupInventoryOutput {
         command: "cleanup.inventory",
@@ -1647,6 +1663,7 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
         candidate_count,
         applied_count,
         skipped_count,
+        applied_category_count,
         estimated_bytes,
         reclaimed_bytes,
         retention: policy,
@@ -1877,6 +1894,18 @@ fn repo_artifact_roots(
         ));
     }
     collection
+}
+
+/// Categories that executed and removed at least one resource.
+///
+/// Counted in categories, deliberately not in resources: a directory-level
+/// atomic cleanup removes many resources in one operation, and folding that into
+/// a resource-unit field made a complete sweep read as a partial one (#9483).
+fn applied_category_count(categories: &[CleanupInventoryCategory]) -> usize {
+    categories
+        .iter()
+        .filter(|category| category.applied_count > 0)
+        .count()
 }
 
 fn category_from_output<T: Serialize>(
@@ -2473,6 +2502,73 @@ fn format_bytes(bytes: u64) -> String {
         _ if (bytes as f64) < MIB => format!("{:.1} KiB", bytes as f64 / KIB),
         _ if (bytes as f64) < GIB => format!("{:.1} MiB", bytes as f64 / MIB),
         _ => format!("{:.1} GiB", bytes as f64 / GIB),
+    }
+}
+
+#[cfg(test)]
+mod count_unit_tests {
+    use super::*;
+
+    fn category(name: &'static str, candidates: usize, applied: usize) -> CleanupInventoryCategory {
+        category_from_command(
+            name,
+            format!("homeboy cleanup --include {name} --apply"),
+            format!("homeboy {name} --apply"),
+            candidates,
+            applied,
+            0,
+            0,
+            0,
+            serde_json::json!({}),
+        )
+        .expect("category fixture")
+    }
+
+    /// A directory-level atomic sweep removes every resource it selected. That
+    /// must read as complete, not as 1-of-588 (#9483).
+    #[test]
+    fn runner_downloads_style_atomic_cleanup_reports_matching_resource_counts() {
+        let categories = vec![category("runner-downloads", 588, 588)];
+
+        assert_eq!(categories[0].candidate_count, 588);
+        assert_eq!(categories[0].applied_count, 588);
+        assert_eq!(
+            applied_category_count(&categories),
+            1,
+            "one category executed, regardless of how many resources it removed"
+        );
+    }
+
+    /// Category-level success and resource-level counts stay in separate units
+    /// across runner downloads, runtime temp, and terminal runs.
+    #[test]
+    fn category_success_is_counted_in_categories_not_resources() {
+        let categories = vec![
+            category("runner-downloads", 588, 588),
+            category("runtime-temp", 12, 12),
+            category("terminal-runs", 4, 0),
+        ];
+
+        let candidate_total: usize = categories.iter().map(|c| c.candidate_count).sum();
+        let applied_total: usize = categories.iter().map(|c| c.applied_count).sum();
+
+        assert_eq!(candidate_total, 604);
+        assert_eq!(applied_total, 600);
+        assert_eq!(
+            applied_category_count(&categories),
+            2,
+            "terminal-runs removed nothing, so only two categories executed"
+        );
+    }
+
+    #[test]
+    fn a_dry_run_with_candidates_has_no_applied_categories() {
+        let categories = vec![
+            category("runner-downloads", 588, 0),
+            category("runtime-temp", 12, 0),
+        ];
+
+        assert_eq!(applied_category_count(&categories), 0);
     }
 }
 

--- a/crates/homeboy-lab-runner/src/execution/paths.rs
+++ b/crates/homeboy-lab-runner/src/execution/paths.rs
@@ -139,11 +139,28 @@ pub(super) fn validate_remote_cwd(root: &str, cwd: &str) -> Result<()> {
     if cwd == root || cwd.starts_with(&format!("{root}/")) {
         return Ok(());
     }
+    // A path outside the remote root that exists locally is almost always a
+    // controller-local checkout handed to a remote-only field. Naming the
+    // built-in materialization path turns an unusable "use a path under
+    // /home/..." hint into the exact command that does what was intended,
+    // instead of sending the operator through a manual `workspace sync` plus
+    // remote-path plumbing (#10364).
+    let mut tried = Vec::new();
+    if std::path::Path::new(&cwd).exists() {
+        tried.push(format!(
+            "`{cwd}` exists on this controller, so it looks like a local checkout passed to a remote-only field."
+        ));
+        tried.push(format!(
+            "To run against it on the runner, replace `--cwd {cwd}` with `--sync-workspace {cwd}`, keeping the rest of the command unchanged."
+        ));
+    }
+    tried.push(format!("Use a remote path under {root}"));
+
     Err(Error::validation_invalid_argument(
         "cwd",
         "remote cwd must be inside the configured runner workspace_root",
         Some(cwd),
-        Some(vec![format!("Use a path under {root}")]),
+        Some(tried),
     ))
 }
 
@@ -153,5 +170,79 @@ pub(super) fn trim_trailing_slashes(path: &str) -> String {
         "/".to_string()
     } else {
         trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod validate_remote_cwd_tests {
+    use super::*;
+
+    fn tried(error: &Error) -> String {
+        error.details["tried"]
+            .as_array()
+            .expect("tried remediation")
+            .iter()
+            .filter_map(|hint| hint.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn remote_cwd_inside_the_workspace_root_is_accepted() {
+        validate_remote_cwd("/home/chubes/Developer", "/home/chubes/Developer").expect("root");
+        validate_remote_cwd(
+            "/home/chubes/Developer",
+            "/home/chubes/Developer/homeboy@fix",
+        )
+        .expect("nested path");
+    }
+
+    /// A local checkout handed to the remote-only `--cwd` must be diagnosed as
+    /// such and answered with the equivalent `--sync-workspace` command (#10364).
+    #[test]
+    fn existing_local_cwd_outside_the_root_recommends_sync_workspace() {
+        let local = tempfile::tempdir().expect("local checkout");
+        let local_path = local.path().to_str().expect("utf-8 path");
+
+        let error = validate_remote_cwd("/home/chubes/Developer", local_path)
+            .expect_err("a local path is not a valid remote cwd");
+
+        let hints = tried(&error);
+        assert!(
+            hints.contains("exists on this controller"),
+            "must classify the value as a local path: {hints}"
+        );
+        assert!(
+            hints.contains(&format!("--sync-workspace {local_path}")),
+            "must name the equivalent one-command path: {hints}"
+        );
+    }
+
+    /// A path that does not exist locally stays fail-closed with the original
+    /// remote-root guidance and no misleading sync suggestion.
+    #[test]
+    fn missing_cwd_outside_the_root_keeps_the_remote_root_guidance() {
+        let error = validate_remote_cwd(
+            "/home/chubes/Developer",
+            "/definitely/not/a/real/path/for/10364",
+        )
+        .expect_err("a nonexistent path is not a valid remote cwd");
+
+        let hints = tried(&error);
+        assert!(
+            hints.contains("Use a remote path under /home/chubes/Developer"),
+            "must retain remote-root guidance: {hints}"
+        );
+        assert!(
+            !hints.contains("--sync-workspace"),
+            "must not suggest syncing a path that does not exist: {hints}"
+        );
+    }
+
+    #[test]
+    fn relative_paths_are_rejected_before_local_classification() {
+        let error = validate_remote_cwd("/home/chubes/Developer", "relative/path")
+            .expect_err("relative remote cwd is rejected");
+        assert!(error.message.contains("must be absolute paths"));
     }
 }

--- a/docs/reference/cli/commands/agent-task.md
+++ b/docs/reference/cli/commands/agent-task.md
@@ -122,8 +122,8 @@ Do not infer the wait policy from client interactivity. An orchestration client 
 | `--to-worktree` | `<HANDLE>` | Workspace handle the cook edits, verifies, and finalizes into (e.g. `repo@branch-slug`). Existing destinations are reused. A missing managed destination is created through its configured provider when --repo, --base, --head, and --task-url declare explicit intent |
 | `--provider-command` | `<COMMAND>` | Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`. |
 | `--provider-argv` | `<ARG>` | Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`. |
-| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
-| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Use for gates whose logs may contain secrets. Repeatable |
+| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Required unless `--private-verify` is given — a cook that cannot verify its work cannot promote it. Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
+| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Satisfies the same mandatory-gate requirement as `--verify`. Use for gates whose logs may contain secrets. Repeatable |
 | `--private-gate-reveal` | `<POLICY>` | How much of a `--private-verify` gate's output to reveal: `summary-only` (default) shows just pass/fail; other policies expose more detail Values: `full-evidence`, `summary-only`, `redacted`, `no-detail`. |
 | `--gate-execution-policy` | `<POLICY>` | Gate scheduling policy: `ordered-fail-fast` (default) skips downstream gates after the first failure; `continue-all` runs every declared gate Values: `ordered-fail-fast`, `continue-all`. |
 | `--gate-timeout-seconds` | `<SECONDS>` | Wall-clock timeout, in seconds, for each verification gate command (default 1800 = 30 min). A gate exceeding this fails |
@@ -604,7 +604,7 @@ _This command declares no clap help text, so no description can be generated for
 
 | Subcommand | Summary |
 | --- | --- |
-| `homeboy agent-task fanout cook-batch` | _no help text_ |
+| `homeboy agent-task fanout cook-batch` | Cook a wave of independent tasks, one child cook per issue |
 | `homeboy agent-task fanout plan` | _no help text_ |
 | `homeboy agent-task fanout submit` | _no help text_ |
 | `homeboy agent-task fanout submit-batch` | _no help text_ |
@@ -619,7 +619,9 @@ _This command declares no clap help text, so no description can be generated for
 homeboy agent-task fanout cook-batch [OPTIONS] <ISSUE_URL>...
 ```
 
-_This command declares no clap help text, so no description can be generated for it._
+Cook a wave of independent tasks, one child cook per issue.
+
+Requires at least one deterministic gate: pass `--verify` or `--private-verify`. The gate is not optional — a child cook that cannot verify its work cannot promote it (#9838).
 
 | Argument | Required | Description |
 | --- | --- | --- |
@@ -639,8 +641,8 @@ _This command declares no clap help text, so no description can be generated for
 | `--provider-profile` | `<PROFILE>` | _no help text_ |
 | `--secret-env` | `<ENV>` | _no help text_ |
 | `--provider-config` | `<JSON>` | _no help text_ |
-| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
-| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Use for gates whose logs may contain secrets. Repeatable |
+| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Required unless `--private-verify` is given — a cook that cannot verify its work cannot promote it. Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
+| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Satisfies the same mandatory-gate requirement as `--verify`. Use for gates whose logs may contain secrets. Repeatable |
 | `--private-gate-reveal` | `<POLICY>` | How much of a `--private-verify` gate's output to reveal: `summary-only` (default) shows just pass/fail; other policies expose more detail Values: `full-evidence`, `summary-only`, `redacted`, `no-detail`. |
 | `--gate-execution-policy` | `<POLICY>` | Gate scheduling policy: `ordered-fail-fast` (default) skips downstream gates after the first failure; `continue-all` runs every declared gate Values: `ordered-fail-fast`, `continue-all`. |
 | `--gate-timeout-seconds` | `<SECONDS>` | Wall-clock timeout, in seconds, for each verification gate command (default 1800 = 30 min). A gate exceeding this fails |
@@ -797,8 +799,8 @@ _This command declares no clap help text, so no description can be generated for
 | `--task-id` | `<TASK_ID>` | _no help text_ |
 | `--artifact-id` | `<ARTIFACT_ID>` | _no help text_ |
 | `--dry-run` | flag | _no help text_ |
-| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
-| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Use for gates whose logs may contain secrets. Repeatable |
+| `--verify` | `<COMMAND>` | Deterministic verification command that must pass before the cook promotes its work (e.g. `--verify "cargo fmt --check"`). Required unless `--private-verify` is given — a cook that cannot verify its work cannot promote it. Runs in the destination worktree. Repeat to require multiple gates; every one must pass. Its output is included in the review evidence |
+| `--private-verify` | `<COMMAND>` | Like `--verify`, but the command's output is treated as private: only a pass/fail summary is revealed by default (see `--private-gate-reveal`). Satisfies the same mandatory-gate requirement as `--verify`. Use for gates whose logs may contain secrets. Repeatable |
 | `--private-gate-reveal` | `<POLICY>` | How much of a `--private-verify` gate's output to reveal: `summary-only` (default) shows just pass/fail; other policies expose more detail Values: `full-evidence`, `summary-only`, `redacted`, `no-detail`. |
 | `--gate-execution-policy` | `<POLICY>` | Gate scheduling policy: `ordered-fail-fast` (default) skips downstream gates after the first failure; `continue-all` runs every declared gate Values: `ordered-fail-fast`, `continue-all`. |
 | `--gate-timeout-seconds` | `<SECONDS>` | Wall-clock timeout, in seconds, for each verification gate command (default 1800 = 30 min). A gate exceeding this fails |

--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -56,7 +56,7 @@ Hand-written narrative lives in the [commands index](../../../commands/commands-
 
 ## Commands shipping without help text
 
-41 visible commands declare no clap `about`/`long_about`, so no description can be generated for them. The fix is a doc comment on the clap variant, not prose in this file.
+40 visible commands declare no clap `about`/`long_about`, so no description can be generated for them. The fix is a doc comment on the clap variant, not prose in this file.
 
 - `homeboy agent-task doctor`
 - `homeboy agent-task loop`
@@ -82,7 +82,6 @@ Hand-written narrative lives in the [commands index](../../../commands/commands-
 - `homeboy agent-task resume`
 - `homeboy agent-task retry`
 - `homeboy agent-task fanout`
-- `homeboy agent-task fanout cook-batch`
 - `homeboy agent-task fanout plan`
 - `homeboy agent-task fanout submit`
 - `homeboy agent-task fanout submit-batch`

--- a/tests/readonly_cli_lock_test.rs
+++ b/tests/readonly_cli_lock_test.rs
@@ -43,17 +43,21 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
                 "{} produced no diagnostic output",
                 args.join(" ")
             );
-            assert_eq!(
-                git_metadata_snapshot(&repository),
-                git_before,
-                "{} changed Git metadata while bypassing the mutation lock",
-                args.join(" ")
+            assert_snapshot_unchanged(
+                &git_metadata_snapshot(&repository),
+                &git_before,
+                &format!(
+                    "{} changed Git metadata while bypassing the mutation lock",
+                    args.join(" ")
+                ),
             );
-            assert_eq!(
-                filesystem_snapshot(home),
-                home_before,
-                "{} changed config or runtime state while bypassing the mutation lock",
-                args.join(" ")
+            assert_snapshot_unchanged(
+                &filesystem_snapshot(home),
+                &home_before,
+                &format!(
+                    "{} changed config or runtime state while bypassing the mutation lock",
+                    args.join(" ")
+                ),
             );
         }
 
@@ -75,15 +79,15 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
             String::from_utf8_lossy(&output.stdout).contains("runtime_promotion.contended"),
             "refresh serialization must report typed promotion contention"
         );
-        assert_eq!(
-            git_metadata_snapshot(&repository),
-            git_before,
-            "blocked refresh changed Git metadata"
+        assert_snapshot_unchanged(
+            &git_metadata_snapshot(&repository),
+            &git_before,
+            "blocked refresh changed Git metadata",
         );
-        assert_eq!(
-            filesystem_snapshot(&promotion_namespace.join("runtime-promotion")),
-            promotion_before,
-            "blocked refresh changed the held promotion lease"
+        assert_snapshot_unchanged(
+            &filesystem_snapshot(&promotion_namespace.join("runtime-promotion")),
+            &promotion_before,
+            "blocked refresh changed the held promotion lease",
         );
 
         let output = run_with_timeout(
@@ -100,15 +104,15 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
             "mutation exclusion must report typed promotion contention: {}",
             String::from_utf8_lossy(&output.stdout)
         );
-        assert_eq!(
-            git_metadata_snapshot(&repository),
-            git_before,
-            "blocked upgrade changed Git metadata"
+        assert_snapshot_unchanged(
+            &git_metadata_snapshot(&repository),
+            &git_before,
+            "blocked upgrade changed Git metadata",
         );
-        assert_eq!(
-            filesystem_snapshot(&promotion_namespace.join("runtime-promotion")),
-            promotion_before,
-            "blocked upgrade changed the held promotion lease"
+        assert_snapshot_unchanged(
+            &filesystem_snapshot(&promotion_namespace.join("runtime-promotion")),
+            &promotion_before,
+            "blocked upgrade changed the held promotion lease",
         );
     });
 }
@@ -190,6 +194,79 @@ fn create_repository(home: &std::path::Path) -> PathBuf {
     repository
 }
 
+/// Maximum characters a snapshot-mismatch message may occupy. A raw
+/// `assert_eq!` on `BTreeMap<PathBuf, Vec<u8>>` prints every file as a decimal
+/// byte vector, which has exceeded log and tool record limits and buried the
+/// one changed path that mattered (#10633).
+const SNAPSHOT_DIFF_MAX_CHARS: usize = 4_000;
+
+type Snapshot = BTreeMap<PathBuf, Vec<u8>>;
+
+/// Assert two filesystem snapshots match, reporting a bounded semantic diff —
+/// added, removed and content-changed paths with size metadata — instead of raw
+/// bytes.
+#[track_caller]
+fn assert_snapshot_unchanged(actual: &Snapshot, expected: &Snapshot, context: &str) {
+    if actual == expected {
+        return;
+    }
+    panic!("{context}\n{}", describe_snapshot_diff(expected, actual));
+}
+
+fn describe_snapshot_diff(before: &Snapshot, after: &Snapshot) -> String {
+    let mut lines = Vec::new();
+
+    for (path, bytes) in after {
+        match before.get(path) {
+            None => lines.push(format!(
+                "  + added   {} ({} bytes)",
+                path.display(),
+                bytes.len()
+            )),
+            Some(previous) if previous != bytes => lines.push(format!(
+                "  ~ changed {} ({} -> {} bytes)",
+                path.display(),
+                previous.len(),
+                bytes.len()
+            )),
+            Some(_) => {}
+        }
+    }
+    for (path, bytes) in before {
+        if !after.contains_key(path) {
+            lines.push(format!(
+                "  - removed {} ({} bytes)",
+                path.display(),
+                bytes.len()
+            ));
+        }
+    }
+
+    if lines.is_empty() {
+        return "  (snapshots differ but no per-path delta was derived)".to_string();
+    }
+
+    let total = lines.len();
+    let mut rendered = String::from("snapshot delta:\n");
+    let mut shown = 0;
+    // Reserve room for the truncation notice up front, so appending it can never
+    // push the message back over the bound it exists to enforce.
+    let remainder_budget = format!("  … and {total} more path(s)\n").len();
+    let line_budget = SNAPSHOT_DIFF_MAX_CHARS.saturating_sub(remainder_budget);
+    for line in &lines {
+        if rendered.len() + line.len() + 1 > line_budget {
+            break;
+        }
+        rendered.push_str(line);
+        rendered.push('\n');
+        shown += 1;
+    }
+    if shown < total {
+        rendered.push_str(&format!("  … and {} more path(s)\n", total - shown));
+    }
+    rendered
+}
+
 fn git_metadata_snapshot(repository: &std::path::Path) -> BTreeMap<PathBuf, Vec<u8>> {
     filesystem_snapshot(&repository.join(".git"))
 }
@@ -218,4 +295,84 @@ fn snapshot_directory(
             );
         }
     }
+}
+
+/// The #10621 delta: two added paths hidden inside a full byte-map dump. The
+/// diff must name them directly (#10633).
+#[test]
+fn snapshot_diff_names_the_added_paths_from_the_10621_regression() {
+    let before = Snapshot::new();
+    let mut after = Snapshot::new();
+    after.insert(
+        PathBuf::from(".config/homeboy/deferred-workloads.json"),
+        b"{}".to_vec(),
+    );
+    after.insert(
+        PathBuf::from(".config/homeboy/deferred-workloads.lock"),
+        Vec::new(),
+    );
+
+    let diff = describe_snapshot_diff(&before, &after);
+
+    assert!(
+        diff.contains(".config/homeboy/deferred-workloads.json"),
+        "diff must name the added JSON record: {diff}"
+    );
+    assert!(
+        diff.contains(".config/homeboy/deferred-workloads.lock"),
+        "diff must name the added lock: {diff}"
+    );
+    assert!(
+        diff.contains("+ added"),
+        "added paths must be labelled: {diff}"
+    );
+}
+
+/// A single oversized file must not reintroduce the unbounded byte dump.
+#[test]
+fn snapshot_diff_reports_sizes_not_bytes_and_stays_bounded() {
+    let mut before = Snapshot::new();
+    before.insert(PathBuf::from("big.bin"), vec![b'a'; 200_000]);
+    let mut after = Snapshot::new();
+    after.insert(PathBuf::from("big.bin"), vec![b'b'; 300_000]);
+
+    let diff = describe_snapshot_diff(&before, &after);
+
+    assert!(
+        diff.len() <= SNAPSHOT_DIFF_MAX_CHARS,
+        "diff must stay bounded"
+    );
+    assert!(
+        diff.contains("200000 -> 300000 bytes"),
+        "changed files report size metadata: {diff}"
+    );
+    assert!(
+        !diff.contains("97, 97"),
+        "raw byte vectors must never be rendered: {diff}"
+    );
+}
+
+/// Many changed paths are truncated with an explicit remainder count rather
+/// than being allowed to grow without limit.
+#[test]
+fn snapshot_diff_truncates_a_large_path_set_with_a_remainder_count() {
+    let before = Snapshot::new();
+    let mut after = Snapshot::new();
+    for index in 0..500 {
+        after.insert(
+            PathBuf::from(format!(".config/homeboy/generated-path-{index:04}.json")),
+            b"{}".to_vec(),
+        );
+    }
+
+    let diff = describe_snapshot_diff(&before, &after);
+
+    assert!(
+        diff.len() <= SNAPSHOT_DIFF_MAX_CHARS,
+        "diff must stay bounded"
+    );
+    assert!(
+        diff.contains("more path(s)"),
+        "truncation must be explicit: {diff}"
+    );
 }


### PR DESCRIPTION
Wave 2 of the 2026-07-29 issue triage quick wins. Five verified, independent fixes, one commit each.

Closes #9867. Closes #9838. Closes #10633. Closes #9483. Closes #10364.

| Issue | Change |
|---|---|
| **#9867** | A validated `finalize-pr --preflight` no longer renders as a failed publication |
| **#9838** | `cook-batch`'s mandatory `--verify` gate is stated in help instead of at execution time |
| **#10633** | Snapshot assertions report a bounded path delta instead of raw byte maps |
| **#9483** | `cleanup` counts candidates in resources, not inspected entries |
| **#10364** | `runner exec --cwd <local-path>` recommends the `--sync-workspace` equivalent |

## Notes worth reading

**#9483 — the root cause is narrower and more concrete than the issue assumed.** The report inferred that `applied_count` was counting categories while `candidate_count` counted resources. It isn't: the aggregate was mapping `candidate_count` from the runner-download sweep's `inspected_count` — *every entry walked past* — while `applied_count` came from `removed_count`. That is what produced `588` vs `1` for a sweep that removed everything it selected. Mapping `candidate_count` from `planned_count` puts both fields in the same unit. I still added `applied_category_count` as the issue asked, since category-level success genuinely is a distinct measurement, and the full inspected total remains visible in each category's nested `output`.

**#9838 — the expensive-preflight half was already fixed.** The gate check is already the first statement in `cook_batch_inner`, before `apply_provider_profile` and provider resolution, so nothing costly ran before the rejection. The live defect was purely descriptive. I put the requirement in the *first* line of both flag doc comments rather than a trailing paragraph, because clap only uses the first paragraph for short help and the generated reference table — a second paragraph would have been invisible on exactly the surface the issue complained about. The generated reference also drops from 41 to 40 commands with no help text.

**#10633 — the truncation notice was itself unbounded.** My first version broke out of the render loop at the character budget and *then* appended `… and N more path(s)`, which could push the message back over the limit it exists to enforce. The budget is now reserved up front. Three fixtures cover it: the exact two-path #10621 delta, a 300 KB changed file (asserting sizes are reported and raw bytes never are), and a 500-path set.

**#10364** keeps the fail-closed behaviour intact. The `--sync-workspace` hint is only emitted when the rejected path actually exists on the controller; nonexistent and relative paths get the original guidance with no misleading suggestion.

## Deliberately avoided `homeboy-agents`

None of these five touch `crates/homeboy-agents`. That is intentional: wave 1 (#10763) touched two test helpers in that crate, which pulled the whole lib test binary — including `agent_task_lifecycle::tests::handoff_and_proxy` — into the changed scope and timed the gate out at 25 minutes with zero counts. Evidence posted to #10687.

## Verification

`cargo fmt --check`, `cargo check --lib --tests` (exit 0), `cargo clippy --lib --tests` on the touched crates (exit 0, no new warnings), and the CLI reference regenerated and checked in.

- `homeboy-cli finalization_handoff` — 3 passed
- `homeboy-cli count_unit_tests` — 3 passed
- `homeboy-lab-runner validate_remote_cwd_tests` — 4 passed
- `readonly_cli_lock_test snapshot_diff` — 3 passed

## Pre-existing failure (NOT from this PR)

`homeboy-cli commands::cleanup::tests::invalid_owned_root_does_not_abort_other_repo_artifact_roots` fails on unmodified `main` with my changes stashed. Not introduced here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
