### PR TITLE
fix(runner): attribute generation daemon stores

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -158,11 +158,17 @@ fn parse_daemon_process_candidate(
         .collect::<Vec<_>>()
         .windows(2)
         .find_map(|pair| (pair[0] == "--addr").then(|| pair[1].to_string()));
+    let state_dir = cmdline
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix(crate::paths::DAEMON_STATE_DIR_ENV))
+        .and_then(|value| value.strip_prefix('='))
+        .filter(|value| !value.trim().is_empty());
     let home = cmdline
         .split_whitespace()
         .find_map(|part| part.strip_prefix("HOME="));
-    let durable_store_path =
-        home.map(|home| Path::new(home).join(".config/homeboy/daemon/jobs.json"));
+    let durable_store_path = state_dir
+        .map(|state_dir| Path::new(state_dir).join("jobs.json"))
+        .or_else(|| home.map(|home| Path::new(home).join(".config/homeboy/daemon/jobs.json")));
     let executable_matches = current_exe.is_some_and(|current| {
         Path::new(&executable).canonicalize().ok().as_deref() == Some(current)
     });

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -344,7 +344,7 @@ fn leaseless_store_aborts_on_ambiguous_or_live_owner_probe() {
 }
 
 #[test]
-fn daemon_process_attribution_matches_only_explicit_store_and_binary_identity() {
+fn daemon_process_attribution_falls_back_to_conventional_home_store() {
     let home = tempfile::tempdir().expect("home");
     let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
     let executable = std::env::current_exe().expect("current executable");
@@ -363,6 +363,55 @@ fn daemon_process_attribution_matches_only_explicit_store_and_binary_identity() 
     );
     assert_eq!(candidate.bind_endpoint.as_deref(), Some("127.0.0.1:7421"));
     assert_eq!(candidate.durable_store_path.as_deref(), jobs.to_str());
+}
+
+#[test]
+fn daemon_process_attribution_matches_explicit_state_directory_store() {
+    let home = tempfile::tempdir().expect("home");
+    let state_dir = tempfile::tempdir().expect("state directory");
+    let jobs = state_dir.path().join("jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4243 {} HOME={} HOMEBOY_DAEMON_STATE_DIR={} {} daemon serve --addr 127.0.0.1:7421",
+        executable.display(),
+        home.path().display(),
+        state_dir.path().display(),
+        executable.display()
+    );
+
+    let candidate =
+        super::parse_daemon_process_candidate(&line, &jobs, Some(&executable)).expect("candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Owning
+    );
+    assert_eq!(candidate.durable_store_path.as_deref(), jobs.to_str());
+}
+
+#[test]
+fn daemon_process_attribution_proves_explicit_different_state_directory_unrelated() {
+    let home = tempfile::tempdir().expect("home");
+    let other_state_dir = tempfile::tempdir().expect("other state directory");
+    let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4244 {} HOME={} HOMEBOY_DAEMON_STATE_DIR={} {} daemon serve --addr 127.0.0.1:7421",
+        executable.display(),
+        home.path().display(),
+        other_state_dir.path().display(),
+        executable.display()
+    );
+
+    let candidate =
+        super::parse_daemon_process_candidate(&line, &jobs, Some(&executable)).expect("candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Unrelated
+    );
+    assert_eq!(
+        candidate.durable_store_path.as_deref(),
+        other_state_dir.path().join("jobs.json").to_str()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- honor `HOMEBOY_DAEMON_STATE_DIR` when attributing foreground daemon candidates
- retain the conventional `HOME` fallback when no explicit state directory exists
- classify retained runner generations as unrelated to the conventional store while preserving fail-closed same-store behavior

Closes #10851.

## Verification

- `cargo test -p homeboy-core daemon_process_attribution` (4 passed)
- `cargo fmt -- --check`
- `git diff --check`
- `cargo clippy -p homeboy-core --tests --no-deps` (passed with existing workspace warnings)

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode implemented the focused parser change and regression tests under Chris Huber's direction. Chris reviewed the complete diff and independently reran the focused tests and formatting checks.