### PR TITLE
feat(runtime): scope invocation temp to managed owners

### DIFF
--- a/crates/homeboy-core/src/engine/invocation.rs
+++ b/crates/homeboy-core/src/engine/invocation.rs
@@ -67,11 +67,12 @@ pub struct InvocationGuard {
     env: InvocationEnv,
     lease_id: Option<String>,
     named_leases: Vec<String>,
-    /// Sibling invocation directories (state, artifact, tmp) under
-    /// [`invocation_runtime_root`]. All three are removed on `Drop` so
-    /// concurrent invocations do not accumulate stale state on disk.
-    /// Decoupled from any caller-provided `RunDir` cleanup.
-    cleanup_paths: [PathBuf; 3],
+    /// State and artifact directories remain short-lived siblings beneath the
+    /// socket-safe invocation root. Workload temp is instead a managed runtime
+    /// entry so cleanup can resolve its durable owner after this guard exits.
+    cleanup_paths: [PathBuf; 2],
+    runtime_tmp_dir: PathBuf,
+    runtime_tmp_pin: Option<super::temp::RuntimeTempPin>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,13 +118,11 @@ impl InvocationGuard {
 
     /// Acquire an isolated invocation environment.
     ///
-    /// `run_dir` is retained for API compatibility and pipeline context,
-    /// but the invocation's state/artifact/tmp directories are placed under
-    /// a short, platform-aware root (see [`invocation_runtime_root`]) rather
-    /// than nested beneath the run dir. This keeps `HOMEBOY_INVOCATION_*`
-    /// paths within the platform `sockaddr_un` budget so downstream
-    /// workloads can place UNIX sockets under them without bespoke
-    /// path-length defense.
+    /// State and artifact directories live under a short, platform-aware root
+    /// (see [`invocation_runtime_root`]) so downstream workloads can place
+    /// UNIX sockets under them without bespoke path-length defense. The
+    /// temporary directory instead lives under managed runtime temp, is bound
+    /// to this invocation lease, and is exported as `TMPDIR` for child tools.
     pub fn acquire(run_dir: &RunDir, requirements: &InvocationRequirements) -> Result<Self> {
         let _ = run_dir; // retained for API compatibility (see doc comment)
         cleanup_stale_child_records()?;
@@ -136,27 +135,24 @@ impl InvocationGuard {
         let id = format!("inv-{}", short);
         let runtime_root = invocation_runtime_root()?;
         // STATE_DIR is the leaf the workload owns: the invocation root
-        // itself. ARTIFACT_DIR and TMP_DIR are siblings with `.a` / `.t`
-        // suffixes so they cannot collide with workload-created subdirs
-        // under STATE_DIR. Removing the `s/a/t` subdir layer used in the
-        // initial PR #2312 reclaims 2 bytes of `sockaddr_un` budget per
+        // itself. ARTIFACT_DIR is its `.a` sibling so it cannot collide with
+        // workload-created subdirs under STATE_DIR. Removing the `s/a` subdir
+        // layer reclaims 2 bytes of `sockaddr_un` budget per
         // invocation and — more importantly — gives downstream workloads
         // exclusive ownership of the leaf they bind sockets under, so
         // no extra workload-id segment is needed under STATE_DIR.
         let state_dir = runtime_root.join(&short);
         let artifact_dir = runtime_root.join(format!("{short}.a"));
-        let tmp_dir = runtime_root.join(format!("{short}.t"));
-
         // Enforce the sockaddr_un budget before creating anything on disk
         // so callers fail fast with a clear error instead of much later in
         // a downstream workload's UDS bind. STATE_DIR is the leaf
         // workloads will append socket names to, so its budget is the one
-        // that matters most; check all three for completeness.
-        for dir in [&state_dir, &artifact_dir, &tmp_dir] {
+        // that matters most; check both socket-capable directories.
+        for dir in [&state_dir, &artifact_dir] {
             enforce_path_budget(dir)?;
         }
 
-        for dir in [&state_dir, &artifact_dir, &tmp_dir] {
+        for dir in [&state_dir, &artifact_dir] {
             fs::create_dir_all(dir)
                 .map_err(|e| errors::invocation_dir_create_error(dir, &runtime_root, e))?;
         }
@@ -198,19 +194,41 @@ impl InvocationGuard {
             return Err(error);
         }
 
-        let cleanup_paths = [state_dir.clone(), artifact_dir.clone(), tmp_dir.clone()];
+        let (runtime_tmp_dir, runtime_tmp_pin) =
+            match super::temp::managed_run_temp_dir_for_producer(
+                "homeboy-invocation-tmp",
+                Some("invocation"),
+            ) {
+                Ok(temp) => temp,
+                Err(error) => {
+                    let _ = fs::remove_file(lease_path(&id)?);
+                    let _ = fs::remove_dir_all(&state_dir);
+                    let _ = fs::remove_dir_all(&artifact_dir);
+                    return Err(error);
+                }
+            };
+        if let Err(error) = super::temp::bind_run_dir_owner(&runtime_tmp_dir, None, Some(&id)) {
+            let _ = fs::remove_dir_all(&runtime_tmp_dir);
+            let _ = fs::remove_file(lease_path(&id)?);
+            let _ = fs::remove_dir_all(&state_dir);
+            let _ = fs::remove_dir_all(&artifact_dir);
+            return Err(error);
+        }
+        let cleanup_paths = [state_dir.clone(), artifact_dir.clone()];
         Ok(Self {
             env: InvocationEnv {
                 id: id.clone(),
                 state_dir,
                 artifact_dir,
-                tmp_dir,
+                tmp_dir: runtime_tmp_dir.clone(),
                 port_base,
                 port_max,
             },
             lease_id: Some(id),
             named_leases: requirements.named_leases.clone(),
             cleanup_paths,
+            runtime_tmp_dir,
+            runtime_tmp_pin: Some(runtime_tmp_pin),
         })
     }
 
@@ -228,6 +246,13 @@ impl InvocationGuard {
             ),
             (
                 "HOMEBOY_INVOCATION_TMP_DIR".to_string(),
+                self.env.tmp_dir.to_string_lossy().to_string(),
+            ),
+            // Toolchains conventionally honor TMPDIR, unlike the Homeboy
+            // invocation-specific name. Exporting both makes their temporary
+            // bytes land under the same durable owner record.
+            (
+                "TMPDIR".to_string(),
                 self.env.tmp_dir.to_string_lossy().to_string(),
             ),
             (
@@ -315,6 +340,11 @@ impl Drop for InvocationGuard {
         for path in &self.cleanup_paths {
             let _ = fs::remove_dir_all(path);
         }
+        // The temp tree is intentionally retained as terminal managed storage.
+        // A killed parent leaves its active metadata/pin behind; a normal
+        // teardown releases the pin and records a reclaimable terminal state.
+        super::temp::mark_run_dir_succeeded(&self.runtime_tmp_dir);
+        self.runtime_tmp_pin.take();
 
         let Some(id) = &self.lease_id else {
             return;

--- a/crates/homeboy-core/src/engine/invocation/runtime.rs
+++ b/crates/homeboy-core/src/engine/invocation/runtime.rs
@@ -22,16 +22,19 @@
 //!    not a real macOS configuration.
 //! 5. `~/.cache/homeboy/inv` fallback on every platform.
 //!
-//! Each invocation owns one short id; the directories are siblings of that
-//! id under the chosen root:
+//! Each invocation owns one short id; its socket-capable directories are
+//! siblings under the chosen root:
 //!
 //! - `<root>/<short-id>`     → `HOMEBOY_INVOCATION_STATE_DIR` (the leaf the
 //!   workload owns; downstream sockets bind directly here).
 //! - `<root>/<short-id>.a`   → `HOMEBOY_INVOCATION_ARTIFACT_DIR`
-//! - `<root>/<short-id>.t`   → `HOMEBOY_INVOCATION_TMP_DIR`
+//! - `<runtime-tmp>/homeboy-invocation-tmp-*` → `HOMEBOY_INVOCATION_TMP_DIR`
+//!   and `TMPDIR`. This is a metadata-backed durable runtime-temp owner rather
+//!   than a sibling here, so cleanup can classify child-created bytes after the
+//!   invocation exits.
 //!
-//! There is no `s/a/t` subdir layer — that would burn `sockaddr_un` budget
-//! for no isolation gain since the invocation is already 1:1 with a single
+//! There is no `s/a` subdir layer — that would burn `sockaddr_un` budget for
+//! no isolation gain since the invocation is already 1:1 with a single
 //! workload run. Workloads that need internal subdirs under STATE_DIR can
 //! still create them, but they own the path-length budget at that point.
 //!

--- a/crates/homeboy-core/src/engine/temp.rs
+++ b/crates/homeboy-core/src/engine/temp.rs
@@ -1,8 +1,8 @@
 mod implementation;
 
 pub(crate) use implementation::{
-    bind_run_dir_owner, managed_run_temp_dir, mark_run_dir_succeeded, pin_runtime_temp_dir,
-    retain_failed_run_dir, RuntimeTempPin,
+    bind_run_dir_owner, managed_run_temp_dir, managed_run_temp_dir_for_producer,
+    mark_run_dir_succeeded, pin_runtime_temp_dir, retain_failed_run_dir, RuntimeTempPin,
 };
 pub use implementation::{
     cleanup_runtime_tmp, cleanup_runtime_tmp_bounded, runtime_temp_dir, unique_name,

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -48,6 +48,10 @@ struct RuntimeRunOwner {
     completed_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
+    /// The generic Homeboy subsystem that created this managed storage.
+    /// Absent values are legacy entries and retain their existing treatment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    producer: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -180,6 +184,18 @@ pub(crate) fn pin_runtime_temp_dir(dir: &Path) -> Result<RuntimeTempPin> {
 }
 
 pub(crate) fn managed_run_temp_dir(prefix: &str) -> Result<(PathBuf, RuntimeTempPin)> {
+    managed_run_temp_dir_for_producer(prefix, None)
+}
+
+/// Create a managed runtime-temp directory for a named generic producer.
+///
+/// The owner record is deliberately written at allocation time, before a
+/// workload can inherit the path. This makes child-created bytes attributable
+/// even if the producer is interrupted before it can write any result data.
+pub(crate) fn managed_run_temp_dir_for_producer(
+    prefix: &str,
+    producer: Option<&str>,
+) -> Result<(PathBuf, RuntimeTempPin)> {
     let root = ensure_runtime_tmp_dir()?;
     let _lock = acquire_cleanup_lock(&root)?;
     let path = root.join(unique_name(prefix, ""));
@@ -199,6 +215,7 @@ pub(crate) fn managed_run_temp_dir(prefix: &str) -> Result<(PathBuf, RuntimeTemp
         created_at: chrono::Utc::now().to_rfc3339(),
         completed_at: None,
         reason: None,
+        producer: producer.map(str::to_string),
     };
     if let Err(error) = write_run_owner(&path, &owner) {
         let _ = fs::remove_dir_all(&path);
@@ -708,6 +725,7 @@ pub fn cleanup_runtime_tmp_bounded(
                     created_at: chrono::DateTime::<chrono::Utc>::from(modified).to_rfc3339(),
                     completed_at: None,
                     reason: Some(error.message.clone()),
+                    producer: None,
                 };
                 let warning = format!("owner metadata is corrupt: {}", error.message);
                 if age < CORRUPT_OWNER_GRACE {

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -15,6 +15,10 @@ fn test_env_vars() {
         assert!(Path::new(&value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR")).is_dir());
         assert!(Path::new(&value_for(&env, "HOMEBOY_INVOCATION_ARTIFACT_DIR")).is_dir());
         assert!(Path::new(&value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR")).is_dir());
+        assert_eq!(
+            value_for(&env, "TMPDIR"),
+            value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR")
+        );
         assert!(value_for_optional(&env, "HOMEBOY_INVOCATION_PORT_BASE").is_none());
         assert!(value_for_optional(&env, "HOMEBOY_INVOCATION_CONTEXT_JSON").is_some());
 
@@ -289,7 +293,7 @@ fn invocation_state_dir_lives_under_runtime_root_not_run_dir() {
 }
 
 #[test]
-fn invocation_state_dir_fits_under_sockaddr_un_budget() {
+fn invocation_socket_dirs_fit_under_sockaddr_un_budget() {
     with_isolated_home(|_| {
         let run_dir = RunDir::create().expect("run dir");
         let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
@@ -299,7 +303,6 @@ fn invocation_state_dir_fits_under_sockaddr_un_budget() {
         for key in [
             "HOMEBOY_INVOCATION_STATE_DIR",
             "HOMEBOY_INVOCATION_ARTIFACT_DIR",
-            "HOMEBOY_INVOCATION_TMP_DIR",
         ] {
             let dir = value_for(&env, key);
             // budget = path bytes + 1 separator + 32-byte filename headroom
@@ -406,7 +409,7 @@ fn invocation_dir_permission_error_names_runtime_root_and_remediation() {
 }
 
 #[test]
-fn invocation_drop_cleans_up_root_directory() {
+fn invocation_drop_retains_managed_temp_directory() {
     with_isolated_home(|_| {
         let run_dir = RunDir::create().expect("run dir");
         let (state_dir, artifact_dir, tmp_dir) = {
@@ -419,13 +422,28 @@ fn invocation_drop_cleans_up_root_directory() {
                 std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR")),
             )
         };
-        for path in [&state_dir, &artifact_dir, &tmp_dir] {
+        for path in [&state_dir, &artifact_dir] {
             assert!(
                 !path.exists(),
                 "invocation dir should be removed on Drop: {}",
                 path.display()
             );
         }
+        assert!(
+            tmp_dir.is_dir(),
+            "managed temp survives for lifecycle cleanup"
+        );
+        let owner: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(tmp_dir.join(".homeboy-run-owner-v1.json")).expect("owner record"),
+        )
+        .expect("owner json");
+        assert_eq!(owner["producer"], "invocation");
+        assert_eq!(owner["state"], "succeeded");
+        assert!(owner["invocation_ids"]
+            .as_array()
+            .is_some_and(|ids| !ids.is_empty()));
+
+        std::fs::remove_dir_all(&tmp_dir).expect("remove managed temp fixture");
 
         run_dir.cleanup();
     });
@@ -517,7 +535,7 @@ fn preserve_artifacts_normalizes_existing_manifest() {
 // --- followup: STATE_DIR is the leaf the workload owns ---------------------
 
 #[test]
-fn state_dir_is_the_invocation_leaf_with_artifact_and_tmp_as_siblings() {
+fn state_dir_is_the_invocation_leaf_with_artifact_as_a_sibling() {
     with_isolated_home(|_| {
         let run_dir = RunDir::create().expect("run dir");
         let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
@@ -526,23 +544,20 @@ fn state_dir_is_the_invocation_leaf_with_artifact_and_tmp_as_siblings() {
 
         let state = std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR"));
         let artifact = std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_ARTIFACT_DIR"));
-        let tmp = std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR"));
 
         // STATE_DIR is the invocation leaf — workloads bind sockets directly
         // under it without any extra Homeboy-injected segment. ARTIFACT_DIR
-        // and TMP_DIR live alongside as siblings under the runtime root, so
-        // they cannot collide with workload-created subdirs under STATE_DIR.
+        // lives alongside it under the runtime root, so it cannot collide with
+        // workload-created subdirs under STATE_DIR. TMP_DIR is a separate
+        // metadata-backed runtime-temp entry so its bytes have a durable owner.
         assert_eq!(
             state.parent(),
             artifact.parent(),
             "siblings under same root"
         );
-        assert_eq!(state.parent(), tmp.parent(), "siblings under same root");
 
         // Distinct leaves (no two env vars pointing at the same dir).
         assert_ne!(state, artifact);
-        assert_ne!(state, tmp);
-        assert_ne!(artifact, tmp);
 
         // No `s/a/t` subdir layer — STATE_DIR's basename is the short id
         // (10 hex chars), not `s`.


### PR DESCRIPTION
## Summary
- allocate every `InvocationGuard` temp root as a metadata-backed runtime-temp entry before child work starts
- bind the temp owner to the invocation lease, mark it terminal after normal teardown, and export it through both `HOMEBOY_INVOCATION_TMP_DIR` and `TMPDIR`
- add generic producer metadata while preserving legacy owner records and unknown directories fail-closed

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core -p homeboy-extension`
- `git diff --check`
- focused invocation tests were attempted with `cargo test -p homeboy-core invocation -- --test-threads=1`, but the test build is blocked by existing unrelated `ProjectComponentAttachment` initializers missing `deployment_provider` in `component/mutations.rs`, `fleet/check.rs`, `harvest.rs`, and project component test helpers.

## Remaining Acceptance Criteria
- Extend the same generic owner allocation contract to direct Lab runner commands that do not acquire an `InvocationGuard`.
- Project direct runner workload/run identity and reconstructability into retained-storage output, including byte attribution and owning cleanup command.
- Add representative Lab compiler-target and input-materialization end-to-end coverage after the runner-side envelope owns its temp root.

Part of #10791

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode general coding subagent investigated the runtime ownership path, implemented this foundational producer-side contract, and ran the listed checks. Chris Huber reviewed and remains responsible for the change.