### PR TITLE
test: isolate cook handoff fixtures from controller transport

### DIFF
--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -1,13 +1,52 @@
-use std::process::{Command, Output};
+use std::process::Output;
 
+use homeboy_core::test_support::{HermeticTestContext, TestBinary};
+
+/// Run the fixture binary through the shared hermetic harness.
+///
+/// Every case in this file asserts that a contradictory invocation is rejected
+/// during argument validation, *before* any worktree or provider resolution.
+/// `route_after_parse` returns early when it detects a Lab-offload or
+/// runner-hosted execution context, and that bail-out sits above the validation
+/// under test. A single inherited controller-transport variable therefore skips
+/// the rejection silently and lets cook proceed into real worktree work, which
+/// can block forever. Because `cargo test` runs integration binaries serially,
+/// one blocked binary strands every binary ordered after it (#10917).
+///
+/// `HermeticTestContext::command` owns the complete isolation contract — HOME,
+/// XDG config and data roots, artifact root, runtime and temp dirs — and strips
+/// the Lab transport variables. Overriding only HOME on a hand-rolled `Command`
+/// leaves that leak open (#10717, #10718).
 fn homeboy(args: &[&str]) -> Output {
-    let home = tempfile::tempdir().expect("isolated home");
-    Command::new(env!("CARGO_BIN_EXE_homeboy"))
+    let context = HermeticTestContext::new();
+    context
+        .command(TestBinary::HomeboyFixture)
         .args(args)
-        .env("HOME", home.path())
-        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
         .output()
         .expect("run homeboy")
+}
+
+#[test]
+fn cook_handoff_subprocesses_do_not_inherit_controller_transport() {
+    // Pins the isolation the rejections below depend on. If these fixtures ever
+    // stop stripping the controller transport variables, the routing bail-out
+    // above `run_split_placement_cook` swallows every rejection this file
+    // asserts, and the suite hangs instead of failing (#10917).
+    let context = HermeticTestContext::new();
+    let command = context.command(TestBinary::HomeboyFixture);
+    let removed_env = command
+        .get_envs()
+        .filter_map(|(key, value)| value.is_none().then(|| key.to_string_lossy().into_owned()))
+        .collect::<std::collections::BTreeSet<_>>();
+
+    assert!(
+        removed_env.contains(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV),
+        "cook handoff fixtures must not inherit Lab offload transport"
+    );
+    assert!(
+        removed_env.contains(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV),
+        "cook handoff fixtures must not inherit the controller source snapshot"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- spawn the five cook handoff fixtures through `HermeticTestContext::command` instead of a hand-rolled `Command` that only overrides `HOME`
- pin the isolation with a regression test so the shared harness cannot be re-invented per test file

## Root Cause

`route_after_parse` opens with three escape hatches:

```rust
if lab_routing::is_lab_offload_subprocess()   // HOMEBOY_LAB_OFFLOAD_JSON
    || managed_runner_placement               // HOMEBOY_RUNNER_HOSTED_EXEC + _PLACEMENT_RESOLVED + _ID
    || runner_resident_execution(cli)
{
    return Ok(None);
}
```

Every case in `tests/cook_lab_handoff_test.rs` asserts that a contradictory invocation is rejected during argument validation, *before* any worktree or provider resolution. That validation sits **below** the bail-out. One inherited controller-transport variable therefore skips the rejection silently and lets cook proceed into real worktree work, which can block indefinitely — newer code reaches `git ls-remote --symref origin HEAD` on that path (#10823).

The file spawned its subprocess with only `HOME` and `HOMEBOY_NO_UPDATE_CHECK` overridden, while homeboy-core already ships the canonical isolated spawner for exactly this, carrying the comment:

```rust
// Lab transport belongs to the runner job that launched this test,
// never to fixture subprocesses unless a test explicitly injects it.
.env_remove(crate::observation::SOURCE_SNAPSHOT_METADATA_ENV)
.env_remove(crate::observation::LAB_OFFLOAD_METADATA_ENV)
```

## Impact

`cargo test` runs integration binaries **serially in alphabetical order**. `cook_lab_handoff_test` is **#7 of 27**, so the block stranded the **20 binaries ordered after it** — they never executed. The Test gate consumed its full budget and exited `124`.

Observed on run 30491724187 (job 90710945713): 1h39m, `exit_code: 124`, in **both** the current and baseline phases. Baseline is the merge base, so this is main's hang.

## Reproduction

Against an installed binary, isolating `HOME` only returns the expected rejection in 0.6s:

```
Invalid argument 'detach-after-handoff': agent-task cook cannot detach after
handoff with --placement local because no runner daemon owns the provider attempt
```

Adding one inherited variable removes it entirely and execution proceeds to worktree destination resolution:

```sh
HOME=$(mktemp -d) HOMEBOY_NO_UPDATE_CHECK=1 \
HOMEBOY_LAB_OFFLOAD_JSON='{"runner_id":"homeboy-lab"}' \
homeboy --placement local --detach-after-handoff agent-task cook \
  --prompt 'implement the fix' --to-worktree missing@worktree --verify true
```

That is precisely what the file's own `assert!(!stdout.contains("worktree provider"))` exists to catch.

## Why The Earlier Fixes Did Not Hold

- **#10717** — same test, "passes alone but took 437 seconds", blocked the v0.322.0 release.
- **#10718** — isolated `HOME` → 52s.

#10718 addressed the symptom (SSH probes against the operator's real runner config) and left the remaining leaked variables in place. Isolating `HOME` only ever narrowed the leak. Routing through the shared harness closes it, and the added regression test keeps it closed.

## Not In Scope

The routing escape hatches still skip **argument validation** outright. An invalid flag combination is invalid regardless of transport context, so validation arguably belongs above the bail-out. That is a behavioral change to production routing with its own blast radius; this PR makes the suite deterministic without it. Tracked in the #10917 follow-up note.

## Tests
- `cargo check --test cook_lab_handoff_test` — passed (exit 0)
- `cargo fmt --all` — clean
- `git diff --check` — clean

The full integration binary could not be built and executed here: this host cannot run `cargo build`/`cargo test` for the workspace without exhausting RAM, so the behavioral verification is delegated to CI. The decisive signal to watch is that the Test gate now runs all 27 integration binaries rather than stopping at the 7th.

Closes #10917
