### PR TITLE
fix(runner): rebind durable replacement replay

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -430,6 +430,32 @@ fn connect_with_orphan_adoption_and_live_lease(
         if let Some((kind, command)) =
             super::generation_store::replacement_operation_replay(runner_id)?
         {
+            let command = if kind == "ensure-running" {
+                if let Err(error) = negotiate_ensure_running_operation_id(
+                    &client,
+                    homeboy,
+                    Some(&replacement_operation_id),
+                ) {
+                    return Ok(failed_connect(
+                        runner_id,
+                        session_path,
+                        RunnerFailureKind::DaemonStartupFailure,
+                        error,
+                    ));
+                }
+                let command =
+                    remote_daemon_ensure_running_command(homeboy, Some(&replacement_operation_id));
+                // Rebind the durable command to the verified selected binary
+                // before crossing the replay mutation boundary.
+                super::generation_store::record_replacement_operation_replay(
+                    runner_id,
+                    "ensure-running",
+                    &command,
+                )?;
+                command
+            } else {
+                command
+            };
             let output = client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
             if !output.success {
                 return Ok(failed_connect(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -688,7 +688,7 @@ fn journal_ensure_running_replay(
     .map_err(|error| error.to_string())
 }
 
-fn negotiate_ensure_running_operation_id(
+pub(super) fn negotiate_ensure_running_operation_id(
     client: &SshClient,
     homeboy: &str,
     replacement_operation_id: Option<&str>,

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1109,8 +1109,11 @@ esac
 #[test]
 fn normal_start_response_loss_replays_b_without_creating_c() {
     test_support::with_isolated_home(|home| {
-        let daemon = home.path().join("remote-homeboy");
+        let old_daemon = home.path().join("old-homeboy");
+        let selected_daemon = home.path().join("selected-homeboy");
         let generation_count = home.path().join("daemon-generations");
+        let old_replay = home.path().join("old-replay");
+        let selected_argv = home.path().join("selected-argv");
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
         let address = listener.local_addr().expect("address");
         let health_requests = Arc::new(AtomicUsize::new(0));
@@ -1143,7 +1146,7 @@ fn normal_start_response_loss_replays_b_without_creating_c() {
             }
         });
         std::fs::write(
-            &daemon,
+            &old_daemon,
             format!(
                 r#"#!/bin/sh
 case "$1 $2" in
@@ -1157,7 +1160,8 @@ case "$1 $2" in
     if [ "$3" = "--help" ]; then
       printf '%s\n' 'OPTIONS:' '    --replacement-operation-id <ID>'
     elif [ -f "{generation_count}" ]; then
-      printf '%s\n' '{{"success":true,"data":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}'
+      printf '%s' 'executed' > "{old_replay}"
+      exit 98
     else
       printf '%s' '1' > "{generation_count}"
       # The daemon has durably recorded B's operation key, but its SSH response
@@ -1167,14 +1171,45 @@ case "$1 $2" in
     ;;
 esac
 "#,
-                address = address,
                 generation_count = generation_count.display(),
+                old_replay = old_replay.display(),
             ),
         )
         .expect("write remote Homeboy shim");
-        let mut permissions = std::fs::metadata(&daemon).expect("metadata").permissions();
+        let mut permissions = std::fs::metadata(&old_daemon)
+            .expect("metadata")
+            .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(&daemon, permissions).expect("make shim executable");
+        std::fs::set_permissions(&old_daemon, permissions).expect("make shim executable");
+        std::fs::write(
+            &selected_daemon,
+            format!(
+                r#"#!/bin/sh
+case "$1 $2" in
+  "self identity")
+    printf '%s\n' '{{"success":true,"data":{{"version":"0.284.0","display":"homeboy 0.284.0+test"}}}}'
+    ;;
+  "daemon ensure-running")
+    if [ "$3" = "--help" ]; then
+      printf '%s\n' 'OPTIONS:' '    --replacement-operation-id <ID>'
+    else
+      printf '%s\n' "$@" > "{selected_argv}"
+      printf '%s\n' '{{"success":true,"data":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}'
+    fi
+    ;;
+esac
+"#,
+                address = address,
+                selected_argv = selected_argv.display(),
+            ),
+        )
+        .expect("write selected Homeboy shim");
+        let mut permissions = std::fs::metadata(&selected_daemon)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&selected_daemon, permissions)
+            .expect("make selected shim executable");
         server::create(
             &serde_json::json!({ "id": "local-runner", "host": "localhost", "user": "test" })
                 .to_string(),
@@ -1185,7 +1220,7 @@ esac
             &serde_json::json!({
                 "id": "local-runner",
                 "kind": "ssh",
-                "homeboy_path": daemon,
+                "homeboy_path": old_daemon,
             })
             .to_string(),
             false,
@@ -1214,6 +1249,16 @@ esac
         assert!(operation["replay_command"]
             .as_str()
             .is_some_and(|command| command.contains("--replacement-operation-id")));
+        let operation_id = operation["operation_id"]
+            .as_str()
+            .expect("ensure-running operation ID")
+            .to_string();
+        crate::merge(
+            Some("local-runner"),
+            &serde_json::json!({ "homeboy_path": selected_daemon }).to_string(),
+            &[],
+        )
+        .expect("select refreshed remote Homeboy");
 
         let (second, second_exit) =
             connect_with_orphan_adoption("local-runner", None, &[], false, None, None, None)
@@ -1231,6 +1276,13 @@ esac
             "replay must return B rather than starting C"
         );
         assert_eq!(health_requests.load(Ordering::SeqCst), 1);
+        assert!(
+            !old_replay.exists(),
+            "the obsolete absolute Homeboy path must not execute the replay"
+        );
+        let selected_argv =
+            std::fs::read_to_string(&selected_argv).expect("selected ensure-running arguments");
+        assert!(selected_argv.contains(&operation_id));
         assert!(!journal_dir.join("pending-replacement.json").exists());
         assert!(!journal_dir.join("replacement-operation.json").exists());
         endpoint.join().expect("endpoint");

--- a/docs/reference/cli/commands/index.md
+++ b/docs/reference/cli/commands/index.md
@@ -6,7 +6,7 @@ Hand-written narrative for these commands lives in `docs/commands/`. -->
 
 # Homeboy CLI reference (generated)
 
-`homeboy` exposes 534 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
+`homeboy` exposes 535 visible commands across 41 top-level command families. Every page below is generated from the clap command tree in `crates/homeboy-cli`, so it cannot drift from the binary.
 
 Hand-written narrative lives in the [commands index](../../../commands/commands-index.md). Global flags are documented in [the root command reference](../homeboy-root-command.md). Machine-readable safety, docs, output, and Lab metadata come from `homeboy contract manifest`.
 

--- a/docs/reference/cli/commands/release.md
+++ b/docs/reference/cli/commands/release.md
@@ -54,6 +54,7 @@ Plan release workflows
 | `homeboy release changes` | Show changes since the last version tag |
 | `homeboy release changelog` | Show generated changelog content |
 | `homeboy release version` | Version inspection helpers |
+| `homeboy release artifact-source-authority` | Write a source-authority manifest for assembled release artifacts |
 
 ## `homeboy release changes`
 
@@ -127,4 +128,22 @@ Show current version (default: discovered component, fallback: homeboy binary)
 | Option | Value | Description |
 | --- | --- | --- |
 | `--path` | `<PATH>` | Override local_path for version file lookup |
+
+## `homeboy release artifact-source-authority`
+
+```sh
+homeboy release artifact-source-authority [OPTIONS] <COMPONENT_ID>
+```
+
+Write a source-authority manifest for assembled release artifacts
+
+| Argument | Required | Description |
+| --- | --- | --- |
+| `<COMPONENT_ID>` | yes | Component prepared for finalization |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dir` | `<DIR>` | Directory containing the assembled publication files |
+| `--tag` | `<TAG>` | Prepared release tag |
+| `--commit` | `<COMMIT>` | Exact commit the prepared tag resolves to |
 


### PR DESCRIPTION
## Summary

- negotiate replay support on the currently selected verified runner binary
- durably rebind pending `ensure-running` replay to that binary before execution
- preserve the exact existing replacement operation ID and receipt semantics
- keep other opaque replay kinds unchanged and fail-closed
- prove a refreshed binary replaces an obsolete absolute path without creating a second replacement generation

Closes #10865. Supersedes #10866 with a clean `main`-based history after #10864 merged.

## Verification

- `cargo test -p homeboy-lab-runner connection::tests::recovery` (57 passed)
- `cargo test -p homeboy-lab-runner normal_start_response_loss_replays_b_without_creating_c`
- `cargo fmt --check`
- `git diff --check`
- live `homeboy-lab` recovery completed; status reports connected, accepting jobs, fresh daemon, and exact controller/runner identity `0.323.0+6899a01ad8d8`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the durable replay pinning from the live runner recovery, drafted the implementation and regression coverage, and ran the listed verification. Chris Huber reviewed and remains responsible for the change.