### PR TITLE
fix(deploy): preserve provider component path

### DIFF
--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -218,6 +218,7 @@ pub fn run_deployment_provider(
     provider_id: &str,
     project_id: &str,
     component_id: &str,
+    component_path: &str,
     contract: &std::path::Path,
     dry_run: bool,
 ) -> Result<ExtensionRunResult> {
@@ -285,7 +286,7 @@ pub fn run_deployment_provider(
             Some(extension_path),
             None,
             None,
-            None,
+            Some(component_path),
         ),
         ExtensionExecutionMode::Captured,
     )?;
@@ -1014,6 +1015,7 @@ mod tests {
     fn deployment_provider_uses_the_declared_non_mutating_command() {
         homeboy_core::test_support::with_isolated_home(|home| {
             let contract = tempfile::NamedTempFile::new().expect("contract");
+            let component = tempfile::tempdir().expect("component");
             write_extension(
                 home.path(),
                 "fixture-provider",
@@ -1025,7 +1027,7 @@ mod tests {
                         "dry_run_command": "sh {{extension_path}}/run.sh validate {{payload.contract}}"
                     }]
                 }),
-                "#!/bin/sh\nprintf '%s' \"$1\"\n",
+                "#!/bin/sh\nprintf '%s|%s' \"$1\" \"$HOMEBOY_COMPONENT_PATH\"\n",
             );
 
             let result = run_deployment_provider(
@@ -1033,13 +1035,17 @@ mod tests {
                 "fixture.deploy",
                 "site",
                 "fixture",
+                component.path().to_str().expect("component path"),
                 contract.path(),
                 true,
             )
             .expect("provider dry run");
 
             assert_eq!(result.exit_code, 0);
-            assert_eq!(result.output.expect("output").stdout, "validate");
+            assert_eq!(
+                result.output.expect("output").stdout,
+                format!("validate|{}", component.path().display())
+            );
         });
     }
 

--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -136,6 +136,7 @@ fn run_component(
             &attachment.provider,
             project_id,
             &component.id,
+            &component.local_path,
             payload.path(),
             dry_run,
         )
@@ -152,6 +153,7 @@ fn run_component(
             &attachment.provider,
             project_id,
             &component.id,
+            &component.local_path,
             &contract,
             dry_run,
         )


### PR DESCRIPTION
## Summary

- thread the already project-resolved component path into deployment-provider execution
- export that explicit path as `HOMEBOY_COMPONENT_PATH` instead of re-resolving only the component ID from standalone storage
- preserve the same path contract for layered and legacy provider dispatch
- prove provider execution works for a project-only path with no standalone component registration

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-extension deployment_provider_uses_the_declared_non_mutating_command --lib --locked`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-release deploy::provider::tests --lib --locked` (5 passed)
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo check -p homeboy-extension -p homeboy-release --locked`

Closes #10952.

Downstream: https://github.com/Extra-Chill/homeboy-extensions/issues/2487
WP Codebox proof: https://github.com/Automattic/wp-codebox/issues/2157

## AI Assistance

OpenCode with OpenAI GPT-5.6 Sol was used to trace the project-path contract mismatch, implement explicit path propagation, add the project-only regression test, and run verification. Chris Huber remains responsible for every line.