### PR TITLE
fix(upgrade): converge runner binary identities

### DIFF
--- a/crates/homeboy-cli/src/commands/upgrade.rs
+++ b/crates/homeboy-cli/src/commands/upgrade.rs
@@ -217,6 +217,29 @@ mod tests {
     }
 
     #[test]
+    fn partial_result_serializes_independent_component_statuses() {
+        let mut result = base_upgrade_result();
+        result.partial = true;
+        result.controller = Some(upgrade::UpgradeComponentStatus {
+            status: "updated".to_string(),
+            summary: "controller installation completed".to_string(),
+        });
+        result.extensions = Some(upgrade::UpgradeComponentStatus {
+            status: "completed".to_string(),
+            summary: "0 updated, 0 skipped".to_string(),
+        });
+        result.runners = Some(upgrade::UpgradeComponentStatus {
+            status: "partial".to_string(),
+            summary: "0 converged, 1 require repair".to_string(),
+        });
+
+        let json = serde_json::to_value(result).expect("upgrade result serializes");
+        assert_eq!(json["controller"]["status"], "updated");
+        assert_eq!(json["extensions"]["status"], "completed");
+        assert_eq!(json["runners"]["status"], "partial");
+    }
+
+    #[test]
     fn non_targeted_runner_failures_keep_best_effort_upgrade_status() {
         let mut result = base_upgrade_result();
         result.runners_skipped.push(upgrade::RunnerUpgradeEntry {
@@ -318,6 +341,9 @@ mod tests {
             new_build_identity: None,
             source_revision: None,
             upgraded: true,
+            controller: None,
+            extensions: None,
+            runners: None,
             partial: false,
             runner_convergence: None,
             message: "Upgraded to 0.228.7".to_string(),

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -70,7 +70,17 @@ pub fn runner_recovery_commands(
     configured_version: Option<&str>,
     bare_version: Option<&str>,
 ) -> Vec<String> {
-    let mut commands = runner_upgrade_recovery_commands(runner_id);
+    let mut commands = if path_drift.is_some() {
+        // The attempted upgrade left the same selected identity in place. Rotate
+        // through the runner's managed materialization path instead of suggesting
+        // the command that just proved ineffective.
+        vec![format!(
+            "homeboy runner refresh-homeboy {} --reconnect",
+            shell_arg(runner_id)
+        )]
+    } else {
+        runner_upgrade_recovery_commands(runner_id, homeboy_path)
+    };
     if path_drift.is_some() {
         commands.push(runner_inspect_bare_homeboy_command(runner_id));
     }
@@ -79,6 +89,13 @@ pub fn runner_recovery_commands(
         && matches!((configured_version, bare_version), (Some(configured), Some(bare)) if version_is_newer(bare, configured))
     {
         commands.push(runner_set_homeboy_path_command(runner_id, "homeboy"));
+    }
+    if path_drift.is_some() && std::path::Path::new(homeboy_path).is_absolute() {
+        commands.push(format!(
+            "homeboy runner exec --ssh {} -- {} self identity",
+            shell_arg(runner_id),
+            shell_arg(homeboy_path)
+        ));
     }
     commands
 }
@@ -100,17 +117,25 @@ pub fn runner_set_homeboy_path_command(runner_id: &str, homeboy_path: &str) -> S
     )
 }
 
-pub fn runner_upgrade_recovery_commands(runner_id: &str) -> Vec<String> {
-    vec![
-        format!(
-            "homeboy runner exec {} -- homeboy upgrade --no-restart",
-            shell_arg(runner_id)
-        ),
-        format!(
-            "homeboy upgrade --force --upgrade-runner {}",
-            shell_arg(runner_id)
-        ),
-    ]
+pub fn runner_upgrade_recovery_commands(
+    runner_id: &str,
+    selected_homeboy_path: &str,
+) -> Vec<String> {
+    let mut commands = vec![format!(
+        "homeboy upgrade --force --upgrade-runner {}",
+        shell_arg(runner_id)
+    )];
+    // A nested repair must never re-resolve `homeboy` through the runner's PATH:
+    // PATH can name a third, older binary than both the configured executable and
+    // the daemon. Only an explicit selected executable is safe to invoke remotely.
+    if std::path::Path::new(selected_homeboy_path).is_absolute() {
+        commands.push(format!(
+            "homeboy runner exec --ssh {} -- {} upgrade --no-restart",
+            shell_arg(runner_id),
+            shell_arg(selected_homeboy_path)
+        ));
+    }
+    commands
 }
 
 pub fn runner_exec_recovery_commands(runner: &Runner, command: &[String]) -> Vec<String> {

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -69,14 +69,15 @@ pub fn runner_recovery_commands(
     path_drift: Option<&String>,
     configured_version: Option<&str>,
     bare_version: Option<&str>,
+    selected_source_revision: Option<&str>,
 ) -> Vec<String> {
     let mut commands = if path_drift.is_some() {
         // The attempted upgrade left the same selected identity in place. Rotate
         // through the runner's managed materialization path instead of suggesting
         // the command that just proved ineffective.
-        vec![format!(
-            "homeboy runner refresh-homeboy {} --reconnect",
-            shell_arg(runner_id)
+        vec![runner_refresh_homeboy_command(
+            runner_id,
+            selected_source_revision,
         )]
     } else {
         runner_upgrade_recovery_commands(runner_id, homeboy_path)
@@ -98,6 +99,20 @@ pub fn runner_recovery_commands(
         ));
     }
     commands
+}
+
+fn runner_refresh_homeboy_command(
+    runner_id: &str,
+    selected_source_revision: Option<&str>,
+) -> String {
+    let revision = selected_source_revision
+        .map(|revision| format!(" --ref {}", shell_arg(revision)))
+        .unwrap_or_default();
+    format!(
+        "homeboy runner refresh-homeboy {}{} --reconnect",
+        shell_arg(runner_id),
+        revision
+    )
 }
 
 pub fn runner_inspect_bare_homeboy_command(runner_id: &str) -> String {

--- a/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
@@ -61,6 +61,8 @@ pub fn recover_and_retry_failed_upgrade(
     command_source_path: Option<&str>,
     original_homeboy_path: &str,
     previous_version: Option<&str>,
+    expected_build_identity: Option<&str>,
+    selected_source_revision: Option<&str>,
     failure: FailedUpgradeOutcome,
     update_homeboy_path: &mut impl FnMut(&str, &str) -> Result<()>,
     exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
@@ -69,6 +71,7 @@ pub fn recover_and_retry_failed_upgrade(
         runner,
         original_homeboy_path,
         previous_version,
+        expected_build_identity,
         update_homeboy_path,
         exec,
     ) {
@@ -127,8 +130,14 @@ pub fn recover_and_retry_failed_upgrade(
                 ),
             );
             entry.path_drift = Some(recovery_detail.clone());
-            entry.recovery_commands =
-                runner_recovery_commands(&runner.id, "homeboy", Some(&recovery_detail), None, None);
+            entry.recovery_commands = runner_recovery_commands(
+                &runner.id,
+                original_homeboy_path,
+                Some(&recovery_detail),
+                None,
+                None,
+                selected_source_revision,
+            );
             Err(entry)
         }
     }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
@@ -24,6 +24,7 @@ pub fn runner_upgrade_failure_entry(
     exit_code: i32,
     detail: String,
 ) -> RunnerUpgradeEntry {
+    let recovery_commands = runner_upgrade_recovery_commands(runner_id, &homeboy_path);
     RunnerUpgradeEntry {
         runner_id: runner_id.to_string(),
         homeboy_path,
@@ -33,7 +34,7 @@ pub fn runner_upgrade_failure_entry(
         new_version: None,
         bare_homeboy_version: None,
         path_drift: None,
-        recovery_commands: runner_upgrade_recovery_commands(runner_id),
+        recovery_commands,
         extensions_synced: Vec::new(),
         extensions_skipped: Vec::new(),
         extensions_failed: Vec::new(),

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -321,6 +321,7 @@ pub fn upgrade_runner_with_executor(
                 .then(|| source_path.and_then(source_checkout_build_identity))
                 .flatten()
         });
+    let selected_source_revision = source_path.and_then(source_checkout_revision);
     let command_source_path = match runner_upgrade_source_path(
         runner,
         method_override,
@@ -380,6 +381,8 @@ pub fn upgrade_runner_with_executor(
             command_source_path.as_deref(),
             &original_homeboy_path,
             previous_version.as_deref(),
+            expected_build_identity.as_deref(),
+            selected_source_revision.as_deref(),
             FailedUpgradeOutcome {
                 exit_code,
                 detail: runner_upgrade_detail(&output),
@@ -394,6 +397,8 @@ pub fn upgrade_runner_with_executor(
             command_source_path.as_deref(),
             &original_homeboy_path,
             previous_version.as_deref(),
+            expected_build_identity.as_deref(),
+            selected_source_revision.as_deref(),
             FailedUpgradeOutcome {
                 exit_code: 1,
                 detail: err.message,
@@ -607,6 +612,7 @@ pub fn upgrade_runner_with_executor(
         path_drift.as_ref(),
         new_version.as_deref(),
         bare_homeboy_version.as_deref(),
+        selected_source_revision.as_deref(),
     );
     let mut stale_daemon_repair_detail = None;
     let mut stale_daemon = runner_stale_daemon(runner, status);

--- a/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
@@ -257,6 +257,7 @@ pub fn recover_runner_homeboy_path_after_failed_upgrade(
     runner: &Runner,
     homeboy_path: &str,
     configured_version: Option<&str>,
+    expected_build_identity: Option<&str>,
     update_homeboy_path: &mut impl FnMut(&str, &str) -> Result<()>,
     exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
 ) -> std::result::Result<Option<FailedUpgradePathRecovery>, String> {
@@ -279,6 +280,18 @@ pub fn recover_runner_homeboy_path_after_failed_upgrade(
     let Some(new_path) = alignment.update_to.as_deref() else {
         return Ok(None);
     };
+
+    if let Some(expected_identity) = expected_build_identity {
+        let observed_identity = runner_homeboy_identity(runner, new_path, exec)
+            .ok()
+            .flatten();
+        if observed_identity.as_deref() != Some(expected_identity) {
+            return Err(format!(
+                "refusing to update runner homeboy_path from `{homeboy_path}` to PATH-visible `{new_path}`: expected controller identity `{expected_identity}`, observed `{}`",
+                observed_identity.as_deref().unwrap_or("unverifiable build identity")
+            ));
+        }
+    }
 
     update_homeboy_path(&runner.id, new_path).map_err(|err| {
         format!(

--- a/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
@@ -409,7 +409,15 @@ pub fn is_homeboy_source_build_path(homeboy_path: &str) -> bool {
         ancestor
             .file_name()
             .and_then(|name| name.to_str())
-            .map(|name| name.starts_with("homeboy@"))
+            .map(|name| {
+                name.starts_with("homeboy@")
+                    || (ancestor
+                        .parent()
+                        .and_then(|parent| parent.file_name())
+                        .and_then(|parent| parent.to_str())
+                        == Some("_homeboy_binaries")
+                        && name.starts_with("homeboy-"))
+            })
             .unwrap_or(false)
     })
 }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
@@ -92,7 +92,7 @@ pub fn runner_upgrade_final_detail(
         ));
         parts.push(format!(
             "retry failed runner sync with `{}` or retry an individual failed extension using its recovery_commands entry",
-            runner_upgrade_recovery_commands(runner_id).join(" && ")
+            runner_upgrade_recovery_commands(runner_id, homeboy_path).join(" && ")
         ));
     }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
@@ -37,6 +37,13 @@ pub fn source_checkout_build_identity(source_path: &Path) -> Option<String> {
     ))
 }
 
+/// Immutable source input used for runner remediation. A branch name is not a
+/// convergence target because it can move after the controller was selected.
+pub fn source_checkout_revision(source_path: &Path) -> Option<String> {
+    output_allow_empty(source_path, &["rev-parse", "HEAD"])
+        .filter(|revision| !revision.trim().is_empty())
+}
+
 pub fn prepare_runner_source_checkout_for_upgrade(
     runner: &Runner,
     method_override: Option<InstallMethod>,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -263,7 +263,7 @@ fn fails_when_configured_runner_path_remains_older_than_local_after_successful_u
         .contains("but local/current reports"));
     assert!(skipped[0]
         .recovery_commands
-        .contains(&"homeboy runner exec homeboy-lab -- homeboy upgrade --no-restart".to_string()));
+        .contains(&"homeboy runner refresh-homeboy homeboy-lab --reconnect".to_string()));
     assert!(skipped[0]
         .detail
         .contains("runner version check: local/current"));
@@ -271,9 +271,60 @@ fn fails_when_configured_runner_path_remains_older_than_local_after_successful_u
     assert!(skipped[0].detail.contains("runner after 0.0.1"));
     assert!(skipped[0]
         .detail
-        .contains("homeboy runner exec homeboy-lab -- homeboy upgrade --no-restart"));
+        .contains("homeboy upgrade --force --upgrade-runner homeboy-lab"));
     assert_eq!(commands[1][0], "/home/user/.cargo/bin/homeboy");
     assert!(commands[1].contains(&"--force".to_string()));
+}
+
+#[test]
+fn binary_store_source_pin_realigns_to_materialized_controller_binary() {
+    let source_dir = git_source_checkout();
+    let expected_identity = source_checkout_build_identity(source_dir.path()).unwrap();
+    let stale_path =
+        "/home/user/Developer/_homeboy_binaries/homeboy-2f9a1eb64e0bb84d/target/release/homeboy";
+    let remote_source = "/home/user/Developer/_homeboy_binaries/homeboy-current";
+    let selected_binary = format!("{remote_source}/target/release/homeboy");
+    let runner = ssh_runner("lab", Some(stale_path));
+    let mut commands = Vec::new();
+    let mut updates = Vec::new();
+
+    let (updated, skipped) = upgrade_runners_with_executor_source_materializer_and_path_updater(
+        &[runner],
+        true,
+        Some(InstallMethod::Source),
+        Some(source_dir.path()),
+        &[],
+        |runner_id, options| {
+            commands.push(options.command.clone());
+            let (stdout, code) = match commands.len() {
+                1 => (format!("homeboy {}+stale\n", current_version()), 0),
+                2 => ("prepared\n".to_string(), 0),
+                3 => ("{\"success\":true}\n".to_string(), 0),
+                4 | 5 => (format!("homeboy {}+stale\n", current_version()), 0),
+                6 => (format!("homeboy {}\n", current_version()), 0),
+                7..=10 => (format!("{expected_identity}\n"), 0),
+                _ => (String::new(), 1),
+            };
+            Ok((
+                exec_output(runner_id, options.command, &stdout, "", code),
+                code,
+            ))
+        },
+        runner_status,
+        |_runner, _path| Ok(remote_source.to_string()),
+        |runner_id, path| {
+            updates.push((runner_id.to_string(), path.to_string()));
+            Ok(())
+        },
+    );
+
+    assert!(skipped.is_empty());
+    assert_eq!(updated[0].homeboy_path, selected_binary);
+    assert_eq!(updates, vec![("lab".to_string(), selected_binary)]);
+    assert!(is_homeboy_source_build_path(stale_path));
+    assert!(!commands
+        .iter()
+        .any(|command| command.first() == Some(&"homeboy".to_string())));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -232,11 +232,26 @@ fn fails_when_managed_bare_homeboy_repair_leaves_path_drift() {
         .contains("managed PATH-visible `homeboy` repair left bare `homeboy` at 0.228.4"));
     assert!(skipped[0]
         .recovery_commands
-        .contains(&"homeboy upgrade --force --upgrade-runner lab".to_string()));
+        .contains(&"homeboy runner refresh-homeboy lab --reconnect".to_string()));
     assert!(skipped[0]
         .detail
         .contains("managed PATH-visible `homeboy` repair completed"));
     assert!(skipped[0].detail.contains("runner PATH drift detected"));
+}
+
+#[test]
+fn recovery_never_emits_bare_homeboy_for_a_selected_binary() {
+    let commands = runner_upgrade_recovery_commands(
+        "homeboy-lab",
+        "/home/user/Developer/_homeboy_binaries/homeboy-current/target/release/homeboy",
+    );
+
+    assert!(commands
+        .iter()
+        .any(|command| command.contains("target/release/homeboy upgrade")));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("-- homeboy upgrade")));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -255,6 +255,95 @@ fn recovery_never_emits_bare_homeboy_for_a_selected_binary() {
 }
 
 #[test]
+fn source_recovery_rejects_mismatched_bare_identity_without_mutating_config() {
+    let runner = ssh_runner(
+        "lab",
+        Some("/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy"),
+    );
+    let mut updates = Vec::new();
+    let mut calls = 0;
+
+    let result = recover_runner_homeboy_path_after_failed_upgrade(
+        &runner,
+        runner.settings.homeboy_path.as_deref().unwrap(),
+        Some("0.228.4"),
+        Some("homeboy 0.228.5+selected"),
+        &mut |runner_id, path| {
+            updates.push((runner_id.to_string(), path.to_string()));
+            Ok(())
+        },
+        &mut |runner_id, options| {
+            calls += 1;
+            let stdout = match calls {
+                1 => "homeboy 0.228.5\n",
+                2 => "homeboy 0.228.5+shadowed\n",
+                _ => panic!("unexpected command: {:?}", options.command),
+            };
+            Ok((exec_output(runner_id, options.command, stdout, "", 0), 0))
+        },
+    );
+
+    let error = result.err().expect("mismatched identity is rejected");
+    assert!(error.contains("expected controller identity"));
+    assert!(updates.is_empty());
+}
+
+#[test]
+fn source_recovery_rejects_unverifiable_bare_identity_without_mutating_config() {
+    let runner = ssh_runner(
+        "lab",
+        Some("/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy"),
+    );
+    let mut updates = Vec::new();
+    let mut calls = 0;
+
+    let result = recover_runner_homeboy_path_after_failed_upgrade(
+        &runner,
+        runner.settings.homeboy_path.as_deref().unwrap(),
+        Some("0.228.4"),
+        Some("homeboy 0.228.5+selected"),
+        &mut |runner_id, path| {
+            updates.push((runner_id.to_string(), path.to_string()));
+            Ok(())
+        },
+        &mut |runner_id, options| {
+            calls += 1;
+            let (stdout, exit_code) = match calls {
+                1 => ("homeboy 0.228.5\n", 0),
+                2 => ("", 1),
+                _ => panic!("unexpected command: {:?}", options.command),
+            };
+            Ok((
+                exec_output(runner_id, options.command, stdout, "", exit_code),
+                exit_code,
+            ))
+        },
+    );
+
+    let error = result.err().expect("unverifiable identity is rejected");
+    assert!(error.contains("unverifiable build identity"));
+    assert!(updates.is_empty());
+}
+
+#[test]
+fn source_drift_recovery_retains_selected_immutable_revision() {
+    let revision = "a".repeat(40);
+    let commands = runner_recovery_commands(
+        "lab",
+        "/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy",
+        Some(&"identity mismatch".to_string()),
+        Some("0.228.4"),
+        Some("0.228.5"),
+        Some(&revision),
+    );
+
+    assert_eq!(
+        commands[0],
+        format!("homeboy runner refresh-homeboy lab --ref {revision} --reconnect")
+    );
+}
+
+#[test]
 fn realigns_stale_source_checkout_homeboy_path_after_upgrade_failure() {
     let _local_version = pin_local_version_for_fixtures();
     let stale_path = "/home/user/Developer/homeboy@upgrade-bootstrap/target/release/homeboy";

--- a/crates/homeboy-lab-runner/src/upgrade_runners/version.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/version.rs
@@ -103,7 +103,7 @@ pub fn runner_local_version_drift(
     Some(format!(
         "configured runner executable `{homeboy_path}` reports {runner_version}, but local/current reports {local_version}; runner before was {}; remediate with `{}`",
         previous_version.unwrap_or("unknown"),
-        runner_upgrade_recovery_commands(runner_id)[0]
+        runner_upgrade_recovery_commands(runner_id, homeboy_path)[0]
     ))
 }
 

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -277,6 +277,9 @@ pub fn run_upgrade_with_method(
                 new_build_identity: None,
                 source_revision: None,
                 upgraded: false,
+                controller: Some(component_status("unchanged", "controller already current")),
+                extensions: Some(extension_component_status(&extensions_updated, &extensions_skipped)),
+                runners: Some(runner_component_status(runner_disposition, &runners_updated, &runners_skipped)),
                 partial,
                 runner_convergence: Some(runner_disposition),
                 message: match runner_disposition {
@@ -376,6 +379,23 @@ pub fn run_upgrade_with_method(
         new_build_identity: new_build_identity.clone(),
         source_revision,
         upgraded: success,
+        controller: Some(component_status(
+            if success { "updated" } else { "failed" },
+            if success {
+                "controller installation completed"
+            } else {
+                "controller installation did not complete"
+            },
+        )),
+        extensions: Some(extension_component_status(
+            &extensions_updated,
+            &extensions_skipped,
+        )),
+        runners: Some(runner_component_status(
+            runner_disposition,
+            &runners_updated,
+            &runners_skipped,
+        )),
         partial: runner_convergence_failed(
             &runners_updated,
             &runners_skipped,
@@ -419,6 +439,12 @@ fn source_upgrade_noop_result(
         new_build_identity: None,
         source_revision: None,
         upgraded: false,
+        controller: Some(component_status("unchanged", "controller was not promoted")),
+        extensions: Some(component_status("skipped", "extensions were not refreshed")),
+        runners: Some(component_status(
+            "not_run",
+            "runner convergence was not attempted",
+        )),
         partial: false,
         // No upgrade occurred, so there is no runner-convergence claim to make.
         runner_convergence: None,
@@ -497,6 +523,24 @@ fn run_targeted_runner_upgrade(
         new_build_identity: Some(previous_build_identity),
         source_revision: None,
         upgraded: false,
+        controller: Some(component_status(
+            "unchanged",
+            "targeted runner operation did not promote controller",
+        )),
+        extensions: Some(component_status(
+            "skipped",
+            "controller extensions were not refreshed",
+        )),
+        runners: Some(runner_component_status(
+            runner_convergence_disposition(
+                false,
+                &runners_updated,
+                &runners_skipped,
+                Some(previous_version.as_str()),
+            ),
+            &runners_updated,
+            &runners_skipped,
+        )),
         partial: runner_convergence_failed(
             &runners_updated,
             &runners_skipped,
@@ -525,6 +569,49 @@ fn run_targeted_runner_upgrade(
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
     })
+}
+
+fn component_status(status: &str, summary: &str) -> UpgradeComponentStatus {
+    UpgradeComponentStatus {
+        status: status.to_string(),
+        summary: summary.to_string(),
+    }
+}
+
+fn extension_component_status(
+    updated: &[ExtensionUpgradeEntry],
+    skipped: &[String],
+) -> UpgradeComponentStatus {
+    let status = if skipped.is_empty() {
+        "completed"
+    } else {
+        "partial"
+    };
+    component_status(
+        status,
+        &format!("{} updated, {} skipped", updated.len(), skipped.len()),
+    )
+}
+
+fn runner_component_status(
+    disposition: RunnerConvergenceDisposition,
+    updated: &[RunnerUpgradeEntry],
+    skipped: &[RunnerUpgradeEntry],
+) -> UpgradeComponentStatus {
+    let status = match disposition {
+        RunnerConvergenceDisposition::Converged => "converged",
+        RunnerConvergenceDisposition::Partial => "partial",
+        RunnerConvergenceDisposition::Skipped => "skipped",
+        RunnerConvergenceDisposition::NoRunnersConfigured => "not_configured",
+    };
+    component_status(
+        status,
+        &format!(
+            "{} converged, {} require repair",
+            updated.len(),
+            skipped.len()
+        ),
+    )
 }
 
 fn runner_convergence_failed(

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -278,7 +278,7 @@ pub fn run_upgrade_with_method(
                 source_revision: None,
                 upgraded: false,
                 controller: Some(component_status("unchanged", "controller already current")),
-                extensions: Some(extension_component_status(&extensions_updated, &extensions_skipped)),
+                extensions: Some(extension_component_status(!skip_extensions, skip_extensions, &extensions_updated, &extensions_skipped)),
                 runners: Some(runner_component_status(runner_disposition, &runners_updated, &runners_skipped)),
                 partial,
                 runner_convergence: Some(runner_disposition),
@@ -388,6 +388,8 @@ pub fn run_upgrade_with_method(
             },
         )),
         extensions: Some(extension_component_status(
+            upgrade_completed,
+            skip_extensions,
             &extensions_updated,
             &extensions_skipped,
         )),
@@ -579,10 +581,16 @@ fn component_status(status: &str, summary: &str) -> UpgradeComponentStatus {
 }
 
 fn extension_component_status(
+    attempted: bool,
+    skipped_by_flag: bool,
     updated: &[ExtensionUpgradeEntry],
     skipped: &[String],
 ) -> UpgradeComponentStatus {
-    let status = if skipped.is_empty() {
+    let status = if skipped_by_flag {
+        "skipped"
+    } else if !attempted {
+        "not_run"
+    } else if skipped.is_empty() {
         "completed"
     } else {
         "partial"
@@ -2023,6 +2031,22 @@ mod convergence_tests {
         runner.success = false;
 
         assert!(runner_convergence_failed(&[], &[runner], None));
+    }
+
+    #[test]
+    fn extension_status_distinguishes_skipped_and_not_run() {
+        assert_eq!(
+            extension_component_status(false, true, &[], &[]).status,
+            "skipped"
+        );
+        assert_eq!(
+            extension_component_status(false, false, &[], &[]).status,
+            "not_run"
+        );
+        assert_eq!(
+            extension_component_status(true, false, &[], &[]).status,
+            "completed"
+        );
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use runner_upgrade_provider::with_runner_upgrade;
 pub use runner_upgrade_provider::{register_runner_upgrade_provider, RunnerUpgradeProvider};
 pub use types::{
     ExtensionUpgradeEntry, InstallMethod, RunnerDaemonDriftEntry, RunnerExtensionSyncEntry,
-    RunnerUpgradeEntry, ServiceRestartEntry, UpgradeResult, VersionCheck,
+    RunnerUpgradeEntry, ServiceRestartEntry, UpgradeComponentStatus, UpgradeResult, VersionCheck,
 };
 pub use validation::check_for_updates;
 

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -85,6 +85,16 @@ pub struct UpgradeResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
     pub upgraded: bool,
+    /// Independent controller mutation outcome. Additive so persisted and
+    /// older callers can continue using `upgraded` and `partial` unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controller: Option<UpgradeComponentStatus>,
+    /// Independent extension refresh outcome.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<UpgradeComponentStatus>,
+    /// Independent configured-runner convergence outcome.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runners: Option<UpgradeComponentStatus>,
     /// True when a requested controller/runner fleet upgrade could not fully
     /// converge. Omitted for successful responses so existing consumers keep
     /// their current payload shape; accepted when reading persisted responses.
@@ -121,6 +131,14 @@ pub struct UpgradeResult {
     /// exact recovery command so the operator can restart it manually.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub services_pending_restart: Vec<ServiceRestartEntry>,
+}
+
+/// Compact named outcome for one upgrade dimension. Detailed build output stays
+/// in the existing per-runner evidence fields rather than obscuring the result.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpgradeComponentStatus {
+    pub status: String,
+    pub summary: String,
 }
 
 /// Outcome of attempting to restart one declared binary-resident service after


### PR DESCRIPTION
## Summary
- Recognize `_homeboy_binaries/homeboy-<hash>/target/{debug,release}/homeboy` source-build pins and realign them to the materialized controller binary after identity verification.
- Bind every source recovery path to selected provenance: use remote URL plus immutable full `HEAD` SHA where available, or a verified materialized runner binary for local-only and snapshot sources.
- Validate PATH-visible build identity before persisting a runner `homeboy_path`, and replace ambiguous nested bare-PATH remediation with selected absolute executables.
- Add additive `controller`, `extensions`, and `runners` component statuses to upgrade results while retaining existing fields and old-response deserialization compatibility. Blocked runner work reports `not_run`.

Closes #10787
Closes #10788
Closes #10789

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner upgrade_runners::tests --lib` (37 passed)
- `cargo test -p homeboy-upgrade --lib` (123 passed)
- `cargo test -p homeboy-cli commands::upgrade::tests --lib` (6 passed)

## AI assistance
- AI assistance: Yes
- Tool: OpenCode
- Model: OpenAI `gpt-5.6-terra`
- Used for: investigating the runner upgrade identity loop, implementing the convergence and result-contract changes, responding to independent review, adding deterministic tests, and preparing this PR.
- Chris Huber remains responsible for every line.