### PR TITLE
Authenticate tracked promotion continuation state

### DIFF
--- a/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_candidate_baseline.rs
@@ -121,7 +121,76 @@ pub(crate) fn validate_gate_feedback_candidate_baseline(
             "recorded current diff does not match the promoted candidate worktree state",
         ));
     }
+    validate_tracked_promotion(root, cook_loop)?;
     Ok(current_diff)
+}
+
+/// A Cook continuation supplies this claim to core's provider preflight. Keep
+/// the integration-specific proof here while core remains responsible for the
+/// generic dirty-worktree admission decision.
+fn validate_tracked_promotion(root: &Path, baseline: &Value) -> Result<()> {
+    let Some(tracked) = baseline.get("tracked_promotion") else {
+        return Ok(());
+    };
+    let expected_path = tracked
+        .get("target_path")
+        .and_then(Value::as_str)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| invalid("tracked promotion has no destination path"))?;
+    let expected_path = std::fs::canonicalize(expected_path).map_err(|error| {
+        invalid(&format!(
+            "tracked promotion destination is unavailable: {error}"
+        ))
+    })?;
+    let actual_path = std::fs::canonicalize(root)
+        .map_err(|error| invalid(&format!("candidate worktree is unavailable: {error}")))?;
+    if actual_path != expected_path {
+        return Err(invalid(
+            "tracked promotion destination differs from the provider-resolved worktree",
+        ));
+    }
+    let expected_branch = tracked
+        .get("branch")
+        .and_then(Value::as_str)
+        .filter(|branch| !branch.is_empty())
+        .ok_or_else(|| invalid("tracked promotion has no destination branch"))?;
+    if git(root, &["branch", "--show-current"])? != expected_branch {
+        return Err(invalid(
+            "tracked promotion destination branch differs from the recorded branch",
+        ));
+    }
+    let expected_candidate = tracked
+        .get("candidate")
+        .cloned()
+        .ok_or_else(|| invalid("tracked promotion has no candidate fingerprint"))?;
+    let expected_candidate = serde_json::from_value(expected_candidate)
+        .map_err(|_| invalid("tracked promotion candidate fingerprint is invalid"))?;
+    let actual_candidate =
+        crate::agent_task_promotion::candidate_fingerprint(actual_path.to_string_lossy().as_ref())?;
+    if actual_candidate != expected_candidate {
+        return Err(invalid(
+            "tracked promotion destination differs from the exact candidate fingerprint",
+        ));
+    }
+    let expected_paths = tracked
+        .get("changed_files")
+        .and_then(Value::as_array)
+        .ok_or_else(|| invalid("tracked promotion has no changed-file list"))?
+        .iter()
+        .map(Value::as_str)
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| invalid("tracked promotion changed-file list is invalid"))?;
+    let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } =
+        actual_candidate
+    else {
+        return Err(invalid("tracked promotion candidate is not a Git worktree"));
+    };
+    if fingerprint.changed_files != expected_paths {
+        return Err(invalid(
+            "tracked promotion changed-file list differs from the exact candidate",
+        ));
+    }
+    Ok(())
 }
 
 /// Validate a committed adoption candidate when an interrupted pre-provider

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3010,6 +3010,15 @@ fn tracked_promotion_continuation(
                 Some("serialize persisted promotion artifact baseline".to_string()),
             )
         })?;
+    // Provider preflight runs before this function can authenticate the resolved
+    // target below. Carry the complete immutable continuation claim through its
+    // baseline verifier so a dirty destination is never admitted provisionally.
+    baseline["tracked_promotion"] = serde_json::json!({
+        "target_path": path,
+        "branch": branch,
+        "candidate": candidate,
+        "changed_files": promotion.changed_files,
+    });
     Ok(Some(TrackedPromotionContinuation {
         baseline,
         path: PathBuf::from(path),

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5720,20 +5720,44 @@ fn record_tracked_promotion_continuation(
         .unwrap();
     let mut checkpoint = serde_json::to_value(promotion(&options.initial_run_id)).unwrap();
     checkpoint["status"] = serde_json::json!("verification_pending");
+    let patch = Command::new("git")
+        .args(["diff", "--binary", "--full-index"])
+        .current_dir(target)
+        .output()
+        .expect("capture promoted patch");
+    assert!(patch.status.success());
+    let patch = String::from_utf8(patch.stdout).expect("patch is UTF-8");
+    let patch_path = target
+        .parent()
+        .expect("candidate parent")
+        .join("candidate.patch");
+    std::fs::write(&patch_path, &patch).expect("persist patch artifact");
+    let candidate =
+        crate::agent_task_promotion::candidate_fingerprint(target.to_str().expect("target path"))
+            .expect("candidate fingerprint");
+    let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } = &candidate
+    else {
+        panic!("fixture target is a Git worktree");
+    };
     checkpoint["to_worktree"] = serde_json::json!(options.to_worktree);
     checkpoint["target"] = serde_json::json!({
         "worktree": options.to_worktree,
         "path": target,
         "branch": "cook-candidate"
     });
+    checkpoint["patch_artifact"] = serde_json::json!({
+        "id": "patch",
+        "kind": "patch",
+        "path": patch_path,
+        "sha256": format!("{:x}", sha2::Sha256::digest(patch.as_bytes())),
+    });
+    checkpoint["changed_files"] = serde_json::json!(fingerprint.changed_files);
     checkpoint["provenance"] = serde_json::json!({
         "post_apply": true,
-        "candidate": crate::agent_task_promotion::candidate_fingerprint(
-            target.to_str().expect("target path")
-        ).unwrap(),
+        "candidate": candidate,
         "gate_feedback_baseline": {
             "schema": "homeboy/agent-task-gate-feedback-baseline/v1",
-            "current_diff": "fixture"
+            "current_diff": patch
         }
     });
     agent_task_lifecycle::record_promotion(&options.initial_run_id, checkpoint).unwrap();
@@ -5795,32 +5819,90 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             .success());
         std::fs::write(target.join("tracked.txt"), "promoted\n").unwrap();
 
-        let options = tracked_promotion_continuation_options(
+        let mut options = tracked_promotion_continuation_options(
             "cook-tracked-promotion",
             "run-tracked-promotion",
             &target,
         );
+        options.to_worktree = "fixture@cook-candidate".to_string();
         record_tracked_promotion_continuation(&options, &target);
+
+        let provider = temp.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{}'\n",
+                serde_json::json!({ "worktrees": [{
+                    "handle": options.to_worktree,
+                    "path": target,
+                    "branch": "cook-candidate",
+                    "safety": { "dirty": true, "unpushed": false, "primary": false },
+                }] })
+            ),
+        )
+        .expect("write provider");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&provider).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&provider, permissions).unwrap();
+        }
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy_core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                    },
+                ),
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+        crate::agent_task_candidate_baseline::register();
 
         let continuation = tracked_promotion_continuation(&options)
             .unwrap()
             .expect("tracked promotion continuation");
         assert_eq!(continuation.baseline["patch_artifact"]["id"], "patch");
 
-        validate_cook_workspace(&options).expect("exact tracked promotion resumes");
+        validate_cook_workspace(&options)
+            .expect("exact dirty promoted provider destination resumes");
 
         std::fs::write(target.join("extra.txt"), "unattributed\n").unwrap();
         let error = validate_cook_workspace(&options).expect_err("extra drift is rejected");
-        assert!(error.message.contains("exact tracked post-apply candidate"));
+        assert!(error
+            .message
+            .contains("promoted candidate baseline could not be verified"));
         std::fs::remove_file(target.join("extra.txt")).unwrap();
 
         std::fs::write(target.join("tracked.txt"), "changed\n").unwrap();
         let error = validate_cook_workspace(&options).expect_err("changed drift is rejected");
-        assert!(error.message.contains("exact tracked post-apply candidate"));
+        assert!(error
+            .message
+            .contains("promoted candidate baseline could not be verified"));
 
         std::fs::write(target.join("tracked.txt"), "base\n").unwrap();
         let error = validate_cook_workspace(&options).expect_err("missing candidate is rejected");
-        assert!(error.message.contains("exact tracked post-apply candidate"));
+        assert!(error
+            .message
+            .contains("promoted candidate baseline could not be verified"));
     });
 }
 


### PR DESCRIPTION
## Summary

Carry the complete persisted promotion identity into candidate-baseline verification so `cook-continue` can authenticate its exact dirty destination before generic provider safety rejects it.

## What changed

- Added destination path, branch, candidate fingerprint, and changed-file identity to the tracked continuation baseline.
- Verified that identity against the provider-resolved worktree before admitting dirty state.
- Expanded the continuation fixture to use a real dirty Git candidate, persisted patch artifact, and command-backed worktree provider.
- Kept extra paths, changed content, and missing candidate state fail-closed.

## Tests

- `cargo fmt --check`
- `cargo test -p homeboy-agents cook_continuation --lib`
- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate --lib`
- `cargo test -p homeboy-agents agent_task_candidate_baseline --lib`
- `cargo test -p homeboy-agents resume_applied_promotion_reruns_gates_for_exact_dirty_candidate --lib`

## Compatibility

Clean worktrees and untracked dirty worktrees keep existing behavior. Only a destination matching the complete persisted promotion claim is admitted.

## AI assistance

- Tool: OpenCode
- Model: openai/gpt-5.6-sol
- Used for: implementation, focused tests, diff review, and PR drafting.

Closes #10834