### PR TITLE
fix(ssh): bound project command deadlines

### DIFF
--- a/crates/homeboy-cli/src/commands/ssh.rs
+++ b/crates/homeboy-cli/src/commands/ssh.rs
@@ -4,6 +4,7 @@ use homeboy::core::server::{self, Server};
 use homeboy::core::server::{resolve_context, SshClient, SshResolveArgs};
 use serde::Serialize;
 use std::io::IsTerminal;
+use std::time::Duration;
 
 use super::CmdResult;
 
@@ -37,6 +38,11 @@ pub struct SshArgs {
     /// persist the structured envelope. Requires a non-interactive command.
     #[arg(long)]
     pub raw: bool,
+
+    /// Bound the complete non-interactive SSH command, in seconds.
+    /// Progress remains on stderr so `--raw` preserves remote stdout.
+    #[arg(long)]
+    pub timeout: Option<u64>,
 
     #[command(subcommand)]
     pub subcommand: Option<SshSubcommand>,
@@ -74,6 +80,8 @@ pub struct SshConnectOutput {
     pub success: bool,
     pub exit_code: i32,
     pub result_classification: String,
+    pub phases: Vec<String>,
+    pub timed_out: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_reason: Option<String>,
 }
@@ -91,6 +99,7 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
             Ok((SshOutput::List(SshListOutput { servers }), 0))
         }
         None => {
+            ssh_phase("target-resolution-start");
             // Build resolve args based on simplified CLI args
             let resolve_args = if args.as_server {
                 SshResolveArgs {
@@ -106,6 +115,7 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
                 }
             };
             let result = resolve_context(&resolve_args)?;
+            ssh_phase("target-resolved");
 
             let command_string: Option<String> = if args.command.is_empty() {
                 None
@@ -142,11 +152,11 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
                         "No command resolved for non-interactive SSH execution".to_string(),
                     )
                 })?;
-                let output = if std::io::stdin().is_terminal() {
-                    client.execute(cmd)
-                } else {
-                    client.execute_with_piped_stdin(cmd)
-                };
+                let timeout = command_timeout(args.timeout)?;
+                ssh_phase("command-start");
+                let output = execute_non_interactive(&client, cmd, timeout);
+                ssh_phase("command-finished");
+                ssh_phase("cleanup-finished");
 
                 Ok((
                     SshOutput::Connect(connect_output_from_execution(
@@ -155,6 +165,7 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
                         &result.server_id,
                         command_string.clone(),
                         &output,
+                        timeout,
                     )),
                     output.exit_code,
                 ))
@@ -174,6 +185,8 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
                         exit_code,
                         result_classification: ssh_result_classification(exit_code == 0, exit_code),
                         failure_reason: ssh_failure_reason(exit_code == 0, exit_code),
+                        phases: vec!["target-resolved".to_string()],
+                        timed_out: false,
                     }),
                     exit_code,
                 ))
@@ -190,6 +203,7 @@ fn connect_output_from_execution(
     // invocations remain unambiguous (e.g. args containing spaces).
     command: Option<String>,
     output: &homeboy::core::server::CommandOutput,
+    timeout: Option<Duration>,
 ) -> SshConnectOutput {
     SshConnectOutput {
         resolved_type: resolved_type.to_string(),
@@ -201,7 +215,21 @@ fn connect_output_from_execution(
         success: output.success,
         exit_code: output.exit_code,
         result_classification: ssh_result_classification(output.success, output.exit_code),
-        failure_reason: ssh_failure_reason(output.success, output.exit_code),
+        failure_reason: if output.timed_out {
+            Some(format!(
+                "SSH command deadline expired after {}ms; transport child process group was terminated",
+                timeout.map_or(0, |timeout| timeout.as_millis())
+            ))
+        } else {
+            ssh_failure_reason(output.success, output.exit_code)
+        },
+        phases: vec![
+            "target-resolved".to_string(),
+            "command-started".to_string(),
+            "command-finished".to_string(),
+            "cleanup-finished".to_string(),
+        ],
+        timed_out: output.timed_out,
     }
 }
 
@@ -209,6 +237,7 @@ fn connect_output_from_execution(
 /// exit code, for `--raw` mode. Resolution mirrors [`run`], but the caller emits
 /// the remote streams directly instead of a JSON envelope.
 pub(super) fn execute_raw_command(args: &SshArgs) -> homeboy::core::Result<(String, String, i32)> {
+    ssh_phase("target-resolution-start");
     let resolve_args = if args.as_server {
         SshResolveArgs {
             id: None,
@@ -223,6 +252,7 @@ pub(super) fn execute_raw_command(args: &SshArgs) -> homeboy::core::Result<(Stri
         }
     };
     let result = resolve_context(&resolve_args)?;
+    ssh_phase("target-resolved");
 
     let command_string: Option<String> = if args.command.len() == 1 {
         Some(args.command[0].clone())
@@ -243,12 +273,42 @@ pub(super) fn execute_raw_command(args: &SshArgs) -> homeboy::core::Result<(Stri
             "No command resolved for non-interactive SSH execution".to_string(),
         )
     })?;
-    let output = if std::io::stdin().is_terminal() {
-        client.execute(cmd)
-    } else {
-        client.execute_with_piped_stdin(cmd)
-    };
+    let timeout = command_timeout(args.timeout)?;
+    ssh_phase("command-start");
+    let output = execute_non_interactive(&client, cmd, timeout);
+    ssh_phase("command-finished");
+    ssh_phase("cleanup-finished");
     Ok((output.stdout, output.stderr, output.exit_code))
+}
+
+fn execute_non_interactive(
+    client: &SshClient,
+    command: &str,
+    timeout: Option<Duration>,
+) -> homeboy::core::server::CommandOutput {
+    match (timeout, std::io::stdin().is_terminal()) {
+        (Some(timeout), true) => client.execute_with_timeout(command, timeout),
+        (Some(timeout), false) => client.execute_with_piped_stdin_and_timeout(command, timeout),
+        (None, false) => client.execute_with_piped_stdin(command),
+        (None, true) => client.execute(command),
+    }
+}
+
+fn command_timeout(seconds: Option<u64>) -> homeboy::core::Result<Option<Duration>> {
+    match seconds {
+        Some(0) => Err(homeboy::core::Error::validation_invalid_argument(
+            "timeout",
+            "SSH command timeout must be at least one second",
+            None,
+            None,
+        )),
+        Some(seconds) => Ok(Some(Duration::from_secs(seconds))),
+        None => Ok(None),
+    }
+}
+
+fn ssh_phase(phase: &str) {
+    eprintln!("[ssh] phase={phase}");
 }
 
 fn ssh_result_classification(success: bool, exit_code: i32) -> String {
@@ -322,6 +382,7 @@ mod tests {
             as_server: false,
             user: None,
             raw,
+            timeout: None,
             subcommand: None,
         }
     }
@@ -334,5 +395,14 @@ mod tests {
         assert!(!is_raw_command(&raw_args(vec!["printf", "hi"], false)));
         // --raw with no command (interactive) is not a raw stdout invocation.
         assert!(!is_raw_command(&raw_args(vec![], true)));
+    }
+
+    #[test]
+    fn command_timeout_requires_a_positive_deadline() {
+        assert_eq!(
+            command_timeout(Some(2)).unwrap(),
+            Some(Duration::from_secs(2))
+        );
+        assert!(command_timeout(Some(0)).is_err());
     }
 }

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -52,6 +52,23 @@ pub(crate) fn execute_local_command_with_piped_stdin(command: &str) -> CommandOu
     execute_local_command_in_dir_impl(command, None, None, None, Some(StdinSource::Piped(stdin)))
 }
 
+pub(crate) fn execute_local_command_with_piped_stdin_and_timeout(
+    command: &str,
+    timeout: Duration,
+) -> CommandOutput {
+    let stdin = match piped_stdin_file() {
+        Ok(stdin) => stdin,
+        Err(error) => return stdin_source_error(error),
+    };
+    execute_local_command_in_dir_impl(
+        command,
+        None,
+        None,
+        Some(timeout),
+        Some(StdinSource::Piped(stdin)),
+    )
+}
+
 pub(crate) fn execute_local_command_with_stdin_and_timeout(
     command: &str,
     stdin: &[u8],

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -19,8 +19,8 @@ use super::host::{is_local_host, is_transient_ssh_error};
 use super::local_exec::{
     execute_local_command, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_with_piped_stdin,
-    execute_local_command_with_stdin, execute_local_command_with_stdin_and_timeout,
-    piped_stdin_file, spawn_stdin_pump, StdinSource,
+    execute_local_command_with_piped_stdin_and_timeout, execute_local_command_with_stdin,
+    execute_local_command_with_stdin_and_timeout, piped_stdin_file, spawn_stdin_pump, StdinSource,
 };
 use super::{CommandOutput, SshClient};
 
@@ -403,6 +403,30 @@ impl SshClient {
         run_command_with_stdin_source(cmd, StdinSource::Piped(stdin))
     }
 
+    /// Execute a stdin-streaming command with a hard wall-clock deadline.
+    pub fn execute_with_piped_stdin_and_timeout(
+        &self,
+        command: &str,
+        timeout: Duration,
+    ) -> CommandOutput {
+        let effective = self.prepend_env(command);
+        if self.is_local {
+            return execute_local_command_with_piped_stdin_and_timeout(&effective, timeout);
+        }
+        let stdin = match piped_stdin_file() {
+            Ok(stdin) => stdin,
+            Err(error) => return ssh_process_error(error),
+        };
+        let args = self.build_ssh_args(Some(&effective), false);
+        let mut cmd = Command::new("ssh");
+        cmd.args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        crate::server::process_cleanup::configure_process_group_cleanup(&mut cmd);
+        execute_command_with_stdin_source_timeout(cmd, StdinSource::Piped(stdin), timeout)
+    }
+
     /// Execute a short, read-only probe with a hard wall-clock deadline.
     ///
     /// Status/version checks must return partial diagnostics instead of allowing
@@ -671,6 +695,63 @@ pub(super) fn execute_command_with_stdin_timeout(
         });
         (writer_rx, writer)
     })
+}
+
+pub(super) fn execute_command_with_stdin_source_timeout(
+    mut cmd: Command,
+    source: StdinSource,
+    timeout: Duration,
+) -> CommandOutput {
+    let started = Instant::now();
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(error) => return ssh_process_error(error),
+    };
+    let pid = child.id();
+    let writer = child
+        .stdin
+        .take()
+        .map(|pipe| spawn_stdin_pump(pipe, source));
+    let stdout = child.stdout.take().map(read_stream);
+    let stderr = child.stderr.take().map(read_stream);
+    let mut timed_out = false;
+    let mut interrupted_signal = None;
+    let status = loop {
+        if let Some(signal) = crate::server::process_cleanup::active_cleanup_signal() {
+            interrupted_signal = Some(signal);
+            break terminate_process_group_with_deadline(&mut child, pid);
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if started.elapsed() < timeout => thread::sleep(Duration::from_millis(25)),
+            Ok(None) => {
+                timed_out = true;
+                break terminate_process_group_with_deadline(&mut child, pid);
+            }
+            Err(_) => break None,
+        }
+    };
+    let stdin_failed = writer
+        .and_then(|writer| writer.finish_after_child())
+        .is_some_and(|result| result.is_err());
+    let stdout = stdout
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    bounded_probe_output(
+        stdout,
+        stderr,
+        BoundedProbeOutcome {
+            exit_code: status.and_then(|status| status.code()),
+            succeeded: status.is_some_and(|status| status.success()),
+            timed_out,
+            stdin_failed,
+            interrupted_signal,
+        },
+        timeout,
+    )
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -14,9 +14,10 @@ use super::local_exec::{
     windows_pipe_error_is_eof, StdinSource,
 };
 use super::ssh_client::{
-    build_secret_env_stdin_block, execute_command_with_stdin_timeout,
-    execute_command_with_writer_factory, run_command_with_stdin_source,
-    wrap_command_with_secret_env_read_loop, SECRET_ENV_STDIN_SENTINEL,
+    build_secret_env_stdin_block, execute_command_with_stdin_source_timeout,
+    execute_command_with_stdin_timeout, execute_command_with_writer_factory,
+    run_command_with_stdin_source, wrap_command_with_secret_env_read_loop,
+    SECRET_ENV_STDIN_SENTINEL,
 };
 use super::{CommandOutput, SshClient};
 
@@ -143,6 +144,29 @@ fn small_secret_stdin_payload_completes_successfully() {
 
     assert!(output.success, "{}", output.stderr);
     assert_eq!(output.stdout, "done");
+}
+
+#[test]
+fn piped_stdin_deadline_terminates_the_command_without_ssh() {
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", "sleep 5"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+    let started = Instant::now();
+
+    let output = execute_command_with_stdin_source_timeout(
+        command,
+        StdinSource::Reader(Box::new(Cursor::new(b"fixture input".to_vec()))),
+        Duration::from_millis(50),
+    );
+
+    assert!(output.timed_out);
+    assert_eq!(output.exit_code, 124);
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(output.stderr.contains("terminated child process group"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `homeboy ssh --timeout <seconds>` with stderr phase progress while preserving `--raw` stdout
- terminate timed-out SSH command process groups, including redirected stdin
- expose timeout and completed phases in the structured SSH response

## Verification

- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo fmt --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-core server::client`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-cli commands::ssh`

Closes #10912

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode general coding task. Used to investigate the existing SSH paths and related trackers, implement the bounded stdin-aware transport deadline and phase diagnostics, and add deterministic process tests. Chris Huber remains responsible for every line.