### PR TITLE
fix(upgrade): harden local runner recovery

### DIFF
--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -74,9 +74,13 @@ pub fn runner_recovery_commands(
     selected_materialized_binary: Option<&str>,
     expected_build_identity: Option<&str>,
 ) -> Vec<String> {
-    let requires_non_mutating_recovery = selected_source_url
-        .is_some_and(|source| !source_url_is_runner_reachable(source))
-        && selected_materialized_binary.is_none();
+    let requires_non_mutating_recovery = selected_materialized_binary.is_none()
+        && match selected_source_url {
+            Some(source) => !source_url_is_runner_reachable(source),
+            // A selected revision or identity without an origin describes a
+            // controller-local snapshot, not the runner's default source.
+            None => selected_source_revision.is_some() || expected_build_identity.is_some(),
+        };
     let mut commands = if path_drift.is_some() {
         // The attempted upgrade left the same selected identity in place. Rotate
         // through the runner's managed materialization path instead of suggesting
@@ -138,7 +142,7 @@ fn runner_inspect_unreachable_source_command(
     };
     format!(
         "{inspect} # controller-local source {}; selected revision {}; expected identity {}",
-        shell_arg(selected_source_url.unwrap_or("unavailable")),
+        shell_arg(selected_source_url.unwrap_or("local snapshot without remote URL")),
         shell_arg(selected_source_revision.unwrap_or("unavailable")),
         shell_arg(expected_build_identity.unwrap_or("unavailable")),
     )

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -70,6 +70,8 @@ pub fn runner_recovery_commands(
     configured_version: Option<&str>,
     bare_version: Option<&str>,
     selected_source_revision: Option<&str>,
+    selected_source_url: Option<&str>,
+    selected_materialized_binary: Option<&str>,
 ) -> Vec<String> {
     let mut commands = if path_drift.is_some() {
         // The attempted upgrade left the same selected identity in place. Rotate
@@ -78,6 +80,8 @@ pub fn runner_recovery_commands(
         vec![runner_refresh_homeboy_command(
             runner_id,
             selected_source_revision,
+            selected_source_url,
+            selected_materialized_binary,
         )]
     } else {
         runner_upgrade_recovery_commands(runner_id, homeboy_path)
@@ -104,13 +108,26 @@ pub fn runner_recovery_commands(
 fn runner_refresh_homeboy_command(
     runner_id: &str,
     selected_source_revision: Option<&str>,
+    selected_source_url: Option<&str>,
+    selected_materialized_binary: Option<&str>,
 ) -> String {
+    if let Some(binary) = selected_materialized_binary {
+        return format!(
+            "homeboy runner refresh-homeboy {} --select {} --reconnect",
+            shell_arg(runner_id),
+            shell_arg(binary)
+        );
+    }
+    let source = selected_source_url
+        .map(|source| format!(" --source {}", shell_arg(source)))
+        .unwrap_or_default();
     let revision = selected_source_revision
         .map(|revision| format!(" --ref {}", shell_arg(revision)))
         .unwrap_or_default();
     format!(
-        "homeboy runner refresh-homeboy {}{} --reconnect",
+        "homeboy runner refresh-homeboy {}{}{} --reconnect",
         shell_arg(runner_id),
+        source,
         revision
     )
 }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -118,18 +118,44 @@ fn runner_refresh_homeboy_command(
             shell_arg(binary)
         );
     }
-    let source = selected_source_url
+    let source = selected_source_url.filter(|source| source_url_is_runner_reachable(source));
+    let source_arg = source
         .map(|source| format!(" --source {}", shell_arg(source)))
         .unwrap_or_default();
-    let revision = selected_source_revision
+    let revision = source
+        .and(selected_source_revision)
         .map(|revision| format!(" --ref {}", shell_arg(revision)))
         .unwrap_or_default();
     format!(
         "homeboy runner refresh-homeboy {}{}{} --reconnect",
         shell_arg(runner_id),
-        source,
+        source_arg,
         revision
     )
+}
+
+/// Whether a Git origin can be resolved from a runner rather than only from
+/// the controller filesystem. Local paths and `file://` URLs must be selected
+/// from an already materialized runner binary instead.
+pub fn source_url_is_runner_reachable(source: &str) -> bool {
+    let source = source.trim();
+    if source.is_empty() || source.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return false;
+    }
+
+    for scheme in ["https://", "ssh://", "git://"] {
+        if let Some(authority) = source.strip_prefix(scheme) {
+            return authority
+                .split('/')
+                .next()
+                .is_some_and(|host| !host.is_empty());
+        }
+    }
+
+    let Some((host, path)) = source.split_once(':') else {
+        return false;
+    };
+    host.contains('@') && !host.ends_with('@') && !path.is_empty()
 }
 
 pub fn runner_inspect_bare_homeboy_command(runner_id: &str) -> String {

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -72,17 +72,31 @@ pub fn runner_recovery_commands(
     selected_source_revision: Option<&str>,
     selected_source_url: Option<&str>,
     selected_materialized_binary: Option<&str>,
+    expected_build_identity: Option<&str>,
 ) -> Vec<String> {
+    let requires_non_mutating_recovery = selected_source_url
+        .is_some_and(|source| !source_url_is_runner_reachable(source))
+        && selected_materialized_binary.is_none();
     let mut commands = if path_drift.is_some() {
         // The attempted upgrade left the same selected identity in place. Rotate
         // through the runner's managed materialization path instead of suggesting
         // the command that just proved ineffective.
-        vec![runner_refresh_homeboy_command(
-            runner_id,
-            selected_source_revision,
-            selected_source_url,
-            selected_materialized_binary,
-        )]
+        vec![if requires_non_mutating_recovery {
+            runner_inspect_unreachable_source_command(
+                runner_id,
+                homeboy_path,
+                selected_source_url,
+                selected_source_revision,
+                expected_build_identity,
+            )
+        } else {
+            runner_refresh_homeboy_command(
+                runner_id,
+                selected_source_revision,
+                selected_source_url,
+                selected_materialized_binary,
+            )
+        }]
     } else {
         runner_upgrade_recovery_commands(runner_id, homeboy_path)
     };
@@ -90,6 +104,7 @@ pub fn runner_recovery_commands(
         commands.push(runner_inspect_bare_homeboy_command(runner_id));
     }
     if path_drift.is_some()
+        && !requires_non_mutating_recovery
         && homeboy_path != "homeboy"
         && matches!((configured_version, bare_version), (Some(configured), Some(bare)) if version_is_newer(bare, configured))
     {
@@ -103,6 +118,30 @@ pub fn runner_recovery_commands(
         ));
     }
     commands
+}
+
+fn runner_inspect_unreachable_source_command(
+    runner_id: &str,
+    homeboy_path: &str,
+    selected_source_url: Option<&str>,
+    selected_source_revision: Option<&str>,
+    expected_build_identity: Option<&str>,
+) -> String {
+    let inspect = if std::path::Path::new(homeboy_path).is_absolute() {
+        format!(
+            "homeboy runner exec --ssh {} -- {} self identity",
+            shell_arg(runner_id),
+            shell_arg(homeboy_path)
+        )
+    } else {
+        runner_inspect_bare_homeboy_command(runner_id)
+    };
+    format!(
+        "{inspect} # controller-local source {}; selected revision {}; expected identity {}",
+        shell_arg(selected_source_url.unwrap_or("unavailable")),
+        shell_arg(selected_source_revision.unwrap_or("unavailable")),
+        shell_arg(expected_build_identity.unwrap_or("unavailable")),
+    )
 }
 
 fn runner_refresh_homeboy_command(

--- a/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
@@ -120,17 +120,17 @@ pub fn recover_and_retry_failed_upgrade(
             failure.detail,
         )),
         Err(recovery_detail) => {
-            let selected_materialized_binary = selected_source_url
-                .is_none()
-                .then(|| {
-                    verified_materialized_source_binary(
-                        runner,
-                        command_source_path,
-                        expected_build_identity,
-                        exec,
-                    )
-                })
-                .flatten();
+            let selected_materialized_binary = (!selected_source_url
+                .is_some_and(source_url_is_runner_reachable))
+            .then(|| {
+                verified_materialized_source_binary(
+                    runner,
+                    command_source_path,
+                    expected_build_identity,
+                    exec,
+                )
+            })
+            .flatten();
             let mut entry = runner_upgrade_failure_entry(
                 &runner.id,
                 original_homeboy_path.to_string(),

--- a/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
@@ -63,6 +63,7 @@ pub fn recover_and_retry_failed_upgrade(
     previous_version: Option<&str>,
     expected_build_identity: Option<&str>,
     selected_source_revision: Option<&str>,
+    selected_source_url: Option<&str>,
     failure: FailedUpgradeOutcome,
     update_homeboy_path: &mut impl FnMut(&str, &str) -> Result<()>,
     exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
@@ -119,6 +120,17 @@ pub fn recover_and_retry_failed_upgrade(
             failure.detail,
         )),
         Err(recovery_detail) => {
+            let selected_materialized_binary = selected_source_url
+                .is_none()
+                .then(|| {
+                    verified_materialized_source_binary(
+                        runner,
+                        command_source_path,
+                        expected_build_identity,
+                        exec,
+                    )
+                })
+                .flatten();
             let mut entry = runner_upgrade_failure_entry(
                 &runner.id,
                 original_homeboy_path.to_string(),
@@ -137,6 +149,8 @@ pub fn recover_and_retry_failed_upgrade(
                 None,
                 None,
                 selected_source_revision,
+                selected_source_url,
+                selected_materialized_binary.as_deref(),
             );
             Err(entry)
         }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
@@ -151,6 +151,7 @@ pub fn recover_and_retry_failed_upgrade(
                 selected_source_revision,
                 selected_source_url,
                 selected_materialized_binary.as_deref(),
+                expected_build_identity,
             );
             Err(entry)
         }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -618,16 +618,19 @@ pub fn upgrade_runner_with_executor(
         &mut extensions_skipped,
         &mut extensions_failed,
     );
-    let selected_materialized_binary = (path_drift.is_some() && selected_source_url.is_none())
-        .then(|| {
-            verified_materialized_source_binary(
-                runner,
-                command_source_path.as_deref(),
-                expected_build_identity.as_deref(),
-                exec,
-            )
-        })
-        .flatten();
+    let selected_materialized_binary = (path_drift.is_some()
+        && !selected_source_url
+            .as_deref()
+            .is_some_and(source_url_is_runner_reachable))
+    .then(|| {
+        verified_materialized_source_binary(
+            runner,
+            command_source_path.as_deref(),
+            expected_build_identity.as_deref(),
+            exec,
+        )
+    })
+    .flatten();
     let recovery_commands = runner_recovery_commands(
         &runner.id,
         &homeboy_path,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -322,6 +322,7 @@ pub fn upgrade_runner_with_executor(
                 .flatten()
         });
     let selected_source_revision = source_path.and_then(source_checkout_revision);
+    let selected_source_url = source_path.and_then(homeboy_core::git::remote_origin_url);
     let command_source_path = match runner_upgrade_source_path(
         runner,
         method_override,
@@ -383,6 +384,7 @@ pub fn upgrade_runner_with_executor(
             previous_version.as_deref(),
             expected_build_identity.as_deref(),
             selected_source_revision.as_deref(),
+            selected_source_url.as_deref(),
             FailedUpgradeOutcome {
                 exit_code,
                 detail: runner_upgrade_detail(&output),
@@ -399,6 +401,7 @@ pub fn upgrade_runner_with_executor(
             previous_version.as_deref(),
             expected_build_identity.as_deref(),
             selected_source_revision.as_deref(),
+            selected_source_url.as_deref(),
             FailedUpgradeOutcome {
                 exit_code: 1,
                 detail: err.message,
@@ -489,6 +492,7 @@ pub fn upgrade_runner_with_executor(
             path_update_detail = Some(repair.detail);
         } else {
             apply_runner_homeboy_path_alignment(
+                runner,
                 &runner.id,
                 alignment,
                 &original_homeboy_path,
@@ -498,6 +502,8 @@ pub fn upgrade_runner_with_executor(
                 &mut path_drift,
                 &mut path_update_detail,
                 update_homeboy_path,
+                expected_build_identity.as_deref(),
+                exec,
             );
         }
     }
@@ -539,6 +545,7 @@ pub fn upgrade_runner_with_executor(
                 Some(alignment) => {
                     path_drift = alignment.drift.clone();
                     apply_runner_homeboy_path_alignment(
+                        runner,
                         &runner.id,
                         alignment,
                         &original_homeboy_path,
@@ -548,6 +555,8 @@ pub fn upgrade_runner_with_executor(
                         &mut path_drift,
                         &mut path_update_detail,
                         update_homeboy_path,
+                        expected_build_identity.as_deref(),
+                        exec,
                     );
                 }
                 None => {
@@ -568,6 +577,7 @@ pub fn upgrade_runner_with_executor(
         ) {
             path_drift = alignment.drift.clone();
             apply_runner_homeboy_path_alignment(
+                runner,
                 &runner.id,
                 alignment,
                 &original_homeboy_path,
@@ -577,6 +587,8 @@ pub fn upgrade_runner_with_executor(
                 &mut path_drift,
                 &mut path_update_detail,
                 update_homeboy_path,
+                expected_build_identity.as_deref(),
+                exec,
             );
         }
     }
@@ -606,6 +618,16 @@ pub fn upgrade_runner_with_executor(
         &mut extensions_skipped,
         &mut extensions_failed,
     );
+    let selected_materialized_binary = (path_drift.is_some() && selected_source_url.is_none())
+        .then(|| {
+            verified_materialized_source_binary(
+                runner,
+                command_source_path.as_deref(),
+                expected_build_identity.as_deref(),
+                exec,
+            )
+        })
+        .flatten();
     let recovery_commands = runner_recovery_commands(
         &runner.id,
         &homeboy_path,
@@ -613,6 +635,8 @@ pub fn upgrade_runner_with_executor(
         new_version.as_deref(),
         bare_homeboy_version.as_deref(),
         selected_source_revision.as_deref(),
+        selected_source_url.as_deref(),
+        selected_materialized_binary.as_deref(),
     );
     let mut stale_daemon_repair_detail = None;
     let mut stale_daemon = runner_stale_daemon(runner, status);

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -640,6 +640,7 @@ pub fn upgrade_runner_with_executor(
         selected_source_revision.as_deref(),
         selected_source_url.as_deref(),
         selected_materialized_binary.as_deref(),
+        expected_build_identity.as_deref(),
     );
     let mut stale_daemon_repair_detail = None;
     let mut stale_daemon = runner_stale_daemon(runner, status);

--- a/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 /// recorded as path drift instead.
 #[allow(clippy::too_many_arguments)]
 pub fn apply_runner_homeboy_path_alignment(
+    runner: &Runner,
     runner_id: &str,
     alignment: RunnerHomeboyPathAlignment,
     original_homeboy_path: &str,
@@ -27,10 +28,24 @@ pub fn apply_runner_homeboy_path_alignment(
     path_drift: &mut Option<String>,
     path_update_detail: &mut Option<String>,
     update_homeboy_path: &mut impl FnMut(&str, &str) -> Result<()>,
+    expected_build_identity: Option<&str>,
+    exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
 ) {
     let Some(new_path) = alignment.update_to.as_deref() else {
         return;
     };
+    if let Some(expected_identity) = expected_build_identity {
+        let observed_identity = runner_homeboy_identity(runner, new_path, exec)
+            .ok()
+            .flatten();
+        if observed_identity.as_deref() != Some(expected_identity) {
+            *path_drift = Some(format!(
+                "refusing to update runner homeboy_path from `{original_homeboy_path}` to PATH-visible `{new_path}`: expected controller identity `{expected_identity}`, observed `{}`",
+                observed_identity.as_deref().unwrap_or("unverifiable build identity")
+            ));
+            return;
+        }
+    }
     match update_homeboy_path(runner_id, new_path) {
         Ok(()) => {
             *homeboy_path = new_path.to_string();
@@ -118,6 +133,39 @@ pub fn source_upgrade_homeboy_path_realignment(
         });
     }
 
+    None
+}
+
+/// Return an already-materialized runner binary only after proving it is the
+/// selected controller build. This is the recovery target for local-only and
+/// snapshot sources that have no cloneable remote URL.
+pub fn verified_materialized_source_binary(
+    runner: &Runner,
+    source_path: Option<&str>,
+    expected_identity: Option<&str>,
+    exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+) -> Option<String> {
+    let source_path = source_path?.trim_end_matches('/');
+    let expected_identity = expected_identity?;
+    for build_dir in ["release", "debug"] {
+        let candidate = format!("{source_path}/target/{build_dir}/homeboy");
+        if runner_homeboy_version(runner, &candidate, exec)
+            .ok()
+            .flatten()
+            .as_deref()
+            != Some(current_version())
+        {
+            continue;
+        }
+        if runner_homeboy_identity(runner, &candidate, exec)
+            .ok()
+            .flatten()
+            .as_deref()
+            == Some(expected_identity)
+        {
+            return Some(candidate);
+        }
+    }
     None
 }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -514,6 +514,10 @@ fn rejects_stale_source_runner_identity_before_extension_sync() {
                 11 => format!("homeboy {}\n", current_version()),
                 12 => format!("homeboy {}+stale\n", current_version()),
                 13 => format!("homeboy {}+stale\n", current_version()),
+                14 => format!("homeboy {}\n", current_version()),
+                15 => format!("homeboy {}+stale\n", current_version()),
+                16 => format!("homeboy {}\n", current_version()),
+                17 => format!("{expected_identity}\n"),
                 other => panic!("unexpected runner command {other}: {:?}", options.command),
             };
             Ok((exec_output(runner_id, options.command, &stdout, "", 0), 0))

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -386,6 +386,7 @@ fn source_drift_recovery_retains_selected_immutable_revision() {
         Some(&revision),
         Some("https://example.test/homeboy.git"),
         None,
+        None,
     );
 
     assert_eq!(
@@ -405,6 +406,7 @@ fn snapshot_recovery_selects_the_verified_materialized_binary() {
         Some("aabbccddeeff"),
         None,
         Some("/home/user/Developer/_lab_workspaces/snapshot/target/release/homeboy"),
+        None,
     );
 
     assert_eq!(
@@ -427,6 +429,7 @@ fn filesystem_origin_recovery_selects_the_verified_materialized_binary() {
         Some("aabbccddeeff"),
         Some("/Users/chubes/Developer/homeboy"),
         Some("/srv/homeboy/target/release/homeboy"),
+        None,
     );
 
     assert_eq!(
@@ -449,6 +452,7 @@ fn file_origin_recovery_selects_the_verified_materialized_binary() {
         Some("aabbccddeeff"),
         Some("file:///Users/chubes/Developer/homeboy"),
         Some("/srv/homeboy/target/release/homeboy"),
+        None,
     );
 
     assert_eq!(
@@ -475,6 +479,7 @@ fn remote_origin_recovery_preserves_reachable_source_provenance() {
             Some(revision),
             Some(source),
             None,
+            None,
         );
 
         assert_eq!(
@@ -484,6 +489,62 @@ fn remote_origin_recovery_preserves_reachable_source_provenance() {
             )
         );
     }
+}
+
+#[test]
+fn filesystem_origin_without_materialized_binary_only_inspects_selected_provenance() {
+    let source = "/Users/chubes/Developer/homeboy";
+    let identity = "homeboy 0.228.5+selected";
+    let commands = runner_recovery_commands(
+        "lab",
+        "/srv/homeboy/target/release/homeboy",
+        Some(&"identity mismatch".to_string()),
+        Some("0.228.4"),
+        Some("0.228.5"),
+        Some("aabbccddeeff"),
+        Some(source),
+        None,
+        Some(identity),
+    );
+
+    assert!(commands[0].contains("self identity"));
+    assert!(commands[0].contains(source));
+    assert!(commands[0].contains(identity));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("refresh-homeboy")));
+    assert!(!commands.iter().any(|command| command.contains("main")));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("runner set")));
+}
+
+#[test]
+fn file_origin_without_materialized_binary_only_inspects_selected_provenance() {
+    let source = "file:///Users/chubes/Developer/homeboy";
+    let identity = "homeboy 0.228.5+selected";
+    let commands = runner_recovery_commands(
+        "lab",
+        "/srv/homeboy/target/release/homeboy",
+        Some(&"identity mismatch".to_string()),
+        Some("0.228.4"),
+        Some("0.228.5"),
+        Some("aabbccddeeff"),
+        Some(source),
+        None,
+        Some(identity),
+    );
+
+    assert!(commands[0].contains("self identity"));
+    assert!(commands[0].contains(source));
+    assert!(commands[0].contains(identity));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("refresh-homeboy")));
+    assert!(!commands.iter().any(|command| command.contains("main")));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("runner set")));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -326,6 +326,55 @@ fn source_recovery_rejects_unverifiable_bare_identity_without_mutating_config() 
 }
 
 #[test]
+fn successful_alignment_rejects_mismatched_bare_identity_without_mutating_config() {
+    let runner = ssh_runner(
+        "lab",
+        Some("/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy"),
+    );
+    let mut path = runner.settings.homeboy_path.clone().unwrap();
+    let mut version = Some("0.228.4".to_string());
+    let mut drift = None;
+    let mut detail = None;
+    let mut updates = Vec::new();
+
+    apply_runner_homeboy_path_alignment(
+        &runner,
+        "lab",
+        RunnerHomeboyPathAlignment {
+            drift: Some("semver permits PATH alignment".to_string()),
+            update_to: Some("homeboy".to_string()),
+        },
+        &path.clone(),
+        Some("0.228.5"),
+        &mut path,
+        &mut version,
+        &mut drift,
+        &mut detail,
+        &mut |runner_id, homeboy_path| {
+            updates.push((runner_id.to_string(), homeboy_path.to_string()));
+            Ok(())
+        },
+        Some("homeboy 0.228.5+selected"),
+        &mut |runner_id, options| {
+            Ok((
+                exec_output(
+                    runner_id,
+                    options.command,
+                    "homeboy 0.228.5+shadowed\n",
+                    "",
+                    0,
+                ),
+                0,
+            ))
+        },
+    );
+
+    assert_eq!(path, runner.settings.homeboy_path.clone().unwrap());
+    assert!(drift.unwrap().contains("expected controller identity"));
+    assert!(updates.is_empty());
+}
+
+#[test]
 fn source_drift_recovery_retains_selected_immutable_revision() {
     let revision = "a".repeat(40);
     let commands = runner_recovery_commands(
@@ -335,11 +384,32 @@ fn source_drift_recovery_retains_selected_immutable_revision() {
         Some("0.228.4"),
         Some("0.228.5"),
         Some(&revision),
+        Some("https://example.test/homeboy.git"),
+        None,
     );
 
     assert_eq!(
         commands[0],
-        format!("homeboy runner refresh-homeboy lab --ref {revision} --reconnect")
+        format!("homeboy runner refresh-homeboy lab --source https://example.test/homeboy.git --ref {revision} --reconnect")
+    );
+}
+
+#[test]
+fn snapshot_recovery_selects_the_verified_materialized_binary() {
+    let commands = runner_recovery_commands(
+        "lab",
+        "/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy",
+        Some(&"identity mismatch".to_string()),
+        Some("0.228.4"),
+        Some("0.228.5"),
+        Some("aabbccddeeff"),
+        None,
+        Some("/home/user/Developer/_lab_workspaces/snapshot/target/release/homeboy"),
+    );
+
+    assert_eq!(
+        commands[0],
+        "homeboy runner refresh-homeboy lab --select /home/user/Developer/_lab_workspaces/snapshot/target/release/homeboy --reconnect"
     );
 }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -548,6 +548,35 @@ fn file_origin_without_materialized_binary_only_inspects_selected_provenance() {
 }
 
 #[test]
+fn local_snapshot_without_materialized_binary_only_inspects_selected_provenance() {
+    let revision = "aabbccddeeff";
+    let identity = "homeboy 0.228.5+selected";
+    let commands = runner_recovery_commands(
+        "lab",
+        "/srv/homeboy/target/release/homeboy",
+        Some(&"identity mismatch".to_string()),
+        Some("0.228.4"),
+        Some("0.228.5"),
+        Some(revision),
+        None,
+        None,
+        Some(identity),
+    );
+
+    assert!(commands[0].contains("self identity"));
+    assert!(commands[0].contains("local snapshot without remote URL"));
+    assert!(commands[0].contains(revision));
+    assert!(commands[0].contains(identity));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("refresh-homeboy")));
+    assert!(!commands.iter().any(|command| command.contains("main")));
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("runner set")));
+}
+
+#[test]
 fn realigns_stale_source_checkout_homeboy_path_after_upgrade_failure() {
     let _local_version = pin_local_version_for_fixtures();
     let stale_path = "/home/user/Developer/homeboy@upgrade-bootstrap/target/release/homeboy";

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -414,6 +414,79 @@ fn snapshot_recovery_selects_the_verified_materialized_binary() {
 }
 
 #[test]
+fn filesystem_origin_recovery_selects_the_verified_materialized_binary() {
+    assert!(!source_url_is_runner_reachable(
+        "/Users/chubes/Developer/homeboy"
+    ));
+    let commands = runner_recovery_commands(
+        "lab",
+        "/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy",
+        Some(&"identity mismatch".to_string()),
+        Some("0.228.4"),
+        Some("0.228.5"),
+        Some("aabbccddeeff"),
+        Some("/Users/chubes/Developer/homeboy"),
+        Some("/srv/homeboy/target/release/homeboy"),
+    );
+
+    assert_eq!(
+        commands[0],
+        "homeboy runner refresh-homeboy lab --select /srv/homeboy/target/release/homeboy --reconnect"
+    );
+}
+
+#[test]
+fn file_origin_recovery_selects_the_verified_materialized_binary() {
+    assert!(!source_url_is_runner_reachable(
+        "file:///Users/chubes/Developer/homeboy"
+    ));
+    let commands = runner_recovery_commands(
+        "lab",
+        "/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy",
+        Some(&"identity mismatch".to_string()),
+        Some("0.228.4"),
+        Some("0.228.5"),
+        Some("aabbccddeeff"),
+        Some("file:///Users/chubes/Developer/homeboy"),
+        Some("/srv/homeboy/target/release/homeboy"),
+    );
+
+    assert_eq!(
+        commands[0],
+        "homeboy runner refresh-homeboy lab --select /srv/homeboy/target/release/homeboy --reconnect"
+    );
+}
+
+#[test]
+fn remote_origin_recovery_preserves_reachable_source_provenance() {
+    let revision = "aabbccddeeff";
+    for source in [
+        "https://github.com/Extra-Chill/homeboy.git",
+        "ssh://git@github.com/Extra-Chill/homeboy.git",
+        "git@github.com:Extra-Chill/homeboy.git",
+    ] {
+        assert!(source_url_is_runner_reachable(source));
+        let commands = runner_recovery_commands(
+            "lab",
+            "/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy",
+            Some(&"identity mismatch".to_string()),
+            Some("0.228.4"),
+            Some("0.228.5"),
+            Some(revision),
+            Some(source),
+            None,
+        );
+
+        assert_eq!(
+            commands[0],
+            format!(
+                "homeboy runner refresh-homeboy lab --source {source} --ref {revision} --reconnect"
+            )
+        );
+    }
+}
+
+#[test]
 fn realigns_stale_source_checkout_homeboy_path_after_upgrade_failure() {
     let _local_version = pin_local_version_for_fixtures();
     let stale_path = "/home/user/Developer/homeboy@upgrade-bootstrap/target/release/homeboy";

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -279,7 +279,7 @@ pub fn run_upgrade_with_method(
                 upgraded: false,
                 controller: Some(component_status("unchanged", "controller already current")),
                 extensions: Some(extension_component_status(!skip_extensions, skip_extensions, &extensions_updated, &extensions_skipped)),
-                runners: Some(runner_component_status(runner_disposition, &runners_updated, &runners_skipped)),
+                runners: Some(runner_component_status(runner_disposition, &runners_updated, &runners_skipped, false)),
                 partial,
                 runner_convergence: Some(runner_disposition),
                 message: match runner_disposition {
@@ -364,7 +364,7 @@ pub fn run_upgrade_with_method(
         restart_resident_services_after_swap(success, skip_services);
 
     let runner_disposition = runner_convergence_disposition(
-        skip_runners,
+        skip_runners || !upgrade_completed,
         &runners_updated,
         &runners_skipped,
         new_version.as_deref(),
@@ -397,6 +397,7 @@ pub fn run_upgrade_with_method(
             runner_disposition,
             &runners_updated,
             &runners_skipped,
+            !upgrade_completed && !skip_runners,
         )),
         partial: runner_convergence_failed(
             &runners_updated,
@@ -542,6 +543,7 @@ fn run_targeted_runner_upgrade(
             ),
             &runners_updated,
             &runners_skipped,
+            false,
         )),
         partial: runner_convergence_failed(
             &runners_updated,
@@ -605,7 +607,14 @@ fn runner_component_status(
     disposition: RunnerConvergenceDisposition,
     updated: &[RunnerUpgradeEntry],
     skipped: &[RunnerUpgradeEntry],
+    blocked_by_controller: bool,
 ) -> UpgradeComponentStatus {
+    if blocked_by_controller {
+        return component_status(
+            "not_run",
+            "controller installation prevented runner convergence",
+        );
+    }
     let status = match disposition {
         RunnerConvergenceDisposition::Converged => "converged",
         RunnerConvergenceDisposition::Partial => "partial",
@@ -2046,6 +2055,14 @@ mod convergence_tests {
         assert_eq!(
             extension_component_status(true, false, &[], &[]).status,
             "completed"
+        );
+    }
+
+    #[test]
+    fn runner_status_is_not_run_when_controller_blocks_convergence() {
+        assert_eq!(
+            runner_component_status(RunnerConvergenceDisposition::Skipped, &[], &[], true,).status,
+            "not_run"
         );
     }
 


### PR DESCRIPTION
## Summary
- Follow up to merged #10813 with the reviewed identity and recovery hardening that was not included in its squash merge.
- Verify PATH-visible and selected runner binaries match the expected controller build identity before persisting runner configuration.
- Preserve source recovery provenance for reachable remote origins; route filesystem, `file://`, and no-origin snapshots through verified runner binaries or a non-mutating identity inspection instead of defaulting to main.
- Report runner convergence as `not_run` when controller installation blocks it.

References #10813, #10787, #10788, and #10789.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner upgrade_runners::tests --lib` (43 passed)
- `cargo test -p homeboy-upgrade --lib` (123 passed)
- `cargo test -p homeboy-cli commands::upgrade::tests --lib` (6 passed)

## AI assistance
- AI assistance: Yes
- Tool: OpenCode
- Model: OpenAI `gpt-5.6-terra`
- Used for: applying reviewed post-merge hardening commits onto current main, resolving compatibility against the squash-merged base, validating the resulting delta, and preparing this follow-up PR.
- Chris Huber remains responsible for every line.