### PR TITLE
Keep recovery manifest paths relative to artifact root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1195,7 +1195,7 @@ jobs:
             --arg version "${RELEASE_VERSION}" \
             --arg commit "${COMMIT}" \
             --argjson expected_assets "${EXPECTED_ASSETS}" \
-            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, artifacts: [$expected_assets[] | {path: ("artifacts/" + .)}]}' > artifacts/manifest.json
+            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, artifacts: [$expected_assets[] | {path: .}]}' > artifacts/manifest.json
 
       - name: Create remote draft adoption manifest
         if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true'

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1023,7 +1023,11 @@ fn incomplete_recovery_delivers_identity_bound_artifacts_to_the_finalizer() {
     assert!(recovery.contains("--arg schema homeboy.package-recovery"));
     assert!(recovery.contains("--arg tag \"${RELEASE_TAG}\""));
     assert!(recovery.contains("--arg commit \"${COMMIT}\""));
-    assert!(recovery.contains("artifacts: [$expected_assets[] | {path: (\"artifacts/\" + .)}]"));
+    assert!(recovery.contains("artifacts: [$expected_assets[] | {path: .}]"));
+    assert!(
+        !recovery.contains("path: (\"artifacts/\" + .)"),
+        "manifest paths are relative to --from-artifacts artifacts"
+    );
     assert!(adoption.contains(
         "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true'"
     ));


### PR DESCRIPTION
## Summary
- emit recovery manifest paths relative to `--from-artifacts artifacts`
- prevent the workflow from resolving assets as `artifacts/artifacts/<name>`
- update focused workflow coverage to reject the duplicated directory prefix

Closes #10869

## Evidence
- Failed run: https://github.com/Extra-Chill/homeboy/actions/runs/30510865405
- Failed job: https://github.com/Extra-Chill/homeboy/actions/runs/30510865405/job/90774962286
- Exact failure: `Recovered release asset artifacts/dist-manifest.json is missing`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test release_workflow_test` (39 passed)
- `cargo test --test release_expected_assets_test` (5 passed)
- `git diff --check`

## Compatibility
The expected publication inventory is unchanged, including `dist-manifest.json`. Source-authority validation remains fail-closed; only the workflow producer is corrected to honor its existing relative-path contract.

## AI Assistance
OpenCode with OpenAI gpt-5.6-sol diagnosed the recovery path mismatch, implemented the bounded workflow/test correction, and ran deterministic verification. Chris Huber remains responsible for the submitted change.