### PR TITLE
fix: restore compilation broken by the deployment provider input field

### DIFF
--- a/crates/homeboy-core/src/project/component/attachments.rs
+++ b/crates/homeboy-core/src/project/component/attachments.rs
@@ -288,6 +288,7 @@ fn rebase_monorepo_component_paths_unlocked(
                         local_path: path.clone(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     });
                 }
             }
@@ -565,18 +566,21 @@ mod tests {
                         local_path: old.join("root").display().to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                     ProjectComponentAttachment {
                         id: "nested".to_string(),
                         local_path: old.join("nested").display().to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                     ProjectComponentAttachment {
                         id: "other-repo".to_string(),
                         local_path: "/other-repo".to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                 ],
                 ..Default::default()
@@ -629,6 +633,7 @@ mod tests {
                     local_path: "/old-root".to_string(),
                     remote_path: None,
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Default::default()
             })


### PR DESCRIPTION
**`homeboy-core` does not compile on `main`.** Every PR's Workspace Tests Compile gate is red and nothing can merge cleanly until this lands.

## Cause

#10928 (`dee3d3f8b`, "rebase monorepo component paths atomically") added a `ProjectComponentAttachment` initializer at the same time `deployment_provider_input` was being added to the struct. The two landed without meeting:

```
error[E0063]: missing field `deployment_provider_input` in initializer of
              `project::types::component::ProjectComponentAttachment`
  --> crates/homeboy-core/src/project/component/attachments.rs:286:45
```

**Line 286 is production code** — `rebase_monorepo_component_paths_unlocked`. `mod tests` does not start until line 444, so this is not a test-only break: the library itself fails to build.

Four further sites inside `mod tests` fail the same way once the lib compiles.

## Fix

The field is `Option<serde_json::Value>`, so each of the five sites takes `deployment_provider_input: None`.

```
1 production site   attachments.rs:286  (rebase_monorepo_component_paths_unlocked)
4 test sites        attachments.rs:564, 570, 576, 628
```

`cargo check --workspace --tests` → exit 0. `cargo test -p homeboy-core --lib project::component::attachments` → 9 passed.

## This is the second occurrence today

#10799 fixed the identical shape this morning for `deployment_provider`, across eight files and eleven initializers.

`ProjectComponentAttachment` is constructed at roughly fifteen sites and has no `Default` impl, so **every optional field added to it is a repo-wide edit** — and two concurrent PRs can each be green in isolation while their merge is broken. That is exactly what happened both times.

Worth considering a constructor or `Default` impl so optional metadata can be added without touching every call site. I have not changed that here: it is a wider API decision and this PR should stay a minimal unblock.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
