### PR TITLE
Bind recovered artifacts to source authority

### DIFF
--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -693,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn prepared_artifact_accepts_authoritative_bare_directory_recovery() {
+    fn prepared_artifact_accepts_source_authority_manifest_recovery() {
         let temp = tempfile::tempdir().expect("temp dir");
         let root = temp.path();
         run_git(root, &["init", "-q", "-b", "main"]);
@@ -708,6 +708,24 @@ mod tests {
         std::fs::create_dir(&artifact_dir).expect("artifact dir");
         let artifact_path = artifact_dir.join("fixture.zip");
         std::fs::write(&artifact_path, b"canonical release bytes").expect("artifact");
+        let commit = run_git(root, &["rev-parse", "HEAD"]);
+        std::fs::write(
+            artifact_dir.join("manifest.json"),
+            serde_json::json!({
+                "schema": crate::release::executor::artifacts::ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA,
+                "schema_version": crate::release::executor::artifacts::ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION,
+                "component_id": "fixture",
+                "tag": "v1.2.3",
+                "version": "1.2.3",
+                "commit": commit,
+                "artifacts": [{
+                    "path": artifact_path,
+                    "sha256": homeboy_engine_primitives::content_hash::sha256_file(&artifact_path).expect("artifact hash")
+                }]
+            })
+            .to_string(),
+        )
+        .expect("source-authority manifest");
 
         let mut state = ReleaseState::default();
         crate::release::executor::artifacts::run_artifact_inventory(
@@ -717,7 +735,7 @@ mod tests {
                 component_id: "fixture",
                 tag: "v1.2.3",
                 version: "1.2.3",
-                commit: &run_git(root, &["rev-parse", "HEAD"]),
+                commit: &commit,
             },
         )
         .expect("recovery inventory");

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -1162,6 +1162,23 @@ mod tests {
             r#"{"artifacts":[{"path":"homeboy-x86_64-unknown-linux-gnu.tar.xz"},{"path":"homeboy-x86_64-unknown-linux-gnu.tar.xz.sha256"}]}"#,
         )
         .expect("write manifest");
+        let artifact_manifest = serde_json::json!({
+            "schema": super::artifacts::ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA,
+            "schema_version": super::artifacts::ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION,
+            "component_id": "homeboy",
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "commit": "commit-for-v1.2.3",
+            "artifacts": [
+                { "path": archive, "sha256": homeboy_engine_primitives::content_hash::sha256_file(&archive).expect("archive hash") },
+                { "path": checksum, "sha256": homeboy_engine_primitives::content_hash::sha256_file(&checksum).expect("checksum hash") }
+            ]
+        });
+        std::fs::write(
+            artifact_dir.path().join("manifest.json"),
+            artifact_manifest.to_string(),
+        )
+        .expect("write source-authority manifest");
 
         let mut state = ReleaseState {
             tag: Some("v1.2.3".to_string()),
@@ -1174,7 +1191,7 @@ mod tests {
                 component_id: "homeboy",
                 tag: "v1.2.3",
                 version: "1.2.3",
-                commit: "unused-for-external-artifacts",
+                commit: "commit-for-v1.2.3",
             },
         )
         .expect("inventory external artifacts");

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -9,6 +9,9 @@ use crate::release::types::DraftAdoptionIntent;
 const PACKAGE_RECOVERY_MANIFEST: &str = "manifest.json";
 pub(crate) const PACKAGE_RECOVERY_MANIFEST_SCHEMA: &str = "homeboy.package-recovery";
 pub(crate) const PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub(crate) const ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA: &str =
+    "homeboy.artifact-source-authority";
+pub(crate) const ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION: u32 = 1;
 const DRAFT_ADOPTION_MANIFEST_SCHEMA: &str = "homeboy.draft-adoption";
 const DRAFT_ADOPTION_MANIFEST_SCHEMA_VERSION: u32 = 1;
 
@@ -115,9 +118,9 @@ pub(crate) struct PackageRecoveryContext<'a> {
     pub(crate) commit: &'a str,
 }
 
-/// Inventory artifacts that were already built by an external release build.
-/// This lets `homeboy release --head --from-artifacts <dir>` reuse the normal
-/// github.release and publish steps without re-running release.package.
+/// Inventory artifact bytes whose source identity is explicitly declared by
+/// their producer. This prevents a bare directory from being relabeled as the
+/// currently checked-out release after its tag or HEAD has advanced.
 pub(crate) fn run_artifact_inventory(
     state: &mut ReleaseState,
     artifact_dir: &str,
@@ -158,10 +161,21 @@ pub(crate) fn run_artifact_inventory(
     }
     let mut artifacts = if manifest_path.is_file() && is_package_recovery_manifest(&manifest_path) {
         inventory_package_recovery_manifest(dir, &manifest_path, recovery_context)?
+    } else if manifest_path.is_file() && is_artifact_source_authority_manifest(&manifest_path) {
+        inventory_artifact_source_authority_manifest(dir, &manifest_path, recovery_context)?
     } else {
-        inventory_directory_files(dir, artifact_dir)?
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Artifact directory '{}' has no source-authority manifest. External CI artifacts must include manifest.json with schema '{}', the active component/tag/version/commit, and a sha256 for every artifact.",
+                artifact_dir, ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA
+            ),
+            Some(artifact_dir.to_string()),
+            None,
+        ));
     };
 
+    collapse_ordinal_durable_duplicates(&mut artifacts)?;
     artifacts.sort_by(|a, b| a.path.cmp(&b.path));
     if artifacts.is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -321,6 +335,17 @@ fn is_draft_adoption_manifest(manifest_path: &std::path::Path) -> bool {
         == Some(DRAFT_ADOPTION_MANIFEST_SCHEMA)
 }
 
+fn is_artifact_source_authority_manifest(manifest_path: &std::path::Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(manifest_path) else {
+        return false;
+    };
+    let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+    manifest.get("schema").and_then(serde_json::Value::as_str)
+        == Some(ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA)
+}
+
 fn inventory_draft_adoption_manifest(
     manifest_path: &std::path::Path,
     context: &PackageRecoveryContext,
@@ -435,56 +460,6 @@ fn valid_asset_name(name: &str) -> bool {
             == Some(name)
         && name != "."
         && name != ".."
-}
-
-fn inventory_directory_files(
-    dir: &std::path::Path,
-    artifact_dir: &str,
-) -> Result<Vec<ReleaseArtifact>> {
-    let mut artifacts = Vec::new();
-    for entry in std::fs::read_dir(dir).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to read artifact directory '{}': {}",
-                artifact_dir, e
-            ),
-            Some(artifact_dir.to_string()),
-        )
-    })? {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(
-                format!("Failed to read artifact directory entry: {}", e),
-                Some(artifact_dir.to_string()),
-            )
-        })?;
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        let canonical = std::fs::canonicalize(&path).map_err(|e| {
-            Error::internal_io(
-                format!(
-                    "Failed to resolve artifact path '{}': {}",
-                    path.display(),
-                    e
-                ),
-                Some(path.display().to_string()),
-            )
-        })?;
-        let canonical = canonical.display().to_string();
-        artifacts.push(ReleaseArtifact {
-            path: canonical.clone(),
-            durable_path: Some(canonical),
-            artifact_type: None,
-            platform: None,
-            phase: "recovery".to_string(),
-            producer: "from-artifacts".to_string(),
-            sha256: None,
-            publication_authority: false,
-        });
-    }
-    collapse_ordinal_durable_duplicates(&mut artifacts)?;
-    Ok(artifacts)
 }
 
 /// Package persistence stores numbered durable copies. A recovery directory can
@@ -664,6 +639,95 @@ fn inventory_package_recovery_manifest(
         .collect()
 }
 
+fn inventory_artifact_source_authority_manifest(
+    artifact_dir: &std::path::Path,
+    manifest_path: &std::path::Path,
+    recovery_context: &PackageRecoveryContext,
+) -> Result<Vec<ReleaseArtifact>> {
+    let mut manifest: PackageRecoveryManifest = read_recovery_manifest(manifest_path)?;
+    if manifest.schema != ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA
+        || manifest.schema_version != ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION
+    {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Artifact source-authority manifest '{}' has an unsupported schema or schema version",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
+    if [
+        manifest.component_id.as_str(),
+        manifest.tag.as_str(),
+        manifest.version.as_str(),
+        manifest.commit.as_str(),
+    ]
+    .iter()
+    .any(|value| value.trim().is_empty())
+    {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Artifact source-authority manifest '{}' has incomplete release identity",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
+    validate_recovery_identity(&manifest, manifest_path, recovery_context)?;
+    if manifest.artifacts.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Artifact source-authority manifest '{}' contains no release assets",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+            None,
+        ));
+    }
+    let artifact_dir = std::fs::canonicalize(artifact_dir).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to resolve artifact directory '{}': {error}",
+                artifact_dir.display()
+            ),
+            Some(artifact_dir.display().to_string()),
+        )
+    })?;
+    manifest
+        .artifacts
+        .drain(..)
+        .map(|artifact| validate_recovery_artifact(&artifact_dir, artifact))
+        .collect()
+}
+
+fn read_recovery_manifest(manifest_path: &std::path::Path) -> Result<PackageRecoveryManifest> {
+    let manifest = std::fs::read_to_string(manifest_path).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to read release artifact manifest '{}': {error}",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+        )
+    })?;
+    serde_json::from_str(&manifest).map_err(|error| {
+        Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Release artifact manifest '{}' is invalid: {error}",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+            None,
+        )
+    })
+}
+
 fn validate_recovery_identity(
     manifest: &PackageRecoveryManifest,
     manifest_path: &std::path::Path,
@@ -703,16 +767,21 @@ fn validate_recovery_artifact(
     artifact_dir: &std::path::Path,
     mut artifact: ReleaseArtifact,
 ) -> Result<ReleaseArtifact> {
-    let path = std::path::Path::new(&artifact.path);
-    let canonical = std::fs::canonicalize(path).map_err(|error| {
+    let declared_path = std::path::Path::new(&artifact.path);
+    let path = if declared_path.is_absolute() {
+        declared_path.to_path_buf()
+    } else {
+        artifact_dir.join(declared_path)
+    };
+    let canonical = std::fs::canonicalize(&path).map_err(|error| {
         Error::validation_invalid_argument(
             "from-artifacts",
             format!(
                 "Recovered release asset '{}' is missing: {}",
-                path.display(),
+                declared_path.display(),
                 error
             ),
-            Some(path.display().to_string()),
+            Some(declared_path.display().to_string()),
             None,
         )
     })?;
@@ -728,8 +797,38 @@ fn validate_recovery_artifact(
             None,
         ));
     }
+    let expected_sha256 = artifact
+        .sha256
+        .as_deref()
+        .filter(|hash| hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "from-artifacts",
+                format!(
+                    "Recovered release asset '{}' is missing a valid sha256",
+                    declared_path.display()
+                ),
+                Some(declared_path.display().to_string()),
+                None,
+            )
+        })?;
+    let actual_sha256 = sha256_file(&canonical.display().to_string())?;
+    if !expected_sha256.eq_ignore_ascii_case(&actual_sha256) {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!(
+                "Recovered release asset '{}' sha256 '{}' does not match declared sha256 '{}'",
+                canonical.display(),
+                actual_sha256,
+                expected_sha256
+            ),
+            Some(canonical.display().to_string()),
+            None,
+        ));
+    }
     artifact.path = canonical.display().to_string();
     artifact.durable_path = Some(artifact.path.clone());
+    artifact.sha256 = Some(actual_sha256);
     Ok(artifact)
 }
 
@@ -738,8 +837,9 @@ mod tests {
     use super::{
         classify_recovery_lineage, establish_publication_authority, run_artifact_inventory,
         PackageRecoveryContext, RecoveryLineage, ReleaseStepResult, Result,
-        PACKAGE_RECOVERY_MANIFEST, PACKAGE_RECOVERY_MANIFEST_SCHEMA,
-        PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
+        ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA,
+        ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION, PACKAGE_RECOVERY_MANIFEST,
+        PACKAGE_RECOVERY_MANIFEST_SCHEMA, PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
     };
     use crate::release::executor::github_release::github_release_publications;
     use crate::release::types::ReleaseArtifact;
@@ -752,6 +852,11 @@ mod tests {
         let artifact_path = temp.path().join("homeboy.tar.gz");
         std::fs::write(&artifact_path, "artifact").expect("write artifact");
         std::fs::create_dir(temp.path().join("nested")).expect("nested dir");
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            source_authority_manifest(&artifact_path).to_string(),
+        )
+        .expect("source authority manifest");
 
         let mut state = ReleaseState::default();
         let result = run_artifact_inventory(
@@ -801,12 +906,14 @@ mod tests {
                     {
                         "path": npm,
                         "durable_path": npm,
-                        "artifact_type": "npm"
+                        "artifact_type": "npm",
+                        "sha256": sha256(&npm)
                     },
                     {
                         "path": wordpress,
                         "durable_path": wordpress,
-                        "artifact_type": "archive"
+                        "artifact_type": "archive",
+                        "sha256": sha256(&wordpress)
                     }
                 ]
             })
@@ -842,6 +949,11 @@ mod tests {
         let ordinal = temp.path().join("01-plugin.zip");
         std::fs::write(&canonical, b"plugin bytes").expect("canonical artifact");
         std::fs::write(&ordinal, b"plugin bytes").expect("ordinal artifact");
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            source_authority_manifest_for(&[&canonical, &ordinal]).to_string(),
+        )
+        .expect("source authority manifest");
 
         let mut state = ReleaseState::default();
         run_artifact_inventory(
@@ -868,10 +980,15 @@ mod tests {
     #[test]
     fn recovery_inventory_rejects_ordinal_copy_with_mismatched_canonical_bytes() {
         let temp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(temp.path().join("plugin.zip"), b"canonical bytes")
-            .expect("canonical artifact");
-        std::fs::write(temp.path().join("01-plugin.zip"), b"ordinal---bytes")
-            .expect("ordinal artifact");
+        let canonical = temp.path().join("plugin.zip");
+        let ordinal = temp.path().join("01-plugin.zip");
+        std::fs::write(&canonical, b"canonical bytes").expect("canonical artifact");
+        std::fs::write(&ordinal, b"ordinal---bytes").expect("ordinal artifact");
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            source_authority_manifest_for(&[&canonical, &ordinal]).to_string(),
+        )
+        .expect("source authority manifest");
 
         let error = run_artifact_inventory(
             &mut ReleaseState::default(),
@@ -953,26 +1070,18 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_manifest_json_remains_an_external_artifact() {
+    fn bare_or_unrecognized_artifact_directories_fail_closed() {
         let temp = tempfile::tempdir().expect("tempdir");
         let manifest = temp.path().join(PACKAGE_RECOVERY_MANIFEST);
         std::fs::write(&manifest, r#"{"component_id":"unrelated"}"#).expect("manifest");
 
-        let mut state = ReleaseState::default();
-        run_artifact_inventory(
-            &mut state,
+        let error = run_artifact_inventory(
+            &mut ReleaseState::default(),
             &temp.path().to_string_lossy(),
             &recovery_context(),
         )
-        .expect("ordinary external manifest inventory");
-        assert_eq!(state.artifacts.len(), 1);
-        assert_eq!(
-            state.artifacts[0].path,
-            std::fs::canonicalize(manifest)
-                .unwrap()
-                .display()
-                .to_string()
-        );
+        .expect_err("unrecognized artifact manifest must not inherit active identity");
+        assert!(error.message.contains("source-authority manifest"));
     }
 
     fn recovery_context() -> PackageRecoveryContext<'static> {
@@ -992,8 +1101,81 @@ mod tests {
             "tag": "v1.2.3",
             "version": "1.2.3",
             "commit": "abc123",
-            "artifacts": [{ "path": artifact }]
+            "artifacts": [{ "path": artifact, "sha256": sha256(artifact) }]
         })
+    }
+
+    fn source_authority_manifest(artifact: &std::path::Path) -> serde_json::Value {
+        source_authority_manifest_for(&[artifact])
+    }
+
+    fn source_authority_manifest_for(artifacts: &[&std::path::Path]) -> serde_json::Value {
+        serde_json::json!({
+            "schema": ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA,
+            "schema_version": ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION,
+            "component_id": "plugin",
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "commit": "abc123",
+            "artifacts": artifacts.iter().map(|artifact| serde_json::json!({
+                "path": artifact
+                    .file_name()
+                    .expect("artifact file name")
+                    .to_string_lossy(),
+                "sha256": sha256(artifact)
+            })).collect::<Vec<_>>()
+        })
+    }
+
+    fn sha256(path: &std::path::Path) -> String {
+        super::sha256_file(&path.display().to_string()).expect("sha256")
+    }
+
+    #[test]
+    fn source_authority_manifest_rejects_old_bytes_after_the_release_commit_advances() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("homeboy.tar.gz");
+        std::fs::write(&artifact, "bytes built at commit A").expect("artifact");
+        let mut manifest = source_authority_manifest(&artifact);
+        manifest["commit"] = serde_json::json!("commit-a");
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            manifest.to_string(),
+        )
+        .expect("manifest");
+
+        let context = PackageRecoveryContext {
+            commit: "commit-b",
+            ..recovery_context()
+        };
+        let error = run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &context,
+        )
+        .expect_err("commit A artifacts must not finalize for commit B");
+        assert!(error.message.contains("commit-a") && error.message.contains("commit-b"));
+    }
+
+    #[test]
+    fn source_authority_manifest_rejects_tampered_bytes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("plugin.zip");
+        std::fs::write(&artifact, "declared bytes").expect("artifact");
+        std::fs::write(
+            temp.path().join(PACKAGE_RECOVERY_MANIFEST),
+            source_authority_manifest(&artifact).to_string(),
+        )
+        .expect("manifest");
+        std::fs::write(&artifact, "replacement bytes").expect("tamper artifact");
+
+        let error = run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &recovery_context(),
+        )
+        .expect_err("tampered artifact must not be published");
+        assert!(error.message.contains("does not match declared sha256"));
     }
 
     #[test]

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -23,7 +23,7 @@ By default Homeboy auto-detects the bump from commit history. Use `--bump <major
 - `--package-only`: Regenerate release assets for an existing tag at the checked-out commit; use with `--head --tag <TAG> --apply`
 - `--tag <TAG>`: Existing release tag to use with `--package-only`
 - `--head`: Finish the release pipeline for the version commit and tag already checked out at HEAD
-- `--from-artifacts <DIR>`: With `--head`, attach/publish existing artifacts from a directory instead of running `release.package`
+- `--from-artifacts <DIR>`: With `--head`, attach/publish existing artifacts from a source-authority manifest in this directory instead of running `release.package`
 - `--skip-checks`: Skip pre-release lint/test checks
 - `--bump <BUMP>`: Force `major`, `minor`, `patch`, or an explicit version like `2.0.0`
 - `--force-lower-bump`: Allow a forced bump lower than the commit-derived recommendation
@@ -39,7 +39,21 @@ By default Homeboy auto-detects the bump from commit history. Use `--bump <major
 
 GitHub Release asset uploads use a 30-minute timeout by default. Set `HOMEBOY_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS` to a positive number of seconds when a slower connection or larger release assets need a longer budget. When `--head` finds an existing draft release, Homeboy resumes it, verifies attached asset metadata, and publishes it only after every requested asset is present.
 
-`--head --package-only --tag <TAG> --apply` is for operator recovery when the release tag already exists but its release assets need to be regenerated. It requires the checked-out `HEAD` to match the existing tag, runs the component build and extension-owned `release.package` actions, copies every release asset into Homeboy's artifact root under `release-packages/<component>/<tag>/`, writes `manifest.json`, and prints both paths. The manifest is a versioned `homeboy.package-recovery` inventory bound to its component, tag, version, and commit; finalization rejects it unless all four match the active tagged HEAD. Other `--from-artifacts` directories remain ordinary file inventories. This recovery does not create tags, push history, create GitHub Releases, publish registries, deploy, or clean up the component build output.
+`--head --package-only --tag <TAG> --apply` is for operator recovery when the release tag already exists but its release assets need to be regenerated. It requires the checked-out `HEAD` to match the existing tag, runs the component build and extension-owned `release.package` actions, copies every release asset into Homeboy's artifact root under `release-packages/<component>/<tag>/`, writes `manifest.json`, and prints both paths. The manifest is a versioned `homeboy.package-recovery` inventory bound to its component, tag, version, and commit; finalization rejects it unless all four match the active tagged HEAD and every declared SHA-256 matches the durable bytes. This recovery does not create tags, push history, create GitHub Releases, publish registries, deploy, or clean up the component build output.
+
+External CI artifacts must also provide `manifest.json`; bare directories are rejected. Use schema `homeboy.artifact-source-authority`, schema version `1`, the active `component_id`, `tag`, `version`, and `commit`, plus an `artifacts` array. Each artifact must name a file inside the directory and include its exact `sha256`. For example:
+
+```json
+{
+  "schema": "homeboy.artifact-source-authority",
+  "schema_version": 1,
+  "component_id": "example-plugin",
+  "tag": "v1.2.3",
+  "version": "1.2.3",
+  "commit": "<tagged HEAD SHA>",
+  "artifacts": [{ "path": "example-plugin.zip", "sha256": "<64-char SHA-256>" }]
+}
+```
 
 Risky real release modes require explicit `--apply`: `--deploy`, `--recover`, `--retag`, `--head`, and bare `--skip-checks`. Dry-run previews never require `--apply`, and granular skips such as `--skip-checks=lint` keep the normal release flow because other quality gates remain active.
 

--- a/docs/reference/cli/commands/release.md
+++ b/docs/reference/cli/commands/release.md
@@ -35,7 +35,7 @@ Plan release workflows
 | `--recover` | flag | Recover from an interrupted release (tag + push current version) |
 | `--retag` | flag | With --recover: if the release tag exists but points at a commit behind HEAD (e.g. config-only commits landed after tagging), move the tag to HEAD instead of refusing. Guarded — the tagged commit must be an ancestor of HEAD, HEAD must satisfy the version targets, and no GitHub Release may exist for the tag |
 | `--head` | flag | Finish the release pipeline for an already-versioned, already-tagged HEAD. Skips changelog/version/git mutation steps and runs package, GitHub Release, publish, cleanup, and post-release hooks against the tag pointing at HEAD |
-| `--from-artifacts` | `<DIR>` | Use existing release artifacts from this directory instead of running release.package. Requires --head |
+| `--from-artifacts` | `<DIR>` | Use existing source-authority-manifested release artifacts from this directory instead of running release.package. Requires --head |
 | `--package-only` | flag | Regenerate only the release package for an existing tag at HEAD. Combine with --head --tag <tag> --apply to write a durable artifact inventory for later --head --from-artifacts finalization |
 | `--tag` | `<TAG>` | Existing release tag to package with --package-only |
 | `--skip-checks` | `<CHECK>` | Skip pre-release quality checks |
@@ -127,4 +127,3 @@ Show current version (default: discovered component, fallback: homeboy binary)
 | Option | Value | Description |
 | --- | --- | --- |
 | `--path` | `<PATH>` | Override local_path for version file lookup |
-

--- a/docs/workflows/release-a-component.md
+++ b/docs/workflows/release-a-component.md
@@ -72,6 +72,8 @@ Finish an already-tagged release from artifacts:
 homeboy release <component-id> --head --from-artifacts ./artifacts --skip-checks --apply
 ```
 
+For artifacts produced outside Homeboy, write `./artifacts/manifest.json` before finalization. It must use `homeboy.artifact-source-authority` schema version `1` and declare the active component, tag, version, commit, and SHA-256 for every artifact. Bare directories are intentionally rejected so bytes built for an older commit cannot be finalized under a newer tag.
+
 Use these intentionally. They are recovery/operator paths, not the default release flow.
 
 ## Code Factory Context


### PR DESCRIPTION
## Summary
- reject bare `--from-artifacts` directories that would otherwise inherit the active release commit by omission
- add a generic `homeboy.artifact-source-authority` manifest for external CI artifacts, binding component, tag, version, commit, paths, and SHA-256 digests
- verify manifest identity, containment, exact bytes, and durable deployment paths before publication
- preserve manifest-backed package recovery, draft adoption, and canonical/numbered duplicate collapse from #10776
- document the external artifact manifest contract and remediation

Closes #10766

## Root Cause
The `v0.322.1` binary was built at `120f0944`, then finalized from a bare artifact directory after the tag/HEAD advanced to `f901edbf`. Bare recovery supplied no source identity, so inventory silently assigned the active commit to older bytes. The published binary consequently lacked #10761 despite the newer tag.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p homeboy-release --lib release::executor::artifacts::tests` (20 passed)
- `cargo test -p homeboy-release --lib release::deployment::tests::prepared_artifact_accepts_source_authority_manifest_recovery`
- `cargo test -p homeboy-release --lib release::deployment::tests::release_recover_resumes_only_failed_project_with_published_source_projection -- --test-threads=1` passed before rebasing #10779; on current main that unrelated fixture now fails because both fake project components have a missing `local_path`

## AI Assistance
OpenCode with OpenAI gpt-5.6-terra drafted the source-authority implementation and tests through Homeboy Cook. OpenAI gpt-5.6-sol via OpenCode corrected the root-cause scope, reviewed the candidate, integrated concurrent #10776 behavior, fixed relative-path semantics, and ran final verification. Chris Huber remains responsible for the submitted change.