### PR TITLE
fix(cleanup): repair reclaimable root fixture

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -3074,6 +3074,26 @@ mod tests {
             .current_dir(repository.path())
             .output()
             .expect("initialize repository");
+        std::fs::write(repository.path().join(".gitignore"), "target/\n")
+            .expect("target ignore rule");
+        Command::new("git")
+            .args(["add", ".gitignore"])
+            .current_dir(repository.path())
+            .output()
+            .expect("stage ignore rule");
+        Command::new("git")
+            .args([
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ])
+            .current_dir(repository.path())
+            .output()
+            .expect("commit ignore rule");
         std::fs::create_dir_all(repository.path().join("target/debug")).expect("target directory");
         std::fs::write(repository.path().join("target/debug/app"), "artifact")
             .expect("target artifact");


### PR DESCRIPTION
## Summary
- make the valid repo fixture declare and commit `target/` as ignored, reconstructable build output
- retain per-root diagnostics proving an invalid configured root does not abort the valid root
- preserve independent untracked-work protection coverage

Closes #10782

## Verification
- `cargo fmt --all -- --check`
- `env -u TMPDIR cargo test -p homeboy-cli commands::cleanup::tests -- --test-threads=1` (28 passed)
- `env -u TMPDIR cargo test --test cleanup_next_actions -- --test-threads=1` (3 passed)
- `cargo check -p homeboy-cli`
- `git diff --check`

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode general coding subagent reproduced the failing fixture, traced the cleanup safety contract, and drafted the test-fixture repair. Chris Huber remains responsible for the change.