### PR TITLE
fix(release): return an incomplete published release to draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1316,7 +1316,9 @@ jobs:
     if: ${{ always() && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # `write` so an incomplete release can be returned to draft. Detecting a
+      # broken published release and leaving it published is not a guard (#8687).
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -1331,7 +1333,14 @@ jobs:
             exit 1
           fi
 
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > release.json
+          # `releases/tags/{tag}` resolves published releases only; a draft 404s
+          # there. Distinguish the two so "never published" cannot be reported as
+          # a malformed API response.
+          if ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > release.json 2>/dev/null; then
+            echo "::error::Release ${RELEASE_TAG} is not published. The tag exists but the GitHub Release is still a draft or absent, so consumers pinning this version get nothing. Recover with a workflow_dispatch run using release_tag=${RELEASE_TAG}."
+            exit 1
+          fi
+
           missing=()
           invalid=()
           while IFS= read -r asset; do
@@ -1346,6 +1355,24 @@ jobs:
           if [ "${#missing[@]}" -gt 0 ] || [ "${#invalid[@]}" -gt 0 ]; then
             [ "${#missing[@]}" -eq 0 ] || echo "::error::Release ${RELEASE_TAG} is missing planned assets: ${missing[*]}"
             [ "${#invalid[@]}" -eq 0 ] || echo "::error::Release ${RELEASE_TAG} has planned assets that are not uploaded or are zero bytes: ${invalid[*]}"
+
+            # Return it to draft. A published release that is missing planned
+            # assets serves 404s for the platforms it dropped, and can become
+            # `latest` if the next release also fails. Failing the run while
+            # leaving it published detects the problem without containing it --
+            # v0.323.1 shipped 2 of 14 assets and stayed live exactly that way.
+            #
+            # This is reversible and non-destructive: the tag, the release body
+            # and every uploaded asset are retained. Only the draft flag flips,
+            # which is what makes the release unreachable to consumers until a
+            # recovery run completes it.
+            if jq -e '.draft == false' release.json >/dev/null; then
+              if gh release edit "${RELEASE_TAG}" --draft=true --repo "${GITHUB_REPOSITORY}"; then
+                echo "::error::Release ${RELEASE_TAG} was returned to DRAFT because it was published without every planned asset. Its tag and uploaded assets are retained. Complete it with a workflow_dispatch run using release_tag=${RELEASE_TAG}, which republishes once the asset set verifies."
+              else
+                echo "::error::Release ${RELEASE_TAG} is published and incomplete, and could not be returned to draft. Un-publish it by hand before any consumer resolves it: gh release edit ${RELEASE_TAG} --draft=true --repo ${GITHUB_REPOSITORY}"
+              fi
+            fi
             exit 1
           fi
           echo "::notice::Release ${RELEASE_TAG} contains every planned asset."

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -631,7 +631,12 @@ fn release_fails_loudly_when_prepared_release_does_not_publish() {
     assert!(verify.contains("needs.prepare.outputs.prepared == 'true'"));
     assert!(verify.contains("needs.prepare.outputs['release-tag'] != ''"));
     assert!(verify.contains("- plan"));
-    assert!(verify.contains("contents: read"));
+    // Previously asserted `contents: read`. The guard now has to be able to
+    // return an incomplete published release to draft (#8687), which needs
+    // write. The least-privilege intent is preserved by scope, not by level:
+    // this job's only mutation is the draft flag, asserted in
+    // `verify_published_returns_an_incomplete_published_release_to_draft`.
+    assert!(verify.contains("contents: write"));
     assert!(verify.contains("GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}"));
     assert!(plan.contains("expected-assets: ${{ steps.plan.outputs.expected-assets }}"));
     assert!(plan.contains(".releases[].artifacts[]? | split(\"/\") | last"));
@@ -1186,6 +1191,69 @@ fn release_recovery_finalizer_executes_the_main_built_binary() {
     assert!(
         finalize.contains("recovery-release == 'true'"),
         "binary-path must be bound to the recovery path so normal releases are unaffected"
+    );
+}
+
+/// Detecting a broken published release is not the same as containing one.
+///
+/// `v0.323.1` published with 2 of 14 assets — both Linux archives missing, so
+/// `releases/download/v0.323.1/homeboy-x86_64-unknown-linux-gnu.tar.xz`
+/// returned 404. The verify job correctly went red and the release stayed
+/// published and reachable, which is the invariant #8687 exists to enforce
+/// ("partially uploaded releases remain draft/failed").
+#[test]
+fn verify_published_returns_an_incomplete_published_release_to_draft() {
+    let workflow = release_workflow();
+    let verify = job_section(workflow, "verify-published");
+
+    assert!(
+        verify.contains("contents: write"),
+        "the job cannot un-publish a broken release without write permission"
+    );
+
+    let step = release_step_block(verify, "name: Verify planned release assets");
+
+    assert!(
+        step.contains("--draft=true"),
+        "an incomplete published release must be returned to draft, not merely reported"
+    );
+    assert!(
+        step.contains("jq -e '.draft == false' release.json"),
+        "only a release that is actually published may be re-drafted"
+    );
+    assert!(
+        step.contains("could not be returned to draft"),
+        "a failed un-publish must escalate with the manual command, never pass silently"
+    );
+
+    // Containment must not weaken the gate: the run still fails either way.
+    // `--draft=true` appears twice (the command, and the manual remediation
+    // hint), so measure from the last one.
+    let after_redraft = step
+        .rsplit("--draft=true")
+        .next()
+        .expect("re-draft branch should exist");
+    assert!(
+        after_redraft.contains("exit 1"),
+        "re-drafting is containment, not absolution -- the run must still fail"
+    );
+}
+
+/// `releases/tags/{tag}` resolves published releases only, so a draft 404s
+/// there. Reporting that as a malformed API response hides the actual state.
+#[test]
+fn verify_published_distinguishes_an_unpublished_release_from_a_broken_one() {
+    let workflow = release_workflow();
+    let verify = job_section(workflow, "verify-published");
+    let step = release_step_block(verify, "name: Verify planned release assets");
+
+    assert!(
+        step.contains("is not published"),
+        "a draft or absent release must be named as such"
+    );
+    assert!(
+        step.contains("still a draft or absent"),
+        "the operator needs to know the tag exists without a consumable release"
     );
 }
 


### PR DESCRIPTION
Fixes #8687.

## The guard detects but does not contain

`verify-published` already compares the published asset set against the plan, and already fails the run. It then leaves the broken release published.

`v0.323.1` is the live case. Release run [30514636525](https://github.com/Extra-Chill/homeboy/actions/runs/30514636525):

| job | result |
|---|---|
| `build (aarch64-unknown-linux-gnu)` | success |
| `build (x86_64-unknown-linux-gnu)` | success |
| `build (aarch64-apple-darwin)` | success |
| `build (x86_64-apple-darwin)` | success |
| `build-global-artifacts` | success |
| `Create GitHub Release` | **failure** |
| `Verify GitHub Release published` | **failure** |

Every artifact built. The publish step failed after uploading two of them, the guard correctly went red — and the release is still published, right now, with **2 of 14 assets**:

```
$ curl -sIL -o /dev/null -w '%{http_code}' \
    .../releases/download/v0.323.1/homeboy-x86_64-unknown-linux-gnu.tar.xz
404
```

Its own `sha256.sum` lists only the two artifacts that made it:

```
d7deab26… *homeboy-aarch64-apple-darwin.tar.xz
b3e893ca… *source.tar.gz
```

Both Linux archives and x86_64-darwin are missing, along with `dist-manifest.json`.

That is exactly the invariant #8687 exists to enforce — *"partially uploaded releases remain draft/failed"* — and detection without containment does not enforce it. It also leaves the release eligible to become `latest` if the next release fails.

## Change

Return an incomplete published release to draft.

This is **reversible and non-destructive**: the tag, the release body, and every uploaded asset are retained. Only the draft flag flips, which is what makes the release unreachable to consumers until a recovery run completes it. The run still exits 1, so containment is not absolution.

Also distinguishes **"not published"** from **"published but incomplete"**. `releases/tags/{tag}` resolves published releases only, so a draft 404s there — that was being surfaced as a malformed API response rather than as a draft.

## Permission change, called out deliberately

The job goes from `contents: read` to `contents: write`. An existing assertion pinned `read`; I updated it rather than working around it, with the reasoning in the test.

Least privilege is preserved **by scope rather than by level**: this job's only mutation is the draft flag, and `verify_published_returns_an_incomplete_published_release_to_draft` asserts that.

## Tests

| test | asserts |
|---|---|
| `verify_published_returns_an_incomplete_published_release_to_draft` | `contents: write`, `--draft=true`, only re-drafts when `.draft == false`, escalates with a manual command if the un-publish fails, and still `exit 1` afterwards |
| `verify_published_distinguishes_an_unpublished_release_from_a_broken_one` | a draft or absent release is named as such |

**Negative control:** stripping the re-draft branch — reproducing today's detect-but-do-not-contain behaviour — fails the first test with *"an incomplete published release must be returned to draft, not merely reported"*.

`cargo test --test release_workflow_test` → **43 passed, 0 failed**. YAML parses.

## Scope

This does not fix what *caused* v0.323.1 to fail. That was:

```
Release step preflight.recovery_artifacts failed: Invalid argument 'from-artifacts':
Recovered release asset 'artifacts/dist-manifest.json' is missing (os error 2)
```

which `107c11746` ("keep recovery artifact paths relative", #10877) appears to address — it merged after this failure, and v0.323.2 then published with 13 assets including `dist-manifest.json` and all four platform archives.

This PR is about the containment gap that let a known-bad release stay live regardless of cause.

## Note

`v0.323.1` is still published and still serving 404s. This change prevents recurrence; it does not retroactively fix that release. Worth deleting or re-drafting it by hand.

Also worth knowing: the job reported `##[error]Release failed: Unknown error`, and the classified reason was only recoverable from the JSON payload. `Extra-Chill/homeboy-action#302` fixes that and had been stranded in unpublished drafts — now deployed, so this class of failure should be legible in the log going forward.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
