### PR TITLE
fix: resolve remote default branch + honor cook's @file prompt contract

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -487,6 +487,9 @@ where
     let provision = provision_cook_destination(&args)?;
 
     let mut dispatch_args = dispatch_args_for_cook(&args);
+    // Resolve @file / stdin / stored-ref prompts before anything consumes the
+    // prompt, so the executor receives the exact bytes (#10100).
+    resolve_dispatch_prompt(&mut dispatch_args)?;
     let requested_cook_id = dispatch_args.run_id.clone();
     if let Some(cook_id) = requested_cook_id.as_deref() {
         dispatch_args.run_id = Some(
@@ -609,6 +612,102 @@ pub(super) fn dispatch_args_for_cook(args: &AgentTaskCookArgs) -> DispatchArgs {
         dispatch_args.prompt = args.goal.clone();
     }
     dispatch_args
+}
+
+/// Resolve `--prompt` through the structured-input contract its help already
+/// advertises: `@file`, `-` for stdin, and stored `@prompt:<id>` references.
+///
+/// Cook previously took `--prompt` as a literal string, so a large Markdown
+/// prompt had to travel as one shell argument. Backticks, `$` expressions and
+/// quotes were then interpreted by the caller's shell before Homeboy ever saw
+/// them — in one case executing prompt text as commands (#10100).
+///
+/// Bytes and newlines are preserved exactly; no trimming.
+pub(super) fn resolve_dispatch_prompt(
+    dispatch_args: &mut DispatchArgs,
+) -> homeboy::core::Result<()> {
+    let Some(spec) = dispatch_args.prompt.as_deref() else {
+        return Ok(());
+    };
+    let resolved = homeboy::agents::agent_task_prompts::read_prompt_input(spec)?;
+    dispatch_args.prompt = Some(resolved);
+    Ok(())
+}
+
+#[cfg(test)]
+mod prompt_input_tests {
+    use super::*;
+
+    fn dispatch_with_prompt(prompt: Option<&str>) -> DispatchArgs {
+        DispatchArgs {
+            prompt: prompt.map(str::to_string),
+            tasks: Vec::new(),
+            cwd: None,
+            workspace: None,
+            repo: None,
+            task_url: None,
+            backend: None,
+            selector: None,
+            model: None,
+            required_capabilities: Vec::new(),
+            secret_env: Vec::new(),
+            concurrency: 1,
+            run_id: None,
+            core: crate::commands::agent_task_dispatch::DispatchCoreArgs {
+                tasks_json: None,
+                provider_config: None,
+                client_context: None,
+                attempts: 1,
+                same_provider_retries: 0,
+                provider_rotations: 0,
+                queue_only: false,
+                timeout_ms: None,
+                resolved_provider_policy: None,
+            },
+        }
+    }
+
+    /// Shell-sensitive prompt content must reach the executor byte-for-byte,
+    /// with no interpolation and no trimming (#10100).
+    #[test]
+    fn at_file_prompt_is_read_verbatim() {
+        let file = tempfile::NamedTempFile::new().expect("prompt file");
+        let body = "Run `cargo test` for $HOME\n\nUse \"quotes\" and 'apostrophes'.\n";
+        std::fs::write(file.path(), body).expect("write prompt");
+
+        let mut args = dispatch_with_prompt(Some(&format!("@{}", file.path().display())));
+        resolve_dispatch_prompt(&mut args).expect("resolve @file prompt");
+
+        assert_eq!(args.prompt.as_deref(), Some(body));
+    }
+
+    #[test]
+    fn inline_prompt_is_unchanged() {
+        let mut args = dispatch_with_prompt(Some("fix the flaky test"));
+        resolve_dispatch_prompt(&mut args).expect("resolve inline prompt");
+
+        assert_eq!(args.prompt.as_deref(), Some("fix the flaky test"));
+    }
+
+    #[test]
+    fn missing_at_file_is_reported_not_passed_through() {
+        let mut args = dispatch_with_prompt(Some("@/definitely/not/a/prompt/file/10100"));
+        resolve_dispatch_prompt(&mut args).expect_err("a missing prompt file must fail");
+    }
+
+    #[test]
+    fn empty_at_prefix_is_rejected() {
+        let mut args = dispatch_with_prompt(Some("@"));
+        let error = resolve_dispatch_prompt(&mut args).expect_err("bare @ is not a path");
+        assert!(error.message.contains("missing file path"), "{error:?}");
+    }
+
+    #[test]
+    fn absent_prompt_is_a_no_op() {
+        let mut args = dispatch_with_prompt(None);
+        resolve_dispatch_prompt(&mut args).expect("no prompt is fine");
+        assert!(args.prompt.is_none());
+    }
 }
 
 /// Compile the one durable provider-cell plan used by local Cook and Lab handoff.

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -97,7 +97,15 @@ impl From<DispatchCoreArgs> for DispatchCoreInputs {
 
 #[derive(Args, Debug, Clone)]
 pub struct DispatchArgs {
-    /// Inline prompt, @file, or - for stdin.
+    /// Inline prompt, `@<path>` to read a file, `-` to read stdin, or
+    /// `@prompt:<id>` for a stored prompt.
+    ///
+    /// Prefer `@<path>` or `-` for anything containing Markdown code spans,
+    /// quotes, or `$` expressions: an inline prompt is interpreted by your shell
+    /// before Homeboy receives it. Bytes and newlines are preserved exactly.
+    ///
+    ///   --prompt @task.md
+    ///   cat task.md | homeboy agent-task cook --prompt - ...
     #[arg(long, value_name = "PROMPT")]
     pub prompt: Option<String>,
 

--- a/crates/homeboy-lab-runner/src/managed_source.rs
+++ b/crates/homeboy-lab-runner/src/managed_source.rs
@@ -165,10 +165,37 @@ fn render_sync_script(path: &str, remote_url: Option<&str>, git_ref: Option<&str
             script.push_str("if [ -n \"$upstream\" ]; then\n");
             script.push_str("  git -C \"$dir\" merge --ff-only \"@{u}\"\n");
             script.push_str("else\n");
-            script.push_str("  target=$(git -C \"$dir\" rev-parse --verify --quiet origin/HEAD || git -C \"$dir\" rev-parse --verify --quiet origin/main)\n");
+            // Resolve the remote's ACTUAL default branch. The previous
+            // `|| origin/main` fallback silently materialized the wrong HEAD on
+            // a trunk-default repository with no `main`, which then failed the
+            // release reachability guard with "latest release tag is not
+            // reachable from HEAD" — the tag was fine, the HEAD was wrong.
+            // Fetching tags cannot fix that, because fetching never moves HEAD
+            // (#6916).
+            script.push_str(
+                "  target=$(git -C \"$dir\" rev-parse --verify --quiet origin/HEAD || true)\n",
+            );
+            // A fresh clone or a mirror fetch may not have origin/HEAD set.
+            script.push_str("  if [ -z \"$target\" ]; then\n");
+            script.push_str(
+                "    git -C \"$dir\" remote set-head origin --auto >/dev/null 2>&1 || true\n",
+            );
+            script.push_str(
+                "    target=$(git -C \"$dir\" rev-parse --verify --quiet origin/HEAD || true)\n",
+            );
+            script.push_str("  fi\n");
+            // Last resort: ask the remote directly for its default branch.
+            script.push_str("  if [ -z \"$target\" ]; then\n");
+            script.push_str("    default_ref=$(git -C \"$dir\" ls-remote --symref origin HEAD 2>/dev/null | awk '/^ref:/ {print $2; exit}')\n");
+            script.push_str("    if [ -n \"$default_ref\" ]; then\n");
+            script.push_str("      target=$(git -C \"$dir\" rev-parse --verify --quiet \"origin/${default_ref#refs/heads/}\" || true)\n");
+            script.push_str("    fi\n");
+            script.push_str("  fi\n");
+            // Fail closed rather than guessing a branch name. Materializing the
+            // wrong HEAD produces a confusing downstream failure far from here.
             script.push_str("  if [ -z \"$target\" ]; then\n");
             script
-                .push_str("    echo \"managed runner source remote default ref not found\" >&2\n");
+                .push_str("    echo \"managed runner source remote default ref not found; set origin/HEAD or declare an explicit ref for this source\" >&2\n");
             script.push_str("    exit 1\n");
             script.push_str("  fi\n");
             script.push_str("  git -C \"$dir\" checkout --quiet --force --detach \"$target\"\n");
@@ -307,6 +334,106 @@ mod tests {
         assert!(plan.script.contains("reset --hard \"$target\""));
     }
 
+    /// The blind `origin/main` fallback is gone: guessing a branch name
+    /// materialized the wrong HEAD on a trunk-default repository and surfaced
+    /// far away as a release reachability refusal (#6916).
+    #[test]
+    fn script_never_falls_back_to_a_guessed_main_branch() {
+        let mut decl = source("src", "/home/r/.cache/src");
+        decl.remote_url = Some("https://example.test/repo.git".to_string());
+        let plan = plan_managed_runner_source_sync(&decl).expect("plan");
+
+        assert!(
+            !plan.script.contains("origin/main"),
+            "default-branch resolution must not guess `main`:\n{}",
+            plan.script
+        );
+        assert!(plan.script.contains("remote set-head origin --auto"));
+        assert!(plan.script.contains("ls-remote --symref origin HEAD"));
+        assert!(plan
+            .script
+            .contains("managed runner source remote default ref not found"));
+    }
+
+    /// End-to-end against a real trunk-default repository with no `main`: the
+    /// generated script must land on `trunk`, where release tags are reachable.
+    /// No network and no release are involved.
+    #[test]
+    fn generated_script_materializes_a_trunk_default_repository_onto_trunk() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let origin = fixture.path().join("origin");
+        let clone = fixture.path().join("clone");
+        std::fs::create_dir_all(&origin).expect("origin dir");
+
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .expect("git");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        };
+
+        // A repository whose default branch is `trunk`, with no `main` at all.
+        git(&origin, &["init", "--quiet", "-b", "trunk"]);
+        git(&origin, &["config", "user.email", "test@example.test"]);
+        git(&origin, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(origin.join("README.md"), "trunk\n").expect("write");
+        git(&origin, &["add", "."]);
+        git(&origin, &["commit", "--quiet", "-m", "release: v0.1.18"]);
+        git(&origin, &["tag", "component-v0.1.18"]);
+        let tagged = git(&origin, &["rev-parse", "HEAD"]);
+
+        git(
+            fixture.path(),
+            &[
+                "clone",
+                "--quiet",
+                origin.to_str().expect("origin path"),
+                clone.to_str().expect("clone path"),
+            ],
+        );
+        // Reproduce the failing shape: a detached checkout with no upstream, and
+        // no local origin/HEAD to read.
+        git(&clone, &["checkout", "--quiet", "--detach", "HEAD"]);
+        let _ = std::process::Command::new("git")
+            .args(["symbolic-ref", "--delete", "refs/remotes/origin/HEAD"])
+            .current_dir(&clone)
+            .output();
+
+        let mut decl = source("src", clone.to_str().expect("clone path"));
+        decl.remote_url = Some(origin.to_string_lossy().to_string());
+        let plan = plan_managed_runner_source_sync(&decl).expect("plan");
+
+        let output = std::process::Command::new("bash")
+            .args(["-c", &plan.script])
+            .output()
+            .expect("run managed source sync script");
+        assert!(
+            output.status.success(),
+            "sync script failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        // HEAD must be the trunk commit, so the release tag is reachable.
+        assert_eq!(git(&clone, &["rev-parse", "HEAD"]), tagged);
+        let reachable = std::process::Command::new("git")
+            .args(["merge-base", "--is-ancestor", "component-v0.1.18", "HEAD"])
+            .current_dir(&clone)
+            .status()
+            .expect("ancestry check");
+        assert!(
+            reachable.success(),
+            "release tag must be reachable from the materialized HEAD"
+        );
+    }
+
     #[test]
     fn script_repairs_detached_dirty_checkout_when_no_ref_declared() {
         let mut decl = source("src", "/home/r/.cache/src");
@@ -316,7 +443,10 @@ mod tests {
         assert!(plan.script.contains("if [ -n \"$upstream\" ]; then"));
         assert!(plan.script.contains("else"));
         assert!(plan.script.contains("origin/HEAD"));
-        assert!(plan.script.contains("origin/main"));
+        // Previously asserted `origin/main` here. That fallback was the #6916
+        // defect: it materialized a wrong HEAD on a trunk-default repository.
+        // Default-branch resolution is now remote-derived, never guessed.
+        assert!(plan.script.contains("ls-remote --symref origin HEAD"));
         assert!(plan
             .script
             .contains("git -C \"$dir\" reset --hard \"$target\""));

--- a/docs/reference/cli/commands/agent-task.md
+++ b/docs/reference/cli/commands/agent-task.md
@@ -99,7 +99,7 @@ Do not infer the wait policy from client interactivity. An orchestration client 
 
 | Option | Value | Description |
 | --- | --- | --- |
-| `--prompt` | `<PROMPT>` | Inline prompt, @file, or - for stdin |
+| `--prompt` | `<PROMPT>` | Inline prompt, `@<path>` to read a file, `-` to read stdin, or `@prompt:<id>` for a stored prompt |
 | `--cwd` | `<PATH>` | Existing local repo checkout or worktree path to cook in |
 | `--workspace` | `<ID_OR_PATH>` | Homeboy workspace ID or existing local workspace path to cook in |
 | `--repo` | `<REPO>` | Repo/component slug for metadata and task grouping, e.g. sample-plugin |

--- a/docs/reference/cli/commands/runner.md
+++ b/docs/reference/cli/commands/runner.md
@@ -635,6 +635,9 @@ Preview or remove orphaned runner-side Lab workspaces
 | `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum workspace age before it can be considered orphaned. Defaults to the shared runner age floor (`cleanup::RUNNER_MIN_AGE_HOURS`) |
 | `--limit` | `<LIMIT>` | Maximum number of orphan candidates to report or remove per pass. Defaults to the shared page size (`cleanup::RUNNER_WORKSPACE_PAGE_LIMIT`) |
 | `--passes` | `<PASSES>` | Maximum apply passes to run. Each pass re-scans and removes at most --limit candidates |
+| `--converge` | flag | Persist each apply page and converge through the bounded pass budget |
+| `--resume` | flag | Resume the durable convergence receipt for this runner and policy |
+| `--max-wall-time-seconds` | `<MAX_WALL_TIME_SECONDS>` | Stop convergence after this many seconds, preserving an exact resume receipt |
 | `--cursor` | `<CURSOR>` | Opaque continuation cursor returned by an incomplete workspace-prune scan |
 
 ## `homeboy runner refresh-plan`


### PR DESCRIPTION
Wave 3 continued. Two verified fixes plus a docs-drift catch-up.

Closes #6916. Closes #10100.

| Issue | Change |
|---|---|
| **#6916** | Managed runner source sync resolves the remote's real default branch instead of guessing `main` |
| **#10100** | `cook --prompt` honors the `@file` / stdin contract its help already advertised |

## #6916 — the maintainer's re-scoped diagnosis was exactly right

The issue originally read as a release blocker. The follow-up comment correctly re-scoped it to runner materialization, and that holds up: `managed_source.rs` fell back to `origin/main` whenever `origin/HEAD` did not resolve. On a trunk-default repository with no `main`, that materialized the **wrong HEAD**, and the failure surfaced far away as:

```
Latest release tag <component>-v0.1.18 is not reachable from HEAD
```

The tag was reachable. The HEAD was wrong. #6919's `fetch_tags` could never fix it, because fetching tags does not move HEAD.

Resolution is now remote-derived in three steps — read `origin/HEAD`, repair it with `remote set-head origin --auto`, then ask the remote directly with `ls-remote --symref origin HEAD` — and **fails closed** rather than guessing a branch name.

**A bug I introduced and caught:** the script runs under `set -e`, and the original `origin/HEAD || origin/main` compound masked a failing `rev-parse`. Splitting it made a miss abort the whole script. Each resolution step now ends in `|| true`.

Covered end-to-end by a hermetic test: a real `trunk`-default repository with no `main`, checked out detached with `refs/remotes/origin/HEAD` deleted, materializes onto trunk with the release tag reachable. No network, no release — as the issue requested.

One existing test asserted the `origin/main` fallback. It now asserts remote-derived resolution; the old assertion was pinning the defect.

## #10100 — the contract existed, it just wasn't wired up

`--prompt` help already said *"Inline prompt, @file, or - for stdin"*. It wasn't true for cook. `read_prompt_input` — which handles `@<path>`, `-`, and `@prompt:<id>` — was only ever called from `agent-task prompts`. Cook took `--prompt` as a literal string.

That's why the reported shell interpolation happened: a large Markdown prompt had no choice but to travel as one shell argument, so zsh evaluated backticks and `$` expressions before Homeboy ran at all.

Resolving through the existing helper before anything consumes the prompt makes the documented contract real. Five tests cover verbatim `@file` bytes (including backticks, `$HOME`, quotes and apostrophes), unchanged inline prompts, a missing file, a bare `@`, and the absent-prompt no-op.

## Third commit: unrelated docs drift

`--from-artifacts` help text and the runner `--converge` / `--resume` / `--max-wall-time-seconds` flags reached main without regenerating the CLI reference. Any branch that regenerates inherits the diff, so it is carried here to keep the CLI Reference Docs gate green. Not from this branch's changes.

## Also verified — no change needed

**#10730 is already fixed** and I closed it rather than duplicating work. #10776 (`c10548461`, for #10487) added `collapse_ordinal_durable_duplicates`, which dedupes recovery artifacts by digest, prefers the canonical publication name, and fails closed on differing bytes — including the exact `01-plugin.zip` / `plugin.zip` fixture #10730 asked for. Both tests pass on main.

## Verification

`cargo fmt --check`; `cargo check --workspace --tests` exit 0; `cargo clippy` on both touched crates exit 0.

- `homeboy-lab-runner managed_source` — 15 passed, including the trunk-default e2e
- `homeboy-cli prompt_input_tests` — 5 passed
- `homeboy-cli cli_surface::reference_docs` — 4 passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
