### PR TITLE
fix(deploy): detect managed roots before payload binding

### DIFF
--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -120,12 +120,36 @@ fn preflight_prepared_payload_binding(
             )
         })
         .collect::<Result<Vec<_>>>()?;
-    binding::bind_project_payloads(
+    let payloads =
+        std::collections::HashMap::from([(artifact.component_id.clone(), artifact.clone())]);
+    match binding::bind_project_payloads(project, &base_path, &components, &payloads) {
+        Ok(_) => return Ok(()),
+        Err(error)
+            if error
+                .details
+                .get("field")
+                .and_then(serde_json::Value::as_str)
+                == Some("remotePath")
+                && error
+                    .details
+                    .get("problem")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|problem| problem.contains("requires path_root")) =>
+        {
+            // Detector-backed roots require read-only remote inspection before binding.
+        }
+        Err(error) => return Err(error),
+    }
+
+    let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
+    let project = path_roots::project_with_detected_path_roots(
         project,
-        &base_path,
         &components,
-        &std::collections::HashMap::from([(artifact.component_id.clone(), artifact.clone())]),
-    )?;
+        &base_path,
+        &ctx.client,
+        "deploy",
+    );
+    binding::bind_project_payloads(&project, &base_path, &components, &payloads)?;
     Ok(())
 }
 
@@ -518,8 +542,12 @@ pub fn resolve_shared_targets(component_ids: &[String]) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_core::component::{Component, ScopedExtensionConfig};
     use homeboy_core::project::{Project, ProjectComponentAttachment};
+    use homeboy_core::server::{self, Server};
     use homeboy_core::test_support::with_isolated_home;
+    use homeboy_extension::{DeployCapability, ExtensionManifest, RemotePathRootRule};
+    use std::collections::{BTreeMap, HashMap};
     use std::path::Path;
 
     fn deploy_config() -> DeployConfig {
@@ -610,6 +638,98 @@ mod tests {
                 error.details.to_string().contains("prepared-artifact.zip"),
                 "prepared artifact validation must fail before SSH resolution: {error:?}"
             );
+        });
+    }
+
+    #[test]
+    fn prepared_payload_preflight_detects_managed_path_roots() {
+        with_isolated_home(|home| {
+            let base_path = home.path().join("runtime");
+            std::fs::create_dir_all(&base_path).expect("runtime root");
+            let managed_root = base_path.join("wp-content");
+            homeboy_extension::save_manifest(&ExtensionManifest {
+                id: "managed-paths".to_string(),
+                name: "Managed Paths".to_string(),
+                version: "1.0.0".to_string(),
+                deploy: Some(DeployCapability {
+                    verifications: Vec::new(),
+                    overrides: Vec::new(),
+                    protected_path_suffixes: Vec::new(),
+                    owner_hints: Vec::new(),
+                    archive_install: Vec::new(),
+                    remote_path_inference: Vec::new(),
+                    path_roots: vec![RemotePathRootRule {
+                        path_prefix: "wp-content".to_string(),
+                        root: "wp_content".to_string(),
+                        strip_prefix: true,
+                        detect_command: Some(format!("printf {}", managed_root.to_string_lossy())),
+                    }],
+                    version_patterns: Vec::new(),
+                    since_tag: None,
+                }),
+                ..serde_json::from_value(serde_json::json!({
+                    "name": "Managed Paths",
+                    "version": "1.0.0"
+                }))
+                .expect("extension manifest")
+            })
+            .expect("save extension");
+            server::save(&Server {
+                id: "local".to_string(),
+                host: "localhost".to_string(),
+                user: "test".to_string(),
+                port: 22,
+                identity_file: None,
+                aliases: vec![],
+                kind: None,
+                auth: None,
+                env: Default::default(),
+                runner: None,
+            })
+            .expect("save local server");
+            let project = Project {
+                id: "site".to_string(),
+                server_id: Some("local".to_string()),
+                base_path: Some(base_path.display().to_string()),
+                components: vec![ProjectComponentAttachment {
+                    id: "plugin".to_string(),
+                    local_path: "/stale/plugin".to_string(),
+                    remote_path: Some("../wp-content/plugins/plugin".to_string()),
+                    deployment_provider: None,
+                }],
+                ..Project::default()
+            };
+            project::save(&project).expect("save project");
+            let component = Component {
+                id: "plugin".to_string(),
+                local_path: "/release/plugin".to_string(),
+                remote_path: "../wp-content/plugins/plugin".to_string(),
+                extensions: Some(HashMap::from([(
+                    "managed-paths".to_string(),
+                    ScopedExtensionConfig::default(),
+                )])),
+                ..Default::default()
+            };
+            let config = DeployConfig {
+                expected_version: Some("1.2.3".to_string()),
+                prepared_projection: Some(PreparedDeployProjection {
+                    components: BTreeMap::from([("site:plugin".to_string(), component)]),
+                }),
+                prepared_artifact: Some(PreparedDeployArtifact {
+                    component_id: "plugin".to_string(),
+                    path: "/source/plugin.zip".to_string(),
+                    durable_path: "/durable/plugin.zip".to_string(),
+                    size_bytes: 7,
+                    sha256: "hash".to_string(),
+                    version: "1.2.3".to_string(),
+                    tag: "v1.2.3".to_string(),
+                    source_commit: "commit".to_string(),
+                }),
+                ..deploy_config()
+            };
+
+            preflight_prepared_payload_binding(&project, "site", &config)
+                .expect("detector-backed managed path binds before lifecycle creation");
         });
     }
 }

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -926,6 +926,64 @@ mod tests {
     }
 
     #[test]
+    fn release_deploy_config_projects_each_targets_remote_path() {
+        with_isolated_home(|_| {
+            for (id, remote_path) in [
+                ("first", "wp-content/plugins/demo"),
+                ("second", "/srv/wp-content/plugins/demo"),
+            ] {
+                project::save(&Project {
+                    id: id.to_string(),
+                    components: vec![ProjectComponentAttachment {
+                        id: "demo".to_string(),
+                        local_path: "/stale/demo".to_string(),
+                        remote_path: Some(remote_path.to_string()),
+                        deployment_provider: None,
+                    }],
+                    ..Default::default()
+                })
+                .expect("save target project");
+            }
+
+            let artifact = crate::deploy::PreparedDeployArtifact {
+                component_id: "demo".to_string(),
+                path: "/source/demo.zip".to_string(),
+                durable_path: "/durable/demo.zip".to_string(),
+                size_bytes: 7,
+                sha256: "hash".to_string(),
+                version: "1.2.3".to_string(),
+                tag: "v1.2.3".to_string(),
+                source_commit: "commit".to_string(),
+            };
+            let config = super::release_deployment_config(
+                &Component {
+                    id: "demo".to_string(),
+                    local_path: "/release/demo".to_string(),
+                    remote_path: "../wp-content/plugins/demo".to_string(),
+                    ..Default::default()
+                },
+                Some("1.2.3"),
+                artifact,
+                &["first".to_string(), "second".to_string()],
+            )
+            .expect("release deploy config");
+            let projection = config.prepared_projection.as_ref().expect("projection");
+
+            for (id, remote_path) in [
+                ("first", "wp-content/plugins/demo"),
+                ("second", "/srv/wp-content/plugins/demo"),
+            ] {
+                let component = projection
+                    .components
+                    .get(&format!("{id}:demo"))
+                    .expect("target projection");
+                assert_eq!(component.remote_path, remote_path);
+                assert_eq!(component.local_path, "/release/demo");
+            }
+        });
+    }
+
+    #[test]
     fn failed_release_deployment_retains_artifact_for_resume() {
         let deployment = ReleaseDeploymentResult {
             projects: vec![],


### PR DESCRIPTION
## Summary

- retry prepared-payload binding with detector-backed managed path roots when local binding identifies an unresolved `path_root`
- preserve the local fast path for configured roots, absolute paths, and non-path binding failures
- prove release projections retain target-specific remote paths across multiple projects

Closes #10817.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-release prepared_payload_preflight_detects_managed_path_roots -- --nocapture`
- `cargo test -p homeboy-release release_deploy_config_projects_each_targets_remote_path -- --nocapture`
- full `cargo test -p homeboy-release`: 777 passed, 10 failed; the adjacent `release_recover_resumes_only_failed_project_with_published_source_projection` failure reproduces unchanged on `origin/main` at `097cd01ab`, and the remaining failures are existing environment/concurrency failures

## AI Assistance

OpenAI GPT-5.6-sol via OpenCode investigated the deployment evidence, identified the preflight/detection ordering defect, drafted the implementation and regression tests, and ran verification. Chris Huber remains responsible for the submitted change.