### PR TITLE
fix(release): carry verified branch identity to prepare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
       recovery-attempts: ${{ steps.check.outputs.recovery-attempts }}
       release-version: ${{ steps.check.outputs['release-version'] }}
       release-tag: ${{ steps.check.outputs['release-tag'] }}
+      verified-release-branch: ${{ steps.attach.outputs['release-branch'] }}
+      verified-release-sha: ${{ steps.attach.outputs['release-sha'] }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -121,6 +123,8 @@ jobs:
 
           git checkout -q -B "${RELEASE_BRANCH}" "${HEAD_SHA}"
           git branch --quiet --set-upstream-to "origin/${RELEASE_BRANCH}" "${RELEASE_BRANCH}" 2>/dev/null || true
+          echo "release-branch=${RELEASE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "release-sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
           echo "::notice::HEAD attached to ${RELEASE_BRANCH} at ${HEAD_SHA:0:8}"
 
       - name: Restore failed release marker
@@ -596,6 +600,28 @@ jobs:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
+      # The check job proved that this immutable push SHA was the release
+      # branch tip before selecting a fresh release. Re-establish precisely
+      # that verified identity here; never relabel an arbitrary detached
+      # checkout as a release branch.
+      - name: Attach verified release branch
+        if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
+        env:
+          VERIFIED_RELEASE_BRANCH: ${{ needs.check.outputs['verified-release-branch'] }}
+          VERIFIED_RELEASE_SHA: ${{ needs.check.outputs['verified-release-sha'] }}
+        run: |
+          set -euo pipefail
+          HEAD_SHA="$(git rev-parse HEAD)"
+
+          if [ "${VERIFIED_RELEASE_BRANCH}" != "${RELEASE_BRANCH}" ] || [ -z "${VERIFIED_RELEASE_SHA}" ] || [ "${VERIFIED_RELEASE_SHA}" != "${HEAD_SHA}" ] || [ "${HEAD_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "::error::Prepare release branch identity is not the check-verified ${RELEASE_BRANCH}@${GITHUB_SHA}. Refusing to attach detached HEAD ${HEAD_SHA}."
+            exit 1
+          fi
+
+          git checkout -q -B "${VERIFIED_RELEASE_BRANCH}" "${VERIFIED_RELEASE_SHA}"
+          git branch --quiet --set-upstream-to "origin/${VERIFIED_RELEASE_BRANCH}" "${VERIFIED_RELEASE_BRANCH}" 2>/dev/null || true
+          echo "::notice::Prepare attached the check-verified ${VERIFIED_RELEASE_BRANCH} at ${VERIFIED_RELEASE_SHA:0:8}"
+
       - name: Preflight release runner disk
         shell: bash
         run: |
@@ -654,6 +680,7 @@ jobs:
           expected-commands: review audit,review lint,review test
           args: --skip-checks=audit,lint,test
           release-dry-run: ${{ inputs.dry-run || 'false' }}
+          release-branch: ${{ needs.check.outputs['verified-release-branch'] }}
           release-skip-publish: 'true'
           release-skip-github-release: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
@@ -689,6 +716,11 @@ jobs:
           PREPARED="${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}"
           RELEASED="${{ steps.recovery.outputs.released || steps.release.outputs.released }}"
           RECOVERY_RELEASE="${{ needs.check.outputs.recovery-release }}"
+
+          if [ -z "${RELEASE_VERSION}" ] || [ -z "${RELEASE_TAG}" ] || [ "${PREPARED}" != "true" ]; then
+            echo "::error::Release check selected work, but Prepare Release produced an incomplete handoff (release-version='${RELEASE_VERSION:-<empty>}', release-tag='${RELEASE_TAG:-<empty>}', prepared='${PREPARED:-<empty>}'). Refusing to skip artifact and publication jobs."
+            exit 1
+          fi
 
           echo "release-version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "release-tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -564,6 +564,9 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
     ));
     assert!(prepare.contains("release-tag: ${{ steps.outputs.outputs['release-tag'] }}"));
     assert!(prepare.contains("downstream jobs will publish it in this run"));
+    assert!(prepare.contains(
+        "Release check selected work, but Prepare Release produced an incomplete handoff"
+    ));
     assert!(
         prepare.contains("Skipping release preparation; downstream jobs will publish existing tag")
     );
@@ -587,6 +590,30 @@ fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
     assert!(
         plan.contains("needs.prepare.result == 'success'"),
         "plan must gate on prepare's result explicitly instead of the implicit success()"
+    );
+}
+
+#[test]
+fn release_prepare_carries_the_check_verified_branch_identity_to_the_action() {
+    let check = job_section(release_workflow(), "check");
+    let prepare = job_section(release_workflow(), "prepare");
+    let attach = step_run_script(prepare, "name: Attach verified release branch");
+    let release = release_step_block(prepare, "uses: Extra-Chill/homeboy-action@v2");
+
+    assert!(
+        check.contains("verified-release-branch: ${{ steps.attach.outputs['release-branch'] }}")
+    );
+    assert!(check.contains("verified-release-sha: ${{ steps.attach.outputs['release-sha'] }}"));
+    assert!(prepare.contains(
+        "VERIFIED_RELEASE_BRANCH: ${{ needs.check.outputs['verified-release-branch'] }}"
+    ));
+    assert!(prepare
+        .contains("VERIFIED_RELEASE_SHA: ${{ needs.check.outputs['verified-release-sha'] }}"));
+    assert!(attach.contains("[ \"${HEAD_SHA}\" != \"${GITHUB_SHA}\" ]"));
+    assert!(attach
+        .contains("git checkout -q -B \"${VERIFIED_RELEASE_BRANCH}\" \"${VERIFIED_RELEASE_SHA}\""));
+    assert!(
+        release.contains("release-branch: ${{ needs.check.outputs['verified-release-branch'] }}")
     );
 }
 
@@ -1158,6 +1185,72 @@ fn run_decide_step(subs: &[(&str, &str)]) -> (i32, String) {
     );
     let _ = std::fs::remove_dir_all(&dir);
     (output.status.code().unwrap_or(-1), combined)
+}
+
+/// Execute Prepare's output handoff exactly as GitHub Actions does. This is the
+/// boundary between a release selected by `check` and every artifact/publish
+/// job, so an absent action output must fail rather than become a green skip.
+fn run_prepare_outputs_step(subs: &[(&str, &str)]) -> (i32, String) {
+    let prepare = job_section(release_workflow(), "prepare");
+    let script = interpolate(
+        &step_run_script(prepare, "name: Resolve release outputs"),
+        subs,
+    );
+
+    let dir = std::env::temp_dir().join(format!(
+        "homeboy-prepare-outputs-{}-{:p}",
+        std::process::id(),
+        &script
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let script_path = dir.join("outputs.sh");
+    let output_path = dir.join("github_output");
+    std::fs::write(&script_path, &script).expect("write script");
+    std::fs::write(&output_path, "").expect("write output file");
+
+    let output = std::process::Command::new("bash")
+        .arg("-e")
+        .arg(&script_path)
+        .env("GITHUB_OUTPUT", &output_path)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("prepare output step should run");
+
+    let combined = format!(
+        "{}{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        std::fs::read_to_string(&output_path).unwrap_or_default()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+    (output.status.code().unwrap_or(-1), combined)
+}
+
+#[test]
+fn release_prepare_requires_a_complete_handoff_before_publication() {
+    let (code, out) = run_prepare_outputs_step(&[]);
+    assert_ne!(
+        code, 0,
+        "an empty prepare handoff must fail before downstream jobs can skip green: {out}"
+    );
+    assert!(out.contains("Release check selected work"));
+
+    let (code, out) = run_prepare_outputs_step(&[
+        ("steps.release.outputs['release-version']", "0.322.2"),
+        ("steps.release.outputs['release-tag']", "v0.322.2"),
+        ("steps.prepared.outputs.prepared", "true"),
+    ]);
+    assert_eq!(
+        code, 0,
+        "a complete prepare handoff must publish outputs: {out}"
+    );
+    for output in [
+        "release-version=0.322.2",
+        "release-tag=v0.322.2",
+        "prepared=true",
+    ] {
+        assert!(out.contains(output), "missing {output} from handoff: {out}");
+    }
 }
 
 /// Regression for #10703, and the fifth instance of the #10685 invariant.


### PR DESCRIPTION
Fixes #10702.

## Root cause
The check job attached the immutable push SHA to `main`, but Prepare checked out that same SHA detached and invoked homeboy-action without restoring the branch identity. The action correctly emitted `wrong-branch`, leaving prepare outputs empty; downstream artifact and publication jobs then skipped while the run stayed green.

## Changes
- Carry check-verified branch and SHA outputs into Prepare.
- Verify Prepare is still at that immutable SHA before attaching the verified branch and passing it through `release-branch` to homeboy-action.
- Fail Prepare when a selected release lacks version, tag, or prepared handoff outputs.
- Add deterministic workflow/script coverage for identity propagation and check-to-publication handoff.

## Evidence
Regression run: https://github.com/Extra-Chill/homeboy/actions/runs/30470577488

## Tests
- `cargo test --test release_workflow_test`
- `cargo check --workspace --tests --locked`
- `cargo test -p homeboy-release test_validate_default_branch_allows_release_branch_at_remote_default_tip`
- `cargo fmt --check`
- YAML parse and `git diff --check`

## AI assistance
OpenCode, OpenAI GPT-5.6 Sol drafted the implementation and tests. Chris Huber is responsible for every line.