### PR TITLE
Preserve malformed record health fixtures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -999,6 +999,18 @@ where
     Ok(record)
 }
 
+/// Inject raw observation metadata for a corruption-recovery fixture.
+///
+/// This intentionally bypasses typed record and Lab handoff validation. Normal
+/// test rewrites must use `rewrite_record_for_test`.
+#[cfg(any(test, feature = "test-support"))]
+pub fn inject_raw_record_metadata_for_corruption_test(
+    run_id: &str,
+    inject: impl FnOnce(&mut Value),
+) -> Result<()> {
+    store::inject_raw_record_metadata_for_corruption_test(&sanitize_run_id(run_id), inject)
+}
+
 /// Reconcile the ownership captured at the local provider boundary. A local
 /// provider has no opaque remote handle, so its reserving process is the only
 /// durable authority that can prove the reservation is still executing.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1896,7 +1896,13 @@ fn record_health_migrates_legacy_and_quarantines_conflicting_projections() {
 fn malformed_typed_pending_handoff_is_health_malformed_and_unreconciled() {
     with_isolated_home(|_| {
         submit_plan(&test_plan(), Some("malformed-typed-pending")).expect("submitted");
-        rewrite_record_for_test("malformed-typed-pending", |record| {
+        let malformed_handoff = json!({
+            "state": "pending",
+            "authority": "controller",
+            "runner_id": "homeboy-lab",
+            "submitted_at": "invalid"
+        });
+        let validation_error = rewrite_record_for_test("malformed-typed-pending", |record| {
             record.lab_handoff = Some(AgentTaskLabHandoff {
                 state: AgentTaskLabHandoffState::Pending,
                 authority: AgentTaskLabHandoffAuthority::Controller,
@@ -1910,7 +1916,13 @@ fn malformed_typed_pending_handoff_is_health_malformed_and_unreconciled() {
                 expired_at: None,
             });
         })
-        .expect("malformed typed state stored");
+        .expect_err("validated test rewrite rejects malformed typed handoff");
+        assert_eq!(validation_error.code, ErrorCode::InternalJsonError);
+
+        inject_raw_record_metadata_for_corruption_test("malformed-typed-pending", |metadata| {
+            metadata["agent_task_run"]["lab_handoff"] = malformed_handoff;
+        })
+        .expect("raw corruption fixture stored");
 
         let health = record_health_summary().expect("health report");
         assert_eq!(health.malformed, 1);

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -253,8 +253,6 @@ pub mod gate {
 
 /// Durable run lifecycle: submit, run-record state, log/artifact loaders.
 pub mod lifecycle {
-    #[cfg(feature = "test-support")]
-    pub use super::super::agent_task_lifecycle::rewrite_record_for_test;
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, cook_index_exists, has_accepted_runner_handoff,
@@ -279,6 +277,10 @@ pub mod lifecycle {
         AgentTaskStatusOutcome, ControllerRuntimePruneResult, DetachedLabRunRecord,
         LabOffloadProxyPlan, RunnerPinnedRuntime, RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT,
         RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL, RUNNER_PROBE_SKIPPED_NOT_RUNNING,
+    };
+    #[cfg(feature = "test-support")]
+    pub use super::super::agent_task_lifecycle::{
+        inject_raw_record_metadata_for_corruption_test, rewrite_record_for_test,
     };
 }
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -238,6 +238,26 @@ pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
     record_from_run(&run)
 }
 
+/// Bypass typed record validation solely to seed corruption-recovery fixtures.
+/// Production writes and normal test rewrites must use `write_record`.
+#[cfg(any(test, feature = "test-support"))]
+pub(super) fn inject_raw_record_metadata_for_corruption_test(
+    run_id: &str,
+    inject: impl FnOnce(&mut Value),
+) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let mut run = store.get_run(run_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "run_id",
+            format!("agent-task run record not found: {run_id}"),
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    inject(&mut run.metadata_json);
+    store.upsert_imported_run(&run)
+}
+
 pub(super) fn write_cook_index_attempt(
     cook_id: &str,
     attempt: u32,


### PR DESCRIPTION
## Summary

Add an explicit test-only raw metadata injection path for corruption-recovery fixtures while keeping ordinary and production record writes fully validated.

## What changed

- Added a narrowly scoped corruption-fixture storage helper under test/test-support builds.
- Kept `rewrite_record_for_test` on the validated typed-write path.
- Updated the malformed Lab handoff health test to prove validation rejects the record before explicitly injecting raw corruption.
- Preserved malformed classification and quarantine assertions.

## Tests

- `cargo fmt --check`
- `cargo test -p homeboy-agents malformed_typed_pending_handoff_is_health_malformed_and_unreconciled`
- `cargo test -p homeboy-agents record_health`
- `cargo test -p homeboy-agents list_records_skips_malformed_observation_records`
- `cargo check -p homeboy-agents --features test-support`

## Compatibility

Production storage behavior is unchanged and remains fail-closed. The raw bypass exists only in test/test-support builds and is explicitly named for corruption fixtures.

## AI assistance

- Tool: OpenCode
- Model: openai/gpt-5.6-sol
- Used for: implementation, focused tests, diff review, and PR drafting.

Closes #10833