### PR TITLE
test(release): pin the control-binary lineage that makes recovery work

### DIFF
--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1124,6 +1124,71 @@ fn release_recovery_records_control_binary_lineage_against_the_release_target() 
     );
 }
 
+/// #10519's actual fix, pinned.
+///
+/// Recovery exists to repair a release whose publisher was broken. That only
+/// works if the binary performing the repair is NEWER than the tag it repairs.
+/// The mechanism is one line: `gate-build` checks out `github.sha` while every
+/// other release job checks out `inputs.release_tag || github.sha`.
+///
+/// That makes `gate-build` look like an inconsistency someone would tidy up,
+/// and tidying it silently restores the trap: recovery rebuilds the defective
+/// binary from the stranded tag and re-runs the bug that stranded it. v0.321.0
+/// burned two 40-minute cycles that way before the roles were separated by
+/// hand.
+#[test]
+fn release_recovery_builds_its_control_binary_from_main_not_the_recovered_tag() {
+    let workflow = release_workflow();
+    let gate_build = job_section(workflow, "gate-build");
+    let checkout = release_step_block(gate_build, "uses: actions/checkout@v4");
+
+    assert!(
+        checkout.contains("ref: ${{ github.sha }}"),
+        "gate-build must check out the event commit so the finalizer carries the \
+         current recovery contract; got:\n{checkout}"
+    );
+    assert!(
+        !checkout.contains("inputs.release_tag"),
+        "gate-build must NOT follow the recovered tag. Building the control binary \
+         from the tag being recovered reruns the publisher bug that stranded it \
+         (#10519); got:\n{checkout}"
+    );
+
+    // The binary that job produces is the one recovery must execute.
+    assert!(
+        gate_build.contains("name: homeboy-binary"),
+        "gate-build must publish its binary as the shared `homeboy-binary` artifact"
+    );
+}
+
+/// The control binary is only load-bearing if the finalizer actually runs it.
+/// `source: '.'` alone would rebuild from the recovered tag's tree, which is
+/// the same trap by a different route (#10519).
+#[test]
+fn release_recovery_finalizer_executes_the_main_built_binary() {
+    let workflow = release_workflow();
+    let host = job_section(workflow, "host");
+
+    let download = release_step_block(host, "name: Download current Homeboy finalizer");
+    assert!(
+        download.contains("name: homeboy-binary") && download.contains("path: .homeboy-bin"),
+        "recovery must fetch the main-built binary produced by gate-build; got:\n{download}"
+    );
+    // The download itself is unconditional -- fetching the binary is cheap and
+    // always-available evidence. The recovery binding lives on `binary-path`
+    // below, which is what decides whether it is actually executed.
+
+    let finalize = release_step_block(host, "name: Finish Homeboy release pipeline at tag");
+    assert!(
+        finalize.contains(".homeboy-bin/homeboy"),
+        "recovery must publish with the downloaded control binary, not a tree rebuild; got:\n{finalize}"
+    );
+    assert!(
+        finalize.contains("recovery-release == 'true'"),
+        "binary-path must be bound to the recovery path so normal releases are unaffected"
+    );
+}
+
 /// Extract the shell body of a `run: |` step so its BEHAVIOUR can be exercised
 /// rather than string-matched. Asserting the effect is the whole point: the
 /// audit gate in #10685 passed for weeks because its test asserted the command


### PR DESCRIPTION
Contributes to #10519 — the last unmet acceptance criterion.

## Most of #10519 is already built

I came to implement this and found the separation of roles already in place on `main`:

| acceptance criterion | status |
|---|---|
| Recovery uses a current trusted binary against the exact tagged tree | ✅ `gate-build` checks out `github.sha`; `host` checks out the tag |
| Records control-binary identity, target tag/SHA, artifact provenance separately | ✅ "Release recovery provenance" step + adoption manifest `control.commit` / `contains_target` |
| Reuses originating run artifacts instead of rebuilding | ✅ `Download GitHub Artifacts` + `draft-adoption` |
| Skips rebuild when the draft already has every authoritative asset | ✅ `plan.outputs.draft-complete`, covered by `release_recovery_skips_the_artifact_rebuild_when_the_draft_is_already_complete` |
| Artifact identity fail-closed by name/size/digest | ✅ `collapse_ordinal_durable_duplicates` + digest verification |
| **A regression test proves a publisher fix merged after tag creation can recover the older draft** | ❌ **this PR** |

There is even an explicit `::warning::` when `CONTROL_SHA == TARGET_SHA`, naming this issue.

## The gap

The whole guarantee rests on **one line**:

```yaml
gate-build:
  - uses: actions/checkout@v4
    with:
      # Recovery checks out an older release tag downstream, but the
      # finalizer must include the current recovery contract from main.
      ref: ${{ github.sha }}
```

Every other checkout in `release.yml` uses `inputs.release_tag || github.sha` — lines 366, 413, 457, 558, 685, 825. `gate-build` is the **only** one that doesn't, which makes it look exactly like an inconsistency someone would tidy up for consistency.

Tidying it silently restores the original trap: recovery rebuilds the defective binary from the stranded tag and reruns the bug that stranded it. That is what burned two 40-minute cycles on v0.321.0 before the roles were separated by hand.

The existing `release_recovery_records_control_binary_lineage_against_the_release_target` covers the adoption **manifest** — `CONTROL_SHA`, the ancestry read, `contains_target`, and the fail-safe-to-null direction. It does not cover the mechanism that makes the control binary current in the first place, nor that the finalizer actually *executes* it rather than rebuilding from the recovered tag's tree via `source: '.'`.

## This PR

Two tests, each verified against a negative control:

| regression simulated | test that catches it |
|---|---|
| `gate-build` checkout changed to `inputs.release_tag \|\| github.sha` | `release_recovery_builds_its_control_binary_from_main_not_the_recovered_tag` |
| finalizer's `binary-path` removed, falling back to a tree rebuild | `release_recovery_finalizer_executes_the_main_built_binary` |

Both were confirmed to **fail** when the regression is introduced and pass when it is reverted.

**No production change.** This pins behaviour that is already correct.

## One correction I made to my own assumption

I first asserted the finalizer download was gated on `recovery-release == 'true'`. It is not — the download is unconditional on current `main`, and the recovery binding lives on `binary-path`. That is the better design (fetching the binary is cheap, always-available evidence), so I moved the assertion to where the binding actually is rather than to where I expected it.

## Verification

`cargo fmt --check` clean. `cargo test --test release_workflow_test` → **41 passed, 0 failed**.

## Still open on #10519

This does not fix the *cause* of stranding. `gh api release metadata exited with status 1` still originates in the publisher's draft-readback path, and the `gh_draft_release_metadata` fallback plus #10576's diagnostics are what currently rescue it. Homeboy's own releases are publishing again (v0.321.0 → v0.323.1 all published; only v0.320.0 remains a stranded draft), so the fallback is working in practice.

Separately, this repository's floating-tag consumer had drifted: `Extra-Chill/homeboy-action`'s `v2` was frozen at v2.8.25 with five unpublished drafts behind it, because `post:release` never runs when the publisher fails. Those are now published and `v2` points at v2.9.2 — see my comments on #10519 for the mechanism.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
