### PR TITLE
test(release): repair four assertions stale since member tests stopped running

### DIFF
--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -345,9 +345,21 @@ mod tests {
         }
     }
 
-    /// Ordering now comes from `semver`'s `Ord`, which implements the full
-    /// precedence rules: a prerelease sorts below its release, and build
-    /// metadata is ignored for precedence (semver §10-11).
+    /// Ordering comes from `semver`'s `Ord`: a prerelease sorts below its
+    /// release, and numeric identifiers compare numerically rather than
+    /// lexically.
+    ///
+    /// Build metadata is the one place `semver::Version` deliberately diverges
+    /// from spec §10 precedence. `Ord` must agree with `Eq`, and `Eq` includes
+    /// build metadata, so `1.2.3+build.5` and `1.2.3` are ordered rather than
+    /// equal. This test previously asserted `Ordering::Equal` and had been
+    /// failing since `706627296` adopted the crate — nothing ran it, because
+    /// member-crate lib tests were never executed in CI (#10477).
+    ///
+    /// The divergence is harmless for tag selection and is asserted as such
+    /// below: build metadata breaks a tie deterministically and can never
+    /// promote a version above a genuinely higher one, which is all `max_by`
+    /// over release tags depends on.
     #[test]
     fn release_tag_versions_sort_by_semver_precedence() {
         let v = |tag: &str| release_tag_version(tag, None).expect(tag);
@@ -357,10 +369,20 @@ mod tests {
         assert!(v("v1.2.3-beta.2") < v("v1.2.3-beta.10"));
         assert!(v("v1.2.3") < v("v1.10.0"));
         assert!(v("v1.9.0") < v("v1.10.0"));
+
+        // Same core precedence: build metadata changes none of the fields spec
+        // §10 actually compares.
+        let build = v("v1.2.3+build.5");
+        let plain = v("v1.2.3");
         assert_eq!(
-            v("v1.2.3+build.5").cmp(&v("v1.2.3")),
-            std::cmp::Ordering::Equal
+            (build.major, build.minor, build.patch, &build.pre),
+            (plain.major, plain.minor, plain.patch, &plain.pre)
         );
+        // Deterministically ordered rather than equal, and never able to
+        // outrank a higher version.
+        assert_ne!(build.cmp(&plain), std::cmp::Ordering::Equal);
+        assert!(build < v("v1.2.4"));
+        assert!(build > v("v1.2.3-beta.1"));
 
         // The regression the hand-rolled compare produced: `v1.x.3` used to
         // parse as `(1, 0, 3)` and could win a `max_by` against a real tag.

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1124,7 +1124,14 @@ mod tests {
             };
 
             let error = validate_lint_quality(&component, "fixture").expect_failed();
-            assert!(error.to_string().contains("Lint runner error"));
+            // The bootstrap failure now surfaces as the extension resolution
+            // failure that actually occurred, rather than the generic
+            // "Lint runner error" this previously asserted.
+            assert!(
+                error.to_string().contains("Extension not found"),
+                "a component declaring an uninstallable lint extension must block \
+                 release on the resolution failure; got: {error}"
+            );
         });
     }
 
@@ -1153,7 +1160,17 @@ mod tests {
                 .insert("lint".to_string(), "unsupported".to_string());
 
             let error = validate_lint_quality(&component, "fixture").expect_failed();
-            assert!(error.to_string().contains("Lint runner error"));
+            // Naming the capability, the selected extension, and why it is
+            // invalid is strictly more actionable than "Lint runner error".
+            let message = error.to_string();
+            assert!(
+                message.contains("capability_extensions.lint"),
+                "the error must name the offending config key; got: {message}"
+            );
+            assert!(
+                message.contains("unsupported") && message.contains("does not provide it"),
+                "the error must name the selected extension and why it is rejected; got: {message}"
+            );
         });
     }
 
@@ -1310,8 +1327,18 @@ exit 1
         });
     }
 
+    /// Malformed evidence and producer errors block release; a clean run that
+    /// reports nothing does not.
+    ///
+    /// The "missing" case changed meaning. `homeboy-extensions@740e20b5` made
+    /// every extension declaring `lint.findings` seed the sidecar with `[]` on
+    /// clean exit paths, so an absent findings file from an exit-0 run is a
+    /// clean pass rather than lost evidence. A runner that actually fails still
+    /// writes its infrastructure finding, so the measurement invariant is intact
+    /// — `[]` is treated as no payload, not as proof of success.
     #[test]
-    fn extension_release_lint_blocks_malformed_missing_and_producer_error_evidence() {
+    fn extension_release_lint_blocks_malformed_and_producer_error_evidence_but_allows_a_clean_run()
+    {
         homeboy_core::test_support::with_isolated_home(|home| {
             let malformed_source = tempfile::tempdir().expect("malformed source dir");
             let malformed = extension_lint_component(
@@ -1321,7 +1348,13 @@ exit 1
                 true,
             );
             let malformed_error = validate_lint_quality(&malformed, "fixture").expect_failed();
-            assert!(malformed_error.to_string().contains("Lint runner error"));
+            // Malformed findings evidence is now reported through the lint
+            // failure itself, carrying the producer-error count.
+            let malformed_message = malformed_error.to_string();
+            assert!(
+                malformed_message.contains("Lint failed") && malformed_message.contains("producer error"),
+                "malformed findings evidence must block release and name the producer error; got: {malformed_message}"
+            );
 
             let missing_source = tempfile::tempdir().expect("missing source dir");
             let missing = extension_lint_component(
@@ -1330,8 +1363,13 @@ exit 1
                 "#!/bin/sh\nexit 0\n",
                 true,
             );
-            let missing_error = validate_lint_quality(&missing, "fixture").expect_failed();
-            assert!(missing_error.to_string().contains("Lint runner error"));
+            // Exit 0 with nothing to report is a clean pass, not missing
+            // evidence. This previously asserted a failure, under the older
+            // contract where a declaring extension left no sidecar behind.
+            assert!(
+                validate_lint_quality(&missing, "fixture").expect_passed_with_value(true),
+                "a clean lint run that reports no findings must not block release"
+            );
 
             let producer_source = tempfile::tempdir().expect("producer error source dir");
             let producer_error = extension_lint_component(


### PR DESCRIPTION
Now that #10477 is live, member-crate lib tests actually execute — and five in `homeboy-release` had been red on `main` with nothing reporting them. This fixes four. **None are production defects**; all are stale assertions.

## planning_quality (3)

All three asserted the generic string `"Lint runner error"`. Every one now produces a more specific message, and the assertions pin that meaning instead of a substring:

| test | actual message now |
|---|---|
| `..._blocks_extension_bootstrap_failure` | `Extension not found` |
| `..._rejects_invalid_explicit_lint_ownership` | `Invalid argument 'capability_extensions.lint': Component 'fixture' selects extension 'unsupported' for lint support, but that extension does not provide it` |
| `..._blocks_malformed_...` | `Invalid argument 'lint': Lint failed (exit code 1, 0 finding(s), 1 producer error(s))` |

Each is strictly more actionable than what it replaced. The assertions now name the config key, the extension, and the producer-error count rather than matching one generic prefix.

## One case changed contract, not just wording

The `missing` sub-case asserted a **failure** for "exit 0, no findings file". That is no longer lost evidence:

`homeboy-extensions@740e20b5` ("seed the declared lint.findings sidecar on clean runs") made every extension declaring `lint.findings` write `[]` on clean exit paths. So an absent findings file from an exit-0 run is a clean pass.

The measurement invariant is intact — a runner that actually fails still writes its infrastructure finding, and `[]` is treated as no payload rather than as proof of success. The test is renamed to state the contract it now covers:

```
extension_release_lint_blocks_malformed_and_producer_error_evidence_but_allows_a_clean_run
```

I flagged this rather than quietly flipping the assertion, because "absent evidence is now a pass" is exactly the kind of change that deserves a second look.

## execution_plan (1)

`release_tag_versions_sort_by_semver_precedence` asserted:

```rust
assert_eq!(v("v1.2.3+build.5").cmp(&v("v1.2.3")), Ordering::Equal);
```

citing spec §10 ("build metadata MUST be ignored for precedence"). `semver::Version` deliberately diverges: `Ord` must agree with `Eq`, and `Eq` includes build metadata. Failing since `706627296` adopted the crate — which correctly replaced hand-rolled parsing but inherited a wrong assumption about the crate's `Ord`.

The divergence is harmless for the one thing this ordering is used for (`max_by` over `ls-remote` tags), and the test now asserts that directly:

- same core precedence — `major`/`minor`/`patch`/`pre` are identical
- deterministically ordered rather than equal
- `build < v1.2.4` and `build > v1.2.3-beta.1`, so build metadata can never promote a version above a genuinely higher one

I did **not** change the production ordering. Making it spec-exact would make two build-metadata variants tie, which is *less* deterministic for tag selection, and homeboy tags do not carry build metadata.

## Result

`cargo test -p homeboy-release --lib` → **818 passed, 2 failed** (was 5 failing).

`cargo fmt --check` clean, `cargo clippy -p homeboy-release --lib --tests` clean.

## Not fixed here — needs a decision

**`release_recover_resumes_only_failed_project_with_published_source_projection`**

```
Invalid argument 'components.local_path': Project component has a missing local_path
```

The test deliberately configures a stale attachment path and asserts *"Release must use its accepted source projection rather than resolving this path."* `resolve_project_component` now calls `validate_component_local_path` and rejects the stale path before any projection is consulted.

That validation landed in `cc91c81ab` ("Fail project deploy readiness on missing component paths") on **2026-06-21** — so this has been red for over a month.

Two defensible outcomes, and they are not equivalent:
1. The release deploy path should bypass attachment resolution and use its own accepted source projection — the validation is running in the wrong place for this path.
2. Deploy readiness should fail closed on a missing path regardless — the test's premise is obsolete.

Picking (1) risks weakening a deploy safety check added deliberately; picking (2) discards a contract the test says exists. That is a design call, not a test repair, so I left it rather than guess.

**`bounded_command_closes_inherited_descendant_pipes`** also remains — it passes in isolation (3/3) but is timing-sensitive under a loaded parallel run, asserting on `Instant::now()` deltas.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
