### PR TITLE
fix(deploy): validate head branch in dry runs

### DIFF
--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -213,6 +213,12 @@ pub(super) fn deploy_components(
         HashMap::new()
     };
 
+    // Dry-run is an approval artifact, so it must reject a non-default --head
+    // source unless the same explicit --force approval required by apply exists.
+    if config.head && !config.skip_build {
+        warn_non_default_branch(&local_build_components, config)?;
+    }
+
     // Check and dry-run modes return early without building or deploying
     if config.check {
         return Ok(run_check_mode(
@@ -254,9 +260,8 @@ pub(super) fn deploy_components(
 
     guard_local_build_source_freshness(&local_build_components, config)?;
 
-    // Warn when --head deploys from a non-default branch (safety guardrail)
+    // Confirm the invocation checkout still matches the registered source.
     if config.head && !config.skip_build {
-        warn_non_default_branch(&local_build_components, config)?;
         // Fail closed when the invocation checkout has advanced past the
         // registered checkout --head would actually build from (#7599).
         guard_head_matches_invocation_checkout(&local_build_components, config)?;

--- a/crates/homeboy-release/src/deploy/orchestration/preflight.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/preflight.rs
@@ -598,6 +598,7 @@ mod tests {
     use super::{
         guard_deployment_provenance, guard_head_matches_invocation_checkout,
         guard_local_build_downgrades, guard_local_build_source_freshness, local_build_components,
+        warn_non_default_branch,
     };
     use crate::deploy::DeployConfig;
     use homeboy_core::component::Component;
@@ -875,6 +876,29 @@ mod tests {
         config.expected_version = Some("1.2.3".to_string());
 
         assert!(local_build_components(&[component], &config).is_empty());
+    }
+
+    #[test]
+    fn non_default_head_requires_force_for_dry_run_and_apply() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        init_repo_with_commit(temp.path());
+        git(temp.path(), &["checkout", "-b", "feature"]);
+        let component = component(temp.path());
+
+        for dry_run in [true, false] {
+            let mut config = config();
+            config.head = true;
+            config.dry_run = dry_run;
+            let error = warn_non_default_branch(&[component.clone()], &config)
+                .expect_err("non-default --head requires --force");
+            assert_eq!(error.details["field"], "head");
+            assert!(error.message.contains("branch 'feature', not 'main'"));
+            assert!(error.details.to_string().contains("Use --force"));
+
+            config.force = true;
+            warn_non_default_branch(&[component.clone()], &config)
+                .expect("--force approves non-default --head for dry-run and apply");
+        }
     }
 
     // Serialize the #7599 tests: they mutate the process CWD, which is global.


### PR DESCRIPTION
## Summary
- run the non-default `--head` branch approval guard before dry-run returns a plan
- cover matching `--force` requirements for dry-run and apply using a real feature-branch fixture

Closes #10911

## Tests
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-release non_default_head_requires_force_for_dry_run_and_apply`

## AI assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: general coding task; investigated dry-run/apply validation parity, implemented the minimal generic fix, and added deterministic tests.

Chris remains responsible for every line.