### PR TITLE
feat(project): batch component path attachment

### DIFF
--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -528,6 +528,7 @@ const PROJECT_MUTATING_PATHS: &[&str] = &[
     "init",
     "components set",
     "components attach-path",
+    "components attach-paths",
     "components remove",
     "components clear",
     "pin add",

--- a/crates/homeboy-cli/src/commands/project.rs
+++ b/crates/homeboy-cli/src/commands/project.rs
@@ -123,6 +123,22 @@ enum ProjectComponentsCommand {
         /// Local repo path containing homeboy.json
         local_path: String,
     },
+    /// Attach multiple repo paths, retaining per-path diagnostics
+    AttachPaths {
+        /// Project ID
+        project_id: String,
+        /// Local repo paths containing homeboy.json
+        local_paths: Vec<String>,
+        /// JSON array of {"path":"/repo","reference":"caller-owned-ref"} inputs
+        #[arg(long)]
+        input: Option<String>,
+        /// Continue all inputs or stop after the first failure
+        #[arg(long, value_enum, default_value_t = BatchFailurePolicyArg::Continue)]
+        failure_policy: BatchFailurePolicyArg,
+        /// Include git worktrees or report them as skipped
+        #[arg(long, value_enum, default_value_t = BatchWorktreePolicyArg::Include)]
+        worktree_policy: BatchWorktreePolicyArg,
+    },
     /// Remove one or more components
     Remove {
         /// Project ID
@@ -207,6 +223,18 @@ enum ProjectPinCommand {
 enum ProjectPinType {
     File,
     Log,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum BatchFailurePolicyArg {
+    Continue,
+    FailFast,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum BatchWorktreePolicyArg {
+    Include,
+    Skip,
 }
 
 pub type ProjectOutput = homeboy::core::project::ProjectReportOutput;
@@ -356,12 +384,75 @@ fn components(command: ProjectComponentsCommand) -> CmdResult<ProjectOutput> {
             project_id,
             local_path,
         } => components_attach_path(&project_id, &local_path),
+        ProjectComponentsCommand::AttachPaths {
+            project_id,
+            local_paths,
+            input,
+            failure_policy,
+            worktree_policy,
+        } => components_attach_paths(
+            &project_id,
+            local_paths,
+            input.as_deref(),
+            failure_policy,
+            worktree_policy,
+        ),
         ProjectComponentsCommand::Remove {
             project_id,
             component_ids,
         } => components_remove(&project_id, component_ids),
         ProjectComponentsCommand::Clear { project_id } => components_clear(&project_id),
     }
+}
+
+fn components_attach_paths(
+    project_id: &str,
+    local_paths: Vec<String>,
+    input: Option<&str>,
+    failure_policy: BatchFailurePolicyArg,
+    worktree_policy: BatchWorktreePolicyArg,
+) -> CmdResult<ProjectOutput> {
+    let mut inputs: Vec<project::BatchComponentAttachmentInput> = local_paths
+        .into_iter()
+        .map(|path| project::BatchComponentAttachmentInput {
+            path,
+            reference: None,
+        })
+        .collect();
+    if let Some(input) = input {
+        let raw = homeboy::core::config::read_json_spec_to_string(input)?;
+        let mut parsed = serde_json::from_str(&raw).map_err(|error| {
+            homeboy::core::Error::validation_invalid_json(
+                error,
+                Some("parse batch component attachment inputs".to_string()),
+                None,
+            )
+        })?;
+        inputs.append(&mut parsed);
+    }
+    let failure_policy = match failure_policy {
+        BatchFailurePolicyArg::Continue => project::BatchComponentAttachmentFailurePolicy::Continue,
+        BatchFailurePolicyArg::FailFast => project::BatchComponentAttachmentFailurePolicy::FailFast,
+    };
+    let worktree_policy = match worktree_policy {
+        BatchWorktreePolicyArg::Include => project::BatchComponentAttachmentWorktreePolicy::Include,
+        BatchWorktreePolicyArg::Skip => project::BatchComponentAttachmentWorktreePolicy::Skip,
+    };
+    let components = project::attach_component_paths_report(
+        project_id,
+        inputs,
+        failure_policy,
+        worktree_policy,
+    )?;
+    let exit_code = components
+        .batch
+        .as_ref()
+        .map(|batch| batch.exit_code)
+        .unwrap_or(0);
+    Ok((
+        project::build_components_output(project_id, "attach_paths", components),
+        exit_code,
+    ))
 }
 
 fn components_list(project_id: &str) -> CmdResult<ProjectOutput> {
@@ -507,6 +598,50 @@ fn pin_update(
         project::build_pin_output("project.pin.update", project_id, pin),
         0,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::cli_surface::Cli;
+
+    #[test]
+    fn component_attach_path_and_batch_surface_parse() {
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "project",
+            "components",
+            "attach-path",
+            "site",
+            "/repo/component",
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "project",
+            "components",
+            "attach-paths",
+            "site",
+            "/repo/first",
+            "/repo/second",
+            "--failure-policy",
+            "continue",
+            "--worktree-policy",
+            "skip",
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "project",
+            "components",
+            "attach-paths",
+            "site",
+            "--input",
+            r#"[{"path":"/repo/component","reference":"primary:component"}]"#,
+        ])
+        .is_ok());
+    }
 }
 
 fn pin_rename(

--- a/crates/homeboy-core/src/project/component/mod.rs
+++ b/crates/homeboy-core/src/project/component/mod.rs
@@ -9,8 +9,9 @@ pub use attachments::{
 };
 pub use overrides::apply_component_overrides;
 pub use report::{
-    attach_component_path_report, clear_components, list_components, remove_components_report,
-    set_components, ProjectComponentsOutput,
+    attach_component_path_report, attach_component_paths_report, clear_components, list_components,
+    remove_components_report, set_components, BatchComponentAttachmentFailurePolicy,
+    BatchComponentAttachmentInput, BatchComponentAttachmentWorktreePolicy, ProjectComponentsOutput,
 };
 pub use resolution::{
     resolve_project_component, resolve_project_component_with_standalone_snapshot,

--- a/crates/homeboy-core/src/project/component/report.rs
+++ b/crates/homeboy-core/src/project/component/report.rs
@@ -157,9 +157,10 @@ pub fn attach_component_paths_report(
     for (index, input) in inputs.into_iter().enumerate() {
         let attempted_command = format!(
             "homeboy project components attach-path {} {}",
-            project_id, input.path
+            crate::engine::shell::quote_arg(project_id),
+            crate::engine::shell::quote_arg(&input.path)
         );
-        let evidence_ref = format!("#/batch/items/{index}");
+        let evidence_ref = format!("#/data/components/batch/items/{index}");
         let (status, component_id, skip_reason, error) = if stopped {
             (
                 BatchComponentAttachmentItemStatus::Skipped,
@@ -168,7 +169,7 @@ pub fn attach_component_paths_report(
                 None,
             )
         } else if worktree_policy == BatchComponentAttachmentWorktreePolicy::Skip
-            && Path::new(&input.path).join(".git").is_file()
+            && is_registered_linked_worktree(Path::new(&input.path))
         {
             (
                 BatchComponentAttachmentItemStatus::Skipped,
@@ -288,6 +289,55 @@ pub fn attach_component_paths_report(
     })
 }
 
+/// Git linked worktrees have a `.git` pointer to `<repo>/.git/worktrees/<id>`
+/// and Git's registration directory points back to that exact `.git` file.
+/// Submodules also use `.git` pointer files, so requiring both registrations
+/// avoids classifying a submodule as a worktree.
+fn is_registered_linked_worktree(path: &Path) -> bool {
+    let pointer = path.join(".git");
+    if !std::fs::symlink_metadata(&pointer)
+        .ok()
+        .is_some_and(|metadata| metadata.is_file())
+    {
+        return false;
+    }
+    let Ok(contents) = std::fs::read_to_string(&pointer) else {
+        return false;
+    };
+    let Some(gitdir) = contents.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix("gitdir:")
+            .map(|value| value.trim())
+    }) else {
+        return false;
+    };
+    let registration = Path::new(gitdir);
+    let registration = if registration.is_absolute() {
+        registration.to_path_buf()
+    } else {
+        pointer.parent().unwrap_or(path).join(registration)
+    };
+    let Some(worktrees) = registration.parent() else {
+        return false;
+    };
+    if worktrees.file_name().is_none_or(|name| name != "worktrees")
+        || !registration.is_dir()
+        || !worktrees.parent().is_some_and(Path::is_dir)
+    {
+        return false;
+    }
+    let Ok(back_pointer) = std::fs::read_to_string(registration.join("gitdir")) else {
+        return false;
+    };
+    let recorded_pointer = Path::new(back_pointer.trim());
+    let recorded_pointer = if recorded_pointer.is_absolute() {
+        recorded_pointer.to_path_buf()
+    } else {
+        registration.join(recorded_pointer)
+    };
+    pointer.canonicalize().ok() == recorded_pointer.canonicalize().ok()
+}
+
 pub fn remove_components_report(
     project_id: &str,
     component_ids: Vec<String>,
@@ -350,7 +400,9 @@ mod tests {
         BatchComponentAttachmentFailurePolicy, BatchComponentAttachmentInput,
         BatchComponentAttachmentItemStatus, BatchComponentAttachmentWorktreePolicy,
     };
-    use crate::project::{load, save, Project, ProjectComponentAttachment};
+    use crate::project::{
+        build_components_output, load, save, Project, ProjectComponentAttachment,
+    };
     use crate::test_support::with_isolated_home;
     use std::fs;
 
@@ -365,6 +417,21 @@ mod tests {
         fs::create_dir_all(path).expect("component directory");
         fs::write(path.join("homeboy.json"), format!(r#"{{"id":"{id}"}}"#))
             .expect("component config");
+    }
+
+    fn register_linked_worktree(source: &std::path::Path, worktree: &std::path::Path, id: &str) {
+        let registration = source.join(".git/worktrees").join(id);
+        fs::create_dir_all(&registration).expect("worktree registration");
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", registration.display()),
+        )
+        .expect("worktree pointer");
+        fs::write(
+            registration.join("gitdir"),
+            worktree.join(".git").display().to_string(),
+        )
+        .expect("worktree back pointer");
     }
 
     #[test]
@@ -467,32 +534,45 @@ mod tests {
                 BatchComponentAttachmentWorktreePolicy::Include,
             )
             .expect("batch output");
-            let batch = output.batch.expect("batch details");
+            let evidence_ref = {
+                let batch = output.batch.as_ref().expect("batch details");
 
-            assert_eq!(batch.attached_count, 2);
-            assert_eq!(batch.failed_count, 1);
-            assert_eq!(batch.skipped_count, 0);
-            assert_eq!(batch.exit_code, 1);
-            assert!(matches!(
-                batch.items[0].status,
-                BatchComponentAttachmentItemStatus::Attached
-            ));
-            assert_eq!(batch.items[0].reference.as_deref(), Some("primary:first"));
-            assert!(matches!(
-                batch.items[1].status,
-                BatchComponentAttachmentItemStatus::Failed
-            ));
-            let error = batch.items[1].error.as_ref().expect("retained error");
-            assert!(!error.code.is_empty());
-            assert!(!error.action.is_empty());
-            assert!(batch.items[1]
-                .attempted_command
-                .contains("attach-path site"));
-            assert_eq!(batch.items[1].evidence_ref, "#/batch/items/1");
-            assert!(matches!(
-                batch.items[2].status,
-                BatchComponentAttachmentItemStatus::Attached
-            ));
+                assert_eq!(batch.attached_count, 2);
+                assert_eq!(batch.failed_count, 1);
+                assert_eq!(batch.skipped_count, 0);
+                assert_eq!(batch.exit_code, 1);
+                assert!(matches!(
+                    batch.items[0].status,
+                    BatchComponentAttachmentItemStatus::Attached
+                ));
+                assert_eq!(batch.items[0].reference.as_deref(), Some("primary:first"));
+                assert!(matches!(
+                    batch.items[1].status,
+                    BatchComponentAttachmentItemStatus::Failed
+                ));
+                let error = batch.items[1].error.as_ref().expect("retained error");
+                assert!(!error.code.is_empty());
+                assert!(!error.action.is_empty());
+                assert!(batch.items[1]
+                    .attempted_command
+                    .contains("attach-path site"));
+                assert!(matches!(
+                    batch.items[2].status,
+                    BatchComponentAttachmentItemStatus::Attached
+                ));
+                batch.items[1].evidence_ref.clone()
+            };
+            let response = serde_json::json!({
+                "data": build_components_output("site", "attach_paths", output),
+            });
+            let pointer = evidence_ref.trim_start_matches('#');
+            assert_eq!(
+                response
+                    .pointer(pointer)
+                    .and_then(|item| item.get("path"))
+                    .and_then(|path| path.as_str()),
+                Some(missing.to_string_lossy().as_ref())
+            );
         });
     }
 
@@ -542,11 +622,9 @@ mod tests {
             .expect("save project");
             let worktree = home.path().join("component-worktree");
             write_component(&worktree, "component-worktree");
-            fs::write(
-                worktree.join(".git"),
-                "gitdir: /tmp/component/.git/worktrees/test\n",
-            )
-            .expect("worktree marker");
+            let source = home.path().join("source");
+            fs::create_dir_all(source.join(".git")).expect("source git directory");
+            register_linked_worktree(&source, &worktree, "test");
 
             let output = attach_component_paths_report(
                 "site",
@@ -567,6 +645,73 @@ mod tests {
                 batch.items[0].skip_reason.as_deref(),
                 Some("git worktree skipped by worktree_policy")
             );
+        });
+    }
+
+    #[test]
+    fn batch_attachment_does_not_skip_submodule_pointer() {
+        with_isolated_home(|home| {
+            save(&Project {
+                id: "site".to_string(),
+                ..Default::default()
+            })
+            .expect("save project");
+            let submodule = home.path().join("submodule");
+            write_component(&submodule, "submodule");
+            fs::write(
+                submodule.join(".git"),
+                "gitdir: ../.git/modules/submodule\n",
+            )
+            .expect("submodule pointer");
+
+            let output = attach_component_paths_report(
+                "site",
+                vec![batch_input(submodule.to_string_lossy())],
+                BatchComponentAttachmentFailurePolicy::Continue,
+                BatchComponentAttachmentWorktreePolicy::Skip,
+            )
+            .expect("batch output");
+            let batch = output.batch.expect("batch details");
+
+            assert_eq!(batch.attached_count, 1);
+            assert_eq!(batch.skipped_count, 0);
+            assert!(matches!(
+                batch.items[0].status,
+                BatchComponentAttachmentItemStatus::Attached
+            ));
+        });
+    }
+
+    #[test]
+    fn batch_attachment_shell_quotes_attempted_command() {
+        with_isolated_home(|home| {
+            let project_id = "site with spaces";
+            save(&Project {
+                id: project_id.to_string(),
+                ..Default::default()
+            })
+            .expect("save project");
+            let component = home.path().join("component 'quoted';$HOME");
+            write_component(&component, "quoted-component");
+
+            let output = attach_component_paths_report(
+                project_id,
+                vec![batch_input(component.to_string_lossy())],
+                BatchComponentAttachmentFailurePolicy::Continue,
+                BatchComponentAttachmentWorktreePolicy::Include,
+            )
+            .expect("batch output");
+            let command = &output.batch.expect("batch details").items[0].attempted_command;
+
+            assert_eq!(
+                command.as_str(),
+                format!(
+                    "homeboy project components attach-path 'site with spaces' {}",
+                    crate::engine::shell::quote_arg(&component.to_string_lossy())
+                )
+            );
+            assert!(command.contains("'\\''"));
+            assert!(command.contains(";$HOME'"));
         });
     }
 
@@ -602,7 +747,10 @@ mod tests {
             assert!(batch.summary_truncated);
             assert_eq!(batch.items.len(), 9);
             assert!(batch.items.iter().all(|item| item.error.is_some()));
-            assert_eq!(batch.items[8].evidence_ref, "#/batch/items/8");
+            assert_eq!(
+                batch.items[8].evidence_ref,
+                "#/data/components/batch/items/8"
+            );
         });
     }
 }

--- a/crates/homeboy-core/src/project/component/report.rs
+++ b/crates/homeboy-core/src/project/component/report.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::component::Component;
 use crate::error::{Error, Result};
@@ -28,6 +28,78 @@ pub struct ProjectComponentsOutput {
     pub components: Vec<Component>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch: Option<BatchComponentAttachmentOutput>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchComponentAttachmentFailurePolicy {
+    #[default]
+    Continue,
+    FailFast,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchComponentAttachmentWorktreePolicy {
+    #[default]
+    Include,
+    Skip,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchComponentAttachmentInput {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchComponentAttachmentItemStatus {
+    Attached,
+    Skipped,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchComponentAttachmentError {
+    pub code: String,
+    pub message: String,
+    pub details: serde_json::Value,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
+    pub action: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchComponentAttachmentItem {
+    pub status: BatchComponentAttachmentItemStatus,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+    pub attempted_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<BatchComponentAttachmentError>,
+    pub evidence_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchComponentAttachmentOutput {
+    pub failure_policy: BatchComponentAttachmentFailurePolicy,
+    pub worktree_policy: BatchComponentAttachmentWorktreePolicy,
+    pub attached_count: usize,
+    pub skipped_count: usize,
+    pub failed_count: usize,
+    pub exit_code: i32,
+    pub summary: Vec<String>,
+    pub summary_truncated: bool,
+    pub items: Vec<BatchComponentAttachmentItem>,
 }
 
 pub fn list_components(project_id: &str) -> Result<ProjectComponentsOutput> {
@@ -65,6 +137,157 @@ pub fn attach_component_path_report(
     )
 }
 
+pub fn attach_component_paths_report(
+    project_id: &str,
+    inputs: Vec<BatchComponentAttachmentInput>,
+    failure_policy: BatchComponentAttachmentFailurePolicy,
+    worktree_policy: BatchComponentAttachmentWorktreePolicy,
+) -> Result<ProjectComponentsOutput> {
+    if inputs.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "paths",
+            "At least one component path is required",
+            Some(project_id.to_string()),
+            None,
+        ));
+    }
+
+    let mut items = Vec::with_capacity(inputs.len());
+    let mut stopped = false;
+    for (index, input) in inputs.into_iter().enumerate() {
+        let attempted_command = format!(
+            "homeboy project components attach-path {} {}",
+            project_id, input.path
+        );
+        let evidence_ref = format!("#/batch/items/{index}");
+        let (status, component_id, skip_reason, error) = if stopped {
+            (
+                BatchComponentAttachmentItemStatus::Skipped,
+                None,
+                Some("not attempted after fail_fast failure".to_string()),
+                None,
+            )
+        } else if worktree_policy == BatchComponentAttachmentWorktreePolicy::Skip
+            && Path::new(&input.path).join(".git").is_file()
+        {
+            (
+                BatchComponentAttachmentItemStatus::Skipped,
+                None,
+                Some("git worktree skipped by worktree_policy".to_string()),
+                None,
+            )
+        } else {
+            match attach_discovered_component_path(project_id, Path::new(&input.path)) {
+                Ok(component_id) => (
+                    BatchComponentAttachmentItemStatus::Attached,
+                    Some(component_id),
+                    None,
+                    None,
+                ),
+                Err(error) => {
+                    stopped = failure_policy == BatchComponentAttachmentFailurePolicy::FailFast;
+                    let action = error
+                        .hints
+                        .first()
+                        .map(|hint| hint.message.clone())
+                        .unwrap_or_else(|| {
+                            "Inspect the retained error details and repair the component path."
+                                .to_string()
+                        });
+                    (
+                        BatchComponentAttachmentItemStatus::Failed,
+                        None,
+                        None,
+                        Some(BatchComponentAttachmentError {
+                            code: error.code.as_str().to_string(),
+                            message: error.message,
+                            details: error.details,
+                            hints: error.hints.into_iter().map(|hint| hint.message).collect(),
+                            action,
+                        }),
+                    )
+                }
+            }
+        };
+        items.push(BatchComponentAttachmentItem {
+            status,
+            path: input.path,
+            reference: input.reference,
+            attempted_command,
+            component_id,
+            skip_reason,
+            error,
+            evidence_ref,
+        });
+    }
+
+    let attached_count = items
+        .iter()
+        .filter(|item| matches!(item.status, BatchComponentAttachmentItemStatus::Attached))
+        .count();
+    let skipped_count = items
+        .iter()
+        .filter(|item| matches!(item.status, BatchComponentAttachmentItemStatus::Skipped))
+        .count();
+    let failed_count = items
+        .iter()
+        .filter(|item| matches!(item.status, BatchComponentAttachmentItemStatus::Failed))
+        .count();
+    const SUMMARY_LIMIT: usize = 8;
+    let summary: Vec<_> = items
+        .iter()
+        .filter_map(|item| match item.status {
+            BatchComponentAttachmentItemStatus::Attached => Some(format!("attached {}", item.path)),
+            BatchComponentAttachmentItemStatus::Skipped => Some(format!(
+                "skipped {}: {}",
+                item.path,
+                item.skip_reason.as_deref().unwrap_or("skipped")
+            )),
+            BatchComponentAttachmentItemStatus::Failed => Some(format!(
+                "failed {} [{}]",
+                item.path,
+                item.error
+                    .as_ref()
+                    .map(|error| error.code.as_str())
+                    .unwrap_or("unknown")
+            )),
+        })
+        .take(SUMMARY_LIMIT)
+        .collect();
+    let batch = BatchComponentAttachmentOutput {
+        failure_policy,
+        worktree_policy,
+        attached_count,
+        skipped_count,
+        failed_count,
+        exit_code: i32::from(failed_count > 0),
+        summary,
+        summary_truncated: items.len() > SUMMARY_LIMIT,
+        items,
+    };
+    let project = load(project_id).ok();
+    Ok(ProjectComponentsOutput {
+        action: "attach_paths".to_string(),
+        project_id: project_id.to_string(),
+        component_ids: project
+            .as_ref()
+            .map(project_component_ids)
+            .unwrap_or_default(),
+        component_count: project
+            .as_ref()
+            .map(|project| project.components.len())
+            .unwrap_or_default(),
+        attached_component_id: None,
+        attached_path: None,
+        components: Vec::new(),
+        warnings: project
+            .as_ref()
+            .map(component_local_path_blockers)
+            .unwrap_or_default(),
+        batch: Some(batch),
+    })
+}
+
 pub fn remove_components_report(
     project_id: &str,
     component_ids: Vec<String>,
@@ -96,6 +319,7 @@ fn build_components_output(
         attached_path: None,
         components,
         warnings: Vec::new(),
+        batch: None,
     })
 }
 
@@ -115,14 +339,33 @@ fn build_components_summary(
         attached_path,
         components: Vec::new(),
         warnings: component_local_path_blockers(project),
+        batch: None,
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_components_summary, remove_components_report};
+    use super::{
+        attach_component_paths_report, build_components_summary, remove_components_report,
+        BatchComponentAttachmentFailurePolicy, BatchComponentAttachmentInput,
+        BatchComponentAttachmentItemStatus, BatchComponentAttachmentWorktreePolicy,
+    };
     use crate::project::{load, save, Project, ProjectComponentAttachment};
     use crate::test_support::with_isolated_home;
+    use std::fs;
+
+    fn batch_input(path: impl Into<String>) -> BatchComponentAttachmentInput {
+        BatchComponentAttachmentInput {
+            path: path.into(),
+            reference: None,
+        }
+    }
+
+    fn write_component(path: &std::path::Path, id: &str) {
+        fs::create_dir_all(path).expect("component directory");
+        fs::write(path.join("homeboy.json"), format!(r#"{{"id":"{id}"}}"#))
+            .expect("component config");
+    }
 
     #[test]
     fn attach_path_summary_omits_resolved_component_payload() {
@@ -193,6 +436,173 @@ mod tests {
             let project = load("site").expect("project still loads");
             assert_eq!(project.components.len(), 1);
             assert_eq!(project.components[0].id, "stale-remaining");
+        });
+    }
+
+    #[test]
+    fn batch_attachment_continues_after_failure_and_retains_diagnostics() {
+        with_isolated_home(|home| {
+            save(&Project {
+                id: "site".to_string(),
+                ..Default::default()
+            })
+            .expect("save project");
+            let first = home.path().join("first");
+            let second = home.path().join("second");
+            write_component(&first, "first");
+            write_component(&second, "second");
+            let missing = home.path().join("missing");
+
+            let output = attach_component_paths_report(
+                "site",
+                vec![
+                    BatchComponentAttachmentInput {
+                        path: first.to_string_lossy().to_string(),
+                        reference: Some("primary:first".to_string()),
+                    },
+                    batch_input(missing.to_string_lossy()),
+                    batch_input(second.to_string_lossy()),
+                ],
+                BatchComponentAttachmentFailurePolicy::Continue,
+                BatchComponentAttachmentWorktreePolicy::Include,
+            )
+            .expect("batch output");
+            let batch = output.batch.expect("batch details");
+
+            assert_eq!(batch.attached_count, 2);
+            assert_eq!(batch.failed_count, 1);
+            assert_eq!(batch.skipped_count, 0);
+            assert_eq!(batch.exit_code, 1);
+            assert!(matches!(
+                batch.items[0].status,
+                BatchComponentAttachmentItemStatus::Attached
+            ));
+            assert_eq!(batch.items[0].reference.as_deref(), Some("primary:first"));
+            assert!(matches!(
+                batch.items[1].status,
+                BatchComponentAttachmentItemStatus::Failed
+            ));
+            let error = batch.items[1].error.as_ref().expect("retained error");
+            assert!(!error.code.is_empty());
+            assert!(!error.action.is_empty());
+            assert!(batch.items[1]
+                .attempted_command
+                .contains("attach-path site"));
+            assert_eq!(batch.items[1].evidence_ref, "#/batch/items/1");
+            assert!(matches!(
+                batch.items[2].status,
+                BatchComponentAttachmentItemStatus::Attached
+            ));
+        });
+    }
+
+    #[test]
+    fn batch_attachment_fail_fast_marks_remaining_inputs_skipped() {
+        with_isolated_home(|home| {
+            save(&Project {
+                id: "site".to_string(),
+                ..Default::default()
+            })
+            .expect("save project");
+            let later = home.path().join("later");
+            write_component(&later, "later");
+
+            let output = attach_component_paths_report(
+                "site",
+                vec![
+                    batch_input(home.path().join("missing").to_string_lossy()),
+                    batch_input(later.to_string_lossy()),
+                ],
+                BatchComponentAttachmentFailurePolicy::FailFast,
+                BatchComponentAttachmentWorktreePolicy::Include,
+            )
+            .expect("batch output");
+            let batch = output.batch.expect("batch details");
+
+            assert_eq!(batch.failed_count, 1);
+            assert_eq!(batch.skipped_count, 1);
+            assert!(matches!(
+                batch.items[1].status,
+                BatchComponentAttachmentItemStatus::Skipped
+            ));
+            assert_eq!(
+                batch.items[1].skip_reason.as_deref(),
+                Some("not attempted after fail_fast failure")
+            );
+        });
+    }
+
+    #[test]
+    fn batch_attachment_skips_git_worktrees_when_requested() {
+        with_isolated_home(|home| {
+            save(&Project {
+                id: "site".to_string(),
+                ..Default::default()
+            })
+            .expect("save project");
+            let worktree = home.path().join("component-worktree");
+            write_component(&worktree, "component-worktree");
+            fs::write(
+                worktree.join(".git"),
+                "gitdir: /tmp/component/.git/worktrees/test\n",
+            )
+            .expect("worktree marker");
+
+            let output = attach_component_paths_report(
+                "site",
+                vec![batch_input(worktree.to_string_lossy())],
+                BatchComponentAttachmentFailurePolicy::Continue,
+                BatchComponentAttachmentWorktreePolicy::Skip,
+            )
+            .expect("batch output");
+            let batch = output.batch.expect("batch details");
+
+            assert_eq!(batch.exit_code, 0);
+            assert_eq!(batch.skipped_count, 1);
+            assert!(matches!(
+                batch.items[0].status,
+                BatchComponentAttachmentItemStatus::Skipped
+            ));
+            assert_eq!(
+                batch.items[0].skip_reason.as_deref(),
+                Some("git worktree skipped by worktree_policy")
+            );
+        });
+    }
+
+    #[test]
+    fn batch_attachment_bounds_summary_without_dropping_failure_evidence() {
+        with_isolated_home(|home| {
+            save(&Project {
+                id: "site".to_string(),
+                ..Default::default()
+            })
+            .expect("save project");
+            let inputs = (0..9)
+                .map(|index| {
+                    batch_input(
+                        home.path()
+                            .join(format!("missing-{index}"))
+                            .to_string_lossy(),
+                    )
+                })
+                .collect();
+
+            let output = attach_component_paths_report(
+                "site",
+                inputs,
+                BatchComponentAttachmentFailurePolicy::Continue,
+                BatchComponentAttachmentWorktreePolicy::Include,
+            )
+            .expect("batch output");
+            let batch = output.batch.expect("batch details");
+
+            assert_eq!(batch.failed_count, 9);
+            assert_eq!(batch.summary.len(), 8);
+            assert!(batch.summary_truncated);
+            assert_eq!(batch.items.len(), 9);
+            assert!(batch.items.iter().all(|item| item.error.is_some()));
+            assert_eq!(batch.items[8].evidence_ref, "#/batch/items/8");
         });
     }
 }

--- a/crates/homeboy-core/src/project/mod.rs
+++ b/crates/homeboy-core/src/project/mod.rs
@@ -22,10 +22,12 @@ mod types;
 
 pub use component::{
     apply_component_overrides, attach_component_path, attach_component_path_report,
-    attach_discovered_component_path, clear_component_attachments, clear_components, has_component,
-    list_components, project_component_ids, remove_components, remove_components_report,
-    resolve_project_component, resolve_project_component_with_standalone_snapshot,
-    resolve_project_components, set_component_attachments, set_components, ProjectComponentsOutput,
+    attach_component_paths_report, attach_discovered_component_path, clear_component_attachments,
+    clear_components, has_component, list_components, project_component_ids, remove_components,
+    remove_components_report, resolve_project_component,
+    resolve_project_component_with_standalone_snapshot, resolve_project_components,
+    set_component_attachments, set_components, BatchComponentAttachmentFailurePolicy,
+    BatchComponentAttachmentInput, BatchComponentAttachmentWorktreePolicy, ProjectComponentsOutput,
     StandaloneComponentConfigSnapshot,
 };
 pub use effective_remote_path::{

--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -6,7 +6,7 @@ Hand-written narrative for these commands lives in `docs/commands/`. -->
 
 # Homeboy CLI reference (generated)
 
-`homeboy` exposes 530 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
+`homeboy` exposes 531 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
 
 Hand-written narrative lives in the [commands index](../../../commands/commands-index.md). Global flags are documented in [the root command reference](../homeboy-root-command.md). Machine-readable safety, docs, output, and Lab metadata come from `homeboy contract manifest`.
 

--- a/docs/reference/cli/commands/project.md
+++ b/docs/reference/cli/commands/project.md
@@ -149,6 +149,7 @@ Manage project components
 | `homeboy project components list` | List associated components |
 | `homeboy project components set` | Replace project components with the provided list |
 | `homeboy project components attach-path` | Attach a repo path for a project component discovered via homeboy.json |
+| `homeboy project components attach-paths` | Attach multiple repo paths, retaining per-path diagnostics |
 | `homeboy project components remove` | Remove one or more components |
 | `homeboy project components clear` | Remove all components |
 
@@ -192,6 +193,25 @@ Attach a repo path for a project component discovered via homeboy.json
 | --- | --- | --- |
 | `<PROJECT_ID>` | yes | Project ID |
 | `<LOCAL_PATH>` | yes | Local repo path containing homeboy.json |
+
+## `homeboy project components attach-paths`
+
+```sh
+homeboy project components attach-paths [OPTIONS] <PROJECT_ID> [LOCAL_PATHS]...
+```
+
+Attach multiple repo paths, retaining per-path diagnostics
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROJECT_ID>` | yes | Project ID |
+| `[LOCAL_PATHS]...` | no | Local repo paths containing homeboy.json |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--input` | `<INPUT>` | JSON array of {"path":"/repo","reference":"caller-owned-ref"} inputs |
+| `--failure-policy` | `<FAILURE_POLICY>` | Continue all inputs or stop after the first failure Values: `continue`, `fail-fast`. |
+| `--worktree-policy` | `<WORKTREE_POLICY>` | Include git worktrees or report them as skipped Values: `include`, `skip`. |
 
 ## `homeboy project components remove`
 

--- a/docs/reference/cli/commands/release.md
+++ b/docs/reference/cli/commands/release.md
@@ -35,7 +35,7 @@ Plan release workflows
 | `--recover` | flag | Recover from an interrupted release (tag + push current version) |
 | `--retag` | flag | With --recover: if the release tag exists but points at a commit behind HEAD (e.g. config-only commits landed after tagging), move the tag to HEAD instead of refusing. Guarded — the tagged commit must be an ancestor of HEAD, HEAD must satisfy the version targets, and no GitHub Release may exist for the tag |
 | `--head` | flag | Finish the release pipeline for an already-versioned, already-tagged HEAD. Skips changelog/version/git mutation steps and runs package, GitHub Release, publish, cleanup, and post-release hooks against the tag pointing at HEAD |
-| `--from-artifacts` | `<DIR>` | Use existing source-authority-manifested release artifacts from this directory instead of running release.package. Requires --head |
+| `--from-artifacts` | `<DIR>` | Use existing release artifacts from this directory instead of running release.package. Requires --head |
 | `--package-only` | flag | Regenerate only the release package for an existing tag at HEAD. Combine with --head --tag <tag> --apply to write a durable artifact inventory for later --head --from-artifacts finalization |
 | `--tag` | `<TAG>` | Existing release tag to package with --package-only |
 | `--skip-checks` | `<CHECK>` | Skip pre-release quality checks |
@@ -127,3 +127,4 @@ Show current version (default: discovered component, fallback: homeboy binary)
 | Option | Value | Description |
 | --- | --- | --- |
 | `--path` | `<PATH>` | Override local_path for version file lookup |
+


### PR DESCRIPTION
## Summary
- add `homeboy project components attach-paths` for positional paths or JSON path/ref inputs
- retain per-item attached, skipped, and failed outcomes with command identity, remediation, structured errors, and JSON-pointer evidence refs
- support explicit continuation/fail-fast and Git-worktree include/skip policies with deterministic aggregate exit status
- validate reciprocal Git linked-worktree registrations so submodule `.git` pointers remain attachable; shell-quote diagnostic commands; and emit final-envelope-resolvable evidence pointers

Closes #10786

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core project::component::report --lib`
- `cargo test -p homeboy-cli commands::project::tests --lib`
- `HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs`

## Residual Risk
Per-item error details and caller-provided path/reference strings remain fully retained. Homeboy has no shared per-item output-budget contract applicable to this report; exceptionally large source errors or inputs can therefore increase response size.

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode drafted the implementation and tests. Chris Huber remains responsible for every line.