### PR TITLE
Authorize fresh CI artifacts before release finalization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1123,6 +1123,26 @@ jobs:
         run: |
           rm -f artifacts/*-dist-manifest.json
 
+      - name: Download current Homeboy finalizer
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
+
+      - name: Create fresh artifact source-authority manifest
+        if: needs.prepare.outputs.recovery-release != 'true' && needs.plan.outputs.draft-complete != 'true'
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs['release-version'] }}
+        run: |
+          set -euo pipefail
+          chmod +x .homeboy-bin/homeboy
+          .homeboy-bin/homeboy release artifact-source-authority homeboy \
+            --dir artifacts \
+            --tag "${RELEASE_TAG}" \
+            --version "${RELEASE_VERSION}" \
+            --commit "$(git rev-parse "${RELEASE_TAG}^{commit}")"
+
       - name: Preserve existing published asset bytes
         if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
         env:
@@ -1231,13 +1251,6 @@ jobs:
             --argjson contains_target "${CONTAINS_TARGET}" \
             '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, expected_assets: $expected_assets, control: {commit: $control_commit, contains_target: $contains_target}}' > draft-adoption/manifest.json
           echo "::notice::Recovery control lineage: control ${CONTROL_SHA} vs target ${COMMIT} (contains_target=${CONTAINS_TARGET})"
-
-      - name: Download current Homeboy finalizer
-        if: needs.prepare.outputs.recovery-release == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: homeboy-binary
-          path: .homeboy-bin
 
       # Recovery has two independent provenances that must never be conflated
       # (issue #10519): the *control binary* that performs publication, and the

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -6,8 +6,9 @@ use homeboy::core::component;
 use homeboy::core::scope::{self, Scope};
 use homeboy_release::deploy::{self, ReleaseStateStatus};
 use homeboy_release::release::{
-    self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan,
-    ReleasePackageResult, ReleasePhase, ReleasePipelineOptions,
+    self, ArtifactSourceAuthorityManifest, BatchReleaseResult, ReleaseCommandInput,
+    ReleaseCommandResult, ReleaseExecutionPlan, ReleasePackageResult, ReleasePhase,
+    ReleasePipelineOptions,
 };
 
 use super::utils::args::DryRunArgs;
@@ -53,6 +54,26 @@ enum ReleaseSubcommand {
     Changelog(changelog::ChangelogArgs),
     /// Version inspection helpers
     Version(ReleaseVersionArgs),
+    /// Write a source-authority manifest for assembled release artifacts
+    ArtifactSourceAuthority(ArtifactSourceAuthorityArgs),
+}
+
+#[derive(Args)]
+struct ArtifactSourceAuthorityArgs {
+    /// Component prepared for finalization
+    component_id: String,
+    /// Directory containing the assembled publication files
+    #[arg(long, value_name = "DIR")]
+    dir: String,
+    /// Prepared release tag
+    #[arg(long)]
+    tag: String,
+    /// Prepared release version
+    #[arg(long)]
+    version: String,
+    /// Exact commit the prepared tag resolves to
+    #[arg(long)]
+    commit: String,
 }
 
 #[derive(Args)]
@@ -227,11 +248,19 @@ pub struct ReleasePackageOutput {
 }
 
 #[derive(Serialize)]
+#[serde(tag = "command", rename = "release.artifact-source-authority")]
+pub struct ArtifactSourceAuthorityOutput {
+    pub variant: &'static str,
+    pub manifest: ArtifactSourceAuthorityManifest,
+}
+
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum ReleaseCommandOutput {
     Single(ReleaseOutput),
     Batch(BatchReleaseOutput),
     Package(ReleasePackageOutput),
+    ArtifactSourceAuthority(ArtifactSourceAuthorityOutput),
     Changes(changes::ChangesCommandOutput),
     Changelog(changelog::ChangelogOutput),
     Version(version::VersionOutput),
@@ -390,6 +419,22 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
                 version::run_command(args.command),
                 ReleaseCommandOutput::Version,
             );
+        }
+        Some(ReleaseSubcommand::ArtifactSourceAuthority(args)) => {
+            let manifest = release::write_artifact_source_authority_manifest(
+                Path::new(&args.dir),
+                &args.component_id,
+                &args.tag,
+                &args.version,
+                &args.commit,
+            )?;
+            return Ok((
+                ReleaseCommandOutput::ArtifactSourceAuthority(ArtifactSourceAuthorityOutput {
+                    variant: "artifact-source-authority",
+                    manifest,
+                }),
+                0,
+            ));
         }
         None => {}
     }

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -1,6 +1,6 @@
 use homeboy_core::error::{Error, Result};
 use homeboy_engine_primitives::content_hash;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use super::{step_success, ReleaseArtifact, ReleaseState, ReleaseStepResult};
@@ -14,6 +14,169 @@ pub(crate) const ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA: &str =
 pub(crate) const ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION: u32 = 1;
 const DRAFT_ADOPTION_MANIFEST_SCHEMA: &str = "homeboy.draft-adoption";
 const DRAFT_ADOPTION_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// A source-bound inventory for artifacts assembled outside Homeboy's package
+/// step. Its compact shape is intentionally shared with the recovery reader.
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactSourceAuthorityManifest {
+    schema: &'static str,
+    schema_version: u32,
+    component_id: String,
+    tag: String,
+    version: String,
+    commit: String,
+    artifacts: Vec<ArtifactSourceAuthorityArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ArtifactSourceAuthorityArtifact {
+    path: String,
+    sha256: String,
+}
+
+/// Write the authority manifest required before externally assembled release
+/// bytes can enter `--from-artifacts` finalization.
+pub fn write_artifact_source_authority_manifest(
+    artifact_dir: &std::path::Path,
+    component_id: &str,
+    tag: &str,
+    version: &str,
+    commit: &str,
+) -> Result<ArtifactSourceAuthorityManifest> {
+    if [component_id, tag, version, commit]
+        .iter()
+        .any(|value| value.trim().is_empty())
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact-source-authority",
+            "component, tag, version, and commit must all be non-empty",
+            None,
+            None,
+        ));
+    }
+    let artifact_dir = std::fs::canonicalize(artifact_dir).map_err(|error| {
+        Error::validation_invalid_argument(
+            "artifact-source-authority",
+            format!(
+                "Artifact directory '{}' cannot be resolved: {error}",
+                artifact_dir.display()
+            ),
+            Some(artifact_dir.display().to_string()),
+            None,
+        )
+    })?;
+    if !artifact_dir.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "artifact-source-authority",
+            format!(
+                "Artifact directory '{}' is not a directory",
+                artifact_dir.display()
+            ),
+            Some(artifact_dir.display().to_string()),
+            None,
+        ));
+    }
+
+    let manifest_path = artifact_dir.join(PACKAGE_RECOVERY_MANIFEST);
+    let mut files = Vec::new();
+    collect_artifact_files(&artifact_dir, &artifact_dir, &manifest_path, &mut files)?;
+    files.sort();
+    if files.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "artifact-source-authority",
+            format!(
+                "Artifact directory '{}' contains no files",
+                artifact_dir.display()
+            ),
+            Some(artifact_dir.display().to_string()),
+            None,
+        ));
+    }
+
+    let manifest = ArtifactSourceAuthorityManifest {
+        schema: ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA,
+        schema_version: ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION,
+        component_id: component_id.to_string(),
+        tag: tag.to_string(),
+        version: version.to_string(),
+        commit: commit.to_string(),
+        artifacts: files
+            .into_iter()
+            .map(|path| {
+                let relative = path
+                    .strip_prefix(&artifact_dir)
+                    .expect("artifact path is rooted");
+                Ok(ArtifactSourceAuthorityArtifact {
+                    path: relative.to_string_lossy().replace('\\', "/"),
+                    sha256: sha256_file(&path.display().to_string())?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?,
+    };
+    let contents = serde_json::to_vec_pretty(&manifest).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to serialize artifact source-authority manifest: {error}"),
+            Some(manifest_path.display().to_string()),
+        )
+    })?;
+    std::fs::write(&manifest_path, contents).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to write artifact source-authority manifest '{}': {error}",
+                manifest_path.display()
+            ),
+            Some(manifest_path.display().to_string()),
+        )
+    })?;
+    Ok(manifest)
+}
+
+fn collect_artifact_files(
+    root: &std::path::Path,
+    directory: &std::path::Path,
+    manifest_path: &std::path::Path,
+    files: &mut Vec<std::path::PathBuf>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(directory).map_err(|error| {
+        Error::internal_io(
+            format!(
+                "Failed to read artifact directory '{}': {error}",
+                directory.display()
+            ),
+            Some(directory.display().to_string()),
+        )
+    })? {
+        let path = entry
+            .map_err(|error| {
+                Error::internal_io(format!("Failed to read artifact entry: {error}"), None)
+            })?
+            .path();
+        let canonical = std::fs::canonicalize(&path).map_err(|error| {
+            Error::internal_io(
+                format!("Failed to resolve artifact '{}': {error}", path.display()),
+                Some(path.display().to_string()),
+            )
+        })?;
+        if !canonical.starts_with(root) {
+            return Err(Error::validation_invalid_argument(
+                "artifact-source-authority",
+                format!(
+                    "Artifact '{}' resolves outside '{}'",
+                    path.display(),
+                    root.display()
+                ),
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+        if canonical.is_dir() {
+            collect_artifact_files(root, &canonical, manifest_path, files)?;
+        } else if canonical.is_file() && canonical != manifest_path {
+            files.push(canonical);
+        }
+    }
+    Ok(())
+}
 
 #[derive(Deserialize)]
 struct PackageRecoveryManifest {
@@ -836,8 +999,8 @@ fn validate_recovery_artifact(
 mod tests {
     use super::{
         classify_recovery_lineage, establish_publication_authority, run_artifact_inventory,
-        PackageRecoveryContext, RecoveryLineage, ReleaseStepResult, Result,
-        ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA,
+        write_artifact_source_authority_manifest, PackageRecoveryContext, RecoveryLineage,
+        ReleaseStepResult, Result, ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA,
         ARTIFACT_SOURCE_AUTHORITY_MANIFEST_SCHEMA_VERSION, PACKAGE_RECOVERY_MANIFEST,
         PACKAGE_RECOVERY_MANIFEST_SCHEMA, PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
     };
@@ -884,6 +1047,87 @@ mod tests {
                     .to_string()
             )
         );
+    }
+
+    #[test]
+    fn generated_source_authority_manifest_finalizes_only_its_bound_bytes_and_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("nested/plugin.zip");
+        std::fs::create_dir_all(artifact.parent().expect("parent")).expect("nested directory");
+        std::fs::write(&artifact, "authoritative bytes").expect("artifact");
+        write_artifact_source_authority_manifest(
+            temp.path(),
+            "plugin",
+            "v1.2.3",
+            "1.2.3",
+            "abc123",
+        )
+        .expect("generate authority manifest");
+
+        let mut state = ReleaseState::default();
+        run_artifact_inventory(
+            &mut state,
+            &temp.path().to_string_lossy(),
+            &recovery_context(),
+        )
+        .expect("generated authority manifest inventories successfully");
+        assert_eq!(state.artifacts.len(), 1);
+        assert_eq!(state.artifacts[0].sha256, Some(sha256(&artifact)));
+
+        let manifest_path = temp.path().join(PACKAGE_RECOVERY_MANIFEST);
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("manifest"))
+                .expect("valid manifest");
+        manifest["commit"] = serde_json::json!("different-commit");
+        std::fs::write(&manifest_path, manifest.to_string()).expect("different commit manifest");
+        assert!(run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &recovery_context(),
+        )
+        .expect_err("different commit must be rejected")
+        .message
+        .contains("different-commit"));
+
+        write_artifact_source_authority_manifest(
+            temp.path(),
+            "plugin",
+            "v1.2.3",
+            "1.2.3",
+            "abc123",
+        )
+        .expect("regenerate authority manifest");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("manifest"))
+                .expect("valid manifest");
+        manifest["artifacts"][0]["path"] = serde_json::json!("../plugin.zip");
+        std::fs::write(&manifest_path, manifest.to_string()).expect("unsafe path manifest");
+        assert!(run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &recovery_context(),
+        )
+        .expect_err("path outside the authority directory must be rejected")
+        .message
+        .contains("../plugin.zip"));
+
+        write_artifact_source_authority_manifest(
+            temp.path(),
+            "plugin",
+            "v1.2.3",
+            "1.2.3",
+            "abc123",
+        )
+        .expect("regenerate authority manifest");
+        std::fs::write(&artifact, "substituted bytes").expect("tamper artifact");
+        assert!(run_artifact_inventory(
+            &mut ReleaseState::default(),
+            &temp.path().to_string_lossy(),
+            &recovery_context(),
+        )
+        .expect_err("digest substitution must be rejected")
+        .message
+        .contains("does not match declared sha256"));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/mod.rs
+++ b/crates/homeboy-release/src/release/mod.rs
@@ -30,6 +30,9 @@ mod workflow;
 mod workflow_recover;
 
 pub use cascade::{run_cascade, CascadeResult, CascadeStepResult, ReleasedCoordinates};
+pub use executor::artifacts::{
+    write_artifact_source_authority_manifest, ArtifactSourceAuthorityManifest,
+};
 pub use package_recovery::{package_existing_tag, ReleasePackageResult};
 pub use pipeline::run;
 pub use planner::plan;

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -7,6 +7,7 @@ homeboy release [OPTIONS] [COMPONENTS]...
 homeboy release version show [<component_id>] [--path <path>]
 homeboy release changes [<component_id>] [--path <path>] [--since <tag>] [--git-diffs]
 homeboy release changelog show [<component_id>]
+homeboy release artifact-source-authority <component_id> --dir <DIR> --tag <TAG> --version <VERSION> --commit <SHA>
 ```
 
 By default Homeboy auto-detects the bump from commit history. Use `--bump <major|minor|patch|VERSION>` to force a bump type or explicit version.
@@ -54,6 +55,8 @@ External CI artifacts must also provide `manifest.json`; bare directories are re
   "artifacts": [{ "path": "example-plugin.zip", "sha256": "<64-char SHA-256>" }]
 }
 ```
+
+`release artifact-source-authority` writes this inventory for a completed artifact directory. It recursively records every publication file (except `manifest.json`) in stable path order and binds its SHA-256 bytes to the supplied release identity. Use it after all platform artifacts have been assembled and before `--from-artifacts` finalization.
 
 Risky real release modes require explicit `--apply`: `--deploy`, `--recover`, `--retag`, `--head`, and bare `--skip-checks`. Dry-run previews never require `--apply`, and granular skips such as `--skip-checks=lint` keep the normal release flow because other quality gates remain active.
 

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -764,6 +764,19 @@ fn release_finish_head_pipeline_uses_homeboy_action_head_inputs() {
     assert!(host.contains("Download current Homeboy finalizer"));
     assert!(host.contains("binary-path: ${{ needs.prepare.outputs.recovery-release == 'true' && '.homeboy-bin/homeboy' || '' }}"));
     assert!(host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}"));
+    let authority = release_step_block(
+        host,
+        "name: Create fresh artifact source-authority manifest",
+    );
+    assert!(authority.contains("needs.prepare.outputs.recovery-release != 'true'"));
+    assert!(authority.contains(".homeboy-bin/homeboy release artifact-source-authority homeboy"));
+    assert!(authority.contains("--dir artifacts"));
+    assert!(authority.contains("git rev-parse \"${RELEASE_TAG}^{commit}\""));
+    assert!(
+        host.find("- name: Create fresh artifact source-authority manifest")
+            < host.find("- name: Finish Homeboy release pipeline at tag"),
+        "fresh artifact authority must precede finalization"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a reusable `homeboy release artifact-source-authority` command that inventories assembled artifacts and binds their paths and SHA-256 bytes to component, tag, version, and commit
- invoke that command in the release workflow after cargo-dist artifacts are assembled and before `--from-artifacts` finalization
- preserve fail-closed validation for missing authority, identity mismatch, unsafe paths, and substituted bytes

Closes #10766

## Evidence
- Failed release: https://github.com/Extra-Chill/homeboy/actions/runs/30486091685
- Failure: fresh `v0.323.0` CI artifacts reached finalization without the `homeboy.artifact-source-authority` manifest required by #10800
- Cook run: `agent-task-2a8550d6-2589-4eab-a352-f160449d169f`

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-release --lib release::executor::artifacts::tests` (21 passed)
- `cargo test --test release_workflow_test release_finish_head_pipeline_uses_homeboy_action_head_inputs`
- `git diff --check`

All four gates passed in Homeboy promotion with isolated HOME/XDG state and `RUSTUP_TOOLCHAIN=stable`.

## Compatibility
Existing external and recovery artifact directories remain subject to the same source-authority validation. The new command produces the existing schema rather than introducing a second manifest contract.

## AI Assistance
Homeboy through OpenCode with OpenAI gpt-5.6-terra generated the candidate implementation. OpenCode with OpenAI gpt-5.6-sol diagnosed the release and control-plane failures, reviewed the candidate, ran deterministic verification, and finalized the PR. Chris Huber remains responsible for the submitted change.