### PR TITLE
fix(release): refuse to publish a partially uploaded draft

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/delivery.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/delivery.rs
@@ -19,7 +19,7 @@
 
 /// What `github.release` must do before it may report success for a tag that
 /// already carries a GitHub Release object.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ExistingReleaseAction {
     /// Published release and nothing to attach in this run: a genuine
     /// idempotent no-op.
@@ -31,6 +31,14 @@ pub(crate) enum ExistingReleaseAction {
     /// nothing to attach. Publishing here would mark an incomplete release
     /// `latest`, so fail loudly and hand the operator the repair commands.
     EmptyDraft,
+    /// Unpublished Draft that carries SOME of the assets its own distribution
+    /// manifest declares. Publishing it ships a release whose missing platforms
+    /// return 404, so it is refused for the same reason as `EmptyDraft`.
+    ///
+    /// This is the case `existing_asset_count == 0` could never see. `v0.323.1`
+    /// published with 2 of 14 assets — both Linux archives absent — because a
+    /// non-zero count classified as `PublishDraft`.
+    PartialDraft { missing: Vec<String> },
     /// This run carries artifacts. Reconcile and verify the assets first; the
     /// publish decision is made only after verification succeeds.
     ReconcileAssets,
@@ -39,12 +47,22 @@ pub(crate) enum ExistingReleaseAction {
 /// Classify an already-existing GitHub Release.
 ///
 /// `has_artifacts` is whether *this run* resolved release artifacts to attach;
-/// `existing_asset_count` is how many assets the release already carries;
-/// `expects_artifacts` reflects whether the component declares a build artifact.
+/// `existing_assets` are the asset names the release already carries;
+/// `declared_assets` is the completeness contract the release declares for
+/// itself (its own `dist-manifest.json`, or an adoption manifest's expected
+/// set) when one could be resolved; `expects_artifacts` reflects whether the
+/// component declares a build artifact.
+///
+/// Taking the declared set rather than only a count is the point. The previous
+/// signature received `existing_asset_count: usize` and so could distinguish
+/// only "empty" from "non-empty" — it was structurally incapable of seeing a
+/// partially uploaded draft, which is how a release with 2 of 14 assets was
+/// published (#8687).
 pub(crate) fn existing_release_action(
     is_draft: bool,
     has_artifacts: bool,
-    existing_asset_count: usize,
+    existing_assets: &[String],
+    declared_assets: Option<&[String]>,
     expects_artifacts: bool,
 ) -> ExistingReleaseAction {
     if has_artifacts {
@@ -53,8 +71,32 @@ pub(crate) fn existing_release_action(
     if !is_draft {
         return ExistingReleaseAction::AlreadyPublished;
     }
-    if existing_asset_count == 0 && expects_artifacts {
+    if existing_assets.is_empty() && expects_artifacts {
         return ExistingReleaseAction::EmptyDraft;
     }
+    let missing = missing_declared_assets(existing_assets, declared_assets);
+    if !missing.is_empty() {
+        return ExistingReleaseAction::PartialDraft { missing };
+    }
     ExistingReleaseAction::PublishDraft
+}
+
+/// Declared assets absent from `existing`.
+///
+/// An unresolvable contract (`None`) yields no missing assets: a release whose
+/// completeness cannot be established must not be blocked on that basis, or a
+/// component that ships no manifest could never publish at all. Refusal is
+/// reserved for a contract that exists and is demonstrably unmet.
+pub(crate) fn missing_declared_assets(
+    existing: &[String],
+    declared: Option<&[String]>,
+) -> Vec<String> {
+    let Some(declared) = declared else {
+        return Vec::new();
+    };
+    declared
+        .iter()
+        .filter(|name| !existing.iter().any(|present| present == *name))
+        .cloned()
+        .collect()
 }

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -383,6 +383,25 @@ pub(crate) fn github_release_asset_paths(state: &ReleaseState) -> Result<Vec<Str
     }
 }
 
+/// Asset names a cargo-dist manifest declares, for verifying a REMOTE release.
+///
+/// `github_release_asset_paths` answers the same question for local files and
+/// resolves paths; a draft on GitHub has only names, so this returns names.
+/// Sharing `collect_manifest_assets` keeps one definition of "what this
+/// manifest declares" rather than a second, drifting one (#8687).
+pub(crate) fn manifest_declared_asset_names(manifest: &str) -> Option<Vec<String>> {
+    let value: serde_json::Value = serde_json::from_str(manifest).ok()?;
+    let mut paths = Vec::new();
+    collect_manifest_assets(&value, std::path::Path::new(""), &mut paths);
+    let mut names = paths
+        .iter()
+        .map(|path| release_asset_name(path))
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    Some(names)
+}
+
 fn collect_manifest_assets(
     value: &serde_json::Value,
     manifest_dir: &std::path::Path,

--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -41,7 +41,9 @@ pub(crate) use gh_cli::{
 #[cfg(test)]
 pub(crate) use crate::release::types::ReleaseStepResult;
 #[cfg(test)]
-pub(crate) use delivery::{existing_release_action, ExistingReleaseAction};
+pub(crate) use delivery::{
+    existing_release_action, missing_declared_assets, ExistingReleaseAction,
+};
 #[cfg(test)]
 pub(crate) use gh_cli::{
     github_cli_env, github_release_artifact_paths, parse_listed_release_metadata,

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -6,6 +6,7 @@ use homeboy_core::error::{Error, Result};
 
 use super::super::step_success;
 use super::delivery::{existing_release_action, ExistingReleaseAction};
+use super::gh_cli::manifest_declared_asset_names;
 use super::gh_cli::{
     gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
     github_release_publications,
@@ -279,10 +280,36 @@ pub(crate) fn run_github_release(
             ));
         }
 
+        // Resolve the completeness contract the release declares for itself.
+        // A draft's own `dist-manifest.json` names every archive it is supposed
+        // to carry, so a partially uploaded draft can be recognised without any
+        // out-of-band plan. An adoption manifest, when present, is authoritative
+        // over it (#8687).
+        let existing_asset_names = metadata
+            .assets
+            .iter()
+            .map(|asset| asset.name.clone())
+            .collect::<Vec<_>>();
+        let declared_assets = state
+            .draft_adoption
+            .as_ref()
+            .map(|adoption| adoption.expected_assets.clone())
+            .or_else(|| {
+                let manifest = metadata
+                    .assets
+                    .iter()
+                    .find(|asset| asset.name == "dist-manifest.json")?;
+                let contents =
+                    download_small_release_asset(&github, &component.github, &repo_flag, manifest)
+                        .ok()?;
+                manifest_declared_asset_names(&contents)
+            });
+
         match existing_release_action(
             metadata.is_draft,
             has_artifacts,
-            metadata.assets.len(),
+            &existing_asset_names,
+            declared_assets.as_deref(),
             component.build_artifact.is_some(),
         ) {
             ExistingReleaseAction::AlreadyPublished => {
@@ -313,6 +340,23 @@ pub(crate) fn run_github_release(
                     &tag,
                     &github,
                     "draft-release-has-no-assets",
+                    &detail,
+                    repair,
+                    &[],
+                ));
+            }
+            ExistingReleaseAction::PartialDraft { missing } => {
+                let detail = format!(
+                    "GitHub Release {tag} for {repo_flag} is an unpublished draft missing {} asset(s) declared by its own distribution manifest: {}. Publishing it would ship a release whose missing platforms return 404.",
+                    missing.len(),
+                    missing.join(", ")
+                );
+                homeboy_core::log_status!("release", "{}", detail);
+                let repair = repair_commands(None, None);
+                return Ok(unfinished_release_result(
+                    &tag,
+                    &github,
+                    "draft-release-incomplete",
                     &detail,
                     repair,
                     &[],

--- a/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
@@ -15,12 +15,21 @@
 //! them whenever the run carried no artifacts of its own, so the pipeline
 //! reported a delivered release over an undeliverable tag.
 
-use super::super::{existing_release_action, ExistingReleaseAction};
+use super::super::{existing_release_action, missing_declared_assets, ExistingReleaseAction};
+
+/// `n` asset names, standing in for a release that carries that many assets.
+/// The classifier now reads names rather than a count, so tests that only care
+/// about "how many" build a set of that size.
+fn assets(count: usize) -> Vec<String> {
+    (0..count)
+        .map(|index| format!("asset-{index}.tar.xz"))
+        .collect()
+}
 
 #[test]
 fn published_release_with_nothing_to_attach_is_an_idempotent_no_op() {
     assert_eq!(
-        existing_release_action(false, false, 13, true),
+        existing_release_action(false, false, &assets(13), None, true),
         ExistingReleaseAction::AlreadyPublished
     );
 }
@@ -31,7 +40,7 @@ fn published_release_with_no_assets_is_still_an_idempotent_no_op() {
     // assets is a delivery problem for `verify-published` to report, not a
     // reason for this step to re-publish something already public.
     assert_eq!(
-        existing_release_action(false, false, 0, true),
+        existing_release_action(false, false, &assets(0), None, true),
         ExistingReleaseAction::AlreadyPublished
     );
 }
@@ -42,11 +51,11 @@ fn stranded_draft_carrying_assets_is_published_not_skipped() {
     // already uploaded every asset, and only the un-draft edit is missing.
     // Reporting `skipped` here is what let those tags sit undeliverable.
     assert_eq!(
-        existing_release_action(true, false, 15, true),
+        existing_release_action(true, false, &assets(15), None, true),
         ExistingReleaseAction::PublishDraft
     );
     assert_eq!(
-        existing_release_action(true, false, 1, true),
+        existing_release_action(true, false, &assets(1), None, true),
         ExistingReleaseAction::PublishDraft
     );
 }
@@ -58,7 +67,7 @@ fn empty_draft_for_artifact_component_is_refused_rather_than_published() {
     // That is strictly worse than leaving the draft for the recovery path,
     // which can still upload artifacts into it.
     assert_eq!(
-        existing_release_action(true, false, 0, true),
+        existing_release_action(true, false, &assets(0), None, true),
         ExistingReleaseAction::EmptyDraft
     );
 }
@@ -66,7 +75,7 @@ fn empty_draft_for_artifact_component_is_refused_rather_than_published() {
 #[test]
 fn empty_draft_for_assetless_component_is_published() {
     assert_eq!(
-        existing_release_action(true, false, 0, false),
+        existing_release_action(true, false, &assets(0), None, false),
         ExistingReleaseAction::PublishDraft
     );
 }
@@ -79,7 +88,7 @@ fn a_run_carrying_artifacts_always_reconciles_before_any_publish_decision() {
     for is_draft in [true, false] {
         for existing in [0usize, 1, 15] {
             assert_eq!(
-                existing_release_action(is_draft, true, existing, true),
+                existing_release_action(is_draft, true, &assets(existing), None, true),
                 ExistingReleaseAction::ReconcileAssets,
                 "is_draft={is_draft} existing_assets={existing}"
             );
@@ -94,10 +103,105 @@ fn no_input_combination_reports_a_draft_as_already_published() {
     for existing in [0usize, 1, 13, 15] {
         for has_artifacts in [true, false] {
             assert_ne!(
-                existing_release_action(true, has_artifacts, existing, true),
+                existing_release_action(true, has_artifacts, &assets(existing), None, true),
                 ExistingReleaseAction::AlreadyPublished,
                 "a draft must never classify as published (has_artifacts={has_artifacts}, existing_assets={existing})"
             );
         }
     }
+}
+
+/// The v0.323.1 state, which `existing_asset_count == 0` could never see.
+///
+/// All four platform builds succeeded; the publish step failed after uploading
+/// two assets. A non-zero count classified the draft as `PublishDraft`, so it
+/// was published with 2 of 14 assets and served 404 for both Linux archives
+/// (#8687).
+#[test]
+fn partially_uploaded_draft_is_refused_rather_than_published() {
+    let declared = vec![
+        "dist-manifest.json".to_string(),
+        "homeboy-aarch64-apple-darwin.tar.xz".to_string(),
+        "homeboy-aarch64-unknown-linux-gnu.tar.xz".to_string(),
+        "homeboy-x86_64-apple-darwin.tar.xz".to_string(),
+        "homeboy-x86_64-unknown-linux-gnu.tar.xz".to_string(),
+    ];
+    let present = vec![
+        "homeboy-aarch64-apple-darwin.tar.xz".to_string(),
+        "source.tar.gz".to_string(),
+    ];
+
+    let action = existing_release_action(true, false, &present, Some(&declared), true);
+
+    match action {
+        ExistingReleaseAction::PartialDraft { missing } => {
+            assert!(missing.contains(&"homeboy-x86_64-unknown-linux-gnu.tar.xz".to_string()));
+            assert!(missing.contains(&"homeboy-aarch64-unknown-linux-gnu.tar.xz".to_string()));
+            assert!(missing.contains(&"dist-manifest.json".to_string()));
+            assert!(
+                !missing.contains(&"homeboy-aarch64-apple-darwin.tar.xz".to_string()),
+                "an asset that IS present must not be reported missing"
+            );
+        }
+        other => panic!("a partially uploaded draft must be refused, got {other:?}"),
+    }
+}
+
+/// A draft carrying everything its manifest declares still publishes. Extra
+/// assets beyond the contract (sidecars, source archives, the Homebrew
+/// formula) are not a reason to refuse.
+#[test]
+fn draft_carrying_every_declared_asset_still_publishes() {
+    let declared = vec![
+        "homeboy-aarch64-apple-darwin.tar.xz".to_string(),
+        "homeboy-x86_64-unknown-linux-gnu.tar.xz".to_string(),
+    ];
+    let present = vec![
+        "homeboy-aarch64-apple-darwin.tar.xz".to_string(),
+        "homeboy-x86_64-unknown-linux-gnu.tar.xz".to_string(),
+        "homeboy.rb".to_string(),
+        "sha256.sum".to_string(),
+        "source.tar.gz".to_string(),
+    ];
+
+    assert_eq!(
+        existing_release_action(true, false, &present, Some(&declared), true),
+        ExistingReleaseAction::PublishDraft
+    );
+}
+
+/// An unresolvable contract must not block publication. A component that ships
+/// no distribution manifest has no declared set to compare against, and
+/// refusing on that basis would make it unreleasable.
+#[test]
+fn a_draft_without_a_resolvable_contract_is_not_refused() {
+    let present = vec!["some-artifact.zip".to_string()];
+
+    assert_eq!(
+        existing_release_action(true, false, &present, None, true),
+        ExistingReleaseAction::PublishDraft
+    );
+    assert!(missing_declared_assets(&present, None).is_empty());
+}
+
+/// An empty declared set is a contract that is trivially met, not an
+/// unresolvable one.
+#[test]
+fn an_empty_declared_contract_is_satisfied() {
+    let present = vec!["anything.zip".to_string()];
+    assert!(missing_declared_assets(&present, Some(&[])).is_empty());
+}
+
+/// Refusal is reserved for drafts. A published release missing declared assets
+/// is `verify-published`'s problem to report; re-classifying it here would let
+/// this step try to re-publish something already public.
+#[test]
+fn a_published_release_is_never_reclassified_as_partial() {
+    let declared = vec!["homeboy-x86_64-unknown-linux-gnu.tar.xz".to_string()];
+    let present = vec!["source.tar.gz".to_string()];
+
+    assert_eq!(
+        existing_release_action(false, false, &present, Some(&declared), true),
+        ExistingReleaseAction::AlreadyPublished
+    );
 }


### PR DESCRIPTION
Fixes #8687. Root-cause counterpart to #10920, which contains the same failure at the workflow layer.

## The signature was the bug

```rust
pub(crate) fn existing_release_action(
    is_draft: bool,
    has_artifacts: bool,
    existing_asset_count: usize,   // <-- how many, never which
    expects_artifacts: bool,
) -> ExistingReleaseAction {
    ...
    if existing_asset_count == 0 && expects_artifacts {
        return ExistingReleaseAction::EmptyDraft;
    }
    ExistingReleaseAction::PublishDraft
}
```

The only completeness test was `== 0`. A draft holding **2 of 14** assets is non-zero, so it classified as `PublishDraft` and published unconditionally.

The `EmptyDraft` doc comment names the exact hazard — *"Publishing here would mark an incomplete release `latest`"* — but the predicate caught only the empty case. Receiving a count rather than the asset set made the classifier **structurally incapable** of seeing a partial draft, so no amount of care at the call sites could have caught it.

That is how `v0.323.1` shipped. All four platform builds succeeded; the publish step failed after uploading two assets:

```
$ curl -sIL -o /dev/null -w '%{http_code}' \
    .../releases/download/v0.323.1/homeboy-x86_64-unknown-linux-gnu.tar.xz
404
```

## Change

`existing_release_action` now takes the asset **names** plus the completeness contract the release declares for itself, and returns a new `PartialDraft { missing }`, refused for the same reason as `EmptyDraft`.

The contract needs no out-of-band plan: **a draft's own `dist-manifest.json` names every archive it should carry**, so a partial draft is recognisable from the release alone. An adoption manifest, when present, is authoritative over it.

`manifest_declared_asset_names` reuses the existing `collect_manifest_assets`, so there is one definition of "what this manifest declares" rather than a second that can drift from `github_release_asset_paths`.

## Deliberately fail-open where the contract is unknowable

`missing_declared_assets(existing, None)` returns empty. A component that ships no distribution manifest has no declared set, and refusing on that basis would make it permanently unreleasable. Refusal is reserved for a contract that **exists and is demonstrably unmet**.

Refusal is also **draft-only**. A published release missing assets is `verify-published`'s to report; re-classifying it here would let this step try to re-publish something already public. Tested.

## On the wider consolidation question

There are four `--draft=false` sites in `run.rs` carrying three different completeness contracts:

| site | gate |
|---|---|
| draft adoption | `validate_draft_adoption` |
| **PublishDraft** | **none — this PR** |
| existing-release repair | `verify_release_publications` |
| normal release | `verify_release_publications` |

This closes the ungated one, which is the path that actually shipped a broken release. Collapsing all four into a single verified publish primitive is the real consolidation and is a larger change — worth its own issue rather than smuggling it in here.

## Tests

12 in `delivery_tests`, 6 new:

- `partially_uploaded_draft_is_refused_rather_than_published` — the exact v0.323.1 shape, asserting the missing set names both Linux archives and does **not** name the asset that is present
- `draft_carrying_every_declared_asset_still_publishes` — extra assets beyond the contract (sidecars, source, Homebrew formula) are not grounds for refusal
- `a_draft_without_a_resolvable_contract_is_not_refused`
- `an_empty_declared_contract_is_satisfied`
- `a_published_release_is_never_reclassified_as_partial`
- plus existing coverage migrated to the new signature

**Negative control:** restoring the count-only classification fails `partially_uploaded_draft_is_refused_rather_than_published` with *"a partially uploaded draft must be refused, got PublishDraft"*.

`cargo fmt --check` clean, `cargo clippy -p homeboy-release --lib --tests` clean.

## Pre-existing failures (not from this change)

`cargo test -p homeboy-release --lib` leaves 6 red, identical to the set documented in #10836: 3 `planning_quality`, 1 `deployment`, `release_tag_versions_sort_by_semver_precedence` (the `semver::Version` `Ord`-includes-build-metadata issue), and the timing-sensitive `bounded_command_closes_inherited_descendant_pipes`.

## Note

`v0.323.1` is still published and still serving 404s. This prevents recurrence; it does not retroactively repair that release.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
