### PR TITLE
docs(cli): document SSH timeout

### DIFF
--- a/docs/reference/cli/commands/ssh.md
+++ b/docs/reference/cli/commands/ssh.md
@@ -30,6 +30,7 @@ SSH into a project server or configured server
 | `--as-server` | flag | Force interpretation as server ID |
 | `--user` | `<USER>` | Override the SSH user (instead of the server's configured user) |
 | `--raw` | flag | Write only the remote command's stdout to local stdout (and its stderr to local stderr), exiting with the remote exit code. Ideal for piping a remote export straight into a file. Combine with `--output <path>` to also persist the structured envelope. Requires a non-interactive command |
+| `--timeout` | `<TIMEOUT>` | Bound the complete non-interactive SSH command, in seconds. Progress remains on stderr so `--raw` preserves remote stdout |
 
 | Subcommand | Summary |
 | --- | --- |


### PR DESCRIPTION
## Summary

Restores the generated `homeboy ssh --timeout` CLI reference row omitted when #10923 merged before its documentation follow-up commit.

Related: #10923
Related: #10912

## Verification

- `HOMEBOY_WRITE_CLI_REFERENCE=1 CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-cli --lib --locked cli_surface::reference_docs`
- Confirmed `git diff --exit-code -- docs/reference/cli/commands` after regeneration
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-cli commands::ssh`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo fmt --all --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode general coding task. Used to inspect the merged PR and failed generated-reference check, isolate the omitted generated documentation row, and verify the follow-up. Chris Huber remains responsible for every line.