### PR TITLE
fix(runner): rebind authoritative idle lease

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -209,10 +209,11 @@ fn converged_idle_generations_rebind_the_normal_disconnect_owner() {
     let daemon = status.daemon.expect("authoritative daemon");
 
     let rebound = super::super::stop_transport_recovery::rebind_idle_generation_owner(
-        &session,
+        &[session.clone(), second.clone(), third.clone()],
         &daemon,
         daemon.lease_id.clone().expect("lease"),
-    );
+    )
+    .expect("retained generation provides an endpoint template");
 
     assert_eq!(
         rebound.remote_daemon_lease_id.as_deref(),

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -296,27 +296,19 @@ fn reconcile_authoritative_idle_stale_generations(
         return Ok(None);
     };
     let daemon = status.daemon.expect("authoritative lease requires daemon");
-    let authoritative_endpoint = generations
-        .iter()
-        .find(|generation| generation.remote_daemon_lease_id.as_deref() == Some(&lease_id))
-        .expect("authoritative lease was selected from retained generations");
-    Ok(Some(rebind_idle_generation_owner(
-        authoritative_endpoint,
-        &daemon,
-        lease_id,
-    )))
+    Ok(rebind_idle_generation_owner(generations, &daemon, lease_id))
 }
 
 pub(in crate::connection) fn rebind_idle_generation_owner(
-    session: &RunnerSession,
+    generations: &[RunnerSession],
     daemon: &remote_daemon::RemoteDaemon,
     lease_id: String,
-) -> RunnerSession {
-    let mut authoritative_session = session.clone();
+) -> Option<RunnerSession> {
+    let mut authoritative_session = generations.first()?.clone();
     authoritative_session.remote_daemon_lease_id = Some(lease_id);
     authoritative_session.remote_daemon_pid = daemon.pid;
     authoritative_session.remote_daemon_address = Some(daemon.address.clone());
-    authoritative_session
+    Some(authoritative_session)
 }
 
 /// Clearing the ledger is safe only when every generation is represented by a


### PR DESCRIPTION
## Summary
- stop requiring a newly discovered authoritative lease to already exist in the stale generation ledger
- rebind a retained direct-SSH endpoint template to the independently verified idle daemon lease, PID, and address
- exercise the production selector with multiple stale generation leases

## Verification
- `cargo test -p homeboy-lab-runner stale_generation` (6 passed)
- `cargo test -p homeboy-lab-runner converged_idle_generations_rebind_the_normal_disconnect_owner`
- `cargo fmt --check`
- `git diff --check`

Closes #10873

## AI assistance
Substantive implementation and tests were drafted with OpenAI GPT-5.6 Sol using OpenCode. Chris Huber reviewed and remains responsible for the change.