### PR TITLE
fix(project): initialize provider input on rebase

### DIFF
--- a/crates/homeboy-core/src/project/component/attachments.rs
+++ b/crates/homeboy-core/src/project/component/attachments.rs
@@ -288,6 +288,7 @@ fn rebase_monorepo_component_paths_unlocked(
                         local_path: path.clone(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     });
                 }
             }
@@ -565,18 +566,21 @@ mod tests {
                         local_path: old.join("root").display().to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                     ProjectComponentAttachment {
                         id: "nested".to_string(),
                         local_path: old.join("nested").display().to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                     ProjectComponentAttachment {
                         id: "other-repo".to_string(),
                         local_path: "/other-repo".to_string(),
                         remote_path: None,
                         deployment_provider: None,
+                        deployment_provider_input: None,
                     },
                 ],
                 ..Default::default()
@@ -629,6 +633,7 @@ mod tests {
                     local_path: "/old-root".to_string(),
                     remote_path: None,
                     deployment_provider: None,
+                    deployment_provider_input: None,
                 }],
                 ..Default::default()
             })


### PR DESCRIPTION
## Summary\n\n- initialize the project-only deployment provider input when monorepo rebase discovers a new component\n- update the #10928 fixtures for the field added by #10922\n- restore current-main library and test compilation after the merge-order conflict\n\n## Verification\n\n- `cargo fmt --all -- --check`\n- `git diff --check`\n- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-core project::component --lib --locked` (38 passed)\n\nCloses #10937.\n\n## AI Assistance\n\nOpenCode with OpenAI GPT-5.6 Sol was used to reproduce the current-main compile failure, trace the merge-order conflict, implement the missing defaults, and run verification. Chris Huber remains responsible for every line.