### PR TITLE
fix(release): resolve a draft by id instead of scanning every release

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -56,6 +56,23 @@ pub(crate) struct GitHubReleaseMetadataError {
     pub diagnostics: Vec<GitHubCommandFailureDiagnostic>,
 }
 
+impl GitHubReleaseMetadataError {
+    /// Combine two resolution failures so neither is lost.
+    ///
+    /// A stranded release is diagnosed from why EVERY lookup failed. Collapsing
+    /// the later failure into the earlier one is what made run 30313665269
+    /// unreadable: it reported only the expected 404 and no trace of why the
+    /// draft lookup did not recover it (#10441).
+    fn join(self, other: Self) -> Self {
+        let mut diagnostics = self.diagnostics;
+        diagnostics.extend(other.diagnostics);
+        Self {
+            message: format!("{}; {}", self.message, other.message),
+            diagnostics,
+        }
+    }
+}
+
 impl std::fmt::Display for GitHubReleaseMetadataError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(&self.message)
@@ -505,8 +522,106 @@ pub(crate) fn gh_release_metadata(
     // that strands a release undiagnosable -- which is exactly what run
     // 30313665269 left behind for v0.321.1: a step error naming only the
     // expected 404, with no trace of why the draft lookup did not recover it.
-    gh_draft_release_metadata(github, config, tag, repo_flag)
-        .map_err(|draft_error| metadata_fallback_error(&endpoint, &output, draft_error))
+    // Resolve the release id directly, then read REST metadata by id.
+    //
+    // `gh release view` is GraphQL-backed and DOES see drafts, so it answers
+    // "which release is this tag" in one call. Reading `releases/{id}` then
+    // returns the REST shape -- including the asset digests recovery depends
+    // on, which the GraphQL asset shape omits.
+    //
+    // This replaces scanning the release list. That scan paginated the whole
+    // repository: `Extra-Chill/homeboy-extensions` carries 920 releases, so
+    // finding a draft created seconds earlier cost ~31 sequential API calls and
+    // intermittently returned nothing at all, leaving
+    // "the draft fallback also failed: no GitHub Release matched tag" and a
+    // stranded draft. The list scan is kept as a last resort so a repository
+    // where `gh release view` cannot resolve the tag still has a path.
+    match gh_release_metadata_by_id(github, config, tag, repo_flag) {
+        Ok(metadata) => Ok(metadata),
+        Err(by_id_error) => {
+            gh_draft_release_metadata(github, config, tag, repo_flag).map_err(|draft_error| {
+                metadata_fallback_error(&endpoint, &output, by_id_error.join(draft_error))
+            })
+        }
+    }
+}
+
+/// Resolve a release (published or draft) by id.
+///
+/// Two calls, both O(1): `gh release view --json databaseId` sees drafts
+/// because it is GraphQL-backed, and `repos/{owner}/{repo}/releases/{id}`
+/// returns the REST shape whose `digest` field recovery requires.
+fn gh_release_metadata_by_id(
+    github: &GitHubRepo,
+    config: &GithubConfig,
+    tag: &str,
+    repo_flag: &str,
+) -> Result<GitHubReleaseMetadata, GitHubReleaseMetadataError> {
+    let view = run_gh_command(
+        gh_command(
+            github,
+            config,
+            &[
+                "release",
+                "view",
+                tag,
+                "--repo",
+                repo_flag,
+                "--json",
+                "databaseId",
+                "--jq",
+                ".databaseId",
+            ],
+        ),
+        github_release_upload_timeout(),
+    );
+    if view.timed_out || view.exit_code != Some(0) {
+        return Err(GitHubReleaseMetadataError {
+            message: gh_failure_detail("gh release view databaseId", &view),
+            diagnostics: vec![gh_failure_diagnostic(
+                "gh release view databaseId",
+                tag,
+                &view,
+            )],
+        });
+    }
+    let release_id = view.stdout.trim();
+    if release_id.is_empty() || !release_id.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(GitHubReleaseMetadataError {
+            message: format!(
+                "gh release view returned no usable release id for {tag} on {repo_flag}"
+            ),
+            diagnostics: vec![gh_failure_diagnostic(
+                "gh release view databaseId",
+                tag,
+                &view,
+            )],
+        });
+    }
+
+    let endpoint = format!("repos/{repo_flag}/releases/{release_id}");
+    let output = run_gh_command(
+        gh_command(github, config, &["api", &endpoint]),
+        github_release_upload_timeout(),
+    );
+    if output.timed_out || output.exit_code != Some(0) {
+        return Err(GitHubReleaseMetadataError {
+            message: gh_failure_detail("gh api release metadata by id", &output),
+            diagnostics: vec![gh_failure_diagnostic(
+                "gh api release metadata by id",
+                &endpoint,
+                &output,
+            )],
+        });
+    }
+    serde_json::from_str(&output.stdout).map_err(|error| GitHubReleaseMetadataError {
+        message: format!("GitHub REST release metadata by id was invalid: {error}"),
+        diagnostics: vec![gh_failure_diagnostic(
+            "gh api release metadata by id",
+            &endpoint,
+            &output,
+        )],
+    })
 }
 
 fn metadata_fallback_error(
@@ -1511,6 +1626,80 @@ pub(crate) fn github_cli_env(github: &GitHubRepo, config: &GithubConfig) -> Vec<
 
 #[cfg(test)]
 mod tests {
+    /// #10519: resolving a just-created draft must not scan the release list.
+    ///
+    /// `releases/tags/{tag}` 404s for a draft by design, so the readback after
+    /// `gh release create --draft` always falls through. The fallback used to
+    /// page the entire repository: `Extra-Chill/homeboy-extensions` carries 920
+    /// releases, so finding a draft created seconds earlier cost ~31 sequential
+    /// API calls and intermittently returned nothing, stranding the release with
+    /// "the draft fallback also failed: no GitHub Release matched tag".
+    ///
+    /// The id path is two O(1) calls regardless of repository size.
+    #[test]
+    fn draft_resolution_prefers_the_id_lookup_over_scanning_every_release() {
+        let source = include_str!("gh_cli.rs");
+        let body = source
+            .split("pub(crate) fn gh_release_metadata(")
+            .nth(1)
+            .expect("gh_release_metadata should exist");
+        let by_id = body
+            .find("gh_release_metadata_by_id")
+            .expect("the id lookup must be attempted");
+        let by_scan = body
+            .find("gh_draft_release_metadata")
+            .expect("the list scan must remain as a last resort");
+
+        assert!(
+            by_id < by_scan,
+            "the O(1) id lookup must be attempted before the O(releases) list scan"
+        );
+    }
+
+    /// Both failures must survive into the message. A stranded release is
+    /// diagnosed from why every lookup failed, not just the first (#10441).
+    #[test]
+    fn joined_resolution_failures_retain_both_messages_and_diagnostics() {
+        let first = GitHubReleaseMetadataError {
+            message: "id lookup failed".to_string(),
+            diagnostics: vec![GitHubCommandFailureDiagnostic {
+                operation: "gh release view databaseId".to_string(),
+                endpoint: "v1.2.3".to_string(),
+                summary: "first".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(1),
+                timed_out: false,
+                http_status: None,
+                github_request_id: None,
+            }],
+        };
+        let second = GitHubReleaseMetadataError {
+            message: "list scan failed".to_string(),
+            diagnostics: vec![GitHubCommandFailureDiagnostic {
+                operation: "gh api releases list".to_string(),
+                endpoint: "repos/o/r/releases".to_string(),
+                summary: "second".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(1),
+                timed_out: false,
+                http_status: None,
+                github_request_id: None,
+            }],
+        };
+
+        let joined = first.join(second);
+
+        assert!(joined.message.contains("id lookup failed"));
+        assert!(joined.message.contains("list scan failed"));
+        assert_eq!(
+            joined.diagnostics.len(),
+            2,
+            "neither diagnostic may be lost"
+        );
+    }
+
     use super::*;
     use std::sync::mpsc;
 


### PR DESCRIPTION
Contributes to #10519 — the publisher half. #10902 pinned the recovery-workflow half.

## The failure

`gh release create --draft` is always followed by a metadata readback, and `releases/tags/{tag}` returns **404 for a draft by design**. So every create falls through to the fallback — and the fallback scanned the entire release list.

`Extra-Chill/homeboy-extensions` holds **920 releases**. Finding a draft created seconds earlier cost ~31 sequential paginated API calls, and it intermittently returned nothing:

```
gh api release metadata exited with status 1 (HTTP 404);
the draft fallback also failed: no GitHub Release (published or draft)
on Extra-Chill/homeboy-extensions matched tag rust-v1.31.2
```

The release then strands as an unpublished draft.

## What that cost

- **5 consecutive extension releases** stranded (rust-v1.31.0/1/2, and others across go/swift/wordpress — 16 drafts total)
- **5 consecutive homeboy-action releases** stranded
- Because `post:release` never runs after a failed publish, the floating **`v2` tag sat four days behind** at v2.8.25 with **six correctness fixes undeployed** — including the #10657 differential-gate fix, which was written, tested, released, and unreachable

The fix for the stranding was itself stranded by the stranding.

## Change

Resolve the release **id** directly rather than searching for it.

`gh release view --json databaseId` is GraphQL-backed and **does** see drafts, so it answers "which release is this tag" in one call. `repos/{owner}/{repo}/releases/{id}` then returns the REST shape — which carries the asset `digest` field that recovery depends on and the GraphQL asset shape omits.

Two O(1) calls, independent of repository size.

### Verified against a real stranded draft

homeboy `v0.320.0`, still a draft with 15 assets:

```
$ gh release view v0.320.0 --json databaseId -q .databaseId
360531007

$ gh api repos/Extra-Chill/homeboy/releases/360531007 --jq '...'
{"draft":true,"tag_name":"v0.320.0","assets":15,
 "first_asset":{"name":"dist-manifest.json","state":"uploaded","size":24194,
                "digest":"sha256:6de0271c5cf035812de05b5fa5bf9564e96fe85382585ae0c52d916fd248603b"}}
```

Draft resolves, assets present, digests intact.

## Kept deliberately

The list scan **remains** as a last resort, so a repository where `gh release view` cannot resolve the tag still has a path. This narrows the common case rather than removing a capability.

Both failures are **joined** rather than collapsed, via a new `GitHubReleaseMetadataError::join`. A stranded release is diagnosed from why *every* lookup failed — collapsing the later failure into the earlier one is precisely what made run 30313665269 unreadable (#10441).

## Tests

- `draft_resolution_prefers_the_id_lookup_over_scanning_every_release` — pins the ordering. **Negative control:** swapping the two paths fails with *"the O(1) id lookup must be attempted before the O(releases) list scan"*.
- `joined_resolution_failures_retain_both_messages_and_diagnostics` — neither message nor diagnostic may be lost.

`cargo fmt --check` clean, `cargo clippy -p homeboy-release --lib --tests` 0 errors, **821 passed**.

## Scope

This does not touch the four `--draft=false` publication sites carrying three completeness contracts — that consolidation is the larger follow-up we discussed, and #10931 already closed the ungated one.

## Pre-existing failures (unrelated)

`release_recover_resumes_only_failed_project_with_published_source_projection` (design decision pending — see #10949) and `bounded_command_closes_inherited_descendant_pipes` (passes 3/3 in isolation, timing-sensitive under parallel load). A third, `release_plan_warns_when_configured_extensions_have_no_publish_action`, appeared in one full-suite run and passes in isolation with and without this change — two consecutive suite runs produced different failure sets, which is the tell.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
