### PR TITLE
fix(runner): bound startup evidence recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
  "libc",
  "regex",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/homeboy-lab-runner/Cargo.toml
+++ b/crates/homeboy-lab-runner/Cargo.toml
@@ -42,3 +42,4 @@ uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
 homeboy-rig = { version = "0.1.0", path = "../homeboy-rig" }
 homeboy-agents = { version = "0.1.0", path = "../homeboy-agents", features = ["test-support"] }
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -16,7 +16,7 @@ use homeboy_core::engine::command::CommandCaptureMetadata;
 use homeboy_core::env_materialization_plan::EnvMaterializationPlan;
 use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::lab_contract::{LabRunnerWorkload, LabRunnerWorkloadArtifactRef};
-use homeboy_core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use homeboy_core::observation::{NewRunRecord, ObservationStore, RunListFilter, RunStatus};
 use homeboy_core::runner_execution_envelope::{
     BinaryProvenance, ExtensionProvenance, OrchestrationTargetProvenance, PathMaterializationEntry,
     PathMaterializationPlan, RunnerExecutionNextAction, RunnerExecutionRecord,

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -2,6 +2,8 @@
 
 use super::*;
 
+const STARTUP_RUNNER_EXEC_RECOVERY_LIMIT: i64 = 100;
+
 /// Scan durable generic runner-exec runs, query their exact accepted runner-job
 /// binding, then retain declared evidence before terminal projection. This runs
 /// before command dispatch so a new daemon operation cannot evict a completed
@@ -9,7 +11,12 @@ use super::*;
 pub fn reconcile_terminal_runner_exec_runs() -> Result<usize> {
     let store = ObservationStore::open_initialized()?;
     let mut reconciled = 0;
-    for run in store.list_active_runs()? {
+    for run in store.list_runs(RunListFilter {
+        kind: Some("runner_execution".to_string()),
+        status: Some(RunStatus::Running.as_str().to_string()),
+        limit: Some(STARTUP_RUNNER_EXEC_RECOVERY_LIMIT),
+        ..RunListFilter::default()
+    })? {
         if run.metadata_json.get("kind").and_then(Value::as_str) != Some("runner_exec") {
             continue;
         }
@@ -225,6 +232,71 @@ mod tests {
     use super::*;
     use homeboy_core::test_support::with_isolated_home;
     use homeboy_core::{Error, ErrorCode};
+
+    #[test]
+    fn startup_recovery_does_not_materialize_unrelated_active_payloads() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let unrelated = store
+                .start_run(NewRunRecord::builder("unrelated").build())
+                .expect("unrelated run");
+            drop(store);
+
+            let path = homeboy_core::observation::store::database_path().expect("database path");
+            let connection = rusqlite::Connection::open(path).expect("open database");
+            connection
+                .execute("DROP INDEX idx_runs_metadata_retry_of", [])
+                .expect("drop metadata expression index");
+            connection
+                .execute(
+                    "UPDATE runs SET metadata_json = 'invalid-json' WHERE id = ?1",
+                    [&unrelated.id],
+                )
+                .expect("corrupt unrelated payload");
+            drop(connection);
+
+            assert_eq!(
+                reconcile_terminal_runner_exec_runs().expect("bounded recovery"),
+                0
+            );
+        });
+    }
+
+    #[test]
+    fn startup_recovery_bounds_runner_exec_candidates() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            drop(store);
+            let path = homeboy_core::observation::store::database_path().expect("database path");
+            let connection = rusqlite::Connection::open(path).expect("open database");
+            connection
+                .execute("DROP INDEX idx_runs_metadata_retry_of", [])
+                .expect("drop metadata expression index");
+            for index in 0..STARTUP_RUNNER_EXEC_RECOVERY_LIMIT {
+                connection
+                    .execute(
+                        "INSERT INTO runs(id, kind, started_at, status, metadata_json) VALUES (?1, 'runner_execution', ?2, 'running', '{\"kind\":\"runner_exec\"}')",
+                        rusqlite::params![
+                            format!("candidate-{index}"),
+                            format!("2026-07-30T{:02}:{:02}:00Z", 18 + index / 60, index % 60)
+                        ],
+                    )
+                    .expect("insert candidate");
+            }
+            connection
+                .execute(
+                    "INSERT INTO runs(id, kind, started_at, status, metadata_json) VALUES ('outside-budget', 'runner_execution', '2026-01-01T00:00:00Z', 'running', 'invalid-json')",
+                    [],
+                )
+                .expect("insert outside-budget candidate");
+            drop(connection);
+
+            assert_eq!(
+                reconcile_terminal_runner_exec_runs().expect("bounded recovery"),
+                0
+            );
+        });
+    }
 
     #[test]
     fn daemon_eviction_preserves_literal_declaration_paths_in_loss_detection() {


### PR DESCRIPTION
## Summary

- query only active `runner_execution` observation rows during pre-dispatch evidence recovery
- cap each startup recovery pass at 100 newest candidates
- prove unrelated active payloads and candidates outside the work budget are not materialized

## Root Cause

Startup recovery called unbounded `list_active_runs()` before command dispatch. On a roughly 20 GB observation database, even `project components attach-path` materialized every active metadata payload, exceeded 2.2 GB RSS, and did not reach project lock handling within 120 seconds.

The replacement uses the existing bounded `RunListFilter` with indexed kind/status predicates, so unrelated rows are excluded by SQLite and startup has a fixed work budget.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-lab-runner execution::recovery::tests --lib --locked` (3 passed)
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo check -p homeboy-lab-runner -p homeboy-cli --locked`
- branch binary against the real observation database: mutating `project components attach-path` probe returned `project.not_found` after dispatch in 4.29 seconds with 47.6 MB maximum RSS; the installed binary previously exceeded 120 seconds and roughly 2.2 GB RSS before dispatch

Closes #10901.

Related read-only bypass: #10919.
Current-main compile interruption was independently resolved by #10930; duplicate #10939 was closed without merge.

## AI Assistance

OpenCode with OpenAI GPT-5.6 Sol was used to sample the blocked process, trace the unbounded observation query, implement bounded indexed recovery, design regression fixtures, and run real-database verification. Chris Huber remains responsible for every line.