### PR TITLE
Restore the Lab submission boundary

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -570,12 +570,6 @@ fn record_lab_offload_proxy(
     if record.state.is_terminal() {
         return Ok(record);
     }
-    let now = chrono::Utc::now();
-    record.lab_handoff = Some(AgentTaskLabHandoff::pending(
-        runner_id,
-        now.to_rfc3339(),
-        (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds())).to_rfc3339(),
-    ));
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
     // This record is the controller's durable projection of a runner handoff.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -506,7 +506,7 @@ fn retry_rebuilds_follow_up_candidate_from_durable_promotion() {
 }
 
 #[test]
-fn controller_proxy_records_pending_handoff_then_binds_runner_child() {
+fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
     with_isolated_home(|_| {
         let command = vec![
             "homeboy".to_string(),
@@ -525,10 +525,7 @@ fn controller_proxy_records_pending_handoff_then_binds_runner_child() {
         assert_eq!(planned.state, AgentTaskRunState::Queued);
         assert!(planned.metadata.get("runner_job_id").is_none());
         assert_eq!(planned.metadata["lifecycle_store_owner"], "controller");
-        let pending = planned.lab_handoff.as_ref().expect("pending handoff");
-        assert_eq!(pending.state, AgentTaskLabHandoffState::Pending);
-        assert_eq!(pending.runner_id, "homeboy-lab");
-        assert!(pending.runner_job_id.is_none());
+        assert!(planned.lab_handoff.is_none());
         assert!(planned.metadata.get("handoff_acceptance").is_none());
         assert!(load_plan("agent-task-controller-proxy")
             .expect("proxy plan")
@@ -1002,10 +999,7 @@ fn preacceptance_snapshot_binds_planned_runner_job_before_validation() {
             Some(&plan),
         )
         .expect("persist planned controller execution");
-        let pending = record.lab_handoff.as_ref().expect("pending handoff");
-        assert_eq!(pending.state, AgentTaskLabHandoffState::Pending);
-        assert_eq!(pending.runner_id, "homeboy-lab");
-        assert!(pending.runner_job_id.is_none());
+        assert!(record.lab_handoff.is_none());
         assert_eq!(record.metadata["runner_id"], "homeboy-lab");
         let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
         snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -142,9 +142,14 @@ fn execution_budget_legacy_plan_migrates_only_for_execution_reads() {
     });
 }
 
+#[cfg(unix)]
 #[test]
 fn pinned_runtime_recovery_retains_the_existing_lab_proxy_identity() {
     with_isolated_home(|_| {
+        let temporary = tempfile::tempdir().expect("temporary controller directory");
+        let pinned = temporary.path().join("runtime-a-homeboy");
+        let identity = "homeboy runtime-a";
+        let digest = fake_controller_artifact(&pinned, identity, "runtime A");
         record_lab_offload_planned(LabOffloadProxyPlan {
             run_id: "runtime-a-lab-proxy",
             runner_id: "homeboy-lab",
@@ -158,8 +163,15 @@ fn pinned_runtime_recovery_retains_the_existing_lab_proxy_identity() {
         })
         .expect("runtime A created proxy");
         rewrite_record_for_test("runtime-a-lab-proxy", |record| {
-            record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
-                ["originating"]["build_identity"] = json!("homeboy runtime-a");
+            let runtime = &mut record.metadata
+                [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY];
+            runtime["requested"] = json!(identity);
+            runtime["originating"]["build_identity"] = json!(identity);
+            runtime["originating"]["executable"] = json!(&pinned);
+            runtime["originating"]["pinned_executable"] = json!(&pinned);
+            runtime["originating"]["sha256"] = json!(digest);
+            runtime["current"] = json!(identity);
+            runtime["executed"] = json!(identity);
         })
         .expect("record runtime A provenance");
 
@@ -1081,7 +1093,7 @@ fn accepted_runner_cancellation_does_not_signal_a_controller_local_pid() {
 }
 
 #[test]
-fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
+fn terminal_transport_recovery_replaces_lossy_aggregate_from_persisted_authoritative_result() {
     with_isolated_home(|_| {
         let run_id = "cook-ssi-510-after-9849-v5-attempt-1-4f0b66a4";
         let runner_job_id = "00000000-0000-0000-0000-000000000123";
@@ -1174,6 +1186,15 @@ fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
             "tasks_omitted": 0,
             "run_id": run_id,
         });
+        let mut authoritative = succeeded_aggregate(&test_plan());
+        authoritative.outcomes[0].summary =
+            compact["tasks"][0]["summary"].as_str().map(str::to_string);
+        authoritative.outcomes[0].artifacts =
+            serde_json::from_value(compact["tasks"][0]["artifacts"].clone())
+                .expect("authoritative artifacts");
+        authoritative.outcomes[0].evidence_refs =
+            serde_json::from_value(compact["tasks"][0]["evidence_refs"].clone())
+                .expect("authoritative evidence refs");
         let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
         snapshot.events[0].kind = JobEventKind::Result;
         snapshot.events[0].data = Some(json!({
@@ -1184,7 +1205,7 @@ fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
                 "command": "agent-task",
                 "success": true,
                 "exit_code": 0,
-                "data": compact,
+                "data": authoritative,
             })),
             "stderr": "",
         }));
@@ -1202,10 +1223,6 @@ fn terminal_transport_recovery_replaces_lossy_historical_compact_aggregate() {
 
         let aggregate = store::read_aggregate(run_id).expect("recovered aggregate persisted");
         assert_eq!(aggregate.outcomes.len(), 1);
-        assert_eq!(
-            aggregate.outcomes[0].metadata["terminal_recovery"],
-            "authenticated_compact_summary"
-        );
         for evidence in &aggregate.outcomes[0].evidence_refs {
             assert!(
                 !evidence.uri.starts_with("file://"),
@@ -1289,16 +1306,7 @@ fn terminal_transport_recovery_accepts_a_verified_older_controller_pin() {
         let mut lossy = succeeded_aggregate(&test_plan());
         lossy.outcomes.clear();
         store::write_aggregate(run_id, &lossy).expect("lossy aggregate");
-        let compact = json!({
-            "schema": "homeboy/agent-task-aggregate/v1",
-            "view": "summary",
-            "plan_id": "plan-a",
-            "status": "succeeded",
-            "totals": { "skipped": 0, "succeeded": 1, "failed": 0 },
-            "tasks": [{ "task_id": "task-a", "status": "succeeded" }],
-            "tasks_omitted": 0,
-            "run_id": run_id,
-        });
+        let authoritative = succeeded_aggregate(&test_plan());
         let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
         snapshot.events[0].kind = JobEventKind::Result;
         snapshot.events[0].data = Some(json!({
@@ -1309,7 +1317,7 @@ fn terminal_transport_recovery_accepts_a_verified_older_controller_pin() {
                 "command": "agent-task",
                 "success": true,
                 "exit_code": 0,
-                "data": compact,
+                "data": authoritative,
             }).to_string(),
             "stderr": "",
         }));


### PR DESCRIPTION
Closes #10853.

## Summary

- remove the pending Lab handoff lease from controller-owned setup proxies
- restore the regression assertions that materialization and preacceptance remain lease-free until the durable submission request exists
- make runtime recovery coverage use coherent executable identity, path, and digest provenance
- update persisted terminal replay fixtures to use authoritative aggregates while retaining compact-summary rejection

## Root cause

PR #10591 reintroduced pending handoff creation in `record_lab_offload_proxy()`, regressing #9271/#9274 by starting the acceptance timeout during materialization. PR #10689 then changed tests to match the regression rather than the submission-boundary contract. Two older recovery fixtures also drifted behind stricter runtime identity and authoritative-aggregate validation.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::`
- 198 lifecycle tests passed

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode performed root-cause analysis, implemented the lifecycle repair, corrected the durable recovery fixtures, and ran focused and partition-level verification. Chris Huber reviewed and owns every line.