### PR TITLE
fix(cli): validate cook arguments before routing bail-outs

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -29,6 +29,13 @@ pub fn route_after_parse(
     normalized_args: &[String],
     output_file: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
+    // Contradictory argument combinations are rejected before any transport
+    // context is consulted. The bail-outs below skip routing, not validation:
+    // an invalid combination stays invalid wherever the process runs, and
+    // letting one through means cook executes a request it already knows it
+    // cannot honor (#10917).
+    reject_contradictory_cook_arguments(cli)?;
+
     // A managed runner executes the controller-selected command once. Its argv
     // retains the controller's explicit placement for provenance, but must not
     // recursively route back through a runner-side controller daemon.
@@ -588,6 +595,56 @@ fn run_split_placement_fanout(
     Ok(Some(exit_code))
 }
 
+/// Reject `agent-task cook` requests whose flags contradict each other.
+///
+/// These are properties of the argument combination alone, not of the execution
+/// context, so they are evaluated before `route_after_parse` consults any
+/// transport state. The bail-outs at the top of routing exist to stop a
+/// runner-side process recursing back through controller routing; they were
+/// never meant to waive validation. While they did, a single inherited
+/// controller-transport variable let a contradictory cook through to real
+/// worktree and provider work instead of a fast rejection (#10917).
+///
+/// This is the only place these two rejections live. `run_split_placement_cook`
+/// deliberately does not repeat them: duplicated validation drifts, and which
+/// message an operator sees should never depend on the path taken to reach it.
+fn reject_contradictory_cook_arguments(cli: &Cli) -> homeboy::core::Result<()> {
+    let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+        command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
+    }) = &cli.command
+    else {
+        return Ok(());
+    };
+
+    if cook.dispatch.core.queue_only {
+        return Err(Error::validation_invalid_argument(
+            "queue-only",
+            "agent-task cook cannot queue its controller-owned lifecycle; it must retain provider completion to ingest artifacts, promote candidates, run gates, and finalize",
+            None,
+            Some(vec![
+                "Use `homeboy agent-task run-plan --plan <materialized-plan> --record-run-id <run-id> --queue-only` only when a controller owns the corresponding continuation.".to_string(),
+            ]),
+        ));
+    }
+
+    // `--runner` implies Lab placement and is mutually exclusive with an
+    // explicit `--placement` at argument parsing, so `--placement local` here
+    // always means a fully local cook with no pinned runner, and no runner
+    // daemon can own the attempt to detach from.
+    if cli.placement == homeboy::cli_surface::Placement::Local && cli.detach_after_handoff {
+        return Err(Error::validation_invalid_argument(
+            "detach-after-handoff",
+            "agent-task cook cannot detach after handoff with --placement local because no runner daemon owns the provider attempt",
+            None,
+            Some(vec![
+                "Use --placement lab or --runner <runner-id> to detach after a runner daemon accepts the provider attempt.".to_string(),
+            ]),
+        ));
+    }
+
+    Ok(())
+}
+
 /// Cook owns controller-local target resolution, promotion, gates, retries, and
 /// finalization. Its provider attempt is the only portable unit: a materialized
 /// typed run-plan that mirrors its aggregate and artifacts back into the same
@@ -604,30 +661,14 @@ fn run_split_placement_cook(
     else {
         return Ok(None);
     };
-    if cook.dispatch.core.queue_only {
-        return Err(Error::validation_invalid_argument(
-            "queue-only",
-            "agent-task cook cannot queue its controller-owned lifecycle; it must retain provider completion to ingest artifacts, promote candidates, run gates, and finalize",
-            None,
-            Some(vec![
-                "Use `homeboy agent-task run-plan --plan <materialized-plan> --record-run-id <run-id> --queue-only` only when a controller owns the corresponding continuation.".to_string(),
-            ]),
-        ));
-    }
+    // Contradictory combinations are already rejected by
+    // `reject_contradictory_cook_arguments` before any routing decision, so
+    // reaching here means the request is internally consistent.
+    //
     // `--runner` implies Lab placement and is mutually exclusive with an
     // explicit `--placement` at argument parsing, so `--placement local` here
     // always means a fully local cook with no pinned runner.
     if cli.placement == homeboy::cli_surface::Placement::Local {
-        if cli.detach_after_handoff {
-            return Err(Error::validation_invalid_argument(
-                "detach-after-handoff",
-                "agent-task cook cannot detach after handoff with --placement local because no runner daemon owns the provider attempt",
-                None,
-                Some(vec![
-                    "Use --placement lab or --runner <runner-id> to detach after a runner daemon accepts the provider attempt.".to_string(),
-                ]),
-            ));
-        }
         return Ok(None);
     }
     let Some(runner_id) = runner_id else {

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -6,17 +6,13 @@ use homeboy_core::test_support::{HermeticTestContext, TestBinary};
 ///
 /// Every case in this file asserts that a contradictory invocation is rejected
 /// during argument validation, *before* any worktree or provider resolution.
-/// `route_after_parse` returns early when it detects a Lab-offload or
-/// runner-hosted execution context, and that bail-out sits above the validation
-/// under test. A single inherited controller-transport variable therefore skips
-/// the rejection silently and lets cook proceed into real worktree work, which
-/// can block forever. Because `cargo test` runs integration binaries serially,
-/// one blocked binary strands every binary ordered after it (#10917).
 ///
 /// `HermeticTestContext::command` owns the complete isolation contract — HOME,
 /// XDG config and data roots, artifact root, runtime and temp dirs — and strips
 /// the Lab transport variables. Overriding only HOME on a hand-rolled `Command`
-/// leaves that leak open (#10717, #10718).
+/// leaves that leak open (#10717, #10718). These cases run with a default
+/// operator context; the transport variables are injected explicitly only by
+/// the case that asserts they cannot change a validation outcome (#10917).
 fn homeboy(args: &[&str]) -> Output {
     let context = HermeticTestContext::new();
     context
@@ -46,6 +42,76 @@ fn cook_handoff_subprocesses_do_not_inherit_controller_transport() {
     assert!(
         removed_env.contains(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV),
         "cook handoff fixtures must not inherit the controller source snapshot"
+    );
+}
+
+#[test]
+fn contradictory_cook_arguments_survive_controller_transport_context() {
+    // The routing bail-outs skip *routing*, not validation. Injecting the exact
+    // transport context that used to suppress these rejections must not change
+    // the outcome: a contradictory flag combination is contradictory wherever
+    // the process runs.
+    //
+    // Before #10917 this context sent both invocations past validation into
+    // real worktree and provider work, where they blocked indefinitely instead
+    // of failing fast.
+    let cook = |args: &[&str]| {
+        let context = HermeticTestContext::new();
+        context
+            .command(TestBinary::HomeboyFixture)
+            .env(
+                homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV,
+                r#"{"runner_id":"homeboy-lab"}"#,
+            )
+            .args(args)
+            .output()
+            .expect("run homeboy")
+    };
+
+    let detach = cook(&[
+        "--placement",
+        "local",
+        "--detach-after-handoff",
+        "agent-task",
+        "cook",
+        "--prompt",
+        "implement the fix",
+        "--to-worktree",
+        "missing@worktree",
+        "--verify",
+        "true",
+    ]);
+    assert!(!detach.status.success());
+    let detach_stdout = String::from_utf8_lossy(&detach.stdout);
+    assert!(
+        detach_stdout.contains("cannot detach after handoff with --placement local"),
+        "{detach_stdout}"
+    );
+    assert!(
+        !detach_stdout.contains("worktree provider"),
+        "{detach_stdout}"
+    );
+
+    let queue_only = cook(&[
+        "agent-task",
+        "cook",
+        "--prompt",
+        "implement the fix",
+        "--to-worktree",
+        "missing@worktree",
+        "--verify",
+        "true",
+        "--queue-only",
+    ]);
+    assert!(!queue_only.status.success());
+    let queue_only_stdout = String::from_utf8_lossy(&queue_only.stdout);
+    assert!(
+        queue_only_stdout.contains("cannot queue its controller-owned lifecycle"),
+        "{queue_only_stdout}"
+    );
+    assert!(
+        !queue_only_stdout.contains("worktree provider"),
+        "{queue_only_stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary
- move the two `agent-task cook` argument rejections above `route_after_parse`'s transport bail-outs
- keep them in exactly one place rather than duplicating them across the routing path
- pin the behaviour with a case that injects the transport context which used to suppress them

Follow-up to #10918, which closed the test-isolation half of #10917. This closes the production half.

## Root Cause

`route_after_parse` opens with three escape hatches:

```rust
if lab_routing::is_lab_offload_subprocess()
    || managed_runner_placement
    || runner_resident_execution(cli)
{
    return Ok(None);
}
```

They exist to stop a runner-side process recursing back through controller routing. They were never meant to waive **validation** — but both cook rejections lived below them, inside `run_split_placement_cook`.

So any inherited controller-transport variable sent a contradictory request straight past validation into real worktree and provider work. An operator invoking cook under any Lab-offload or runner-hosted context got no argument validation at all.

Reproduced against 0.321.0 — isolating `HOME` alone gives the correct rejection in 0.6s:

```
Invalid argument 'detach-after-handoff': agent-task cook cannot detach after
handoff with --placement local because no runner daemon owns the provider attempt
```

Adding one variable removes it and execution proceeds to worktree destination resolution:

```sh
HOMEBOY_LAB_OFFLOAD_JSON='{"runner_id":"homeboy-lab"}' homeboy \
  --placement local --detach-after-handoff agent-task cook \
  --prompt 'implement the fix' --to-worktree missing@worktree --verify true
```

This got materially worse when #10831 landed. Before it, the bypassed path errored quickly on a missing `--repo`. After it, cook projects a `review_form` contract and dispatches provider attempts, so the same bypass blocks indefinitely. The `homeboy / Test` gate produced its last pass at `2026-07-29T17:40Z`, and #10831 is the only commit between that run and the first failure at `18:03Z`. Full evidence in https://github.com/Extra-Chill/homeboy/issues/10917#issuecomment-5134703127.

## Why These Two Are Context-Free

Both are properties of the argument combination alone:

- `--queue-only` contradicts cook owning its controller-local lifecycle
- `--placement local` contradicts detaching after handoff, because no runner daemon exists to own the attempt

Neither depends on where the process runs, so neither belongs below a transport check.

## Moved, Not Duplicated

`run_split_placement_cook` keeps only its routing decision (`placement == Local` → fall through to local execution). Leaving a second copy of the rejections there would drift, and which message an operator sees must not depend on the path taken to reach it.

## Safety

No transport path reconstructs a contradictory cook argv. `lab_cook_attempt_args` builds the runner-side child as:

```rust
["homeboy", "--placement", "local", "agent-task", "run-plan", "--plan", ..., "--record-run-id", ...]
```

That is `run-plan`, not `cook`, so it does not match the pattern these rejections guard. The `detach_after_handoff: true` in `dispatch_controller_plan_to_lab` is a `LabCookAttemptDispatcher` struct field describing controller-side behaviour, not a flag forwarded to any child.

## Tests

- `cargo check -p homeboy-cli --lib` — passed
- `cargo check --test cook_lab_handoff_test` — passed
- `cargo fmt --all` — clean
- `git diff --check` — clean

New case `contradictory_cook_arguments_survive_controller_transport_context` explicitly injects `HOMEBOY_LAB_OFFLOAD_JSON` and asserts both rejections still fire and neither reaches worktree provider resolution. It is the inverse of `cook_handoff_subprocesses_do_not_inherit_controller_transport`: one proves the fixtures do not inherit the context, this one proves the outcome would not change if they did.

Behavioural verification is delegated to CI. This host cannot build the `homeboy` binary that `CARGO_BIN_EXE_homeboy` resolves to without exhausting RAM, so the integration cases could not be executed locally.

Refs #10917
