### PR TITLE
feat(cli): preserve argument source provenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 tempfile = "3.14"
 
 # CLI dependencies
-clap = { version = "4.5", features = ["derive", "string"] }
+clap = { version = "4.5", features = ["derive", "env", "string"] }
 
 [dev-dependencies]
 # Enable homeboy-core's shared hermetic test fixtures for this crate's test build

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -49,7 +49,7 @@ semver = "1.0"
 libc = "0.2"
 serde_json_path = "0.7"
 tempfile = "3.14"
-clap = { version = "4.5", features = ["derive", "string"] }
+clap = { version = "4.5", features = ["derive", "env", "string"] }
 sha2 = "0.10.9"
 fs4 = "0.13"
 

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -407,10 +407,12 @@ impl CliRuntime {
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
 
-        let (mut cli, command_spec) = match Cli::from_registered_arg_matches(&matches) {
+        let (compiled, command_spec) = match Cli::compile_registered_arg_matches(&matches) {
             Ok(parsed) => parsed,
             Err(err) => err.exit(),
         };
+        let mut cli = compiled.value;
+        let command_provenance = compiled.provenance;
         let notification_route = match crate::core::notification_route::from_cli_or_env(
             cli.notification_transport.as_deref(),
             cli.notification_route.as_deref(),
@@ -459,7 +461,12 @@ impl CliRuntime {
 
         if let Commands::AgentTask(agent_task) = &cli.command {
             if let crate::commands::agent_task::AgentTaskCommand::Cook(cook) = &agent_task.command {
-                if let Err(err) = crate::commands::agent_task::run::validate_cook_request(cook) {
+                if let Err(err) =
+                    crate::commands::agent_task::run::validate_cook_request_with_provenance(
+                        cook,
+                        Some(&command_provenance),
+                    )
+                {
                     output_runtime::emit_json_result_for_identity(
                         Err(err),
                         output_file.as_deref(),
@@ -540,8 +547,12 @@ impl CliRuntime {
         // placement routing can consume controller transport markers.
         crate::commands::utils::execution_provenance::capture(&cli, &normalized);
 
-        let route_result =
-            crate::commands::route::route_after_parse(&cli, &normalized, output_file.as_deref());
+        let route_result = crate::commands::route::route_after_parse_with_provenance(
+            &cli,
+            &normalized,
+            output_file.as_deref(),
+            Some(&command_provenance),
+        );
         if managed_runner_placement {
             resource_policy::clear_managed_runner_placement_context();
         }
@@ -575,6 +586,7 @@ impl CliRuntime {
                 command_spec,
                 output_file.as_deref(),
                 &command_identity,
+                command_provenance,
             )
         });
         std::process::ExitCode::from(exit_code_to_u8(exit_code))

--- a/crates/homeboy-cli/src/cli_surface/argument_provenance.rs
+++ b/crates/homeboy-cli/src/cli_surface/argument_provenance.rs
@@ -1,0 +1,366 @@
+//! Typed command values and their argument-source provenance.
+//!
+//! Clap owns parser mechanics. This module turns its ephemeral `ArgMatches`
+//! sources into a serializable contract that policy and execution layers can
+//! validate or persist without depending on Clap.
+
+use clap::{parser::ValueSource, ArgMatches};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArgumentSource {
+    CommandLine,
+    Environment,
+    Configuration,
+    Policy,
+    Generated,
+    Default,
+}
+
+impl ArgumentSource {
+    fn from_clap(source: ValueSource) -> Self {
+        match source {
+            ValueSource::CommandLine => Self::CommandLine,
+            ValueSource::EnvVariable => Self::Environment,
+            ValueSource::DefaultValue => Self::Default,
+            _ => Self::Default,
+        }
+    }
+}
+
+/// Serializable source map for a parsed command. Keys are canonical Clap
+/// argument IDs, so aliases share their declared argument's provenance.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CommandArgumentProvenance(BTreeMap<String, ArgumentSource>);
+
+impl CommandArgumentProvenance {
+    pub fn from_matches(matches: &ArgMatches) -> Self {
+        let mut provenance = Self::default();
+        provenance.collect(matches);
+        provenance
+    }
+
+    /// Records a non-parser resolution (configuration, policy, or generated
+    /// value) after command compilation.
+    pub fn set(&mut self, argument: impl Into<String>, source: ArgumentSource) {
+        self.0.insert(argument.into(), source);
+    }
+
+    pub fn source(&self, argument: &str) -> Option<ArgumentSource> {
+        self.0.get(argument).copied()
+    }
+
+    /// Rejects a source policy before a caller starts workspace, provider, or
+    /// other external work. A single policy can cover an argument group.
+    pub fn require_sources(
+        &self,
+        arguments: &[&str],
+        allowed: &[ArgumentSource],
+    ) -> Result<(), ArgumentSourcePolicyError> {
+        let rejected: Vec<_> = arguments
+            .iter()
+            .filter_map(|argument| {
+                let source = self.source(argument)?;
+                (!allowed.contains(&source)).then(|| ArgumentSourceViolation {
+                    argument: (*argument).to_string(),
+                    source,
+                })
+            })
+            .collect();
+        let missing: Vec<_> = arguments
+            .iter()
+            .filter(|argument| self.source(argument).is_none())
+            .map(|argument| (*argument).to_string())
+            .collect();
+
+        if rejected.is_empty() && missing.is_empty() {
+            Ok(())
+        } else {
+            Err(ArgumentSourcePolicyError { rejected, missing })
+        }
+    }
+
+    /// Adds durable provenance to a plan or evidence JSON object.
+    pub fn project_into(&self, value: &mut serde_json::Value) {
+        if !value.is_object() {
+            *value = serde_json::json!({});
+        }
+        value["command_argument_provenance"] =
+            serde_json::to_value(self).expect("argument provenance serializes");
+    }
+
+    fn collect(&mut self, matches: &ArgMatches) {
+        for id in matches.ids() {
+            if let Some(source) = matches.value_source(id.as_str()) {
+                self.set(id.as_str(), ArgumentSource::from_clap(source));
+            }
+        }
+        if let Some((_, child)) = matches.subcommand() {
+            self.collect(child);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArgumentSourceViolation {
+    pub argument: String,
+    pub source: ArgumentSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArgumentSourcePolicyError {
+    pub rejected: Vec<ArgumentSourceViolation>,
+    pub missing: Vec<String>,
+}
+
+/// A parsed typed command plus the sources used to compile it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledCommand<T> {
+    pub value: T,
+    pub provenance: CommandArgumentProvenance,
+}
+
+impl<T> CompiledCommand<T> {
+    pub fn new(value: T, provenance: CommandArgumentProvenance) -> Self {
+        Self { value, provenance }
+    }
+
+    pub fn map<U>(self, map: impl FnOnce(T) -> U) -> CompiledCommand<U> {
+        CompiledCommand {
+            value: map(self.value),
+            provenance: self.provenance,
+        }
+    }
+}
+
+/// Adapter for policy compilers such as tracker-resolved Cook (#10889). The
+/// adapter deliberately takes already-typed values: tracker resolution owns
+/// how values are derived, while this shared contract owns their provenance.
+pub struct TrackerCookArgumentAdapter;
+
+impl TrackerCookArgumentAdapter {
+    pub fn compile<T>(
+        value: T,
+        sources: impl IntoIterator<Item = (&'static str, ArgumentSource)>,
+    ) -> CompiledCommand<T> {
+        let mut provenance = CommandArgumentProvenance::default();
+        for (argument, source) in sources {
+            provenance.set(argument, source);
+        }
+        CompiledCommand::new(value, provenance)
+    }
+
+    /// Tracker policy can reject caller overrides before it provisions a
+    /// worktree or discovers a provider.
+    pub fn require_policy_owned(
+        provenance: &CommandArgumentProvenance,
+        arguments: &[&str],
+    ) -> Result<(), ArgumentSourcePolicyError> {
+        provenance.require_sources(
+            arguments,
+            &[
+                ArgumentSource::Configuration,
+                ArgumentSource::Policy,
+                ArgumentSource::Generated,
+                ArgumentSource::Default,
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
+
+    #[derive(Args)]
+    struct FlattenedArgs {
+        #[arg(long, default_value_t = 3)]
+        max_attempts: u32,
+    }
+
+    #[derive(Args)]
+    struct NestedArgs {
+        #[command(flatten)]
+        flattened: FlattenedArgs,
+        #[arg(long, env = "HOMEBOY_PROVENANCE_TEST_ENV")]
+        from_env: Option<String>,
+        #[arg(long, visible_alias = "base-branch", default_value = "main")]
+        base: String,
+        #[arg(long, hide = true)]
+        compatibility: bool,
+        #[arg(long)]
+        labels: Vec<String>,
+    }
+
+    #[derive(Subcommand)]
+    enum TestCommand {
+        Cook(NestedArgs),
+    }
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[arg(long, global = true, default_value = "auto")]
+        placement: String,
+        #[command(subcommand)]
+        command: TestCommand,
+    }
+
+    #[test]
+    fn captures_parser_sources_through_nested_flattened_global_alias_hidden_and_repeated_arguments()
+    {
+        let matches = TestCli::command()
+            .try_get_matches_from([
+                "homeboy",
+                "--placement",
+                "local",
+                "cook",
+                "--max-attempts",
+                "3",
+                "--base-branch",
+                "main",
+                "--compatibility",
+                "--labels",
+                "one",
+                "--labels",
+                "two",
+            ])
+            .expect("parse command");
+        let typed = TestCli::from_arg_matches(&matches).expect("typed command");
+        let compiled =
+            CompiledCommand::new(typed, CommandArgumentProvenance::from_matches(&matches));
+
+        assert_eq!(
+            compiled.provenance.source("placement"),
+            Some(ArgumentSource::CommandLine)
+        );
+        assert_eq!(
+            compiled.provenance.source("max_attempts"),
+            Some(ArgumentSource::CommandLine)
+        );
+        assert_eq!(
+            compiled.provenance.source("base"),
+            Some(ArgumentSource::CommandLine)
+        );
+        assert_eq!(
+            compiled.provenance.source("compatibility"),
+            Some(ArgumentSource::CommandLine)
+        );
+        assert_eq!(
+            compiled.provenance.source("labels"),
+            Some(ArgumentSource::CommandLine)
+        );
+        let TestCommand::Cook(args) = compiled.value.command;
+        assert_eq!(args.labels, ["one", "two"]);
+    }
+
+    #[test]
+    fn keeps_implicit_and_explicit_default_values_distinct() {
+        let implicit = TestCli::command()
+            .try_get_matches_from(["homeboy", "cook"])
+            .expect("parse defaults");
+        let explicit = TestCli::command()
+            .try_get_matches_from(["homeboy", "cook", "--max-attempts", "3"])
+            .expect("parse explicit default");
+
+        assert_eq!(
+            CommandArgumentProvenance::from_matches(&implicit).source("max_attempts"),
+            Some(ArgumentSource::Default)
+        );
+        assert_eq!(
+            CommandArgumentProvenance::from_matches(&explicit).source("max_attempts"),
+            Some(ArgumentSource::CommandLine)
+        );
+    }
+
+    #[test]
+    fn captures_environment_and_allows_non_parser_resolution_sources() {
+        let previous = std::env::var_os("HOMEBOY_PROVENANCE_TEST_ENV");
+        std::env::set_var("HOMEBOY_PROVENANCE_TEST_ENV", "configured");
+        let result = (|| {
+            let matches = TestCli::command()
+                .try_get_matches_from(["homeboy", "cook"])
+                .expect("parse environment default");
+            let mut provenance = CommandArgumentProvenance::from_matches(&matches);
+            assert_eq!(
+                provenance.source("from_env"),
+                Some(ArgumentSource::Environment)
+            );
+
+            provenance.set("base", ArgumentSource::Configuration);
+            provenance.set("head", ArgumentSource::Policy);
+            provenance.set("run_id", ArgumentSource::Generated);
+            let mut plan = serde_json::json!({"schema": "test/plan/v1"});
+            provenance.project_into(&mut plan);
+            assert_eq!(plan["command_argument_provenance"]["base"], "configuration");
+            provenance
+                .require_sources(
+                    &["base", "head"],
+                    &[ArgumentSource::Configuration, ArgumentSource::Policy],
+                )
+                .expect("allowed source group");
+        })();
+        if let Some(previous) = previous {
+            std::env::set_var("HOMEBOY_PROVENANCE_TEST_ENV", previous);
+        } else {
+            std::env::remove_var("HOMEBOY_PROVENANCE_TEST_ENV");
+        }
+        result
+    }
+
+    #[test]
+    fn rejects_disallowed_sources_before_effects() {
+        let matches = TestCli::command()
+            .try_get_matches_from(["homeboy", "cook", "--max-attempts", "3"])
+            .expect("parse command");
+        let provenance = CommandArgumentProvenance::from_matches(&matches);
+        let error = provenance
+            .require_sources(&["max_attempts"], &[ArgumentSource::Policy])
+            .expect_err("explicit override must be rejected");
+
+        assert_eq!(error.rejected[0].argument, "max_attempts");
+        assert_eq!(error.rejected[0].source, ArgumentSource::CommandLine);
+    }
+
+    #[test]
+    fn tracker_cook_fixture_keeps_resolved_values_and_rejects_cli_policy_overrides() {
+        // This is the #10889 handoff shape. It intentionally contains no
+        // tracker implementation; that feature supplies these typed values.
+        #[derive(Debug, PartialEq, Eq)]
+        struct TrackerCookFixture {
+            issue: u64,
+            base: String,
+            max_attempts: u32,
+            placement: String,
+        }
+
+        let compiled = TrackerCookArgumentAdapter::compile(
+            TrackerCookFixture {
+                issue: 10889,
+                base: "main".to_string(),
+                max_attempts: 3,
+                placement: "lab".to_string(),
+            },
+            [
+                ("base", ArgumentSource::Configuration),
+                ("max_attempts", ArgumentSource::Policy),
+                ("placement", ArgumentSource::Policy),
+            ],
+        );
+        TrackerCookArgumentAdapter::require_policy_owned(
+            &compiled.provenance,
+            &["base", "max_attempts", "placement"],
+        )
+        .expect("tracker policy sources are accepted");
+        assert_eq!(compiled.value.issue, 10889);
+
+        let mut overridden = compiled.provenance.clone();
+        overridden.set("base", ArgumentSource::CommandLine);
+        let error = TrackerCookArgumentAdapter::require_policy_owned(&overridden, &["base"])
+            .expect_err("explicit base override is rejected before mutation");
+        assert_eq!(error.rejected[0].source, ArgumentSource::CommandLine);
+    }
+}

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -10,6 +10,12 @@ use crate::commands::{
     stack, status, trace, triage, tunnel, upgrade, worktree,
 };
 
+mod argument_provenance;
+pub use argument_provenance::{
+    ArgumentSource, ArgumentSourcePolicyError, ArgumentSourceViolation, CommandArgumentProvenance,
+    CompiledCommand, TrackerCookArgumentAdapter,
+};
+
 const VERSION: &str = homeboy_product_identity::product_version();
 const DEFAULT_COMMAND_SURFACE_DEPTH: usize = 8;
 
@@ -140,6 +146,23 @@ impl Cli {
             .and_then(crate::command_contract::registered_command)
             .expect("built-in top-level command should be registered");
         Ok((cli, spec))
+    }
+
+    /// Compiles parser matches into typed values plus durable source metadata.
+    pub fn compile_registered_arg_matches(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            CompiledCommand<Self>,
+            &'static crate::command_contract::CommandSpec,
+        ),
+        clap::Error,
+    > {
+        let (cli, spec) = Self::from_registered_arg_matches(matches)?;
+        Ok((
+            CompiledCommand::new(cli, CommandArgumentProvenance::from_matches(matches)),
+            spec,
+        ))
     }
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -100,18 +100,29 @@ pub(crate) fn run_with_cook_progress(
         &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
     >,
 ) -> CmdResult<Value> {
+    run_with_cook_progress_and_provenance(args, progress, None)
+}
+
+pub(crate) fn run_with_cook_progress_and_provenance(
+    args: AgentTaskArgs,
+    progress: Option<
+        &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
+    >,
+    provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
+) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::Doctor(doctor_args) => doctor::doctor(doctor_args),
         AgentTaskCommand::Cook(cook_args) => {
             // Reject unsupported Cook source shapes before discovering a provider
             // or preparing the local/Lab execution route.
-            run::validate_cook_request(&cook_args)?;
+            run::validate_cook_request_with_provenance(&cook_args, provenance)?;
             if progress.is_some() {
                 run::run_cook_with_executor_and_dispatcher_with_progress(
                     cook_args,
                     homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
                     None,
                     progress,
+                    provenance,
                 )
             } else {
                 run::run_cook(cook_args)

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -362,6 +362,32 @@ pub(crate) fn record_cook_provision(plan: &mut AgentTaskPlan, provision: Value) 
 }
 
 pub(crate) fn validate_cook_request(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    validate_cook_request_with_provenance(args, None)
+}
+
+/// Validates Cook input authority before destination provisioning, provider
+/// discovery, or any other external effect starts.
+pub(crate) fn validate_cook_request_with_provenance(
+    args: &AgentTaskCookArgs,
+    provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
+) -> homeboy::core::Result<()> {
+    if args.no_finalize {
+        if let Some(provenance) = provenance {
+            provenance
+                .require_sources(
+                    &["no_finalize"],
+                    &[crate::cli_surface::ArgumentSource::CommandLine],
+                )
+                .map_err(|error| {
+                    homeboy::core::Error::validation_invalid_argument(
+                        "no_finalize",
+                        "--no-finalize must be explicitly authorized on the command line",
+                        Some(serde_json::to_string(&error).expect("source policy serializes")),
+                        None,
+                    )
+                })?;
+        }
+    }
     if args.goal.is_some() && !args.dispatch.tasks.is_empty() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "task",
@@ -458,7 +484,13 @@ pub(crate) fn run_cook_with_executor_and_dispatcher<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    run_cook_with_executor_and_dispatcher_with_progress(args, executor, attempt_dispatcher, None)
+    run_cook_with_executor_and_dispatcher_with_progress(
+        args,
+        executor,
+        attempt_dispatcher,
+        None,
+        None,
+    )
 }
 
 pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress<E>(
@@ -470,11 +502,12 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress<E>(
     progress: Option<
         &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
     >,
+    provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> CmdResult<Value>
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    validate_cook_request(&args)?;
+    validate_cook_request_with_provenance(&args, provenance)?;
     // Deterministic gates exist to make *publication* safe: a green gate is the
     // proof a cook may commit, push, and open a PR. A `--no-finalize` cook does
     // none of those, so a gate is not meaningful there — read-only/exploratory
@@ -521,6 +554,9 @@ where
     if args.attempt_plan.is_some() {
         record_cook_provision(&mut initial_plan, provision);
         record_cook_goal(&mut initial_plan, args.goal.as_deref());
+    }
+    if let Some(provenance) = provenance {
+        record_cook_argument_provenance(&mut initial_plan, provenance);
     }
     // Capture the resolved task workspace before dispatch. The provider may
     // commit and leave a clean tree, so resolving this after it runs would
@@ -601,6 +637,13 @@ where
         ),
         result.exit_code,
     ))
+}
+
+pub(crate) fn record_cook_argument_provenance(
+    plan: &mut AgentTaskPlan,
+    provenance: &crate::cli_surface::CommandArgumentProvenance,
+) {
+    provenance.project_into(&mut plan.metadata);
 }
 
 pub(super) fn dispatch_args_for_cook(args: &AgentTaskCookArgs) -> DispatchArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -7,7 +7,7 @@ use homeboy::agents::agent_task_service::{
 };
 use homeboy::core::{Error, Result};
 
-use crate::cli_surface::{Cli, Commands};
+use crate::cli_surface::{ArgumentSource, Cli, Commands};
 
 use super::super::AgentTaskCommand;
 
@@ -75,6 +75,55 @@ fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
             .contains("cannot queue its controller-owned lifecycle"));
         assert!(!homeboy::agents::agent_task_service::recipe_exists("cook-queue-only").unwrap());
     });
+}
+
+#[test]
+fn cook_rejects_non_cli_no_finalize_authorization_before_provisioning() {
+    let matches = Cli::command_with_scoped_lab_args()
+        .try_get_matches_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "missing@worktree",
+            "--no-finalize",
+        ])
+        .expect("parse Cook");
+    let (compiled, _) = Cli::compile_registered_arg_matches(&matches).expect("compile Cook");
+    let Commands::AgentTask(agent_task) = compiled.value.command else {
+        panic!("agent-task Cook command");
+    };
+    let AgentTaskCommand::Cook(cook) = agent_task.command else {
+        panic!("Cook command");
+    };
+    let mut provenance = compiled.provenance;
+    provenance.set("no_finalize", ArgumentSource::Configuration);
+
+    let error = super::super::run::validate_cook_request_with_provenance(&cook, Some(&provenance))
+        .expect_err("configuration cannot authorize finalization suppression");
+
+    assert!(error.message.contains("explicitly authorized"));
+}
+
+#[test]
+fn cook_plan_records_compiled_argument_provenance() {
+    let mut plan = AgentTaskPlan::new("cook-provenance", Vec::new());
+    let mut provenance = crate::cli_surface::CommandArgumentProvenance::default();
+    provenance.set("base", ArgumentSource::Configuration);
+    provenance.set("run_id", ArgumentSource::Generated);
+
+    super::super::run::record_cook_argument_provenance(&mut plan, &provenance);
+
+    assert_eq!(
+        plan.metadata["command_argument_provenance"]["base"],
+        "configuration"
+    );
+    assert_eq!(
+        plan.metadata["command_argument_provenance"]["run_id"],
+        "generated"
+    );
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/infra/output_runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/output_runtime.rs
@@ -4,7 +4,7 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use crate::cli_surface::Commands;
+use crate::cli_surface::{CommandArgumentProvenance, Commands};
 use crate::command_contract::CommandOutputFileMode;
 
 use crate::commands::utils::response::{self as output, CommandIdentity};
@@ -458,6 +458,7 @@ pub fn run_command(
     spec: &'static crate::command_contract::CommandSpec,
     requested_output_file: Option<&str>,
     identity: &CommandIdentity,
+    provenance: CommandArgumentProvenance,
 ) -> i32 {
     let output_file = command_runtime_output_file(&command, requested_output_file);
     let plan = command.response_plan(spec, output_file.is_some());
@@ -467,7 +468,8 @@ pub fn run_command(
         crate::commands::raw_output::CommandRunPreparation::Handled(exit_code) => return exit_code,
         crate::commands::raw_output::CommandRunPreparation::Json(command) => {
             return output_service.emit_run(
-                run_json(*command, spec, plan.output_file, output_file).with_identity(identity),
+                run_json(*command, spec, plan.output_file, output_file, &provenance)
+                    .with_identity(identity),
                 plan.output_file,
             );
         }
@@ -534,6 +536,7 @@ pub fn run_json(
     spec: &crate::command_contract::CommandSpec,
     mode: CommandOutputFileMode,
     output_file: Option<&str>,
+    provenance: &CommandArgumentProvenance,
 ) -> CommandRun {
     match (mode, command) {
         (CommandOutputFileMode::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
@@ -552,7 +555,7 @@ pub fn run_json(
             }
         }
         (_, command) => {
-            crate::commands::json_output::run_command_output(command, spec, output_file)
+            crate::commands::json_output::run_command_output(command, spec, output_file, provenance)
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -29,6 +29,17 @@ pub fn route_after_parse(
     normalized_args: &[String],
     output_file: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
+    route_after_parse_with_provenance(cli, normalized_args, output_file, None)
+}
+
+/// Routes typed commands while retaining their parser-source contract through
+/// controller-side plan materialization and Lab handoff.
+pub fn route_after_parse_with_provenance(
+    cli: &Cli,
+    normalized_args: &[String],
+    output_file: Option<&str>,
+    provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
+) -> homeboy::core::Result<Option<i32>> {
     // Contradictory argument combinations are rejected before any transport
     // context is consulted. The bail-outs below skip routing, not validation:
     // an invalid combination stays invalid wherever the process runs, and
@@ -195,6 +206,7 @@ pub fn route_after_parse(
         &normalized_args,
         output_file,
         inferred_runner_id.as_deref(),
+        provenance,
     )? {
         return Ok(Some(exit_code));
     }
@@ -255,7 +267,7 @@ pub fn route_after_parse(
         lab_command
     };
     let cook_plan = if lab_command.is_some() && inferred_runner_id.is_some() {
-        materialize_agent_task_cook_plan(cli)?
+        materialize_agent_task_cook_plan(cli, provenance)?
     } else {
         None
     };
@@ -654,6 +666,7 @@ fn run_split_placement_cook(
     _normalized_args: &[String],
     output_file: Option<&str>,
     runner_id: Option<&str>,
+    provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> homeboy::core::Result<Option<i32>> {
     let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
         command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
@@ -675,7 +688,7 @@ fn run_split_placement_cook(
         return Ok(None);
     };
 
-    let plan = materialize_agent_task_cook_plan(cli)?.expect("cook plan");
+    let plan = materialize_agent_task_cook_plan(cli, provenance)?.expect("cook plan");
     let serialized_plan = serde_json::to_string(&plan).map_err(|error| {
         Error::internal_json(
             error.to_string(),
@@ -716,6 +729,7 @@ fn run_split_placement_cook(
             homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
             Some(dispatcher),
             Some(&progress),
+            provenance,
         )?;
     let stdout = serde_json::to_string_pretty(&value).map_err(|error| {
         Error::internal_json(
@@ -1175,6 +1189,7 @@ fn inject_agent_task_cook_attempt_plan(
 /// user task a later retry must execute.
 fn materialize_agent_task_cook_plan(
     cli: &Cli,
+    provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> homeboy::core::Result<Option<homeboy::agents::agent_tasks::scheduler::AgentTaskPlan>> {
     let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
         command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
@@ -1182,9 +1197,13 @@ fn materialize_agent_task_cook_plan(
     else {
         return Ok(None);
     };
-    crate::commands::agent_task::run::validate_cook_request(cook)?;
+    crate::commands::agent_task::run::validate_cook_request_with_provenance(cook, provenance)?;
     let provision = crate::commands::agent_task::run::provision_cook_destination(cook)?;
-    crate::commands::agent_task::run::compile_cook_plan(cook, provision).map(Some)
+    let mut plan = crate::commands::agent_task::run::compile_cook_plan(cook, provision)?;
+    if let Some(provenance) = provenance {
+        crate::commands::agent_task::run::record_cook_argument_provenance(&mut plan, provenance);
+    }
+    Ok(Some(plan))
 }
 
 fn inline_test_settings_profiles(cli: &Cli, args: &[String]) -> homeboy::core::Result<Vec<String>> {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1260,9 +1260,22 @@ fn lab_cook_attempt_preserves_authorized_dirty_baseline_in_the_run_plan() {
 #[test]
 fn lab_cook_materializes_goal_and_explicit_task_as_one_durable_cell() {
     crate::test_support::with_isolated_home(|_| {
-        let workspace = tempfile::tempdir().expect("workspace");
-        git_init(workspace.path());
-        let workspace = workspace.path().display().to_string();
+        let primary = tempfile::tempdir().expect("primary workspace");
+        git_init(primary.path());
+        let workspace = primary.path().join("provenance-worktree");
+        let linked = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "provenance-worktree",
+                workspace.to_str().expect("utf8 workspace"),
+            ])
+            .current_dir(primary.path())
+            .output()
+            .expect("create linked workspace");
+        assert!(linked.status.success(), "{linked:?}");
+        let workspace = workspace.display().to_string();
         let cook = Cli::parse_from([
             "homeboy",
             "agent-task",
@@ -1282,7 +1295,7 @@ fn lab_cook_materializes_goal_and_explicit_task_as_one_durable_cell() {
             "cook-lab-goal-task",
         ]);
 
-        let plan = materialize_agent_task_cook_plan(&cook)
+        let plan = materialize_agent_task_cook_plan(&cook, None)
             .expect("materialize Lab Cook plan")
             .expect("Cook plan");
         assert_eq!(plan.tasks.len(), 1);
@@ -1315,6 +1328,112 @@ fn lab_cook_materializes_goal_and_explicit_task_as_one_durable_cell() {
         assert_eq!(handoff.plan.tasks, plan.tasks);
         assert_eq!(handoff.plan.options, plan.options);
         assert_eq!(handoff.plan.metadata, plan.metadata);
+    });
+}
+
+#[test]
+fn lab_cook_plan_preserves_actual_cli_provenance_through_handoff_serialization() {
+    crate::test_support::with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary workspace");
+        git_init(primary.path());
+        let workspace = primary.path().join("provenance-worktree");
+        let linked = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "provenance-worktree",
+                workspace.to_str().expect("utf8 workspace"),
+            ])
+            .current_dir(primary.path())
+            .output()
+            .expect("create linked workspace");
+        assert!(linked.status.success(), "{linked:?}");
+        let workspace = workspace.display().to_string();
+        let matches = Cli::command_with_scoped_lab_args()
+            .try_get_matches_from([
+                "homeboy",
+                "--placement",
+                "lab",
+                "agent-task",
+                "cook",
+                "--prompt",
+                "Repair provenance",
+                "--to-worktree",
+                &workspace,
+                "--backend",
+                "fixture",
+                "--dispatch-provider-id",
+                "fixture-provider",
+                "--max-attempts",
+                "3",
+                "--max-provider-executions",
+                "1",
+                "--protected-branch",
+                "main",
+                "--protected-branch",
+                "release",
+                "--attempt-run-id",
+                "generated-attempt",
+                "--no-finalize",
+            ])
+            .expect("parse Cook");
+        let (compiled, _) = Cli::compile_registered_arg_matches(&matches).expect("compile Cook");
+        let plan = materialize_agent_task_cook_plan(&compiled.value, Some(&compiled.provenance))
+            .expect("materialize Lab Cook plan")
+            .expect("Cook plan");
+
+        for argument in [
+            "placement",
+            "selector",
+            "max_attempts",
+            "attempts",
+            "protected_branches",
+            "attempt_run_id",
+            "no_finalize",
+        ] {
+            assert_eq!(
+                plan.metadata["command_argument_provenance"][argument], "command_line",
+                "{argument} source must survive plan materialization"
+            );
+        }
+
+        let argv = inject_agent_task_cook_attempt_plan(
+            &[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ],
+            Some(&plan),
+        )
+        .expect("inject Lab attempt plan");
+        let serialized = argv
+            .windows(2)
+            .find_map(|pair| (pair[0] == "--attempt-plan").then(|| pair[1].as_str()))
+            .expect("Lab argv contains plan");
+        let handoff_plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan =
+            serde_json::from_str(serialized).expect("decode plan");
+        assert_eq!(
+            handoff_plan.metadata["command_argument_provenance"],
+            plan.metadata["command_argument_provenance"]
+        );
+
+        // Split-placement Cook sends the plan through `run-plan`, rather than
+        // rebuilding it from runner-side command-line arguments.
+        let runner_args = lab_cook_attempt_args(
+            serde_json::to_string(&plan).expect("serialize runner plan"),
+            "generated-attempt",
+        );
+        let runner_plan = runner_args
+            .windows(2)
+            .find_map(|pair| (pair[0] == "--plan").then(|| pair[1].as_str()))
+            .expect("Lab runner invocation contains plan");
+        let rehydrated_plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan =
+            serde_json::from_str(runner_plan).expect("rehydrate runner plan");
+        assert_eq!(
+            rehydrated_plan.metadata["command_argument_provenance"],
+            plan.metadata["command_argument_provenance"]
+        );
     });
 }
 
@@ -1743,7 +1862,7 @@ fn explicit_local_cook_does_not_enter_lab_attempt_dispatch() {
     ]);
 
     assert!(
-        run_split_placement_cook(&cli, &[], None, Some("homeboy-lab"))
+        run_split_placement_cook(&cli, &[], None, Some("homeboy-lab"), None)
             .expect("local placement bypasses Lab cook dispatch")
             .is_none()
     );
@@ -1857,7 +1976,7 @@ fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
             "--prompt",
             "retry this task",
         ]);
-        let plan = materialize_agent_task_cook_plan(&cook_cli)
+        let plan = materialize_agent_task_cook_plan(&cook_cli, None)
             .expect("materialize cook plan")
             .expect("cook plan");
         let expected_root = provider_workspace.display().to_string();

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::cli_surface::Commands;
+use crate::cli_surface::{CommandArgumentProvenance, Commands};
 use crate::command_contract::{CommandJsonFamily, CommandSpec};
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
@@ -24,6 +24,7 @@ pub fn run_command_output(
     command: Commands,
     spec: &CommandSpec,
     output_file: Option<&str>,
+    provenance: &CommandArgumentProvenance,
 ) -> CommandRun {
     crate::commands::utils::tty::status("homeboy is working...");
     let run = match command {
@@ -49,7 +50,11 @@ pub fn run_command_output(
                         lease.progress(phase, cook_id, run_id)
                     };
                     let (result, exit_code) = map(
-                        crate::commands::agent_task::run_with_cook_progress(args, Some(&progress)),
+                        crate::commands::agent_task::run_with_cook_progress_and_provenance(
+                            args,
+                            Some(&progress),
+                            Some(provenance),
+                        ),
                     );
                     if let Err(error) = lease.finish(
                         &result,

--- a/docs/internals/development/contracts/command-argument-provenance.md
+++ b/docs/internals/development/contracts/command-argument-provenance.md
@@ -1,0 +1,51 @@
+# Command argument provenance contract
+
+CLI compilation produces a typed command together with a source map for every
+resolved Clap argument. The public Rust surface is:
+
+```rust
+use homeboy_cli::cli_surface::{
+    ArgumentSource, CommandArgumentProvenance, CompiledCommand,
+    TrackerCookArgumentAdapter,
+};
+```
+
+`CompiledCommand<T>` carries the typed command and its
+`CommandArgumentProvenance`. Parser sources are `command_line`, `environment`,
+and `default`. Resolution layers may annotate values as `configuration`,
+`policy`, or `generated` before validation or durable-plan creation.
+
+## Durable schema
+
+Cook plans and evidence store the source map in their existing free-form
+`metadata` object:
+
+```json
+{
+  "command_argument_provenance": {
+    "no_finalize": "command_line",
+    "base": "configuration",
+    "attempt_run_id": "generated"
+  }
+}
+```
+
+The metadata key is optional. Readers that do not understand it continue to
+receive the existing plan schema unchanged, while readers that do understand it
+must preserve it when forwarding, serializing, or rehydrating a plan. This is
+why split-placement Cook transfers the typed plan through `agent-task run-plan`
+instead of recompiling runner-side arguments.
+
+## Policy adapters
+
+Policy compilers that already have typed values use
+`TrackerCookArgumentAdapter::compile` to create the same public contract. The
+adapter accepts the resolved value and canonical argument/source pairs, keeping
+tracker-specific resolution outside the generic CLI surface. A tracker Cook
+implementation such as #10889 can call `require_policy_owned` before it creates
+a workspace or discovers a provider, rejecting command-line overrides of
+policy-owned fields.
+
+Cook currently requires `--no-finalize` to be sourced from `command_line` when
+provenance is available. The check happens before workspace provisioning,
+provider discovery, or other external effects.

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -21,6 +21,7 @@ Internals docs are for people maintaining Homeboy itself: architecture, implemen
 ## Development Contracts
 
 - [Compiler warning extension](development/contracts/compiler-warning-extension.md)
+- [Command argument provenance](development/contracts/command-argument-provenance.md)
 - [Verification phases](development/contracts/verification-phases.md)
 
 ## Docs Maintenance


### PR DESCRIPTION
## Summary

- add a typed command-compilation contract that preserves argument values together with their command-line, environment, default, config, policy, or generated source
- carry provenance through normal Cook routing and split-placement Lab plan serialization
- enforce source-sensitive policy before provisioning or provider discovery
- document the public compatibility seam that tracker-resolved Cook can consume

## Scope

This is prerequisite foundation for #10945 and #10889. Tracker-resolved Cook is not present on `main`, so this PR intentionally does not close either issue and does not claim that migration is complete.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli argument_provenance --lib`
- `cargo test -p homeboy-cli lab_cook_plan_preserves_actual_cli_provenance_through_handoff_serialization --lib`
- rebased onto current `origin/main`

Broader Cook failures were reproduced unchanged on pristine `origin/main`; focused candidate paths pass.

## AI assistance

Substantive implementation and tests were drafted with OpenCode using `openai/gpt-5.6-sol`, with independent coding-agent review and human-owned final responsibility.