### PR TITLE
fix(runner): converge controller skew recovery

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -723,6 +723,7 @@ fn compact_status_prioritizes_dirty_controller_before_runner_convergence() {
                 Some("homeboy 0.321.1+configured".to_string()),
             )
             .with_controller_compatibility(
+                "homeboy-lab",
                 "0.321.1".to_string(),
                 "homeboy 0.321.1+configured-dirty".to_string(),
                 false,

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -2566,6 +2566,7 @@ fn stale_daemon_warning(
             identity_comparison == IdentityComparison::Unverifiable,
         )
         .with_controller_compatibility(
+            &runner.id,
             controller_identity.version,
             controller_identity.display,
             controller_version_matches,

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -551,6 +551,7 @@ fn same_version_different_controller_build_is_incompatible_and_truthful() {
         Some("homeboy 0.321.1+configured".to_string()),
     )
     .with_controller_compatibility(
+        "homeboy-lab",
         "0.321.1".to_string(),
         "homeboy 0.321.1+controller".to_string(),
         true,
@@ -578,6 +579,11 @@ fn same_version_different_controller_build_is_incompatible_and_truthful() {
     );
     assert!(warning.message.contains("configured job command binary"));
     assert!(warning.message.contains("controller"));
+    assert_eq!(
+        warning.recovery_commands,
+        ["homeboy runner refresh-homeboy homeboy-lab --ref controller --reconnect --allow-downgrade"]
+    );
+    assert!(!warning.refresh_command.contains("--ref configured"));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -1114,6 +1114,7 @@ impl RunnerStaleDaemonWarning {
 
     pub fn with_controller_compatibility(
         mut self,
+        runner_id: &str,
         controller_version: String,
         controller_build_identity: String,
         controller_version_matches: bool,
@@ -1144,6 +1145,21 @@ impl RunnerStaleDaemonWarning {
                     .as_deref()
                     .unwrap_or(&self.job_command_binary_version),
             );
+            if controller_version_matches {
+                if let Some(controller_commit) =
+                    homeboy_upgrade::upgrade::parse_build_identity_display(
+                        &controller_build_identity,
+                    )
+                    .filter(|identity| identity.git_dirty != Some(true))
+                    .and_then(|identity| identity.git_commit)
+                {
+                    self.recovery_commands = vec![format!(
+                        "homeboy runner refresh-homeboy {} --ref {controller_commit} --reconnect --allow-downgrade",
+                        shell::quote_arg(runner_id),
+                    )];
+                    self.refresh_command = self.recovery_commands.join(" && ");
+                }
+            }
         }
         self
     }


### PR DESCRIPTION
## Summary

- retarget same-version controller/configured runner skew recovery to the clean controller's immutable commit
- include explicit `--allow-downgrade` so an operator-approved convergence can replace a newer same-version runner build
- preserve configured-binary recovery for ordinary daemon drift

Closes #10909.

## Runtime proof

Before the repair, admission emitted the circular command targeting configured/daemon commit `4734640be67a` while the controller was `3a05254f918c`.

The corrected command completed successfully:
`homeboy runner refresh-homeboy homeboy-lab --ref 3a05254f918c --reconnect --allow-downgrade`

Afterward, controller, configured executable, active daemon, and admission owner all reported `3a05254f918c`; `accepting_jobs` and `daemon_fresh` were both true.

## Verification

- `cargo fmt -- --check`
- `cargo test -p homeboy-lab-runner same_version_different_controller_build_is_incompatible_and_truthful`
- `cargo test -p homeboy-cli commands::runner::tests::status::` (16 passed)
- `git diff --check`

The broader pre-existing session fixture suite reached 60/62; `disconnect_removes_existing_session_file` and `refresh_disconnect_accepts_local_tunnel_rotation_and_uses_the_current_tunnel` fail in their SSH authority fixtures and do not exercise this recovery-command change.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the runtime failure, implemented the remediation fix and regression assertion, and ran the verification commands under Chris Huber's direction. Chris remains responsible for the complete change.