### PR TITLE
fix(release): allow persisted notes during head recovery

### DIFF
--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -345,7 +345,16 @@ fn run_working_tree_preflight(
     step: &PlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
-    match super::planning_worktree::validate_working_tree_fail_fast(context.component) {
+    let release_notes_tag = context
+        .options
+        .pipeline
+        .head
+        .then_some(context.state.tag.as_deref())
+        .flatten();
+    match super::planning_worktree::validate_working_tree_fail_fast(
+        context.component,
+        release_notes_tag,
+    ) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
             step_type: step.kind.clone(),
@@ -933,7 +942,7 @@ mod tests {
         release_step_unexpected_dirty_files, ReleaseExecutionContext,
     };
     use crate::release::types::{
-        ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
+        ReleaseOptions, ReleasePipelineOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
     };
     use homeboy_core::component::{Component, ComponentScriptsConfig, VersionTarget};
     use homeboy_core::deps::{DependencyCommandResult, DependencyInstallResult};
@@ -1594,6 +1603,52 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         assert!(!release_step_is_show_stopper(&result));
+    }
+
+    #[test]
+    fn head_preflight_recovers_with_the_persisted_release_notes_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        run_in(temp.path(), &["git", "init", "-q"]);
+        configure_git_user(temp.path());
+        std::fs::write(temp.path().join("README.md"), "fixture\n").expect("write fixture");
+        run_in(temp.path(), &["git", "add", "."]);
+        run_in(
+            temp.path(),
+            &["git", "commit", "-q", "-m", "Initial commit"],
+        );
+        std::fs::create_dir(temp.path().join("build")).expect("create build directory");
+        std::fs::write(temp.path().join("build/v1.2.3-release-notes.md"), "notes\n")
+            .expect("write persisted notes");
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let options = ReleaseOptions {
+            pipeline: ReleasePipelineOptions {
+                head: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState {
+                tag: Some("v1.2.3".to_string()),
+                ..Default::default()
+            },
+            publish_failed: false,
+        };
+
+        let result = execute_release_plan_step(&plan_step("preflight.working_tree"), &mut context)
+            .expect("dispatch")
+            .expect("result");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -33,6 +33,7 @@ mod tagging;
 pub(crate) mod version_targets;
 
 pub(crate) use git_push::run_git_push;
+pub(crate) use github_release::release_notes_path as github_release_notes_path;
 pub(crate) use github_release::run_github_release;
 pub(crate) use package::{build_release_payload, run_extension_release_preflight, run_package};
 pub(crate) use publish::{publish_response_output, run_publish};

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -18,6 +18,7 @@ mod run;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use notes::release_notes_path;
 pub(crate) use run::run_github_release;
 
 #[cfg(test)]

--- a/crates/homeboy-release/src/release/executor/github_release/notes.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/notes.rs
@@ -201,7 +201,7 @@ pub(super) fn persist_release_body(component: &Component, tag: &str, body: &str)
         );
         return None;
     }
-    let file = build_dir.join(format!("{}-release-notes.md", safe_filename(tag)));
+    let file = std::path::Path::new(&component.local_path).join(release_notes_path(tag));
     match std::fs::write(&file, body) {
         Ok(()) => Some(file.to_string_lossy().replace('\\', "/")),
         Err(err) => {
@@ -209,6 +209,11 @@ pub(super) fn persist_release_body(component: &Component, tag: &str, body: &str)
             None
         }
     }
+}
+
+/// Relative path reserved for the exact GitHub Release body persisted by Homeboy.
+pub(crate) fn release_notes_path(tag: &str) -> String {
+    format!("build/{}-release-notes.md", safe_filename(tag))
 }
 
 fn github_generated_notes(

--- a/crates/homeboy-release/src/release/planning_worktree.rs
+++ b/crates/homeboy-release/src/release/planning_worktree.rs
@@ -71,7 +71,10 @@ pub(super) fn validate_release_worktree(
 
 /// Stage 0 fail-fast: refuse to run release work when the working tree has
 /// unexplained dirty files before lint/test/build can drown out the real error.
-pub(super) fn validate_working_tree_fail_fast(component: &Component) -> Result<()> {
+pub(super) fn validate_working_tree_fail_fast(
+    component: &Component,
+    release_notes_tag: Option<&str>,
+) -> Result<()> {
     let uncommitted = homeboy_core::git::get_uncommitted_changes(&component.local_path)?;
     if !uncommitted.has_changes {
         return Ok(());
@@ -97,6 +100,19 @@ pub(super) fn validate_working_tree_fail_fast(component: &Component) -> Result<(
             .iter()
             .any(|allowed| paths_match(file, allowed))
     });
+    if let Some(tag) = release_notes_tag {
+        let release_notes_path = super::executor::github_release_notes_path(tag);
+        unexpected.retain(|file| {
+            !uncommitted.untracked.iter().any(|untracked| {
+                paths_are_equal(untracked, file)
+                    && untracked_entry_is_only_release_notes(
+                        Path::new(&component.local_path),
+                        untracked,
+                        &release_notes_path,
+                    )
+            })
+        });
+    }
     if unexpected.is_empty() {
         return Ok(());
     }
@@ -290,6 +306,86 @@ fn paths_match(file: &str, allowed: &str) -> bool {
     file == allowed || file.ends_with(allowed) || allowed.ends_with(file)
 }
 
+fn paths_are_equal(left: &str, right: &str) -> bool {
+    normalize_relative_path(left) == normalize_relative_path(right)
+}
+
+fn untracked_entry_is_only_release_notes(
+    repo_root: &Path,
+    entry: &str,
+    release_notes_path: &str,
+) -> bool {
+    let entry = normalize_relative_path(entry);
+    let release_notes_path = normalize_relative_path(release_notes_path);
+    if entry == release_notes_path {
+        return std::fs::symlink_metadata(repo_root.join(&entry))
+            .is_ok_and(|metadata| metadata.file_type().is_file());
+    }
+    if !release_notes_path.starts_with(&format!("{entry}/")) {
+        return false;
+    }
+
+    let entry_path = repo_root.join(&entry);
+    let Ok(mut entries) = std::fs::read_dir(entry_path) else {
+        return false;
+    };
+    let mut files = Vec::new();
+    while let Some(entry) = entries.next() {
+        let Ok(dir_entry) = entry else {
+            return false;
+        };
+        let path = dir_entry.path();
+        let Ok(file_type) = dir_entry.file_type() else {
+            return false;
+        };
+        if file_type.is_symlink() {
+            return false;
+        }
+        if file_type.is_dir() {
+            let relative = match path.strip_prefix(repo_root) {
+                Ok(relative) => relative,
+                Err(_) => return false,
+            };
+            if !untracked_entry_is_only_release_notes(
+                repo_root,
+                &relative.to_string_lossy(),
+                &release_notes_path,
+            ) {
+                return false;
+            }
+        } else if file_type.is_file() {
+            let relative = match path.strip_prefix(repo_root) {
+                Ok(relative) => normalize_relative_path(&relative.to_string_lossy()),
+                Err(_) => return false,
+            };
+            files.push(relative);
+        } else {
+            return false;
+        }
+    }
+
+    files.len() == 1 && files[0] == release_notes_path
+}
+
+fn normalize_relative_path(path: &str) -> String {
+    path.replace('\\', "/")
+        .split('/')
+        .filter(|part| !part.is_empty() && *part != ".")
+        .fold(Vec::new(), |mut parts, part| {
+            if part == ".." {
+                if parts.last().is_some_and(|previous| *previous != "..") {
+                    parts.pop();
+                } else {
+                    parts.push(part);
+                }
+            } else {
+                parts.push(part);
+            }
+            parts
+        })
+        .join("/")
+}
+
 fn declared_build_artifact_paths(component: &Component) -> Vec<String> {
     let status_root = Path::new(&component.local_path);
     let scan_root = homeboy_core::component::resolution::detect_git_root(status_root)
@@ -367,8 +463,8 @@ fn should_skip_artifact_scan_dir(path: &Path) -> bool {
 mod tests {
     use super::{
         declared_build_artifact_paths, filter_homeboy_managed, get_release_allowed_files,
-        get_unexpected_uncommitted_files, is_homeboy_managed_path, validate_release_worktree,
-        validate_working_tree_fail_fast,
+        get_unexpected_uncommitted_files, is_homeboy_managed_path, normalize_relative_path,
+        validate_release_worktree, validate_working_tree_fail_fast,
     };
     use crate::release::types::ReleaseOptions;
     use crate::release::version::{ComponentVersionInfo, VersionTargetInfo};
@@ -526,7 +622,7 @@ mod tests {
         run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
         std::fs::write(dir.join("src.rs"), "unexpected\n").unwrap();
 
-        let err = validate_working_tree_fail_fast(&git_component(dir))
+        let err = validate_working_tree_fail_fast(&git_component(dir), None)
             .expect_err("unexpected user file should fail fast");
 
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
@@ -552,7 +648,7 @@ mod tests {
         let mut component = git_component(dir);
         component.changelog_target = Some("docs/CHANGELOG.md".to_string());
 
-        validate_working_tree_fail_fast(&component)
+        validate_working_tree_fail_fast(&component, None)
             .expect("a bootstrapped changelog must not abort the release that created it");
     }
 
@@ -574,9 +670,81 @@ mod tests {
         let mut component = git_component(dir);
         component.changelog_target = Some("docs/CHANGELOG.md".to_string());
 
-        let err = validate_working_tree_fail_fast(&component)
+        let err = validate_working_tree_fail_fast(&component, None)
             .expect_err("unrelated dirty files must still fail fast");
         assert!(err.details.to_string().contains("src.rs"));
+    }
+
+    #[test]
+    fn head_recovery_allows_only_its_untracked_persisted_release_notes() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("README.md"), "initial\n").unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+        std::fs::create_dir(dir.join("build")).unwrap();
+        std::fs::write(dir.join("build/v1.2.3-release-notes.md"), "notes\n").unwrap();
+
+        validate_working_tree_fail_fast(&git_component(dir), Some("v1.2.3"))
+            .expect("head recovery should allow the exact persisted release notes file");
+
+        std::fs::write(dir.join("build/other-release-notes.md"), "other\n").unwrap();
+        let err = validate_working_tree_fail_fast(&git_component(dir), Some("v1.2.3"))
+            .expect_err("other build files must remain blocked");
+        assert!(err.details.to_string().contains("build/"));
+    }
+
+    #[test]
+    fn head_recovery_blocks_tracked_persisted_release_notes_modifications() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::create_dir(dir.join("build")).unwrap();
+        std::fs::write(dir.join("build/v1.2.3-release-notes.md"), "initial\n").unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+        std::fs::write(dir.join("build/v1.2.3-release-notes.md"), "modified\n").unwrap();
+
+        let err = validate_working_tree_fail_fast(&git_component(dir), Some("v1.2.3"))
+            .expect_err("tracked release notes modifications must remain blocked");
+        assert!(err
+            .details
+            .to_string()
+            .contains("build/v1.2.3-release-notes.md"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn head_recovery_blocks_an_untracked_release_notes_symlink() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("README.md"), "initial\n").unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+        std::fs::create_dir(dir.join("build")).unwrap();
+        std::os::unix::fs::symlink(
+            dir.join("README.md"),
+            dir.join("build/v1.2.3-release-notes.md"),
+        )
+        .unwrap();
+
+        validate_working_tree_fail_fast(&git_component(dir), Some("v1.2.3"))
+            .expect_err("a symlink must not be accepted as Homeboy-generated release notes");
+    }
+
+    #[test]
+    fn release_notes_path_matching_normalizes_git_path_spellings() {
+        assert_eq!(
+            normalize_relative_path("./build\\v1.2.3-release-notes.md"),
+            "build/v1.2.3-release-notes.md"
+        );
+        assert_eq!(
+            normalize_relative_path("build//nested/../v1.2.3-release-notes.md"),
+            "build/v1.2.3-release-notes.md"
+        );
+        assert_eq!(
+            normalize_relative_path("../build/v1.2.3-release-notes.md"),
+            "../build/v1.2.3-release-notes.md"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n\n- allow the exact Homeboy-generated release notes file for the target tag during `--head` working-tree preflight\n- preserve strict rejection of unrelated files, tracked modifications, extra build files, and symlinks\n- share the release-note path contract with GitHub publication\n\nCloses #10876\n\n## Verification\n\n- `cargo fmt --check`\n- `cargo test -p homeboy-release planning_worktree::tests --lib` (24 passed)\n- `cargo test -p homeboy-release execution_dispatch::tests::head_preflight_recovers_with_the_persisted_release_notes_file --lib`\n- `git diff --check`\n\n## AI Assistance\n\nOpenCode with `openai/gpt-5.6-sol` implemented and tested the release recovery contract under Chris Huber's direction. Chris reviewed the behavioral boundary and remains responsible for every line.