### PR TITLE
Fix deploy lifecycle progress for exact refs

### DIFF
--- a/crates/homeboy-cli/src/commands/deploy.rs
+++ b/crates/homeboy-cli/src/commands/deploy.rs
@@ -128,6 +128,8 @@ pub struct DeployOutput {
     pub summary: DeploySummary,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release_set_identity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_run_id: Option<String>,
     #[serde(
         rename = "_homeboy_actionable",
         skip_serializing_if = "Option::is_none"
@@ -279,6 +281,7 @@ pub fn run(mut args: DeployArgs) -> CmdResult<DeployCommandOutput> {
             results: result.results,
             summary: result.summary,
             release_set_identity: release_set.map(|value| value.identity.clone()),
+            deploy_run_id: result.deploy_run_id,
             actionable: Some(deploy_actionable(&project_id)),
         }),
         exit_code,

--- a/crates/homeboy-release/src/deploy/lifecycle.rs
+++ b/crates/homeboy-release/src/deploy/lifecycle.rs
@@ -4,12 +4,108 @@ use std::fs;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use homeboy_core::error::{Error, Result};
+use homeboy_core::observation::{NewRunRecord, ObservationStore, RunStatus};
 use homeboy_core::paths;
 use homeboy_core::phase_timing::PhaseTimingReport;
 
 const SCHEMA_VERSION: u32 = 1;
+
+/// A durable activity projection for the single-project deploy lifecycle.
+///
+/// The observation store is the generic activity surface. The file-backed
+/// multi-project lifecycle below remains the resumable aggregate checkpoint.
+pub(super) struct DeployObservation {
+    store: ObservationStore,
+    run_id: String,
+    metadata: serde_json::Value,
+    finished: bool,
+}
+
+impl DeployObservation {
+    pub(super) fn start(project_id: &str, source: &str) -> Result<Self> {
+        let store = ObservationStore::open_initialized()?;
+        let metadata = json!({
+            "schema": "homeboy/deploy-lifecycle/v1",
+            "source": source,
+            "phase": "admitted",
+            "phase_history": [{ "phase": "admitted", "at": chrono::Utc::now().to_rfc3339() }],
+            "remote_mutation_started": false,
+        });
+        let run = store.start_run(
+            NewRunRecord::builder("deploy")
+                .component_id(project_id)
+                .command(format!("homeboy deploy {project_id}"))
+                .current_homeboy_version()
+                .metadata(metadata.clone())
+                .build(),
+        )?;
+        Ok(Self {
+            store,
+            run_id: run.id,
+            metadata,
+            finished: false,
+        })
+    }
+
+    pub(super) fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    pub(super) fn phase(&mut self, phase: &str, remote_mutation_started: bool) -> Result<()> {
+        let at = chrono::Utc::now().to_rfc3339();
+        let object = self
+            .metadata
+            .as_object_mut()
+            .expect("deploy metadata object");
+        object.insert("phase".to_string(), json!(phase));
+        if remote_mutation_started {
+            object.insert("remote_mutation_started".to_string(), json!(true));
+        }
+        object
+            .get_mut("phase_history")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("deploy phase history")
+            .push(json!({ "phase": phase, "at": at }));
+        self.store
+            .update_run_metadata(&self.run_id, self.metadata.clone())?;
+        Ok(())
+    }
+
+    pub(super) fn finish(&mut self, status: RunStatus, error: Option<String>) {
+        if self.finished {
+            return;
+        }
+        let _ = self.phase(
+            if status == RunStatus::Pass {
+                "completed"
+            } else {
+                "failed"
+            },
+            false,
+        );
+        if let Some(error) = error {
+            self.metadata["error"] = json!(error);
+        }
+        let _ = self
+            .store
+            .finish_running_run(&self.run_id, status, Some(self.metadata.clone()));
+        self.finished = true;
+    }
+}
+
+impl Drop for DeployObservation {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.finish(
+                RunStatus::Error,
+                Some("deploy process ended before a terminal result; inspect this run before retrying".to_string()),
+            );
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeployRunIdentity {
@@ -249,6 +345,59 @@ mod tests {
                     .map(|span| span.status),
                 Some(homeboy_core::phase_timing::PhaseStatus::Failed)
             );
+        });
+    }
+
+    #[test]
+    fn deploy_observation_persists_phase_progress_and_terminal_success() {
+        with_isolated_home(|_| {
+            let mut observation = DeployObservation::start("site", "HEAD").expect("admit run");
+            let run_id = observation.run_id().to_string();
+            observation
+                .phase("artifact_preparation", false)
+                .expect("persist preparation phase");
+            observation
+                .phase("transfer", true)
+                .expect("persist transfer phase");
+            observation.finish(RunStatus::Pass, None);
+
+            let run = ObservationStore::open_initialized()
+                .expect("store")
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run");
+            assert_eq!(run.status, RunStatus::Pass.as_str());
+            assert_eq!(run.metadata_json["phase"], "completed");
+            assert_eq!(run.metadata_json["remote_mutation_started"], true);
+            assert_eq!(
+                run.metadata_json["phase_history"].as_array().map(Vec::len),
+                Some(4)
+            );
+        });
+    }
+
+    #[test]
+    fn dropped_deploy_observation_terminalizes_before_remote_mutation() {
+        with_isolated_home(|_| {
+            let run_id = {
+                let mut observation =
+                    DeployObservation::start("site", "refs/heads/fix").expect("admit run");
+                observation
+                    .phase("artifact_preparation", false)
+                    .expect("persist preparation phase");
+                observation.run_id().to_string()
+            };
+
+            let run = ObservationStore::open_initialized()
+                .expect("store")
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run");
+            assert_eq!(run.status, RunStatus::Error.as_str());
+            assert_eq!(run.metadata_json["remote_mutation_started"], false);
+            assert!(run.metadata_json["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("terminal result")));
         });
     }
 }

--- a/crates/homeboy-release/src/deploy/mod.rs
+++ b/crates/homeboy-release/src/deploy/mod.rs
@@ -82,7 +82,24 @@ fn run_with_release_artifacts(
     release_artifacts: &mut homeboy_core::git::release_download::ReleaseArtifactStore,
 ) -> Result<DeployOrchestrationResult> {
     let project = project::load(project_id)?;
-    if let Some(result) = provider::run_if_configured(project_id, &project, config)? {
+    let source =
+        lifecycle_identity(&[project_id.to_string()], &config.component_ids, config).source;
+    let mut observation = (config.head || config.has_requested_refs())
+        .then(|| lifecycle::DeployObservation::start(project_id, &source))
+        .transpose()?;
+    if let Some(mut result) = provider::run_if_configured(project_id, &project, config)? {
+        if let Some(observation) = observation.as_mut() {
+            observation.finish(
+                if result.summary.failed == 0 {
+                    homeboy_core::observation::RunStatus::Pass
+                } else {
+                    homeboy_core::observation::RunStatus::Fail
+                },
+                (result.summary.failed > 0)
+                    .then_some("deployment provider reported failure".to_string()),
+            );
+            result.deploy_run_id = Some(observation.run_id().to_string());
+        }
         return Ok(result);
     }
     // A version-pinned release asset is resolved remotely before orchestration;
@@ -93,7 +110,27 @@ fn run_with_release_artifacts(
     }
     preflight_prepared_payload_binding(&project, project_id, config)?;
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
-    orchestration::deploy_components(config, &project, &ctx, &base_path, release_artifacts)
+    let mut result = orchestration::deploy_components(
+        config,
+        &project,
+        &ctx,
+        &base_path,
+        release_artifacts,
+        observation.as_mut(),
+    )?;
+    if let Some(observation) = observation.as_mut() {
+        observation.finish(
+            if result.summary.failed == 0 {
+                homeboy_core::observation::RunStatus::Pass
+            } else {
+                homeboy_core::observation::RunStatus::Fail
+            },
+            (result.summary.failed > 0)
+                .then_some("deployment reported one or more failures".to_string()),
+        );
+        result.deploy_run_id = Some(observation.run_id().to_string());
+    }
+    Ok(result)
 }
 
 /// Bind caller-supplied payloads before SSH context or lifecycle work begins.

--- a/crates/homeboy-release/src/deploy/orchestration/mod.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/mod.rs
@@ -10,6 +10,7 @@ use super::execution::{
     execute_preflighted_component_deploy, release_artifact_plan, resolve_planned_release_artifact,
     ReleaseArtifactPlan,
 };
+use super::lifecycle::DeployObservation;
 use super::orchestration_ref_checkout::{ExactRefCheckout, ExactRefIdentity};
 use super::orchestration_tag_checkout::{
     checkout_resolved_deploy_tags, partition_shared_root_conflicts, resolve_deploy_tags,
@@ -43,7 +44,11 @@ pub(super) fn deploy_components(
     ctx: &RemoteProjectContext,
     base_path: &str,
     release_artifacts: &mut ReleaseArtifactStore,
+    mut observation: Option<&mut DeployObservation>,
 ) -> Result<DeployOrchestrationResult> {
+    if let Some(observation) = observation.as_deref_mut() {
+        observation.phase("source_resolution", false)?;
+    }
     let mut effective_config = config.clone();
     let loaded = load_project_components_with_projection(
         project,
@@ -69,6 +74,7 @@ pub(super) fn deploy_components(
                 failed: 0,
                 skipped,
             },
+            deploy_run_id: None,
         });
     }
 
@@ -121,6 +127,7 @@ pub(super) fn deploy_components(
                 failed: 0,
                 skipped: 0,
             },
+            deploy_run_id: None,
         });
     }
 
@@ -367,6 +374,9 @@ pub(super) fn deploy_components(
     )?;
 
     // Build and validate every local artifact before the first remote write.
+    if let Some(observation) = observation.as_deref_mut() {
+        observation.phase("artifact_preparation", false)?;
+    }
     let prepared_deployments = match prepare_component_deployments(
         &components,
         config,
@@ -390,12 +400,16 @@ pub(super) fn deploy_components(
                     failed,
                     skipped: 0,
                 },
+                deploy_run_id: None,
             });
         }
     };
 
     // Re-probe immediately before the first destructive write. A same-version
     // mismatch is remote-only content drift, not an ordinary local update.
+    if let Some(observation) = observation.as_deref_mut() {
+        observation.phase("transfer", true)?;
+    }
     for prepared in prepared_deployments.iter() {
         let exclusions = resolve_component_scope(&prepared.component, ScopeCommand::Deploy).exclude;
         let manifest = match (
@@ -579,6 +593,9 @@ pub(super) fn deploy_components(
     // to fresh visitors should fail the deploy here so it gets rolled back
     // instead of sitting live. Catches runtime errors that a syntax-only
     // preflight structurally cannot. See homeboy#5471.
+    if let Some(observation) = observation.as_deref_mut() {
+        observation.phase("verification", true)?;
+    }
     if succeeded > 0 {
         if let Some(smoke) = run_post_deploy_smoke(&project, &mut results) {
             if smoke {
@@ -608,6 +625,7 @@ pub(super) fn deploy_components(
             failed,
             skipped: 0,
         },
+        deploy_run_id: None,
     })
 }
 

--- a/crates/homeboy-release/src/deploy/orchestration/modes.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/modes.rs
@@ -138,6 +138,7 @@ pub(super) fn run_check_mode(
             failed: 0,
             skipped,
         },
+        deploy_run_id: None,
     }
 }
 
@@ -243,6 +244,7 @@ pub(super) fn run_dry_run_mode(
             failed: 0,
             skipped: 0,
         },
+        deploy_run_id: None,
     })
 }
 

--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -40,6 +40,7 @@ pub(super) fn run_if_configured(
                 failed,
                 skipped: 0,
             },
+            deploy_run_id: None,
         }));
     }
     Ok(None)

--- a/crates/homeboy-release/src/deploy/types.rs
+++ b/crates/homeboy-release/src/deploy/types.rs
@@ -1269,4 +1269,6 @@ pub struct DeploySummary {
 pub struct DeployOrchestrationResult {
     pub results: Vec<ComponentDeployResult>,
     pub summary: DeploySummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_run_id: Option<String>,
 }


### PR DESCRIPTION
## Summary

Advances #10914.

- admit single-project `--ref` and `--head` deploys into the existing durable observation/activity store before source or build work
- persist source resolution, artifact preparation, transfer, verification, terminal status, and the remote-mutation boundary
- return the durable deploy run ID in single-deploy output so `homeboy activity show/watch <run-id>` can inspect it
- terminalize an interrupted in-process lifecycle with explicit pre-upload recovery evidence

This is a minimal vertical on the existing generic observation lifecycle. It deliberately does not introduce deploy-specific controller behavior in Homeboy core.

## Verification

- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-release deploy::lifecycle::tests --locked -- --test-threads=1`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo check -p homeboy-release -p homeboy-cli --locked`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo fmt --all --check`
- `git diff --check`

## AI assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding task
- Used for: source tracing, implementation, lifecycle/recovery tests, and verification. Chris Huber remains responsible for every line.