### PR TITLE
test(release): make deploy guard baselines independent of host state

### DIFF
--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -844,6 +844,21 @@ mod tests {
         }
     }
 
+    /// Install the real release provider for this test binary.
+    ///
+    /// `detect_tag_gap` resolves the latest component tag through the release
+    /// provider registry, and that registry is only populated by the CLI at
+    /// startup. In a `homeboy-release` lib test the `NoopProvider` returns
+    /// `None`, so no tag gap is ever detected and every deploy guard passes
+    /// vacuously — the negative assertions below could not fail for the right
+    /// reason, and the positive one passed for the wrong one (#10126).
+    ///
+    /// Registration overwrites a mutex slot, so calling this from each test is
+    /// safe under any thread count or ordering.
+    fn with_release_provider() {
+        crate::release::provider_impl::register();
+    }
+
     fn init_repo_with_tag_gap(path: &Path) {
         let run = |args: &[&str]| {
             std::process::Command::new("git")
@@ -1442,6 +1457,7 @@ mod tests {
 
     #[test]
     fn default_tagged_release_guard_still_blocks_unreleased_head() {
+        with_release_provider();
         let dir = TempDir::new().expect("temp dir");
         init_repo_with_tag_gap(dir.path());
 
@@ -1459,6 +1475,7 @@ mod tests {
 
     #[test]
     fn default_release_guard_accepts_component_prefixed_tag_at_head() {
+        with_release_provider();
         let dir = TempDir::new().expect("temp dir");
         let root = dir.path();
         let plugin_path = root.join("plugins/host/studio-native");
@@ -1489,6 +1506,7 @@ mod tests {
 
     #[test]
     fn default_release_guard_rejects_commits_after_component_prefixed_tag() {
+        with_release_provider();
         let dir = TempDir::new().expect("temp dir");
         let root = dir.path();
         let plugin_path = root.join("plugins/host/studio-native");

--- a/crates/homeboy-release/src/deploy/safety_and_artifact.rs
+++ b/crates/homeboy-release/src/deploy/safety_and_artifact.rs
@@ -542,45 +542,52 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_directory_artifact_normalizes_group_write_and_setgid() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let source = temp.path().join("source");
-        let target = temp.path().join("plugins").join("sample-plugin");
-        fs::create_dir_all(&source).expect("source dir");
-        fs::create_dir_all(target.parent().expect("target parent")).expect("target parent dir");
-        fs::write(source.join("plugin.php"), "<?php").expect("source file");
-        fs::set_permissions(source.join("plugin.php"), fs::Permissions::from_mode(0o644))
-            .expect("source permissions");
+        // `deploy_artifact` resolves its permission modes through
+        // `defaults::load_defaults()`, which reads the host's Homeboy config. An
+        // operator-configured `permissions.remote` therefore decided whether
+        // this assertion held, so the test could fail on a correct build purely
+        // because of machine state (#10126).
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("temp dir");
+            let source = temp.path().join("source");
+            let target = temp.path().join("plugins").join("sample-plugin");
+            fs::create_dir_all(&source).expect("source dir");
+            fs::create_dir_all(target.parent().expect("target parent")).expect("target parent dir");
+            fs::write(source.join("plugin.php"), "<?php").expect("source file");
+            fs::set_permissions(source.join("plugin.php"), fs::Permissions::from_mode(0o644))
+                .expect("source permissions");
 
-        let result = deploy_artifact(
-            &local_client(),
-            &source,
-            target.to_str().expect("target path"),
-            None,
-            None,
-            None,
-        )
-        .expect("deploy result");
+            let result = deploy_artifact(
+                &local_client(),
+                &source,
+                target.to_str().expect("target path"),
+                None,
+                None,
+                None,
+            )
+            .expect("deploy result");
 
-        assert!(result.success, "{}", result.error.unwrap_or_default());
-        let file_mode = fs::metadata(target.join("plugin.php"))
-            .expect("target file")
-            .permissions()
-            .mode();
-        let dir_mode = fs::metadata(&target)
-            .expect("target dir")
-            .permissions()
-            .mode();
-        assert_ne!(
-            0,
-            file_mode & 0o020,
-            "deployed file should be group-writable"
-        );
-        assert_ne!(0, dir_mode & 0o020, "deployed dir should be group-writable");
-        assert_ne!(
-            0,
-            dir_mode & 0o2000,
-            "deployed dir should inherit its group"
-        );
+            assert!(result.success, "{}", result.error.unwrap_or_default());
+            let file_mode = fs::metadata(target.join("plugin.php"))
+                .expect("target file")
+                .permissions()
+                .mode();
+            let dir_mode = fs::metadata(&target)
+                .expect("target dir")
+                .permissions()
+                .mode();
+            assert_ne!(
+                0,
+                file_mode & 0o020,
+                "deployed file should be group-writable"
+            );
+            assert_ne!(0, dir_mode & 0o020, "deployed dir should be group-writable");
+            assert_ne!(
+                0,
+                dir_mode & 0o2000,
+                "deployed dir should inherit its group"
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
Closes #10126.

## What the failures actually were

The issue attributed all three to "host git and group state." Two of them have a different and more consequential cause.

`detect_tag_gap` resolves the latest component tag through the **release provider registry**, and that registry is only populated by the CLI at startup (`cli_runtime.rs:153`). In a `homeboy-release` lib test, `NoopProvider::latest_component_tag` returns `None`, so `detect_tag_gap` returns `None`, no gap is ever found, and every deploy guard passes vacuously.

That explains the reported symptom precisely — the two negative tests "unexpectedly return `Ok(())`" because the guard *cannot* refuse without a provider.

**It also means the positive test was passing for the wrong reason.** `default_release_guard_accepts_component_prefixed_tag_at_head` asserts `Ok(())` from a guard that had no way to fail. It has never verified anything. Registering the provider makes all three meaningful; all three now pass.

The setgid test is a genuine host-state dependency, just not the one described. `deploy_artifact` resolves permission modes through `defaults::load_defaults()`, which reads the host's Homeboy config — so an operator-configured `permissions.remote` decided whether the assertion held. It is now wrapped in `with_isolated_home` so it reads built-in defaults. (It passes as root on this host either way, so the reporter's failure was almost certainly config, not gid.)

## Verification

`cargo fmt --check`; `cargo check --workspace --tests` exit 0.

Serial `cargo test -p homeboy-release --lib -- --test-threads=1`:

| | failures |
|---|---|
| unmodified `main` | **12** |
| this branch | **10** |

## ⚠️ 10 pre-existing failures remain on main — no gate reports them

All verified red on unmodified `main` with my changes stashed. They fail in **parallel runs too**, and at least one fails **in complete isolation**, so this is not test pollution:

```
release::deployment::tests::release_recover_resumes_only_failed_project_with_published_source_projection
release::execution_plan::tests::release_tag_versions_sort_by_semver_precedence
release::executor::github_release::gh_cli::tests::bounded_command_closes_inherited_descendant_pipes
release::executor::github_release::gh_cli::tests::bounded_command_preserves_nonzero_empty_stderr
release::executor::github_release::gh_cli::tests::bounded_command_reports_timeout
release::executor::github_release::gh_cli::tests::bounded_command_retains_large_release_metadata_but_diagnostics_stay_compact
release::executor::github_release::gh_cli::tests::bounded_command_times_out_with_continuous_output
release::planning_quality::tests::extension_release_lint_blocks_extension_bootstrap_failure
release::planning_quality::tests::extension_release_lint_blocks_malformed_missing_and_producer_error_evidence
release::planning_quality::tests::extension_release_lint_rejects_invalid_explicit_lint_ownership
```

I diagnosed one of them while here. **`release_tag_versions_sort_by_semver_precedence`** fails in isolation at `execution_plan.rs:360`:

```
assertion `left == right` failed
  left: Greater
 right: Equal
```

The assertion is `v("v1.2.3+build.5").cmp(&v("v1.2.3")) == Ordering::Equal`, and the doc comment above it states *"build metadata is ignored for precedence (semver §10-11)"*. That is true of semver **precedence**, but `semver::Version` implements `Ord` consistent with its `Eq`, which includes build metadata — so `cmp` returns `Greater`. Introduced by `706627296` ("parse versions with semver instead of splitting on dots"), which correctly replaced hand-rolled parsing but inherited an incorrect assumption about the crate's `Ord`.

Fixing it means deciding whether release tag selection should follow spec precedence (strip build before comparing) or the crate's total order. That has release-selection consequences, so I left it rather than changing ordering semantics inside a test-isolation PR.

**These five `gh_cli::bounded_command_*` failures are worth attention given the release-pipeline work in #10519 and #10733** — they cover exactly the bounded-download and timeout paths that pipeline depends on.

This is #10477 in the flesh: member-crate lib tests are compiled but never executed, so ten red tests in `homeboy-release` have been invisible to CI.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
