### PR TITLE
fix(status): resolve linked worktrees before fast fallback

### DIFF
--- a/crates/homeboy-cli/src/commands/status/context_paths.rs
+++ b/crates/homeboy-cli/src/commands/status/context_paths.rs
@@ -1,16 +1,14 @@
 //! Registered-context detection for the default `status` view.
 //!
-//! Determines whether the current (or git-root) directory maps to a registered
-//! component/project checkout, so `homeboy status` can fast-return an
-//! actionable "unregistered context" hint instead of scanning every configured
-//! component.
+//! Keeps the unregistered fast path cheap for ordinary directories while using
+//! canonical worktree resolution for linked task checkouts.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use homeboy::core::git;
+use homeboy::core::{component, git};
 
 use super::types::UnregisteredContextStatusOutput;
 
@@ -55,7 +53,26 @@ pub(super) fn unregistered_cwd_status_output() -> Option<UnregisteredContextStat
 fn path_is_registered_context(path: &Path) -> bool {
     registered_local_paths().into_iter().any(|registered| {
         path_is_at_or_inside(&registered, path) || path_is_at_or_inside(path, &registered)
+    }) || linked_worktree_resolves_to_registered_component(path)
+}
+
+fn linked_worktree_resolves_to_registered_component(path: &Path) -> bool {
+    let Some(git_root) = component::resolution::detect_git_root(path) else {
+        return false;
+    };
+    // A regular checkout has a `.git` directory. Restrict the inventory-backed
+    // resolver to linked worktrees so unregistered CWD status remains fast.
+    if !git_root.join(".git").is_file() {
+        return false;
+    }
+
+    component::resolve_target(component::TargetSpec {
+        path_override: Some(git_root.to_string_lossy().as_ref()),
+        allow_synthetic: true,
+        accept_bare_directory: true,
+        ..component::TargetSpec::default()
     })
+    .is_ok_and(|target| !target.synthetic)
 }
 
 fn registered_local_paths() -> Vec<PathBuf> {

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -923,6 +923,67 @@ mod tests {
         }
     }
 
+    #[test]
+    fn default_status_matches_git_status_for_registered_worktree_without_attach_path() {
+        let _guard = CWD_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        crate::test_support::with_isolated_home(|home| {
+            let primary = home.path().join("fixture");
+            fs::create_dir_all(&primary).expect("primary directory");
+            run_git(&primary, &["init"]);
+            fs::write(primary.join("file.txt"), "seed\n").expect("seed file");
+            run_git(&primary, &["add", "."]);
+            run_git(&primary, &["commit", "-m", "seed"]);
+
+            let registration_dir = home.path().join(".config/homeboy/components");
+            fs::create_dir_all(&registration_dir).expect("registration directory");
+            let registration = registration_dir.join("fixture.json");
+            fs::write(
+                &registration,
+                serde_json::json!({ "local_path": primary }).to_string(),
+            )
+            .expect("component registration");
+            let registration_before = fs::read_to_string(&registration).expect("registration");
+
+            let worktree = home.path().join("fixture@task");
+            run_git(
+                &primary,
+                &["worktree", "add", "-b", "task", worktree.to_str().unwrap()],
+            );
+
+            let git_status = homeboy::core::git::status_at(None, worktree.to_str())
+                .expect("git status resolves worktree");
+            assert_eq!(git_status.component_id, "fixture");
+            assert_eq!(
+                PathBuf::from(&git_status.path)
+                    .canonicalize()
+                    .expect("git status path"),
+                worktree.canonicalize().expect("worktree path")
+            );
+
+            let original_cwd = env::current_dir().expect("current directory");
+            env::set_current_dir(&worktree).expect("set worktree cwd");
+            let result = run(default_status_args());
+            env::set_current_dir(original_cwd).expect("restore cwd");
+
+            let (result, code) = result.expect("top-level status resolves worktree");
+            assert_eq!(code, 0);
+            match result {
+                StatusResult::Summary(output) => assert_eq!(output.total, 1),
+                StatusResult::UnregisteredContext(output) => panic!(
+                    "top-level status must match git status for {}: {}",
+                    git_status.path, output.suggestion
+                ),
+                StatusResult::Full(_) => panic!("expected summary status"),
+                StatusResult::Dashboard(_) => panic!("expected summary status"),
+            }
+            assert_eq!(
+                fs::read_to_string(&registration).expect("registration after status"),
+                registration_before,
+                "status must not attach the ephemeral worktree path"
+            );
+        });
+    }
+
     fn run_git(repo: &std::path::Path, args: &[&str]) {
         let status = Command::new("git")
             .args(args)


### PR DESCRIPTION
## Summary
- route linked Git worktrees through the existing canonical component resolver before `status` returns its unregistered fast fallback
- retain the lightweight path scan for ordinary checkouts
- add a regression test that compares `homeboy status` with `homeboy git status` and proves no worktree attach-path mutation

## Testing
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-cli commands::status::tests`

Closes #9895

## AI assistance
- AI assistance: Yes
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding task
- Used for: inspected the prior fix and current status resolver, implemented the linked-worktree fast-path parity repair, and added regression coverage.

Chris remains responsible for every line.