### PR TITLE
fix(config): make the config lock reentrancy-safe and bounded

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -934,6 +934,70 @@ fn retry_uses_controller_plan_when_runner_projection_replaces_plan_path() {
     });
 }
 
+/// Persisting a terminal Lab-bound record from inside a config-lock section is
+/// the deadlock class behind #10751.
+///
+/// `store::write_record` reaches `workspace_authority::persist_terminal_from_record`,
+/// which acquires the config lock, but only when the record is terminal *and*
+/// Lab-runner bound *and* carries a `remote_workspace`. `flock(2)` is owned by
+/// the open file description, so before the reentrancy repair that nested
+/// acquisition blocked in the kernel forever, poisoning the process-wide
+/// isolated-home mutex and wedging every remaining test in this binary.
+///
+/// #10754 removed the one nesting site it found (`store::mutate_record`); the
+/// stall reappeared at `agent_task_service::execution`, which holds the lock
+/// across `record_cook_attempt` -> `store::write_record`. This pins the shape
+/// rather than either individual call site.
+///
+/// The write runs on a worker thread under a bounded wait so a regression fails
+/// this test by name instead of consuming the entire CI test phase silently.
+#[test]
+fn terminal_lab_record_persists_from_inside_a_config_lock_section() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "config-lock-nested-terminal",
+            runner_id: "homeboy-lab",
+            runner_job_id: "job-nested",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("detached lab run");
+        record.state = AgentTaskRunState::Succeeded;
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = sender.send(homeboy_core::config::with_config_lock(|| {
+                store::write_record(&record)
+            }));
+        });
+
+        receiver
+            .recv_timeout(std::time::Duration::from_secs(90))
+            .expect(
+                "persisting a terminal Lab-bound record inside a config-lock section deadlocked; \
+                 the config lock is not reentrancy-safe",
+            )
+            .expect("terminal record persists");
+
+        let stored = store::read_record("config-lock-nested-terminal").expect("stored record");
+        assert_eq!(stored.state, AgentTaskRunState::Succeeded);
+
+        let authority =
+            crate::agent_task_lifecycle::workspace_authority::resolve_workspace_terminal_authority(
+                "config-lock-nested-terminal",
+                "homeboy-lab",
+                "/runner/workspace/homeboy",
+                Some("job-nested"),
+            )
+            .expect("terminal authority resolves");
+        assert!(
+            authority.is_some(),
+            "the nested write must still persist terminal workspace authority, not skip it"
+        );
+    });
+}
+
 #[test]
 fn logs_expose_mirrored_live_runner_events_before_terminal_aggregate() {
     with_isolated_home(|_| {

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -144,69 +144,83 @@ pub fn with_config_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
     operation()
 }
 
+/// Take an exclusive `flock(2)` on `file` under a deadline.
+///
+/// This is the supported way to take an exclusive file lock in Homeboy. Bare
+/// `LOCK_EX` blocks in the kernel indefinitely, so any holder that wedges takes
+/// every other waiter with it: inside a parallel test binary one stuck thread
+/// silently consumes the entire phase and libtest reports no failure at all.
+/// Polling `LOCK_EX | LOCK_NB` against a deadline turns that into a single
+/// attributable error naming the lock file and the wait.
+///
+/// `context` is the short operation label used in error details (for example
+/// `"lock config"`). The bound is shared with the config lock and configurable
+/// through [`CONFIG_LOCK_TIMEOUT_ENV`]; `0` restores unbounded blocking.
+///
+/// Note that this bounds *contention*, not re-entry. `flock` locks belong to
+/// the open file description, so a caller that opens the same lock file twice
+/// on one thread still self-deadlocks — bounded now, but still wrong. Callers
+/// that can nest need re-entry tracking as well; see [`with_config_lock`].
+#[cfg(unix)]
+pub fn lock_exclusive_bounded(file: &File, lock_path: &Path, context: &str) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let timeout = config_lock_timeout();
+    let started = Instant::now();
+    let mut backoff = Duration::from_millis(1);
+
+    loop {
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            return Ok(());
+        }
+
+        let error = std::io::Error::last_os_error();
+        match error.raw_os_error() {
+            Some(libc::EINTR) => continue,
+            Some(libc::EWOULDBLOCK) => {}
+            _ => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(context.to_string()),
+                ))
+            }
+        }
+
+        if let Some(timeout) = timeout {
+            let waited = started.elapsed();
+            if waited >= timeout {
+                return Err(Error::internal_io(
+                    format!(
+                        "timed out after {}s waiting for the exclusive lock at {}; another \
+                         thread or process has held it far longer than this operation should \
+                         take. Set {} to change or disable the bound.",
+                        waited.as_secs(),
+                        lock_path.display(),
+                        CONFIG_LOCK_TIMEOUT_ENV
+                    ),
+                    Some(context.to_string()),
+                ));
+            }
+        }
+
+        std::thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_millis(50));
+    }
+}
+
+#[cfg(not(unix))]
+pub fn lock_exclusive_bounded(_file: &File, _lock_path: &Path, _context: &str) -> Result<()> {
+    Ok(())
+}
+
 struct ConfigLockGuard {
     #[allow(dead_code)]
     file: File,
 }
 
 impl ConfigLockGuard {
-    /// Acquire the lock under a deadline.
-    ///
-    /// `LOCK_EX` alone blocks in the kernel indefinitely, so any holder that
-    /// wedges takes every other waiter with it — one stuck thread silently
-    /// consumes an entire CI phase and reports nothing. Polling `LOCK_EX |
-    /// LOCK_NB` against a deadline converts that into a single attributable
-    /// error naming the lock file.
-    #[cfg(unix)]
     fn lock(file: File, lock_path: &Path) -> Result<Self> {
-        use std::os::fd::AsRawFd;
-
-        let timeout = config_lock_timeout();
-        let started = Instant::now();
-        let mut backoff = Duration::from_millis(1);
-
-        loop {
-            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-            if result == 0 {
-                return Ok(Self { file });
-            }
-
-            let error = std::io::Error::last_os_error();
-            match error.raw_os_error() {
-                Some(libc::EINTR) => continue,
-                Some(libc::EWOULDBLOCK) => {}
-                _ => {
-                    return Err(Error::internal_io(
-                        error.to_string(),
-                        Some("lock config".to_string()),
-                    ))
-                }
-            }
-
-            if let Some(timeout) = timeout {
-                let waited = started.elapsed();
-                if waited >= timeout {
-                    return Err(Error::internal_io(
-                        format!(
-                            "timed out after {}s waiting for the Homeboy config lock at {}; \
-                             another thread or process has held it far longer than any config \
-                             operation should take. Set {} to change or disable the bound.",
-                            waited.as_secs(),
-                            lock_path.display(),
-                            CONFIG_LOCK_TIMEOUT_ENV
-                        ),
-                        Some("lock config".to_string()),
-                    ));
-                }
-            }
-
-            std::thread::sleep(backoff);
-            backoff = (backoff * 2).min(Duration::from_millis(50));
-        }
-    }
-
-    #[cfg(not(unix))]
-    fn lock(file: File, _lock_path: &Path) -> Result<Self> {
+        lock_exclusive_bounded(&file, lock_path, "lock config")?;
         Ok(Self { file })
     }
 }
@@ -1183,8 +1197,13 @@ mod tests {
         });
     }
 
+    /// Unix-only: the bound is implemented with `flock(2)`, and on other
+    /// platforms `lock_exclusive_bounded` is a no-op that cannot time out.
+    #[cfg(unix)]
     #[test]
     fn a_held_config_lock_times_out_with_an_attributable_error() {
+        use std::os::fd::AsRawFd;
+
         crate::test_support::with_isolated_home(|_home| {
             // A second open file description on the same file is exactly what a
             // competing process looks like to flock(2), so this exercises the
@@ -1198,15 +1217,11 @@ mod tests {
                 .open(&lock_path)
                 .expect("holder handle");
 
-            #[cfg(unix)]
-            {
-                use std::os::fd::AsRawFd;
-                assert_eq!(
-                    unsafe { libc::flock(holder.as_raw_fd(), libc::LOCK_EX) },
-                    0,
-                    "holder acquires the lock"
-                );
-            }
+            assert_eq!(
+                unsafe { libc::flock(holder.as_raw_fd(), libc::LOCK_EX) },
+                0,
+                "holder acquires the lock"
+            );
 
             let error = bounded("bounded config lock acquire", || {
                 std::env::set_var(CONFIG_LOCK_TIMEOUT_ENV, "1");
@@ -1221,7 +1236,7 @@ mod tests {
             assert!(
                 error.details["error"]
                     .as_str()
-                    .is_some_and(|message| message.contains("waiting for the Homeboy config lock")),
+                    .is_some_and(|message| message.contains("waiting for the exclusive lock")),
                 "timeout must name the lock: {:?}",
                 error.details
             );

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -11,7 +11,6 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::cell::Cell;
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
 
 mod json_io;
 mod json_ops;
@@ -41,6 +40,7 @@ pub const CONFIG_LOCK_STRICT_ENV: &str = "HOMEBOY_CONFIG_LOCK_STRICT";
 /// guards small JSON writes and, at worst, a runtime-package refresh), while
 /// staying far below the CI test-phase budget so a wedged holder surfaces as a
 /// named failure rather than consuming the whole phase.
+#[cfg(unix)]
 const DEFAULT_CONFIG_LOCK_TIMEOUT_SECS: u64 = 600;
 
 thread_local! {
@@ -81,13 +81,14 @@ impl Drop for ConfigLockDepthGuard {
     }
 }
 
-fn config_lock_timeout() -> Option<Duration> {
+#[cfg(unix)]
+fn config_lock_timeout() -> Option<std::time::Duration> {
     let seconds = std::env::var(CONFIG_LOCK_TIMEOUT_ENV)
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_CONFIG_LOCK_TIMEOUT_SECS);
 
-    (seconds > 0).then(|| Duration::from_secs(seconds))
+    (seconds > 0).then(|| std::time::Duration::from_secs(seconds))
 }
 
 fn config_lock_strict() -> bool {
@@ -164,6 +165,7 @@ pub fn with_config_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
 #[cfg(unix)]
 pub fn lock_exclusive_bounded(file: &File, lock_path: &Path, context: &str) -> Result<()> {
     use std::os::fd::AsRawFd;
+    use std::time::{Duration, Instant};
 
     let timeout = config_lock_timeout();
     let started = Instant::now();
@@ -1057,6 +1059,7 @@ fn find_similar_ids_in<T: ConfigEntity>(target: &str, entities: &[T]) -> Vec<Str
 mod tests {
     use super::*;
     use serde::Deserialize;
+    use std::time::Duration;
 
     #[derive(Deserialize, Serialize)]
     struct TestEntity {

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -8,8 +8,10 @@ use crate::output::{
 use crate::paths;
 use crate::Result;
 use serde::{de::DeserializeOwned, Serialize};
+use std::cell::Cell;
 use std::fs::{self, File, OpenOptions};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 mod json_io;
 mod json_ops;
@@ -25,7 +27,99 @@ pub use json_ops::{merge_config, remove_config};
 pub use json_pointer::value_type_name;
 pub use json_pointer::{remove_json_pointer, set_json_pointer};
 
+/// Bound on how long a thread will wait for the config lock before failing with
+/// an attributable error. `0` restores the historical unbounded wait.
+pub const CONFIG_LOCK_TIMEOUT_ENV: &str = "HOMEBOY_CONFIG_LOCK_TIMEOUT_SECS";
+
+/// When set to a truthy value, a nested acquisition returns an error naming the
+/// re-entry instead of transparently joining the enclosing critical section.
+/// Off by default: nesting is safe, but this lets us drive it to zero
+/// deliberately rather than discovering it as a production hang.
+pub const CONFIG_LOCK_STRICT_ENV: &str = "HOMEBOY_CONFIG_LOCK_STRICT";
+
+/// Generous enough that no legitimate config operation can reach it (the lock
+/// guards small JSON writes and, at worst, a runtime-package refresh), while
+/// staying far below the CI test-phase budget so a wedged holder surfaces as a
+/// named failure rather than consuming the whole phase.
+const DEFAULT_CONFIG_LOCK_TIMEOUT_SECS: u64 = 600;
+
+thread_local! {
+    /// Depth of nested `with_config_lock` sections on the current thread.
+    ///
+    /// `flock(2)` locks are owned by the *open file description*, not by the
+    /// process or the thread: "If a process uses open(2) ... to obtain more
+    /// than one file descriptor for the same file, these file descriptors are
+    /// treated independently by flock(). An attempt to lock the file using one
+    /// of these file descriptors may be denied by a lock that the calling
+    /// process has already placed via another file descriptor."
+    ///
+    /// Every `with_config_lock` call opens the lock file afresh, so a nested
+    /// acquisition on one thread asks for a lock that same thread already
+    /// holds through a different description, and `LOCK_EX` blocks in the
+    /// kernel forever. Tracking depth per thread makes the enclosing section
+    /// visible so re-entry can pass through instead of self-deadlocking.
+    static CONFIG_LOCK_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Nesting depth of config-lock sections held by the current thread.
+pub fn config_lock_depth() -> u32 {
+    CONFIG_LOCK_DEPTH.with(Cell::get)
+}
+
+struct ConfigLockDepthGuard;
+
+impl ConfigLockDepthGuard {
+    fn enter() -> Self {
+        CONFIG_LOCK_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+impl Drop for ConfigLockDepthGuard {
+    fn drop(&mut self) {
+        CONFIG_LOCK_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
+fn config_lock_timeout() -> Option<Duration> {
+    let seconds = std::env::var(CONFIG_LOCK_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CONFIG_LOCK_TIMEOUT_SECS);
+
+    (seconds > 0).then(|| Duration::from_secs(seconds))
+}
+
+fn config_lock_strict() -> bool {
+    std::env::var(CONFIG_LOCK_STRICT_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes"))
+}
+
+/// Run `operation` while holding the exclusive Homeboy config lock.
+///
+/// Exclusion is preserved across processes and across threads. Re-entry on a
+/// thread that already holds the lock is a pass-through: the enclosing critical
+/// section already provides exactly the exclusion the inner one is asking for,
+/// so joining it is a no-op on lock semantics, whereas acquiring again is an
+/// unrecoverable self-deadlock (see `CONFIG_LOCK_DEPTH`).
 pub fn with_config_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    if config_lock_depth() > 0 {
+        if config_lock_strict() {
+            return Err(Error::internal_io(
+                format!(
+                    "config lock re-entered at depth {} on a thread that already holds it; \
+                     the enclosing critical section should own this write, or the inner \
+                     acquisition should be hoisted out of it",
+                    config_lock_depth() + 1
+                ),
+                Some("lock config".to_string()),
+            ));
+        }
+        let _depth = ConfigLockDepthGuard::enter();
+        return operation();
+    }
+
     let lock_path = paths::homeboy()?.join("config.lock");
     if let Some(parent) = lock_path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
@@ -45,7 +139,8 @@ pub fn with_config_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
             Error::internal_io(error.to_string(), Some("open config lock".to_string()))
         })?;
 
-    let _guard = ConfigLockGuard::lock(lock_file)?;
+    let _guard = ConfigLockGuard::lock(lock_file, &lock_path)?;
+    let _depth = ConfigLockDepthGuard::enter();
     operation()
 }
 
@@ -55,23 +150,63 @@ struct ConfigLockGuard {
 }
 
 impl ConfigLockGuard {
+    /// Acquire the lock under a deadline.
+    ///
+    /// `LOCK_EX` alone blocks in the kernel indefinitely, so any holder that
+    /// wedges takes every other waiter with it — one stuck thread silently
+    /// consumes an entire CI phase and reports nothing. Polling `LOCK_EX |
+    /// LOCK_NB` against a deadline converts that into a single attributable
+    /// error naming the lock file.
     #[cfg(unix)]
-    fn lock(file: File) -> Result<Self> {
+    fn lock(file: File, lock_path: &Path) -> Result<Self> {
         use std::os::fd::AsRawFd;
 
-        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-        if result != 0 {
-            return Err(Error::internal_io(
-                std::io::Error::last_os_error().to_string(),
-                Some("lock config".to_string()),
-            ));
-        }
+        let timeout = config_lock_timeout();
+        let started = Instant::now();
+        let mut backoff = Duration::from_millis(1);
 
-        Ok(Self { file })
+        loop {
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if result == 0 {
+                return Ok(Self { file });
+            }
+
+            let error = std::io::Error::last_os_error();
+            match error.raw_os_error() {
+                Some(libc::EINTR) => continue,
+                Some(libc::EWOULDBLOCK) => {}
+                _ => {
+                    return Err(Error::internal_io(
+                        error.to_string(),
+                        Some("lock config".to_string()),
+                    ))
+                }
+            }
+
+            if let Some(timeout) = timeout {
+                let waited = started.elapsed();
+                if waited >= timeout {
+                    return Err(Error::internal_io(
+                        format!(
+                            "timed out after {}s waiting for the Homeboy config lock at {}; \
+                             another thread or process has held it far longer than any config \
+                             operation should take. Set {} to change or disable the bound.",
+                            waited.as_secs(),
+                            lock_path.display(),
+                            CONFIG_LOCK_TIMEOUT_ENV
+                        ),
+                        Some("lock config".to_string()),
+                    ));
+                }
+            }
+
+            std::thread::sleep(backoff);
+            backoff = (backoff * 2).min(Duration::from_millis(50));
+        }
     }
 
     #[cfg(not(unix))]
-    fn lock(file: File) -> Result<Self> {
+    fn lock(file: File, _lock_path: &Path) -> Result<Self> {
         Ok(Self { file })
     }
 }

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -1098,6 +1098,137 @@ mod tests {
             vec!["beta-project (alias: staging)".to_string()]
         );
     }
+
+    /// Run `body` on a worker thread and fail, rather than hang, if it does not
+    /// finish in time.
+    ///
+    /// A regression in config-lock reentrancy blocks in the kernel forever. If
+    /// these tests called the nesting directly, that regression would wedge the
+    /// whole lib-test binary and libtest would report no failure at all — the
+    /// exact 45-minute silent CI timeout this module exists to prevent. Bounding
+    /// the wait converts it into a named assertion failure.
+    fn bounded<T: Send + 'static>(
+        label: &str,
+        body: impl FnOnce() -> T + Send + 'static,
+    ) -> std::thread::Result<T> {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = sender.send(std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)));
+        });
+        receiver
+            .recv_timeout(Duration::from_secs(90))
+            .unwrap_or_else(|_| {
+                panic!("{label} did not finish within 90s; the config lock deadlocked")
+            })
+    }
+
+    #[test]
+    fn nested_config_lock_on_one_thread_does_not_deadlock() {
+        crate::test_support::with_isolated_home(|_home| {
+            let value = bounded("nested config lock", || {
+                with_config_lock(|| with_config_lock(|| Ok(7u32)))
+            })
+            .expect("nested config lock panicked")
+            .expect("nested config lock returned an error");
+
+            assert_eq!(value, 7);
+        });
+    }
+
+    #[test]
+    fn nested_config_lock_reports_depth_and_restores_it() {
+        crate::test_support::with_isolated_home(|_home| {
+            // Depth is thread-local, so the probe has to observe it from the
+            // same thread that holds the lock.
+            let depths = bounded("config lock depth", || {
+                let before = config_lock_depth();
+                let (outer, inner, after_inner) = with_config_lock(|| {
+                    let outer = config_lock_depth();
+                    let inner = with_config_lock(|| Ok(config_lock_depth()))?;
+                    Ok((outer, inner, config_lock_depth()))
+                })?;
+                Ok::<_, Error>((before, outer, inner, after_inner, config_lock_depth()))
+            })
+            .expect("depth probe panicked")
+            .expect("depth probe returned an error");
+
+            assert_eq!(
+                depths,
+                (0, 1, 2, 1, 0),
+                "re-entry must nest and unwind, not re-acquire"
+            );
+        });
+    }
+
+    #[test]
+    fn strict_mode_names_the_reentrancy_instead_of_joining_it() {
+        crate::test_support::with_isolated_home(|_home| {
+            let error = bounded("strict nested config lock", || {
+                std::env::set_var(CONFIG_LOCK_STRICT_ENV, "1");
+                let result = with_config_lock(|| with_config_lock(|| Ok(())));
+                std::env::remove_var(CONFIG_LOCK_STRICT_ENV);
+                result
+            })
+            .expect("strict probe panicked")
+            .expect_err("strict mode must reject re-entry");
+
+            assert_eq!(error.code, crate::error::ErrorCode::InternalIoError);
+            assert!(
+                error.details["error"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("re-entered at depth 2")),
+                "strict re-entry must name the depth: {:?}",
+                error.details
+            );
+        });
+    }
+
+    #[test]
+    fn a_held_config_lock_times_out_with_an_attributable_error() {
+        crate::test_support::with_isolated_home(|_home| {
+            // A second open file description on the same file is exactly what a
+            // competing process looks like to flock(2), so this exercises the
+            // real contended path rather than a simulated one.
+            let lock_path = paths::homeboy().expect("config root").join("config.lock");
+            std::fs::create_dir_all(lock_path.parent().expect("lock parent")).expect("config dir");
+            let holder = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .expect("holder handle");
+
+            #[cfg(unix)]
+            {
+                use std::os::fd::AsRawFd;
+                assert_eq!(
+                    unsafe { libc::flock(holder.as_raw_fd(), libc::LOCK_EX) },
+                    0,
+                    "holder acquires the lock"
+                );
+            }
+
+            let error = bounded("bounded config lock acquire", || {
+                std::env::set_var(CONFIG_LOCK_TIMEOUT_ENV, "1");
+                let result = with_config_lock(|| Ok(()));
+                std::env::remove_var(CONFIG_LOCK_TIMEOUT_ENV);
+                result
+            })
+            .expect("bounded acquire panicked")
+            .expect_err("a held lock must time out rather than block forever");
+
+            assert_eq!(error.code, crate::error::ErrorCode::InternalIoError);
+            assert!(
+                error.details["error"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("waiting for the Homeboy config lock")),
+                "timeout must name the lock: {:?}",
+                error.details
+            );
+
+            drop(holder);
+        });
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Refs #10751. Supersedes the site-by-site approach of #10754.

## Root cause

`flock(2)` locks are owned by the **open file description**, not the process or thread — and `with_config_lock` opens the lock file on *every* call. So a nested acquisition on a single thread requests a lock that same thread already holds through a different description, and blocks in the kernel **forever**.

That is the deadlock class behind #10751. #10754 removed one nesting site and the stall simply reappeared at another — which is what you'd predict if the bug is the lock's own semantics rather than any particular call site.

## Symptom this explains

`unittests src/lib.rs (homeboy_agents-…)` declares 1198/1199 tests, **never emits `test result:`**, and exits 124 after the full 2700s budget — in *both* differential phases, so it burns 2× the budget. 13 of 14 recent CI runs failed this way.

## Fix

- **Track config-lock depth per thread**, so re-entry joins the enclosing critical section instead of self-deadlocking.
- **Acquire under a deadline**, so a genuinely wedged holder surfaces as an attributable error rather than silently consuming an entire CI test phase.

The second half matters independently of the first: it converts the *next* instance of this class from a 45-minute silent burn into a named failure. That's the same principle as #10685 — a gate must not report nothing and let it read as success.

- `lock_exclusive_bounded` extracted as the single supported file-lock acquire
- timeout helpers scoped to unix so Windows Compile stays warning-clean
- tests pin reentrancy, bounding, and the terminal-Lab write path

## Honesty

A green CI run does **not** by itself prove this is fixed — the hang is nondeterministic (`05e27a4c` completed clean 75 minutes after `5a97d37e` burned both phases on the same code). The argument here is structural, not empirical.

Recovered from an interrupted cook; commits carry the reasoning.