### PR TITLE
fix(deploy): report unverified manifest evidence

### DIFF
--- a/crates/contracts/homeboy-release-contract/src/lib.rs
+++ b/crates/contracts/homeboy-release-contract/src/lib.rs
@@ -33,6 +33,8 @@ pub enum DeployReason {
 pub enum ComponentStatus {
     /// Local and remote versions match
     UpToDate,
+    /// Versions match, but content-manifest verification did not produce digest proof.
+    VersionUpToDateContentUnverified,
     /// Local version ahead of remote (needs deploy)
     NeedsUpdate,
     /// Remote version ahead of local (local behind)

--- a/crates/homeboy-cli/src/commands/fleet.rs
+++ b/crates/homeboy-cli/src/commands/fleet.rs
@@ -476,6 +476,7 @@ fn log_fleet_dashboard(result: &FleetStatusResult) {
             let remote = comp.remote_version.as_deref().unwrap_or("-");
             let drift_icon = match &comp.drift {
                 FleetComponentDrift::Current => "✅ current",
+                FleetComponentDrift::VersionUpToDateContentUnverified => "⚠️  content unverified",
                 FleetComponentDrift::NeedsUpdate => "⚠️  outdated",
                 FleetComponentDrift::BehindRemote => "🔙 behind",
                 FleetComponentDrift::BehindUpstream => "⬇️  behind upstream",

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -510,6 +510,7 @@ fn deployed_version_dashboard_status(
         }
         homeboy_release::deploy::ComponentStatus::BehindUpstream
         | homeboy_release::deploy::ComponentStatus::SourceStale
+        | homeboy_release::deploy::ComponentStatus::VersionUpToDateContentUnverified
         | homeboy_release::deploy::ComponentStatus::RemoteModified
         | homeboy_release::deploy::ComponentStatus::Missing
         | homeboy_release::deploy::ComponentStatus::MixedDrift => {

--- a/crates/homeboy-core/src/fleet/check.rs
+++ b/crates/homeboy-core/src/fleet/check.rs
@@ -52,6 +52,9 @@ pub fn collect_check(
                 for comp_result in &results {
                     let status_str = match &comp_result.component_status {
                         Some(ComponentStatus::UpToDate) => "up_to_date",
+                        Some(ComponentStatus::VersionUpToDateContentUnverified) => {
+                            "version_up_to_date_content_unverified"
+                        }
                         Some(ComponentStatus::NeedsUpdate) => "needs_update",
                         Some(ComponentStatus::BehindRemote) => "behind_remote",
                         Some(ComponentStatus::BehindUpstream) => "behind_upstream",
@@ -67,7 +70,9 @@ pub fn collect_check(
                         Some(status) if status.requires_deploy() => {
                             summary.components_needs_update += 1
                         }
-                        Some(ComponentStatus::Unknown) | None => summary.components_unknown += 1,
+                        Some(ComponentStatus::VersionUpToDateContentUnverified)
+                        | Some(ComponentStatus::Unknown)
+                        | None => summary.components_unknown += 1,
                         Some(_) => {}
                     }
 

--- a/crates/homeboy-core/src/fleet/status.rs
+++ b/crates/homeboy-core/src/fleet/status.rs
@@ -29,6 +29,8 @@ pub struct FleetComponentStatus {
 pub enum FleetComponentDrift {
     /// Local and remote versions match
     Current,
+    /// Versions match but content-manifest verification lacks digest proof.
+    VersionUpToDateContentUnverified,
     /// Local version is ahead of remote (needs deploy)
     NeedsUpdate,
     /// Remote version is ahead of local
@@ -302,6 +304,7 @@ fn collect_project_component_statuses(
                     // deployment required from the configured source.
                     FleetComponentDrift::BehindRemote
                     | FleetComponentDrift::BehindUpstream
+                    | FleetComponentDrift::VersionUpToDateContentUnverified
                     | FleetComponentDrift::RemoteModified
                     | FleetComponentDrift::Missing
                     | FleetComponentDrift::MixedDrift => {}
@@ -378,6 +381,9 @@ fn resolve_component_drift(
     // Fall back to deploy status for drift detection
     let drift = match deploy_status {
         Some(ComponentStatus::UpToDate) => FleetComponentDrift::Current,
+        Some(ComponentStatus::VersionUpToDateContentUnverified) => {
+            FleetComponentDrift::VersionUpToDateContentUnverified
+        }
         Some(ComponentStatus::NeedsUpdate) => FleetComponentDrift::NeedsUpdate,
         Some(ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
         Some(ComponentStatus::BehindUpstream) => FleetComponentDrift::BehindUpstream,

--- a/crates/homeboy-release/src/deploy/content_manifest.rs
+++ b/crates/homeboy-release/src/deploy/content_manifest.rs
@@ -688,22 +688,29 @@ fn parse_remote_manifest(output: &str, exclusions: &[String]) -> Result<Manifest
     let mut manifest = Manifest::default();
     for line in output.lines() {
         let mut fields = line.splitn(4, '\t');
-        let (Some(kind), Some(path), Some(mode), Some(value)) =
-            (fields.next(), fields.next(), fields.next(), fields.next())
-        else {
-            return Err("malformed remote manifest evidence".to_string());
-        };
-        let path = normalize_path(path)?;
+        let kind = fields
+            .next()
+            .ok_or_else(|| malformed_remote_field("kind", line))?;
+        let path = fields
+            .next()
+            .ok_or_else(|| malformed_remote_field("path", line))?;
+        let mode = fields
+            .next()
+            .ok_or_else(|| malformed_remote_field("mode", line))?;
+        let value = fields
+            .next()
+            .ok_or_else(|| malformed_remote_field("value", line))?;
+        let path = normalize_path(path).map_err(|_| malformed_remote_field("path", path))?;
         if ignored(&path, exclusions) {
             continue;
         }
         let kind = match kind {
             "f" => TreeEntryKind::File,
             "l" => TreeEntryKind::Symlink,
-            _ => return Err("unsupported remote manifest entry".to_string()),
+            _ => return Err(malformed_remote_field("kind", kind)),
         };
-        let mode = u32::from_str_radix(mode, 8)
-            .map_err(|_| "malformed remote manifest mode".to_string())?;
+        let mode =
+            u32::from_str_radix(mode, 8).map_err(|_| malformed_remote_field("mode", mode))?;
         let mode = if kind == TreeEntryKind::Symlink {
             "0".to_string()
         } else {
@@ -712,10 +719,11 @@ fn parse_remote_manifest(output: &str, exclusions: &[String]) -> Result<Manifest
         if kind == TreeEntryKind::File
             && (value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()))
         {
-            return Err("malformed remote SHA-256 evidence".to_string());
+            return Err(malformed_remote_field("sha256", value));
         }
         if kind == TreeEntryKind::Symlink {
-            let value = validate_link_target(&path, value)?;
+            let value = validate_link_target(&path, value)
+                .map_err(|_| malformed_remote_field("symlink_target", value))?;
             manifest.entries.insert(
                 path,
                 TreeEntry {
@@ -739,6 +747,21 @@ fn parse_remote_manifest(output: &str, exclusions: &[String]) -> Result<Manifest
         );
     }
     Ok(manifest)
+}
+
+fn malformed_remote_field(field: &str, value: &str) -> String {
+    const MAX_DIAGNOSTIC_VALUE_BYTES: usize = 160;
+
+    let mut diagnostic = String::new();
+    for character in value.chars() {
+        let escaped = character.escape_default().to_string();
+        if diagnostic.len() + escaped.len() > MAX_DIAGNOSTIC_VALUE_BYTES {
+            diagnostic.push_str("...");
+            break;
+        }
+        diagnostic.push_str(&escaped);
+    }
+    format!("malformed remote manifest field '{field}': '{diagnostic}'")
 }
 
 /// Paths excluded from every deploy manifest, whatever produced it.
@@ -884,13 +907,39 @@ mod tests {
     }
     #[test]
     fn remote_manifest_requires_well_formed_hash_evidence() {
-        assert!(parse_remote_manifest("f\tpath\t644\n", &[]).is_err());
-        assert!(parse_remote_manifest("f\tpath\t644\tnot-a-hash\n", &[]).is_err());
+        let missing = parse_remote_manifest("f\tpath\t644\n", &[]).expect_err("missing hash");
+        assert_eq!(
+            missing,
+            "malformed remote manifest field 'value': 'f\\tpath\\t644'"
+        );
+        let malformed =
+            parse_remote_manifest("f\tpath\t644\tnot-a-hash\n", &[]).expect_err("malformed hash");
+        assert_eq!(
+            malformed,
+            "malformed remote manifest field 'sha256': 'not-a-hash'"
+        );
+        let oversized = parse_remote_manifest(&format!("f\tpath\t644\t{}\n", "x".repeat(200)), &[])
+            .expect_err("oversized malformed hash");
+        assert!(oversized.ends_with("...'"), "{oversized}");
+        assert!(oversized.len() < 210, "{oversized}");
         assert!(parse_remote_manifest(
             "f\t../path\t644\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
             &[]
         )
         .is_err());
+    }
+
+    #[test]
+    fn remote_manifest_valid_digest_matches_local_tree() {
+        let temp = tempfile::tempdir().expect("temp");
+        let local = temp.path().join("local");
+        fs::create_dir_all(&local).expect("local");
+        fs::write(local.join("plugin.php"), "release").expect("plugin");
+        let digest = sha256(&local.join("plugin.php")).expect("digest");
+
+        let remote = parse_remote_manifest(&format!("f\tplugin.php\t644\t{digest}\n"), &[])
+            .expect("valid remote evidence");
+        assert!(differences(&local_manifest(&local).expect("local manifest"), &remote).is_empty());
     }
 
     /// #10290: deploy and recovery now share one walker, and this pins the two

--- a/crates/homeboy-release/src/deploy/orchestration/modes.rs
+++ b/crates/homeboy-release/src/deploy/orchestration/modes.rs
@@ -106,6 +106,9 @@ pub(super) fn run_check_mode(
             } else if manifest.status == "different" && !matches!(status, ComponentStatus::UpToDate)
             {
                 status = ComponentStatus::MixedDrift;
+            } else if manifest.status == "unavailable" && matches!(status, ComponentStatus::UpToDate)
+            {
+                status = ComponentStatus::VersionUpToDateContentUnverified;
             }
             let mut result = ComponentDeployResult::new_for_project(c, project, base_path)
                 .with_status("checked")
@@ -822,6 +825,10 @@ mod tests {
             .expect("unavailable canonical package evidence");
         assert_eq!(manifest.status, "unavailable");
         assert_eq!(manifest.scope, "canonical-package-unavailable");
+        assert_eq!(
+            mutated.results[0].component_status,
+            Some(ComponentStatus::VersionUpToDateContentUnverified)
+        );
         assert_eq!(
             manifest
                 .provenance

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -83,7 +83,7 @@ If no component IDs are provided and none of `--all`, `--outdated`, `--behind-up
       "id": "<component_id>",
       "status": "deployed|failed|skipped|planned|checked",
       "deploy_reason": "explicitly_selected|all_selected|version_mismatch|unknown_local_version|unknown_remote_version",
-      "component_status": "up_to_date|needs_update|behind_remote|behind_upstream|source_stale|unknown",
+      "component_status": "up_to_date|version_up_to_date_content_unverified|needs_update|behind_remote|behind_upstream|source_stale|remote_modified|missing|mixed_drift|unknown",
       "local_version": "<v>|null",
       "remote_version": "<v>|null",
       "error": "<string>|null",
@@ -125,6 +125,7 @@ Note: `build_exit_code`/`deploy_exit_code` are numbers when present (not strings
 When using `--check`, each component result includes a `component_status` field:
 
 - `up_to_date`: local and remote versions match
+- `version_up_to_date_content_unverified`: versions match, but content-manifest verification did not produce digest proof
 - `needs_update`: local version ahead of remote (needs deployment)
 - `behind_remote`: remote version ahead of local (local is behind)
 - `behind_upstream`: local checkout is behind its upstream branch


### PR DESCRIPTION
Fixes #10947

## Summary
- classify malformed remote archive manifests by field and retain escaped, bounded raw evidence
- report `version_up_to_date_content_unverified` when versions match but content digest proof is unavailable
- propagate the status through fleet output and document the contract

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-release remote_manifest_`
- `cargo test -p homeboy-release check_uses_canonical_package_for_clean_and_modified_production_trees`
- `cargo test -p homeboy-core fleet`
- `cargo check --workspace --quiet`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the WordPress archive remote-manifest producer/parser, drafted the implementation and tests, and ran verification. Chris Huber is responsible for every line.