### PR TITLE
fix(cleanup): protect active Cargo targets

### DIFF
--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 
@@ -5,10 +7,10 @@ use homeboy::core::cleanup::{
     self as artifact_cleanup, ArtifactCleanupOptions, ArtifactCleanupOutput, ArtifactCleanupSort,
 };
 use homeboy::core::worktree::{
-    self, CleanupPolicy, WorktreeAdoptOptions, WorktreeAdoptOutput, WorktreeCleanupOptions,
-    WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput, WorktreeListOutput,
-    WorktreeQueueCreateOptions, WorktreeQueueCreateOutput, WorktreeRemoveOptions,
-    WorktreeRemoveOutput, WorktreeStatusOutput,
+    self, CleanupPolicy, TaskWorktreeRegistryQuarantine, WorktreeAdoptOptions, WorktreeAdoptOutput,
+    WorktreeCleanupOptions, WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput,
+    WorktreeListOutput, WorktreeQueueCreateOptions, WorktreeQueueCreateOutput,
+    WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeStatusOutput,
 };
 
 use crate::command_contract::{LabCommandContract, WORKTREE_CLEANUP_LAB_LABEL};
@@ -132,6 +134,25 @@ enum WorktreeCommand {
         #[arg(long, requires = "cleanup_branches")]
         allow_unmerged_branches: bool,
     },
+    /// Inspect or explicitly reconcile quarantined malformed task-worktree records
+    Quarantine {
+        #[command(subcommand)]
+        command: WorktreeQuarantineCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum WorktreeQuarantineCommand {
+    /// List quarantined records still protecting Cargo targets
+    List,
+    /// Mark one quarantined record terminally reconciled while retaining its original evidence
+    Clear {
+        /// Provenance sidecar reported by cleanup or `worktree quarantine list`
+        provenance_path: PathBuf,
+        /// Confirms terminal state was independently verified before clearing protection
+        #[arg(long)]
+        verified_terminal: bool,
+    },
 }
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -159,6 +180,8 @@ pub enum WorktreeOutput {
     Status(WorktreeStatusOutput),
     Remove(WorktreeRemoveOutput),
     Cleanup(WorktreeCleanupCommandOutput),
+    QuarantineList(Vec<TaskWorktreeRegistryQuarantine>),
+    QuarantineClear(TaskWorktreeRegistryQuarantine),
 }
 
 #[derive(Serialize)]
@@ -278,6 +301,20 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                 deprecated_flag: deprecated_dry_run.then_some("--dry-run"),
             })
         }
+        WorktreeCommand::Quarantine { command } => match command {
+            WorktreeQuarantineCommand::List => {
+                WorktreeOutput::QuarantineList(worktree::list_task_worktree_registry_quarantines()?)
+            }
+            WorktreeQuarantineCommand::Clear {
+                provenance_path,
+                verified_terminal,
+            } => {
+                WorktreeOutput::QuarantineClear(worktree::clear_task_worktree_registry_quarantine(
+                    &provenance_path,
+                    verified_terminal,
+                )?)
+            }
+        },
     };
     Ok((output, 0))
 }

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -145,6 +145,8 @@ pub struct ArtifactCleanupOutput {
     pub applied: Vec<ArtifactCleanupApplied>,
     pub failed: Vec<ArtifactCleanupFailed>,
     pub registry_quarantines: Vec<crate::worktree::TaskWorktreeRegistryQuarantine>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_run_ref: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -342,7 +344,8 @@ fn canonical_or_owned(path: &Path) -> PathBuf {
 }
 
 pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactCleanupOutput> {
-    let registry_quarantines = crate::worktree::quarantine_malformed_task_worktree_records()?;
+    let registry_quarantines =
+        crate::worktree::reconcile_malformed_task_worktree_records(options.apply)?;
     crate::worktree::with_task_worktree_registry_read_lock(|| {
         let root = resolve_root(&options)?;
         let worktrees = discover_worktrees(&root)?;
@@ -375,7 +378,7 @@ fn artifact_cleanup_run_status(failure_count: usize) -> crate::observation::RunS
 /// Remove declared rebuildable artifacts from one completed worktree without
 /// inspecting sibling worktrees that may still be owned by active tasks.
 pub fn cleanup_worktree_artifacts(worktree: &Path) -> Result<ArtifactCleanupOutput> {
-    let registry_quarantines = crate::worktree::quarantine_malformed_task_worktree_records()?;
+    let registry_quarantines = crate::worktree::reconcile_malformed_task_worktree_records(true)?;
     crate::worktree::with_task_worktree_registry_read_lock(|| {
         let root = git_root(worktree)?;
         let worktree = root.clone();
@@ -619,6 +622,9 @@ fn cleanup_artifacts_in_worktrees(
         .apply
         .then(|| start_artifact_cleanup_run(&root))
         .transpose()?;
+    let cleanup_run_ref = cleanup_run
+        .as_ref()
+        .map(|(_, run_id)| format!("homeboy://run/{run_id}"));
     let (applied, failed) = if options.apply {
         let run_ref = cleanup_run
             .as_ref()
@@ -692,6 +698,7 @@ fn cleanup_artifacts_in_worktrees(
         applied,
         failed,
         registry_quarantines,
+        cleanup_run_ref,
     };
     if let Some((store, run_id)) = cleanup_run {
         store.finish_run(
@@ -704,6 +711,7 @@ fn cleanup_artifacts_in_worktrees(
                     "policy": "reconstructable artifact passed Git, age, and worktree activity gates",
                     "applied": output.applied,
                     "failed": output.failed,
+                    "registry_quarantines": output.registry_quarantines,
                 }
             })),
         )?;
@@ -3347,28 +3355,76 @@ mod tests {
             fs::create_dir_all(&store).expect("create task worktree registry");
             fs::write(store.join("corrupt.json"), "{").expect("write corrupt registry record");
 
+            let preview = cleanup_artifacts(ArtifactCleanupOptions {
+                apply: false,
+                ..dry_run_options(repo.path())
+            })
+            .expect("preview with unreadable registry");
+
+            assert!(repo.path().join("target/release/homeboy").exists());
+            assert!(preview.skipped.iter().any(|row| {
+                row.relative_path == "target" && row.reason.contains("registry could not be read")
+            }));
+            assert_eq!(preview.worktrees[0].liveness, LIVENESS_UNKNOWN);
+            assert_eq!(preview.registry_quarantines.len(), 1);
+            assert!(preview.registry_quarantines[0].planned);
+            assert!(std::path::Path::new(&preview.registry_quarantines[0].record_path).exists());
+            assert!(
+                !std::path::Path::new(&preview.registry_quarantines[0].quarantine_path).exists()
+            );
+
             let output = cleanup_artifacts(ArtifactCleanupOptions {
                 apply: true,
                 ..dry_run_options(repo.path())
             })
-            .expect("cleanup with unreadable registry");
-
-            assert!(repo.path().join("target/release/homeboy").exists());
-            assert!(output.skipped.iter().any(|row| {
-                row.relative_path == "target" && row.reason.contains("registry could not be read")
-            }));
-            assert_eq!(output.worktrees[0].liveness, LIVENESS_UNKNOWN);
+            .expect("apply with unreadable registry");
             assert_eq!(output.registry_quarantines.len(), 1);
             let quarantine = &output.registry_quarantines[0];
+            assert!(!quarantine.planned);
             assert!(!std::path::Path::new(&quarantine.record_path).exists());
             assert!(std::path::Path::new(&quarantine.quarantine_path).exists());
             assert!(std::path::Path::new(&quarantine.provenance_path).exists());
 
+            let persistent = cleanup_artifacts(ArtifactCleanupOptions {
+                apply: true,
+                ..dry_run_options(repo.path())
+            })
+            .expect("cleanup retains unresolved quarantine");
+            assert!(persistent.applied.is_empty());
+            assert_eq!(persistent.registry_quarantines.len(), 1);
+            assert!(repo.path().join("target").exists());
+
+            let run_id = output
+                .cleanup_run_ref
+                .as_deref()
+                .expect("apply cleanup run reference")
+                .strip_prefix("homeboy://run/")
+                .expect("run reference format");
+            let run = crate::observation::ObservationStore::open_readonly()
+                .expect("open cleanup provenance store")
+                .get_run(run_id)
+                .expect("read cleanup run")
+                .expect("cleanup run exists");
+            assert_eq!(
+                run.metadata_json["cleanup"]["registry_quarantines"][0]["provenance_path"],
+                quarantine.provenance_path
+            );
+
+            assert!(crate::worktree::clear_task_worktree_registry_quarantine(
+                std::path::Path::new(&quarantine.provenance_path),
+                false,
+            )
+            .is_err());
+            crate::worktree::clear_task_worktree_registry_quarantine(
+                std::path::Path::new(&quarantine.provenance_path),
+                true,
+            )
+            .expect("verified terminal reconciliation");
             let repaired = cleanup_artifacts(ArtifactCleanupOptions {
                 apply: true,
                 ..dry_run_options(repo.path())
             })
-            .expect("cleanup after registry repair");
+            .expect("cleanup after verified reconciliation");
             assert!(repaired.registry_quarantines.is_empty());
             assert!(repaired
                 .applied

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::defaults::HomeboyConfig;
 use crate::resource_cleanup_intent::ResourceCleanupIntent;
@@ -221,6 +222,17 @@ pub struct ArtifactCleanupApplied {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rehydrate_command: Option<String>,
     pub removed: bool,
+    pub provenance: ArtifactCleanupDeletionProvenance,
+}
+
+/// Durable identity and decision facts for a reconstructable artifact removal.
+/// `run_ref` resolves through `homeboy runs show <id>`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactCleanupDeletionProvenance {
+    pub run_ref: String,
+    pub deleted_at: String,
+    pub policy: String,
+    pub protection_decision: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -313,6 +325,20 @@ pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactClea
     let root = resolve_root(&options)?;
     let worktrees = discover_worktrees(&root)?;
     cleanup_artifacts_in_worktrees(root, worktrees, &options, true)
+}
+
+fn start_artifact_cleanup_run(
+    root: &Path,
+) -> Result<(crate::observation::ObservationStore, String)> {
+    let store = crate::observation::ObservationStore::open_initialized()?;
+    let run = store.start_run(
+        crate::observation::NewRunRecord::builder("cleanup.artifacts")
+            .command("homeboy cleanup artifacts")
+            .cwd_path(root)
+            .metadata(json!({ "cleanup": { "command": "cleanup.artifacts" } }))
+            .build(),
+    )?;
+    Ok((store, run.id))
 }
 
 /// Remove declared rebuildable artifacts from one completed worktree without
@@ -420,8 +446,8 @@ fn collect_worktree_candidates(
             continue;
         }
         if declaration.liveness_protected
-            && !options.include_active_worktrees
             && liveness == LIVENESS_ACTIVE
+            && (!options.include_active_worktrees || declaration.kind == "rust_target")
         {
             skipped.push(skip_row(
                 worktree,
@@ -542,10 +568,39 @@ fn cleanup_artifacts_in_worktrees(
 
     order_and_limit_candidates(&mut candidates, options.sort, options.limit);
 
+    let cleanup_run = options
+        .apply
+        .then(|| start_artifact_cleanup_run(&root))
+        .transpose()?;
     let (applied, failed) = if options.apply {
+        let run_ref = cleanup_run
+            .as_ref()
+            .expect("apply cleanup has a provenance run")
+            .1
+            .clone();
         apply_artifact_candidates(&candidates, |candidate| {
+            // Re-read durable worktree activity immediately before mutation so a
+            // task admitted after planning cannot lose its local Cargo output.
+            if candidate.kind == "rust_target"
+                && ActiveWorktrees::resolve().liveness(Path::new(&candidate.worktree))
+                    == LIVENESS_ACTIVE
+            {
+                return None;
+            }
             let path = Path::new(&candidate.path);
-            path.exists().then(|| remove_artifact_path(path))
+            path.exists().then(|| {
+                remove_artifact_path(path).map(|()| {
+                    applied_row(
+                        candidate,
+                        ArtifactCleanupDeletionProvenance {
+                            run_ref: format!("homeboy://run/{run_ref}"),
+                            deleted_at: chrono::Utc::now().to_rfc3339(),
+                            policy: "reconstructable artifact passed Git, age, and worktree activity gates".to_string(),
+                            protection_decision: "no registered active task worktree".to_string(),
+                        },
+                    )
+                })
+            })
         })
     } else {
         (Vec::new(), Vec::new())
@@ -568,7 +623,7 @@ fn cleanup_artifacts_in_worktrees(
         remaining_candidate_bytes,
     );
 
-    Ok(ArtifactCleanupOutput {
+    let output = ArtifactCleanupOutput {
         command: "cleanup.artifacts",
         mode: if options.apply { "apply" } else { "dry_run" },
         root: root.to_string_lossy().to_string(),
@@ -590,7 +645,23 @@ fn cleanup_artifacts_in_worktrees(
         skipped,
         applied,
         failed,
-    })
+    };
+    if let Some((store, run_id)) = cleanup_run {
+        store.finish_run(
+            &run_id,
+            crate::observation::RunStatus::Pass,
+            Some(json!({
+                "cleanup": {
+                    "command": output.command,
+                    "mode": output.mode,
+                    "policy": "reconstructable artifact passed Git, age, and worktree activity gates",
+                    "applied": output.applied,
+                    "failed": output.failed,
+                }
+            })),
+        )?;
+    }
+    Ok(output)
 }
 
 fn artifact_cleanup_apply_command(options: &ArtifactCleanupOptions) -> String {
@@ -847,13 +918,13 @@ fn apply_artifact_candidates<Remove>(
     mut remove: Remove,
 ) -> (Vec<ArtifactCleanupApplied>, Vec<ArtifactCleanupFailed>)
 where
-    Remove: FnMut(&ArtifactCleanupCandidate) -> Option<Result<()>>,
+    Remove: FnMut(&ArtifactCleanupCandidate) -> Option<Result<ArtifactCleanupApplied>>,
 {
     let mut applied = Vec::new();
     let mut failed = Vec::new();
     for candidate in candidates {
         match remove(candidate) {
-            Some(Ok(())) => applied.push(applied_row(candidate)),
+            Some(Ok(row)) => applied.push(row),
             Some(Err(error)) => failed.push(failed_row(candidate, error.message)),
             None => {}
         }
@@ -914,7 +985,7 @@ pub fn artifact_declarations(worktree: &Path) -> Result<Vec<ArtifactDeclaration>
             reconstructable: true,
             rehydrate_command: None,
             min_age_days: None,
-            liveness_protected: false,
+            liveness_protected: true,
         })
         .collect();
 
@@ -1130,7 +1201,10 @@ fn has_untracked_work_at(untracked_paths: &[String], relative_path: &str) -> boo
     })
 }
 
-fn applied_row(candidate: &ArtifactCleanupCandidate) -> ArtifactCleanupApplied {
+fn applied_row(
+    candidate: &ArtifactCleanupCandidate,
+    provenance: ArtifactCleanupDeletionProvenance,
+) -> ArtifactCleanupApplied {
     ArtifactCleanupApplied {
         worktree: candidate.worktree.clone(),
         path: candidate.path.clone(),
@@ -1141,6 +1215,7 @@ fn applied_row(candidate: &ArtifactCleanupCandidate) -> ArtifactCleanupApplied {
         allocated_bytes: candidate.allocated_bytes,
         rehydrate_command: candidate.rehydrate_command.clone(),
         removed: true,
+        provenance,
     }
 }
 
@@ -1503,7 +1578,7 @@ mod tests {
             );
             assert_eq!(declarations[0].category, LEGACY_ARTIFACT_CATEGORY);
             assert!(declarations[0].reconstructable);
-            assert!(!declarations[0].liveness_protected);
+            assert!(declarations[0].liveness_protected);
         });
     }
 
@@ -2328,7 +2403,15 @@ mod tests {
             .relative_path
             .as_str()
         {
-            "target" => Some(Ok(())),
+            "target" => Some(Ok(applied_row(
+                candidate,
+                ArtifactCleanupDeletionProvenance {
+                    run_ref: "homeboy://run/test".to_string(),
+                    deleted_at: "2026-01-01T00:00:00Z".to_string(),
+                    policy: "test".to_string(),
+                    protection_decision: "test".to_string(),
+                },
+            ))),
             "dist" => Some(Err(Error::internal_unexpected("remove failed"))),
             _ => None,
         });
@@ -3107,8 +3190,46 @@ mod tests {
                 "liveness state is reported for the checkout"
             );
             assert!(
-                !repo.path().join("target").exists(),
-                "built-in declarations keep their existing behavior on active checkouts"
+                repo.path().join("target").exists(),
+                "active worktrees protect built-in Cargo targets"
+            );
+
+            crate::worktree::remove_record_for_test("fixture-active");
+            let output = cleanup_artifacts(ArtifactCleanupOptions {
+                apply: true,
+                ..dry_run_options(repo.path())
+            })
+            .expect("cleanup after task worktree activity ends");
+            let target = output
+                .applied
+                .iter()
+                .find(|row| row.relative_path == "target")
+                .expect("target becomes eligible after activity ends");
+            assert!(!repo.path().join("target").exists());
+            assert!(target.provenance.run_ref.starts_with("homeboy://run/"));
+            assert_eq!(
+                target.provenance.protection_decision,
+                "no registered active task worktree"
+            );
+
+            let run_id = target
+                .provenance
+                .run_ref
+                .strip_prefix("homeboy://run/")
+                .expect("run reference format");
+            let run = crate::observation::ObservationStore::open_readonly()
+                .expect("open cleanup provenance store")
+                .get_run(run_id)
+                .expect("read cleanup run")
+                .expect("cleanup run exists");
+            assert_eq!(run.kind, "cleanup.artifacts");
+            assert_eq!(
+                run.metadata_json["cleanup"]["applied"][0]["path"],
+                target.path
+            );
+            assert_eq!(
+                run.metadata_json["cleanup"]["applied"][0]["provenance"]["run_ref"],
+                target.provenance.run_ref
             );
         });
     }

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -144,6 +144,7 @@ pub struct ArtifactCleanupOutput {
     pub skipped: Vec<ArtifactCleanupSkipped>,
     pub applied: Vec<ArtifactCleanupApplied>,
     pub failed: Vec<ArtifactCleanupFailed>,
+    pub registry_quarantines: Vec<crate::worktree::TaskWorktreeRegistryQuarantine>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -341,10 +342,11 @@ fn canonical_or_owned(path: &Path) -> PathBuf {
 }
 
 pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactCleanupOutput> {
+    let registry_quarantines = crate::worktree::quarantine_malformed_task_worktree_records()?;
     crate::worktree::with_task_worktree_registry_read_lock(|| {
         let root = resolve_root(&options)?;
         let worktrees = discover_worktrees(&root)?;
-        cleanup_artifacts_in_worktrees(root, worktrees, &options, true)
+        cleanup_artifacts_in_worktrees(root, worktrees, &options, true, registry_quarantines)
     })
 }
 
@@ -373,6 +375,7 @@ fn artifact_cleanup_run_status(failure_count: usize) -> crate::observation::RunS
 /// Remove declared rebuildable artifacts from one completed worktree without
 /// inspecting sibling worktrees that may still be owned by active tasks.
 pub fn cleanup_worktree_artifacts(worktree: &Path) -> Result<ArtifactCleanupOutput> {
+    let registry_quarantines = crate::worktree::quarantine_malformed_task_worktree_records()?;
     crate::worktree::with_task_worktree_registry_read_lock(|| {
         let root = git_root(worktree)?;
         let worktree = root.clone();
@@ -384,6 +387,7 @@ pub fn cleanup_worktree_artifacts(worktree: &Path) -> Result<ArtifactCleanupOutp
                 ..Default::default()
             },
             false,
+            registry_quarantines,
         )
     })
 }
@@ -573,10 +577,14 @@ fn cleanup_artifacts_in_worktrees(
     worktrees: Vec<WorktreeInfo>,
     options: &ArtifactCleanupOptions,
     include_self_temp_artifacts: bool,
+    registry_quarantines: Vec<crate::worktree::TaskWorktreeRegistryQuarantine>,
 ) -> Result<ArtifactCleanupOutput> {
     let mut candidates = Vec::new();
     let mut skipped = Vec::new();
-    let active = ActiveWorktrees::resolve();
+    let mut active = ActiveWorktrees::resolve();
+    if !registry_quarantines.is_empty() {
+        active.available = false;
+    }
 
     for worktree in &worktrees {
         // A single stale/non-Git/vanished worktree candidate must not abort the
@@ -683,6 +691,7 @@ fn cleanup_artifacts_in_worktrees(
         skipped,
         applied,
         failed,
+        registry_quarantines,
     };
     if let Some((store, run_id)) = cleanup_run {
         store.finish_run(
@@ -2968,6 +2977,7 @@ mod tests {
             ],
             &ArtifactCleanupOptions::default(),
             false,
+            Vec::new(),
         )
         .expect("batch must not abort on one bad worktree");
 
@@ -3348,6 +3358,23 @@ mod tests {
                 row.relative_path == "target" && row.reason.contains("registry could not be read")
             }));
             assert_eq!(output.worktrees[0].liveness, LIVENESS_UNKNOWN);
+            assert_eq!(output.registry_quarantines.len(), 1);
+            let quarantine = &output.registry_quarantines[0];
+            assert!(!std::path::Path::new(&quarantine.record_path).exists());
+            assert!(std::path::Path::new(&quarantine.quarantine_path).exists());
+            assert!(std::path::Path::new(&quarantine.provenance_path).exists());
+
+            let repaired = cleanup_artifacts(ArtifactCleanupOptions {
+                apply: true,
+                ..dry_run_options(repo.path())
+            })
+            .expect("cleanup after registry repair");
+            assert!(repaired.registry_quarantines.is_empty());
+            assert!(repaired
+                .applied
+                .iter()
+                .any(|row| row.relative_path == "target"));
+            assert!(!repo.path().join("target").exists());
         });
     }
 

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -50,6 +50,7 @@ const LEGACY_ARTIFACT_CATEGORY: &str = "build_output";
 /// Liveness of the checkout an artifact belongs to.
 const LIVENESS_ACTIVE: &str = "active_task_worktree";
 const LIVENESS_IDLE: &str = "idle";
+const LIVENESS_UNKNOWN: &str = "unknown";
 
 /// What the checkout needs before it is usable again once the artifact is gone.
 const READINESS_REHYDRATION_REQUIRED: &str = "rehydration_required";
@@ -289,15 +290,19 @@ struct GitSafety {
 
 /// Paths of checkouts Homeboy currently records as active task worktrees.
 /// Resolved once per invocation so the registry is read a single time.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 struct ActiveWorktrees {
     paths: HashSet<PathBuf>,
+    available: bool,
 }
 
 impl ActiveWorktrees {
     fn resolve() -> Self {
-        let Ok(listing) = crate::worktree::list() else {
-            return Self::default();
+        let Ok(listing) = crate::worktree::list_unlocked() else {
+            return Self {
+                paths: HashSet::new(),
+                available: false,
+            };
         };
         let paths = listing
             .worktrees
@@ -305,14 +310,28 @@ impl ActiveWorktrees {
             .filter(|record| record.state == crate::worktree::TaskWorktreeState::Active)
             .map(|record| canonical_or_owned(Path::new(&record.worktree_path)))
             .collect();
-        Self { paths }
+        Self {
+            paths,
+            available: true,
+        }
     }
 
     fn liveness(&self, worktree: &Path) -> &'static str {
-        if self.paths.contains(&canonical_or_owned(worktree)) {
+        if !self.available {
+            LIVENESS_UNKNOWN
+        } else if self.paths.contains(&canonical_or_owned(worktree)) {
             LIVENESS_ACTIVE
         } else {
             LIVENESS_IDLE
+        }
+    }
+}
+
+impl Default for ActiveWorktrees {
+    fn default() -> Self {
+        Self {
+            paths: HashSet::new(),
+            available: true,
         }
     }
 }
@@ -322,9 +341,11 @@ fn canonical_or_owned(path: &Path) -> PathBuf {
 }
 
 pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactCleanupOutput> {
-    let root = resolve_root(&options)?;
-    let worktrees = discover_worktrees(&root)?;
-    cleanup_artifacts_in_worktrees(root, worktrees, &options, true)
+    crate::worktree::with_task_worktree_registry_read_lock(|| {
+        let root = resolve_root(&options)?;
+        let worktrees = discover_worktrees(&root)?;
+        cleanup_artifacts_in_worktrees(root, worktrees, &options, true)
+    })
 }
 
 fn start_artifact_cleanup_run(
@@ -341,20 +362,30 @@ fn start_artifact_cleanup_run(
     Ok((store, run.id))
 }
 
+fn artifact_cleanup_run_status(failure_count: usize) -> crate::observation::RunStatus {
+    if failure_count == 0 {
+        crate::observation::RunStatus::Pass
+    } else {
+        crate::observation::RunStatus::Fail
+    }
+}
+
 /// Remove declared rebuildable artifacts from one completed worktree without
 /// inspecting sibling worktrees that may still be owned by active tasks.
 pub fn cleanup_worktree_artifacts(worktree: &Path) -> Result<ArtifactCleanupOutput> {
-    let root = git_root(worktree)?;
-    let worktree = root.clone();
-    cleanup_artifacts_in_worktrees(
-        root,
-        vec![WorktreeInfo { path: worktree }],
-        &ArtifactCleanupOptions {
-            apply: true,
-            ..Default::default()
-        },
-        false,
-    )
+    crate::worktree::with_task_worktree_registry_read_lock(|| {
+        let root = git_root(worktree)?;
+        let worktree = root.clone();
+        cleanup_artifacts_in_worktrees(
+            root,
+            vec![WorktreeInfo { path: worktree }],
+            &ArtifactCleanupOptions {
+                apply: true,
+                ..Default::default()
+            },
+            false,
+        )
+    })
 }
 
 /// Candidates and skips discovered for a single worktree.
@@ -445,15 +476,23 @@ fn collect_worktree_candidates(
             ));
             continue;
         }
-        if declaration.liveness_protected
-            && liveness == LIVENESS_ACTIVE
-            && (!options.include_active_worktrees || declaration.kind == "rust_target")
-        {
+        let protected_by_activity = if declaration.kind == "rust_target" {
+            liveness != LIVENESS_IDLE
+        } else {
+            declaration.liveness_protected
+                && liveness == LIVENESS_ACTIVE
+                && !options.include_active_worktrees
+        };
+        if protected_by_activity {
             skipped.push(skip_row(
                 worktree,
                 &declaration,
                 display_path,
-                "checkout is a registered active task worktree",
+                if liveness == LIVENESS_UNKNOWN {
+                    "task worktree registry could not be read; Cargo target retained"
+                } else {
+                    "checkout is a registered active task worktree"
+                },
             ));
             continue;
         }
@@ -579,11 +618,10 @@ fn cleanup_artifacts_in_worktrees(
             .1
             .clone();
         apply_artifact_candidates(&candidates, |candidate| {
-            // Re-read durable worktree activity immediately before mutation so a
-            // task admitted after planning cannot lose its local Cargo output.
+            // The enclosing registry read lease blocks Homeboy admission from
+            // changing liveness between this final check and deletion.
             if candidate.kind == "rust_target"
-                && ActiveWorktrees::resolve().liveness(Path::new(&candidate.worktree))
-                    == LIVENESS_ACTIVE
+                && active.liveness(Path::new(&candidate.worktree)) != LIVENESS_IDLE
             {
                 return None;
             }
@@ -649,7 +687,7 @@ fn cleanup_artifacts_in_worktrees(
     if let Some((store, run_id)) = cleanup_run {
         store.finish_run(
             &run_id,
-            crate::observation::RunStatus::Pass,
+            artifact_cleanup_run_status(output.failure_count),
             Some(json!({
                 "cleanup": {
                     "command": output.command,
@@ -2393,6 +2431,58 @@ mod tests {
     }
 
     #[test]
+    fn artifact_cleanup_run_status_fails_when_any_removal_fails() {
+        assert_eq!(
+            artifact_cleanup_run_status(0),
+            crate::observation::RunStatus::Pass
+        );
+        assert_eq!(
+            artifact_cleanup_run_status(1),
+            crate::observation::RunStatus::Fail
+        );
+    }
+
+    #[test]
+    fn failed_cleanup_run_retains_successful_deletion_provenance() {
+        crate::test_support::with_isolated_home(|_| {
+            let store = crate::observation::ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(crate::observation::NewRunRecord::builder("cleanup.artifacts").build())
+                .expect("start cleanup run");
+            let provenance = ArtifactCleanupDeletionProvenance {
+                run_ref: format!("homeboy://run/{}", run.id),
+                deleted_at: "2026-01-01T00:00:00Z".to_string(),
+                policy: "reconstructable artifact passed Git, age, and worktree activity gates"
+                    .to_string(),
+                protection_decision: "no registered active task worktree".to_string(),
+            };
+
+            store
+                .finish_run(
+                    &run.id,
+                    artifact_cleanup_run_status(1),
+                    Some(json!({
+                        "cleanup": {
+                            "applied": [{ "path": "/repo/target", "provenance": provenance }],
+                            "failed": [{ "path": "/repo/dist" }],
+                        }
+                    })),
+                )
+                .expect("finish failed cleanup run");
+
+            let persisted = store
+                .get_run(&run.id)
+                .expect("read cleanup run")
+                .expect("cleanup run exists");
+            assert_eq!(persisted.status, "fail");
+            assert_eq!(
+                persisted.metadata_json["cleanup"]["applied"][0]["provenance"]["run_ref"],
+                format!("homeboy://run/{}", run.id)
+            );
+        });
+    }
+
+    #[test]
     fn artifact_cleanup_reports_partial_removal_failures_without_aborting() {
         let candidates = vec![
             artifact_candidate("target"),
@@ -3231,6 +3321,33 @@ mod tests {
                 run.metadata_json["cleanup"]["applied"][0]["provenance"]["run_ref"],
                 target.provenance.run_ref
             );
+        });
+    }
+
+    #[test]
+    fn unreadable_task_worktree_registry_retains_cargo_targets() {
+        crate::test_support::with_isolated_home(|_| {
+            let repo = repo_with_ignored_artifacts();
+            write_file(&repo.path().join("target/release/homeboy"), "artifact");
+            let store = crate::paths::observation_db()
+                .expect("observation database path")
+                .parent()
+                .expect("observation data root")
+                .join("task-worktrees");
+            fs::create_dir_all(&store).expect("create task worktree registry");
+            fs::write(store.join("corrupt.json"), "{").expect("write corrupt registry record");
+
+            let output = cleanup_artifacts(ArtifactCleanupOptions {
+                apply: true,
+                ..dry_run_options(repo.path())
+            })
+            .expect("cleanup with unreadable registry");
+
+            assert!(repo.path().join("target/release/homeboy").exists());
+            assert!(output.skipped.iter().any(|row| {
+                row.relative_path == "target" && row.reason.contains("registry could not be read")
+            }));
+            assert_eq!(output.worktrees[0].liveness, LIVENESS_UNKNOWN);
         });
     }
 

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use crate::ownership;
 use crate::{git, paths};
 use fs4::fs_std::FileExt;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 mod queue_ops;
 mod store_ops;
@@ -46,19 +46,24 @@ pub(crate) fn list_unlocked() -> Result<WorktreeListOutput> {
 /// Evidence retained when a malformed task-worktree record is removed from the
 /// active registry. The original bytes and this provenance sidecar remain under
 /// `.quarantine`, so uncertain activity is never silently discarded.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskWorktreeRegistryQuarantine {
     pub record_path: String,
     pub quarantine_path: String,
     pub provenance_path: String,
     pub reason: String,
+    #[serde(default)]
+    pub planned: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleared_at: Option<String>,
     pub quarantined_at: String,
 }
 
-/// Move a bounded number of unreadable records out of the active registry.
-/// Callers must treat any returned quarantine as unknown activity for their
-/// current operation; the next operation can safely read the repaired set.
-pub(crate) fn quarantine_malformed_task_worktree_records(
+/// Plan or apply bounded malformed-record quarantine. Every returned record
+/// remains active protection until `clear_task_worktree_registry_quarantine`
+/// records an explicit verified terminal reconciliation.
+pub(crate) fn reconcile_malformed_task_worktree_records(
+    apply: bool,
 ) -> Result<Vec<TaskWorktreeRegistryQuarantine>> {
     with_task_worktree_registry_write_lock(|| {
         let store = metadata_dir()?;
@@ -76,9 +81,10 @@ pub(crate) fn quarantine_malformed_task_worktree_records(
             })?;
         entries.sort_by_key(|entry| entry.file_name());
 
-        let mut quarantined = Vec::new();
+        let mut quarantined = active_task_worktree_registry_quarantines(&quarantine)?;
+        let mut repaired_count = 0;
         for entry in entries {
-            if quarantined.len() == MALFORMED_RECORD_REPAIR_LIMIT
+            if repaired_count == MALFORMED_RECORD_REPAIR_LIMIT
                 || entry
                     .path()
                     .extension()
@@ -91,20 +97,28 @@ pub(crate) fn quarantine_malformed_task_worktree_records(
             let Err(error) = read_record_path(&path) else {
                 continue;
             };
-            fs::create_dir_all(&quarantine).map_err(|error| {
-                Error::internal_io(error.to_string(), Some(quarantine.display().to_string()))
-            })?;
             let quarantined_at = chrono::Utc::now().to_rfc3339();
             let name = entry.file_name().to_string_lossy().to_string();
             let quarantined_path = quarantine.join(format!("{name}-{}.json", uuid::Uuid::new_v4()));
             let provenance_path = quarantined_path.with_extension("provenance.json");
-            let record = TaskWorktreeRegistryQuarantine {
+            let mut record = TaskWorktreeRegistryQuarantine {
                 record_path: path.display().to_string(),
                 quarantine_path: quarantined_path.display().to_string(),
                 provenance_path: provenance_path.display().to_string(),
                 reason: error.message,
+                planned: !apply,
+                cleared_at: None,
                 quarantined_at,
             };
+            if !apply {
+                quarantined.push(record);
+                repaired_count += 1;
+                continue;
+            }
+            fs::create_dir_all(&quarantine).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(quarantine.display().to_string()))
+            })?;
+            record.planned = false;
             let provenance = serde_json::to_string_pretty(&record).map_err(|error| {
                 Error::internal_json(error.to_string(), Some(record.provenance_path.clone()))
             })?;
@@ -124,9 +138,117 @@ pub(crate) fn quarantine_malformed_task_worktree_records(
                 ));
             }
             quarantined.push(record);
+            repaired_count += 1;
         }
         Ok(quarantined)
     })
+}
+
+/// Mark one retained quarantine as terminally reconciled without deleting its
+/// original bytes. The caller supplies the explicit verified-terminal decision.
+pub fn clear_task_worktree_registry_quarantine(
+    provenance_path: &Path,
+    verified_terminal: bool,
+) -> Result<TaskWorktreeRegistryQuarantine> {
+    if !verified_terminal {
+        return Err(Error::validation_invalid_argument(
+            "verified_terminal",
+            "clearing quarantined worktree evidence requires verified terminal reconciliation",
+            Some(provenance_path.display().to_string()),
+            None,
+        ));
+    }
+    with_task_worktree_registry_write_lock(|| {
+        let quarantine = metadata_dir()?.join(".quarantine");
+        if !provenance_path.starts_with(&quarantine) {
+            return Err(Error::validation_invalid_argument(
+                "provenance_path",
+                "quarantine provenance path is outside the task-worktree registry",
+                Some(provenance_path.display().to_string()),
+                None,
+            ));
+        }
+        let raw = fs::read_to_string(provenance_path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(provenance_path.display().to_string()),
+            )
+        })?;
+        let mut record: TaskWorktreeRegistryQuarantine =
+            serde_json::from_str(&raw).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some(provenance_path.display().to_string()),
+                )
+            })?;
+        if !Path::new(&record.quarantine_path).exists() {
+            return Err(Error::validation_invalid_argument(
+                "provenance_path",
+                "quarantined worktree evidence is missing",
+                Some(record.quarantine_path.clone()),
+                None,
+            ));
+        }
+        record.planned = false;
+        record.cleared_at = Some(chrono::Utc::now().to_rfc3339());
+        let raw = serde_json::to_string_pretty(&record).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(provenance_path.display().to_string()),
+            )
+        })?;
+        crate::io::write_output_file_atomically(
+            provenance_path,
+            format!("{raw}\n"),
+            crate::io::OutputWriteOptions::file(),
+        )
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(provenance_path.display().to_string()),
+            )
+        })?;
+        Ok(record)
+    })
+}
+
+pub fn list_task_worktree_registry_quarantines() -> Result<Vec<TaskWorktreeRegistryQuarantine>> {
+    with_task_worktree_registry_read_lock(|| {
+        active_task_worktree_registry_quarantines(&metadata_dir()?.join(".quarantine"))
+    })
+}
+
+fn active_task_worktree_registry_quarantines(
+    quarantine: &Path,
+) -> Result<Vec<TaskWorktreeRegistryQuarantine>> {
+    if !quarantine.exists() {
+        return Ok(Vec::new());
+    }
+    let mut quarantines = Vec::new();
+    for entry in fs::read_dir(quarantine).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(quarantine.display().to_string()))
+    })? {
+        let path = entry
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(quarantine.display().to_string()))
+            })?
+            .path();
+        if !path.to_string_lossy().ends_with(".provenance.json") {
+            continue;
+        }
+        let raw = fs::read_to_string(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?;
+        let record: TaskWorktreeRegistryQuarantine =
+            serde_json::from_str(&raw).map_err(|error| {
+                Error::internal_json(error.to_string(), Some(path.display().to_string()))
+            })?;
+        if record.cleared_at.is_none() {
+            quarantines.push(record);
+        }
+    }
+    quarantines.sort_by(|left, right| left.provenance_path.cmp(&right.provenance_path));
+    Ok(quarantines)
 }
 
 /// Hold a shared lease over the task-worktree registry while a caller reads

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -7,12 +7,14 @@ use crate::error::{Error, Result};
 use crate::ownership;
 use crate::{git, paths};
 use fs4::fs_std::FileExt;
+use serde::Serialize;
 
 mod queue_ops;
 mod store_ops;
 mod types;
 
 static TASK_WORKTREE_REGISTRY_GATE: OnceLock<RwLock<()>> = OnceLock::new();
+const MALFORMED_RECORD_REPAIR_LIMIT: usize = 20;
 
 pub use types::{
     AdoptedWorkspaceRecord, BranchCleanupIntent, BranchCleanupStatus, CleanupPolicy,
@@ -39,6 +41,92 @@ pub fn list() -> Result<WorktreeListOutput> {
 
 pub(crate) fn list_unlocked() -> Result<WorktreeListOutput> {
     list_with_store(&metadata_dir()?)
+}
+
+/// Evidence retained when a malformed task-worktree record is removed from the
+/// active registry. The original bytes and this provenance sidecar remain under
+/// `.quarantine`, so uncertain activity is never silently discarded.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TaskWorktreeRegistryQuarantine {
+    pub record_path: String,
+    pub quarantine_path: String,
+    pub provenance_path: String,
+    pub reason: String,
+    pub quarantined_at: String,
+}
+
+/// Move a bounded number of unreadable records out of the active registry.
+/// Callers must treat any returned quarantine as unknown activity for their
+/// current operation; the next operation can safely read the repaired set.
+pub(crate) fn quarantine_malformed_task_worktree_records(
+) -> Result<Vec<TaskWorktreeRegistryQuarantine>> {
+    with_task_worktree_registry_write_lock(|| {
+        let store = metadata_dir()?;
+        if !store.exists() {
+            return Ok(Vec::new());
+        }
+        let quarantine = store.join(".quarantine");
+        let mut entries: Vec<_> = fs::read_dir(&store)
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(store.display().to_string()))
+            })?
+            .collect::<std::result::Result<_, _>>()
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(store.display().to_string()))
+            })?;
+        entries.sort_by_key(|entry| entry.file_name());
+
+        let mut quarantined = Vec::new();
+        for entry in entries {
+            if quarantined.len() == MALFORMED_RECORD_REPAIR_LIMIT
+                || entry
+                    .path()
+                    .extension()
+                    .and_then(|extension| extension.to_str())
+                    != Some("json")
+            {
+                continue;
+            }
+            let path = entry.path();
+            let Err(error) = read_record_path(&path) else {
+                continue;
+            };
+            fs::create_dir_all(&quarantine).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(quarantine.display().to_string()))
+            })?;
+            let quarantined_at = chrono::Utc::now().to_rfc3339();
+            let name = entry.file_name().to_string_lossy().to_string();
+            let quarantined_path = quarantine.join(format!("{name}-{}.json", uuid::Uuid::new_v4()));
+            let provenance_path = quarantined_path.with_extension("provenance.json");
+            let record = TaskWorktreeRegistryQuarantine {
+                record_path: path.display().to_string(),
+                quarantine_path: quarantined_path.display().to_string(),
+                provenance_path: provenance_path.display().to_string(),
+                reason: error.message,
+                quarantined_at,
+            };
+            let provenance = serde_json::to_string_pretty(&record).map_err(|error| {
+                Error::internal_json(error.to_string(), Some(record.provenance_path.clone()))
+            })?;
+            crate::io::write_output_file_atomically(
+                &provenance_path,
+                format!("{provenance}\n"),
+                crate::io::OutputWriteOptions::file(),
+            )
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(record.provenance_path.clone()))
+            })?;
+            if let Err(error) = fs::rename(&path, &quarantined_path) {
+                let _ = fs::remove_file(&provenance_path);
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some(path.display().to_string()),
+                ));
+            }
+            quarantined.push(record);
+        }
+        Ok(quarantined)
+    })
 }
 
 /// Hold a shared lease over the task-worktree registry while a caller reads

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -119,6 +119,12 @@ pub(crate) fn record_active_for_test(id: &str, worktree_path: &Path) {
     write_record(&store, &record).expect("write task worktree record");
 }
 
+#[cfg(test)]
+pub(crate) fn remove_record_for_test(id: &str) {
+    let store = metadata_dir().expect("task worktree store");
+    fs::remove_file(record_path(&store, id)).expect("remove task worktree record");
+}
+
 use store_ops::*;
 
 pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueueCreateOutput> {

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -1,14 +1,18 @@
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
 
 use crate::component::{self, TargetSpec};
 use crate::error::{Error, Result};
 use crate::ownership;
 use crate::{git, paths};
+use fs4::fs_std::FileExt;
 
 mod queue_ops;
 mod store_ops;
 mod types;
+
+static TASK_WORKTREE_REGISTRY_GATE: OnceLock<RwLock<()>> = OnceLock::new();
 
 pub use types::{
     AdoptedWorkspaceRecord, BranchCleanupIntent, BranchCleanupStatus, CleanupPolicy,
@@ -30,7 +34,75 @@ pub fn adopt(options: WorktreeAdoptOptions) -> Result<WorktreeAdoptOutput> {
 }
 
 pub fn list() -> Result<WorktreeListOutput> {
+    with_task_worktree_registry_read_lock(list_unlocked)
+}
+
+pub(crate) fn list_unlocked() -> Result<WorktreeListOutput> {
     list_with_store(&metadata_dir()?)
+}
+
+/// Hold a shared lease over the task-worktree registry while a caller reads
+/// liveness and mutates a worktree-local resource. Registry writers take the
+/// matching exclusive lease before atomically publishing their next snapshot.
+pub(crate) fn with_task_worktree_registry_read_lock<T>(
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    let _gate = TASK_WORKTREE_REGISTRY_GATE
+        .get_or_init(|| RwLock::new(()))
+        .read()
+        .map_err(|_| Error::internal_unexpected("task worktree registry read gate poisoned"))?;
+    let lock = open_task_worktree_registry_lock()?;
+    lock.lock_shared().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("lock task worktree registry for read".to_string()),
+        )
+    })?;
+    operation()
+}
+
+pub(super) fn with_task_worktree_registry_write_lock<T>(
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    let _gate = TASK_WORKTREE_REGISTRY_GATE
+        .get_or_init(|| RwLock::new(()))
+        .write()
+        .map_err(|_| Error::internal_unexpected("task worktree registry write gate poisoned"))?;
+    let lock = open_task_worktree_registry_lock()?;
+    lock.lock_exclusive().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("lock task worktree registry for write".to_string()),
+        )
+    })?;
+    operation()
+}
+
+fn open_task_worktree_registry_lock() -> Result<std::fs::File> {
+    let store = metadata_dir()?;
+    let parent = store.parent().ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "task worktree store has no parent: {}",
+            store.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", parent.display())),
+        )
+    })?;
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(parent.join("task-worktrees.lock"))
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("open task worktree registry lock".to_string()),
+            )
+        })
 }
 
 pub fn status(id: &str) -> Result<WorktreeStatusOutput> {

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -664,18 +664,29 @@ pub(super) fn record_path(store_dir: &Path, id: &str) -> PathBuf {
 }
 
 pub(super) fn write_record(store_dir: &Path, record: &TaskWorktreeRecord) -> Result<()> {
-    let store_owner = ownership::owner_for_path_or_ancestor(store_dir)?;
-    fs::create_dir_all(store_dir).map_err(|err| {
-        Error::internal_io(err.to_string(), Some(store_dir.display().to_string()))
-    })?;
-    let json = serde_json::to_string_pretty(record)
-        .map_err(|err| Error::internal_json(err.to_string(), Some(record.id.clone())))?;
-    let path = record_path(store_dir, &record.id);
-    fs::write(&path, format!("{json}\n"))
+    with_task_worktree_registry_write_lock(|| {
+        let store_owner = ownership::owner_for_path_or_ancestor(store_dir)?;
+        fs::create_dir_all(store_dir).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(store_dir.display().to_string()))
+        })?;
+        let json = serde_json::to_string_pretty(record)
+            .map_err(|err| Error::internal_json(err.to_string(), Some(record.id.clone())))?;
+        let path = record_path(store_dir, &record.id);
+        crate::io::write_output_file_atomically(
+            &path,
+            format!("{json}\n"),
+            crate::io::OutputWriteOptions::file(),
+        )
         .map_err(|err| Error::internal_io(err.to_string(), Some(record.id.clone())))?;
-    ownership::normalize_created_path(store_dir, store_owner, false, "write worktree metadata")?;
-    ownership::normalize_created_path(&path, store_owner, false, "write worktree metadata")?;
-    Ok(())
+        ownership::normalize_created_path(
+            store_dir,
+            store_owner,
+            false,
+            "write worktree metadata",
+        )?;
+        ownership::normalize_created_path(&path, store_owner, false, "write worktree metadata")?;
+        Ok(())
+    })
 }
 
 pub(super) fn write_adopted_record(

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -1,5 +1,47 @@
 use super::*;
 
+#[test]
+fn registry_read_lease_blocks_active_worktree_publication() {
+    crate::test_support::with_isolated_home(|_| {
+        let worktree = tempfile::tempdir().expect("worktree");
+        let (reader_ready_tx, reader_ready_rx) = std::sync::mpsc::channel();
+        let (reader_release_tx, reader_release_rx) = std::sync::mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            with_task_worktree_registry_read_lock(|| {
+                reader_ready_tx.send(()).expect("announce read lease");
+                reader_release_rx.recv().expect("release read lease");
+                Ok(())
+            })
+        });
+        reader_ready_rx.recv().expect("read lease acquired");
+
+        let path = worktree.path().to_path_buf();
+        let (writer_done_tx, writer_done_rx) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            record_active_for_test("admitted-during-cleanup", &path);
+            writer_done_tx.send(()).expect("announce published record");
+        });
+        assert!(
+            writer_done_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "active worktree publication must wait for the cleanup read lease"
+        );
+
+        reader_release_tx.send(()).expect("release reader");
+        reader.join().expect("join reader").expect("reader result");
+        writer_done_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("writer completes after read lease release");
+        writer.join().expect("join writer");
+        assert!(list()
+            .expect("list worktrees")
+            .worktrees
+            .iter()
+            .any(|record| record.id == "admitted-during-cleanup"));
+    });
+}
+
 fn run_git(dir: &Path, args: &[&str]) {
     let output = std::process::Command::new("git")
         .args(args)


### PR DESCRIPTION
## Summary
- protect worktree-local Rust `target/` directories while their task worktree is active
- atomically publish task-worktree records and coordinate cleanup/admission with a shared registry lease
- fail closed for local Cargo targets when task-worktree liveness cannot be read
- preview malformed-record quarantine without mutation; apply quarantines up to 20 records with retained original bytes and provenance
- retain quarantine protection across later cleanup passes until `homeboy worktree quarantine clear <provenance-path> --verified-terminal` records explicit terminal reconciliation
- persist successful artifact deletion and quarantine provenance in resolvable `cleanup.artifacts` runs, and mark runs failed if any deletion fails

Closes #10785

## Verification
- `cargo fmt --all`
- `cargo test -p homeboy-core cleanup::tests::unreadable_task_worktree_registry_retains_cargo_targets`
- `cargo test -p homeboy-core cleanup::tests::active_task_worktrees_protect_extension_declared_artifacts`
- `cargo test -p homeboy-core worktree::tests::registry_read_lease_blocks_active_worktree_publication`
- `cargo check -p homeboy`

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode drafted the implementation and tests. Chris Huber remains responsible for every line.