### PR TITLE
Fix read-only inventory startup recovery

### DIFF
--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -37,6 +37,15 @@ pub fn classify(args: &[String]) -> CommandCapability {
         {
             CommandCapability::ReadOnly
         }
+        [command, rest @ ..]
+            if matches!(command.as_str(), "activity" | "project" | "rig" | "server")
+                && matches!(rest.first().map(String::as_str), None | Some("list")) =>
+        {
+            CommandCapability::ReadOnly
+        }
+        [command, subcommand, ..] if command == "runner" && subcommand == "status" => {
+            CommandCapability::ReadOnly
+        }
         _ => CommandCapability::Mutation,
     }
 }
@@ -68,6 +77,24 @@ mod tests {
             ]),
         ] {
             assert_eq!(classify(&command), CommandCapability::ReadOnly);
+        }
+    }
+
+    #[test]
+    fn classifies_inventory_readers_as_read_only_during_active_controller_work() {
+        for command in [
+            args(&["homeboy", "activity"]),
+            args(&["homeboy", "activity", "list"]),
+            args(&["homeboy", "project", "list"]),
+            args(&["homeboy", "rig", "list"]),
+            args(&["homeboy", "server", "list"]),
+            args(&["homeboy", "runner", "status"]),
+        ] {
+            assert_eq!(
+                classify(&command),
+                CommandCapability::ReadOnly,
+                "{command:?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- classify the reported inventory readers as read-only before startup recovery
- avoid runner-exec reconciliation while those readers inspect active controller work
- cover the full reported command matrix

## Tests

- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-cli command_capability::tests --lib --locked`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo fmt --all --check`
- `git diff --check`

Closes #10910

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding task was used for investigation, implementation, and tests. Chris Huber remains responsible for every line.