### PR TITLE
fix(promotion): scope provider timeout tests

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -36,10 +36,7 @@ const PROMOTION_CAPTURE_LIMIT_BYTES: usize = 65_536;
 const PROMOTION_PROVIDER_RESPONSE_LIMIT_BYTES: usize = 1_048_576;
 /// A provider is a control-plane dependency. Bound a silent command so a Cook
 /// can persist its failure and release its exactly-once claim for recovery.
-#[cfg(not(test))]
 const PROMOTION_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
-#[cfg(test)]
-const PROMOTION_PROVIDER_TIMEOUT: Duration = Duration::from_millis(100);
 
 struct ProviderCapturedStream {
     response: Vec<u8>,
@@ -602,6 +599,23 @@ pub(crate) fn run_provider_command(
     invocation: &CommandInvocation,
     request: &AgentTaskPromotionApplyRequest,
 ) -> Result<AgentTaskPromotionWorkspace> {
+    run_provider_command_with_timeout(invocation, request, PROMOTION_PROVIDER_TIMEOUT)
+}
+
+#[cfg(test)]
+pub(crate) fn run_provider_command_with_timeout_for_test(
+    invocation: &CommandInvocation,
+    request: &AgentTaskPromotionApplyRequest,
+    timeout: Duration,
+) -> Result<AgentTaskPromotionWorkspace> {
+    run_provider_command_with_timeout(invocation, request, timeout)
+}
+
+fn run_provider_command_with_timeout(
+    invocation: &CommandInvocation,
+    request: &AgentTaskPromotionApplyRequest,
+    timeout: Duration,
+) -> Result<AgentTaskPromotionWorkspace> {
     let (program, args) = invocation_program_and_args(invocation).ok_or_else(|| {
         Error::validation_invalid_argument(
             "promotion_provider.argv",
@@ -714,7 +728,7 @@ pub(crate) fn run_provider_command(
         })? {
             break status;
         }
-        if started_at.elapsed() >= PROMOTION_PROVIDER_TIMEOUT {
+        if started_at.elapsed() >= timeout {
             timed_out = true;
             process.kill().map_err(|error| {
                 Error::internal_io(
@@ -792,8 +806,8 @@ pub(crate) fn run_provider_command(
         return Err(Error::validation_invalid_argument_with_evidence(
             "promotion_provider.command",
             format!(
-                "promotion provider command timed out after {} seconds: {}",
-                PROMOTION_PROVIDER_TIMEOUT.as_secs(),
+                "promotion provider command timed out after {}: {}",
+                format_timeout(timeout),
                 display
             ),
             None,
@@ -935,6 +949,14 @@ pub(crate) fn run_provider_command(
         path: workspace_path,
         command_evidence,
     })
+}
+
+fn format_timeout(timeout: Duration) -> String {
+    if timeout.subsec_nanos() == 0 {
+        format!("{} seconds", timeout.as_secs())
+    } else {
+        format!("{} milliseconds", timeout.as_millis())
+    }
 }
 
 fn validate_provider_workspace_path(path: &Path) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -8,9 +8,10 @@ use sha2::{Digest, Sha256};
 
 use super::apply::{
     preflight_configured_workspace_provider_with_config, run_provider_command,
-    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
-    AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
-    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+    run_provider_command_with_timeout_for_test, AgentTaskPromotionApplyRequest,
+    AgentTaskPromotionWorkspace, AgentTaskPromotionWorkspaceProvider,
+    ExternalPromotionWorkspaceProvider, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
+    AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
 
 use super::promote::{

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1969,17 +1969,19 @@ fn configured_provider_timeout_is_bounded_and_retains_command_evidence() {
         trusted_unpushed_candidate_destination: None,
     };
     let started = std::time::Instant::now();
-    let error = run_provider_command(
+    let error = run_provider_command_with_timeout_for_test(
         &CommandInvocation {
             argv: vec!["sh".to_string(), "-c".to_string(), "sleep 2".to_string()],
             ..Default::default()
         },
         &request,
+        std::time::Duration::from_millis(100),
     )
     .expect_err("silent provider must be terminated");
 
     assert!(started.elapsed() < std::time::Duration::from_secs(1));
     assert!(error.message.contains("timed out"));
+    assert!(error.message.contains("100 milliseconds"));
     assert_eq!(
         error.details["command_evidence"]["command"],
         "sh -c sleep 2"


### PR DESCRIPTION
## Summary
- keep the production 30-second promotion-provider timeout in realistic test workflows
- inject a 100 ms timeout only into the dedicated blocking-provider test
- render subsecond timeout diagnostics with millisecond precision

Closes #10832

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents configured_provider_ -- --nocapture` (4 passed)
- `git diff --check`
- The formerly timing-out Cook reproduction now completes provider promotion; it then exposes the separately tracked model-lineage failure in #10843.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode diagnosed the global test-timeout leak, drafted the scoped injection and assertions, and ran verification. Chris Huber reviewed and remains responsible for the change.