### PR TITLE
Inject promotion provider timeouts in tests

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -36,10 +36,7 @@ const PROMOTION_CAPTURE_LIMIT_BYTES: usize = 65_536;
 const PROMOTION_PROVIDER_RESPONSE_LIMIT_BYTES: usize = 1_048_576;
 /// A provider is a control-plane dependency. Bound a silent command so a Cook
 /// can persist its failure and release its exactly-once claim for recovery.
-#[cfg(not(test))]
 const PROMOTION_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
-#[cfg(test)]
-const PROMOTION_PROVIDER_TIMEOUT: Duration = Duration::from_millis(100);
 
 struct ProviderCapturedStream {
     response: Vec<u8>,
@@ -602,6 +599,14 @@ pub(crate) fn run_provider_command(
     invocation: &CommandInvocation,
     request: &AgentTaskPromotionApplyRequest,
 ) -> Result<AgentTaskPromotionWorkspace> {
+    run_provider_command_with_timeout(invocation, request, PROMOTION_PROVIDER_TIMEOUT)
+}
+
+pub(super) fn run_provider_command_with_timeout(
+    invocation: &CommandInvocation,
+    request: &AgentTaskPromotionApplyRequest,
+    timeout: Duration,
+) -> Result<AgentTaskPromotionWorkspace> {
     let (program, args) = invocation_program_and_args(invocation).ok_or_else(|| {
         Error::validation_invalid_argument(
             "promotion_provider.argv",
@@ -714,7 +719,7 @@ pub(crate) fn run_provider_command(
         })? {
             break status;
         }
-        if started_at.elapsed() >= PROMOTION_PROVIDER_TIMEOUT {
+        if started_at.elapsed() >= timeout {
             timed_out = true;
             process.kill().map_err(|error| {
                 Error::internal_io(
@@ -792,8 +797,8 @@ pub(crate) fn run_provider_command(
         return Err(Error::validation_invalid_argument_with_evidence(
             "promotion_provider.command",
             format!(
-                "promotion provider command timed out after {} seconds: {}",
-                PROMOTION_PROVIDER_TIMEOUT.as_secs(),
+                "promotion provider command timed out after {}: {}",
+                format_timeout(timeout),
                 display
             ),
             None,
@@ -935,6 +940,14 @@ pub(crate) fn run_provider_command(
         path: workspace_path,
         command_evidence,
     })
+}
+
+fn format_timeout(timeout: Duration) -> String {
+    if timeout.subsec_millis() == 0 {
+        format!("{} seconds", timeout.as_secs())
+    } else {
+        format!("{} ms", timeout.as_millis())
+    }
 }
 
 fn validate_provider_workspace_path(path: &Path) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -3,7 +3,7 @@
 
 use super::super::apply::{
     preflight_configured_workspace_provider_with_config, run_provider_command,
-    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
+    run_provider_command_with_timeout, AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
     AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
     AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
@@ -1969,17 +1969,18 @@ fn configured_provider_timeout_is_bounded_and_retains_command_evidence() {
         trusted_unpushed_candidate_destination: None,
     };
     let started = std::time::Instant::now();
-    let error = run_provider_command(
+    let error = run_provider_command_with_timeout(
         &CommandInvocation {
             argv: vec!["sh".to_string(), "-c".to_string(), "sleep 2".to_string()],
             ..Default::default()
         },
         &request,
+        std::time::Duration::from_millis(100),
     )
     .expect_err("silent provider must be terminated");
 
     assert!(started.elapsed() < std::time::Duration::from_secs(1));
-    assert!(error.message.contains("timed out"));
+    assert!(error.message.contains("timed out after 100 ms"));
     assert_eq!(
         error.details["command_evidence"]["command"],
         "sh -c sleep 2"


### PR DESCRIPTION
## Summary

Keep the production promotion-provider timeout at 30 seconds in every build and inject the 100 ms deadline only into the dedicated timeout test.

## What changed

- Added an internal timeout-parameterized provider command path.
- Removed the global `cfg(test)` timeout that leaked into Git-backed Cook tests.
- Rendered subsecond timeout diagnostics in milliseconds instead of `0 seconds`.

## Tests

- `cargo fmt --check`
- `cargo test -p homeboy-agents configured_provider_timeout_is_bounded_and_retains_command_evidence`
- `cargo test -p homeboy-agents adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_finalizes`

## Compatibility

Production behavior remains bounded at 30 seconds. Only test timeout injection and diagnostic precision change.

## AI assistance

- Tool: OpenCode
- Model: openai/gpt-5.6-sol
- Used for: implementation, focused tests, diff review, and PR drafting.

Closes #10832