### PR TITLE
fix(runner): converge compatible refresh promotions

### DIFF
--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -195,7 +195,7 @@ pub fn acquire_waiting_for_compatible(
     operation: &str,
     target: impl Into<String>,
     timeout: Duration,
-    mut progress: impl FnMut(RuntimePromotionWaitEvent),
+    progress: impl FnMut(RuntimePromotionWaitEvent),
 ) -> Result<RuntimePromotionLease> {
     acquire_waiting_for_compatible_key(operation, target, "", timeout, progress)
 }

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -58,6 +58,11 @@ pub struct RuntimePromotionLeaseRecord {
     pub operation: String,
     pub target: String,
     pub generation: String,
+    /// Non-secret result fingerprint used for exact compatible-owner waits.
+    /// Error diagnostics expose it, so callers must use immutable revision IDs
+    /// or hashes rather than credentials or request payloads.
+    #[serde(default)]
+    pub compatibility_key: String,
     pub started_at: String,
     /// Linux start ticks fence PID reuse. Platforms that cannot supply this
     /// evidence retain a live PID as a fail-closed owner.
@@ -112,6 +117,7 @@ pub struct RuntimePromotionLease {
     primary: bool,
     generation: String,
     target: String,
+    compatibility_key: String,
     owner_pid: u32,
     capability: String,
     // Held from reservation through promotion completion. Pin creation takes a
@@ -152,6 +158,7 @@ impl Drop for RuntimePromotionLease {
                 record.pid == self.owner_pid
                     && record.target == self.target
                     && record.generation == self.generation
+                    && record.compatibility_key == self.compatibility_key
                     && record.capability == self.capability
             }) {
                 let _ = fs::remove_dir_all(&self.path);
@@ -170,7 +177,12 @@ impl Drop for RuntimeGenerationPinGuard {
 /// and generation. A child process must present the capability explicitly
 /// attached by [`RuntimePromotionLease::authorize_subprocess`].
 pub fn acquire(operation: &str, target: impl Into<String>) -> Result<RuntimePromotionLease> {
-    acquire_with_pin_policy(operation, target.into(), ForeignPinPolicy::Block)
+    acquire_with_pin_policy(
+        operation,
+        target.into(),
+        String::new(),
+        ForeignPinPolicy::Block,
+    )
 }
 
 /// Wait for a compatible owner to finish, then acquire the writer lease.
@@ -185,18 +197,35 @@ pub fn acquire_waiting_for_compatible(
     timeout: Duration,
     mut progress: impl FnMut(RuntimePromotionWaitEvent),
 ) -> Result<RuntimePromotionLease> {
+    acquire_waiting_for_compatible_key(operation, target, "", timeout, progress)
+}
+
+/// Wait only for an owner with an exactly matching opaque result key.
+pub fn acquire_waiting_for_compatible_key(
+    operation: &str,
+    target: impl Into<String>,
+    compatibility_key: impl Into<String>,
+    timeout: Duration,
+    mut progress: impl FnMut(RuntimePromotionWaitEvent),
+) -> Result<RuntimePromotionLease> {
     let target = target.into();
+    let compatibility_key = compatibility_key.into();
     let generation = current_generation();
     let deadline = Instant::now() + timeout;
     let mut last_owner = None;
     let mut last_progress = None;
 
     loop {
-        match acquire(operation, target.clone()) {
+        match acquire_with_pin_policy(
+            operation,
+            target.clone(),
+            compatibility_key.clone(),
+            ForeignPinPolicy::Block,
+        ) {
             Ok(lease) => return Ok(lease),
             Err(error) if is_contention_error(&error) => {
                 let owner = contention_owner(&error)?;
-                if !is_compatible_owner(&owner, &target, &generation) {
+                if !is_compatible_owner(&owner, &target, &generation, &compatibility_key) {
                     return Err(error);
                 }
                 let owner_identity = format!("{}:{}:{}", owner.pid, owner.operation, owner.target);
@@ -241,7 +270,12 @@ pub fn acquire_for_generation_rotation(
     operation: &str,
     target: impl Into<String>,
 ) -> Result<RuntimePromotionLease> {
-    acquire_with_pin_policy(operation, target.into(), ForeignPinPolicy::Allow)
+    acquire_with_pin_policy(
+        operation,
+        target.into(),
+        String::new(),
+        ForeignPinPolicy::Allow,
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -253,6 +287,7 @@ enum ForeignPinPolicy {
 fn acquire_with_pin_policy(
     operation: &str,
     target: String,
+    compatibility_key: String,
     foreign_pin_policy: ForeignPinPolicy,
 ) -> Result<RuntimePromotionLease> {
     let root = paths::runtime_promotion_dir()?;
@@ -273,6 +308,7 @@ fn acquire_with_pin_policy(
                 operation: operation.to_string(),
                 target: target.clone(),
                 generation: generation.clone(),
+                compatibility_key: compatibility_key.clone(),
                 started_at: now(),
                 linux_starttime_ticks: crate::process::linux_process_starttime_ticks(pid)
                     .ok()
@@ -287,7 +323,12 @@ fn acquire_with_pin_policy(
                 // after mkdir and before publication. Retry from acquisition;
                 // never return an unpublished guard.
                 if !path.exists() {
-                    return acquire_with_pin_policy(operation, target, foreign_pin_policy);
+                    return acquire_with_pin_policy(
+                        operation,
+                        target,
+                        compatibility_key,
+                        foreign_pin_policy,
+                    );
                 }
                 return Err(error);
             }
@@ -297,6 +338,7 @@ fn acquire_with_pin_policy(
                 primary: true,
                 generation,
                 target,
+                compatibility_key,
                 owner_pid: pid,
                 capability,
                 admission_lock: None,
@@ -309,6 +351,7 @@ fn acquire_with_pin_policy(
                     primary: false,
                     generation,
                     target,
+                    compatibility_key: held.compatibility_key.clone(),
                     owner_pid: held.pid,
                     capability: held.capability,
                     admission_lock: None,
@@ -322,6 +365,7 @@ fn acquire_with_pin_policy(
                     primary: false,
                     generation,
                     target,
+                    compatibility_key: held.compatibility_key.clone(),
                     owner_pid: held.pid,
                     capability: held.capability,
                     admission_lock: None,
@@ -331,9 +375,21 @@ fn acquire_with_pin_policy(
                 // Rename is the ownership CAS: one recovery moves the stale
                 // directory while former owners cannot remove its replacement.
                 match archive_stale_lease(&root, &path, &held) {
-                    Ok(_) => return acquire_with_pin_policy(operation, target, foreign_pin_policy),
+                    Ok(_) => {
+                        return acquire_with_pin_policy(
+                            operation,
+                            target,
+                            compatibility_key,
+                            foreign_pin_policy,
+                        )
+                    }
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                        return acquire_with_pin_policy(operation, target, foreign_pin_policy)
+                        return acquire_with_pin_policy(
+                            operation,
+                            target,
+                            compatibility_key,
+                            foreign_pin_policy,
+                        )
                     }
                     Err(error) => return Err(io("archive stale runtime promotion lease")(error)),
                 }
@@ -448,6 +504,7 @@ impl RuntimePromotionLease {
         if record.pid != self.owner_pid
             || record.target != self.target
             || record.generation != self.generation
+            || record.compatibility_key != self.compatibility_key
             || record.capability != self.capability
         {
             return Err(Error::internal_unexpected(
@@ -716,6 +773,7 @@ fn blocked_error(held: &RuntimePromotionLeaseRecord, reclaimable: bool) -> Error
             "holder_pid": held.pid,
             "holder_operation": held.operation,
             "holder_generation": held.generation,
+            "holder_compatibility_key": held.compatibility_key,
             "reclaimable": reclaimable,
             "tried": [action, "Follow: `homeboy self doctor`"],
         }),
@@ -738,6 +796,10 @@ fn contention_owner(error: &Error) -> Result<RuntimePromotionLeaseRecord> {
         operation: string("holder_operation")?,
         target: string("target")?,
         generation: string("holder_generation")?,
+        compatibility_key: details["holder_compatibility_key"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
         started_at: String::new(),
         linux_starttime_ticks: None,
         process_start_identity: None,
@@ -751,8 +813,13 @@ fn is_compatible_owner(
     owner: &RuntimePromotionLeaseRecord,
     target: &str,
     generation: &str,
+    compatibility_key: &str,
 ) -> bool {
-    owner.target == target && owner.generation == generation
+    owner.target == target
+        && owner.generation == generation
+        && (compatibility_key.is_empty()
+            || (!owner.compatibility_key.is_empty()
+                && owner.compatibility_key == compatibility_key))
 }
 
 fn wait_timeout_error(owner: &RuntimePromotionLeaseRecord, timeout: Duration) -> Error {
@@ -775,6 +842,7 @@ fn wait_timeout_error(owner: &RuntimePromotionLeaseRecord, timeout: Duration) ->
             "holder_pid": owner.pid,
             "holder_operation": owner.operation,
             "holder_generation": owner.generation,
+            "holder_compatibility_key": owner.compatibility_key,
             "tried": ["The compatible promotion owner did not finish before the admission deadline.", "Retry the same command after the owner completes or inspect its runtime-promotion lease."],
         }),
     )
@@ -895,6 +963,7 @@ mod tests {
             operation: "upgrade".to_string(),
             target: "main".to_string(),
             generation: "old".to_string(),
+            compatibility_key: String::new(),
             started_at: now(),
             linux_starttime_ticks: None,
             process_start_identity: None,
@@ -949,6 +1018,7 @@ mod tests {
             operation: "runner refresh".to_string(),
             target: "lab".to_string(),
             generation: "old".to_string(),
+            compatibility_key: String::new(),
             started_at: now(),
             linux_starttime_ticks: None,
             process_start_identity: None,
@@ -965,19 +1035,31 @@ mod tests {
     }
 
     #[test]
-    fn compatible_contenders_wait_for_the_owner_then_each_acquire() {
+    fn compatible_same_target_and_generation_contenders_converge_after_owner_release() {
         crate::test_support::with_isolated_home(|_| {
-            let mut owner = compatible_wait_owner();
+            let owner = acquire_waiting_for_compatible_key(
+                "owner",
+                "lab",
+                "candidate-a",
+                Duration::from_secs(1),
+                |_| unreachable!("uncontended owner does not queue"),
+            )
+            .expect("owner acquires lease");
             let (queued, queued_result) = std::sync::mpsc::channel();
             let contenders = (0..3)
                 .map(|_| {
                     let queued = queued.clone();
                     std::thread::spawn(move || {
-                        acquire_waiting_for_compatible(
+                        acquire_waiting_for_compatible_key(
                             "contender",
                             "lab",
+                            "candidate-a",
                             Duration::from_secs(1),
-                            |event| queued.send(event.owner_pid).expect("report queued owner"),
+                            |event| {
+                                queued
+                                    .send((event.owner_pid, event.target, event.owner_generation))
+                                    .expect("report queued owner")
+                            },
                         )
                         .map(drop)
                     })
@@ -990,16 +1072,16 @@ mod tests {
                     queued_result
                         .recv_timeout(Duration::from_secs(1))
                         .expect("contender reports the current owner"),
-                    owner.id()
+                    (std::process::id(), "lab".to_string(), current_generation(),)
                 );
             }
-            owner.wait().expect("owner exits");
+            drop(owner);
 
             for contender in contenders {
                 contender
                     .join()
                     .expect("contender exits")
-                    .expect("compatible contender acquires after handoff");
+                    .expect("compatible contender acquires after deterministic handoff");
             }
         });
     }
@@ -1051,7 +1133,7 @@ mod tests {
     #[test]
     fn incompatible_contender_remains_fail_closed() {
         crate::test_support::with_isolated_home(|_| {
-            let _owner = acquire("owner", "lab").expect("owner acquires lease");
+            let _owner = acquire("owner operation", "lab").expect("owner acquires lease");
             let error = acquire_waiting_for_compatible(
                 "other target",
                 "other-lab",
@@ -1060,15 +1142,49 @@ mod tests {
             )
             .expect_err("different promotion target remains serialized");
             assert_eq!(error.code, ErrorCode::RuntimePromotionContended);
+            assert_eq!(error.details["holder_pid"], std::process::id());
+            assert_eq!(error.details["holder_operation"], "owner operation");
+            assert_eq!(error.details["target"], "lab");
+            assert_eq!(error.details["holder_generation"], current_generation());
         });
     }
 
     #[test]
-    fn compatibility_requires_the_same_target_and_generation() {
+    fn compatibility_is_asymmetric_for_unkeyed_and_keyed_owners() {
         let owner = lease_record();
-        assert!(is_compatible_owner(&owner, "lab", "generation-a"));
-        assert!(!is_compatible_owner(&owner, "other-lab", "generation-a"));
-        assert!(!is_compatible_owner(&owner, "lab", "generation-b"));
+        assert!(is_compatible_owner(
+            &owner,
+            "lab",
+            "generation-a",
+            "candidate-a"
+        ));
+        assert!(!is_compatible_owner(
+            &owner,
+            "other-lab",
+            "generation-a",
+            "candidate-a"
+        ));
+        assert!(!is_compatible_owner(
+            &owner,
+            "lab",
+            "generation-b",
+            "candidate-a"
+        ));
+        assert!(!is_compatible_owner(
+            &owner,
+            "lab",
+            "generation-a",
+            "candidate-b"
+        ));
+        let mut legacy_owner = owner.clone();
+        legacy_owner.compatibility_key.clear();
+        assert!(is_compatible_owner(&owner, "lab", "generation-a", ""));
+        assert!(!is_compatible_owner(
+            &legacy_owner,
+            "lab",
+            "generation-a",
+            "candidate-a"
+        ));
     }
 
     fn compatible_wait_owner() -> std::process::Child {
@@ -1107,6 +1223,7 @@ mod tests {
             operation: "runner refresh".to_string(),
             target: "lab".to_string(),
             generation: "generation-a".to_string(),
+            compatibility_key: "candidate-a".to_string(),
             started_at: now(),
             linux_starttime_ticks: Some(42),
             process_start_identity: Some(crate::process::ProcessStartIdentity::Linux {
@@ -1595,6 +1712,43 @@ mod tests {
     }
 
     #[test]
+    fn keyed_owner_allows_legacy_reentrancy_without_releasing_its_transaction() {
+        crate::test_support::with_isolated_home(|_| {
+            let outer = acquire_waiting_for_compatible_key(
+                "keyed owner",
+                "lab",
+                "candidate-a",
+                Duration::from_secs(1),
+                |_| unreachable!("uncontended owner does not queue"),
+            )
+            .expect("keyed owner acquires lease");
+            let inner = acquire("legacy nested operation", "lab")
+                .expect("the owner's exact local capability permits legacy reentrancy");
+
+            assert!(!inner.primary, "nested lease must not own cleanup");
+            assert_eq!(inner.compatibility_key, "candidate-a");
+            drop(inner);
+
+            let path = paths::runtime_promotion_dir()
+                .expect("runtime promotion directory")
+                .join(LEASE_DIR);
+            let record = read_record(&path).expect("primary lease remains published");
+            assert_eq!(record.compatibility_key, "candidate-a");
+            assert_eq!(record.capability, outer.capability);
+
+            let contention = std::thread::spawn(|| acquire("independent operation", "lab"))
+                .join()
+                .expect("independent contender exits")
+                .expect_err("another thread cannot use the owner's local capability");
+            assert_eq!(contention.code, ErrorCode::RuntimePromotionContended);
+
+            drop(outer);
+            acquire("later operation", "lab")
+                .expect("dropping the primary releases the transaction after nested cleanup");
+        });
+    }
+
+    #[test]
     fn primary_cleanup_keeps_a_replaced_lease() {
         let temporary = tempfile::tempdir().expect("temporary lease directory");
         let path = temporary.path().join(LEASE_DIR);
@@ -1606,6 +1760,7 @@ mod tests {
             primary: true,
             generation: record.generation.clone(),
             target: record.target.clone(),
+            compatibility_key: record.compatibility_key.clone(),
             owner_pid: record.pid,
             capability: record.capability.clone(),
             admission_lock: None,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -33,6 +33,10 @@ pub(super) use super::{extension_materialization, Runner};
 const DEFAULT_HOMEBOY_REMOTE: &str = "https://github.com/Extra-Chill/homeboy.git";
 const DEFAULT_HOMEBOY_REF: &str = "main";
 const DISCONNECTED_SSH_REFRESH_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+// A reconnect owner is bounded by the runner connection contract. Admission
+// shares that bound so an equivalent refresh can converge while a stuck owner
+// yields the runtime-promotion timeout evidence instead of an open-ended wait.
+const RUNNER_BINARY_PROMOTION_ADMISSION_TIMEOUT: Duration = Duration::from_secs(30);
 const RECONNECT_VERIFICATION_WINDOW: Duration = Duration::from_secs(3);
 const RECONNECT_VERIFICATION_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 /// A freshly reconnected daemon reports the right identity a beat before its
@@ -411,10 +415,12 @@ pub fn refresh_homeboy_binary(
     // A Cook pin reserves its exact runtime from provider preflight through
     // durable runner-job binding. A refresh must drain that reservation rather
     // than rotating the configured binary underneath an admitted handoff.
-    let promotion_lease = homeboy_core::runtime_promotion::acquire(
-        "runner binary promotion",
-        options.runner_id.clone(),
-    )?;
+    let promotion_candidate = parse_identity(&exec_output.stdout)
+        .ok()
+        .and_then(|identity| identity_commit(&identity))
+        .unwrap_or_else(|| format!("unverified-{}", uuid::Uuid::new_v4()));
+    let promotion_lease =
+        acquire_runner_binary_promotion(&options.runner_id, &promotion_candidate)?;
     // Materialization may have waited behind a newer refresh. Re-read every
     // authority while holding the promotion lease so an old candidate cannot
     // overwrite a newer controller selection or reconnect over its daemon.
@@ -824,6 +830,31 @@ pub fn refresh_homeboy_binary(
         },
         0,
     ))
+}
+
+fn acquire_runner_binary_promotion(
+    runner_id: &str,
+    candidate_commit: &str,
+) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
+    acquire_runner_binary_promotion_with(
+        runner_id,
+        candidate_commit,
+        super::lab_selection::emit_runtime_promotion_wait,
+    )
+}
+
+fn acquire_runner_binary_promotion_with(
+    runner_id: &str,
+    candidate_commit: &str,
+    progress: impl FnMut(homeboy_core::runtime_promotion::RuntimePromotionWaitEvent),
+) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
+    homeboy_core::runtime_promotion::acquire_waiting_for_compatible_key(
+        "runner binary promotion",
+        runner_id.to_string(),
+        candidate_commit,
+        RUNNER_BINARY_PROMOTION_ADMISSION_TIMEOUT,
+        progress,
+    )
 }
 
 fn should_rotate_daemon_generation(

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -497,6 +497,124 @@ fn controller_binary_selection_is_idempotent() {
 }
 
 #[test]
+fn equivalent_refresh_waiter_reloads_the_owner_selection_after_promotion_handoff() {
+    test_support::with_isolated_home(|_| {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let selected = fixture.path().join("homeboy");
+        std::fs::write(
+            &selected,
+            "#!/bin/sh\nprintf '%s\\n' 'homeboy 0.1.0+0123456789ab'\n",
+        )
+        .expect("write selected binary");
+        assert!(Command::new("chmod")
+            .args(["0755", selected.to_str().expect("binary path")])
+            .status()
+            .expect("make binary executable")
+            .success());
+        crate::create(
+            r#"{"id":"lab","kind":"local","homeboy_path":"/before"}"#,
+            false,
+        )
+        .expect("create runner");
+
+        let owner = acquire_runner_binary_promotion("lab", "0123456789ab").expect("owner lease");
+        let (queued_tx, queued_rx) = std::sync::mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            let _lease = acquire_runner_binary_promotion_with("lab", "0123456789ab", |event| {
+                queued_tx.send(event).expect("report queued owner")
+            })?;
+            refresh_promotion_authorities("lab")?;
+            crate::load("lab")
+        });
+        let event = queued_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("waiter queues behind the owner");
+        assert_eq!(event.target, "lab");
+        assert_eq!(event.owner_operation, "runner binary promotion");
+        assert_eq!(event.owner_pid, std::process::id());
+        promote_verified_runner_binary("lab", selected.to_str().expect("selected path"))
+            .expect("owner selects candidate");
+        drop(owner);
+
+        let reloaded = waiter
+            .join()
+            .expect("waiter exits")
+            .expect("waiter reloads promotion authorities");
+        assert_eq!(reloaded.settings.homeboy_path.as_deref(), selected.to_str());
+    });
+}
+
+#[test]
+fn divergent_refresh_candidate_is_rejected_while_owner_keeps_selection() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab","kind":"local","homeboy_path":"/stable"}"#,
+            false,
+        )
+        .expect("create runner");
+        let owner = acquire_runner_binary_promotion("lab", "newer").expect("owner lease");
+
+        let error = std::thread::spawn(|| {
+            acquire_runner_binary_promotion_with("lab", "diverged", |_| {
+                panic!("divergent candidate must not queue")
+            })
+        })
+        .join()
+        .expect("divergent contender exits")
+        .expect_err("divergent candidate remains fail-closed");
+        assert_eq!(
+            error.code,
+            homeboy_core::ErrorCode::RuntimePromotionContended
+        );
+        assert_eq!(error.details["holder_compatibility_key"], "newer");
+        assert_eq!(
+            crate::load("lab")
+                .expect("reload runner")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            Some("/stable")
+        );
+        drop(owner);
+    });
+}
+
+#[test]
+fn strict_ancestor_refresh_candidate_is_rejected_while_owner_keeps_selection() {
+    test_support::with_isolated_home(|_| {
+        crate::create(
+            r#"{"id":"lab","kind":"local","homeboy_path":"/stable"}"#,
+            false,
+        )
+        .expect("create runner");
+        let owner = acquire_runner_binary_promotion("lab", "descendant").expect("owner lease");
+
+        let error = std::thread::spawn(|| {
+            acquire_runner_binary_promotion_with("lab", "ancestor", |_| {
+                panic!("strict ancestor candidate must not queue")
+            })
+        })
+        .join()
+        .expect("strict ancestor contender exits")
+        .expect_err("strict ancestor candidate remains fail-closed");
+        assert_eq!(
+            error.code,
+            homeboy_core::ErrorCode::RuntimePromotionContended
+        );
+        assert_eq!(error.details["holder_compatibility_key"], "descendant");
+        assert_eq!(
+            crate::load("lab")
+                .expect("reload runner")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            Some("/stable")
+        );
+        drop(owner);
+    });
+}
+
+#[test]
 fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
     test_support::with_isolated_home(|_| {
         let fixture = tempfile::tempdir().expect("fixture");


### PR DESCRIPTION
## Summary

- queue equivalent same-runner refreshes behind an active promotion instead of returning transient contention
- bind refresh compatibility to the verified candidate commit so divergent or stale candidates remain fail-closed
- preserve unkeyed Lab handoff and tunnel-recovery convergence behind keyed refreshes
- preserve capability-authorized nested reconnect participation and structured malformed-identity failures
- reload promotion authorities after admission before selection or reconnect

Closes #10859.

## Verification

- `cargo fmt -- --check`
- `cargo test -p homeboy-core runtime_promotion::tests` (25 passed, 4 helper tests ignored)
- `cargo test -p homeboy-lab-runner homeboy_refresh::tests` (74 passed)
- `git diff --check`

Coverage includes exact-candidate convergence, divergent and ancestor fail-closed behavior, asymmetric keyed/unkeyed cross-operation compatibility, capability-authorized nested reentrancy, nested-drop safety, authority reload after handoff, and retained runner selection. Existing workspace warnings remain.

## Compatibility

The lease field is additive with a serde default. New keyed refreshes fail closed behind old unkeyed owners; unkeyed handoff/recovery callers continue to wait behind keyed owners. Compatibility keys are non-secret immutable revision fingerprints and remain in typed contention evidence.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode general coding agents implemented and independently reviewed the repair under Chris Huber's direction. Chris reviewed the complete diff, identified reentrancy and cross-operation compatibility risks, and independently reran all focused gates.