### PR TITLE
fix(project): rebase monorepo component paths atomically

### DIFF
--- a/crates/homeboy-cli/src/commands/project.rs
+++ b/crates/homeboy-cli/src/commands/project.rs
@@ -116,12 +116,15 @@ enum ProjectComponentsCommand {
         #[arg(long)]
         json: String,
     },
-    /// Attach a repo path for a project component discovered via homeboy.json
+    /// Rebase matching project components discovered below a monorepo checkout
     AttachPath {
         /// Project ID
         project_id: String,
         /// Local repo path containing homeboy.json
         local_path: String,
+        /// Preview every nested component path rebase without updating project config
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Attach multiple repo paths, retaining per-path diagnostics
     AttachPaths {
@@ -383,7 +386,8 @@ fn components(command: ProjectComponentsCommand) -> CmdResult<ProjectOutput> {
         ProjectComponentsCommand::AttachPath {
             project_id,
             local_path,
-        } => components_attach_path(&project_id, &local_path),
+            dry_run,
+        } => components_attach_path(&project_id, &local_path, dry_run),
         ProjectComponentsCommand::AttachPaths {
             project_id,
             local_paths,
@@ -469,8 +473,13 @@ fn components_set(project_id: &str, json: &str) -> CmdResult<ProjectOutput> {
     ))
 }
 
-fn components_attach_path(project_id: &str, local_path: &str) -> CmdResult<ProjectOutput> {
-    let components = project::attach_component_path_report(project_id, Path::new(local_path))?;
+fn components_attach_path(
+    project_id: &str,
+    local_path: &str,
+    dry_run: bool,
+) -> CmdResult<ProjectOutput> {
+    let components =
+        project::attach_component_path_report(project_id, Path::new(local_path), dry_run)?;
     Ok(write_project_components_response(
         project_id,
         "attach_path",
@@ -615,6 +624,7 @@ mod tests {
             "attach-path",
             "site",
             "/repo/component",
+            "--dry-run",
         ])
         .is_ok());
         assert!(Cli::try_parse_from([

--- a/crates/homeboy-core/src/project/component/attachments.rs
+++ b/crates/homeboy-core/src/project/component/attachments.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 
@@ -209,6 +210,169 @@ pub fn attach_discovered_component_path(project_id: &str, local_path: &Path) -> 
     })
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonorepoComponentPathChange {
+    pub id: String,
+    pub path: String,
+    pub status: MonorepoComponentPathStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonorepoComponentPathStatus {
+    Attached,
+    Unchanged,
+    Missing,
+    Unrelated,
+}
+
+/// Discovers portable components below one checkout and commits all matching
+/// project-path rebases with a single config-lock acquisition and save.
+pub fn rebase_monorepo_component_paths(
+    project_id: &str,
+    root: &Path,
+    dry_run: bool,
+) -> Result<Vec<MonorepoComponentPathChange>> {
+    crate::config::with_config_lock(|| {
+        rebase_monorepo_component_paths_unlocked(project_id, root, dry_run)
+    })
+}
+
+fn rebase_monorepo_component_paths_unlocked(
+    project_id: &str,
+    root: &Path,
+    dry_run: bool,
+) -> Result<Vec<MonorepoComponentPathChange>> {
+    let discovered = discover_portable_component_paths(root)?;
+    let mut project = load(project_id)?;
+    let root_id = infer_portable_component_id(root)?;
+    let mut changes = Vec::new();
+    let mut selected = HashSet::new();
+
+    for (id, paths) in &discovered {
+        if paths.len() > 1 {
+            return Err(Error::validation_invalid_argument(
+                "local_path",
+                format!("Ambiguous component ID '{id}' appears at multiple paths"),
+                Some(project_id.to_string()),
+                Some(
+                    paths
+                        .iter()
+                        .map(|path| path.display().to_string())
+                        .collect(),
+                ),
+            ));
+        }
+        if id == &root_id || has_component(&project, id) {
+            selected.insert(id.clone());
+            let path = paths[0].to_string_lossy().to_string();
+            let status = project
+                .components
+                .iter()
+                .find(|component| component.id == *id)
+                .map(|component| component.local_path == path)
+                .unwrap_or(false)
+                .then_some(MonorepoComponentPathStatus::Unchanged)
+                .unwrap_or(MonorepoComponentPathStatus::Attached);
+            if status == MonorepoComponentPathStatus::Attached {
+                preserve_remote_path_on_reattach(&mut project, id, &path);
+                if let Some(component) = project
+                    .components
+                    .iter_mut()
+                    .find(|component| component.id == *id)
+                {
+                    component.local_path = path.clone();
+                } else {
+                    project.components.push(ProjectComponentAttachment {
+                        id: id.clone(),
+                        local_path: path.clone(),
+                        remote_path: None,
+                        deployment_provider: None,
+                    });
+                }
+            }
+            changes.push(MonorepoComponentPathChange {
+                id: id.clone(),
+                path,
+                status,
+            });
+        } else {
+            changes.push(MonorepoComponentPathChange {
+                id: id.clone(),
+                path: paths[0].to_string_lossy().to_string(),
+                status: MonorepoComponentPathStatus::Missing,
+            });
+        }
+    }
+
+    for component in &project.components {
+        if !selected.contains(&component.id) {
+            changes.push(MonorepoComponentPathChange {
+                id: component.id.clone(),
+                path: component.local_path.clone(),
+                status: if Path::new(&component.local_path).starts_with(root) {
+                    MonorepoComponentPathStatus::Missing
+                } else {
+                    MonorepoComponentPathStatus::Unrelated
+                },
+            });
+        }
+    }
+    changes.sort_by(|left, right| left.id.cmp(&right.id).then(left.path.cmp(&right.path)));
+
+    if !dry_run
+        && changes
+            .iter()
+            .any(|change| change.status == MonorepoComponentPathStatus::Attached)
+    {
+        save(&project)?;
+    }
+    Ok(changes)
+}
+
+fn discover_portable_component_paths(root: &Path) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+    if !root.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "local_path",
+            "Monorepo root must be an existing directory",
+            Some(root.display().to_string()),
+            None,
+        ));
+    }
+    let mut pending = vec![root.to_path_buf()];
+    let mut discovered = BTreeMap::new();
+    while let Some(directory) = pending.pop() {
+        if directory.join("homeboy.json").is_file() {
+            let id = infer_portable_component_id(&directory)?;
+            discovered
+                .entry(id)
+                .or_insert_with(Vec::new)
+                .push(directory.clone());
+        }
+        let mut children: Vec<_> = std::fs::read_dir(&directory)
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "local_path",
+                    format!("Unable to read monorepo directory: {error}"),
+                    Some(directory.display().to_string()),
+                    None,
+                )
+            })?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name() != ".git")
+            .filter_map(|entry| {
+                entry
+                    .file_type()
+                    .ok()
+                    .filter(|kind| kind.is_dir())
+                    .map(|_| entry.path())
+            })
+            .collect();
+        children.sort();
+        pending.extend(children.into_iter().rev());
+    }
+    Ok(discovered)
+}
+
 fn attach_discovered_component_path_unlocked(
     project_id: &str,
     local_path: &Path,
@@ -384,6 +548,97 @@ mod tests {
             let mut ids = project_component_ids(&load("site").expect("load project"));
             ids.sort();
             assert_eq!(ids, vec!["component-a", "component-b"]);
+        });
+    }
+
+    #[test]
+    fn monorepo_rebase_previews_then_commits_all_matching_components_together() {
+        with_isolated_home(|home| {
+            let old = home.path().join("deleted-checkout");
+            save(&Project {
+                id: "site".to_string(),
+                components: vec![
+                    ProjectComponentAttachment {
+                        id: "root".to_string(),
+                        local_path: old.join("root").display().to_string(),
+                        remote_path: None,
+                        deployment_provider: None,
+                    },
+                    ProjectComponentAttachment {
+                        id: "nested".to_string(),
+                        local_path: old.join("nested").display().to_string(),
+                        remote_path: None,
+                        deployment_provider: None,
+                    },
+                    ProjectComponentAttachment {
+                        id: "other-repo".to_string(),
+                        local_path: "/other-repo".to_string(),
+                        remote_path: None,
+                        deployment_provider: None,
+                    },
+                ],
+                ..Default::default()
+            })
+            .expect("save project");
+            let root = home.path().join("checkout");
+            fs::create_dir_all(root.join("nested")).expect("nested directory");
+            fs::write(root.join("homeboy.json"), r#"{"id":"root"}"#).expect("root config");
+            fs::write(root.join("nested/homeboy.json"), r#"{"id":"nested"}"#)
+                .expect("nested config");
+
+            let preview = rebase_monorepo_component_paths("site", &root, true).expect("preview");
+            assert_eq!(
+                preview
+                    .iter()
+                    .filter(|change| change.status == MonorepoComponentPathStatus::Attached)
+                    .count(),
+                2
+            );
+            assert_eq!(
+                load("site").expect("unchanged project").components[0].local_path,
+                old.join("root").display().to_string()
+            );
+
+            let applied = rebase_monorepo_component_paths("site", &root, false).expect("apply");
+            assert_eq!(applied, preview);
+            let project = load("site").expect("rebased project");
+            assert_eq!(project.components[0].local_path, root.display().to_string());
+            assert_eq!(
+                project.components[1].local_path,
+                root.join("nested").display().to_string()
+            );
+            assert_eq!(project.components[2].local_path, "/other-repo");
+        });
+    }
+
+    #[test]
+    fn monorepo_rebase_rejects_duplicate_ids_without_mutating_config() {
+        with_isolated_home(|home| {
+            let root = home.path().join("checkout");
+            fs::create_dir_all(root.join("one")).expect("one directory");
+            fs::create_dir_all(root.join("two")).expect("two directory");
+            fs::write(root.join("homeboy.json"), r#"{"id":"root"}"#).expect("root config");
+            fs::write(root.join("one/homeboy.json"), r#"{"id":"duplicate"}"#).expect("one config");
+            fs::write(root.join("two/homeboy.json"), r#"{"id":"duplicate"}"#).expect("two config");
+            save(&Project {
+                id: "site".to_string(),
+                components: vec![ProjectComponentAttachment {
+                    id: "root".to_string(),
+                    local_path: "/old-root".to_string(),
+                    remote_path: None,
+                    deployment_provider: None,
+                }],
+                ..Default::default()
+            })
+            .expect("save project");
+
+            let error =
+                rebase_monorepo_component_paths("site", &root, false).expect_err("duplicates fail");
+            assert!(error.message.contains("Ambiguous component ID 'duplicate'"));
+            assert_eq!(
+                load("site").expect("unchanged project").components[0].local_path,
+                "/old-root"
+            );
         });
     }
 }

--- a/crates/homeboy-core/src/project/component/mod.rs
+++ b/crates/homeboy-core/src/project/component/mod.rs
@@ -5,7 +5,8 @@ pub mod resolution;
 
 pub use attachments::{
     attach_component_path, attach_discovered_component_path, clear_component_attachments,
-    has_component, project_component_ids, remove_components, set_component_attachments,
+    has_component, project_component_ids, rebase_monorepo_component_paths, remove_components,
+    set_component_attachments, MonorepoComponentPathChange, MonorepoComponentPathStatus,
 };
 pub use overrides::apply_component_overrides;
 pub use report::{

--- a/crates/homeboy-core/src/project/component/report.rs
+++ b/crates/homeboy-core/src/project/component/report.rs
@@ -11,7 +11,8 @@ use crate::project::{
 
 use super::{
     attach_discovered_component_path, clear_component_attachments, project_component_ids,
-    remove_components, set_component_attachments,
+    rebase_monorepo_component_paths, remove_components, set_component_attachments,
+    MonorepoComponentPathChange, MonorepoComponentPathStatus,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -30,6 +31,25 @@ pub struct ProjectComponentsOutput {
     pub warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch: Option<BatchComponentAttachmentOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monorepo: Option<MonorepoComponentAttachmentOutput>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MonorepoComponentAttachmentOutput {
+    pub dry_run: bool,
+    pub attached_count: usize,
+    pub unchanged_count: usize,
+    pub missing_count: usize,
+    pub unrelated_count: usize,
+    pub components: Vec<MonorepoComponentAttachmentItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MonorepoComponentAttachmentItem {
+    pub id: String,
+    pub path: String,
+    pub status: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -125,16 +145,63 @@ pub fn set_components(project_id: &str, json_spec: &str) -> Result<ProjectCompon
 pub fn attach_component_path_report(
     project_id: &str,
     local_path: &Path,
+    dry_run: bool,
 ) -> Result<ProjectComponentsOutput> {
-    let attached_component_id = attach_discovered_component_path(project_id, local_path)?;
+    let changes = rebase_monorepo_component_paths(project_id, local_path, dry_run)?;
     let project = load(project_id)?;
-    build_components_summary(
+    let attached_component_id = changes
+        .iter()
+        .find(|change| change.path == local_path.to_string_lossy())
+        .map(|change| change.id.clone());
+    let mut output = build_components_summary(
         project_id,
         "attach_path",
         &project,
-        Some(attached_component_id),
+        attached_component_id,
         Some(local_path.to_string_lossy().to_string()),
-    )
+    )?;
+    output.monorepo = Some(build_monorepo_attachment_output(changes, dry_run));
+    Ok(output)
+}
+
+fn build_monorepo_attachment_output(
+    changes: Vec<MonorepoComponentPathChange>,
+    dry_run: bool,
+) -> MonorepoComponentAttachmentOutput {
+    let mut output = MonorepoComponentAttachmentOutput {
+        dry_run,
+        attached_count: 0,
+        unchanged_count: 0,
+        missing_count: 0,
+        unrelated_count: 0,
+        components: Vec::with_capacity(changes.len()),
+    };
+    for change in changes {
+        let status = match change.status {
+            MonorepoComponentPathStatus::Attached => {
+                output.attached_count += 1;
+                "attached"
+            }
+            MonorepoComponentPathStatus::Unchanged => {
+                output.unchanged_count += 1;
+                "unchanged"
+            }
+            MonorepoComponentPathStatus::Missing => {
+                output.missing_count += 1;
+                "missing"
+            }
+            MonorepoComponentPathStatus::Unrelated => {
+                output.unrelated_count += 1;
+                "unrelated"
+            }
+        };
+        output.components.push(MonorepoComponentAttachmentItem {
+            id: change.id,
+            path: change.path,
+            status: status.to_string(),
+        });
+    }
+    output
 }
 
 pub fn attach_component_paths_report(
@@ -286,6 +353,7 @@ pub fn attach_component_paths_report(
             .map(component_local_path_blockers)
             .unwrap_or_default(),
         batch: Some(batch),
+        monorepo: None,
     })
 }
 
@@ -370,6 +438,7 @@ fn build_components_output(
         components,
         warnings: Vec::new(),
         batch: None,
+        monorepo: None,
     })
 }
 
@@ -390,6 +459,7 @@ fn build_components_summary(
         components: Vec::new(),
         warnings: component_local_path_blockers(project),
         batch: None,
+        monorepo: None,
     })
 }
 

--- a/crates/homeboy-core/src/project/mod.rs
+++ b/crates/homeboy-core/src/project/mod.rs
@@ -23,12 +23,13 @@ mod types;
 pub use component::{
     apply_component_overrides, attach_component_path, attach_component_path_report,
     attach_component_paths_report, attach_discovered_component_path, clear_component_attachments,
-    clear_components, has_component, list_components, project_component_ids, remove_components,
-    remove_components_report, resolve_project_component,
-    resolve_project_component_with_standalone_snapshot, resolve_project_components,
-    set_component_attachments, set_components, BatchComponentAttachmentFailurePolicy,
-    BatchComponentAttachmentInput, BatchComponentAttachmentWorktreePolicy, ProjectComponentsOutput,
-    StandaloneComponentConfigSnapshot,
+    clear_components, has_component, list_components, project_component_ids,
+    rebase_monorepo_component_paths, remove_components, remove_components_report,
+    resolve_project_component, resolve_project_component_with_standalone_snapshot,
+    resolve_project_components, set_component_attachments, set_components,
+    BatchComponentAttachmentFailurePolicy, BatchComponentAttachmentInput,
+    BatchComponentAttachmentWorktreePolicy, MonorepoComponentPathChange,
+    MonorepoComponentPathStatus, ProjectComponentsOutput, StandaloneComponentConfigSnapshot,
 };
 pub use effective_remote_path::{
     component_remote_path, project_with_detected_path_roots, resolve_effective_remote_path,

--- a/docs/reference/cli/commands/project.md
+++ b/docs/reference/cli/commands/project.md
@@ -148,7 +148,7 @@ Manage project components
 | --- | --- |
 | `homeboy project components list` | List associated components |
 | `homeboy project components set` | Replace project components with the provided list |
-| `homeboy project components attach-path` | Attach a repo path for a project component discovered via homeboy.json |
+| `homeboy project components attach-path` | Rebase matching project components discovered below a monorepo checkout |
 | `homeboy project components attach-paths` | Attach multiple repo paths, retaining per-path diagnostics |
 | `homeboy project components remove` | Remove one or more components |
 | `homeboy project components clear` | Remove all components |
@@ -184,15 +184,19 @@ Replace project components with the provided list
 ## `homeboy project components attach-path`
 
 ```sh
-homeboy project components attach-path <PROJECT_ID> <LOCAL_PATH>
+homeboy project components attach-path [OPTIONS] <PROJECT_ID> <LOCAL_PATH>
 ```
 
-Attach a repo path for a project component discovered via homeboy.json
+Rebase matching project components discovered below a monorepo checkout
 
 | Argument | Required | Description |
 | --- | --- | --- |
 | `<PROJECT_ID>` | yes | Project ID |
 | `<LOCAL_PATH>` | yes | Local repo path containing homeboy.json |
+
+| Option | Value | Description |
+| --- | --- | --- |
+| `--dry-run` | flag | Preview every nested component path rebase without updating project config |
 
 ## `homeboy project components attach-paths`
 


### PR DESCRIPTION
## Summary
- make `project components attach-path` discover portable components nested below the supplied checkout root
- validate duplicate component IDs before mutating and save all matching component path rebases in one config transaction
- add `--dry-run` and structured attached, unchanged, missing, and unrelated output

Closes #10915

## Verification
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-core project::component --lib`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-cli commands::project::tests --lib`
- `HOMEBOY_WRITE_CLI_REFERENCE=1 CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-cli --lib cli_surface::reference_docs`
- `cargo fmt --check`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode general coding task drafted the implementation and tests. Chris Huber remains responsible for every line.