### PR TITLE
perf(test): optimize hash crates in dev builds, cutting cook invocations 26x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,29 @@ slow-tests = []
 # this crate's integration tests.
 test-support = ["homeboy-core/test-support"]
 
+# Hash and compression crates run at optimization even in dev/test builds.
+#
+# `agent-task cook` pins an immutable content-addressed controller runtime, which
+# means SHA-256 over the homeboy executable. That binary is ~700 MB unoptimized,
+# and `sha2` compiled at opt-level 0 hashes it roughly 40x slower than an
+# optimized build: ~40 s per digest instead of ~0.5 s.
+#
+# Every cook integration test spawns the real binary, so each one paid ~44 s of
+# pure hashing. That is the dominant cost in the test gate's 2700 s budget
+# (#10687). Optimizing just these dependencies keeps our own crates fully
+# debuggable while removing the cost.
+[profile.dev.package.sha2]
+opt-level = 3
+
+[profile.dev.package.sha1]
+opt-level = 3
+
+[profile.dev.package.digest]
+opt-level = 3
+
+[profile.dev.package.crypto-common]
+opt-level = 3
+
 [profile.dist]
 inherits = "release"
 lto = "thin"


### PR DESCRIPTION
Closes #10687.

Re-submitting `70bc2645b` — it landed on the `quickwins-wave4` branch minutes after #10836 was merged, so it never reached `main`. Verified again here against fresh `main`.

## The tests were never slow. Hashing was.

Every `agent-task cook` invocation took **~44 seconds before doing any work**.

`cook` pins an immutable content-addressed controller runtime, which means SHA-256 over the homeboy executable. That binary is **698 MB** unoptimized, and `sha2` compiled at `opt-level = 0` hashes it roughly 40x slower than optimized code — `sha256sum` does the same file in **0.54 s**. The digest is memoized per file identity, but two distinct files are hashed per run, so every invocation paid the full cost.

Every cook integration test spawns the real binary, so each one paid it. `tests/cook_lab_handoff_test.rs` alone has five.

## How it was isolated

- `--version`, `--help`, and even a flag-conflict rejection are all **≤0.05 s**, so this is not general startup cost.
- Every `agent-task cook` variant is ~44 s regardless of flags; `agent-task status` is 0.09 s.
- `/proc/<pid>/wchan` sits in `do_wait`, so the parent is waiting on a child and the "user CPU" belonged to that child.
- `strace -f -e trace=execve` shows the process copying itself into `controller-runtimes/<content-hash>/homeboy` and **re-execing** it.
- A second run with the pin already present is *also* ~44 s, so this is per-invocation verification, not one-time pin creation.
- `sha256sum` on the same 698 MB file: 0.54 s. Optimized vs unoptimized hashing is the whole gap.

## Fix

Raise `opt-level` for the hash dependencies only — `sha2`, `sha1`, `digest`, `crypto-common`. Our own crates stay fully unoptimized and debuggable. Four `[profile.dev.package.*]` entries, no code change.

## Measured

Fresh build from this branch on `main`:

| | before | after |
|---|---|---|
| `agent-task cook` (cold pin) | 44.3 s | **1.68 s** |
| `agent-task cook` (warm pin) | 44.1 s | **1.3 s** |
| `cook_lab_handoff_test` (5 tests) | >100 s | **1.80 s total** |
| `agent_task_promotion_provider` (2) | — | 1.84 s |
| `agent_task_provider_flag_diagnostic` (3) | — | 0.17 s |

## Why this matters beyond one test file

#10836's Test gate failed at **1h39m52s** with `exit_code: 124` in **both** candidate and baseline phases, and the observation `stdout_tail` named `cook_rejects_local_detach_before_worktree_resolution has been running for over 60 seconds` — a test whose entire job is to assert a flag combination is rejected before worktree resolution.

The 2700 s budget was accommodating this, not measuring it. This removes the dominant per-invocation cost instead of raising the ceiling again.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
