### PR TITLE
fix(release): allow persisted notes during planning

### DIFF
--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -159,7 +159,13 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     }
 
     if let Some(ref info) = version_info {
-        if let Some(details) = validate_release_worktree(&component, options, info)? {
+        let release_notes_tag = options
+            .pipeline
+            .head
+            .then(|| release_scope.tag_name(&info.version));
+        if let Some(details) =
+            validate_release_worktree(&component, options, info, release_notes_tag.as_deref())?
+        {
             v.push(
                 "working_tree",
                 "Uncommitted changes detected",
@@ -331,9 +337,10 @@ fn is_explicit_patch_bump(requested_bump: &str, current_version: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::guard_stale_primary_at_head;
-    use super::{apply_oversized_patch_release_policy, oversized_patch_release_bump};
+    use super::{apply_oversized_patch_release_policy, oversized_patch_release_bump, plan};
     use crate::release::types::{
-        ReleaseChangelogPlan, ReleaseSemverCommit, ReleaseSemverRecommendation,
+        ReleaseChangelogPlan, ReleaseOptions, ReleasePipelineOptions, ReleaseSemverCommit,
+        ReleaseSemverRecommendation,
     };
     use std::collections::HashMap;
 
@@ -386,6 +393,80 @@ mod tests {
             joined.contains("Cargo.lock"),
             "dirty file list must reach the JSON envelope, got: {joined}"
         );
+    }
+
+    #[test]
+    fn head_plan_allows_only_the_matching_scoped_release_notes_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        std::fs::create_dir_all(dir.join("packages/fixture")).expect("component directory");
+        std::fs::write(
+            dir.join("homeboy.json"),
+            r#"{
+                "id": "fixture",
+                "type": "fixture",
+                "changelog_target": "CHANGELOG.md",
+                "version_targets": [{
+                    "file": "packages/fixture/manifest.toml",
+                    "pattern": "version = \\\"([0-9.]+)\\\""
+                }],
+                "scopes": {
+                    "release": {"include": ["packages/fixture/**"]}
+                }
+            }"#,
+        )
+        .expect("portable config");
+        std::fs::write(dir.join("CHANGELOG.md"), "# Changelog\n").expect("changelog");
+        std::fs::write(
+            dir.join("packages/fixture/manifest.toml"),
+            "version = \"1.2.3\"\n",
+        )
+        .expect("version target");
+        git(dir, &["init", "-q"]);
+        git(dir, &["config", "user.email", "test@example.com"]);
+        git(dir, &["config", "user.name", "Test"]);
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "-q", "-m", "release: fixture-v1.2.3"]);
+        git(dir, &["tag", "fixture-v1.2.3"]);
+        std::fs::create_dir(dir.join("build")).expect("build directory");
+        std::fs::write(
+            dir.join("build/fixture-v1.2.3-release-notes.md"),
+            "release notes\n",
+        )
+        .expect("persisted notes");
+
+        let plan_result = plan(
+            "fixture",
+            &ReleaseOptions {
+                path_override: Some(dir.to_string_lossy().to_string()),
+                pipeline: ReleasePipelineOptions {
+                    head: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            plan_result.is_ok(),
+            "matching scoped release notes must not block --head planning: {plan_result:?}"
+        );
+
+        std::fs::write(dir.join("build/operator-file"), "operator drift\n")
+            .expect("unrelated dirty file");
+        let error = plan(
+            "fixture",
+            &ReleaseOptions {
+                path_override: Some(dir.to_string_lossy().to_string()),
+                pipeline: ReleasePipelineOptions {
+                    head: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .expect_err("unrelated build files must still block --head planning");
+        assert!(error.details.to_string().contains("build/"));
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/planning_worktree.rs
+++ b/crates/homeboy-release/src/release/planning_worktree.rs
@@ -13,6 +13,7 @@ pub(super) fn validate_release_worktree(
     component: &Component,
     options: &ReleaseOptions,
     version_info: &ComponentVersionInfo,
+    release_notes_tag: Option<&str>,
 ) -> Result<Option<serde_json::Value>> {
     if options.pipeline.head && options.pipeline.from_artifacts.is_some() {
         return Ok(None);
@@ -36,7 +37,8 @@ pub(super) fn validate_release_worktree(
         Path::new(&component.local_path),
     );
     let build_artifacts = declared_build_artifact_paths(component);
-    let unexpected = get_unexpected_uncommitted_files(&uncommitted, &allowed, &build_artifacts);
+    let mut unexpected = get_unexpected_uncommitted_files(&uncommitted, &allowed, &build_artifacts);
+    filter_release_owned_notes(&mut unexpected, &uncommitted, component, release_notes_tag);
 
     if !unexpected.is_empty() {
         return Ok(Some(serde_json::json!({
@@ -100,19 +102,7 @@ pub(super) fn validate_working_tree_fail_fast(
             .iter()
             .any(|allowed| paths_match(file, allowed))
     });
-    if let Some(tag) = release_notes_tag {
-        let release_notes_path = super::executor::github_release_notes_path(tag);
-        unexpected.retain(|file| {
-            !uncommitted.untracked.iter().any(|untracked| {
-                paths_are_equal(untracked, file)
-                    && untracked_entry_is_only_release_notes(
-                        Path::new(&component.local_path),
-                        untracked,
-                        &release_notes_path,
-                    )
-            })
-        });
-    }
+    filter_release_owned_notes(&mut unexpected, &uncommitted, component, release_notes_tag);
     if unexpected.is_empty() {
         return Ok(());
     }
@@ -136,6 +126,28 @@ pub(super) fn validate_working_tree_fail_fast(
             ),
         ]),
     ))
+}
+
+fn filter_release_owned_notes(
+    unexpected: &mut Vec<String>,
+    uncommitted: &UncommittedChanges,
+    component: &Component,
+    release_notes_tag: Option<&str>,
+) {
+    let Some(tag) = release_notes_tag else {
+        return;
+    };
+    let release_notes_path = super::executor::github_release_notes_path(tag);
+    unexpected.retain(|file| {
+        !uncommitted.untracked.iter().any(|untracked| {
+            paths_are_equal(untracked, file)
+                && untracked_entry_is_only_release_notes(
+                    Path::new(&component.local_path),
+                    untracked,
+                    &release_notes_path,
+                )
+        })
+    });
 }
 
 /// Paths a first-release changelog bootstrap can legitimately make dirty.
@@ -574,6 +586,7 @@ mod tests {
             &git_component(dir),
             &ReleaseOptions::default(),
             &version_info(dir),
+            None,
         )
         .expect("worktree policy should inspect changes")
         .expect("unexpected user file should be reported");
@@ -607,6 +620,7 @@ mod tests {
                 ..Default::default()
             },
             &version_info(dir),
+            None,
         )
         .expect("head artifact releases should allow artifact directories");
 


### PR DESCRIPTION
## Summary\n\n- apply the exact-tag persisted release-notes allowance during planning as well as execution\n- derive scoped component tags through `ReleaseScope`\n- retain strict rejection of every unrelated dirty file\n\nCompletes #10876 after end-to-end validation found the planning gate missed by #10878.\n\n## Verification\n\n- real `v0.323.1 --head` recovery passed planning and execution dirty-tree gates with `build/v0.323.1-release-notes.md` present\n- `cargo test -p homeboy-release planner::tests::head_plan_allows_only_the_matching_scoped_release_notes_path --lib`\n- `cargo test -p homeboy-release planning_worktree::tests --lib` (24 passed)\n- `cargo fmt --check`\n- `git diff --check`\n\n## AI Assistance\n\nOpenCode with `openai/gpt-5.6-sol` implemented and tested the planner recovery contract under Chris Huber's direction. Chris reviewed the end-to-end evidence and remains responsible for every line.