### PR TITLE
Fix Cook output projection for null inputs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -664,6 +664,9 @@ fn project_output_declarations_for_provider(request: &mut AgentTaskRequest) -> R
     }
     let output_declarations = request.output_declarations.clone();
 
+    if request.inputs.is_null() {
+        request.inputs = json!({});
+    }
     let inputs = request.inputs.as_object_mut().ok_or_else(|| {
         "output declarations require object task inputs for provider projection".to_string()
     })?;

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -358,7 +358,6 @@ process.stdin.on('end', () => {
             },
         }),
     }];
-    request.inputs = json!({});
     request.executor.config = json!({ "mode": "valid" });
 
     let valid = run_provider_command_once(&request, &provider);
@@ -411,6 +410,16 @@ process.stdin.on('end', () => {
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.class == "agent_task.output_oversized"));
+
+    request.inputs = json!("caller-owned scalar input");
+    let invalid_inputs = run_provider_command_once(&request, &provider);
+    assert_eq!(invalid_inputs.status, AgentTaskOutcomeStatus::Failed);
+    assert!(invalid_inputs.diagnostics.iter().any(|diagnostic| {
+        diagnostic.class == "agent_task.output_declaration_invalid"
+            && diagnostic
+                .message
+                .contains("output declarations require object task inputs")
+    }));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- initialize missing/null task inputs before projecting provider-facing output declarations
- preserve fail-closed behavior for explicit non-object caller inputs
- cover the normal null-input path and scalar rejection through provider execution

Closes #10862

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents --lib agent_task_provider::tests::manifest_tests::provider_validates_declared_outputs`
- `git diff --check`

## AI Assistance
OpenCode with OpenAI gpt-5.6-sol reproduced the Cook failure, isolated the projection contract mismatch, implemented the bounded fix, and ran deterministic verification. Chris Huber remains responsible for the submitted change.