### PR TITLE
feat(deploy): layer provider target inputs

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/config.rs
+++ b/crates/contracts/homeboy-component-contract/src/config.rs
@@ -432,12 +432,17 @@ pub struct ComponentDeployConfig<'a> {
     pub cleanup_artifacts: &'a [CleanupArtifactDeclaration],
 }
 
-/// A repository-owned contract executed by an extension-declared deployment provider.
+/// Repository-owned deployment policy executed by an extension-declared provider.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeploymentProviderAttachment {
     pub extension: String,
     pub provider: String,
-    pub contract: String,
+    /// Legacy repository-relative contract file for unlayered providers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract: Option<String>,
+    /// Opaque inline repository policy for layered providers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<serde_json::Value>,
 }
 
 impl ComponentDeployConfig<'_> {

--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -585,6 +585,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn portable_component_round_trips_inline_deployment_policy() {
+        let component: Component = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "deployment_provider": {
+                "extension": "fixture-extension",
+                "provider": "fixture.deploy",
+                "policy": { "mode": "portable" }
+            }
+        }))
+        .expect("portable component");
+
+        let serialized = serde_json::to_value(component).expect("serialize component");
+        assert_eq!(
+            serialized["deployment_provider"]["policy"],
+            serde_json::json!({ "mode": "portable" })
+        );
+        assert!(serialized["deployment_provider"].get("contract").is_none());
+        assert!(serialized.get("deployment_provider_input").is_none());
+    }
+
+    #[test]
     fn canonical_attachment_identity_ignores_build_artifact_but_catches_config_drift() {
         let base = Component::new(
             "agents-api".to_string(),

--- a/crates/homeboy-core/src/component/mutations.rs
+++ b/crates/homeboy-core/src/component/mutations.rs
@@ -343,6 +343,7 @@ mod tests {
                     local_path: old_repo.to_string_lossy().to_string(),
                     remote_path: Some("wp-content/plugins/studio-web".to_string()),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Default::default()
             };

--- a/crates/homeboy-core/src/fleet/check.rs
+++ b/crates/homeboy-core/src/fleet/check.rs
@@ -196,6 +196,7 @@ mod tests {
                 local_path: component_dir.to_string_lossy().to_string(),
                 remote_path: None,
                 deployment_provider: None,
+                deployment_provider_input: None,
             });
             project::save(&project).expect("project config");
 

--- a/crates/homeboy-core/src/harvest.rs
+++ b/crates/homeboy-core/src/harvest.rs
@@ -514,6 +514,7 @@ mod tests {
                     local_path: local.display().to_string(),
                     remote_path: Some("managed/component".to_string()),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 extensions: Some(HashMap::from([(
                     "managed-host".to_string(),

--- a/crates/homeboy-core/src/project/component/attachments.rs
+++ b/crates/homeboy-core/src/project/component/attachments.rs
@@ -146,6 +146,7 @@ fn attach_component_path_unlocked(
             local_path: local_path.to_string(),
             remote_path: None,
             deployment_provider: None,
+            deployment_provider_input: None,
         });
     }
 
@@ -291,6 +292,7 @@ mod tests {
                 local_path: format!("/workspace/{}", id),
                 remote_path: None,
                 deployment_provider: None,
+                deployment_provider_input: None,
             });
         }
         project

--- a/crates/homeboy-core/src/project/component/report.rs
+++ b/crates/homeboy-core/src/project/component/report.rs
@@ -443,6 +443,7 @@ mod tests {
                 local_path: "/repo/plugin".to_string(),
                 remote_path: None,
                 deployment_provider: None,
+                deployment_provider_input: None,
             }],
             ..Default::default()
         };
@@ -474,12 +475,14 @@ mod tests {
                         local_path: "/tmp/homeboy-remove-me-missing".to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                     ProjectComponentAttachment {
                         id: "stale-remaining".to_string(),
                         local_path: "/tmp/homeboy-stale-remaining-missing".to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                 ],
                 ..Default::default()

--- a/crates/homeboy-core/src/project/component/resolution.rs
+++ b/crates/homeboy-core/src/project/component/resolution.rs
@@ -243,6 +243,7 @@ mod tests {
                 local_path,
                 remote_path: remote_path.map(str::to_string),
                 deployment_provider: None,
+                deployment_provider_input: None,
             }],
             ..Default::default()
         }

--- a/crates/homeboy-core/src/project/readiness.rs
+++ b/crates/homeboy-core/src/project/readiness.rs
@@ -237,6 +237,7 @@ mod tests {
                 local_path,
                 remote_path: Some("wp-content/plugins/plugin".to_string()),
                 deployment_provider: None,
+                deployment_provider_input: None,
             }],
             ..Project::default()
         }
@@ -270,6 +271,7 @@ mod tests {
                     local_path,
                     remote_path: Some(format!("wp-content/plugins/{id}")),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 })
                 .collect(),
             ..Project::default()

--- a/crates/homeboy-core/src/project/report.rs
+++ b/crates/homeboy-core/src/project/report.rs
@@ -361,6 +361,7 @@ mod tests {
                     local_path: "/tmp/homeboy-missing-component-path".to_string(),
                     remote_path: Some("wp-content/plugins/plugin".to_string()),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Project::default()
             })

--- a/crates/homeboy-core/src/project/types/component.rs
+++ b/crates/homeboy-core/src/project/types/component.rs
@@ -14,6 +14,40 @@ pub struct ProjectComponentAttachment {
     pub remote_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployment_provider: Option<crate::component::DeploymentProviderAttachment>,
+    /// Opaque project-owned input for a layered deployment provider.
+    ///
+    /// This deliberately belongs to the project attachment rather than the
+    /// portable component model: target identity is environment-owned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment_provider_input: Option<serde_json::Value>,
 }
 
 pub type ProjectComponentOverrides = crate::component::ComponentOverrideConfig;
+
+#[cfg(test)]
+mod tests {
+    use super::ProjectComponentAttachment;
+
+    #[test]
+    fn provider_input_is_project_only() {
+        let attachment: ProjectComponentAttachment = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "local_path": "/source/fixture",
+            "deployment_provider_input": { "credential": "project-secret" }
+        }))
+        .expect("project attachment");
+
+        assert_eq!(
+            attachment.deployment_provider_input,
+            Some(serde_json::json!({ "credential": "project-secret" }))
+        );
+        let portable: crate::component::Component = serde_json::from_value(
+            serde_json::json!({ "id": "fixture", "deployment_provider_input": { "credential": "ignored" } }),
+        )
+        .expect("portable component");
+        assert!(serde_json::to_value(portable)
+            .expect("portable component serialization")
+            .get("deployment_provider_input")
+            .is_none());
+    }
+}

--- a/crates/homeboy-extension/src/capability.rs
+++ b/crates/homeboy-extension/src/capability.rs
@@ -135,6 +135,7 @@ mod tests {
                     local_path: component_dir.path().to_string_lossy().to_string(),
                     remote_path: None,
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Default::default()
             };

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -986,6 +986,7 @@ mod tests {
                     local_path: attachment.path().to_string_lossy().to_string(),
                     remote_path: None,
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Default::default()
             })

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -105,12 +105,13 @@ pub use lifecycle::{
 };
 pub use maintenance::{exec_tool, update_all};
 pub use manifest::{
-    deployment_providers, structured_sidecar_schema_version, structured_sidecars, ActionConfig,
-    ActionType, AgentRuntimeManifestConfig, AuditCapability, AutofixVerifyConfig,
-    BehaviorScenarioNames, BenchConfig, BuildConfig, CiCapability, CiJobFidelity, CiJobMapping,
-    CiJobSpec, CiLocalContext, CiProfileSpec, CliAutoFlag, CliAutoFlagCondition, CliConfig,
-    CliHelpConfig, ComponentEnvConfig, DatabaseCliConfig, DatabaseConfig, DeployCapability,
-    DeployOverride, DeployOwnerHint, DeployVerification, DeploymentProviderManifest, DepsConfig,
+    deployment_provider_layered_input, deployment_providers, structured_sidecar_schema_version,
+    structured_sidecars, ActionConfig, ActionType, AgentRuntimeManifestConfig, AuditCapability,
+    AutofixVerifyConfig, BehaviorScenarioNames, BenchConfig, BuildConfig, CiCapability,
+    CiJobFidelity, CiJobMapping, CiJobSpec, CiLocalContext, CiProfileSpec, CliAutoFlag,
+    CliAutoFlagCondition, CliConfig, CliHelpConfig, ComponentEnvConfig, DatabaseCliConfig,
+    DatabaseConfig, DeployCapability, DeployOverride, DeployOwnerHint, DeployVerification,
+    DeploymentProviderLayeredInputManifest, DeploymentProviderManifest, DepsConfig,
     DiscoveryConfig, DiscoveryMarkerConfig, DocTarget, ExecutableCapability,
     ExtensionContractProducer, ExtensionContractProducerInvocation,
     ExtensionContractProducerOutput, ExtensionContractProducerOutputKind,
@@ -128,7 +129,7 @@ pub use manifest::{
     TestPassthroughFilterStrategy, TestSecretEnvProjection, TestSettingStringPredicate,
     TestVacuityPolicy, TraceBrowserArtifactMapConfig, TraceBrowserEvidenceAdapterConfig,
     TraceBrowserMetricAliasConfig, TraceBrowserSummaryAliasConfig, TraceConfig,
-    VersionPatternConfig, EXTENSION_CONTRACT_PRODUCER_SCHEMA,
+    VersionPatternConfig, DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA, EXTENSION_CONTRACT_PRODUCER_SCHEMA,
     EXTENSION_MATERIALIZATION_SOURCE_SCHEMA, NOTIFICATION_TRANSPORT_SCHEMA,
 };
 pub use refactor_protocol::{

--- a/crates/homeboy-extension/src/manifest.rs
+++ b/crates/homeboy-extension/src/manifest.rs
@@ -79,7 +79,23 @@ pub struct DeploymentProviderManifest {
     pub command: String,
     #[serde(default)]
     pub dry_run_command: Option<String>,
+    #[serde(default)]
+    pub layered_input: Option<DeploymentProviderLayeredInputManifest>,
 }
+
+/// Opt-in capability for providers that receive a versioned layered payload.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct DeploymentProviderLayeredInputManifest {
+    pub schema: String,
+    #[serde(default)]
+    pub target_required: bool,
+    /// Schema for provider-produced structured evidence. Providers declaring this
+    /// contract are responsible for emitting already-redacted JSON.
+    #[serde(default)]
+    pub result_schema: Option<String>,
+}
+
+pub const DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA: &str = "homeboy/deployment-provider-payload/v1";
 
 /// Extension manifests retain provider descriptors as extension-owned data until
 /// the shared manifest contract publishes this capability.
@@ -92,6 +108,23 @@ pub fn deployment_providers(manifest: &ExtensionManifest) -> Vec<DeploymentProvi
         .unwrap_or_default()
 }
 
+pub fn deployment_provider_layered_input(
+    extension_id: &str,
+    provider_id: &str,
+) -> Result<Option<DeploymentProviderLayeredInputManifest>> {
+    let extension = super::load_extension(extension_id)?;
+    let provider = deployment_providers(&extension)
+        .into_iter()
+        .find(|provider| provider.id == provider_id)
+        .ok_or_else(|| Error::validation_invalid_argument(
+            "deployment_provider.provider",
+            format!("Extension '{extension_id}' does not declare deployment provider '{provider_id}'"),
+            None,
+            None,
+        ))?;
+    Ok(provider.layered_input)
+}
+
 #[cfg(test)]
 mod deployment_provider_tests {
     use super::*;
@@ -102,7 +135,7 @@ mod deployment_provider_tests {
             "name": "fixture", "version": "1.0.0",
             "deployment_providers": [
                 { "id": "fixture.alpha", "command": "fixture-alpha --contract {{payload.contract}}" },
-                { "id": "fixture.beta", "command": "fixture-beta --contract {{payload.contract}}", "dry_run_command": "fixture-beta --dry-run --contract {{payload.contract}}" }
+                { "id": "fixture.beta", "command": "fixture-beta --contract {{payload.contract}}", "dry_run_command": "fixture-beta --dry-run --contract {{payload.contract}}", "layered_input": { "schema": "homeboy/deployment-provider-payload/v1", "target_required": true, "result_schema": "fixture/deployment-result/v1" } }
             ]
         }))
         .expect("fixture manifest");
@@ -115,6 +148,21 @@ mod deployment_provider_tests {
         assert_eq!(
             providers[1].dry_run_command.as_deref(),
             Some("fixture-beta --dry-run --contract {{payload.contract}}")
+        );
+        assert_eq!(
+            providers[1]
+                .layered_input
+                .as_ref()
+                .expect("layered input")
+                .schema,
+            DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA
+        );
+        assert!(
+            providers[1]
+                .layered_input
+                .as_ref()
+                .expect("layered input")
+                .target_required
         );
     }
 }

--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -591,6 +591,7 @@ mod tests {
                     local_path: "/tmp/homeboy-missing-component-path".to_string(),
                     remote_path: Some("wp-content/plugins/plugin".to_string()),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Project::default()
             })
@@ -696,6 +697,7 @@ mod tests {
                     local_path: "/stale/plugin".to_string(),
                     remote_path: Some("../wp-content/plugins/plugin".to_string()),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Project::default()
             };

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -1092,6 +1092,7 @@ mod tests {
                     local_path: path.to_string_lossy().to_string(),
                     remote_path: None,
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 })
                 .collect(),
             ..Default::default()

--- a/crates/homeboy-release/src/deploy/planning.rs
+++ b/crates/homeboy-release/src/deploy/planning.rs
@@ -1050,12 +1050,14 @@ mod tests {
                     local_path: "/stale/a".to_string(),
                     remote_path: Some("plugins/a".to_string()),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 },
                 homeboy_core::project::ProjectComponentAttachment {
                     id: "b".to_string(),
                     local_path: "/stale/b".to_string(),
                     remote_path: Some("plugins/b".to_string()),
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 },
             ],
             ..Default::default()
@@ -1549,6 +1551,7 @@ mod tests {
                 local_path: dir.to_string_lossy().to_string(),
                 remote_path: None,
                 deployment_provider: None,
+                deployment_provider_input: None,
             };
 
             let project = Project {

--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
@@ -25,7 +26,7 @@ pub(super) fn run_if_configured(
     {
         let results = components
             .iter()
-            .map(|component| run_component(project_id, component, config))
+            .map(|component| run_component(project_id, project, component, config))
             .collect::<Result<Vec<_>>>()?;
         let failed = results
             .iter()
@@ -47,26 +48,125 @@ pub(super) fn run_if_configured(
 
 fn run_component(
     project_id: &str,
+    project: &Project,
     component: &Component,
     config: &DeployConfig,
 ) -> Result<ComponentDeployResult> {
+    let project_attachment = project
+        .components
+        .iter()
+        .find(|attachment| attachment.id == component.id)
+        .expect("component resolution requires an attachment");
+    if project_attachment.deployment_provider_input.is_some()
+        && project_attachment.deployment_provider.is_some()
+    {
+        return Err(Error::validation_invalid_argument(
+            "components.deployment_provider_input",
+            "Project deployment provider policy override cannot be combined with project provider input",
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+
+    // With target input, the resolved provider attachment is necessarily the
+    // repository-owned policy because a project override was rejected above.
+    // Without input, retain the legacy resolved project override behavior.
     let attachment = component
         .deployment_provider
         .as_ref()
         .expect("checked by caller");
-    let contract = repository_contract(component, &attachment.contract)?;
-    let run = homeboy_extension::run_deployment_provider(
+    let layered = homeboy_extension::deployment_provider_layered_input(
         &attachment.extension,
         &attachment.provider,
-        project_id,
-        &component.id,
-        &contract,
-        config.dry_run || config.check,
     )?;
+    let target_input = project_attachment.deployment_provider_input.as_ref();
+    let layered = match layered {
+        Some(layered)
+            if layered.schema == homeboy_extension::DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA =>
+        {
+            Some(layered)
+        }
+        Some(_) => {
+            return Err(Error::validation_invalid_argument(
+                "deployment_provider.layered_input",
+                "Deployment provider declares an unsupported layered input schema",
+                Some(component.id.clone()),
+                None,
+            ));
+        }
+        None => None,
+    };
+    if target_input.is_some() && layered.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "components.deployment_provider_input",
+            "Deployment provider does not support project provider input",
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+    if layered
+        .as_ref()
+        .is_some_and(|layered| layered.target_required)
+        && target_input.is_none()
+    {
+        return Err(Error::validation_invalid_argument(
+            "components.deployment_provider_input",
+            "Deployment provider requires project provider input",
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+
+    validate_repository_policy(component, layered.is_some(), attachment)?;
+
+    let is_layered = layered.is_some();
+    let layered_result_schema = layered
+        .as_ref()
+        .and_then(|layered| layered.result_schema.as_deref());
+    let dry_run = config.dry_run || config.check;
+    let run = if layered.is_some() {
+        let payload = layered_payload(
+            component,
+            attachment.policy.as_ref().expect("validated inline policy"),
+            target_input,
+        )?;
+        homeboy_extension::run_deployment_provider(
+            &attachment.extension,
+            &attachment.provider,
+            project_id,
+            &component.id,
+            payload.path(),
+            dry_run,
+        )
+    } else {
+        let contract = repository_contract(
+            component,
+            attachment
+                .contract
+                .as_deref()
+                .expect("validated legacy contract"),
+        )?;
+        homeboy_extension::run_deployment_provider(
+            &attachment.extension,
+            &attachment.provider,
+            project_id,
+            &component.id,
+            &contract,
+            dry_run,
+        )
+    }?;
     let evidence = run.output.unwrap_or_default();
     let output = format!("{}{}", evidence.stdout, evidence.stderr);
-    let provider_result = serde_json::from_str::<serde_json::Value>(&evidence.stdout)
-        .unwrap_or_else(|_| serde_json::json!({ "status": "unstructured", "output": output }));
+    // Layered input can contain target secrets. Provider output is therefore not
+    // promoted into deploy evidence or errors on that path.
+    let provider_result = if is_layered && layered_result_schema.is_some() {
+        layered_provider_evidence(&evidence.stdout, layered_result_schema.expect("checked"))
+    } else if is_layered {
+        serde_json::json!({ "status": "opaque" })
+    } else {
+        serde_json::from_str::<serde_json::Value>(&evidence.stdout)
+            .unwrap_or_else(|_| serde_json::json!({ "status": "unstructured", "output": output }))
+    };
     let status = if run.exit_code == 0 {
         if config.dry_run || config.check {
             "validated"
@@ -77,17 +177,139 @@ fn run_component(
         "failed"
     };
     let mut result = ComponentDeployResult::new(component, "").with_status(status);
+    if is_layered {
+        result.local_path = None;
+    }
     result.deploy_exit_code = Some(run.exit_code);
-    result.error = (run.exit_code != 0).then(|| output);
+    result.error = (run.exit_code != 0).then(|| {
+        if is_layered {
+            "Deployment provider failed".to_string()
+        } else {
+            output
+        }
+    });
     result.deployment_provider = Some(provider_result);
     Ok(result)
 }
 
+fn layered_provider_evidence(stdout: &str, expected_schema: &str) -> serde_json::Value {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) else {
+        return serde_json::json!({ "status": "opaque" });
+    };
+    if value
+        .as_object()
+        .and_then(|object| object.get("schema"))
+        .and_then(serde_json::Value::as_str)
+        == Some(expected_schema)
+    {
+        value
+    } else {
+        serde_json::json!({ "status": "opaque" })
+    }
+}
+
+fn layered_payload(
+    component: &Component,
+    policy: &serde_json::Value,
+    target: Option<&serde_json::Value>,
+) -> Result<tempfile::NamedTempFile> {
+    let policy_bytes = serde_json::to_vec(policy)
+        .map_err(|_| Error::internal_io("Could not serialize deployment provider policy", None))?;
+    let revision = clean_head_revision(component)?;
+    let payload = serde_json::json!({
+        "schema": homeboy_extension::DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA,
+        "policy": {
+            "value": policy,
+            "reference": {
+                "component": component.id,
+                "path": "homeboy.json#/deployment_provider/policy",
+                "digest": homeboy_engine_primitives::content_hash::sha256_hex(&policy_bytes),
+            }
+        },
+        "target": target,
+        "source": { "component": component.id, "revision": revision },
+    });
+    let mut file = tempfile::NamedTempFile::new()
+        .map_err(|_| Error::internal_io("Could not prepare deployment provider input", None))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|_| Error::internal_io("Could not secure deployment provider input", None))?;
+    }
+    serde_json::to_writer(&mut file, &payload)
+        .map_err(|_| Error::internal_io("Could not prepare deployment provider input", None))?;
+    file.flush()
+        .map_err(|_| Error::internal_io("Could not prepare deployment provider input", None))?;
+    Ok(file)
+}
+
+fn provider_policy_error(component: &Component, message: &str) -> Error {
+    Error::validation_invalid_argument(
+        "deployment_provider",
+        message,
+        Some(component.id.clone()),
+        None,
+    )
+}
+
+fn validate_repository_policy(
+    component: &Component,
+    layered: bool,
+    attachment: &homeboy_core::component::DeploymentProviderAttachment,
+) -> Result<()> {
+    match (layered, &attachment.contract, &attachment.policy) {
+        (true, None, Some(_)) | (false, Some(_), None) => Ok(()),
+        (true, Some(_), _) => Err(provider_policy_error(
+            component,
+            "Layered deployment provider must use inline repository policy without a legacy contract",
+        )),
+        (true, None, None) => Err(provider_policy_error(
+            component,
+            "Layered deployment provider requires inline repository policy",
+        )),
+        (false, None, Some(_)) => Err(provider_policy_error(
+            component,
+            "Unlayered deployment provider does not support inline repository policy",
+        )),
+        (false, Some(_), Some(_)) => Err(provider_policy_error(
+            component,
+            "Deployment provider must declare exactly one repository policy source",
+        )),
+        (false, None, None) => Err(provider_policy_error(
+            component,
+            "Unlayered deployment provider requires a legacy contract",
+        )),
+    }
+}
+
+fn clean_head_revision(component: &Component) -> Result<String> {
+    let root = Path::new(&component.local_path);
+    let revision = homeboy_core::git::head_sha(root).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "deployment_provider.source",
+            "Deployment provider source must be a checked-out Git revision",
+            Some(component.id.clone()),
+            None,
+        )
+    })?;
+    if homeboy_core::git::status_porcelain(root).as_deref() != Some("") {
+        return Err(Error::validation_invalid_argument(
+            "deployment_provider.source",
+            "Deployment provider source checkout must be clean",
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+    Ok(revision)
+}
+
 fn repository_contract(component: &Component, contract: &str) -> Result<PathBuf> {
-    let root = std::fs::canonicalize(&component.local_path).map_err(|error| {
+    let root = std::fs::canonicalize(&component.local_path).map_err(|_| {
         Error::validation_invalid_argument(
             "deployment_provider.contract",
-            format!("Component source is unavailable: {error}"),
+            "Component source is unavailable",
             None,
             None,
         )
@@ -114,8 +336,12 @@ fn repository_contract(component: &Component, contract: &str) -> Result<PathBuf>
 
 #[cfg(test)]
 mod tests {
-    use super::repository_contract;
-    use homeboy_core::component::Component;
+    use super::{
+        layered_payload, layered_provider_evidence, repository_contract, validate_repository_policy,
+    };
+    use homeboy_core::component::{Component, DeploymentProviderAttachment};
+    use homeboy_core::project::{Project, ProjectComponentAttachment};
+    use std::process::Command;
 
     #[test]
     fn requires_a_repository_contained_contract_file() {
@@ -134,5 +360,198 @@ mod tests {
             std::fs::canonicalize(&contract).expect("canonical contract")
         );
         assert!(repository_contract(&component, "../deploy-contract.json").is_err());
+    }
+
+    #[test]
+    fn repository_policy_source_is_unambiguous_by_provider_kind() {
+        let component = Component::new("fixture".to_string(), String::new(), String::new(), None);
+        let attachment = |contract: Option<&str>, policy: Option<serde_json::Value>| {
+            DeploymentProviderAttachment {
+                extension: "fixture-extension".to_string(),
+                provider: "fixture.deploy".to_string(),
+                contract: contract.map(str::to_string),
+                policy,
+            }
+        };
+
+        assert!(validate_repository_policy(
+            &component,
+            true,
+            &attachment(None, Some(serde_json::json!({})))
+        )
+        .is_ok());
+        assert!(validate_repository_policy(
+            &component,
+            false,
+            &attachment(Some("legacy.json"), None)
+        )
+        .is_ok());
+        assert!(validate_repository_policy(&component, true, &attachment(None, None)).is_err());
+        assert!(validate_repository_policy(
+            &component,
+            true,
+            &attachment(Some("legacy.json"), Some(serde_json::json!({})))
+        )
+        .is_err());
+        assert!(validate_repository_policy(
+            &component,
+            false,
+            &attachment(None, Some(serde_json::json!({})))
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn layered_evidence_requires_the_declared_object_schema() {
+        let accepted = layered_provider_evidence(
+            r#"{"schema":"fixture/result/v1","status":"ok"}"#,
+            "fixture/result/v1",
+        );
+        assert_eq!(accepted["status"], "ok");
+
+        for rejected in [
+            r#"{"schema":"fixture/result/v2","target":"private-target","path":"/private/payload"}"#,
+            r#"not json /private/payload private-target"#,
+            r#"["fixture/result/v1"]"#,
+        ] {
+            let evidence = layered_provider_evidence(rejected, "fixture/result/v1");
+            assert_eq!(evidence, serde_json::json!({ "status": "opaque" }));
+            assert!(!evidence.to_string().contains("private-target"));
+            assert!(!evidence.to_string().contains("/private/payload"));
+        }
+    }
+
+    #[test]
+    fn project_targets_are_distinct_from_shared_inline_policy() {
+        let component: Component = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "deployment_provider": {
+                "extension": "fixture-extension",
+                "provider": "fixture.deploy",
+                "policy": { "repository": "shared" }
+            }
+        }))
+        .expect("portable component");
+        let project = |id: &str, target: serde_json::Value| Project {
+            id: id.to_string(),
+            components: vec![ProjectComponentAttachment {
+                id: "fixture".to_string(),
+                local_path: "/source/fixture".to_string(),
+                remote_path: None,
+                deployment_provider: None,
+                deployment_provider_input: Some(target),
+            }],
+            ..Default::default()
+        };
+        let first = project("first", serde_json::json!({ "target": "one" }));
+        let second = project("second", serde_json::json!({ "target": "two" }));
+
+        assert_eq!(
+            component
+                .deployment_provider
+                .as_ref()
+                .expect("provider")
+                .policy,
+            Some(serde_json::json!({ "repository": "shared" }))
+        );
+        assert!(serde_json::to_value(&component)
+            .expect("portable serialization")
+            .get("deployment_provider_input")
+            .is_none());
+        assert_ne!(
+            first.components[0].deployment_provider_input,
+            second.components[0].deployment_provider_input
+        );
+    }
+
+    fn git(path: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git command");
+        assert!(output.status.success(), "git {:?} failed", args);
+    }
+
+    #[test]
+    fn layered_payload_is_namespaced_private_and_removed() {
+        let repository = tempfile::tempdir().expect("repository");
+        std::fs::write(repository.path().join("README.md"), "fixture\n").expect("source");
+        git(repository.path(), &["init", "--quiet"]);
+        git(repository.path(), &["add", "."]);
+        git(
+            repository.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        let component = Component::new(
+            "fixture".to_string(),
+            repository.path().display().to_string(),
+            String::new(),
+            None,
+        );
+        let payload = layered_payload(
+            &component,
+            &serde_json::json!({ "policy": "repository" }),
+            Some(&serde_json::json!({ "target": "one" })),
+        )
+        .expect("payload");
+        let path = payload.path().to_path_buf();
+        assert!(!path.starts_with(repository.path()));
+        let value: serde_json::Value =
+            serde_json::from_reader(payload.reopen().expect("reopen")).expect("payload json");
+        assert_eq!(value["schema"], "homeboy/deployment-provider-payload/v1");
+        assert_eq!(
+            value["policy"]["value"],
+            serde_json::json!({ "policy": "repository" })
+        );
+        assert_eq!(value["policy"]["reference"]["component"], "fixture");
+        assert_eq!(
+            value["policy"]["reference"]["path"],
+            "homeboy.json#/deployment_provider/policy"
+        );
+        assert_eq!(
+            value["policy"]["reference"]["digest"],
+            homeboy_engine_primitives::content_hash::sha256_hex(
+                &serde_json::to_vec(&serde_json::json!({ "policy": "repository" }))
+                    .expect("policy bytes")
+            )
+        );
+        assert_eq!(value["target"], serde_json::json!({ "target": "one" }));
+        assert_eq!(value["source"]["revision"].as_str().map(str::len), Some(40));
+        let second = layered_payload(
+            &component,
+            &serde_json::json!({ "policy": "repository" }),
+            Some(&serde_json::json!({ "target": "two" })),
+        )
+        .expect("second payload");
+        let second_value: serde_json::Value =
+            serde_json::from_reader(second.reopen().expect("reopen")).expect("payload json");
+        assert_eq!(second_value["policy"], value["policy"]);
+        assert_ne!(second_value["target"], value["target"]);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        drop(payload);
+        assert!(
+            !path.exists(),
+            "payload must be removed after provider execution"
+        );
     }
 }

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -939,6 +939,7 @@ mod tests {
                         local_path: "/stale/demo".to_string(),
                         remote_path: Some(remote_path.to_string()),
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     }],
                     ..Default::default()
                 })
@@ -1079,6 +1080,7 @@ mod tests {
                             .to_string(),
                         remote_path: Some(format!("plugins/{id}")),
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     }],
                     ..Project::default()
                 })

--- a/docs/reference/schemas/portable-config.md
+++ b/docs/reference/schemas/portable-config.md
@@ -21,6 +21,11 @@ A `homeboy.json` file in a repo root defines portable component configuration th
   "changelog_target": "string",
   "extensions": {
     "extension_id": {}
+  },
+  "deployment_provider": {
+    "extension": "string",
+    "provider": "string",
+    "policy": {}
   }
 }
 ```
@@ -42,6 +47,13 @@ The component `id` field is required and must be a non-empty string. All other f
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
     "wordpress": {}
+  },
+  "deployment_provider": {
+    "extension": "hosting-provider",
+    "provider": "hosting.deploy",
+    "policy": {
+      "deployment_mode": "release"
+    }
   }
 }
 ```
@@ -81,10 +93,13 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 | `scripts` | Optional component-owned `lint`, `test`, `build`, `bench`, and `trace` shell commands |
 | `extensions` | Extension configuration (e.g., `{"wordpress": {}}`) |
 | `capability_extensions` | Optional explicit extension ownership by capability label (e.g., `{"deps": "nodejs"}`) when more than one linked extension supports the same capability |
+| `deployment_provider` | Repository-owned provider policy: extension, provider ID, and opaque inline `policy` |
 
 Build, lint, test, bench, trace, and deps behavior resolves from `scripts.<capability>` first, then linked extensions. When multiple linked extensions support the same capability, set `capability_extensions.<capability>` to the owning extension. Use `scripts.build` for component-owned shell builds; component-level `build_command` is not supported.
 
 Use `deploy_together` for coupled components that are versioned or built separately but must stay in sync at runtime. When a deploy selection includes one member of a declared group without the rest, Homeboy fails the plan before building or uploading.
+
+Layered deployment providers keep all repository-owned Homeboy policy inline in root `homeboy.json` under `deployment_provider.policy`. Product, application, and runtime code has no Homeboy dependency and does not need a separate deployment contract file. `deployment_provider.contract` remains available only for legacy unlayered providers. Provider target input is intentionally project-only and never belongs in portable `homeboy.json`.
 
 ## Precedence
 

--- a/docs/reference/schemas/project-schema.md
+++ b/docs/reference/schemas/project-schema.md
@@ -27,7 +27,9 @@ matter when the workflow needs environment context.
     {
       "id": "string",
       "local_path": "string",
-      "remote_path": "string"
+      "remote_path": "string",
+      "deployment_provider": { "extension": "string", "provider": "string", "contract": "string" },
+      "deployment_provider_input": {}
     }
   ],
   "component_overrides": {},
@@ -85,7 +87,7 @@ matter when the workflow needs environment context.
 - **`table_prefix`** (string): Database table prefix (e.g., `"wp_"`)
 - **`shared_tables`** (array): List of shared table names across multi-site installations
 - **`sub_targets`** (array): Sub-target paths for multi-component sites
-- **`components`** (array): Project-attached component checkouts. Each entry requires `id` and `local_path`; optional `remote_path` overrides the repo-owned component `remote_path` for this project so the same component can deploy to projects with different filesystem layouts.
+- **`components`** (array): Project-attached component checkouts. Each entry requires `id` and `local_path`; optional `remote_path` overrides the repo-owned component `remote_path` for this project so the same component can deploy to projects with different filesystem layouts. `deployment_provider_input` is opaque project-only target input for a provider that declares layered input support. `deployment_provider` remains a legacy project policy override and cannot be combined with `deployment_provider_input`.
 - **`component_overrides`** (object): Per-component project overrides keyed by component ID. These remain the most-specific deploy overrides and take precedence over `components[].remote_path`.
 - **`services`** (array): Service names checked by project/fleet health status
 - **`changelog_next_section_label`** (string): Project-level changelog next-section label override


### PR DESCRIPTION
## Summary\n\n- keep layered provider policy inline in repository-root `homeboy.json` while target identity remains project-only\n- pass policy, opaque target input, and concrete clean source revision in separate namespaces through a private mode-0600 temporary payload\n- preserve legacy repository contract files and project provider overrides without silently mixing ownership models\n- require extension-declared layered input/result schemas and suppress malformed or mismatched provider evidence\n- document that product/application/runtime code has no Homeboy dependency\n\n## Ownership Contract\n\n- repository: provider selector and opaque inline policy\n- project: environment-owned target input\n- Homeboy: immutable source identity and private payload lifecycle\n- extension: provider-specific validation, secret resolution, deployment, and redacted result schema\n\nNo provider-specific field names or Cloudflare/WordPress behavior were added to Homeboy core.\n\n## Verification\n\n- `cargo fmt --all -- --check`\n- `cargo test -p homeboy-component-contract portable_component_round_trips_inline_deployment_policy`\n- `cargo test -p homeboy-core project::types::component::tests`\n- `cargo test -p homeboy-extension manifest::deployment_provider_tests`\n- `cargo test -p homeboy-release deploy::provider::tests`\n- `cargo check -p homeboy-release -p homeboy-extension -p homeboy-core`\n- `git diff --check origin/main...HEAD`\n\n## Known Gap\n\nProvider dispatch currently derives the concrete full SHA from the clean current checkout. Routing provider dispatch through ordinary deploy exact-ref materialization remains separate work; this PR fails closed on dirty or non-Git source rather than claiming that compatibility proof.\n\nCloses #10908.\n\nDownstream: https://github.com/Automattic/wp-codebox/issues/2157\nInvalid public-target approach closed: https://github.com/Automattic/wp-codebox/pull/2169\n\n## AI Assistance\n\nOpenCode with OpenAI GPT-5.6 Sol was used to trace the ownership boundary, implement the layered contract, review evidence security, and run verification. Chris Huber remains responsible for every line.