### PR TITLE
fix(runner): recheck identity after dirty controller upgrade

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -774,8 +774,15 @@ fn compact_status_prioritizes_dirty_controller_before_runner_convergence() {
         .risk
         .iter()
         .any(|risk| risk.contains("homeboy 0.321.1+configured-dirty")));
-    assert!(summary.next_action.starts_with("homeboy upgrade --force"));
-    assert!(summary.next_action.contains("refresh-homeboy homeboy-lab"));
+    assert_eq!(summary.next_action, "homeboy upgrade --force");
+    assert!(!summary.next_action.contains("refresh-homeboy"));
+    assert!(!summary.next_action.contains("--ref"));
+    let warning = report.stale_daemon.as_ref().expect("stale daemon warning");
+    assert_eq!(
+        warning.recovery_commands,
+        vec!["homeboy upgrade --force".to_string()]
+    );
+    assert!(warning.message.contains("rerun `homeboy runner status`"));
     assert!(
         report.connected,
         "liveness remains independently observable"

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -1100,13 +1100,12 @@ impl RunnerStaleDaemonWarning {
         if controller_dirty {
             self.compatibility_reason = Some("controller_dirty");
             self.message = format!(
-                "controller `{controller_build_identity}` is dirty and cannot prove compatibility with runner `{}`; rebuild or upgrade the controller first, then converge the runner daemon/configured binary with the subsequent recovery command",
+                "controller `{controller_build_identity}` is dirty and cannot prove compatibility with runner `{}`; rebuild or upgrade the controller first, then rerun `homeboy runner status` to derive runner convergence from the upgraded controller identity",
                 self.job_command_binary_build_identity
                     .as_deref()
                     .unwrap_or(&self.job_command_binary_version),
             );
-            self.recovery_commands
-                .insert(0, "homeboy upgrade --force".to_string());
+            self.recovery_commands = vec!["homeboy upgrade --force".to_string()];
             self.refresh_command = self.recovery_commands.join(" && ");
         } else if daemon_matches_configured {
             self.compatibility_reason = Some(if controller_version_matches {


### PR DESCRIPTION
## Summary

Follow-up to #10811 for #10784.

When the controller is dirty, the previously reported runner refresh command can embed the controller commit that existed before `homeboy upgrade --force`. Chaining that stale `--ref` after the upgrade can leave the runner converged to the old identity rather than the upgraded controller.

Dirty-controller recovery now emits only `homeboy upgrade --force`. The status evidence instructs the operator to rerun `homeboy runner status` after the upgrade, so any runner convergence action is derived from the controller's fresh identity.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::runner::tests::status::compact_status_prioritizes_dirty_controller_before_runner_convergence --lib`
- `cargo test -p homeboy-lab-runner same_version_different_controller_build_is_incompatible_and_truthful --lib`

## AI Assistance

GPT-5.6 Terra (`openai/gpt-5.6-terra`) via OpenCode drafted the focused follow-up, tests, and PR description. Chris Huber remains responsible for every line.