### PR TITLE
fix: restore workspace test compilation broken by #10779

### DIFF
--- a/crates/homeboy-core/src/component/mutations.rs
+++ b/crates/homeboy-core/src/component/mutations.rs
@@ -342,6 +342,7 @@ mod tests {
                     id: "studio-web".to_string(),
                     local_path: old_repo.to_string_lossy().to_string(),
                     remote_path: Some("wp-content/plugins/studio-web".to_string()),
+                    deployment_provider: None,
                 }],
                 ..Default::default()
             };

--- a/crates/homeboy-core/src/fleet/check.rs
+++ b/crates/homeboy-core/src/fleet/check.rs
@@ -195,6 +195,7 @@ mod tests {
                 id: "tooling-component".to_string(),
                 local_path: component_dir.to_string_lossy().to_string(),
                 remote_path: None,
+                deployment_provider: None,
             });
             project::save(&project).expect("project config");
 

--- a/crates/homeboy-core/src/harvest.rs
+++ b/crates/homeboy-core/src/harvest.rs
@@ -513,6 +513,7 @@ mod tests {
                     id: "component".to_string(),
                     local_path: local.display().to_string(),
                     remote_path: Some("managed/component".to_string()),
+                    deployment_provider: None,
                 }],
                 extensions: Some(HashMap::from([(
                     "managed-host".to_string(),

--- a/crates/homeboy-core/src/project/component/attachments.rs
+++ b/crates/homeboy-core/src/project/component/attachments.rs
@@ -290,6 +290,7 @@ mod tests {
                 id: id.to_string(),
                 local_path: format!("/workspace/{}", id),
                 remote_path: None,
+                deployment_provider: None,
             });
         }
         project

--- a/crates/homeboy-core/src/project/component/report.rs
+++ b/crates/homeboy-core/src/project/component/report.rs
@@ -132,6 +132,7 @@ mod tests {
                 id: "plugin".to_string(),
                 local_path: "/repo/plugin".to_string(),
                 remote_path: None,
+                deployment_provider: None,
             }],
             ..Default::default()
         };
@@ -162,11 +163,13 @@ mod tests {
                         id: "remove-me".to_string(),
                         local_path: "/tmp/homeboy-remove-me-missing".to_string(),
                         remote_path: None,
+                        deployment_provider: None,
                     },
                     ProjectComponentAttachment {
                         id: "stale-remaining".to_string(),
                         local_path: "/tmp/homeboy-stale-remaining-missing".to_string(),
                         remote_path: None,
+                        deployment_provider: None,
                     },
                 ],
                 ..Default::default()

--- a/crates/homeboy-core/src/project/component/resolution.rs
+++ b/crates/homeboy-core/src/project/component/resolution.rs
@@ -242,6 +242,7 @@ mod tests {
                 id: "fixture".to_string(),
                 local_path,
                 remote_path: remote_path.map(str::to_string),
+                deployment_provider: None,
             }],
             ..Default::default()
         }

--- a/crates/homeboy-core/src/project/readiness.rs
+++ b/crates/homeboy-core/src/project/readiness.rs
@@ -236,6 +236,7 @@ mod tests {
                 id: "plugin".to_string(),
                 local_path,
                 remote_path: Some("wp-content/plugins/plugin".to_string()),
+                deployment_provider: None,
             }],
             ..Project::default()
         }
@@ -268,6 +269,7 @@ mod tests {
                     id: id.to_string(),
                     local_path,
                     remote_path: Some(format!("wp-content/plugins/{id}")),
+                    deployment_provider: None,
                 })
                 .collect(),
             ..Project::default()

--- a/crates/homeboy-core/src/project/report.rs
+++ b/crates/homeboy-core/src/project/report.rs
@@ -360,6 +360,7 @@ mod tests {
                     id: "plugin".to_string(),
                     local_path: "/tmp/homeboy-missing-component-path".to_string(),
                     remote_path: Some("wp-content/plugins/plugin".to_string()),
+                    deployment_provider: None,
                 }],
                 ..Project::default()
             })


### PR DESCRIPTION
`main` currently fails `cargo check --workspace --tests`. Every open PR has a red **Workspace Tests Compile** gate, and the release pipeline cannot produce a clean test verdict.

## Cause

#10779 (`feat(deploy): lower extension deployment providers`, `6d8317b0f`) added a field to `ProjectComponentAttachment`:

```rust
#[serde(skip_serializing_if = "Option::is_none")]
pub deployment_provider: Option<crate::component::DeploymentProviderAttachment>,
```

Eleven test initializers across eight files in `homeboy-core` were not updated, so they fail with:

```
error[E0063]: missing field `deployment_provider` in initializer of
              `project::types::component::ProjectComponentAttachment`
```

## Fix

The field is `Option`, so each site takes `deployment_provider: None`. All eleven are inside `mod tests`; no production initializer was missing it.

```
crates/homeboy-core/src/component/mutations.rs            1
crates/homeboy-core/src/fleet/check.rs                    1
crates/homeboy-core/src/harvest.rs                        1
crates/homeboy-core/src/project/component/attachments.rs  1
crates/homeboy-core/src/project/component/report.rs       3
crates/homeboy-core/src/project/component/resolution.rs   1
crates/homeboy-core/src/project/readiness.rs              2
crates/homeboy-core/src/project/report.rs                 1
```

## Why this reached main

A root-level `cargo check --lib --tests` — the most natural local check — does **not** compile workspace member crates' test targets, so this break is invisible from it. `cargo check --workspace --tests` catches it immediately.

That is the same blind spot #10477 describes for the review test gate, and it is worth noting that the gate which *did* catch this (Workspace Tests Compile) is a compile-only gate. The member-crate tests still never execute.

I hit this while verifying #10794 and initially mistook it for my own regression.

## Verification

`cargo fmt`, then `cargo check --workspace --tests` → **exit 0**, no errors.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
