### PR TITLE
Fix Homeboy release artifact path

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -2799,6 +2799,9 @@
     }
   ],
   "docs_dir": "docs",
+  "env": {
+    "CARGO_TARGET_DIR": "target"
+  },
   "extensions": {
     "rust": {}
   },


### PR DESCRIPTION
## Summary
- pin Homeboy component builds to the repository-local `target` directory
- suppress the Rust extension shared-target default for this component
- align the successful Cargo build with the declared `target/release/homeboy` release artifact

Closes #10860

## Root cause

The linked Rust extension correctly defaults Rust components to a shared external `CARGO_TARGET_DIR`. Homeboy itself declares `build_artifact: target/release/homeboy`, so release packaging could not find the successful build output. The component-scoped override keeps the generic extension behavior intact for other repositories.

## Verification
- `jq -e '.env.CARGO_TARGET_DIR == "target" and .build_artifact == "target/release/homeboy"' homeboy.json`\n- `cargo fmt --check`\n- `CARGO_TARGET_DIR=target cargo build --release`\n- `target/release/homeboy --version` -> `homeboy 0.323.0+2177c7b6ff6a-dirty`\n- `git diff --check`\n\n## AI Assistance\nOpenCode with OpenAI GPT-5.6 Terra generated an initial diagnostic candidate. OpenCode with OpenAI GPT-5.6 Sol reviewed and rejected that candidate, traced the Rust extension environment provider, implemented the component-scoped fix, and ran verification. Chris Huber remains responsible for every line.