### PR TITLE
fix(review): emit valid lint remediation commands

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/runner_contract.rs
+++ b/crates/contracts/homeboy-extension-contract/src/runner_contract.rs
@@ -19,7 +19,7 @@ pub const GENERIC_INFRASTRUCTURE_FAILURE_MARKERS: &[&str] = &[
 
 /// Shared verification phase vocabulary for isolated commands and composed runners.
 ///
-/// `homeboy lint`, `homeboy audit`, and `homeboy test` stay independent. A
+/// `homeboy review lint`, `homeboy review audit`, and `homeboy review test` stay independent. A
 /// future composed command can run these phases in canonical order while reusing
 /// the same phase reports and exit-code semantics.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1105,6 +1105,23 @@ mod tests {
     }
 
     #[test]
+    fn generated_quality_remediation_commands_parse() {
+        for argv in [
+            ["homeboy", "review", "audit", "fixture"].as_slice(),
+            ["homeboy", "review", "lint", "fixture"].as_slice(),
+            ["homeboy", "review", "test", "fixture"].as_slice(),
+            [
+                "homeboy", "refactor", "fixture", "--from", "lint", "--write",
+            ]
+            .as_slice(),
+        ] {
+            Cli::try_parse_from(argv).unwrap_or_else(|error| {
+                panic!("generated quality remediation failed to parse: {argv:?}\n{error}")
+            });
+        }
+    }
+
+    #[test]
     fn core_command_docs_do_not_drift_from_registry() {
         let root = workspace_root();
         let registered_docs = crate::command_contract::COMMAND_SPECS

--- a/crates/homeboy-core/src/engine/run_dir.rs
+++ b/crates/homeboy-core/src/engine/run_dir.rs
@@ -63,7 +63,7 @@ pub fn run_dir_env() -> String {
 
 /// A run directory for a single pipeline execution.
 ///
-/// Created once per `homeboy lint`, `homeboy test`, `homeboy refactor`, etc.
+/// Created once per `homeboy review lint`, `homeboy review test`, `homeboy refactor`, etc.
 /// Provides well-known paths for step outputs and generates backward-compatible
 /// env var mappings for extension scripts.
 #[derive(Debug, Clone)]

--- a/crates/homeboy-core/src/http_api/sandbox_tools.rs
+++ b/crates/homeboy-core/src/http_api/sandbox_tools.rs
@@ -16,7 +16,7 @@ pub struct SandboxToolDescriptor {
 const SANDBOX_TOOLS: &[SandboxToolDescriptor] = &[
     SandboxToolDescriptor {
         id: "homeboy.audit",
-        command: "homeboy audit",
+        command: "homeboy review audit",
         required_capability: "run:audit",
         risk: "bounded_local_run",
         runs_as_job: true,
@@ -33,7 +33,7 @@ const SANDBOX_TOOLS: &[SandboxToolDescriptor] = &[
     },
     SandboxToolDescriptor {
         id: "homeboy.lint",
-        command: "homeboy lint",
+        command: "homeboy review lint",
         required_capability: "run:lint",
         risk: "bounded_local_run",
         runs_as_job: true,
@@ -54,7 +54,7 @@ const SANDBOX_TOOLS: &[SandboxToolDescriptor] = &[
     },
     SandboxToolDescriptor {
         id: "homeboy.test",
-        command: "homeboy test",
+        command: "homeboy review test",
         required_capability: "run:test",
         risk: "bounded_local_run",
         runs_as_job: true,
@@ -190,7 +190,24 @@ pub fn kind(id: &str) -> Result<JobReadyRunKind> {
 
 #[cfg(test)]
 mod tests {
-    use super::{get, kind};
+    use super::{all, get, kind};
+
+    #[test]
+    fn quality_tool_descriptors_use_nested_review_commands() {
+        for (id, command) in [
+            ("homeboy.audit", "homeboy review audit"),
+            ("homeboy.lint", "homeboy review lint"),
+            ("homeboy.test", "homeboy review test"),
+        ] {
+            assert_eq!(
+                all()
+                    .iter()
+                    .find(|tool| tool.id == id)
+                    .map(|tool| tool.command),
+                Some(command)
+            );
+        }
+    }
 
     #[test]
     fn fuzz_descriptor_exposes_safe_non_job_subcommands() {

--- a/crates/homeboy-core/src/observation/records/run_builder.rs
+++ b/crates/homeboy-core/src/observation/records/run_builder.rs
@@ -105,10 +105,13 @@ mod tests {
     #[test]
     fn test_command() {
         let record = NewRunRecord::builder("lint")
-            .command("homeboy lint homeboy")
+            .command("homeboy review lint homeboy")
             .build();
 
-        assert_eq!(record.command.as_deref(), Some("homeboy lint homeboy"));
+        assert_eq!(
+            record.command.as_deref(),
+            Some("homeboy review lint homeboy")
+        );
     }
 
     #[test]
@@ -178,24 +181,27 @@ mod tests {
     #[test]
     fn test_metadata() {
         let record = NewRunRecord::builder("lint")
-            .metadata(serde_json::json!({ "source": "homeboy lint" }))
+            .metadata(serde_json::json!({ "source": "homeboy review lint" }))
             .build();
 
-        assert_eq!(record.metadata_json["source"], "homeboy lint");
+        assert_eq!(record.metadata_json["source"], "homeboy review lint");
     }
 
     #[test]
     fn test_build() {
         let record = NewRunRecord::builder("lint")
             .component_id("homeboy")
-            .command("homeboy lint homeboy")
+            .command("homeboy review lint homeboy")
             .cwd_path(Path::new("/tmp/homeboy"))
             .current_homeboy_version()
             .build();
 
         assert_eq!(record.kind, "lint");
         assert_eq!(record.component_id.as_deref(), Some("homeboy"));
-        assert_eq!(record.command.as_deref(), Some("homeboy lint homeboy"));
+        assert_eq!(
+            record.command.as_deref(),
+            Some("homeboy review lint homeboy")
+        );
         assert_eq!(record.cwd.as_deref(), Some("/tmp/homeboy"));
         assert_eq!(
             record.homeboy_version.as_deref(),

--- a/crates/homeboy-core/src/observation/store/findings.rs
+++ b/crates/homeboy-core/src/observation/store/findings.rs
@@ -314,7 +314,7 @@ mod tests {
     fn new_run() -> NewRunRecord {
         NewRunRecord::builder("lint")
             .component_id("homeboy")
-            .command("homeboy lint")
+            .command("homeboy review lint")
             .cwd_path(std::path::Path::new("/tmp/homeboy"))
             .homeboy_version("test")
             .build()

--- a/crates/homeboy-extension/src/lint/run/hints.rs
+++ b/crates/homeboy-extension/src/lint/run/hints.rs
@@ -1,31 +1,11 @@
-//! Auto-fix hint assembly — renders the `homeboy lint --fix` / `homeboy
-//! refactor --from lint --write` CTAs while preserving the active scope flags.
+//! Auto-fix hint assembly — renders the `homeboy refactor --from lint --write`
+//! CTA while preserving the active scope flags.
 
 use super::types::LintRunWorkflowArgs;
 use homeboy_engine_primitives::shell;
 
 pub(super) fn build_autofix_hint(args: &LintRunWorkflowArgs) -> String {
-    let lint_command = lint_autofix_command(args);
-
-    if refactor_can_preserve_scope(args) {
-        let refactor_command = refactor_autofix_command(args);
-        format!("Auto-fix: {lint_command} (or {refactor_command})")
-    } else {
-        format!("Auto-fix: {lint_command}")
-    }
-}
-
-fn lint_autofix_command(args: &LintRunWorkflowArgs) -> String {
-    let mut parts = vec![
-        "homeboy".to_string(),
-        "lint".to_string(),
-        args.component_label.clone(),
-    ];
-
-    append_common_scope_args(&mut parts, args);
-    parts.push("--fix".to_string());
-
-    shell::quote_args(&parts)
+    format!("Auto-fix: {}", refactor_autofix_command(args))
 }
 
 fn refactor_autofix_command(args: &LintRunWorkflowArgs) -> String {
@@ -43,25 +23,6 @@ fn refactor_autofix_command(args: &LintRunWorkflowArgs) -> String {
     ]);
 
     shell::quote_args(&parts)
-}
-
-fn refactor_can_preserve_scope(args: &LintRunWorkflowArgs) -> bool {
-    args.file.is_none() && args.glob.is_none() && !args.changed_only
-}
-
-fn append_common_scope_args(parts: &mut Vec<String>, args: &LintRunWorkflowArgs) {
-    append_path_and_changed_since_args(parts, args);
-    if let Some(file) = &args.file {
-        parts.push("--file".to_string());
-        parts.push(file.clone());
-    }
-    if let Some(glob) = &args.glob {
-        parts.push("--glob".to_string());
-        parts.push(glob.clone());
-    }
-    if args.changed_only {
-        parts.push("--changed-only".to_string());
-    }
 }
 
 fn append_path_and_changed_since_args(parts: &mut Vec<String>, args: &LintRunWorkflowArgs) {

--- a/crates/homeboy-extension/src/lint/run/tests/hints.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/hints.rs
@@ -9,11 +9,10 @@ fn autofix_hint_preserves_changed_since_scope() {
 
     let hint = build_autofix_hint(&args);
 
-    assert!(hint
-        .contains("homeboy lint demo --path '/tmp/pr checkout' --changed-since origin/main --fix"));
-    assert!(hint.contains(
-        "homeboy refactor demo --path '/tmp/pr checkout' --changed-since origin/main --from lint --write"
-    ));
+    assert_eq!(
+        hint,
+        "Auto-fix: homeboy refactor demo --path '/tmp/pr checkout' --changed-since origin/main --from lint --write"
+    );
 }
 
 #[test]
@@ -24,6 +23,5 @@ fn autofix_hint_preserves_changed_only_and_file_scope() {
 
     let hint = build_autofix_hint(&args);
 
-    assert!(hint.contains("homeboy lint demo --file src/lib.rs --changed-only --fix"));
-    assert!(!hint.contains("homeboy refactor"));
+    assert_eq!(hint, "Auto-fix: homeboy refactor demo --from lint --write");
 }

--- a/crates/homeboy-issues/src/lib.rs
+++ b/crates/homeboy-issues/src/lib.rs
@@ -1,7 +1,7 @@
 //! Issue reconciliation: finding-stream → tracker.
 //!
 //! This module turns a structured stream of categorized findings (from
-//! `homeboy audit`, `homeboy lint`, `homeboy test`) into a deterministic
+//! `homeboy review audit`, `homeboy review lint`, `homeboy review test`) into a deterministic
 //! plan against an issue tracker. The plan can then be printed (dry-run)
 //! or executed via a [`Tracker`] implementation.
 //!

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2897,16 +2897,16 @@ mod tests {
             .expect("controller repair surface");
         write_executable(
             &tools.join("homeboy"),
-            "#!/bin/sh\n[ \"$1\" = lint ] && [ \"$2\" = fixture ] && [ \"$3\" = --path ] && [ -f \"$4/lint-target\" ] && [ \"$5\" = --fix ]\n",
+            "#!/bin/sh\n[ \"$1\" = refactor ] && [ \"$2\" = fixture ] && [ \"$3\" = --path ] && [ -f \"$4/lint-target\" ] && [ \"$5\" = --from ] && [ \"$6\" = lint ] && [ \"$7\" = --write ]\n",
         );
 
         let remote = runner_source.display().to_string();
         let local = controller_source.display().to_string();
         let output = serde_json::json!({
             "success": false,
-            "hints": [format!("Auto-fix: homeboy lint fixture --path {remote} --fix")],
+            "hints": [format!("Auto-fix: homeboy refactor fixture --path {remote} --from lint --write")],
             "next_actions": [{
-                "command": format!("homeboy lint fixture --path {remote} --fix")
+                "command": format!("homeboy refactor fixture --path {remote} --from lint --write")
             }],
             "data": {
                 "source_sidecar_path": format!("{remote}/lint-findings.json"),
@@ -2929,7 +2929,10 @@ mod tests {
         let action = result["next_actions"][0]["command"]
             .as_str()
             .expect("repair action");
-        assert_eq!(action, format!("homeboy lint fixture --path {local} --fix"));
+        assert_eq!(
+            action,
+            format!("homeboy refactor fixture --path {local} --from lint --write")
+        );
         assert!(
             std::path::Path::new(&local).join("lint-target").is_file(),
             "the translated action still targets the controller repair surface after cleanup"

--- a/crates/homeboy-refactor/src/plan/sources/cache.rs
+++ b/crates/homeboy-refactor/src/plan/sources/cache.rs
@@ -45,7 +45,7 @@ pub(super) fn try_load_cached_audit() -> Option<CodeAuditResult> {
     Some(result)
 }
 
-/// Try to load cached lint findings from a previous `homeboy lint` run.
+/// Try to load cached lint findings from a previous `homeboy review lint` run.
 ///
 /// Checks `HOMEBOY_OUTPUT_DIR/lint.json` for a `CliResponse<LintCommandOutput>`
 /// envelope. If found and the run passed (zero findings), returns `Clean`

--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -537,7 +537,7 @@ fn unapplied_fixable_warning(
     Some(format!(
         "Lint advertised {advertised_fixable} auto-fixable finding(s) but the fixer pass applied 0 edits. \
 The linter's fixer (e.g. phpcbf + custom fixers) could not automatically rewrite these findings — \
-they may require manual remediation despite being flagged fixable. Re-run `homeboy lint <component>` \
+they may require manual remediation despite being flagged fixable. Re-run `homeboy review lint <component>` \
 to see the remaining findings."
     ))
 }
@@ -1076,6 +1076,7 @@ mod tests {
             warning.contains("2 auto-fixable finding(s) but the fixer pass applied 0 edits"),
             "warning must report the discrepancy: {warning}"
         );
+        assert!(warning.contains("homeboy review lint <component>"));
     }
 
     #[test]

--- a/crates/homeboy-review/src/review/render.rs
+++ b/crates/homeboy-review/src/review/render.rs
@@ -521,7 +521,7 @@ mod tests {
             passed: true,
             exit_code: 0,
             finding_count: 0,
-            hint: "Deep dive: homeboy audit my-comp".to_string(),
+            hint: "Deep dive: homeboy review audit my-comp".to_string(),
             skipped_reason: None,
             output: Some(audit_full_with_findings(Vec::new())),
         }
@@ -534,7 +534,7 @@ mod tests {
             passed: true,
             exit_code: 0,
             finding_count: 0,
-            hint: "Deep dive: homeboy lint my-comp".to_string(),
+            hint: "Deep dive: homeboy review lint my-comp".to_string(),
             skipped_reason: None,
             output: Some(lint_with_findings(Vec::new())),
         }
@@ -547,7 +547,7 @@ mod tests {
             passed: true,
             exit_code: 0,
             finding_count: 0,
-            hint: "Deep dive: homeboy test my-comp".to_string(),
+            hint: "Deep dive: homeboy review test my-comp".to_string(),
             skipped_reason: None,
             output: Some(test_with_counts(passed, 0, 0)),
         }
@@ -1188,9 +1188,9 @@ mod tests {
     fn renders_deep_dive_hints_for_ran_stages() {
         let env = passing_envelope();
         let md = render_pr_comment(&env);
-        assert!(md.contains("> Deep dive: homeboy audit my-comp"));
-        assert!(md.contains("> Deep dive: homeboy lint my-comp"));
-        assert!(md.contains("> Deep dive: homeboy test my-comp"));
+        assert!(md.contains("> Deep dive: homeboy review audit my-comp"));
+        assert!(md.contains("> Deep dive: homeboy review lint my-comp"));
+        assert!(md.contains("> Deep dive: homeboy review test my-comp"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #10934

## Summary
- replace the nonexistent `homeboy lint --fix` remediation with the canonical `homeboy refactor --from lint --write` command
- update emitted audit, lint, and test descriptor commands to their nested `homeboy review` grammar
- cover generated quality remediation command parsing and Lab path-remapped repair actions

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-extension lint::run::tests::hints`
- `cargo test -p homeboy-refactor advertised_fixable_with_zero_edits_warns`
- `cargo test -p homeboy-core http_api::sandbox_tools`
- `cargo test -p homeboy-cli generated_quality_remediation_commands_parse`
- `cargo test -p homeboy-review review::render`
- `cargo test -p homeboy-lab-runner portable_result_keeps_repair_actions_and_sidecars_valid_after_runner_cleanup`
- `cargo check -p homeboy-extension -p homeboy-refactor -p homeboy-core -p homeboy-cli -p homeboy-review -p homeboy-lab-runner -p homeboy-issues -p homeboy-extension-contract`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to investigate the command-surface regression, implement the remediation updates, and add regression coverage. Chris Huber is responsible for every line.