### PR TITLE
fix(release): preserve test budget ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,6 +491,10 @@ jobs:
       - gate-build
     if: needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true'
     runs-on: ubuntu-latest
+    # Match the repository-scoped Test budget in ci.yml. The inner Homeboy
+    # timeout must remain below the action's outer process-group backstop.
+    env:
+      HOMEBOY_TEST_TIMEOUT_SECONDS: '2700'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -528,6 +532,7 @@ jobs:
           expected-commands: review audit,review lint,review test
           args: ${{ github.event.before && format('--skip-lint --changed-since {0}', github.event.before) || '--skip-lint' }}
           autofix: 'false'
+          execution-timeout-seconds: '3000'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   # ── Step 3b: Release-blocking quality policy ──

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -758,6 +758,14 @@ fn release_test_gate_exposes_release_blocking_policy_to_rust_tests() {
 }
 
 #[test]
+fn release_test_gate_preserves_the_repository_test_budget_ordering() {
+    let gate_test = job_section(release_workflow(), "gate-test");
+
+    assert!(gate_test.contains("HOMEBOY_TEST_TIMEOUT_SECONDS: '2700'"));
+    assert!(gate_test.contains("execution-timeout-seconds: '3000'"));
+}
+
+#[test]
 fn release_finish_head_pipeline_uses_homeboy_action_head_inputs() {
     let host = job_section(release_workflow(), "host");
 


### PR DESCRIPTION
## Summary

- give the release Test gate the same repository-scoped 2,700-second inner budget as normal CI
- retain a 3,000-second action-level process-group backstop so Homeboy structured evidence wins timeout races
- pin both release-specific values in the workflow contract test
- leave global Homeboy and homeboy-action defaults unchanged

## Production Evidence

- failed release: https://github.com/Extra-Chill/homeboy/actions/runs/30576923317
- test job: https://github.com/Extra-Chill/homeboy/actions/runs/30576923317/job/90998413996
- observed: `test phase timed out after 1500s before reporting test counts`

## Verification

- `cargo test --test release_workflow_test --locked` (43 passed before adding the focused assertion)
- `cargo test --test release_workflow_test release_test_gate_preserves_the_repository_test_budget_ordering --locked`
- Ruby YAML parse of `.github/workflows/release.yml`
- `cargo fmt --all --check`
- `git diff --check`

Closes #10972.

Downstream proof: https://github.com/Automattic/wp-codebox/issues/2157

## AI Assistance

OpenCode with OpenAI GPT-5.6 Sol correlated the release timeout with #10639, implemented the repository-scoped release budget repair, added contract coverage, and ran verification. Chris Huber remains responsible for every line.