### PR TITLE
docs(cli): refresh command reference

### DIFF
--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -6,7 +6,7 @@ Hand-written narrative for these commands lives in `docs/commands/`. -->
 
 # Homeboy CLI reference (generated)
 
-`homeboy` exposes 531 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
+`homeboy` exposes 534 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
 
 Hand-written narrative lives in the [commands index](../../../commands/commands-index.md). Global flags are documented in [the root command reference](../homeboy-root-command.md). Machine-readable safety, docs, output, and Lab metadata come from `homeboy contract manifest`.
 

--- a/docs/reference/cli/commands/runner.md
+++ b/docs/reference/cli/commands/runner.md
@@ -635,6 +635,9 @@ Preview or remove orphaned runner-side Lab workspaces
 | `--min-age-hours` | `<MIN_AGE_HOURS>` | Minimum workspace age before it can be considered orphaned. Defaults to the shared runner age floor (`cleanup::RUNNER_MIN_AGE_HOURS`) |
 | `--limit` | `<LIMIT>` | Maximum number of orphan candidates to report or remove per pass. Defaults to the shared page size (`cleanup::RUNNER_WORKSPACE_PAGE_LIMIT`) |
 | `--passes` | `<PASSES>` | Maximum apply passes to run. Each pass re-scans and removes at most --limit candidates |
+| `--converge` | flag | Persist each apply page and converge through the bounded pass budget |
+| `--resume` | flag | Resume the durable convergence receipt for this runner and policy |
+| `--max-wall-time-seconds` | `<MAX_WALL_TIME_SECONDS>` | Stop convergence after this many seconds, preserving an exact resume receipt |
 | `--cursor` | `<CURSOR>` | Opaque continuation cursor returned by an incomplete workspace-prune scan |
 
 ## `homeboy runner refresh-plan`

--- a/docs/reference/cli/commands/worktree.md
+++ b/docs/reference/cli/commands/worktree.md
@@ -29,6 +29,7 @@ Manage component-backed task worktrees
 | `homeboy worktree status` | Inspect one task worktree and its safety gates |
 | `homeboy worktree remove` | Remove one task worktree after safety checks |
 | `homeboy worktree cleanup` | Remove cleanup-eligible task worktrees after safety checks |
+| `homeboy worktree quarantine` | Inspect or explicitly reconcile quarantined malformed task-worktree records |
 
 ## `homeboy worktree create`
 
@@ -143,4 +144,41 @@ Remove cleanup-eligible task worktrees after safety checks
 | `--cleanup-artifacts` | flag | Also remove declared rebuildable artifacts from the Homeboy checkout that built this binary |
 | `--cleanup-branches` | flag | Delete merged task branches for removed cleanup candidates |
 | `--allow-unmerged-branches` | flag | Permit deleting unmerged task branches. Requires --cleanup-branches |
+
+## `homeboy worktree quarantine`
+
+```sh
+homeboy worktree quarantine <COMMAND>
+```
+
+Inspect or explicitly reconcile quarantined malformed task-worktree records
+
+| Subcommand | Summary |
+| --- | --- |
+| `homeboy worktree quarantine list` | List quarantined records still protecting Cargo targets |
+| `homeboy worktree quarantine clear` | Mark one quarantined record terminally reconciled while retaining its original evidence |
+
+## `homeboy worktree quarantine list`
+
+```sh
+homeboy worktree quarantine list
+```
+
+List quarantined records still protecting Cargo targets
+
+## `homeboy worktree quarantine clear`
+
+```sh
+homeboy worktree quarantine clear [OPTIONS] <PROVENANCE_PATH>
+```
+
+Mark one quarantined record terminally reconciled while retaining its original evidence
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<PROVENANCE_PATH>` | yes | Provenance sidecar reported by cleanup or `worktree quarantine list` |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--verified-terminal` | flag | Confirms terminal state was independently verified before clearing protection |
 


### PR DESCRIPTION
## Summary
- regenerate the checked-in clap CLI reference from current `main`
- document runner cleanup convergence flags and worktree quarantine commands
- restore the CLI Reference Docs required gate after #10815

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/homeboy-b706ed1ffed4 cargo test -p homeboy-cli --lib --locked cli_surface::reference_docs`
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol using OpenCode diagnosed the failed generated-doc gate, regenerated the canonical reference, and verified the resulting diff and tests. Chris Huber remains responsible for the change.