### PR TITLE
fix(deploy): canonicalize provider policy digest

### DIFF
--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -501,13 +501,12 @@ mod tests {
             None,
         );
         let policy = serde_json::json!({
-            "wrangler": {
-                "config_ref": "wrangler.jsonc",
-                "config": "wrangler.jsonc",
-                "binary": "wrangler"
+            "limits": {
+                "timeout_ms": 120000,
+                "attempts": 3
             },
-            "timeout_ms": 120000,
-            "expected_bindings": ["DATABASE"]
+            "steps": ["prepare", "apply"],
+            "mode": "strict"
         });
         let payload = layered_payload(
             &component,
@@ -528,7 +527,7 @@ mod tests {
         );
         assert_eq!(
             value["policy"]["reference"]["digest"],
-            "13d79940b8c45f3df966296bf3080f254c281aaefd09b3308497ed94aede0486"
+            "949ad67abac10d72ad874d207bff61620811c313540a65be3a9d697d280f5412"
         );
         assert_eq!(value["target"], serde_json::json!({ "target": "one" }));
         assert_eq!(value["source"]["revision"].as_str().map(str::len), Some(40));

--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -216,7 +216,7 @@ fn layered_payload(
     policy: &serde_json::Value,
     target: Option<&serde_json::Value>,
 ) -> Result<tempfile::NamedTempFile> {
-    let policy_bytes = serde_json::to_vec(policy)
+    let policy_bytes = homeboy_engine_primitives::canonical_json::canonical_json_bytes(policy)
         .map_err(|_| Error::internal_io("Could not serialize deployment provider policy", None))?;
     let revision = clean_head_revision(component)?;
     let payload = serde_json::json!({
@@ -500,9 +500,18 @@ mod tests {
             String::new(),
             None,
         );
+        let policy = serde_json::json!({
+            "wrangler": {
+                "config_ref": "wrangler.jsonc",
+                "config": "wrangler.jsonc",
+                "binary": "wrangler"
+            },
+            "timeout_ms": 120000,
+            "expected_bindings": ["DATABASE"]
+        });
         let payload = layered_payload(
             &component,
-            &serde_json::json!({ "policy": "repository" }),
+            &policy,
             Some(&serde_json::json!({ "target": "one" })),
         )
         .expect("payload");
@@ -511,10 +520,7 @@ mod tests {
         let value: serde_json::Value =
             serde_json::from_reader(payload.reopen().expect("reopen")).expect("payload json");
         assert_eq!(value["schema"], "homeboy/deployment-provider-payload/v1");
-        assert_eq!(
-            value["policy"]["value"],
-            serde_json::json!({ "policy": "repository" })
-        );
+        assert_eq!(value["policy"]["value"], policy);
         assert_eq!(value["policy"]["reference"]["component"], "fixture");
         assert_eq!(
             value["policy"]["reference"]["path"],
@@ -522,16 +528,13 @@ mod tests {
         );
         assert_eq!(
             value["policy"]["reference"]["digest"],
-            homeboy_engine_primitives::content_hash::sha256_hex(
-                &serde_json::to_vec(&serde_json::json!({ "policy": "repository" }))
-                    .expect("policy bytes")
-            )
+            "13d79940b8c45f3df966296bf3080f254c281aaefd09b3308497ed94aede0486"
         );
         assert_eq!(value["target"], serde_json::json!({ "target": "one" }));
         assert_eq!(value["source"]["revision"].as_str().map(str::len), Some(40));
         let second = layered_payload(
             &component,
-            &serde_json::json!({ "policy": "repository" }),
+            &policy,
             Some(&serde_json::json!({ "target": "two" })),
         )
         .expect("second payload");

--- a/docs/reference/schemas/portable-config.md
+++ b/docs/reference/schemas/portable-config.md
@@ -99,7 +99,7 @@ Build, lint, test, bench, trace, and deps behavior resolves from `scripts.<capab
 
 Use `deploy_together` for coupled components that are versioned or built separately but must stay in sync at runtime. When a deploy selection includes one member of a declared group without the rest, Homeboy fails the plan before building or uploading.
 
-Layered deployment providers keep all repository-owned Homeboy policy inline in root `homeboy.json` under `deployment_provider.policy`. Product, application, and runtime code has no Homeboy dependency and does not need a separate deployment contract file. `deployment_provider.contract` remains available only for legacy unlayered providers. Provider target input is intentionally project-only and never belongs in portable `homeboy.json`.
+Layered deployment providers keep all repository-owned Homeboy policy inline in root `homeboy.json` under `deployment_provider.policy`. Product, application, and runtime code has no Homeboy dependency and does not need a separate deployment contract file. `deployment_provider.contract` remains available only for legacy unlayered providers. Provider target input is intentionally project-only and never belongs in portable `homeboy.json`. The `homeboy/deployment-provider-payload/v1` policy reference digest is SHA-256 over Homeboy canonical JSON bytes: object keys are recursively sorted, arrays preserve order, and scalar values are unchanged.
 
 ## Precedence
 


### PR DESCRIPTION
## Summary

- generate layered deployment policy digests from the shared canonical JSON bytes primitive
- document the exact key, array, and scalar encoding contract for provider consumers
- pin an opaque nested policy to a fixed SHA-256 vector reproducible outside Rust
- preserve payload shape, private temporary-file lifecycle, and target separation

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-release deploy::provider::tests --lib --locked` (5 passed)
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-shared-target cargo test -p homeboy-engine-primitives canonical_json --lib --locked` (5 passed)
- `cargo test -p homeboy-release layered_payload_is_namespaced_private_and_removed` (1 passed after generic fixture correction)

Closes #10956.

Consumer: https://github.com/Extra-Chill/homeboy-extensions/issues/2487
WP Codebox proof: https://github.com/Automattic/wp-codebox/issues/2157

## AI Assistance

OpenCode with OpenAI GPT-5.6 Sol was used to review cross-language digest compatibility, route the producer through the shared canonical JSON primitive, establish the fixed generic compatibility vector, and run verification. Chris Huber remains responsible for every line.