### PR TITLE
feat(deploy): run provider dry-run commands

### DIFF
--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -219,6 +219,7 @@ pub fn run_deployment_provider(
     project_id: &str,
     component_id: &str,
     contract: &std::path::Path,
+    dry_run: bool,
 ) -> Result<ExtensionRunResult> {
     let extension = load_extension(extension_id)?;
     let provider = super::deployment_providers(&extension)
@@ -253,8 +254,20 @@ pub fn run_deployment_provider(
         )
     })?;
     let quoted_contract = shell_quote(contract);
+    let command_template = if dry_run {
+        provider.dry_run_command.as_deref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "deployment_provider.dry_run_command",
+                format!("Provider '{provider_id}' does not declare a non-mutating dry-run command"),
+                None,
+                None,
+            )
+        })?
+    } else {
+        &provider.command
+    };
     let command = template::render(
-        &provider.command,
+        command_template,
         &[
             ("extension_path", extension_path),
             ("payload.contract", &quoted_contract),
@@ -993,6 +1006,39 @@ mod tests {
                 result.output.expect("output").stdout,
                 attachment.path().to_string_lossy()
             );
+        });
+    }
+
+    #[test]
+    fn deployment_provider_uses_the_declared_non_mutating_command() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let contract = tempfile::NamedTempFile::new().expect("contract");
+            write_extension(
+                home.path(),
+                "fixture-provider",
+                serde_json::json!({
+                    "name": "fixture-provider", "version": "1.0.0",
+                    "deployment_providers": [{
+                        "id": "fixture.deploy",
+                        "command": "sh {{extension_path}}/run.sh apply {{payload.contract}}",
+                        "dry_run_command": "sh {{extension_path}}/run.sh validate {{payload.contract}}"
+                    }]
+                }),
+                "#!/bin/sh\nprintf '%s' \"$1\"\n",
+            );
+
+            let result = run_deployment_provider(
+                "fixture-provider",
+                "fixture.deploy",
+                "site",
+                "fixture",
+                contract.path(),
+                true,
+            )
+            .expect("provider dry run");
+
+            assert_eq!(result.exit_code, 0);
+            assert_eq!(result.output.expect("output").stdout, "validate");
         });
     }
 

--- a/crates/homeboy-extension/src/manifest.rs
+++ b/crates/homeboy-extension/src/manifest.rs
@@ -76,6 +76,8 @@ pub use homeboy_extension_contract::ExtensionManifest;
 pub struct DeploymentProviderManifest {
     pub id: String,
     pub command: String,
+    #[serde(default)]
+    pub dry_run_command: Option<String>,
 }
 
 /// Extension manifests retain provider descriptors as extension-owned data until
@@ -99,7 +101,7 @@ mod deployment_provider_tests {
             "name": "fixture", "version": "1.0.0",
             "deployment_providers": [
                 { "id": "fixture.alpha", "command": "fixture-alpha --contract {{payload.contract}}" },
-                { "id": "fixture.beta", "command": "fixture-beta --contract {{payload.contract}}" }
+                { "id": "fixture.beta", "command": "fixture-beta --contract {{payload.contract}}", "dry_run_command": "fixture-beta --dry-run --contract {{payload.contract}}" }
             ]
         }))
         .expect("fixture manifest");
@@ -108,6 +110,11 @@ mod deployment_provider_tests {
         assert_eq!(providers.len(), 2);
         assert_eq!(providers[0].id, "fixture.alpha");
         assert_eq!(providers[1].id, "fixture.beta");
+        assert!(providers[0].dry_run_command.is_none());
+        assert_eq!(
+            providers[1].dry_run_command.as_deref(),
+            Some("fixture-beta --dry-run --contract {{payload.contract}}")
+        );
     }
 }
 

--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -55,33 +55,24 @@ fn run_component(
         .as_ref()
         .expect("checked by caller");
     let contract = repository_contract(component, &attachment.contract)?;
-    if config.dry_run || config.check {
-        // A provider command is allowed to mutate even when its contract has a
-        // preflight capability. Until its manifest declares a separate dry-run
-        // command, Homeboy fails closed rather than treating a preview as safe.
-        return Err(Error::validation_invalid_argument(
-            "deployment_provider",
-            format!("Provider '{}' requires an extension-owned dry-run command", attachment.provider),
-            None,
-            Some(vec![format!(
-                "Add a dry-run command to provider '{}' and rerun homeboy deploy {} --project {} --dry-run",
-                attachment.provider, component.id, project_id
-            )]),
-        ));
-    }
     let run = homeboy_extension::run_deployment_provider(
         &attachment.extension,
         &attachment.provider,
         project_id,
         &component.id,
         &contract,
+        config.dry_run || config.check,
     )?;
     let evidence = run.output.unwrap_or_default();
     let output = format!("{}{}", evidence.stdout, evidence.stderr);
     let provider_result = serde_json::from_str::<serde_json::Value>(&evidence.stdout)
         .unwrap_or_else(|_| serde_json::json!({ "status": "unstructured", "output": output }));
     let status = if run.exit_code == 0 {
-        "deployed"
+        if config.dry_run || config.check {
+            "validated"
+        } else {
+            "deployed"
+        }
     } else {
         "failed"
     };


### PR DESCRIPTION
## Summary
- parse generic extension deployment-provider `dry_run_command` metadata
- route `homeboy deploy --dry-run` and `--check` through only that explicit non-mutating command
- preserve structured provider evidence with a validated deploy result

Fixes #10772

Requires Extra-Chill/homeboy-extensions#2480, which supplies the Cloudflare Workers provider implementation.

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-extension deployment_provider_tests --lib`
- `cargo test -p homeboy-extension deployment_provider_uses_the_declared_non_mutating_command --lib`
- `cargo test -p homeboy-release deploy::provider::tests --lib`
- `git diff --check`

## AI Assistance
OpenCode using OpenAI GPT-5.6 Sol implemented the provider-agnostic dry-run manifest and execution contract with deterministic coverage. Chris responsible.