### PR TITLE
fix(runner): exclude recovery journals from peer scans

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -426,7 +426,11 @@ fn live_peer_session_in(
 /// Only controller session records participate in peer scans. Other state in a
 /// runner directory has its own schema and must not be parsed as a session.
 fn is_controller_session_file(path: &std::path::Path) -> bool {
-    const RESERVED_SIDECARS: &[&str] = &["generations.json"];
+    const RESERVED_SIDECARS: &[&str] = &[
+        "generations.json",
+        "pending-replacement.json",
+        "replacement-operation.json",
+    ];
 
     path.is_file()
         && path
@@ -683,7 +687,7 @@ mod tests {
     }
 
     #[test]
-    fn peer_scans_ignore_reserved_generation_sidecars() {
+    fn peer_scans_ignore_reserved_sidecars() {
         let root = TempDir::new().expect("session directory");
         let owner = session("controller-owner", "lease-live");
         let peer = session("controller-peer", "lease-live");
@@ -691,8 +695,13 @@ mod tests {
             .expect("write owner session");
         write_session_at(&root.path().join("controller-peer.json"), &peer)
             .expect("write peer session");
-        std::fs::write(root.path().join("generations.json"), "{}")
-            .expect("write generation sidecar");
+        for sidecar in [
+            "generations.json",
+            "pending-replacement.json",
+            "replacement-operation.json",
+        ] {
+            std::fs::write(root.path().join(sidecar), "{}").expect("write reserved sidecar");
+        }
 
         let live_peer = live_peer_session_in(
             &root.path().to_path_buf(),


### PR DESCRIPTION
## Summary

- exclude all durable runner JSON sidecars from controller peer-session discovery
- preserve fail-closed parsing for malformed controller session records
- cover generation, pending replacement, and replacement operation journals in the regression test

Closes #10846.

## Verification

- `cargo test -p homeboy-lab-runner --lib peer_scans_ignore_reserved_sidecars`
- `cargo test -p homeboy-lab-runner --lib peer_scans_fail_closed_for_malformed_controller_sessions`
- `cargo fmt --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the live recovery failure, drafted the implementation and regression-test update, and ran the listed verification. Chris Huber reviewed and remains responsible for the change.