### PR TITLE
fix(runtime): shorten invocation temp socket paths

### DIFF
--- a/crates/homeboy-core/src/engine/invocation.rs
+++ b/crates/homeboy-core/src/engine/invocation.rs
@@ -72,6 +72,7 @@ pub struct InvocationGuard {
     /// entry so cleanup can resolve its durable owner after this guard exits.
     cleanup_paths: [PathBuf; 2],
     runtime_tmp_dir: PathBuf,
+    runtime_tmp_alias: Option<PathBuf>,
     runtime_tmp_pin: Option<super::temp::RuntimeTempPin>,
 }
 
@@ -214,13 +215,24 @@ impl InvocationGuard {
             let _ = fs::remove_dir_all(&artifact_dir);
             return Err(error);
         }
+        let (exported_tmp_dir, runtime_tmp_alias) =
+            match exported_runtime_tmp_dir(&runtime_root, &short, &runtime_tmp_dir) {
+                Ok(exported) => exported,
+                Err(error) => {
+                    let _ = fs::remove_dir_all(&runtime_tmp_dir);
+                    let _ = fs::remove_file(lease_path(&id)?);
+                    let _ = fs::remove_dir_all(&state_dir);
+                    let _ = fs::remove_dir_all(&artifact_dir);
+                    return Err(error);
+                }
+            };
         let cleanup_paths = [state_dir.clone(), artifact_dir.clone()];
         Ok(Self {
             env: InvocationEnv {
                 id: id.clone(),
                 state_dir,
                 artifact_dir,
-                tmp_dir: runtime_tmp_dir.clone(),
+                tmp_dir: exported_tmp_dir,
                 port_base,
                 port_max,
             },
@@ -228,6 +240,7 @@ impl InvocationGuard {
             named_leases: requirements.named_leases.clone(),
             cleanup_paths,
             runtime_tmp_dir,
+            runtime_tmp_alias,
             runtime_tmp_pin: Some(runtime_tmp_pin),
         })
     }
@@ -333,7 +346,11 @@ impl InvocationGuard {
 
 impl Drop for InvocationGuard {
     fn drop(&mut self) {
-        // Best-effort cleanup of all three sibling invocation directories.
+        // Best-effort cleanup of the short-lived invocation directories and
+        // the socket-safe alias to durable managed temp.
+        if let Some(alias) = &self.runtime_tmp_alias {
+            let _ = fs::remove_file(alias);
+        }
         // Decoupled from any caller-provided `RunDir` cleanup so concurrent
         // invocations do not accumulate stale state under the short
         // platform runtime root.
@@ -362,6 +379,36 @@ impl Drop for InvocationGuard {
             let _ = fs::remove_file(path);
         }
     }
+}
+
+#[cfg(unix)]
+fn exported_runtime_tmp_dir(
+    runtime_root: &Path,
+    short: &str,
+    runtime_tmp_dir: &Path,
+) -> Result<(PathBuf, Option<PathBuf>)> {
+    let alias = runtime_root.join(format!("{short}.t"));
+    enforce_path_budget(&alias)?;
+    std::os::unix::fs::symlink(runtime_tmp_dir, &alias).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to create invocation temp alias {} -> {}: {error}",
+                alias.display(),
+                runtime_tmp_dir.display()
+            ),
+            Some("invocation.tmp.alias".to_string()),
+        )
+    })?;
+    Ok((alias.clone(), Some(alias)))
+}
+
+#[cfg(not(unix))]
+fn exported_runtime_tmp_dir(
+    _runtime_root: &Path,
+    _short: &str,
+    runtime_tmp_dir: &Path,
+) -> Result<(PathBuf, Option<PathBuf>)> {
+    Ok((runtime_tmp_dir.to_path_buf(), None))
 }
 
 fn validate_named_leases(invocation_id: &str, wanted: &[String]) -> Result<()> {

--- a/crates/homeboy-core/src/engine/invocation/runtime.rs
+++ b/crates/homeboy-core/src/engine/invocation/runtime.rs
@@ -28,10 +28,10 @@
 //! - `<root>/<short-id>`     → `HOMEBOY_INVOCATION_STATE_DIR` (the leaf the
 //!   workload owns; downstream sockets bind directly here).
 //! - `<root>/<short-id>.a`   → `HOMEBOY_INVOCATION_ARTIFACT_DIR`
-//! - `<runtime-tmp>/homeboy-invocation-tmp-*` → `HOMEBOY_INVOCATION_TMP_DIR`
-//!   and `TMPDIR`. This is a metadata-backed durable runtime-temp owner rather
-//!   than a sibling here, so cleanup can classify child-created bytes after the
-//!   invocation exits.
+//! - `<root>/<short-id>.t` → Unix-only socket-safe alias exported as
+//!   `HOMEBOY_INVOCATION_TMP_DIR` and `TMPDIR`. It resolves to a
+//!   metadata-backed durable runtime-temp owner so cleanup can classify
+//!   child-created bytes after the invocation exits.
 //!
 //! There is no `s/a` subdir layer — that would burn `sockaddr_un` budget for
 //! no isolation gain since the invocation is already 1:1 with a single

--- a/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation/tests/retention_tests.rs
@@ -11,7 +11,11 @@ fn active_invocation_lease_survives_transient_pin_loss() {
         &super::super::super::invocation::InvocationRequirements::default(),
     )
     .expect("invocation");
-    let path = invocation.context().tmp_dir;
+    let exported_path = invocation.context().tmp_dir;
+    #[cfg(unix)]
+    let path = fs::read_link(&exported_path).expect("managed invocation temp target");
+    #[cfg(not(unix))]
+    let path = exported_path.clone();
     fs::remove_file(path.join(RUNTIME_TEMP_PIN_FILE)).expect("simulate pin loss");
     let mut options = bounded_options(false, Some("homeboy-invocation-tmp"));
     options.older_than_days = 0;
@@ -36,6 +40,11 @@ fn active_invocation_lease_survives_transient_pin_loss() {
     assert!(path.exists());
 
     drop(invocation);
+    #[cfg(unix)]
+    assert!(
+        !exported_path.exists(),
+        "short temp alias is removed on drop"
+    );
     let removed = cleanup_runtime_tmp_bounded(options).expect("released cleanup");
     assert_eq!(removed.removed_count, 1);
     assert!(!path.exists());

--- a/tests/agent_task_promotion_provider.rs
+++ b/tests/agent_task_promotion_provider.rs
@@ -153,7 +153,8 @@ fn promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_i
 
     assert_eq!(
         report.status,
-        homeboy::agents::agent_task_promotion::AgentTaskPromotionStatus::Applied
+        homeboy::agents::agent_task_promotion::AgentTaskPromotionStatus::Applied,
+        "promotion report: {report:#?}"
     );
     let socket_path = report.deterministic_gates[0].stdout.trim();
     assert!(socket_path.ends_with("gate.sock"));

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -317,7 +317,17 @@ fn invocation_socket_dirs_fit_under_sockaddr_un_budget() {
             assert!(
                 headroom >= SOCKET_HEADROOM_BYTES,
                 "{key} = {dir} only leaves {headroom} bytes of headroom, \
-                 less than required {SOCKET_HEADROOM_BYTES}"
+                less than required {SOCKET_HEADROOM_BYTES}"
+            );
+        }
+        #[cfg(unix)]
+        {
+            let dir = value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR");
+            let needed = dir.len() + 1 + SOCKET_HEADROOM_BYTES;
+            assert!(
+                needed <= SUN_PATH_CAPACITY,
+                "HOMEBOY_INVOCATION_TMP_DIR = {dir} needs {needed} bytes, exceeds \
+                 sockaddr_un capacity {SUN_PATH_CAPACITY}"
             );
         }
 
@@ -412,14 +422,16 @@ fn invocation_dir_permission_error_names_runtime_root_and_remediation() {
 fn invocation_drop_retains_managed_temp_directory() {
     with_isolated_home(|_| {
         let run_dir = RunDir::create().expect("run dir");
-        let (state_dir, artifact_dir, tmp_dir) = {
+        let (state_dir, artifact_dir, tmp_dir, managed_tmp_dir) = {
             let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
                 .expect("invocation guard");
             let env = guard.env_vars();
+            let tmp_dir = std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR"));
             (
                 std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR")),
                 std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_ARTIFACT_DIR")),
-                std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR")),
+                tmp_dir.clone(),
+                std::fs::canonicalize(&tmp_dir).expect("managed temp target"),
             )
         };
         for path in [&state_dir, &artifact_dir] {
@@ -430,11 +442,14 @@ fn invocation_drop_retains_managed_temp_directory() {
             );
         }
         assert!(
-            tmp_dir.is_dir(),
+            managed_tmp_dir.is_dir(),
             "managed temp survives for lifecycle cleanup"
         );
+        #[cfg(unix)]
+        assert!(!tmp_dir.exists(), "short temp alias is removed on drop");
         let owner: serde_json::Value = serde_json::from_slice(
-            &std::fs::read(tmp_dir.join(".homeboy-run-owner-v1.json")).expect("owner record"),
+            &std::fs::read(managed_tmp_dir.join(".homeboy-run-owner-v1.json"))
+                .expect("owner record"),
         )
         .expect("owner json");
         assert_eq!(owner["producer"], "invocation");
@@ -443,7 +458,7 @@ fn invocation_drop_retains_managed_temp_directory() {
             .as_array()
             .is_some_and(|ids| !ids.is_empty()));
 
-        std::fs::remove_dir_all(&tmp_dir).expect("remove managed temp fixture");
+        std::fs::remove_dir_all(&managed_tmp_dir).expect("remove managed temp fixture");
 
         run_dir.cleanup();
     });


### PR DESCRIPTION
## Summary
- export invocation temp through a short Unix symlink under the bounded runtime root
- retain the canonical managed temp directory for lifecycle ownership and cleanup
- cover socket-path budget, alias cleanup, durable retention, and the promotion-gate regression

Closes #9701

## Verification
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/homeboy-b706ed1ffed4 cargo test -p homeboy-core invocation -- --nocapture` (43 passed)
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/homeboy-b706ed1ffed4 cargo test -p homeboy --test agent_task_promotion_provider -- --nocapture` (2 passed)
- `git diff --check`

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode diagnosed the socket-path regression, drafted the implementation and tests, and ran the verification commands. Chris Huber reviewed and remains responsible for the change.