### PR TITLE
fix(observation): derive the store schema version from its migration list

### DIFF
--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -27,7 +27,17 @@ pub use artifacts::ArtifactPublication;
 
 pub(crate) use helpers::*;
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 11;
+/// The schema version a fully migrated store reports.
+///
+/// Always the last declared migration. Writing it down separately is what let
+/// it fall behind the migration list.
+pub const CURRENT_SCHEMA_VERSION: i64 = schema::LATEST_MIGRATION_VERSION;
+
+/// Migrations a fully initialized store has applied.
+///
+/// Exposed so callers assert against the declared schema rather than a copied
+/// number that goes stale the next time a migration is added.
+pub const CURRENT_MIGRATION_COUNT: i64 = schema::MIGRATION_COUNT;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ObservationDbStatus {

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -215,6 +215,25 @@ const MIGRATIONS: &[Migration] = &[
     },
 ];
 
+/// The schema version a freshly initialized store lands on.
+///
+/// Derived from `MIGRATIONS` rather than written down separately. A
+/// hand-maintained copy drifted: migration 12 was added and the constant stayed
+/// at 11, so a correctly migrated store reported a version its own code did not
+/// recognise as current. Five store-initialization tests had been failing on
+/// that for as long as the drift existed, unseen because member-crate lib tests
+/// were compiled and never executed (#10477).
+/// How many migrations a fully initialized store has applied.
+///
+/// Derived for the same reason as [`LATEST_MIGRATION_VERSION`]: the test suite
+/// asserted a hand-written `11` and adding migration 12 silently invalidated it.
+pub(crate) const MIGRATION_COUNT: i64 = MIGRATIONS.len() as i64;
+
+pub(crate) const LATEST_MIGRATION_VERSION: i64 = {
+    assert!(!MIGRATIONS.is_empty(), "the store must declare a schema");
+    MIGRATIONS[MIGRATIONS.len() - 1].version
+};
+
 static MIGRATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 pub(crate) fn database_path() -> Result<PathBuf> {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -4,8 +4,8 @@
 //! never read or written.
 
 use crate::observation::store::{
-    self, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,
-    SOURCE_SNAPSHOT_METADATA_ENV,
+    self, ObservationStore, CURRENT_MIGRATION_COUNT, CURRENT_SCHEMA_VERSION,
+    LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV,
 };
 use crate::observation::{
     FindingListFilter, NewFindingRecord, NewRunRecord, RunContext, RunListFilter, RunProvenance,
@@ -112,7 +112,7 @@ mod store_init_tests {
 
             assert!(status.exists);
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 11);
+            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
             assert_eq!(status.table_count, 8);
         });
     }
@@ -127,7 +127,7 @@ mod store_init_tests {
             let status = second.status().expect("status");
 
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 11);
+            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
             assert_eq!(status.table_count, 8);
         });
     }
@@ -149,7 +149,7 @@ mod store_init_tests {
             let status = reopened.status().expect("status");
 
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 11);
+            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
         });
     }
 
@@ -175,7 +175,7 @@ mod store_init_tests {
             for handle in handles {
                 let status = handle.join().expect("worker joined");
                 assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-                assert_eq!(status.migration_count, 11);
+                assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
             }
         });
     }
@@ -198,7 +198,25 @@ mod store_init_tests {
                        (3, '2026-01-01T00:00:00Z'), (4, '2026-01-01T00:00:00Z'),
                        (5, '2026-01-01T00:00:00Z'), (6, '2026-01-01T00:00:00Z'),
                        (7, '2026-01-01T00:00:00Z'), (8, '2026-01-01T00:00:00Z');
-                CREATE TABLE runs (id TEXT PRIMARY KEY);
+                -- Faithful to the migration-1 `runs` table. A stub with only
+                -- `id` used to be enough, but migration 10 indexes
+                -- `json_extract(metadata_json, ...)`, so an unfaithful fixture
+                -- fails the upgrade with `no such column: metadata_json` and
+                -- misreports a fixture gap as a broken migration path.
+                CREATE TABLE runs (
+                    id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL DEFAULT 'test',
+                    component_id TEXT,
+                    started_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                    finished_at TEXT,
+                    status TEXT NOT NULL DEFAULT 'success',
+                    command TEXT,
+                    cwd TEXT,
+                    homeboy_version TEXT,
+                    git_sha TEXT,
+                    rig_id TEXT,
+                    metadata_json TEXT NOT NULL DEFAULT '{}'
+                );
                 CREATE TABLE artifacts (
                     id TEXT PRIMARY KEY,
                     run_id TEXT NOT NULL,
@@ -229,7 +247,7 @@ mod store_init_tests {
             let store = ObservationStore::open_initialized_at(&path).expect("migrate version 8");
             let status = store.status().expect("status");
             assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, 11);
+            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
 
             let db = rusqlite::Connection::open(path).expect("inspect migrated db");
             let indexes = db


### PR DESCRIPTION
Five `store_init_tests` were red on `main`. **Three distinct causes**, all invisible because member-crate lib tests were compiled and never executed (#10477).

## 1. The declared schema version had drifted from the schema

```rust
pub const CURRENT_SCHEMA_VERSION: i64 = 11;
```

`MIGRATIONS` contains `Migration { version: 12, .. }`. So a correctly migrated store reported version **12** while the code declared **11** as current — the store did not recognise its own schema as up to date.

The constant is only read by tests, so nothing in production misbehaved. But it is a self-description that had quietly become false, and the only thing checking it was a suite nobody was running.

Now derived:

```rust
pub(crate) const LATEST_MIGRATION_VERSION: i64 = {
    assert!(!MIGRATIONS.is_empty(), "the store must declare a schema");
    MIGRATIONS[MIGRATIONS.len() - 1].version
};
```

A hand-maintained copy of a value that already exists **is** the defect.

## 2. `migration_count` was hardcoded

`assert_eq!(status.migration_count, 11)` in five places. Exposed as `CURRENT_MIGRATION_COUNT`, derived from `MIGRATIONS.len()`.

## 3. A fixture gap masquerading as a broken upgrade path

`migration_from_version_8_preserves_artifacts_and_adds_query_indexes` failed with:

```
apply migration 10: no such column: metadata_json
```

That reads like version-8 stores cannot migrate — a serious upgrade bug. It is not.

The fixture built a stub `CREATE TABLE runs (id TEXT PRIMARY KEY)` while a real version-8 store carries the full migration-1 `runs` table, which has `metadata_json`. Migration 10 indexes `json_extract(metadata_json, ...)`, so the stub failed on a column the real schema has always had.

The fixture is now faithful to migration 1. **Real version-8 stores were never affected** — worth stating plainly, because the error message says otherwise.

## Verified by simulation, not assertion

The interesting question is not "do the tests pass now" but "does this stop recurring":

| simulated change | before | after |
|---|---|---|
| add a table-neutral migration 13 | 5 tests break | **0 tests break** |
| add a migration that creates a table | 5 tests break | 2 tests break (`table_count`) |

The second is the **correct** outcome, not a gap. The table set is a real claim about schema shape and deserves review when it changes. A version number can only ever be the last migration, so asserting it by hand buys nothing and costs exactly what happened here.

`cargo fmt --check` clean, `cargo clippy -p homeboy-core --lib --tests` 0 errors, `observation::` **232 passed, 0 failed**.

## Why this matters beyond the tests

#10603's deadlock is "cleanup cannot run because the observation store cannot open." Finding five red tests in store *initialization and migration* sitting next to that was worth pulling on — this turned out to be drift rather than a second live defect, which is itself useful to know.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
