### PR TITLE
fix(audit): stop trailing comments from hiding every later symbol

### DIFF
--- a/crates/homeboy-engine-primitives/src/grammar/mod.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/mod.rs
@@ -328,6 +328,56 @@ mod tests {
         assert_eq!(lines[1].depth, 0);
     }
 
+    /// A trailing line comment containing an apostrophe must not open a string
+    /// region that swallows every following symbol (#10362).
+    #[test]
+    fn trailing_comment_apostrophe_does_not_hide_later_methods() {
+        let content = "<?php\nclass A {\n    public function registerCallback(): void {\n        $s = [\n            'properties' => [\n                'title' => [ 'type' => 'string' ], // the post's title\n            ],\n        ];\n    }\n    public function execute(): void {}\n}\n";
+        let grammar = php_grammar();
+
+        assert_eq!(
+            method_names(&extract(content, &grammar)),
+            vec!["registerCallback", "execute"]
+        );
+    }
+
+    /// PHP `#` comments have the same hazard as `//`.
+    #[test]
+    fn trailing_hash_comment_apostrophe_does_not_hide_later_methods() {
+        let content = "<?php\nclass A {\n    public function first(): void {\n        $x = 1; # don't do this\n    }\n    public function execute(): void {}\n}\n";
+        let grammar = php_grammar();
+
+        assert_eq!(
+            method_names(&extract(content, &grammar)),
+            vec!["first", "execute"]
+        );
+    }
+
+    /// A brace in comment prose is not structure, so it must not shift depth.
+    #[test]
+    fn trailing_comment_brace_does_not_shift_block_depth() {
+        let content = "<?php\nclass A {\n    public function first(): void {\n        $x = 1; // open { but never close\n    }\n    public function execute(): void {}\n}\n";
+        let grammar = php_grammar();
+
+        assert_eq!(
+            method_names(&extract(content, &grammar)),
+            vec!["first", "execute"]
+        );
+    }
+
+    /// A comment marker inside a string is not a comment, so the string must
+    /// still be scanned for real unclosed quotes.
+    #[test]
+    fn comment_marker_inside_a_string_is_not_treated_as_a_comment() {
+        let content = "<?php\nclass A {\n    public function first(): void {\n        $url = 'https://example.test/#frag';\n    }\n    public function execute(): void {}\n}\n";
+        let grammar = php_grammar();
+
+        assert_eq!(
+            method_names(&extract(content, &grammar)),
+            vec!["first", "execute"]
+        );
+    }
+
     #[test]
     fn php_hash_comments() {
         let content = "<?php\n# this is a comment\n$x = 1;\n";

--- a/crates/homeboy-engine-primitives/src/grammar/parser.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/parser.rs
@@ -3,6 +3,7 @@
 //! Walks source line-by-line tracking brace depth and whether the cursor is
 //! inside comments or strings. Consumers filter lines by depth/region.
 
+use super::strings::code_before_line_comment;
 use super::types::{BlockSyntax, CommentSyntax, Grammar, StringSyntax};
 use super::{
     find_unclosed_raw_string_on_line, line_closes_regular_string, unclosed_regular_string_quote,
@@ -170,12 +171,17 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
             if in_block_comment {
                 Region::BlockComment
             } else {
+                // Scan only the code portion: a trailing `// the post's title`
+                // must not open a single-quoted string that swallows every
+                // following line (#10362).
+                let code =
+                    code_before_line_comment(line, &grammar.comments.line, &quote_chars, escape);
                 // Check for multi-line raw string opening.
-                if let Some(close) = find_unclosed_raw_string_on_line(line) {
+                if let Some(close) = find_unclosed_raw_string_on_line(code) {
                     in_raw_string = true;
                     raw_string_close = close;
                 } else if let Some(quote) =
-                    unclosed_regular_string_quote(line, &quote_chars, escape)
+                    unclosed_regular_string_quote(code, &quote_chars, escape)
                 {
                     regular_string_quote = Some(quote);
                 }
@@ -185,9 +191,11 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
             }
         };
 
-        // Track brace depth for code lines
+        // Track brace depth for code lines. Braces inside a trailing comment
+        // are prose, not structure (#10362).
         if region == Region::Code {
-            update_depth(line, &grammar.blocks, &grammar.strings, &mut ctx);
+            let code = code_before_line_comment(line, &grammar.comments.line, &quote_chars, escape);
+            update_depth(code, &grammar.blocks, &grammar.strings, &mut ctx);
         }
 
         result.push(ContextualLine {

--- a/crates/homeboy-engine-primitives/src/grammar/strings.rs
+++ b/crates/homeboy-engine-primitives/src/grammar/strings.rs
@@ -114,3 +114,45 @@ fn is_escaped_with(bytes: &[u8], pos: usize, escape: u8) -> bool {
 
     backslashes % 2 == 1
 }
+
+/// Return the code portion of a line, excluding any trailing line comment.
+///
+/// String-aware: a comment marker inside a string literal (`"http://x"`,
+/// `['#fff']`) does not start a comment.
+///
+/// This exists because quote and brace scanning must not read comment prose as
+/// code. A trailing `// the post's title` otherwise opens a single-quoted string
+/// that never closes, and every following line is misclassified as string
+/// content — silently dropping every symbol after it (#10362).
+pub(crate) fn code_before_line_comment<'a>(
+    line: &'a str,
+    line_comment_markers: &[String],
+    quote_chars: &[char],
+    escape: char,
+) -> &'a str {
+    if line_comment_markers.is_empty() {
+        return line;
+    }
+    let bytes = line.as_bytes();
+    let mut active_quote: Option<char> = None;
+
+    for (index, ch) in line.char_indices() {
+        if quote_chars.contains(&ch) && !is_escaped_with(bytes, index, escape as u8) {
+            match active_quote {
+                Some(open) if open == ch => active_quote = None,
+                None => active_quote = Some(ch),
+                Some(_) => {}
+            }
+            continue;
+        }
+        if active_quote.is_none()
+            && line_comment_markers
+                .iter()
+                .any(|marker| line[index..].starts_with(marker.as_str()))
+        {
+            return &line[..index];
+        }
+    }
+
+    line
+}


### PR DESCRIPTION
Closes #10362.

## Root cause

Not a nesting-depth limit. The grammar walker scanned the **raw line** for unclosed string quotes and for brace depth, without excluding a trailing line comment.

```php
'title' => [ 'type' => 'string' ], // the post's title
```

The apostrophe in `post's` opens a single-quoted string that never closes. `walk_lines` then classifies every following line as `Region::StringLiteral` until something happens to contain another `'`. Every symbol after that point is dropped.

That is exactly the reported shape: the detector recognised the methods **before** `registerCallback()` and reported `execute()` as absent. The deeply nested `output_schema` array was incidental — it was the trailing comment inside it that did the damage.

The same gap let a brace in comment prose shift block depth:

```rust
let x = 1; // open { but never close
```

## Reproduction

Confirmed against the PHP grammar before the fix — `execute` is missing in three of four cases:

```
trailing-comment-apostrophe:    ["first"]                  <- expected first, execute
nested-array-trailing-comment:  ["registerCallback"]       <- expected registerCallback, execute
hash-trailing-comment:          ["first"]                  <- expected first, execute
comment-marker-inside-string:   ["first", "execute"]       ok
```

After the fix all four return both methods.

## Fix

A string-aware `code_before_line_comment` in `grammar/strings.rs`; `walk_lines` scans only the code portion for both unclosed quotes and brace depth. A comment marker inside a string literal (`'https://example.test/#frag'`, `"http://x"`, `['#fff']`) is still not a comment.

## Blast radius — please read

**This is language-agnostic.** PHP `//` and `#`, and Rust `//`, were all affected. In this repository alone:

- **166** `.rs` files have code followed by a trailing comment containing `{` or `}`
- **33** have code followed by a trailing comment containing an apostrophe

Those files were previously parsed with corrupted depth or truncated symbol lists, so the audit will now see them correctly. **That may move the audit baseline**, in either direction — previously-hidden symbols can introduce findings, and previously-misattributed depth can remove them.

I could not evaluate the repo-wide audit locally without a full build. If the Audit gate reports drift, the regenerated baseline is uploaded as an artifact by the existing workflow and I will land it as a follow-up commit rather than suppressing the finding.

## Verification

`cargo fmt --check`; `cargo check --workspace --tests` exit 0; `cargo test -p homeboy-code-audit --lib` → **864 passed, 0 failed**; `cargo test -p homeboy-engine-primitives --lib grammar` → **47 passed**.

## Out of scope

PHP heredoc/nowdoc bodies are still unmodeled (`strings.multiline` is empty for PHP), so a heredoc containing an apostrophe can still hide later symbols. Distinct gap, worth its own issue.

## Pre-existing failure (NOT from this PR)

`homeboy-engine-primitives measurement::measurement_registry_test::every_gate_layer_decision_declares_how_it_established_measurement` is red on unmodified `main` with my changes stashed. Notable given #10747 just extended that registry for #10741.

---
�� Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
