### PR TITLE
fix(deploy): retain preparation build provenance

### DIFF
--- a/crates/homeboy-release/src/deploy/orchestration/prepared_payloads.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/prepared_payloads.rs
@@ -7,6 +7,7 @@ use homeboy_core::project::Project;
 use super::super::binding::bind_project_payloads;
 use super::super::execution::{prepare_component_deploy, PreparedComponentDeploy};
 use super::super::preparation::{ComponentPayloadPreparationRequest, PreparedPayloadCollection};
+use super::super::provenance::record_payload_preparation_build;
 use super::super::types::{ComponentDeployResult, DeployConfig};
 use homeboy_core::git::release_download::{ReleaseArtifactLease, ReleaseArtifactStore};
 
@@ -77,11 +78,12 @@ pub(super) fn prepare_component_deployments(
                 match payloads.prepare(request, &mut release_artifact_store) {
                     Ok(payload) => {
                         binding_payloads.insert(component.id.clone(), payload.artifact.clone());
+                        let payload_build_ran = payload.build_ran;
                         let mut prepared = effective_config;
                         prepared.prepared_artifact = Some(payload.artifact.clone());
                         prepared.skip_build = true;
                         prepared.requested_ref = None;
-                        prepared
+                        (prepared, payload_build_ran)
                     }
                     Err(error) => {
                         let mut failure = ComponentDeployResult::failed(
@@ -99,19 +101,24 @@ pub(super) fn prepare_component_deployments(
                     }
                 }
             } else {
-                effective_config
+                (effective_config, false)
             };
 
         match prepare_component_deploy(
             &component,
-            &effective_config,
+            &effective_config.0,
             base_path,
             project,
             local_versions.get(&component.id).cloned(),
             remote_versions.get(&component.id).cloned(),
             release_artifacts.get(&component.id).cloned(),
         ) {
-            Ok(prepared) => prepared_deployments.push(prepared),
+            Ok(mut prepared) => {
+                if effective_config.1 {
+                    record_payload_preparation_build(&mut prepared.build_provenance);
+                }
+                prepared_deployments.push(prepared);
+            }
             Err(result) => failures.push(result),
         }
     }

--- a/crates/homeboy-release/src/deploy/preparation.rs
+++ b/crates/homeboy-release/src/deploy/preparation.rs
@@ -230,6 +230,8 @@ impl From<&DeployConfig> for PreparationConfig {
 pub(crate) struct PreparedComponentPayload {
     pub artifact: PreparedDeployArtifact,
     pub source_commit: String,
+    /// Whether preparing this payload ran a fresh build in this lifecycle.
+    pub build_ran: bool,
     _release_artifact: Option<ReleaseArtifactLease>,
     _exact_ref_checkout: Option<ExactRefCheckout>,
     payload_artifact: PreparedArtifactCleanup,
@@ -415,6 +417,7 @@ fn prepare_payload(
         return Ok(PreparedComponentPayload {
             source_commit: artifact.source_commit.clone(),
             artifact,
+            build_ran: false,
             _release_artifact: None,
             _exact_ref_checkout: None,
             payload_artifact: PreparedArtifactCleanup(None),
@@ -574,6 +577,7 @@ fn prepare_payload(
     Ok(PreparedComponentPayload {
         artifact,
         source_commit,
+        build_ran: release_artifact.is_none() && !request.config.skip_build,
         _release_artifact: release_artifact,
         _exact_ref_checkout: checkout,
         payload_artifact,

--- a/crates/homeboy-release/src/deploy/provenance.rs
+++ b/crates/homeboy-release/src/deploy/provenance.rs
@@ -13,7 +13,7 @@ use homeboy_core::component::Component;
 use homeboy_core::engine::command;
 
 use super::generated_artifacts::uncommitted_file_report_excluding_known_generated;
-use super::types::{ArtifactIdentity, BuildProvenance, BuildSource};
+use super::types::{ArtifactIdentity, BuildPhase, BuildProvenance, BuildSource};
 
 /// Capture explicit build provenance for a prepared deploy.
 ///
@@ -46,12 +46,23 @@ pub(super) fn capture_build_provenance(
 
     BuildProvenance {
         source,
+        phase: if build_ran {
+            BuildPhase::Deploy
+        } else {
+            BuildPhase::NotRun
+        },
         build_ran,
         built_from_ref: None,
         built_from_commit,
         working_tree_dirty,
         artifact_identity,
     }
+}
+
+/// Mark a payload that was built before the deploy transfer began.
+pub(super) fn record_payload_preparation_build(provenance: &mut BuildProvenance) {
+    provenance.phase = BuildPhase::PayloadPreparation;
+    provenance.build_ran = true;
 }
 
 fn resolve_artifact_identity(path: &Path) -> Option<ArtifactIdentity> {
@@ -138,6 +149,7 @@ mod provenance_tests {
         );
 
         assert_eq!(provenance.source, BuildSource::FreshBuild);
+        assert_eq!(provenance.phase, BuildPhase::Deploy);
         assert!(provenance.build_ran);
         assert!(provenance.built_from_ref.is_none());
         assert_eq!(
@@ -183,6 +195,7 @@ mod provenance_tests {
         );
 
         assert_eq!(provenance.source, BuildSource::DownloadedRelease);
+        assert_eq!(provenance.phase, BuildPhase::NotRun);
         assert!(!provenance.build_ran);
         // Local tree dirtiness is not meaningful provenance for a downloaded asset.
         assert_eq!(provenance.working_tree_dirty, None);
@@ -203,7 +216,40 @@ mod provenance_tests {
         );
 
         assert_eq!(provenance.source, BuildSource::ReusedArtifact);
+        assert_eq!(provenance.phase, BuildPhase::NotRun);
         assert!(!provenance.build_ran);
         assert!(provenance.artifact_identity.is_some());
+    }
+
+    #[test]
+    fn prepared_artifact_preserves_an_earlier_lifecycle_build() {
+        let temp = committed_repo();
+        let dir = temp.path();
+        let artifact = dir.join("plugin.zip");
+        std::fs::write(&artifact, b"prepared").expect("artifact");
+
+        let mut provenance = capture_build_provenance(
+            &component_at(dir),
+            BuildSource::PreparedArtifact,
+            false,
+            Some(artifact.as_path()),
+        );
+        record_payload_preparation_build(&mut provenance);
+
+        assert_eq!(provenance.source, BuildSource::PreparedArtifact);
+        assert_eq!(provenance.phase, BuildPhase::PayloadPreparation);
+        assert!(provenance.build_ran);
+    }
+
+    #[test]
+    fn legacy_provenance_without_a_phase_remains_readable() {
+        let provenance: BuildProvenance = serde_json::from_value(serde_json::json!({
+            "source": "fresh_build",
+            "build_ran": true
+        }))
+        .expect("legacy provenance");
+
+        assert_eq!(provenance.phase, BuildPhase::Unknown);
+        assert!(provenance.build_ran);
     }
 }

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -317,6 +317,30 @@ pub enum BuildSource {
     FileCopy,
 }
 
+/// The deploy lifecycle phase in which the reported build ran.
+///
+/// A payload can be built during lifecycle preparation, then transferred by the
+/// deploy phase as a prepared artifact. Keeping this distinct from `source`
+/// makes both facts visible without treating the transfer as a skipped build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildPhase {
+    /// The deploy phase built the payload directly.
+    Deploy,
+    /// Lifecycle payload preparation built the payload before deploy transfer.
+    PayloadPreparation,
+    /// No build ran in this deploy lifecycle.
+    NotRun,
+    /// The phase was not recorded by an older persisted result.
+    Unknown,
+}
+
+impl Default for BuildPhase {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
 /// Content identity of a deployed artifact file, so stale artifacts are detectable.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArtifactIdentity {
@@ -344,8 +368,14 @@ pub struct ArtifactIdentity {
 pub struct BuildProvenance {
     /// Where the deployed payload came from.
     pub source: BuildSource,
+    /// The lifecycle phase in which a build ran. Older persisted provenance did
+    /// not include a phase and deserializes as `unknown`.
+    #[serde(default)]
+    pub phase: BuildPhase,
     /// Whether a fresh build ran for this deploy (vs. a reused or downloaded
-    /// artifact, or a strategy that ships source directly).
+    /// artifact, or a strategy that ships source directly). When the source is
+    /// `prepared_artifact`, `phase` distinguishes an upstream preparation build
+    /// from an externally supplied artifact.
     pub build_ran: bool,
     /// The git ref the payload was built/deployed from (tag, or `"<branch> (HEAD)"`).
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

Deploy results now distinguish the payload source from the lifecycle phase that built it. When payload preparation builds an artifact before terminal transfer, the result reports `source: prepared_artifact`, `phase: payload_preparation`, and `build_ran: true`. Externally supplied, reused, and downloaded artifacts remain `phase: not_run`.

Legacy persisted `build_provenance` records without `phase` deserialize as `unknown`, preserving the existing schema.

Closes #6864

## Testing

- `cargo fmt --all --check`
- `cargo test -p homeboy-release deploy::provenance` — passed (5 tests) before the final compatibility-test addition
- `cargo test -p homeboy-release` — timed out after 10 minutes during compilation; no test failure was reported
- Follow-up focused test was blocked by concurrent jobs holding the required shared `CARGO_TARGET_DIR` lock and did not execute

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode general coding task
- **Used for:** Inspected the merged provenance implementation and current deploy lifecycle, implemented phase-aware build provenance propagation, and added focused regression and compatibility tests. Reviewed by the submitter.