### PR TITLE
perf(cli): add lightweight cleanup command contract

### DIFF
--- a/.github/workflows/command-contract-boundary.yml
+++ b/.github/workflows/command-contract-boundary.yml
@@ -1,0 +1,35 @@
+# Keeps command-surface parser and rendering tests outside execution stacks.
+#
+# The complete binary and workspace compile gates remain in ci.yml. This is the
+# focused local/CI path for contracts that only need clap and serializable data.
+
+name: Command Contract Boundary
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/contracts/homeboy-command-contract/**'
+      - 'crates/homeboy-cli/src/commands/cleanup.rs'
+      - 'crates/homeboy-cli/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/command-contract-boundary.yml'
+  workflow_dispatch:
+
+jobs:
+  command-contract-boundary:
+    name: homeboy / Command Contract Boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Verify the focused command-contract dependency budget
+        run: |
+          cargo tree --locked -p homeboy-command-contract -e normal --prefix none > command-contract.tree
+          if grep -E '^homeboy-(agents|release|rig|lab-runner|extension|core) ' command-contract.tree; then
+            echo 'homeboy-command-contract must remain outside execution stacks' >&2
+            exit 1
+          fi
+          cargo test --locked -p homeboy-command-contract cleanup::tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "fs4",
  "glob",
  "homeboy-agents",
+ "homeboy-command-contract",
  "homeboy-core",
  "homeboy-engine-primitives",
  "homeboy-extension",
@@ -841,6 +842,7 @@ dependencies = [
 name = "homeboy-command-contract"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "serde",
  "serde_json",
 ]

--- a/crates/contracts/homeboy-command-contract/Cargo.toml
+++ b/crates/contracts/homeboy-command-contract/Cargo.toml
@@ -13,5 +13,6 @@ name = "homeboy_command_contract"
 path = "src/lib.rs"
 
 [dependencies]
+clap = { version = "4.5", features = ["derive", "string"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/contracts/homeboy-command-contract/src/cleanup.rs
+++ b/crates/contracts/homeboy-command-contract/src/cleanup.rs
@@ -1,0 +1,285 @@
+//! Cleanup command parsing and canonical operator-command rendering.
+//!
+//! This is a command-surface contract, not a cleanup implementation. Keeping it
+//! here lets parser and reference tests compile without execution adapters.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand, ValueEnum};
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct CleanupArgs {
+    /// Apply cleanup across the selected categories. Omit for inventory dry-run output.
+    #[arg(long)]
+    pub apply: bool,
+
+    /// Include only these cleanup categories. Comma-separated or repeatable.
+    /// `runner-downloads` is opt-in only: it holds artifacts an operator asked
+    /// Homeboy to fetch, so a bare sweep never includes it.
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub include: Vec<CleanupCategoryArg>,
+
+    /// Exclude these cleanup categories. Comma-separated or repeatable.
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub exclude: Vec<CleanupCategoryArg>,
+
+    /// Override the configured terminal-run retention window for this invocation.
+    #[arg(long, value_name = "DAYS")]
+    pub older_than_days: Option<i64>,
+
+    /// Override the age floor for metadata-backed runtime temp entries only.
+    /// Unmanaged entries retain the configured runtime temp age floor.
+    #[arg(long, value_name = "DAYS")]
+    pub runtime_tmp_managed_older_than_days: Option<u64>,
+
+    /// Override the configured maximum number of persisted artifacts inspected.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<i64>,
+
+    /// Include every controller-scratch candidate and retained-resource detail.
+    /// Default output keeps representative detail within the shared response budget.
+    #[arg(long)]
+    pub full: bool,
+
+    /// Continue a bounded shared-store cleanup inventory from this cursor.
+    #[arg(long, value_name = "CURSOR")]
+    pub cursor: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<CleanupCommand>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CleanupCategoryArg {
+    RepoArtifacts,
+    TaskWorktrees,
+    WorktreeProviders,
+    TerminalRuns,
+    PersistedRunArtifacts,
+    OrphanedArtifactBytes,
+    RunnerDownloads,
+    RunnerBinaryCaches,
+    RemoteLabWorkspaces,
+    RuntimeTmp,
+    ControllerScratch,
+    SharedCargoTargets,
+    ControllerRuntimes,
+}
+
+#[derive(Subcommand, Debug, PartialEq, Eq)]
+pub enum CleanupCommand {
+    /// Inspect or remove declared reconstructable artifacts across repo worktrees
+    Artifacts(CleanupArtifactsArgs),
+    /// Aggregate cleanup across configured external worktree providers
+    Worktrees(CleanupWorktreesArgs),
+    /// Explain retained Homeboy storage without deleting or reconciling resources.
+    ///
+    /// Reports lifecycle aggregates alongside root filesystem accounting, top-level
+    /// stores, largest child paths, ownership classification, and cleanup guidance.
+    RetainedStorage(CleanupRetainedStorageArgs),
+    /// Run one configured, bounded retention pass
+    AutomaticRetention,
+}
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct CleanupRetainedStorageArgs {
+    /// Maximum largest-byte examples to return. The report always aggregates all inspected sources.
+    #[arg(long, default_value_t = 20)]
+    pub limit: usize,
+    /// Continue largest-byte examples after this deterministic reference token.
+    #[arg(long)]
+    pub cursor: Option<String>,
+}
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct CleanupArtifactsArgs {
+    /// Apply cleanup. Omit for dry-run output.
+    #[arg(long)]
+    pub apply: bool,
+    /// Clean artifacts from the Homeboy source checkout that built this binary.
+    #[arg(long = "self", conflicts_with = "path")]
+    pub self_artifacts: bool,
+    /// Resolve managed worktrees from this checkout instead of the current directory.
+    #[arg(long, value_name = "PATH")]
+    pub path: Option<PathBuf>,
+    /// Also scan this temp root for detached Homeboy build artifacts. Repeatable.
+    #[arg(long, value_name = "PATH")]
+    pub temp_root: Vec<PathBuf>,
+    /// Sort artifact candidates before reporting or applying cleanup.
+    #[arg(long, value_enum, default_value = "discovery")]
+    pub sort: CleanupArtifactsSortArg,
+    /// Limit artifact candidates reported or removed after sorting.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<usize>,
+    /// Only reclaim artifacts from worktrees whose branch is already merged
+    /// into its upstream. Preserves in-progress cooks' build dirs.
+    #[arg(long)]
+    pub merged_only: bool,
+    /// Only reclaim artifacts untouched for at least this many days. Composes
+    /// with any age floor a declaration owner sets; the stricter one wins.
+    #[arg(long, value_name = "DAYS")]
+    pub min_age_days: Option<u64>,
+    /// Also reclaim extension-declared artifacts from checkouts registered as
+    /// active task worktrees. Those are protected by default because removing
+    /// an install tree leaves a live checkout unusable until it is rehydrated.
+    #[arg(long)]
+    pub include_active_worktrees: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum CleanupArtifactsSortArg {
+    #[default]
+    Discovery,
+    Size,
+}
+
+#[derive(Args, Debug, PartialEq, Eq)]
+pub struct CleanupWorktreesArgs {
+    /// Cleanup a specific configured provider. Repeatable.
+    #[arg(long = "provider", value_name = "ID", conflicts_with = "all_providers")]
+    pub provider: Vec<String>,
+    /// Cleanup every enabled configured provider.
+    #[arg(long)]
+    pub all_providers: bool,
+    /// Apply cleanup. Omit for provider preview/dry-run output.
+    #[arg(long)]
+    pub apply: bool,
+}
+
+/// Naming for one cleanup category plus its specialist command.
+#[derive(Clone, Copy)]
+pub struct CleanupInventoryCategoryMetadata {
+    pub category: &'static str,
+    pub include_arg: &'static str,
+    pub dry_run_command: &'static str,
+    pub apply_command: &'static str,
+}
+
+impl CleanupInventoryCategoryMetadata {
+    pub fn specialist_command(self, apply: bool) -> &'static str {
+        if apply {
+            self.apply_command
+        } else {
+            self.dry_run_command
+        }
+    }
+
+    pub fn canonical_cleanup_command(self, apply: bool) -> String {
+        let command = format!("homeboy cleanup --include {}", self.include_arg);
+        if apply {
+            format!("{command} --apply")
+        } else {
+            command
+        }
+    }
+}
+
+pub const RUNNER_DOWNLOADS_METADATA: CleanupInventoryCategoryMetadata =
+    CleanupInventoryCategoryMetadata {
+        category: "runner_downloads",
+        include_arg: "runner-downloads",
+        dry_run_command: "homeboy runs artifact cleanup-downloads",
+        apply_command: "homeboy runs artifact cleanup-downloads --apply",
+    };
+
+/// Renders the aggregate cleanup command for the managed runtime-temp override.
+pub fn runtime_tmp_commands(apply: bool, managed_older_than_days: u64) -> (String, String) {
+    let apply_arg = if apply { " --apply" } else { "" };
+    let command = format!(
+        "homeboy cleanup --include runtime-tmp --runtime-tmp-managed-older-than-days {managed_older_than_days}{apply_arg}"
+    );
+    (command.clone(), command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[derive(Parser)]
+    struct CleanupParserTest {
+        #[command(flatten)]
+        cleanup: CleanupArgs,
+    }
+
+    #[test]
+    fn parser_accepts_cleanup_front_door_and_managed_runtime_override() {
+        let parsed = CleanupParserTest::parse_from([
+            "cleanup",
+            "--include",
+            "repo-artifacts,task-worktrees",
+            "--exclude",
+            "runtime-tmp",
+            "--apply",
+        ]);
+        assert!(parsed.cleanup.apply);
+        assert_eq!(
+            parsed.cleanup.include,
+            vec![
+                CleanupCategoryArg::RepoArtifacts,
+                CleanupCategoryArg::TaskWorktrees
+            ]
+        );
+        assert_eq!(parsed.cleanup.exclude, vec![CleanupCategoryArg::RuntimeTmp]);
+    }
+
+    #[test]
+    fn parser_accepts_cleanup_subcommands_and_managed_runtime_override() {
+        let parsed = CleanupParserTest::parse_from([
+            "cleanup",
+            "--include",
+            "runtime-tmp",
+            "--runtime-tmp-managed-older-than-days",
+            "0",
+        ]);
+        assert_eq!(parsed.cleanup.include, vec![CleanupCategoryArg::RuntimeTmp]);
+        assert_eq!(parsed.cleanup.runtime_tmp_managed_older_than_days, Some(0));
+
+        let parsed = CleanupParserTest::parse_from([
+            "cleanup",
+            "artifacts",
+            "--sort",
+            "size",
+            "--limit",
+            "7",
+            "--merged-only",
+        ]);
+        let Some(CleanupCommand::Artifacts(args)) = parsed.cleanup.command else {
+            panic!("expected cleanup artifacts command");
+        };
+        assert_eq!(args.sort, CleanupArtifactsSortArg::Size);
+        assert_eq!(args.limit, Some(7));
+        assert!(args.merged_only);
+
+        let parsed = CleanupParserTest::parse_from([
+            "cleanup",
+            "retained-storage",
+            "--limit",
+            "3",
+            "--cursor",
+            "prior-reference",
+        ]);
+        let Some(CleanupCommand::RetainedStorage(args)) = parsed.cleanup.command else {
+            panic!("expected retained storage command");
+        };
+        assert_eq!(args.limit, 3);
+        assert_eq!(args.cursor.as_deref(), Some("prior-reference"));
+    }
+
+    #[test]
+    fn cleanup_reference_surface_and_canonical_commands_are_stable() {
+        let command = CleanupParserTest::command();
+        assert!(command
+            .get_arguments()
+            .any(|arg| arg.get_long() == Some("include")));
+        assert_eq!(
+            RUNNER_DOWNLOADS_METADATA.canonical_cleanup_command(true),
+            "homeboy cleanup --include runner-downloads --apply"
+        );
+        assert_eq!(
+            runtime_tmp_commands(false, 0).0,
+            "homeboy cleanup --include runtime-tmp --runtime-tmp-managed-older-than-days 0"
+        );
+    }
+}

--- a/crates/contracts/homeboy-command-contract/src/lib.rs
+++ b/crates/contracts/homeboy-command-contract/src/lib.rs
@@ -5,6 +5,7 @@
 //! They depend only on serde, which keeps this a leaf crate other crates can
 //! depend on without pulling in core.
 
+pub mod cleanup;
 pub mod command_invocation;
 
 pub use command_invocation::{

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
+homeboy-command-contract = { version = "0.1.0", path = "../contracts/homeboy-command-contract" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -3,7 +3,6 @@ use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use clap::{Args, Subcommand, ValueEnum};
 use fs4::fs_std::FileExt;
 use homeboy::core::cleanup::{
     self, ArtifactCleanupOptions, ArtifactCleanupSort, CleanupPolicy, CleanupPolicyOverrides,
@@ -24,54 +23,17 @@ use homeboy::runner::runners::{
     self as runner, RunnerBinaryCachePruneOptions, RunnerBinaryCachePruneOutput,
     RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput,
 };
+pub use homeboy_command_contract::cleanup::{
+    runtime_tmp_commands, CleanupArgs, CleanupArtifactsArgs, CleanupArtifactsSortArg,
+    CleanupCategoryArg, CleanupCommand, CleanupInventoryCategoryMetadata,
+    CleanupRetainedStorageArgs, CleanupWorktreesArgs, RUNNER_DOWNLOADS_METADATA,
+};
 use serde::Serialize;
 use serde_json::Value;
 
 use super::runs::{runs_resources, RunsOutput, RunsResourcesArgs, RunsResourcesOutput};
 use super::utils::response::{CommandActionableMetadata, CommandNextAction};
 use super::CmdResult;
-
-#[derive(Args)]
-pub struct CleanupArgs {
-    /// Apply cleanup across the selected categories. Omit for inventory dry-run output.
-    #[arg(long)]
-    pub apply: bool,
-
-    /// Include only these cleanup categories. Comma-separated or repeatable.
-    /// `runner-downloads` is opt-in only: it holds artifacts an operator asked
-    /// Homeboy to fetch, so a bare sweep never includes it.
-    #[arg(long, value_enum, value_delimiter = ',')]
-    pub include: Vec<CleanupCategoryArg>,
-
-    /// Exclude these cleanup categories. Comma-separated or repeatable.
-    #[arg(long, value_enum, value_delimiter = ',')]
-    pub exclude: Vec<CleanupCategoryArg>,
-
-    /// Override the configured terminal-run retention window for this invocation.
-    #[arg(long, value_name = "DAYS")]
-    pub older_than_days: Option<i64>,
-
-    /// Override the age floor for metadata-backed runtime temp entries only.
-    /// Unmanaged entries retain the configured runtime temp age floor.
-    #[arg(long, value_name = "DAYS")]
-    pub runtime_tmp_managed_older_than_days: Option<u64>,
-
-    /// Override the configured maximum number of persisted artifacts inspected.
-    #[arg(long, value_name = "N")]
-    pub limit: Option<i64>,
-
-    /// Include every controller-scratch candidate and retained-resource detail.
-    /// Default output keeps representative detail within the shared response budget.
-    #[arg(long)]
-    pub full: bool,
-
-    /// Continue a bounded shared-store cleanup inventory from this cursor.
-    #[arg(long, value_name = "CURSOR")]
-    pub cursor: Option<String>,
-
-    #[command(subcommand)]
-    pub command: Option<CleanupCommand>,
-}
 
 const AUTOMATIC_RETENTION_LOCK_FILE: &str = "automatic-retention-controller.lock";
 const AUTOMATIC_RETENTION_STATE_FILE: &str = "automatic-retention-controller.json";
@@ -90,24 +52,6 @@ struct AutomaticRetentionControllerOutput {
     cleanup: Value,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-#[value(rename_all = "kebab-case")]
-pub enum CleanupCategoryArg {
-    RepoArtifacts,
-    TaskWorktrees,
-    WorktreeProviders,
-    TerminalRuns,
-    PersistedRunArtifacts,
-    OrphanedArtifactBytes,
-    RunnerDownloads,
-    RunnerBinaryCaches,
-    RemoteLabWorkspaces,
-    RuntimeTmp,
-    ControllerScratch,
-    SharedCargoTargets,
-    ControllerRuntimes,
-}
-
 const AUTOMATIC_RETENTION_CATEGORIES: [CleanupCategoryArg; 6] = [
     CleanupCategoryArg::TerminalRuns,
     CleanupCategoryArg::PersistedRunArtifacts,
@@ -116,100 +60,6 @@ const AUTOMATIC_RETENTION_CATEGORIES: [CleanupCategoryArg; 6] = [
     CleanupCategoryArg::ControllerScratch,
     CleanupCategoryArg::ControllerRuntimes,
 ];
-
-#[derive(Subcommand)]
-pub enum CleanupCommand {
-    /// Inspect or remove declared reconstructable artifacts across repo worktrees
-    Artifacts(CleanupArtifactsArgs),
-
-    /// Aggregate cleanup across configured external worktree providers
-    Worktrees(CleanupWorktreesArgs),
-
-    /// Explain retained Homeboy storage without deleting or reconciling resources.
-    ///
-    /// Reports lifecycle aggregates alongside root filesystem accounting, top-level
-    /// stores, largest child paths, ownership classification, and cleanup guidance.
-    RetainedStorage(CleanupRetainedStorageArgs),
-
-    /// Run one configured, bounded retention pass
-    AutomaticRetention,
-}
-
-#[derive(Args)]
-pub struct CleanupRetainedStorageArgs {
-    /// Maximum largest-byte examples to return. The report always aggregates all inspected sources.
-    #[arg(long, default_value_t = 20)]
-    pub limit: usize,
-
-    /// Continue largest-byte examples after this deterministic reference token.
-    #[arg(long)]
-    pub cursor: Option<String>,
-}
-
-#[derive(Args)]
-pub struct CleanupArtifactsArgs {
-    /// Apply cleanup. Omit for dry-run output.
-    #[arg(long)]
-    pub apply: bool,
-
-    /// Clean artifacts from the Homeboy source checkout that built this binary.
-    #[arg(long = "self", conflicts_with = "path")]
-    pub self_artifacts: bool,
-
-    /// Resolve managed worktrees from this checkout instead of the current directory.
-    #[arg(long, value_name = "PATH")]
-    pub path: Option<PathBuf>,
-
-    /// Also scan this temp root for detached Homeboy build artifacts. Repeatable.
-    #[arg(long, value_name = "PATH")]
-    pub temp_root: Vec<PathBuf>,
-
-    /// Sort artifact candidates before reporting or applying cleanup.
-    #[arg(long, value_enum, default_value = "discovery")]
-    pub sort: CleanupArtifactsSortArg,
-
-    /// Limit artifact candidates reported or removed after sorting.
-    #[arg(long, value_name = "N")]
-    pub limit: Option<usize>,
-
-    /// Only reclaim artifacts from worktrees whose branch is already merged
-    /// into its upstream. Preserves in-progress cooks' build dirs.
-    #[arg(long)]
-    pub merged_only: bool,
-
-    /// Only reclaim artifacts untouched for at least this many days. Composes
-    /// with any age floor a declaration owner sets; the stricter one wins.
-    #[arg(long, value_name = "DAYS")]
-    pub min_age_days: Option<u64>,
-
-    /// Also reclaim extension-declared artifacts from checkouts registered as
-    /// active task worktrees. Those are protected by default because removing
-    /// an install tree leaves a live checkout unusable until it is rehydrated.
-    #[arg(long)]
-    pub include_active_worktrees: bool,
-}
-
-#[derive(Clone, Copy, Debug, Default, ValueEnum)]
-pub enum CleanupArtifactsSortArg {
-    #[default]
-    Discovery,
-    Size,
-}
-
-#[derive(Args)]
-pub struct CleanupWorktreesArgs {
-    /// Cleanup a specific configured provider. Repeatable.
-    #[arg(long = "provider", value_name = "ID", conflicts_with = "all_providers")]
-    pub provider: Vec<String>,
-
-    /// Cleanup every enabled configured provider.
-    #[arg(long)]
-    pub all_providers: bool,
-
-    /// Apply cleanup. Omit for provider preview/dry-run output.
-    #[arg(long)]
-    pub apply: bool,
-}
 
 pub fn run(args: CleanupArgs) -> CmdResult<Value> {
     match args.command {
@@ -1080,60 +930,6 @@ pub struct CleanupInventoryCategory {
     pub output: Value,
 }
 
-/// Naming for one cleanup category plus the specialist command that reaches it
-/// with category-specific arguments.
-///
-/// The specialist names are deliberately retained. #10316 proposed deleting
-/// them and re-homing every specialist option as an `--include`-scoped flag on
-/// the aggregate, but each surviving specialist accepts a *narrowing* argument
-/// the aggregate cannot express (`--run-id`, `--kind`, `--component`,
-/// `--prefix`, `--runner`, `--passes`, `--cursor`) or is an explicit destructive
-/// escape hatch (`runtime controller-prune --ignore-retention`). Folding those
-/// into one command would put a dozen single-category flags on a surface that
-/// sweeps thirteen categories.
-///
-/// What was genuinely duplicated is the *policy*: each specialist used to carry
-/// its own `default_value_t` retention literal. Those now resolve through
-/// [`cleanup::resolve_cleanup_policy`], so a widened configuration window
-/// applies to every entry point. See `docs/commands/cleanup.md` for the full
-/// classification.
-#[derive(Clone, Copy)]
-pub(crate) struct CleanupInventoryCategoryMetadata {
-    pub(crate) category: &'static str,
-    pub(crate) include_arg: &'static str,
-    pub(crate) dry_run_command: &'static str,
-    pub(crate) apply_command: &'static str,
-}
-
-impl CleanupInventoryCategoryMetadata {
-    pub(crate) fn specialist_command(self, apply: bool) -> &'static str {
-        if apply {
-            self.apply_command
-        } else {
-            self.dry_run_command
-        }
-    }
-
-    pub(crate) fn canonical_cleanup_command(self, apply: bool) -> String {
-        let command = format!("homeboy cleanup --include {}", self.include_arg);
-        if apply {
-            format!("{command} --apply")
-        } else {
-            command
-        }
-    }
-}
-
-fn runtime_tmp_commands(apply: bool, managed_older_than_days: u64) -> (String, String) {
-    let apply_arg = if apply { " --apply" } else { "" };
-    let command = format!(
-        "homeboy cleanup --include runtime-tmp --runtime-tmp-managed-older-than-days {managed_older_than_days}{apply_arg}"
-    );
-    // The legacy specialist age flag applies to unmanaged entries too, so it
-    // cannot faithfully represent this managed-only policy.
-    (command.clone(), command)
-}
-
 const REPO_ARTIFACTS_METADATA: CleanupInventoryCategoryMetadata =
     CleanupInventoryCategoryMetadata {
         category: "repo_artifacts",
@@ -1189,14 +985,6 @@ const ORPHANED_ARTIFACT_BYTES_METADATA: CleanupInventoryCategoryMetadata =
         include_arg: "orphaned-artifact-bytes",
         dry_run_command: "homeboy cleanup --include orphaned-artifact-bytes",
         apply_command: "homeboy cleanup --include orphaned-artifact-bytes --apply",
-    };
-
-pub(crate) const RUNNER_DOWNLOADS_METADATA: CleanupInventoryCategoryMetadata =
-    CleanupInventoryCategoryMetadata {
-        category: "runner_downloads",
-        include_arg: "runner-downloads",
-        dry_run_command: "homeboy runs artifact cleanup-downloads",
-        apply_command: "homeboy runs artifact cleanup-downloads --apply",
     };
 
 const RUNTIME_TMP_METADATA: CleanupInventoryCategoryMetadata = CleanupInventoryCategoryMetadata {
@@ -2478,102 +2266,12 @@ fn format_bytes(bytes: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
     use homeboy::runner::runners::{RunnerActiveJobState, RunnerSessionState, RunnerStatusReport};
     use serde_json::json;
     use std::process::Command;
     use tempfile::TempDir;
 
-    use crate::cli_surface::{Cli, Commands};
-
     use super::*;
-
-    #[test]
-    fn cleanup_artifacts_cli_accepts_bounded_review_flags() {
-        let cli = Cli::parse_from([
-            "homeboy",
-            "cleanup",
-            "artifacts",
-            "--sort",
-            "size",
-            "--limit",
-            "7",
-            "--merged-only",
-        ]);
-
-        let Commands::Cleanup(args) = cli.command else {
-            panic!("expected cleanup command");
-        };
-        let Some(CleanupCommand::Artifacts(args)) = args.command else {
-            panic!("expected cleanup artifacts command");
-        };
-        assert!(matches!(args.sort, CleanupArtifactsSortArg::Size));
-        assert_eq!(args.limit, Some(7));
-        assert!(args.merged_only);
-    }
-
-    #[test]
-    fn cleanup_front_door_accepts_include_exclude_without_subcommand() {
-        let cli = Cli::parse_from([
-            "homeboy",
-            "cleanup",
-            "--include",
-            "repo-artifacts,task-worktrees",
-            "--exclude",
-            "runtime-tmp",
-            "--apply",
-        ]);
-
-        let Commands::Cleanup(args) = cli.command else {
-            panic!("expected cleanup command");
-        };
-        assert!(args.apply);
-        assert!(args.command.is_none());
-        assert_eq!(args.include.len(), 2);
-        assert!(args.include.contains(&CleanupCategoryArg::RepoArtifacts));
-        assert!(args.include.contains(&CleanupCategoryArg::TaskWorktrees));
-        assert_eq!(args.exclude, vec![CleanupCategoryArg::RuntimeTmp]);
-    }
-
-    #[test]
-    fn cleanup_front_door_accepts_managed_runtime_tmp_age_override() {
-        let cli = Cli::parse_from([
-            "homeboy",
-            "cleanup",
-            "--include",
-            "runtime-tmp",
-            "--runtime-tmp-managed-older-than-days",
-            "0",
-        ]);
-
-        let Commands::Cleanup(args) = cli.command else {
-            panic!("expected cleanup command");
-        };
-        assert_eq!(args.include, vec![CleanupCategoryArg::RuntimeTmp]);
-        assert_eq!(args.runtime_tmp_managed_older_than_days, Some(0));
-    }
-
-    #[test]
-    fn retained_storage_cli_accepts_a_bounded_example_limit() {
-        let cli = Cli::parse_from([
-            "homeboy",
-            "cleanup",
-            "retained-storage",
-            "--limit",
-            "3",
-            "--cursor",
-            "prior-reference",
-        ]);
-
-        let Commands::Cleanup(args) = cli.command else {
-            panic!("expected cleanup command");
-        };
-        let Some(CleanupCommand::RetainedStorage(args)) = args.command else {
-            panic!("expected retained storage command");
-        };
-        assert_eq!(args.limit, 3);
-        assert_eq!(args.cursor.as_deref(), Some("prior-reference"));
-    }
 
     #[test]
     fn retained_storage_aggregation_is_bounded_and_groups_lifecycle_dimensions() {


### PR DESCRIPTION
## Summary
- Part of #10793. Extract cleanup Clap parsing and canonical command rendering into `homeboy-command-contract`.
- Keep `homeboy-cli` as the runtime adapter and preserve the generated CLI reference contract.
- Add a path-filtered CI dependency-boundary gate that rejects agents, release, rig, Lab runner, extension, and core execution crates from the focused contract target.

## Validation
- `cargo test -p homeboy-command-contract --locked`
- `cargo test -p homeboy-cli --lib --locked cli_surface::reference_docs`
- `cargo check -p homeboy-cli --locked`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --workspace --tests --locked` remains blocked by existing `ProjectComponentAttachment` initializers missing `deployment_provider` in `homeboy-core`; this change does not touch those files.

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode general coding subagent extracted the command contract, added tests and the dependency-boundary gate, and ran validation. Chris Huber remains responsible for the change.