### PR TITLE
fix(refactor): fail local lint writes without changes

### DIFF
--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -471,7 +471,7 @@ pub(super) fn run_lint_stage(
         (Vec::new(), Vec::new(), Vec::new())
     };
 
-    let (stage_changed_files, mut stage_warnings, fix_results) = {
+    let (stage_changed_files, stage_warnings, fix_results) = {
         let (changed, results, warnings) = merge_lint_extension_stage(
             extension_stage,
             stage_changed_files,
@@ -482,20 +482,11 @@ pub(super) fn run_lint_stage(
     };
     let edit_count = fix_results.len();
 
-    // Reconcile advertised auto-fixable findings against what the fixer pass
-    // actually applied. The lint diagnostic advertises "N findings can be fixed
-    // automatically — run homeboy refactor --from lint --write", but the fixer
-    // pass (phpcbf + custom fixers) may apply zero edits — e.g. PHPCS marks a
-    // finding `fixable` but no registered sniff actually rewrites it, or the
-    // findings are warnings the fixer's severity config suppresses. Previously
-    // this returned a nominal success with edit_count: 0 and no explanation,
-    // sending operators to a command that does nothing (#9618). Surface the
-    // discrepancy as an explicit warning so the no-op is legible instead of
-    // silent.
+    // The diagnostic advertises these findings as safe to write. Returning a
+    // successful write result without a controller-worktree change would make
+    // callers retry the same fixer indefinitely.
     if write {
-        if let Some(warning) = unapplied_fixable_warning(&lint_findings, edit_count) {
-            stage_warnings.push(warning);
-        }
+        reject_unapplied_fixable_findings(&lint_findings, &stage_changed_files)?;
     }
 
     Ok(PlannedStage {
@@ -515,30 +506,33 @@ pub(super) fn run_lint_stage(
     })
 }
 
-/// Reconcile advertised auto-fixable findings against edits the fixer actually
-/// applied. Returns a warning when the lint diagnostic flagged findings as
-/// auto-fixable but the fixer pass applied zero edits (#9618). Returns `None`
-/// when no fixable findings were advertised or at least one edit landed, so a
-/// genuine fix run stays quiet.
-fn unapplied_fixable_warning(
+/// Fail a write that advertised fixable findings but left the local worktree
+/// unchanged. A warning is insufficient because it permits repeated no-op
+/// producer/fixer scans (#10935).
+fn reject_unapplied_fixable_findings(
     lint_findings: &[homeboy_core::finding::HomeboyFinding],
-    edit_count: usize,
-) -> Option<String> {
-    if edit_count > 0 {
-        return None;
+    changed_files: &[String],
+) -> homeboy_core::Result<()> {
+    if !changed_files.is_empty() {
+        return Ok(());
     }
     let advertised_fixable = lint_findings
         .iter()
         .filter(|finding| finding.fix.fixable == Some(true))
         .count();
     if advertised_fixable == 0 {
-        return None;
+        return Ok(());
     }
-    Some(format!(
-        "Lint advertised {advertised_fixable} auto-fixable finding(s) but the fixer pass applied 0 edits. \
-The linter's fixer (e.g. phpcbf + custom fixers) could not automatically rewrite these findings — \
-they may require manual remediation despite being flagged fixable. Re-run `homeboy lint <component>` \
-to see the remaining findings."
+    Err(Error::validation_invalid_argument(
+        "fix",
+        format!(
+            "Lint advertised {advertised_fixable} auto-fixable finding(s), but the fixer did not modify the local worktree"
+        ),
+        None,
+        Some(vec![
+            "Inspect the extension fixer output and local worktree permissions".to_string(),
+            "Run homeboy lint without --fix to inspect the remaining findings".to_string(),
+        ]),
     ))
 }
 
@@ -914,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    fn glob_fix_routes_diagnostics_to_extension_fixer_and_reruns_lint() {
+    fn local_lint_write_applies_routed_fixer_once_and_reports_changed_file() {
         homeboy_core::test_support::with_isolated_home(|home| {
             let root = tmp_dir("glob-routed-fix");
             init_routed_lint_repo(&root);
@@ -940,6 +934,8 @@ mod tests {
                 "resolved\n"
             );
             assert_eq!(stage.summary.changed_files, vec!["src/example.fixture"]);
+            assert!(stage.summary.applied);
+            assert_eq!(stage.summary.files_modified, 1);
             assert_eq!(
                 fs::read_to_string(root.join("runner.log")).unwrap(),
                 "diagnose:all\n1:fixture-fixer\ndiagnose:all\n"
@@ -1063,36 +1059,33 @@ mod tests {
     }
 
     #[test]
-    fn advertised_fixable_with_zero_edits_warns() {
-        // #9618: lint flags findings auto-fixable but the fixer applies nothing.
-        // The no-op must be surfaced instead of a silent success.
+    fn advertised_fixable_with_no_local_changes_fails() {
         let findings = vec![
             fixable_finding("src/a.php", true),
             fixable_finding("src/b.php", true),
         ];
-        let warning = unapplied_fixable_warning(&findings, 0)
-            .expect("advertised-fixable + zero edits must warn");
+        let error = reject_unapplied_fixable_findings(&findings, &[])
+            .expect_err("advertised-fixable + no local change must fail");
         assert!(
-            warning.contains("2 auto-fixable finding(s) but the fixer pass applied 0 edits"),
-            "warning must report the discrepancy: {warning}"
+            error.message.contains(
+                "2 auto-fixable finding(s), but the fixer did not modify the local worktree"
+            ),
+            "error must report the discrepancy: {error}"
         );
     }
 
     #[test]
-    fn advertised_fixable_with_edits_is_quiet() {
-        // A genuine fix run (at least one edit) must not warn.
+    fn advertised_fixable_with_local_changes_passes() {
         let findings = vec![fixable_finding("src/a.php", true)];
-        assert!(unapplied_fixable_warning(&findings, 3).is_none());
+        reject_unapplied_fixable_findings(&findings, &["src/a.php".to_string()]).unwrap();
     }
 
     #[test]
-    fn no_fixable_findings_is_quiet() {
-        // Findings exist but none are auto-fixable — zero edits is expected, so
-        // no misleading "fixer applied nothing" warning.
+    fn no_fixable_findings_with_no_local_changes_passes() {
         let findings = vec![
             fixable_finding("src/a.php", false),
             homeboy_core::finding::HomeboyFinding::builder("phpstan", "type error").build(),
         ];
-        assert!(unapplied_fixable_warning(&findings, 0).is_none());
+        reject_unapplied_fixable_findings(&findings, &[]).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- fail local lint refactor writes when advertised fixable findings leave the controller worktree unchanged
- retain durable changed-file reporting for successful local fixer runs
- cover one routed local write and the explicit no-change failure

Fixes #10935

## Tests
- cargo fmt --check
- cargo check -p homeboy-refactor
- cargo test -p homeboy-refactor plan::sources::stages::tests

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the refactor lint write path, drafted the focused fix and regression coverage. Chris Huber is responsible for every line.