### PR TITLE
Bound aggregate cleanup output

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -16,6 +16,7 @@ use homeboy::core::observation::runs_service::{
     self, OrphanedArtifactBytesCleanupOptions, PersistedArtifactCleanupOptions,
     RunnerDownloadCleanupOptions,
 };
+use homeboy::core::output::OutputBudget;
 use homeboy::core::resource_cleanup_intent::ResourceCleanupIntent;
 use homeboy::core::worktree::{self, WorktreeCleanupOptions, WorktreeCleanupOutput};
 use homeboy::core::worktree_providers::WorktreeProviderCleanupOptions;
@@ -173,6 +174,10 @@ struct RetainedStorageReport {
     by_age: Vec<RetainedStorageAggregate>,
     largest_examples: Vec<RetainedStorageRecord>,
     continuation: Option<String>,
+    /// `false` when a source inventory reached its bounded page before every
+    /// record could be accounted for. Aggregates then describe only this page.
+    totals_complete: bool,
+    source_continuations: Vec<String>,
     safe_next_commands: Vec<String>,
     sqlite: RetainedStorageSqlite,
     /// Added in #9824. Existing lifecycle aggregates above retain their
@@ -323,13 +328,20 @@ fn retained_storage_report(
             older_than_days: policy.runtime_tmp_days,
             managed_older_than_days: None,
             prefix: None,
-            // A read-only accounting pass: the report must total every retained
-            // entry, so it is not bounded by the delete-path record budget.
-            limit: usize::MAX,
+            // Retained-storage is an operator report, not an unbounded disk
+            // walk. It shares the cleanup record budget and names a cursor for
+            // the next runtime-temp page below.
+            limit: policy.scan_limit(),
             run_max_bytes: policy.runtime_run_max_bytes,
             run_max_count: policy.runtime_run_max_count,
             cursor: None,
         })?;
+    let runtime_tmp_continuation = runtime_tmp.next_cursor.as_ref().map(|cursor| {
+        format!(
+            "homeboy cleanup --include runtime-tmp --cursor {}",
+            quote_arg(cursor)
+        )
+    });
     records.extend(
         runtime_tmp
             .rows
@@ -366,13 +378,18 @@ fn retained_storage_report(
     }
 
     let filesystem = retained_storage_filesystem_inventory()?;
-    Ok(build_retained_storage_report(
+    let mut report = build_retained_storage_report(
         records,
         args.limit,
         args.cursor.as_deref(),
         sqlite,
         filesystem,
-    ))
+    );
+    if let Some(command) = runtime_tmp_continuation {
+        report.totals_complete = false;
+        report.source_continuations.push(command);
+    }
+    Ok(report)
 }
 
 fn runtime_tmp_retained_record(row: engine::temp::RuntimeTempCleanupRow) -> RetainedStorageRecord {
@@ -857,6 +874,8 @@ fn build_retained_storage_report(
         by_age: aggregate_retained(&records, |record| record.age.clone()),
         largest_examples: examples,
         continuation,
+        totals_complete: true,
+        source_continuations: Vec::new(),
         // One entry per category this report can account for. Omitting the
         // artifact-root categories used to leave an operator staring at bytes
         // the report itself could not name a reclaim command for.
@@ -1159,7 +1178,7 @@ fn automatic_retention() -> CmdResult<Value> {
 }
 
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
-    let selected = CleanupCategorySelection::new(args.include, args.exclude);
+    let selected = CleanupCategorySelection::new(args.include.clone(), args.exclude.clone());
     let apply = args.apply;
     let config = defaults::load_config();
     // One resolver for every category and every specialist command. The
@@ -1270,11 +1289,19 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     }
 
     if selected.includes(CleanupCategoryArg::OrphanedArtifactBytes) {
-        let output =
+        let mut output =
             runs_service::cleanup_orphaned_artifact_bytes(OrphanedArtifactBytesCleanupOptions {
                 apply,
+                // Orphaned artifacts have no cursor. Restricting their source
+                // scan would leave later entries unreachable, so execution
+                // always receives the configured retention limit.
                 limit: policy.scan_limit(),
             })?;
+        runs_service::present_orphaned_artifact_bytes_cleanup(
+            &mut output,
+            args.full,
+            cleanup_replay_command(&args, true, true),
+        )?;
         categories.push(category_from_output(
             ORPHANED_ARTIFACT_BYTES_METADATA,
             apply,
@@ -1321,17 +1348,27 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     }
 
     if selected.includes(CleanupCategoryArg::RuntimeTmp) {
-        let output =
+        let mut output =
             engine::temp::cleanup_runtime_tmp_bounded(engine::temp::RuntimeTempCleanupOptions {
                 apply,
                 older_than_days: policy.runtime_tmp_days,
                 managed_older_than_days: Some(policy.runtime_tmp_managed_days),
                 prefix: None,
-                limit: policy.scan_limit(),
+                limit: if apply || args.full {
+                    policy.scan_limit()
+                } else {
+                    policy.scan_limit().min(OutputBudget::COLLECTION.max_items)
+                },
                 run_max_bytes: policy.runtime_run_max_bytes,
                 run_max_count: policy.runtime_run_max_count,
                 cursor: args.cursor.as_deref(),
             })?;
+        engine::temp::present_runtime_temp_cleanup(
+            &mut output,
+            args.full,
+            cleanup_replay_command(&args, false, false),
+            cleanup_replay_command(&args, true, true),
+        )?;
         let mut category = category_from_output(
             RUNTIME_TMP_METADATA,
             apply,
@@ -1474,6 +1511,69 @@ fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<Value> {
     .map_err(|err| {
         homeboy::core::Error::internal_json(err.to_string(), Some("cleanup inventory".to_string()))
     })
+}
+
+fn cleanup_replay_command(args: &CleanupArgs, full: bool, include_cursor: bool) -> String {
+    let mut command = "homeboy cleanup".to_string();
+    if !args.include.is_empty() {
+        command.push_str(&format!(
+            " --include {}",
+            args.include
+                .iter()
+                .map(cleanup_category_arg_name)
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+    if !args.exclude.is_empty() {
+        command.push_str(&format!(
+            " --exclude {}",
+            args.exclude
+                .iter()
+                .map(cleanup_category_arg_name)
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+    if args.apply {
+        command.push_str(" --apply");
+    }
+    if let Some(days) = args.older_than_days {
+        command.push_str(&format!(" --older-than-days {days}"));
+    }
+    if let Some(days) = args.runtime_tmp_managed_older_than_days {
+        command.push_str(&format!(" --runtime-tmp-managed-older-than-days {days}"));
+    }
+    if let Some(limit) = args.limit {
+        command.push_str(&format!(" --limit {limit}"));
+    }
+    if include_cursor {
+        if let Some(cursor) = &args.cursor {
+            command.push_str(&format!(" --cursor {}", quote_arg(cursor)));
+        }
+    }
+    if full {
+        command.push_str(" --full");
+    }
+    command
+}
+
+fn cleanup_category_arg_name(category: &CleanupCategoryArg) -> &'static str {
+    match category {
+        CleanupCategoryArg::RepoArtifacts => "repo-artifacts",
+        CleanupCategoryArg::TaskWorktrees => "task-worktrees",
+        CleanupCategoryArg::WorktreeProviders => "worktree-providers",
+        CleanupCategoryArg::TerminalRuns => "terminal-runs",
+        CleanupCategoryArg::PersistedRunArtifacts => "persisted-run-artifacts",
+        CleanupCategoryArg::OrphanedArtifactBytes => "orphaned-artifact-bytes",
+        CleanupCategoryArg::RunnerDownloads => "runner-downloads",
+        CleanupCategoryArg::RunnerBinaryCaches => "runner-binary-caches",
+        CleanupCategoryArg::RemoteLabWorkspaces => "remote-lab-workspaces",
+        CleanupCategoryArg::RuntimeTmp => "runtime-tmp",
+        CleanupCategoryArg::ControllerScratch => "controller-scratch",
+        CleanupCategoryArg::SharedCargoTargets => "shared-cargo-targets",
+        CleanupCategoryArg::ControllerRuntimes => "controller-runtimes",
+    }
 }
 
 struct CleanupCategorySelection {

--- a/crates/homeboy-core/src/engine/temp.rs
+++ b/crates/homeboy-core/src/engine/temp.rs
@@ -5,9 +5,9 @@ pub(crate) use implementation::{
     mark_run_dir_succeeded, pin_runtime_temp_dir, retain_failed_run_dir, RuntimeTempPin,
 };
 pub use implementation::{
-    cleanup_runtime_tmp, cleanup_runtime_tmp_bounded, runtime_temp_dir, unique_name,
-    CleanupSizeTotals, RuntimeTempCleanupOptions, RuntimeTempCleanupOutput, RuntimeTempCleanupRow,
-    RuntimeTempOwner,
+    cleanup_runtime_tmp, cleanup_runtime_tmp_bounded, present_runtime_temp_cleanup,
+    runtime_temp_dir, unique_name, CleanupSizeTotals, RuntimeTempCleanupOptions,
+    RuntimeTempCleanupOutput, RuntimeTempCleanupRow, RuntimeTempOwner,
 };
 
 // Keep implementation references scoped to the engine-owned sibling modules.

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -1,6 +1,7 @@
 //! Runtime-temp implementation behind the stable `engine::temp` facade.
 
 use crate::error::{Error, Result};
+use crate::output::{OutputBudget, OutputPresentation, OutputTruncation};
 use crate::paths;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -651,6 +652,10 @@ pub struct RuntimeTempCleanupOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
     pub rows: Vec<RuntimeTempCleanupRow>,
+    /// Bounded presentation metadata. Omitted for specialist callers that
+    /// retain their historical lossless row contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row_detail: Option<OutputTruncation>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -676,6 +681,81 @@ pub struct RuntimeTempCleanupRow {
     pub age_seconds: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protection_reason: Option<String>,
+}
+
+/// Present an already-planned runtime-temp cleanup without changing its totals
+/// or mutation set. Aggregate cleanup uses this agent-facing view; specialist
+/// commands retain their established lossless output unless they opt in.
+#[allow(dead_code)]
+pub fn present_runtime_temp_cleanup(
+    output: &mut RuntimeTempCleanupOutput,
+    full: bool,
+    continue_command: String,
+    export_command: String,
+) -> Result<()> {
+    let total_items = output.rows.len();
+    if full {
+        let total_bytes = output.rows.iter().try_fold(0usize, |total, row| {
+            serde_json::to_vec(row)
+                .map(|value| total.saturating_add(value.len()))
+                .map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("serialize runtime temp row".to_string()),
+                    )
+                })
+        })?;
+        output.row_detail = Some(OutputTruncation {
+            presentation: OutputPresentation::LosslessExport,
+            total_items,
+            returned_items: total_items,
+            omitted_items: 0,
+            total_bytes,
+            returned_bytes: total_bytes,
+            omitted_bytes: 0,
+            total_bytes_known: true,
+            truncated: false,
+            continue_command,
+            export_command,
+        });
+        return Ok(());
+    }
+
+    let mut rows = Vec::new();
+    let mut returned_bytes = 0usize;
+    for row in output.rows.drain(..) {
+        let bytes = serde_json::to_vec(&row)
+            .map(|value| value.len())
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize runtime temp row".to_string()),
+                )
+            })?;
+        if rows.len() >= OutputBudget::COLLECTION.max_items
+            || returned_bytes.saturating_add(bytes) > OutputBudget::COLLECTION.max_bytes
+        {
+            break;
+        }
+        returned_bytes = returned_bytes.saturating_add(bytes);
+        rows.push(row);
+    }
+    let returned_items = rows.len();
+    output.rows = rows;
+    output.row_detail = Some(OutputTruncation {
+        presentation: OutputPresentation::BoundedCollection,
+        total_items,
+        returned_items,
+        omitted_items: total_items.saturating_sub(returned_items),
+        total_bytes: returned_bytes,
+        returned_bytes,
+        omitted_bytes: 0,
+        total_bytes_known: returned_items == total_items,
+        truncated: returned_items < total_items,
+        continue_command,
+        export_command,
+    });
+    Ok(())
 }
 
 pub fn cleanup_runtime_tmp(
@@ -726,6 +806,7 @@ pub fn cleanup_runtime_tmp_bounded(
         has_more: false,
         next_cursor: None,
         rows: Vec::new(),
+        row_detail: None,
     };
 
     if !root.exists() {
@@ -1490,6 +1571,67 @@ mod tests {
             run_max_count: 100,
             cursor: None,
         }
+    }
+
+    #[test]
+    fn runtime_temp_presentation_bounds_high_cardinality_rows_and_preserves_export() {
+        let row = |index| RuntimeTempCleanupRow {
+            path: format!("/tmp/runtime-{index}"),
+            name: format!("runtime-{index}"),
+            action: "skip".to_string(),
+            reason: "owner is active".to_string(),
+            size_bytes: 0,
+            allocated_bytes: 0,
+            verified_reclaimed_bytes: 0,
+            owner_id: None,
+            owner_pid: None,
+            owner_state: None,
+            producer: None,
+            run_id: None,
+            age_seconds: None,
+            protection_reason: None,
+        };
+        let mut output = RuntimeTempCleanupOutput {
+            command: "self.cleanup-runtime-tmp",
+            dry_run: true,
+            runtime_tmp_root: "/tmp".to_string(),
+            older_than_days: 7,
+            managed_older_than_days: 7,
+            run_max_bytes: 0,
+            run_max_count: 0,
+            prefix: None,
+            totals: CleanupSizeTotals {
+                inspected_count: 1_000,
+                planned_size_bytes: 0,
+                removed_size_bytes: 0,
+            },
+            planned_count: 0,
+            removed_count: 0,
+            skipped_count: 1_000,
+            planned_allocated_bytes: 0,
+            removed_allocated_bytes: 0,
+            verified_reclaimed_bytes: 0,
+            has_more: true,
+            next_cursor: Some("runtime-1000".to_string()),
+            rows: (0..1_000).map(row).collect(),
+            row_detail: None,
+        };
+
+        present_runtime_temp_cleanup(
+            &mut output,
+            false,
+            "homeboy cleanup --include runtime-tmp --cursor runtime-1000".to_string(),
+            "homeboy cleanup --include runtime-tmp --full".to_string(),
+        )
+        .expect("present bounded rows");
+
+        assert!(output.rows.len() <= OutputBudget::COLLECTION.max_items);
+        let detail = output.row_detail.expect("output budget metadata");
+        assert_eq!(detail.total_items, 1_000);
+        assert_eq!(detail.omitted_items, 1_000 - output.rows.len());
+        assert!(detail.truncated);
+        assert!(detail.continue_command.contains("runtime-1000"));
+        assert!(detail.export_command.ends_with("--full"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes.rs
+++ b/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes.rs
@@ -56,6 +56,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+use crate::output::{OutputBudget, OutputPresentation, OutputTruncation};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -114,6 +115,77 @@ pub struct OrphanedArtifactBytesCleanupOutcome {
     /// True when the sweep stopped at `limit` with candidates still unread.
     pub truncated: bool,
     pub rows: Vec<OrphanedArtifactBytesRow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row_detail: Option<OutputTruncation>,
+}
+
+pub fn present_orphaned_artifact_bytes_cleanup(
+    output: &mut OrphanedArtifactBytesCleanupOutcome,
+    full: bool,
+    export_command: String,
+) -> Result<()> {
+    let total_items = output.rows.len();
+    if full {
+        let total_bytes = output.rows.iter().try_fold(0usize, |total, row| {
+            serde_json::to_vec(row)
+                .map(|value| total.saturating_add(value.len()))
+                .map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("serialize orphaned artifact row".to_string()),
+                    )
+                })
+        })?;
+        output.row_detail = Some(OutputTruncation {
+            presentation: OutputPresentation::LosslessExport,
+            total_items,
+            returned_items: total_items,
+            omitted_items: 0,
+            total_bytes,
+            returned_bytes: total_bytes,
+            omitted_bytes: 0,
+            total_bytes_known: true,
+            truncated: false,
+            continue_command: export_command.clone(),
+            export_command,
+        });
+        return Ok(());
+    }
+    let mut rows = Vec::new();
+    let mut returned_bytes = 0usize;
+    for row in output.rows.drain(..) {
+        let bytes = serde_json::to_vec(&row)
+            .map(|value| value.len())
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize orphaned artifact row".to_string()),
+                )
+            })?;
+        if rows.len() >= OutputBudget::COLLECTION.max_items
+            || returned_bytes.saturating_add(bytes) > OutputBudget::COLLECTION.max_bytes
+        {
+            break;
+        }
+        returned_bytes = returned_bytes.saturating_add(bytes);
+        rows.push(row);
+    }
+    let returned_items = rows.len();
+    output.rows = rows;
+    output.row_detail = Some(OutputTruncation {
+        presentation: OutputPresentation::BoundedCollection,
+        total_items,
+        returned_items,
+        omitted_items: total_items.saturating_sub(returned_items),
+        total_bytes: returned_bytes,
+        returned_bytes,
+        omitted_bytes: 0,
+        total_bytes_known: returned_items == total_items,
+        truncated: returned_items < total_items,
+        continue_command: export_command.clone(),
+        export_command,
+    });
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -175,6 +247,7 @@ fn sweep(
         removed_size_bytes: 0,
         truncated: false,
         rows: Vec::new(),
+        row_detail: None,
     };
 
     for top_level in sorted_child_names(artifact_root)? {


### PR DESCRIPTION
## Summary
- bound runtime-temp and orphaned-artifact presentation with typed item and byte budgets
- preserve configured mutation throughput independently from output limits
- expose honest truncation, full-review, and continuation metadata without cursor gaps

## Verification
- `cargo test -p homeboy-cli commands::cleanup::tests --lib` (25 passed)
- focused core runtime-temp presentation test
- `git diff --check`

Closes #10884

## AI assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding task subagents
- Use: implementation, high-cardinality output tests, compatibility review, and multiple review-driven revisions. Chris Huber reviewed and remains responsible for the submitted changes.