### PR TITLE
fix(daemon): revalidate supervised stale stops

### DIFF
--- a/crates/homeboy-core/src/daemon/stop.rs
+++ b/crates/homeboy-core/src/daemon/stop.rs
@@ -163,26 +163,12 @@ fn terminate_exact_supervised_daemon(
     let supervisor_signal = match supervisor {
         Some(pid) if wait_for_pid_exit(pid, TERM_GRACE) => "exited after child",
         Some(pid) => {
-            if !pid_has_ownership_token(pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)? {
-                return Err(Error::validation_invalid_argument(
-                    "daemon_lease",
-                    format!("supervisor pid {pid} no longer owns the daemon startup token"),
-                    Some(pid.to_string()),
-                    None,
-                ));
-            }
+            revalidate_exact_supervisor_termination_target(path, identity, state, pid)?;
             signal_pid(pid, SIGNAL_TERMINATE)?;
             if wait_for_pid_exit(pid, TERM_GRACE) {
                 "SIGTERM"
             } else {
-                if !pid_has_ownership_token(pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)? {
-                    return Err(Error::validation_invalid_argument(
-                        "daemon_lease",
-                        format!("supervisor pid {pid} changed identity before SIGKILL"),
-                        Some(pid.to_string()),
-                        None,
-                    ));
-                }
+                revalidate_exact_supervisor_termination_target(path, identity, state, pid)?;
                 signal_pid(pid, SIGNAL_KILL)?;
                 if !wait_for_pid_exit(pid, KILL_GRACE) {
                     return Err(Error::internal_unexpected(format!(
@@ -222,6 +208,40 @@ fn revalidate_exact_termination_target(
                 state.pid
             ),
             Some(state.pid.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// The child is already absent when this runs, so the supervisor's token is the
+/// remaining exact process proof. The lease and job gates still have to be
+/// rechecked before each supervisor signal because they can change while the
+/// child is being terminated.
+fn revalidate_exact_supervisor_termination_target(
+    path: &std::path::Path,
+    identity: &DaemonLeaseIdentity,
+    state: &DaemonState,
+    supervisor_pid: u32,
+) -> Result<()> {
+    let current = read_lease_if_identity_matches(path, identity)?;
+    if current.pid != state.pid || !active_daemon_job_ids()?.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "daemon_stop",
+            "daemon lease or active durable jobs changed before supervisor termination; refusing to signal",
+            Some(state.lease_id.clone()),
+            None,
+        ));
+    }
+    if !pid_has_ownership_token(
+        supervisor_pid,
+        DAEMON_STARTUP_TOKEN_ENV,
+        &state.startup_token,
+    )? {
+        return Err(Error::validation_invalid_argument(
+            "daemon_lease",
+            format!("supervisor pid {supervisor_pid} no longer owns the daemon startup token"),
+            Some(supervisor_pid.to_string()),
             None,
         ));
     }

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -29,10 +29,11 @@ multi-user service.
 
 When a recorded daemon is stale or unreachable but its PID is still live, an
 operator can use a lease-bound local force stop. It never uses the daemon HTTP
-endpoint, sends SIGTERM only after the persisted lease matches exactly, waits
-for process death, and refuses while durable jobs are active. Forced process
-termination currently requires Linux `/proc` evidence that the target owns the
-persisted daemon startup token:
+endpoint, revalidates the exact persisted lease and zero-job state before every
+signal, and refuses while durable jobs are active. It uses Linux `/proc` token
+evidence on Linux and the explicit startup-token command argument on other Unix
+controllers, with bounded SIGTERM-to-SIGKILL escalation for the exact supervised
+daemon pair:
 
 ```sh
 homeboy daemon stop --force --lease-id <exact-live-lease>

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2156,6 +2156,59 @@ fn force_stop_escalates_when_a_token_owned_daemon_ignores_sigterm() {
     assert!(!pid_is_running(pid));
 }
 
+#[cfg(unix)]
+#[test]
+fn lease_bound_stop_converges_term_resistant_mixed_version_supervisor_and_daemon() {
+    let _home = HomeGuard::new();
+    let startup_token = "mixed-version-supervised-daemon";
+    let marker = tempfile::NamedTempFile::new().expect("child PID marker");
+    let marker_path = marker.path().to_string_lossy().into_owned();
+    let supervisor = Command::new("sh")
+        .args([
+            "-c",
+            ": daemon supervise; trap '' TERM; sh -c 'trap \"\" TERM; while :; do sleep 1; done' homeboy daemon serve --startup-token \"$2\" & echo $! > \"$3\"; child=$!; while kill -0 \"$child\" 2>/dev/null; do sleep 1; done; while :; do sleep 1; done",
+            "homeboy",
+            "--startup-token",
+            startup_token,
+            marker_path.as_str(),
+        ])
+        .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
+        .spawn()
+        .expect("start TERM-resistant mixed-version supervisor");
+    let supervisor_pid = supervisor.id();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let daemon_pid = loop {
+        if let Ok(pid) = std::fs::read_to_string(&marker_path)
+            .map(|pid| pid.trim().parse::<u32>().expect("child PID"))
+        {
+            break pid;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "supervisor did not start daemon child"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    let mut state = daemon_state_for_test(daemon_pid, "127.0.0.1:1");
+    state.build_identity.version = "0.321.1".to_string();
+    state.build_identity.display = "homeboy 0.321.1+92323a8adef6".to_string();
+    state.binary_sha256 = Some("recorded-homeboy-0.321.1".to_string());
+    state.startup_token = startup_token.to_string();
+    write_daemon_state_for_test(&state);
+
+    let started = Instant::now();
+    let result = stop_for_lease(&state.lease_id).expect("managed lease stop converges pair");
+
+    assert!(result.stopped);
+    assert!(started.elapsed() < Duration::from_secs(10));
+    let evidence = result.termination_evidence.expect("termination evidence");
+    assert!(evidence.os_evidence.contains("daemon pid"));
+    assert!(evidence.os_evidence.contains("supervisor SIGKILL"));
+    assert!(!pid_is_running(daemon_pid));
+    assert!(!pid_is_running(supervisor_pid));
+    assert!(!state_path().expect("state path").exists());
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn lease_bound_stop_recovers_only_the_exact_daemon_after_binary_rebuild() {


### PR DESCRIPTION
## Summary
- revalidate the exact lease, zero-job gate, and startup token immediately before each managed supervisor TERM/KILL signal
- cover a TERM-resistant, tokenized supervisor/child pair with a persisted 0.321.1-shaped stale identity
- document portable Unix ownership evidence and bounded managed escalation

Closes #10780.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p homeboy-core`
- `cargo check -p homeboy-core --target aarch64-apple-darwin --quiet`

## Baseline Failure
- `cargo test -p homeboy-core lease_bound_stop_converges_term_resistant_mixed_version_supervisor_and_daemon --lib` cannot compile the existing core test target because 11 unrelated `ProjectComponentAttachment` initializers omit required `deployment_provider`. No errors were reported from this PR's fixture.

## AI Assistance
- Model: OpenAI `gpt-5.6-sol`
- Tool: OpenCode general coding subagent
- Used for: issue-history review, implementation, deterministic regression coverage, and verification.
- Chris Huber remains responsible for every line.