### PR TITLE
fix(upgrade): target configured runner identity

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -754,24 +754,14 @@ fn stale_daemon_warning_includes_explicit_refresh_recovery_command() {
     );
     assert_eq!(
         warning.refresh_command,
-        format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            homeboy_product_identity::build_identity()
-                .git_commit
-                .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
-        )
+        "homeboy runner refresh-homeboy homeboy-lab --ref new --reconnect"
     );
     assert!(warning.message.contains("daemon control plane"));
     assert!(warning.message.contains("job command binary"));
     assert!(warning.message.contains("active jobs are drained"));
     assert_eq!(
         warning.recovery_commands,
-        vec![format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            homeboy_product_identity::build_identity()
-                .git_commit
-                .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
-        )]
+        ["homeboy runner refresh-homeboy homeboy-lab --ref new --reconnect"]
     );
     assert_ne!(
         warning.refresh_command,
@@ -853,12 +843,7 @@ fn runtime_path_warning_uses_rebuild_specific_message() {
     assert!(warning.message.contains("runtime paths are stale"));
     assert_eq!(
         warning.recovery_commands,
-        vec![format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            homeboy_product_identity::build_identity()
-                .git_commit
-                .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
-        )]
+        ["homeboy runner refresh-homeboy homeboy-lab --ref same --reconnect"]
     );
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -1112,12 +1112,7 @@ fn runner_homeboy_metadata_carries_stale_daemon_details() {
     );
     // The explicit refresh owns the reconnect, so the recovery command avoids
     // a redundant disconnect/connect loop.
-    let expected_refresh = format!(
-        "homeboy runner refresh-homeboy lab --ref {} --reconnect",
-        homeboy_product_identity::build_identity()
-            .git_commit
-            .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
-    );
+    let expected_refresh = "homeboy runner refresh-homeboy lab --ref new --reconnect";
     assert_eq!(
         metadata["stale_daemon"]["refresh_command"],
         expected_refresh
@@ -1134,9 +1129,7 @@ fn runner_homeboy_metadata_carries_stale_daemon_details() {
         serde_json::json!([
             format!(
                 "homeboy runner refresh-homeboy lab --ref {} --reconnect",
-                homeboy_product_identity::build_identity()
-                    .git_commit
-                    .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
+                expected_controller_refresh_ref()
             ),
             "homeboy runner disconnect lab",
             "homeboy runner connect lab"

--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -257,10 +257,7 @@ fn lab_runner_preparation_falls_back_for_stale_default_runtime_paths() {
     assert_eq!(
         prepared,
         LabRunnerPreparation::FallBackLocal {
-            reason: format!(
-                "connected runner `lab` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `homeboy runner refresh-homeboy lab --ref {} --reconnect`",
-                homeboy_product_identity::build_identity().git_commit.unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
-            )
+            reason: "connected runner `lab` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `homeboy runner refresh-homeboy lab --ref bbbbbbbbbbbb --reconnect`".to_string()
         }
     );
 }
@@ -325,6 +322,7 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
     assert_eq!(action["args"][1], "refresh-homeboy");
     assert_eq!(action["args"][2], "lab");
     assert_eq!(action["args"][3], "--ref");
+    assert_eq!(action["args"][4], "bbbbbbbbbbbb");
     assert_eq!(action["args"][5], "--reconnect");
     assert_eq!(
         action["evidence"]["recovery_plan"][0],
@@ -854,8 +852,8 @@ fn stale_daemon_warning(runner_id: &str) -> RunnerStaleDaemonWarning {
         runner_id,
         "homeboy 0.218.0".to_string(),
         "homeboy 0.219.0".to_string(),
-        Some("homeboy 0.218.0+old".to_string()),
-        Some("homeboy 0.219.0+new".to_string()),
+        Some("homeboy 0.218.0+aaaaaaaaaaaa".to_string()),
+        Some("homeboy 0.219.0+bbbbbbbbbbbb".to_string()),
     )
 }
 
@@ -884,8 +882,8 @@ fn stale_runtime_path_warning(runner_id: &str) -> RunnerStaleDaemonWarning {
         runner_id,
         "homeboy 0.219.0".to_string(),
         "homeboy 0.219.0".to_string(),
-        Some("homeboy 0.219.0+same".to_string()),
-        Some("homeboy 0.219.0+same".to_string()),
+        Some("homeboy 0.219.0+aaaaaaaaaaaa".to_string()),
+        Some("homeboy 0.219.0+bbbbbbbbbbbb".to_string()),
     )
     .with_runtime_paths(
         runner_id,

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -716,9 +716,12 @@ fn daemon_repair_command(runner_id: &str, status: &RunnerStatusReport) -> String
 fn daemon_repair_action(runner_id: &str, status: &RunnerStatusReport) -> Option<ExecutableAction> {
     let steps = daemon_repair_steps(runner_id, status);
     let recovery_plan: Vec<&str> = steps.iter().map(|step| step.command.as_str()).collect();
-    let recovery_ref = homeboy_product_identity::build_identity()
-        .git_commit
-        .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()));
+    let recovery_ref = match status.stale_daemon.as_ref() {
+        Some(warning) => warning.recovery_ref()?,
+        None => homeboy_product_identity::build_identity()
+            .git_commit
+            .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version())),
+    };
     let action = ExecutableAction::new(
         "runner.refresh_homeboy",
         format!("refresh runner {runner_id}"),

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -956,6 +956,34 @@ mod status_serialization_tests {
     }
 
     #[test]
+    fn recovery_command_targets_the_configured_job_binary_commit() {
+        let initiating = homeboy_product_identity::BuildIdentity {
+            version: "0.323.1".to_string(),
+            git_commit: Some("6899aabbccdd".to_string()),
+            git_dirty: Some(false),
+            display: "homeboy 0.323.1+6899aabbccdd".to_string(),
+        };
+
+        assert_eq!(
+            recovery_command(
+                "homeboy-lab",
+                Some("homeboy 0.323.1+c8a6673b6abc"),
+                &initiating,
+            ),
+            ["homeboy runner refresh-homeboy homeboy-lab --ref c8a6673b6abc --reconnect"]
+        );
+        for configured in [
+            "homeboy 0.323.1+c8a6673b6abc-dirty",
+            "homeboy not-a-version",
+        ] {
+            assert_eq!(
+                recovery_command("homeboy-lab", Some(configured), &initiating),
+                Vec::<String>::new(),
+            );
+        }
+    }
+
+    #[test]
     fn admission_summary_disconnected_points_to_connect() {
         let mut report = base_report();
         report.connected = false;
@@ -1044,14 +1072,11 @@ impl RunnerStaleDaemonWarning {
         session_homeboy_build_identity: Option<String>,
         current_homeboy_build_identity: Option<String>,
     ) -> Self {
-        let recovery_ref = homeboy_product_identity::build_identity()
-            .git_commit
-            .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()));
-        let recovery_commands = vec![format!(
-            "homeboy runner refresh-homeboy {} --ref {} --reconnect",
-            shell::quote_arg(runner_id),
-            recovery_ref,
-        )];
+        let recovery_commands = recovery_command(
+            runner_id,
+            current_homeboy_build_identity.as_deref(),
+            &homeboy_product_identity::build_identity(),
+        );
         let message = if !same_homeboy_version(&session_homeboy_version, &current_homeboy_version) {
             format!(
                 "connected runner daemon control plane version `{session_homeboy_version}` differs from configured job command binary version `{current_homeboy_version}`; run recovery_commands in order when runner active jobs are drained"
@@ -1175,6 +1200,34 @@ impl RunnerStaleDaemonWarning {
         }
         self
     }
+}
+
+fn recovery_command(
+    runner_id: &str,
+    configured_identity: Option<&str>,
+    initiating_identity: &homeboy_product_identity::BuildIdentity,
+) -> Vec<String> {
+    let recovery_ref = match configured_identity {
+        // The runner's configured executable is the desired post-recovery job
+        // binary. A present but dirty or unverifiable identity must not be
+        // replaced with the initiating controller's unrelated commit.
+        Some(identity) => homeboy_upgrade::upgrade::parse_build_identity_display(identity)
+            .filter(|identity| identity.git_dirty != Some(true))
+            .and_then(|identity| identity.git_commit),
+        None if initiating_identity.git_dirty != Some(true) => {
+            initiating_identity.git_commit.clone()
+        }
+        None => None,
+    };
+    recovery_ref
+        .map(|recovery_ref| {
+            format!(
+                "homeboy runner refresh-homeboy {} --ref {recovery_ref} --reconnect",
+                shell::quote_arg(runner_id),
+            )
+        })
+        .into_iter()
+        .collect()
 }
 
 fn same_homeboy_version(left: &str, right: &str) -> bool {

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -1148,6 +1148,13 @@ impl RunnerStaleDaemonWarning {
         self
     }
 
+    pub(crate) fn recovery_ref(&self) -> Option<String> {
+        recovery_ref(
+            self.current_homeboy_build_identity.as_deref(),
+            &homeboy_product_identity::build_identity(),
+        )
+    }
+
     pub fn with_identity_unverifiable(
         mut self,
         runner_id: &str,
@@ -1207,7 +1214,22 @@ fn recovery_command(
     configured_identity: Option<&str>,
     initiating_identity: &homeboy_product_identity::BuildIdentity,
 ) -> Vec<String> {
-    let recovery_ref = match configured_identity {
+    recovery_ref(configured_identity, initiating_identity)
+        .map(|recovery_ref| {
+            format!(
+                "homeboy runner refresh-homeboy {} --ref {recovery_ref} --reconnect",
+                shell::quote_arg(runner_id),
+            )
+        })
+        .into_iter()
+        .collect()
+}
+
+fn recovery_ref(
+    configured_identity: Option<&str>,
+    initiating_identity: &homeboy_product_identity::BuildIdentity,
+) -> Option<String> {
+    match configured_identity {
         // The runner's configured executable is the desired post-recovery job
         // binary. A present but dirty or unverifiable identity must not be
         // replaced with the initiating controller's unrelated commit.
@@ -1218,16 +1240,7 @@ fn recovery_command(
             initiating_identity.git_commit.clone()
         }
         None => None,
-    };
-    recovery_ref
-        .map(|recovery_ref| {
-            format!(
-                "homeboy runner refresh-homeboy {} --ref {recovery_ref} --reconnect",
-                shell::quote_arg(runner_id),
-            )
-        })
-        .into_iter()
-        .collect()
+    }
 }
 
 fn same_homeboy_version(left: &str, right: &str) -> bool {

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -1053,7 +1053,7 @@ fn paths_identify_same_binary(a: &Path, b: &Path) -> bool {
 /// the form `homeboy <version>[+<commit>[-dirty]]` (the exact format
 /// `homeboy_product_identity` emits). Returns `None` for an unrecognizable
 /// string so callers can fall back to the safe unverifiable-replacement path.
-pub(crate) fn parse_build_identity_display(
+pub fn parse_build_identity_display(
     display: &str,
 ) -> Option<homeboy_core::build_identity::BuildIdentity> {
     let display = display.trim();

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -347,7 +347,7 @@ pub fn run_upgrade_with_method(
                 runner_method_override,
                 source_upgrade_path.as_deref(),
                 source_path.is_some(),
-                None,
+                new_build_identity.as_deref(),
                 runner_targets,
                 &extensions_updated,
             )

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -9,6 +9,7 @@ pub mod update_check;
 mod validation;
 
 pub(crate) use constants::VERSION;
+pub use execution::parse_build_identity_display;
 pub use helpers::{
     current_build_version, current_version, detect_install_method, fetch_latest_version,
     run_upgrade_with_method, version_is_newer,


### PR DESCRIPTION
## Summary
- derive stale-daemon recovery commands from the configured runner job-binary identity
- carry the newly installed controller identity through source-upgrade runner restart reporting
- align typed executable recovery actions with the same configured identity
- suppress automatic mutation commands when the configured identity is dirty or cannot be parsed

## Verification
- `cargo test -p homeboy-upgrade` (123 passed)
- `cargo test -p homeboy-lab-runner stale_daemon` (16 passed)
- `cargo test -p homeboy-lab-runner lab_runner_preparation_` (9 passed)
- `cargo test -p homeboy-lab-runner recovery_command_targets_the_configured_job_binary_commit`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- Homeboy review run `55ca1b46-38f5-4092-9c60-9be5f1b1440e`: audit passed with no introduced findings; lint passed with zero findings; umbrella test infrastructure terminated at the known repository timeout with exit 143 and no reported test failure

Closes #10871

## AI assistance
Substantive implementation and tests were drafted with OpenAI GPT-5.6 Sol using OpenCode. Chris Huber reviewed and remains responsible for the change.