### PR TITLE
fix(daemon): block dead-lease replacement conflicts

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -1774,9 +1774,6 @@ fn start_or_return_live_unlocked_with_startup_token(
 /// evidence immediately and never signal a process we cannot prove we own.
 fn refuse_unleased_process_conflict() -> Result<()> {
     let state_path = crate::paths::daemon_state_file()?;
-    if state_path.exists() {
-        return Ok(());
-    }
     let candidates = daemon_process_candidates(&crate::paths::daemon_jobs_file()?)?
         .into_iter()
         .filter(|candidate| {
@@ -1786,17 +1783,35 @@ fn refuse_unleased_process_conflict() -> Result<()> {
             )
         })
         .collect::<Vec<_>>();
+    refuse_unleased_process_conflict_with_candidates(&state_path, candidates)
+}
+
+/// A stale lease does not authorize replacement when foreground process
+/// evidence is still ambiguous. Bound the returned evidence so status and
+/// recovery errors remain safe to render in control-plane callers.
+fn refuse_unleased_process_conflict_with_candidates(
+    state_path: &Path,
+    candidates: Vec<DaemonProcessCandidate>,
+) -> Result<()> {
     if candidates.is_empty() {
         return Ok(());
     }
+    const EVIDENCE_LIMIT: usize = 8;
+    let candidate_count = candidates.len();
+    let candidates = candidates
+        .into_iter()
+        .take(EVIDENCE_LIMIT)
+        .collect::<Vec<_>>();
 
     let mut error = Error::internal_unexpected(
-        "daemon lease is missing while foreground daemon candidates remain live; refusing replacement without an authoritative lease",
+        "daemon lease is absent or stale while foreground daemon candidates remain live; refusing replacement without an authoritative lease",
     );
     error.details = serde_json::json!({
         "classification": "daemon_unleased_process_conflict",
         "state_path": state_path,
         "candidates": candidates,
+        "candidate_count": candidate_count,
+        "candidates_truncated": candidate_count > EVIDENCE_LIMIT,
         "safe_next_action": "Run `homeboy daemon status` and reconcile only a daemon whose PID, binary identity, durable-store path, and startup token are all attributable to this state directory.",
     });
     Err(error.with_hint(

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -420,6 +420,86 @@ fn multiple_ambiguous_candidates_block_recovery_and_pid_reuse_blocks_adoption() 
 }
 
 #[test]
+fn dead_persisted_lease_with_ambiguous_candidates_refuses_replacement_before_spawn() {
+    let candidate = super::super::DaemonProcessCandidate {
+        pid: 71,
+        executable: "/tmp/homeboy".to_string(),
+        cmdline: "homeboy daemon serve --addr 127.0.0.1:0".to_string(),
+        bind_endpoint: Some("127.0.0.1:0".to_string()),
+        durable_store_path: None,
+        build_identity: None,
+        ownership: super::super::DaemonProcessOwnership::Ambiguous,
+    };
+    let state = tempfile::tempdir().expect("state directory");
+    let state_path = state.path().join("state.json");
+    std::fs::write(&state_path, "dead persisted lease").expect("persist dead lease");
+    let started = std::time::Instant::now();
+
+    let error = super::refuse_unleased_process_conflict_with_candidates(
+        &state_path,
+        vec![candidate.clone(), candidate],
+    )
+    .expect_err("ambiguous foreground processes block a dead-lease replacement");
+
+    assert!(started.elapsed() < Duration::from_millis(100));
+    assert_eq!(
+        error.details["classification"],
+        "daemon_unleased_process_conflict"
+    );
+    assert_eq!(error.details["candidate_count"], 2);
+    assert_eq!(
+        error.details["candidates"].as_array().map(Vec::len),
+        Some(2)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn adopt_orphan_with_dead_lease_and_ambiguous_listeners_never_spawns_replacement() {
+    with_isolated_home(|_| {
+        let mut first = Command::new("sh")
+            .args([
+                "-c",
+                "sleep 30 & wait # homeboy daemon serve --addr 127.0.0.1:0",
+            ])
+            .spawn()
+            .expect("first ambiguous daemon candidate");
+        let mut second = Command::new("sh")
+            .args([
+                "-c",
+                "sleep 30 & wait # homeboy daemon serve --addr 127.0.0.1:0",
+            ])
+            .spawn()
+            .expect("second ambiguous daemon candidate");
+        let state_path = crate::paths::daemon_state_file().expect("state path");
+        let mut state = fake_daemon_state(fake_daemon(u32::MAX, "lease-dead"));
+        state.state_path = state_path.display().to_string();
+        std::fs::create_dir_all(state_path.parent().expect("state parent")).expect("state parent");
+        std::fs::write(&state_path, serde_json::to_vec(&state).expect("state JSON"))
+            .expect("persist dead lease");
+        let original = std::fs::read(&state_path).expect("read persisted lease");
+        let started = std::time::Instant::now();
+
+        let result = super::adopt_orphaned_lease("lease-dead", &[], "127.0.0.1:0");
+        first.kill().expect("stop first candidate");
+        second.kill().expect("stop second candidate");
+        first.wait().expect("reap first candidate");
+        second.wait().expect("reap second candidate");
+        let error = result.expect_err("ambiguous listeners prevent dead-lease replacement");
+
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert_eq!(
+            error.details["classification"],
+            "daemon_unleased_process_conflict"
+        );
+        assert_eq!(
+            std::fs::read(&state_path).expect("read retained lease"),
+            original
+        );
+    });
+}
+
+#[test]
 fn concurrent_leaseless_recovery_callers_commit_once_and_preserve_job_evidence() {
     with_isolated_home(|_| {
         let path = crate::paths::daemon_jobs_file().expect("jobs path");


### PR DESCRIPTION
Closes #10783

## Summary
- Apply the existing typed unleased-process conflict guard even when a persisted daemon lease is stale, so every path through the shared replacement spawn funnel fails before launching a replacement.
- Bound `daemon_unleased_process_conflict` evidence to eight candidates while retaining the total count and truncation signal.
- Add deterministic core coverage for two ambiguous foreground candidates plus a dead persisted lease, including real `adopt-orphan` recovery with an unchanged lease as proof no replacement launcher ran.
- Leave post-spawn startup-publication diagnostics to #9865.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p homeboy-core --lib`
- `cargo test -p homeboy-lab-runner readonly_probe --lib` (5 passed)
- `cargo test -p homeboy-lab-runner indexed_discovery_has_no_reconnect_or_ssh_path --lib` (1 passed)

## Baselines
- The focused `homeboy-core` daemon test target cannot compile because 11 unrelated test-only `ProjectComponentAttachment` initializers omit the required `deployment_provider` field.
- `cargo clippy -p homeboy-core --lib -- -D warnings` is blocked before Homeboy core by existing `homeboy-lab-runner-contract` violations: `derivable_impls` in `placement.rs` and `filter_map_bool_then` in `lib.rs`.

## AI Assistance
OpenAI gpt-5.6-terra via OpenCode general coding subagent investigated lifecycle paths, implemented the daemon conflict guard, added tests, and ran verification. Chris remains responsible for every line.