### PR TITLE
fix(observation): report inode pressure alongside byte capacity

### DIFF
--- a/crates/homeboy-core/src/observation/disk_budget.rs
+++ b/crates/homeboy-core/src/observation/disk_budget.rs
@@ -2,18 +2,36 @@
 //!
 //! Extracted from the `commands::runs::disk` adapter so the evidence report
 //! service and other observation consumers can compute the same disk budget
-//! without depending on a CLI command module. Output shape is unchanged.
+//! without depending on a CLI command module.
+//!
+//! Byte capacity is not the only way a filesystem runs out. A workspace mount
+//! reached ZERO free inodes with ~34 GB still free, and every byte-only probe
+//! reported `ok` right up to hard `ENOSPC` — tests then failed while writing
+//! their own resource summary, and Git could not create `index.lock`. Cleanup
+//! could not recover it either, because opening the SQLite observation store
+//! needs a journal file it had no inode for (#10603).
+//!
+//! `statvfs` already returns inode counts in the same call that returns block
+//! counts, so reporting them costs nothing and closes that blind spot.
 
 use std::path::Path;
 
 use serde::Serialize;
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Default)]
 pub struct DiskBudget {
     pub path: String,
     pub available_bytes: Option<u64>,
     pub total_bytes: Option<u64>,
     pub used_percent: Option<f64>,
+    /// Free inodes. A filesystem with capacity in bytes and none here still
+    /// fails every write (#10603).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_inodes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_inodes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inodes_used_percent: Option<f64>,
     pub status: String,
     pub warning: Option<String>,
 }
@@ -39,7 +57,20 @@ pub fn disk_budget(path: &Path, subject: &str, _unavailable_message: &str) -> Di
         }
         _ => None,
     };
-    let warning = match (available, total) {
+    // `f_files` is 0 on filesystems that do not report inodes at all (some
+    // network and pseudo filesystems), which must read as "not measured"
+    // rather than as total exhaustion.
+    let reports_inodes = stat.f_files > 0;
+    let total_inodes = reports_inodes.then(|| u64::from(stat.f_files));
+    let available_inodes = reports_inodes.then(|| u64::from(stat.f_favail));
+    let inodes_used_percent = match (total_inodes, available_inodes) {
+        (Some(total), Some(available)) if total > 0 => {
+            Some(((total.saturating_sub(available)) as f64 / total as f64) * 100.0)
+        }
+        _ => None,
+    };
+
+    let byte_warning = match (available, total) {
         (Some(available), Some(total)) if total > 0 && available < total / 10 => {
             Some(format!("{subject} filesystem has less than 10% free space"))
         }
@@ -48,13 +79,54 @@ pub fn disk_budget(path: &Path, subject: &str, _unavailable_message: &str) -> Di
         )),
         _ => None,
     };
+    // Inode exhaustion is reported even when bytes look healthy, which is the
+    // exact state that produced a silent `ok` before hard ENOSPC.
+    let inode_warning = inode_warning_for(subject, available_inodes, total_inodes);
+    let warning = combine_warnings(byte_warning, inode_warning);
+
     DiskBudget {
         path: path.display().to_string(),
         available_bytes: available,
         total_bytes: total,
         used_percent,
+        available_inodes,
+        total_inodes,
+        inodes_used_percent,
         status: if warning.is_some() { "warning" } else { "ok" }.to_string(),
         warning,
+    }
+}
+
+/// Inode pressure for a probed filesystem.
+///
+/// Exhaustion is called out separately from "low", and both are reported even
+/// when byte capacity is healthy — that combination is precisely what read as
+/// `ok` until every write failed (#10603).
+#[cfg(unix)]
+fn inode_warning_for(
+    subject: &str,
+    available_inodes: Option<u64>,
+    total_inodes: Option<u64>,
+) -> Option<String> {
+    match (available_inodes, total_inodes) {
+        (Some(0), _) => Some(format!(
+            "{subject} filesystem has NO free inodes; writes will fail regardless of free bytes"
+        )),
+        (Some(available), Some(total)) if total > 0 && available < total / 10 => Some(format!(
+            "{subject} filesystem has less than 10% free inodes"
+        )),
+        _ => None,
+    }
+}
+
+/// Keep both pressures. Reporting only the first would let byte pressure mask
+/// inode exhaustion, or the reverse.
+#[cfg(unix)]
+fn combine_warnings(bytes: Option<String>, inodes: Option<String>) -> Option<String> {
+    match (bytes, inodes) {
+        (Some(bytes), Some(inodes)) => Some(format!("{bytes}; {inodes}")),
+        (Some(only), None) | (None, Some(only)) => Some(only),
+        (None, None) => None,
     }
 }
 
@@ -69,7 +141,74 @@ fn unavailable_disk_budget(path: &Path, warning: &str) -> DiskBudget {
         available_bytes: None,
         total_bytes: None,
         used_percent: None,
+        available_inodes: None,
+        total_inodes: None,
+        inodes_used_percent: None,
         status: "unknown".to_string(),
         warning: Some(warning.to_string()),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// A real probe must now carry inode counts. `statvfs` already returns them
+    /// alongside the block counts, so this costs no extra syscall (#10603).
+    #[test]
+    fn a_probe_reports_inode_capacity_alongside_bytes() {
+        let budget = disk_budget(Path::new("/"), "test", "unavailable");
+
+        assert!(
+            budget.total_inodes.is_some() && budget.available_inodes.is_some(),
+            "a probed filesystem must report inode capacity: {:?}",
+            budget.warning
+        );
+        assert!(
+            budget.inodes_used_percent.is_some(),
+            "inode utilisation must be derivable"
+        );
+    }
+
+    /// The #10603 state: ~34 GB free and ZERO free inodes. A byte-only probe
+    /// reported `ok` right up to hard ENOSPC, so cleanup was never prompted and
+    /// the store could not open a journal to plan one.
+    #[test]
+    fn zero_free_inodes_warns_even_when_byte_capacity_is_healthy() {
+        let warning = inode_warning_for("workspace", Some(0), Some(13_107_200));
+
+        let warning = warning.expect("no free inodes must warn regardless of free bytes");
+        assert!(
+            warning.contains("NO free inodes"),
+            "the warning must name inode exhaustion explicitly: {warning}"
+        );
+        assert!(
+            warning.contains("regardless of free bytes"),
+            "the warning must pre-empt the 'but there is plenty of space' reading: {warning}"
+        );
+    }
+
+    #[test]
+    fn low_free_inodes_warns_before_exhaustion() {
+        assert!(inode_warning_for("workspace", Some(1_000), Some(13_107_200)).is_some());
+        assert!(inode_warning_for("workspace", Some(9_000_000), Some(13_107_200)).is_none());
+    }
+
+    /// Filesystems that do not track inodes report `f_files == 0`. That must
+    /// read as "not measured", never as total exhaustion.
+    #[test]
+    fn a_filesystem_without_inode_accounting_is_not_reported_as_exhausted() {
+        assert!(inode_warning_for("workspace", None, None).is_none());
+    }
+
+    /// Both pressures must survive into one message; neither may mask the other.
+    #[test]
+    fn byte_and_inode_warnings_are_both_retained() {
+        let combined = combine_warnings(
+            Some("low bytes".to_string()),
+            Some("low inodes".to_string()),
+        );
+        let combined = combined.expect("both warnings present");
+        assert!(combined.contains("low bytes") && combined.contains("low inodes"));
     }
 }

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -1146,11 +1146,8 @@ mod tests {
     fn sample_disk_budget() -> DiskBudget {
         DiskBudget {
             path: "/tmp".to_string(),
-            available_bytes: None,
-            total_bytes: None,
-            used_percent: None,
             status: "unavailable".to_string(),
-            warning: None,
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
Addresses the diagnostics half of #10603.

## The blind spot

A workspace mount reached **zero free inodes with ~34 GB still free**:

```
Filesystem       Inodes    IUsed IFree IUse% Mounted on
/dev/sdb       13107200 13107200     0  100% /mnt/extrachill-workspace
```

Every byte-only probe reported `ok` right up to hard `ENOSPC`. Tests then failed *while writing their own resource summary*, Git could not create `index.lock`, and cleanup could not recover the state — opening the SQLite observation store needs a journal file it had no inode for.

## It cost nothing to keep and nothing to close

`disk_budget` already calls `statvfs`, and `statvfs` returns `f_files` and `f_favail` **in the same struct** as the block counts it was already reading. The inode data was fetched and discarded.

## Change

Report `available_inodes`, `total_inodes`, `inodes_used_percent`, and warn on inode pressure **independently of byte pressure**:

```
workspace filesystem has NO free inodes; writes will fail regardless of free bytes
```

The wording is deliberate. The entire trap is that plenty of space is visible at the same time, so the warning has to pre-empt the "but `df -h` looks fine" reading.

Both warnings are retained when both apply — neither masks the other.

**`f_files == 0` means the filesystem does not account for inodes at all** (some network and pseudo filesystems). That reads as *not measured*, never as total exhaustion, so those filesystems do not start warning spuriously.

## Compatibility

New fields are `#[serde(skip_serializing_if = "Option::is_none")]`, so an evidence report from a filesystem without inode accounting serializes byte-for-byte unchanged.

## Tests

Five, including the exact #10603 shape:

- `a_probe_reports_inode_capacity_alongside_bytes` — a real probe carries inode counts
- `zero_free_inodes_warns_even_when_byte_capacity_is_healthy` — the reported state
- `low_free_inodes_warns_before_exhaustion` — warns at <10%, silent at 69% free
- `a_filesystem_without_inode_accounting_is_not_reported_as_exhausted`
- `byte_and_inode_warnings_are_both_retained`

The warning logic is extracted into `inode_warning_for` / `combine_warnings` so it is testable without putting a filesystem into that state.

## Also

`DiskBudget` now derives `Default`, and its one exhaustive test literal uses `..Default::default()`. Same reasoning as #10959 — otherwise adding these three fields would itself have been a repo-wide edit, which is the pattern that broke the build twice yesterday.

`cargo fmt --check` clean, `cargo clippy -p homeboy-core --lib --tests` 0 errors, `observation::disk_budget` 5 passed.

## Scope

This is the **diagnostics** half only. Two asks from #10603 remain open and are larger:

1. Bounded retention on runtime directories, so inode use cannot grow without limit.
2. A cleanup path that stays operable at zero free inodes — today it needs a SQLite journal it cannot create, which is the deadlock.

Suggest keeping #10603 open for those.

## Pre-existing failures (unrelated)

`observation::store::store_test::store_init_tests` has **5 failures on unmodified `origin/main`** — verified by checking out `origin/main` in the same worktree and re-running: 7 passed, 5 failed there too. Not from this change, but worth its own look given they are observation-store initialization and migration tests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
