### PR TITLE
Retain extension test artifacts for result parsing

### DIFF
--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -1,4 +1,5 @@
-use std::path::{Path, PathBuf};
+use std::io;
+use std::path::{Component as PathComponent, Path, PathBuf};
 use std::time::Duration;
 
 use crate::{ExtensionCapability, ExtensionPhaseTiming};
@@ -332,7 +333,15 @@ impl ExtensionRunner {
         if let (Some(run_dir_path), Some(invocation)) = (&self.run_dir_path, invocation.as_ref()) {
             let run_dir =
                 homeboy_core::engine::run_dir::RunDir::from_existing(run_dir_path.clone())?;
-            invocation.preserve_artifacts(&run_dir)?;
+            if let Some(artifacts) = invocation.preserve_artifacts(&run_dir)? {
+                materialize_reported_test_artifacts(
+                    self.execution_context.capability,
+                    &artifacts,
+                    &run_dir,
+                    &output.stdout,
+                    &output.stderr,
+                )?;
+            }
         }
 
         Ok(RunnerOutput {
@@ -435,6 +444,145 @@ impl ExtensionRunner {
         }
         command
     }
+}
+
+fn materialize_reported_test_artifacts(
+    capability: ExtensionCapability,
+    artifact_root: &Path,
+    run_dir: &RunDir,
+    stdout: &str,
+    stderr: &str,
+) -> Result<()> {
+    if capability != ExtensionCapability::Test {
+        return Ok(());
+    }
+
+    let manifest = homeboy_core::artifact_manifest::read_manifest_from_root(artifact_root)?;
+    let locator = regex::Regex::new(r"artifact://files/[A-Za-z0-9._/-]+")
+        .expect("artifact locator regex is valid");
+    let mut reported = std::collections::BTreeSet::new();
+    for value in [stdout, stderr] {
+        for candidate in locator.find_iter(value).map(|matched| matched.as_str()) {
+            let relative = candidate.trim_start_matches("artifact://files/");
+            let path = Path::new(relative);
+            if !path.as_os_str().is_empty()
+                && !path.is_absolute()
+                && path
+                    .components()
+                    .all(|component| matches!(component, PathComponent::Normal(_)))
+            {
+                reported.insert(path.to_path_buf());
+            }
+        }
+    }
+
+    for relative in reported.into_iter().take(32) {
+        let manifest_suffix = Path::new("files").join(&relative);
+        let suffix_matches = manifest
+            .artifacts
+            .iter()
+            .filter(|entry| Path::new(&entry.path).ends_with(&manifest_suffix))
+            .collect::<Vec<_>>();
+        let relative_id = relative.to_string_lossy();
+        let id_matches = suffix_matches
+            .iter()
+            .filter(|entry| entry.id.as_deref() == Some(relative_id.as_ref()))
+            .copied()
+            .collect::<Vec<_>>();
+        let entry = match (id_matches.as_slice(), suffix_matches.as_slice()) {
+            ([entry], _) => *entry,
+            ([], [entry]) => *entry,
+            ([], []) => continue,
+            _ => {
+                return Err(Error::validation_invalid_argument(
+                    "artifact",
+                    "reported test artifact matches multiple registered invocation artifacts",
+                    Some(format!("artifact://files/{}", relative.display())),
+                    None,
+                ));
+            }
+        };
+
+        let source = artifact_root.join(&entry.path);
+        let destination = run_dir.path().join("files").join(&relative);
+        if destination.exists() {
+            continue;
+        }
+        let parent = destination
+            .parent()
+            .expect("artifact destination has parent");
+        std::fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "create test artifact directory {}",
+                    parent.display()
+                )),
+            )
+        })?;
+        let canonical_run_dir = std::fs::canonicalize(run_dir.path()).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("resolve test run directory".to_string()),
+            )
+        })?;
+        let canonical_parent = std::fs::canonicalize(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "resolve test artifact directory {}",
+                    parent.display()
+                )),
+            )
+        })?;
+        if !canonical_parent.starts_with(&canonical_run_dir) {
+            return Err(Error::validation_invalid_argument(
+                "artifact",
+                "test artifact destination escapes its run directory",
+                Some(destination.display().to_string()),
+                None,
+            ));
+        }
+
+        let temporary = parent.join(format!(".homeboy-artifact-{}.tmp", uuid::Uuid::new_v4()));
+        let mut input = std::fs::File::open(&source).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "open registered test artifact {}",
+                    source.display()
+                )),
+            )
+        })?;
+        let mut output = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("create test artifact {}", temporary.display())),
+                )
+            })?;
+        if let Err(error) = io::copy(&mut input, &mut output) {
+            let _ = std::fs::remove_file(&temporary);
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "copy registered test artifact {}",
+                    source.display()
+                )),
+            ));
+        }
+        std::fs::rename(&temporary, &destination).map_err(|error| {
+            let _ = std::fs::remove_file(&temporary);
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("publish test artifact {}", destination.display())),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 fn redact_runner_output(

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -991,8 +991,11 @@ fn run_declared_result_parser(
     })?;
 
     let results_file = run_dir.step_file(run_dir::files::TEST_RESULTS);
+    let provider_results_file = run_dir.path().join("files/test-results.json");
     let source_file = if results_file.is_file() {
         results_file
+    } else if provider_results_file.is_file() {
+        provider_results_file
     } else {
         let stdout_file = run_dir.path().join("test-output.txt");
         if let Some(parent) = stdout_file.parent() {

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -456,6 +456,87 @@ homeboy_write_test_results 2 2 0 0
 }
 
 #[test]
+fn nested_runner_artifact_handoff_supplies_declared_parser() {
+    with_isolated_home(|home| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+  "id": "fixture",
+  "extensions": { "fixture-extension": {} }
+}"#,
+        )
+        .expect("homeboy.json should be written");
+
+        let extension_dir = home
+            .path()
+            .join(".config/homeboy/extensions/fixture-extension");
+        fs::create_dir_all(&extension_dir).expect("extension dir should be created");
+        fs::write(
+            extension_dir.join("fixture-extension.json"),
+            r#"{
+  "name": "Fixture extension",
+  "version": "1.0.0",
+  "test": {
+    "extension_script": "test.sh",
+    "result_parse": { "extension_script": "parse-results.sh", "adapters": ["provider-json"] }
+  }
+}"#,
+        )
+        .expect("extension manifest should be written");
+        let extension_script = extension_dir.join("test.sh");
+        fs::write(
+            &extension_script,
+            r#"#!/bin/sh
+set -eu
+root="$HOMEBOY_INVOCATION_ARTIFACT_DIR"
+mkdir -p "$root/nested/files" "$root/decoy/files"
+printf '{"schema":"provider/test-results/v1","summary":{"total":3,"passed":3,"failed":0,"skipped":0}}\n' > "$root/nested/files/test-results.json"
+printf '{"schema":"provider/test-results/v1","summary":{"total":1,"passed":0,"failed":1,"skipped":0}}\n' > "$root/decoy/files/test-results.json"
+printf 'passing provider output\n' > "$root/nested/files/phpunit-output.log"
+printf '{"schema":"homeboy/artifact-manifest/v1","artifacts":[{"id":"test-results.json","path":"nested/files/test-results.json","kind":"test-results","semantic_key":"test_results"},{"id":"decoy-results.json","path":"decoy/files/test-results.json","kind":"test-results"},{"id":"phpunit-output.log","path":"nested/files/phpunit-output.log","kind":"phpunit-output","semantic_key":"phpunit_output"}]}\n' > "$root/homeboy-artifact-manifest.json"
+printf 'artifact://files/test-results.json artifact://files/phpunit-output.log\n'
+"#,
+        )
+        .expect("extension script should be written");
+        let parser_script = extension_dir.join("parse-results.sh");
+        fs::write(
+            &parser_script,
+            r#"#!/bin/sh
+set -eu
+test "${2:-}" = provider-json
+grep -q 'provider/test-results/v1' "$1"
+source "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS"
+homeboy_write_test_results 3 3 0 0
+"#,
+        )
+        .expect("parser script should be written");
+        for script in [&extension_script, &parser_script] {
+            let mut perms = fs::metadata(script).expect("script metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(script, perms).expect("script should be executable");
+        }
+
+        let (output, exit_code) =
+            run_test(test_command_args(dir.path())).expect("extension test should run");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.passed);
+        assert_eq!(output.test_counts.expect("test counts").passed, 3);
+        let artifacts = output
+            .extension_phase_timings
+            .iter()
+            .flat_map(|timing| timing.artifacts.iter())
+            .collect::<Vec<_>>();
+        assert_eq!(artifacts.len(), 2);
+        assert!(artifacts.iter().all(|artifact| artifact
+            .get("available")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)));
+    });
+}
+
+#[test]
 fn changed_wordpress_php_smoke_test_executes_with_generic_result_adapter() {
     with_isolated_home(|home| {
         let dir = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
## Summary

- preserve provider-reported test artifacts from the invocation artifact manifest in the run-scoped `files` namespace
- feed the preserved structured result into the declared result parser before stdout fallback
- keep direct canonical sidecars authoritative and fail closed for missing, ambiguous, or escaping artifact paths

## Production evidence

Static Site Importer run https://github.com/Automattic/static-site-importer/actions/runs/30420379059 attempt 3 proves the released `v0.322.1` path still loses `artifact://files/test-results.json` and `artifact://files/phpunit-output.log` after the WP Codebox runner exits successfully. All PHP 8.1-8.4 lanes finish with null test counts and unavailable controller-local artifacts.

This repair is bounded to test-capability artifacts that are both explicitly reported with `artifact://files/...` and registered in the validated invocation artifact manifest. Unreported artifacts and other capabilities retain existing behavior. Manifest IDs disambiguate duplicate basenames, and materialization is capped at the same 32 locators accepted by the evidence collector.

## Verification

- `cargo test -p homeboy-cli component_script_test -- --nocapture` (17 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

The regression models nested structured results and raw test output, duplicate result basenames, canonical parser normalization, and reviewer-facing artifact availability.

Closes #10528.

## AI assistance

OpenCode with `openai/gpt-5.6-sol` and Homeboy agent-task with `openai/gpt-5.6-terra` traced the production artifact handoff, drafted and reviewed the generic runtime repair, and produced the regression coverage. Chris Huber reviewed and remains responsible for the change.