### PR TITLE
feat(fanout): model candidate dependencies

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1,10 +1,13 @@
 use chrono::Utc;
 use serde_json::{json, Value};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 use uuid::Uuid;
 
+use crate::agent_task_dependency_graph::{
+    dependency_graph_readiness, AgentTaskDependencyNode, AgentTaskDependencyState,
+};
 use crate::agent_task_lifecycle::{self, AgentTaskRunState};
 use crate::agent_task_schedule::AgentTaskPlan;
 use homeboy_core::{paths, Error, Result};
@@ -292,27 +295,44 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
         }
     }
     totals.unavailable = unavailable_child_runs.len();
-    let state = aggregate_state(&totals);
+    let mut state = aggregate_state(&totals);
     if batch.state != state {
         batch.state = state;
         changed = true;
     }
+    let dependency_graph = refresh_dependency_graph(&mut batch)?;
+    if let Some(graph) = &dependency_graph {
+        state = aggregate_state_after_graph_refresh(&totals, graph, state);
+        if batch.state != state {
+            batch.state = state;
+            changed = true;
+        }
+    }
+    // A status read only persists a changed durable projection. In particular,
+    // repeated observations must retain the existing timestamp byte-for-byte.
     if changed {
         batch.updated_at = Some(now_timestamp());
         write_batch(&batch)?;
     }
-
+    let mut next_actions = batch_next_actions(
+        &unavailable_child_runs,
+        &projection_pending_child_runs,
+        &resumable_child_runs,
+        &commands(&batch.batch_id),
+    );
+    if let Some(graph) = &dependency_graph {
+        if let Some(action) = graph["readiness"]["next_action"].as_str() {
+            next_actions.insert(0, action.to_string());
+        }
+    }
+    next_actions.truncate(8);
     let resumable = !resumable_child_runs.is_empty();
     let commands = commands(&batch.batch_id);
     Ok(AgentTaskBatchStatusReport {
         schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
         status: state.outcome_status().to_string(),
-        next_actions: batch_next_actions(
-            &unavailable_child_runs,
-            &projection_pending_child_runs,
-            &resumable_child_runs,
-            &commands,
-        ),
+        dependency_graph,
+        next_actions,
         commands,
         batch,
         totals,
@@ -321,6 +341,170 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
         resumable_child_runs,
         resumable,
     })
+}
+
+/// Return the same dependency projection used by resume without persisting a
+/// read-side PR observation into either the lifecycle or batch record.
+pub fn fanout_dependency_graph_with_finalization_statuses(
+    batch_id: &str,
+    statuses: &BTreeMap<String, String>,
+) -> Result<Option<Value>> {
+    let mut batch = read_batch(batch_id)?;
+    refresh_dependency_graph_with_finalization_statuses(&mut batch, Some(statuses))
+}
+
+fn aggregate_state_after_graph_refresh(
+    totals: &AgentTaskBatchTotals,
+    graph: &Value,
+    state: AgentTaskBatchState,
+) -> AgentTaskBatchState {
+    if state != AgentTaskBatchState::Succeeded {
+        return state;
+    }
+    let pending = graph["readiness"]["states"]
+        .as_object()
+        .is_some_and(|states| {
+            states.values().any(|state| {
+                !matches!(
+                    state.as_str(),
+                    Some("succeeded" | "rejected" | "failed" | "cancelled")
+                )
+            })
+        });
+    if pending {
+        // Child lifecycle success only means Cook completed. A queued dependent,
+        // gate invalidation, or pending PR acceptance keeps the fanout active.
+        if totals.queued > 0 {
+            AgentTaskBatchState::Queued
+        } else {
+            AgentTaskBatchState::Running
+        }
+    } else {
+        state
+    }
+}
+
+/// Apply a read-only fanout graph projection to an already reconciled batch
+/// aggregate. Status uses this after observing live PR state without mutation.
+pub fn fanout_aggregate_state(totals: &AgentTaskBatchTotals, graph: &Value) -> AgentTaskBatchState {
+    aggregate_state_after_graph_refresh(totals, graph, aggregate_state(totals))
+}
+
+/// Reconcile persisted fanout graph state from durable child observations. A
+/// candidate that passed gates but is still awaiting human merge remains an
+/// explicit blocker; only a recorded merge releases its dependents.
+fn refresh_dependency_graph(batch: &mut AgentTaskBatchRecord) -> Result<Option<Value>> {
+    refresh_dependency_graph_with_finalization_statuses(batch, None)
+}
+
+fn refresh_dependency_graph_with_finalization_statuses(
+    batch: &mut AgentTaskBatchRecord,
+    finalization_statuses: Option<&BTreeMap<String, String>>,
+) -> Result<Option<Value>> {
+    let Some(graph) = batch.metadata.get("dependency_graph").cloned() else {
+        return Ok(None);
+    };
+    let Some(nodes_value) = graph.get("nodes").cloned() else {
+        return Ok(None);
+    };
+    let nodes: Vec<AgentTaskDependencyNode> = serde_json::from_value(nodes_value)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    let mut states = BTreeMap::new();
+    for child in &batch.child_runs {
+        let finalization_status = finalization_statuses
+            .and_then(|statuses| statuses.get(&child.task_id).cloned())
+            .or_else(|| {
+                agent_task_lifecycle::status(&child.run_id)
+                    .ok()
+                    .and_then(|record| record.metadata.get("cook_finalization").cloned())
+                    .and_then(|value| {
+                        value
+                            .get("status")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+            });
+        let has_finalization = finalization_status.is_some();
+        let mut state = match child.state {
+            AgentTaskRunState::Failed => AgentTaskDependencyState::Failed,
+            AgentTaskRunState::Cancelled => AgentTaskDependencyState::Cancelled,
+            AgentTaskRunState::CandidateRecoverable | AgentTaskRunState::PartialRecoverable => {
+                AgentTaskDependencyState::BlockedByGate
+            }
+            AgentTaskRunState::Succeeded => match finalization_status.as_deref() {
+                // A review-ready candidate is a valid stack base. Its exact head
+                // is bound by the action receipt before the dependent is resumed.
+                Some("merged" | "review_ready") => AgentTaskDependencyState::Succeeded,
+                Some("rejected") => AgentTaskDependencyState::Rejected,
+                _ => AgentTaskDependencyState::AwaitingAcceptance,
+            },
+            _ => AgentTaskDependencyState::Queued,
+        };
+        // A merged upstream is not enough to release a terminal dependent: its
+        // rebased head must finish every durable Git/PR and invalidation step.
+        // Once invalidated, remove the old review terminal state from this
+        // projection so `resume` re-enters Cook's gate/review lifecycle.
+        for receipt in batch.metadata["dependency_action_receipts"]
+            .as_object()
+            .into_iter()
+            .flat_map(|receipts| receipts.values())
+        {
+            if receipt["action"]["downstream_id"].as_str() != Some(child.task_id.as_str()) {
+                continue;
+            }
+            match receipt["status"].as_str() {
+                // A completed invalidation only holds the child at the Cook
+                // frontier while it has no replacement finalization. Once its
+                // gates/review complete again, the new review state (including
+                // a merge) is authoritative.
+                Some("completed")
+                    if receipt["gates_invalidated"] == Value::Bool(true) && !has_finalization =>
+                {
+                    state = AgentTaskDependencyState::Queued;
+                }
+                Some("blocked" | "running" | "pending") | None => {
+                    state = AgentTaskDependencyState::BlockedByDependency;
+                }
+                _ => {}
+            }
+        }
+        states.insert(child.task_id.clone(), state);
+    }
+    let (edges, readiness) = dependency_graph_readiness(&nodes, &states)?;
+    let graph = json!({
+        "schema": "homeboy/agent-task-fanout-dependency-graph/v1",
+        "nodes": nodes,
+        "edges": edges,
+        "readiness": readiness,
+    });
+    if batch.metadata["dependency_graph"] != graph {
+        batch.metadata["dependency_graph"] = graph.clone();
+    }
+    Ok(Some(graph))
+}
+
+/// Read the graph-projected executable frontier. Resume callers use this to
+/// avoid finalizing a dependent before its upstream candidate is accepted.
+pub fn fanout_ready_child_run_ids(batch_id: &str) -> Result<Option<HashSet<String>>> {
+    let report = status(batch_id)?;
+    let Some(graph) = report.dependency_graph else {
+        return Ok(None);
+    };
+    let ready = graph["readiness"]["ready"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<HashSet<_>>();
+    Ok(Some(
+        report
+            .batch
+            .child_runs
+            .into_iter()
+            .filter(|child| ready.contains(child.task_id.as_str()))
+            .map(|child| child.run_id)
+            .collect(),
+    ))
 }
 
 /// A child is resumable when its provider attempt reached a terminal, recoverable
@@ -657,6 +841,35 @@ pub fn record_child_finalization(
         .as_object_mut()
         .expect("child_finalizations is an object")
         .insert(child_run_id.to_string(), finalization);
+    batch.updated_at = Some(now_timestamp());
+    write_batch(&batch)
+}
+
+pub fn dependency_action_receipt(batch_id: &str, key: &str) -> Result<Option<Value>> {
+    let batch = read_batch(batch_id)?;
+    Ok(batch.metadata["dependency_action_receipts"][key]
+        .as_object()
+        .map(|_| batch.metadata["dependency_action_receipts"][key].clone()))
+}
+
+pub fn record_dependency_action_receipt(batch_id: &str, key: &str, receipt: Value) -> Result<()> {
+    let mut batch = read_batch(batch_id)?;
+    if !batch.metadata.is_object() {
+        batch.metadata = json!({});
+    }
+    let receipts = batch
+        .metadata
+        .as_object_mut()
+        .expect("metadata object")
+        .entry("dependency_action_receipts")
+        .or_insert_with(|| json!({}));
+    if !receipts.is_object() {
+        *receipts = json!({});
+    }
+    receipts
+        .as_object_mut()
+        .expect("receipts object")
+        .insert(key.to_string(), receipt);
     batch.updated_at = Some(now_timestamp());
     write_batch(&batch)
 }
@@ -1066,6 +1279,82 @@ mod tests {
             .next_actions
             .iter()
             .any(|action| action.contains("withheld")));
+    }
+
+    #[test]
+    fn graph_pending_acceptance_prevents_a_succeeded_batch_aggregate() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let plan = AgentTaskPlan::new("fanout/acceptance", vec![request("a"), request("b")]);
+        submit_plan_batch(&plan, Some("batch/acceptance")).expect("batch submitted");
+        for run_id in ["batch_acceptance-a", "batch_acceptance-b"] {
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.state = AgentTaskRunState::Succeeded;
+                record.metadata["cook_finalization"] = json!({ "status": "review_ready" });
+            })
+            .expect("stage review-ready child");
+        }
+        let mut batch = read_batch("batch/acceptance").expect("batch record");
+        batch.metadata = json!({ "dependency_graph": { "nodes": [
+            { "id": "a", "depends_on": [] },
+            { "id": "b", "depends_on": ["a"] }
+        ]}});
+        write_batch(&batch).expect("persist graph");
+
+        let report = status("batch/acceptance").expect("batch status");
+
+        assert_eq!(report.totals.succeeded, 2);
+        assert_eq!(report.batch.state, AgentTaskBatchState::Running);
+        assert_eq!(report.status, "running");
+    }
+
+    #[test]
+    fn status_keeps_timestamps_stable_without_a_durable_change() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let plan = AgentTaskPlan::new("fanout/stable-status", vec![request("a")]);
+        submit_plan_batch(&plan, Some("batch/stable-status")).expect("batch submitted");
+        let before = read_batch("batch/stable-status").expect("batch record");
+
+        let report = status("batch/stable-status").expect("status observation");
+
+        assert_eq!(report.batch.updated_at, before.updated_at);
+        assert_eq!(
+            read_batch("batch/stable-status")
+                .expect("persisted batch")
+                .updated_at,
+            before.updated_at
+        );
+    }
+
+    #[test]
+    fn merged_dependent_terminalizes_after_its_invalidated_review_is_recompleted() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let plan = AgentTaskPlan::new("fanout/merged-dependent", vec![request("a")]);
+        submit_plan_batch(&plan, Some("batch/merged-dependent")).expect("batch submitted");
+        agent_task_lifecycle::rewrite_record_for_test("batch_merged-dependent-a", |record| {
+            record.state = AgentTaskRunState::Succeeded;
+            record.metadata["cook_finalization"] = json!({ "status": "merged" });
+        })
+        .expect("stage merged child");
+        let mut batch = read_batch("batch/merged-dependent").expect("batch record");
+        batch.metadata = json!({
+            "dependency_graph": { "nodes": [{ "id": "a", "depends_on": [] }] },
+            "dependency_action_receipts": {
+                "upstream:a:revision": {
+                    "status": "completed",
+                    "action": { "downstream_id": "a" },
+                    "gates_invalidated": true
+                }
+            }
+        });
+        write_batch(&batch).expect("persist graph");
+
+        let report = status("batch/merged-dependent").expect("batch status");
+
+        assert_eq!(report.batch.state, AgentTaskBatchState::Succeeded);
+        assert_eq!(
+            report.dependency_graph.unwrap()["readiness"]["states"]["a"],
+            "succeeded"
+        );
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -86,6 +86,10 @@ pub struct AgentTaskBatchStatusReport {
     /// True when one or more children are resumable and the batch can be carried
     /// to PR-ready finalization by re-running the coordinator.
     pub resumable: bool,
+    /// Dependency topology and current readiness for fanout batches that
+    /// declared explicit child dependencies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency_graph: Option<Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<String>,
     pub commands: AgentTaskBatchCommands,

--- a/crates/homeboy-agents/src/agent_task_dependency_actions.rs
+++ b/crates/homeboy-agents/src/agent_task_dependency_actions.rs
@@ -1,0 +1,549 @@
+//! Durable, provider-neutral follow-up actions for resolved fanout dependencies.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::agent_task_batch;
+use homeboy_core::{Error, Result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DependencyResolution {
+    pub child_id: String,
+    /// Exact upstream head or merge revision the dependent is rebased onto.
+    pub upstream_revision: String,
+    /// The PR base after this transition: an upstream candidate branch before
+    /// merge, and the resolved target branch after merge.
+    pub target_base: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DependencyAction {
+    pub upstream_id: String,
+    pub downstream_id: String,
+    pub worktree: String,
+    pub head: String,
+    pub upstream_revision: String,
+    pub target_base: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request: Option<String>,
+}
+
+/// External mutations owned by the caller. Every call is journaled separately
+/// by [`execute_resolved_dependency_actions`], rather than making rebase/push
+/// one unrecoverable operation.
+pub trait DependencyActionExecutor {
+    /// Check a claimed external mutation against its desired after-state before
+    /// retrying it after coordinator loss.
+    fn side_effect_applied(&mut self, action: &DependencyAction, step: &str) -> Result<bool>;
+    fn fetch(&mut self, action: &DependencyAction) -> Result<()>;
+    fn rebase(&mut self, action: &DependencyAction) -> Result<()>;
+    fn push(&mut self, action: &DependencyAction) -> Result<()>;
+    fn update_pull_request_base(&mut self, action: &DependencyAction) -> Result<()>;
+    fn invalidate_review(&mut self, action: &DependencyAction) -> Result<()>;
+}
+
+const STEPS: [&str; 6] = [
+    "fetch",
+    "rebase",
+    "push",
+    "pull_request_base_update",
+    "gates_invalidate",
+    "review_invalidate",
+];
+
+/// Execute transitions from their first incomplete durable step. A claimed
+/// record is written before every side effect and a completed record after it;
+/// completed pushes are therefore never issued again on a later resume.
+pub fn execute_resolved_dependency_actions<E: DependencyActionExecutor>(
+    batch_id: &str,
+    resolutions: &[DependencyResolution],
+    executor: &mut E,
+) -> Result<Vec<Value>> {
+    let batch = agent_task_batch::read_batch_record(batch_id)?;
+    let nodes = batch.metadata["dependency_graph"]["nodes"]
+        .as_array()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "batch_id",
+                "fanout batch has no dependency graph",
+                Some(batch_id.into()),
+                None,
+            )
+        })?;
+    let mut actions = Vec::new();
+    for resolution in resolutions {
+        if resolution.upstream_revision.trim().is_empty()
+            || resolution.target_base.trim().is_empty()
+        {
+            return Err(Error::validation_invalid_argument(
+                "dependency",
+                "dependency transition must include an exact upstream revision and target base",
+                Some(resolution.child_id.clone()),
+                None,
+            ));
+        }
+        let tracker = nodes
+            .iter()
+            .find(|node| node["id"].as_str() == Some(&resolution.child_id))
+            .and_then(|node| node["tracker_url"].as_str());
+        for node in nodes {
+            if !node["depends_on"].as_array().is_some_and(|dependencies| {
+                dependencies.iter().any(|dependency| {
+                    dependency.as_str() == Some(&resolution.child_id)
+                        || dependency.as_str() == tracker
+                })
+            }) {
+                continue;
+            }
+            let downstream_id = node["id"].as_str().unwrap_or_default();
+            let worktree = required_node_value(node, "worktree", downstream_id)?;
+            let head = required_node_value(node, "head", downstream_id)?;
+            let pull_request = batch
+                .child_runs
+                .iter()
+                .find(|child| child.task_id == downstream_id)
+                .and_then(|child| crate::agent_task_lifecycle::status(&child.run_id).ok())
+                .and_then(|record| record.metadata.get("cook_finalization").cloned())
+                .and_then(|value| {
+                    value["pr_url"]
+                        .as_str()
+                        .map(str::to_string)
+                        .or_else(|| value["pr_number"].as_u64().map(|number| number.to_string()))
+                        .or_else(|| value["pr"]["url"].as_str().map(str::to_string))
+                        .or_else(|| {
+                            value["pr"]["number"]
+                                .as_u64()
+                                .map(|number| number.to_string())
+                        })
+                })
+                // Prior stack transitions retain the PR identity after their
+                // gate invalidation removes the old finalization record. A
+                // later upstream merge must still move that same PR to target.
+                .or_else(|| {
+                    batch.metadata["dependency_action_receipts"]
+                        .as_object()
+                        .into_iter()
+                        .flat_map(|receipts| receipts.values())
+                        .filter(|receipt| {
+                            receipt["action"]["downstream_id"].as_str() == Some(downstream_id)
+                        })
+                        .rev()
+                        .find_map(|receipt| {
+                            receipt["action"]["pull_request"]
+                                .as_str()
+                                .map(str::to_string)
+                        })
+                });
+            actions.push(DependencyAction {
+                upstream_id: resolution.child_id.clone(),
+                downstream_id: downstream_id.to_string(),
+                worktree,
+                head,
+                upstream_revision: resolution.upstream_revision.clone(),
+                target_base: resolution.target_base.clone(),
+                pull_request,
+            });
+        }
+    }
+
+    let mut receipts = Vec::new();
+    for action in actions {
+        let key = format!(
+            "{}:{}:{}:{}",
+            action.upstream_id, action.downstream_id, action.upstream_revision, action.target_base
+        );
+        let mut receipt = agent_task_batch::dependency_action_receipt(batch_id, &key)?
+            .unwrap_or_else(|| json!({ "status": "pending", "action": action, "steps": {} }));
+        for step in STEPS {
+            if receipt["steps"][step]["status"] == "completed"
+                || (step == "pull_request_base_update" && action.pull_request.is_none())
+            {
+                continue;
+            }
+            if matches!(
+                receipt["steps"][step]["status"].as_str(),
+                Some("claimed" | "blocked")
+            ) && executor.side_effect_applied(&action, step)?
+            {
+                receipt["steps"][step] = json!({ "status": "completed", "before": { "action": action }, "after": { "action": action }, "reconciled": true });
+                agent_task_batch::record_dependency_action_receipt(
+                    batch_id,
+                    &key,
+                    receipt.clone(),
+                )?;
+                continue;
+            }
+            receipt["status"] = Value::String("running".into());
+            receipt["steps"][step] = json!({ "status": "claimed", "before": { "action": action } });
+            agent_task_batch::record_dependency_action_receipt(batch_id, &key, receipt.clone())?;
+            let result = match step {
+                "fetch" => executor.fetch(&action),
+                "rebase" => executor.rebase(&action),
+                "push" => executor.push(&action),
+                "pull_request_base_update" => executor.update_pull_request_base(&action),
+                "gates_invalidate" => invalidate_downstream_cook(batch_id, &action),
+                "review_invalidate" => executor.invalidate_review(&action),
+                _ => unreachable!(),
+            };
+            match result {
+                Ok(()) => {
+                    receipt["steps"][step] = json!({ "status": "completed", "before": { "action": action }, "after": { "action": action } });
+                    agent_task_batch::record_dependency_action_receipt(
+                        batch_id,
+                        &key,
+                        receipt.clone(),
+                    )?;
+                }
+                Err(error) => {
+                    receipt["status"] = Value::String("blocked".into());
+                    receipt["blocked_step"] = Value::String(step.into());
+                    receipt["steps"][step] = json!({ "status": "blocked", "before": { "action": action }, "error": error.message });
+                    receipt["resolution"] = Value::String(format!(
+                        "resolve {} for '{}' and resume fanout {}",
+                        step, action.worktree, batch_id
+                    ));
+                    agent_task_batch::record_dependency_action_receipt(
+                        batch_id,
+                        &key,
+                        receipt.clone(),
+                    )?;
+                    break;
+                }
+            }
+        }
+        if STEPS.iter().all(|step| {
+            receipt["steps"][step]["status"] == "completed"
+                || (*step == "pull_request_base_update" && action.pull_request.is_none())
+        }) {
+            receipt["status"] = Value::String("completed".into());
+            receipt["gates_invalidated"] = Value::Bool(true);
+            receipt["review_invalidated"] = Value::Bool(true);
+            agent_task_batch::record_dependency_action_receipt(batch_id, &key, receipt.clone())?;
+        }
+        receipts.push(receipt);
+    }
+    Ok(receipts)
+}
+
+fn required_node_value(node: &Value, field: &str, downstream_id: &str) -> Result<String> {
+    node[field]
+        .as_str()
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                format!("dependency_graph.nodes.{field}"),
+                "dependent action requires a materialized worktree and head branch",
+                Some(downstream_id.into()),
+                None,
+            )
+        })
+}
+
+/// This is the lifecycle mutation, not just a display marker: it removes the
+/// completed finalization and re-arms Cook's promoted-candidate verification.
+fn invalidate_downstream_cook(batch_id: &str, action: &DependencyAction) -> Result<()> {
+    let batch = agent_task_batch::read_batch_record(batch_id)?;
+    let Some(child) = batch
+        .child_runs
+        .iter()
+        .find(|child| child.task_id == action.downstream_id)
+    else {
+        return Ok(());
+    };
+    crate::agent_task_lifecycle::invalidate_cook_finalization_for_dependency(
+        &child.run_id,
+        &action.upstream_revision,
+        &format!("homeboy agent-task fanout resume {batch_id}"),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_task_batch::{persist_fanout_run_batch, FanoutRunBatchChild};
+
+    #[derive(Default)]
+    struct Fake {
+        calls: Vec<&'static str>,
+        fail: Option<&'static str>,
+        applied: Vec<&'static str>,
+    }
+    impl DependencyActionExecutor for Fake {
+        fn side_effect_applied(&mut self, _: &DependencyAction, step: &str) -> Result<bool> {
+            Ok(self.applied.contains(&step))
+        }
+
+        fn fetch(&mut self, _: &DependencyAction) -> Result<()> {
+            self.calls.push("fetch");
+            Ok(())
+        }
+        fn rebase(&mut self, _: &DependencyAction) -> Result<()> {
+            self.calls.push("rebase");
+            if self.fail == Some("rebase") {
+                Err(Error::git_command_failed("conflict"))
+            } else {
+                Ok(())
+            }
+        }
+        fn push(&mut self, _: &DependencyAction) -> Result<()> {
+            self.calls.push("push");
+            Ok(())
+        }
+        fn update_pull_request_base(&mut self, _: &DependencyAction) -> Result<()> {
+            self.calls.push("pr");
+            if self.fail == Some("pr") {
+                Err(Error::git_command_failed("edit failed"))
+            } else {
+                Ok(())
+            }
+        }
+        fn invalidate_review(&mut self, _: &DependencyAction) -> Result<()> {
+            self.calls.push("review");
+            Ok(())
+        }
+    }
+    fn metadata() -> Value {
+        json!({ "dependency_graph": { "nodes": [{"id":"foundation","depends_on":[]},{"id":"dependent","depends_on":["foundation"],"worktree":"/tmp/dependent","head":"feature/dependent"}]}})
+    }
+    #[test]
+    fn resumes_from_incomplete_invalidation_without_repeating_push() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let id = format!("dependency-steps-{}", uuid::Uuid::new_v4());
+        persist_fanout_run_batch(
+            &id,
+            &id,
+            &[FanoutRunBatchChild {
+                task_id: "dependent".into(),
+                run_id: "cook-dependent".into(),
+            }],
+            metadata(),
+        )
+        .unwrap();
+        let resolution = DependencyResolution {
+            child_id: "foundation".into(),
+            upstream_revision: "a".repeat(40),
+            target_base: "main".into(),
+        };
+        let mut first = Fake::default();
+        execute_resolved_dependency_actions(&id, &[resolution.clone()], &mut first).unwrap();
+        assert_eq!(first.calls, ["fetch", "rebase", "push"]);
+        let mut resumed = Fake::default();
+        execute_resolved_dependency_actions(&id, &[resolution], &mut resumed).unwrap();
+        assert!(!resumed.calls.contains(&"push"));
+    }
+
+    #[test]
+    fn reconciles_claimed_push_after_crash_without_repeating_it() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let id = format!("dependency-crash-push-{}", uuid::Uuid::new_v4());
+        persist_fanout_run_batch(
+            &id,
+            &id,
+            &[FanoutRunBatchChild {
+                task_id: "dependent".into(),
+                run_id: "missing-run".into(),
+            }],
+            metadata(),
+        )
+        .unwrap();
+        let resolution = DependencyResolution {
+            child_id: "foundation".into(),
+            upstream_revision: "a".repeat(40),
+            target_base: "main".into(),
+        };
+        let key = format!(
+            "foundation:dependent:{}:{}",
+            resolution.upstream_revision, resolution.target_base
+        );
+        agent_task_batch::record_dependency_action_receipt(
+            &id,
+            &key,
+            json!({
+                "status": "running",
+                "steps": {
+                    "fetch": { "status": "completed" },
+                    "rebase": { "status": "completed" },
+                    "push": { "status": "claimed" }
+                }
+            }),
+        )
+        .unwrap();
+
+        let mut resumed = Fake {
+            applied: vec!["push"],
+            ..Default::default()
+        };
+        execute_resolved_dependency_actions(&id, &[resolution], &mut resumed).unwrap();
+
+        assert!(!resumed.calls.contains(&"push"));
+        let receipt = agent_task_batch::dependency_action_receipt(&id, &key)
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt["steps"]["push"]["status"], "completed");
+        assert_eq!(receipt["steps"]["push"]["reconciled"], true);
+    }
+
+    #[test]
+    fn reconciles_claimed_pr_edit_after_crash_without_repeating_it() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let id = format!("dependency-crash-pr-{}", uuid::Uuid::new_v4());
+        crate::agent_task_lifecycle::submit_plan(
+            &crate::agent_task_schedule::AgentTaskPlan::new("dependent", Vec::new()),
+            Some("dependent-run"),
+        )
+        .unwrap();
+        crate::agent_task_lifecycle::record_cook_finalization(
+            "dependent-run",
+            json!({ "pr_url": "https://example.test/pr/1" }),
+        )
+        .unwrap();
+        persist_fanout_run_batch(
+            &id,
+            &id,
+            &[FanoutRunBatchChild {
+                task_id: "dependent".into(),
+                run_id: "dependent-run".into(),
+            }],
+            metadata(),
+        )
+        .unwrap();
+        let resolution = DependencyResolution {
+            child_id: "foundation".into(),
+            upstream_revision: "a".repeat(40),
+            target_base: "main".into(),
+        };
+        let key = format!(
+            "foundation:dependent:{}:{}",
+            resolution.upstream_revision, resolution.target_base
+        );
+        agent_task_batch::record_dependency_action_receipt(
+            &id,
+            &key,
+            json!({
+                "status": "running",
+                "steps": {
+                    "fetch": { "status": "completed" },
+                    "rebase": { "status": "completed" },
+                    "push": { "status": "completed" },
+                    "pull_request_base_update": { "status": "claimed" }
+                }
+            }),
+        )
+        .unwrap();
+
+        let mut resumed = Fake {
+            applied: vec!["pull_request_base_update"],
+            ..Default::default()
+        };
+        execute_resolved_dependency_actions(&id, &[resolution], &mut resumed).unwrap();
+
+        assert!(!resumed.calls.contains(&"pr"));
+        let receipt = agent_task_batch::dependency_action_receipt(&id, &key)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            receipt["steps"]["pull_request_base_update"]["status"],
+            "completed"
+        );
+        assert_eq!(
+            receipt["steps"]["pull_request_base_update"]["reconciled"],
+            true
+        );
+    }
+
+    #[test]
+    fn reconciles_blocked_push_after_the_remote_applied_it() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let id = format!("dependency-blocked-push-{}", uuid::Uuid::new_v4());
+        persist_fanout_run_batch(
+            &id,
+            &id,
+            &[FanoutRunBatchChild {
+                task_id: "dependent".into(),
+                run_id: "missing-run".into(),
+            }],
+            metadata(),
+        )
+        .unwrap();
+        let resolution = DependencyResolution {
+            child_id: "foundation".into(),
+            upstream_revision: "a".repeat(40),
+            target_base: "main".into(),
+        };
+        let key = format!(
+            "foundation:dependent:{}:{}",
+            resolution.upstream_revision, resolution.target_base
+        );
+        agent_task_batch::record_dependency_action_receipt(
+            &id,
+            &key,
+            json!({
+                "status": "blocked",
+                "steps": {
+                    "fetch": { "status": "completed" },
+                    "rebase": { "status": "completed" },
+                    "push": { "status": "blocked", "error": "connection lost" }
+                }
+            }),
+        )
+        .unwrap();
+
+        let mut resumed = Fake {
+            applied: vec!["push"],
+            ..Default::default()
+        };
+        execute_resolved_dependency_actions(&id, &[resolution], &mut resumed).unwrap();
+
+        assert!(!resumed.calls.contains(&"push"));
+        let receipt = agent_task_batch::dependency_action_receipt(&id, &key)
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt["steps"]["push"]["status"], "completed");
+        assert_eq!(receipt["steps"]["push"]["reconciled"], true);
+    }
+
+    #[test]
+    fn repeated_local_invalidation_preserves_the_original_finalization() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        crate::agent_task_lifecycle::submit_plan(
+            &crate::agent_task_schedule::AgentTaskPlan::new("dependent", Vec::new()),
+            Some("dependent-run"),
+        )
+        .unwrap();
+        crate::agent_task_lifecycle::record_promotion(
+            "dependent-run",
+            json!({ "status": "succeeded" }),
+        )
+        .unwrap();
+        let finalization =
+            json!({ "status": "review_ready", "pr_url": "https://example.test/pr/1" });
+        crate::agent_task_lifecycle::record_cook_finalization(
+            "dependent-run",
+            finalization.clone(),
+        )
+        .unwrap();
+
+        crate::agent_task_lifecycle::invalidate_cook_finalization_for_dependency(
+            "dependent-run",
+            "a".repeat(40).as_str(),
+            "resume",
+        )
+        .unwrap();
+        let first = crate::agent_task_lifecycle::persisted_status("dependent-run").unwrap();
+        crate::agent_task_lifecycle::invalidate_cook_finalization_for_dependency(
+            "dependent-run",
+            "a".repeat(40).as_str(),
+            "resume",
+        )
+        .unwrap();
+        let second = crate::agent_task_lifecycle::persisted_status("dependent-run").unwrap();
+
+        assert_eq!(second.updated_at, first.updated_at);
+        assert_eq!(
+            second.metadata["cook_recovery_source_checkpoint"]["prior_finalization"],
+            finalization
+        );
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_dependency_graph.rs
+++ b/crates/homeboy-agents/src/agent_task_dependency_graph.rs
@@ -1,0 +1,297 @@
+//! Provider-neutral dependency graph and readiness projection for durable fanout.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, VecDeque};
+
+use homeboy_core::{Error, Result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskDependencyNode {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tracker_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head: Option<String>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskDependencyEdge {
+    pub upstream_id: String,
+    pub downstream_id: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskDependencyState {
+    Queued,
+    Ready,
+    BlockedByDependency,
+    BlockedByGate,
+    AwaitingAcceptance,
+    Succeeded,
+    Rejected,
+    Failed,
+    Cancelled,
+}
+
+impl AgentTaskDependencyState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Rejected | Self::Failed | Self::Cancelled
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskDependencyReadiness {
+    pub states: BTreeMap<String, AgentTaskDependencyState>,
+    pub ready: Vec<String>,
+    pub blocked_paths: BTreeMap<String, Vec<String>>,
+    pub next_action: String,
+}
+
+/// Validate durable child identities and project executable siblings. This is a
+/// generic read-side seam: callers own candidate, gate, and PR mutation.
+pub fn dependency_graph_readiness(
+    nodes: &[AgentTaskDependencyNode],
+    states: &BTreeMap<String, AgentTaskDependencyState>,
+) -> Result<(Vec<AgentTaskDependencyEdge>, AgentTaskDependencyReadiness)> {
+    let mut by_id = BTreeMap::new();
+    let mut tracker_ids = BTreeMap::new();
+    for node in nodes {
+        if node.id.trim().is_empty() {
+            return Err(graph_error("child id must not be empty"));
+        }
+        if by_id.insert(node.id.as_str(), node).is_some() {
+            return Err(graph_error(&format!("duplicate child id '{}'", node.id)));
+        }
+        if let Some(url) = node.tracker_url.as_deref() {
+            if tracker_ids.insert(url, node.id.as_str()).is_some() {
+                return Err(graph_error(&format!("duplicate tracker URL '{url}'")));
+            }
+        }
+    }
+
+    let mut edges = Vec::new();
+    for node in nodes {
+        for reference in &node.depends_on {
+            let upstream = by_id
+                .get(reference.as_str())
+                .copied()
+                .or_else(|| {
+                    tracker_ids
+                        .get(reference.as_str())
+                        .and_then(|id| by_id.get(id).copied())
+                })
+                .ok_or_else(|| {
+                    graph_error(&format!(
+                        "child '{}' depends on missing or ambiguous child/tracker '{}'",
+                        node.id, reference
+                    ))
+                })?;
+            if upstream.repository != node.repository {
+                return Err(graph_error(&format!(
+                    "cross-repository edge '{}' -> '{}' is unsupported",
+                    upstream.id, node.id
+                )));
+            }
+            edges.push(AgentTaskDependencyEdge {
+                upstream_id: upstream.id.clone(),
+                downstream_id: node.id.clone(),
+            });
+        }
+    }
+    edges.sort_by(|a, b| {
+        (&a.downstream_id, &a.upstream_id).cmp(&(&b.downstream_id, &b.upstream_id))
+    });
+    detect_cycle(nodes, &edges)?;
+
+    let mut projected = BTreeMap::new();
+    let mut ready = Vec::new();
+    let mut blocked_paths = BTreeMap::new();
+    for node in nodes {
+        let current = states
+            .get(&node.id)
+            .copied()
+            .unwrap_or(AgentTaskDependencyState::Queued);
+        let dependencies = edges
+            .iter()
+            .filter(|edge| edge.downstream_id == node.id)
+            .collect::<Vec<_>>();
+        let failed = dependencies.iter().find(|edge| {
+            matches!(
+                states.get(&edge.upstream_id).copied(),
+                Some(
+                    AgentTaskDependencyState::Rejected
+                        | AgentTaskDependencyState::Failed
+                        | AgentTaskDependencyState::Cancelled
+                )
+            )
+        });
+        let pending = dependencies.iter().find(|edge| {
+            states
+                .get(&edge.upstream_id)
+                .copied()
+                .unwrap_or(AgentTaskDependencyState::Queued)
+                != AgentTaskDependencyState::Succeeded
+        });
+        let state = if current.is_terminal()
+            || matches!(
+                current,
+                AgentTaskDependencyState::BlockedByGate
+                    | AgentTaskDependencyState::AwaitingAcceptance
+            ) {
+            current
+        } else if let Some(edge) = failed {
+            blocked_paths.insert(
+                node.id.clone(),
+                vec![node.id.clone(), edge.upstream_id.clone()],
+            );
+            AgentTaskDependencyState::BlockedByDependency
+        } else if let Some(edge) = pending {
+            blocked_paths.insert(
+                node.id.clone(),
+                vec![node.id.clone(), edge.upstream_id.clone()],
+            );
+            AgentTaskDependencyState::BlockedByDependency
+        } else {
+            ready.push(node.id.clone());
+            AgentTaskDependencyState::Ready
+        };
+        projected.insert(node.id.clone(), state);
+    }
+    let next_action = if let Some(id) = ready.first() {
+        format!("dispatch ready child '{id}'")
+    } else if let Some((id, path)) = blocked_paths.iter().next() {
+        format!(
+            "resolve dependency path {} before dispatching '{id}'",
+            path.join(" <- ")
+        )
+    } else {
+        "inspect terminal child evidence and accept or retry the next candidate".to_string()
+    };
+    Ok((
+        edges,
+        AgentTaskDependencyReadiness {
+            states: projected,
+            ready,
+            blocked_paths,
+            next_action,
+        },
+    ))
+}
+
+fn detect_cycle(
+    nodes: &[AgentTaskDependencyNode],
+    edges: &[AgentTaskDependencyEdge],
+) -> Result<()> {
+    let mut incoming = nodes
+        .iter()
+        .map(|node| (node.id.clone(), 0usize))
+        .collect::<BTreeMap<_, _>>();
+    let mut outgoing = BTreeMap::<String, Vec<String>>::new();
+    for edge in edges {
+        *incoming
+            .get_mut(&edge.downstream_id)
+            .expect("validated node") += 1;
+        outgoing
+            .entry(edge.upstream_id.clone())
+            .or_default()
+            .push(edge.downstream_id.clone());
+    }
+    let mut queue = incoming
+        .iter()
+        .filter(|(_, count)| **count == 0)
+        .map(|(id, _)| id.clone())
+        .collect::<VecDeque<_>>();
+    let mut visited = 0;
+    while let Some(id) = queue.pop_front() {
+        visited += 1;
+        for downstream in outgoing.get(&id).into_iter().flatten() {
+            let count = incoming.get_mut(downstream).expect("validated node");
+            *count -= 1;
+            if *count == 0 {
+                queue.push_back(downstream.clone());
+            }
+        }
+    }
+    if visited != nodes.len() {
+        let cycle = incoming
+            .into_iter()
+            .filter_map(|(id, count)| (count > 0).then_some(id))
+            .take(8)
+            .collect::<Vec<_>>();
+        return Err(graph_error(&format!(
+            "dependency cycle detected among: {}",
+            cycle.join(", ")
+        )));
+    }
+    Ok(())
+}
+
+fn graph_error(message: &str) -> Error {
+    Error::validation_invalid_argument("dependencies", message, None, Some(vec!["Use unique child IDs or tracker URLs, and declare dependencies only within one repository.".to_string()]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str, depends_on: &[&str]) -> AgentTaskDependencyNode {
+        AgentTaskDependencyNode {
+            id: id.into(),
+            tracker_url: Some(format!("https://tracker/{id}")),
+            repository: Some("homeboy".into()),
+            worktree: Some(format!("/tmp/{id}")),
+            head: Some(format!("feature/{id}")),
+            depends_on: depends_on.iter().map(ToString::to_string).collect(),
+        }
+    }
+
+    #[test]
+    fn schedules_independent_siblings_then_their_dependent() {
+        let nodes = vec![
+            node("foundation", &[]),
+            node("sibling", &[]),
+            node("dependent", &["https://tracker/foundation"]),
+        ];
+        let (edges, initial) =
+            dependency_graph_readiness(&nodes, &BTreeMap::new()).expect("valid graph");
+        assert_eq!(edges.len(), 1);
+        assert_eq!(initial.ready, vec!["foundation", "sibling"]);
+        assert_eq!(
+            initial.states["dependent"],
+            AgentTaskDependencyState::BlockedByDependency
+        );
+        let states = BTreeMap::from([
+            ("foundation".into(), AgentTaskDependencyState::Succeeded),
+            ("sibling".into(), AgentTaskDependencyState::Succeeded),
+        ]);
+        let (_, ready) = dependency_graph_readiness(&nodes, &states).expect("ready dependent");
+        assert_eq!(ready.ready, vec!["dependent"]);
+    }
+
+    #[test]
+    fn rejects_cycles_and_cross_repository_edges_before_dispatch() {
+        let cycle = vec![node("a", &["b"]), node("b", &["a"])];
+        assert!(dependency_graph_readiness(&cycle, &BTreeMap::new())
+            .unwrap_err()
+            .message
+            .contains("cycle"));
+        let mut other = node("other", &["a"]);
+        other.repository = Some("other".into());
+        assert!(
+            dependency_graph_readiness(&[node("a", &[]), other], &BTreeMap::new())
+                .unwrap_err()
+                .message
+                .contains("cross-repository")
+        );
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2101,6 +2101,64 @@ pub fn record_cook_recovery_checkpoint(
     }
 }
 
+/// Re-arm a finalized candidate after a dependency rebase. The original
+/// provider output remains authoritative; Cook resumes at the promotion/gate
+/// boundary and finalizes a fresh review only after those gates pass again.
+pub fn invalidate_cook_finalization_for_dependency(
+    run_id: &str,
+    dependency_revision: &str,
+    next_command: &str,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        // Retrying the same invalidation after an interrupted coordinator must
+        // preserve the original review evidence and leave its timestamp stable.
+        if metadata.get("cook_finalization").is_none()
+            && metadata
+                .get("cook_recovery_source_checkpoint")
+                .is_some_and(|checkpoint| {
+                    checkpoint["phase"] == "verification_pending"
+                        && checkpoint["dependency_revision"] == dependency_revision
+                })
+        {
+            return false;
+        }
+        let prior = metadata.remove("cook_finalization");
+        let original_prior = metadata
+            .get("cook_recovery_source_checkpoint")
+            .and_then(|checkpoint| checkpoint.get("prior_finalization"))
+            .cloned()
+            .unwrap_or_else(|| prior.clone().unwrap_or(Value::Null));
+        let Some(mut promotion) = metadata.get("latest_promotion").cloned() else {
+            // A terminal child can have no promotion only when it was never a
+            // review-ready Cook; retain an inspectable invalidation marker.
+            metadata.insert("dependency_rebase".to_string(), json!({ "revision": dependency_revision, "next_command": next_command, "prior_finalization": original_prior }));
+            record.updated_at = Some(now_timestamp());
+            return true;
+        };
+        promotion["status"] = json!("verification_pending");
+        promotion["dependency_revision"] = json!(dependency_revision);
+        metadata.insert("latest_promotion".to_string(), promotion);
+        metadata.insert(
+            "cook_recovery_source_checkpoint".to_string(),
+            json!({
+                "schema": "homeboy/agent-task-cook-recovery-checkpoint/v1",
+                "phase": "verification_pending",
+                "next_command": next_command,
+                "dependency_revision": dependency_revision,
+                "prior_finalization": original_prior,
+            }),
+        );
+        record.updated_at = Some(now_timestamp());
+        true
+    })?;
+    match record {
+        Some(record) => Ok(record),
+        None => store::read_record(&run_id),
+    }
+}
+
 pub fn cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
     store::read_cook_index(&sanitize_run_id(cook_id))
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -946,9 +946,24 @@ where
         ));
     }
 
+    let ready = crate::agent_task_batch::fanout_ready_child_run_ids(batch_id)?;
     let total = batch.child_runs.len();
     let mut cells = Vec::with_capacity(total);
     for child in &batch.child_runs {
+        if ready
+            .as_ref()
+            .is_some_and(|ready| !ready.contains(&child.run_id))
+        {
+            cells.push(AgentTaskCookBatchCellReport {
+                cook_id: child.task_id.clone(),
+                initial_run_id: child.run_id.clone(),
+                status: "blocked_by_dependency".to_string(),
+                exit_code: 0,
+                result: None,
+                error: None,
+            });
+            continue;
+        }
         // The persisted batch child `run_id` is the cook id (`cook-<id>`), which
         // is exactly the durable recipe key. Reconstruct from that recipe so the
         // resumed cook re-runs its own gates and finalization contract.

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -185,12 +185,30 @@ pub mod cook_loop {
 /// Durable batch/fanout lifecycle records built from independent child runs.
 pub mod batch {
     pub use super::super::agent_task_batch::{
-        artifacts, persist_fanout_run_batch, read_batch_record,
+        artifacts, fanout_aggregate_state, fanout_dependency_graph_with_finalization_statuses,
+        fanout_ready_child_run_ids, persist_fanout_run_batch, read_batch_record,
         record_fanout_run_batch_failed_admissions, status, submit_plan_batch,
         AgentTaskBatchArtifactsReport, AgentTaskBatchChildArtifacts, AgentTaskBatchChildRun,
         AgentTaskBatchCommands, AgentTaskBatchRecord, AgentTaskBatchState,
         AgentTaskBatchStatusReport, AgentTaskBatchTotals, FanoutRunBatchChild,
         AGENT_TASK_BATCH_ARTIFACTS_SCHEMA, AGENT_TASK_BATCH_SCHEMA, AGENT_TASK_BATCH_STATUS_SCHEMA,
+    };
+}
+
+/// Generic dependency graph validation and readiness projection for fanout and
+/// supervisor orchestration.
+pub mod dependency_graph {
+    pub use super::super::agent_task_dependency_graph::{
+        dependency_graph_readiness, AgentTaskDependencyEdge, AgentTaskDependencyNode,
+        AgentTaskDependencyReadiness, AgentTaskDependencyState,
+    };
+}
+
+/// Durable Git/PR actions released by a merged fanout dependency.
+pub mod dependency_actions {
+    pub use super::super::agent_task_dependency_actions::{
+        execute_resolved_dependency_actions, DependencyAction, DependencyActionExecutor,
+        DependencyResolution,
     };
 }
 
@@ -256,27 +274,28 @@ pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run,
         cook_attempt_run_id, cook_index, cook_index_exists, has_accepted_runner_handoff,
-        list_records, load_controller_plan, load_plan, logs, mark_resuming, mark_running,
-        materialize_recovered_patch_artifact, pin_current_controller_runtime,
-        pinned_runtime_for_mutation, prune_controller_runtime_pins, reconcile_record_health,
-        reconcile_terminal_artifact_projection, record_completed_run, record_cook_attempt,
-        record_detached_lab_run, record_health_summary, record_lab_offload_phase,
-        record_lab_offload_planned, record_pre_dispatch_failure, record_pre_execution_failure,
-        record_promotion, record_remote_dispatch_failure, record_run_aggregate,
-        record_runner_job_identity, resolve_promotion_patch_artifact_id, retry,
-        run_id_for_aggregate_path, run_record_exists, run_record_exists_resolved, run_status,
-        runner_pinned_runtime_for_mutation, runner_probe_plan, select_cook_candidate_from_attempts,
-        status, status_with_options, submit_plan, verified_controller_artifact_projection_path,
-        AgentTaskArtifactRef, AgentTaskCookIndex, AgentTaskCookIndexAttempt,
-        AgentTaskEventEnvelope, AgentTaskPreDispatchFailure, AgentTaskRecordHealthItem,
-        AgentTaskRecordHealthReason, AgentTaskRecordHealthSummary,
-        AgentTaskRecordReconciliationItem, AgentTaskRecordReconciliationReport,
-        AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
-        AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunStatus,
-        AgentTaskRunTask, AgentTaskRunnerProbe, AgentTaskRunnerProbePlan, AgentTaskStatusOptions,
-        AgentTaskStatusOutcome, ControllerRuntimePruneResult, DetachedLabRunRecord,
-        LabOffloadProxyPlan, RunnerPinnedRuntime, RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT,
-        RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL, RUNNER_PROBE_SKIPPED_NOT_RUNNING,
+        invalidate_cook_finalization_for_dependency, list_records, load_controller_plan, load_plan,
+        logs, mark_resuming, mark_running, materialize_recovered_patch_artifact,
+        pin_current_controller_runtime, pinned_runtime_for_mutation, prune_controller_runtime_pins,
+        reconcile_record_health, reconcile_terminal_artifact_projection, record_completed_run,
+        record_cook_attempt, record_cook_finalization, record_detached_lab_run,
+        record_health_summary, record_lab_offload_phase, record_lab_offload_planned,
+        record_pre_dispatch_failure, record_pre_execution_failure, record_promotion,
+        record_remote_dispatch_failure, record_run_aggregate, record_runner_job_identity,
+        resolve_promotion_patch_artifact_id, retry, run_id_for_aggregate_path, run_record_exists,
+        run_record_exists_resolved, run_status, runner_pinned_runtime_for_mutation,
+        runner_probe_plan, select_cook_candidate_from_attempts, status, status_with_options,
+        submit_plan, verified_controller_artifact_projection_path, AgentTaskArtifactRef,
+        AgentTaskCookIndex, AgentTaskCookIndexAttempt, AgentTaskEventEnvelope,
+        AgentTaskPreDispatchFailure, AgentTaskRecordHealthItem, AgentTaskRecordHealthReason,
+        AgentTaskRecordHealthSummary, AgentTaskRecordReconciliationItem,
+        AgentTaskRecordReconciliationReport, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
+        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
+        AgentTaskRunStatus, AgentTaskRunTask, AgentTaskRunnerProbe, AgentTaskRunnerProbePlan,
+        AgentTaskStatusOptions, AgentTaskStatusOutcome, ControllerRuntimePruneResult,
+        DetachedLabRunRecord, LabOffloadProxyPlan, RunnerPinnedRuntime,
+        RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT, RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL,
+        RUNNER_PROBE_SKIPPED_NOT_RUNNING,
     };
     #[cfg(feature = "test-support")]
     pub use super::super::agent_task_lifecycle::{

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -15,6 +15,8 @@ pub mod agent_task_config_materialization;
 pub mod agent_task_contract;
 pub mod agent_task_controller_service;
 pub mod agent_task_cook_loop;
+pub mod agent_task_dependency_actions;
+pub mod agent_task_dependency_graph;
 pub mod agent_task_dispatch_plan;
 pub mod agent_task_dispatch_service;
 pub mod agent_task_executor_evidence;

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -3,10 +3,18 @@
 use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
+use std::process::Command;
 
 use homeboy::agents::agent_task_provider::AgentTaskProviderProfileDeclaration;
 use homeboy::agents::agent_tasks::batch;
+use homeboy::agents::agent_tasks::dependency_actions::{
+    execute_resolved_dependency_actions, DependencyAction, DependencyActionExecutor,
+    DependencyResolution,
+};
+use homeboy::agents::agent_tasks::dependency_graph::{
+    dependency_graph_readiness, AgentTaskDependencyNode,
+};
 use homeboy::agents::agent_tasks::dispatch_service::{
     AgentTaskDispatchCommand, DispatchCoreInputs,
 };
@@ -117,7 +125,19 @@ fn submit_fanout_batch(args: AgentTaskFanoutSubmitBatchArgs) -> CmdResult<Value>
 }
 
 fn batch_status(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
-    let report = batch::status(&args.batch_id)?;
+    let observations = reconcile_fanout_pr_states(&args.batch_id, false)?;
+    let mut report = batch::status(&args.batch_id)?;
+    if !observations.is_empty() {
+        report.dependency_graph = batch::fanout_dependency_graph_with_finalization_statuses(
+            &args.batch_id,
+            &observations,
+        )?;
+        if let Some(graph) = &report.dependency_graph {
+            let state = batch::fanout_aggregate_state(&report.totals, graph);
+            report.batch.state = state;
+            report.status = state.outcome_status().to_string();
+        }
+    }
     let exit_code = report.batch.state.exit_code();
     Ok((command_json_value(report)?, exit_code))
 }
@@ -128,6 +148,7 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
 /// contract, reconciling per-child state back into the durable batch record so
 /// repeated resume calls converge without duplicate PRs (#9525).
 fn batch_resume(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
+    reconcile_fanout_pr_states(&args.batch_id, true)?;
     let result = agent_task_service::resume_cook_batch(
         &args.batch_id,
         provider::ExtensionProviderAgentTaskExecutor::discover(),
@@ -135,6 +156,309 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
     )?;
     let exit_code = result.exit_code;
     Ok(batch_resume_result(result.value, exit_code, &args.batch_id))
+}
+
+/// GitHub is the authority for whether a review-ready candidate was accepted.
+/// Persist that observation before asking the durable graph for its executable
+/// frontier, so a merge releases only its newly-ready descendants.
+fn reconcile_fanout_pr_states(batch_id: &str, mutate: bool) -> Result<BTreeMap<String, String>> {
+    let batch = batch::read_batch_record(batch_id)?;
+    let mut resolutions = Vec::new();
+    let mut statuses = BTreeMap::new();
+    for child in batch.child_runs {
+        let Ok(record) = agent_task_lifecycle::status(&child.run_id) else {
+            continue;
+        };
+        let Some(mut finalization) = record.metadata.get("cook_finalization").cloned() else {
+            continue;
+        };
+        let pr_ref = finalization
+            .get("pr_url")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| {
+                finalization
+                    .get("pr_number")
+                    .and_then(Value::as_u64)
+                    .map(|number| number.to_string())
+            })
+            // Older durable finalization records used a nested PR reference.
+            .or_else(|| {
+                finalization
+                    .get("pr")
+                    .and_then(|pr| pr.get("url"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .or_else(|| {
+                finalization
+                    .get("pr")
+                    .and_then(|pr| pr.get("number"))
+                    .and_then(Value::as_u64)
+                    .map(|number| number.to_string())
+            });
+        let Some(pr_ref) = pr_ref else { continue };
+        let observation = observe_pr_state(&pr_ref)?;
+        let status = observation.verdict();
+        let mut pr_observation = observation.as_value();
+        if let Some(candidate_revision) = finalization
+            .pointer("/publication_proof/binding/candidate_sha")
+            .and_then(Value::as_str)
+        {
+            // The PR head is the precise candidate that was reviewed. Retain
+            // the comparison with the merge observation so a changed upstream
+            // revision always re-runs dependent invalidation/review instead of
+            // trusting the prior candidate's gates.
+            pr_observation["candidate_revision"] = Value::String(candidate_revision.to_string());
+            pr_observation["candidate_revision_matches"] = Value::Bool(
+                observation
+                    .head_ref_oid
+                    .as_deref()
+                    .is_none_or(|head| head == candidate_revision),
+            );
+        }
+        statuses.insert(child.task_id.clone(), status.to_string());
+        let transition = match status {
+            // An approved candidate makes the next stack level reviewable now.
+            // Bind it to the exact head observed so a later force-push/new commit
+            // is a distinct durable rebase, gate, and review invalidation.
+            "review_ready" => observation
+                .head_ref_oid
+                .clone()
+                .zip(observation.head_ref_name.clone()),
+            // Once merged, move the dependent from the candidate branch back to
+            // the PR's resolved target branch using the merge commit.
+            "merged" => observation
+                .merge_commit
+                .as_ref()
+                .map(|commit| commit.oid.clone())
+                .zip(observation.base_ref_name.clone()),
+            _ => None,
+        };
+        if let Some((upstream_revision, target_base)) = transition {
+            resolutions.push(DependencyResolution {
+                child_id: child.task_id.clone(),
+                upstream_revision,
+                target_base,
+            });
+        }
+        if !mutate
+            || (finalization.get("status").and_then(Value::as_str) == Some(status)
+                && finalization.get("pr_observation") == Some(&pr_observation))
+        {
+            continue;
+        }
+        finalization["status"] = Value::String(status.to_string());
+        finalization["pr_observation"] = pr_observation;
+        agent_task_lifecycle::record_cook_finalization(&child.run_id, finalization)?;
+    }
+    if mutate && !resolutions.is_empty() {
+        execute_resolved_dependency_actions(
+            batch_id,
+            &resolutions,
+            &mut LocalDependencyActionExecutor,
+        )?;
+    }
+    Ok(statuses)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FanoutPrObservation {
+    state: String,
+    #[serde(default)]
+    merged_at: Option<String>,
+    #[serde(default)]
+    review_decision: Option<String>,
+    #[serde(default)]
+    merge_state_status: Option<String>,
+    #[serde(default)]
+    merge_commit: Option<FanoutMergeCommit>,
+    #[serde(default)]
+    base_ref_name: Option<String>,
+    #[serde(default)]
+    head_ref_oid: Option<String>,
+    #[serde(default)]
+    head_ref_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FanoutMergeCommit {
+    oid: String,
+}
+
+impl FanoutPrObservation {
+    fn verdict(&self) -> &'static str {
+        match self.state.as_str() {
+            "MERGED" | "CLOSED" if self.merged_at.is_some() => "merged",
+            "CLOSED" => "rejected",
+            "OPEN" if self.review_decision.as_deref() == Some("CHANGES_REQUESTED") => {
+                "revision_requested"
+            }
+            _ => "review_ready",
+        }
+    }
+
+    fn as_value(&self) -> Value {
+        serde_json::json!({
+            "state": self.state,
+            "merged_at": self.merged_at,
+            "review_decision": self.review_decision,
+            "merge_state_status": self.merge_state_status,
+            "merge_commit_oid": self.merge_commit.as_ref().map(|commit| &commit.oid),
+            "base_ref_name": self.base_ref_name,
+            "head_ref_oid": self.head_ref_oid,
+            "head_ref_name": self.head_ref_name,
+        })
+    }
+}
+
+fn observe_pr_state(pr: &str) -> Result<FanoutPrObservation> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            pr,
+            "--json",
+            "state,mergedAt,reviewDecision,mergeStateStatus,mergeCommit,baseRefName,headRefOid,headRefName",
+        ])
+        .output()
+        .map_err(|error| Error::git_command_failed(format!("gh pr view {pr}: {error}")))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "gh pr view {pr}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| Error::internal_json(format!("parse gh pr view {pr}: {error}"), None))
+}
+
+struct LocalDependencyActionExecutor;
+
+impl DependencyActionExecutor for LocalDependencyActionExecutor {
+    fn side_effect_applied(&mut self, action: &DependencyAction, step: &str) -> Result<bool> {
+        match step {
+            "fetch" => run_dependency_command(
+                &action.worktree,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    &format!("{}^{{commit}}", action.upstream_revision),
+                ],
+            )
+            .map(|()| true)
+            .or_else(|_| Ok(false)),
+            "rebase" => Command::new("git")
+                .args([
+                    "merge-base",
+                    "--is-ancestor",
+                    &action.upstream_revision,
+                    "HEAD",
+                ])
+                .current_dir(&action.worktree)
+                .status()
+                .map(|status| status.success())
+                .map_err(|error| Error::git_command_failed(format!("git merge-base: {error}"))),
+            "push" => {
+                let local = dependency_command_output(&action.worktree, &["rev-parse", "HEAD"])?;
+                let remote = dependency_command_output(
+                    &action.worktree,
+                    &[
+                        "ls-remote",
+                        "--heads",
+                        "origin",
+                        &format!("refs/heads/{}", action.head),
+                    ],
+                )?;
+                Ok(remote
+                    .split_whitespace()
+                    .next()
+                    .is_some_and(|revision| revision == local))
+            }
+            "pull_request_base_update" => {
+                let Some(pr) = action.pull_request.as_deref() else {
+                    return Ok(true);
+                };
+                let observation = observe_pr_state(pr)?;
+                Ok(observation.base_ref_name.as_deref() == Some(&action.target_base))
+            }
+            // These are durable-local transitions, not GitHub/Git side effects.
+            _ => Ok(false),
+        }
+    }
+
+    fn fetch(&mut self, action: &DependencyAction) -> Result<()> {
+        run_dependency_command(
+            &action.worktree,
+            &["fetch", "--no-tags", "origin", &action.upstream_revision],
+        )
+    }
+
+    fn rebase(&mut self, action: &DependencyAction) -> Result<()> {
+        run_dependency_command(&action.worktree, &["rebase", &action.upstream_revision])
+    }
+
+    fn push(&mut self, action: &DependencyAction) -> Result<()> {
+        run_dependency_command(
+            &action.worktree,
+            &[
+                "push",
+                "--force-with-lease",
+                "origin",
+                &format!("HEAD:{}", action.head),
+            ],
+        )
+    }
+
+    fn update_pull_request_base(&mut self, action: &DependencyAction) -> Result<()> {
+        let Some(pr) = action.pull_request.as_deref() else {
+            return Ok(());
+        };
+        let output = Command::new("gh")
+            .args(["pr", "edit", pr, "--base", &action.target_base])
+            .current_dir(&action.worktree)
+            .output()
+            .map_err(|error| Error::git_command_failed(format!("gh pr edit {pr}: {error}")))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(Error::git_command_failed(format!(
+                "gh pr edit {pr}: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )))
+        }
+    }
+
+    fn invalidate_review(&mut self, action: &DependencyAction) -> Result<()> {
+        // The Cook lifecycle has already been re-armed by the preceding durable
+        // gate-invalidation step. Keep review invalidation as its own receipt.
+        let _ = action;
+        Ok(())
+    }
+}
+
+fn run_dependency_command(path: &str, arguments: &[&str]) -> Result<()> {
+    dependency_command_output(path, arguments).map(|_| ())
+}
+
+fn dependency_command_output(path: &str, arguments: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(path)
+        .output()
+        .map_err(|error| {
+            Error::git_command_failed(format!("git {}: {error}", arguments.join(" ")))
+        })?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(Error::git_command_failed(format!(
+            "git {}: {}",
+            arguments.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )))
+    }
 }
 
 fn batch_resume_result(
@@ -213,6 +537,7 @@ fn persist_fanout_run_batch_record(plan: &BatchCookFanoutPlan) -> Result<()> {
         serde_json::json!({
             "source": "fanout-run-plan",
             "durable_child_runs": true,
+            "dependency_graph": plan.dependency_graph_metadata()?,
         }),
     )?;
     Ok(())
@@ -223,10 +548,12 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
     attempt_dispatcher: &CookAttemptDispatcherFactory,
 ) -> CmdResult<Value> {
     persist_fanout_run_batch_record(&plan)?;
+    persist_batch_cook_recipes(&plan)?;
+    let ready_plan = plan.ready_plan()?;
     let result = agent_task_service::run_cook_batch(
         agent_task_service::AgentTaskCookBatchOptions {
             batch_id: plan.fanout_id.clone(),
-            cooks: compile_batch_cooks(&plan, |options| {
+            cooks: compile_batch_cooks(&ready_plan, |options| {
                 options.attempt_dispatcher = Some(attempt_dispatcher(options));
             })?,
             max_concurrency: batch_worker_limit(&plan),
@@ -252,16 +579,28 @@ where
     E: homeboy::agents::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone + Send,
 {
     persist_fanout_run_batch_record(&plan)?;
+    persist_batch_cook_recipes(&plan)?;
+    let ready_plan = plan.ready_plan()?;
     let result = agent_task_service::run_cook_batch(
         agent_task_service::AgentTaskCookBatchOptions {
             batch_id: plan.fanout_id.clone(),
-            cooks: compile_batch_cooks(&plan, |_| {})?,
+            cooks: compile_batch_cooks(&ready_plan, |_| {})?,
             max_concurrency: batch_worker_limit(&plan),
         },
         executor,
     )?;
     record_terminal_batch_admission_failures(&plan, &result.value)?;
     Ok(batch_cook_result(&plan, result))
+}
+
+/// Recipes are the durable restart boundary. Persist blocked dependents before
+/// dispatching any sibling so a later merge can release them through `resume`
+/// without reconstructing mutable operator input or re-planning a branch.
+fn persist_batch_cook_recipes(plan: &BatchCookFanoutPlan) -> Result<()> {
+    for options in compile_batch_cooks(plan, |_| {})? {
+        agent_task_service::persist_initial_recipe(&options)?;
+    }
+    Ok(())
 }
 
 /// A failure before Cook creates its durable child record is nevertheless a
@@ -694,25 +1033,108 @@ impl BatchCookFanoutPlan {
         for cook in &mut plan.cooks {
             cook.apply_defaults(args)?;
         }
+        plan.resolve_dependencies()?;
         Ok(plan)
     }
 
     fn rekey(&mut self, fanout_id: String) {
         let previous_prefix = format!("{}-", self.fanout_id);
+        let mut ids = BTreeMap::new();
         for cook in &mut self.cooks {
             let cell_id = cook
                 .cook_id
                 .strip_prefix(&previous_prefix)
                 .unwrap_or(&cook.cook_id);
+            let previous = cook.cook_id.clone();
             cook.cook_id = format!("{fanout_id}-{cell_id}");
+            ids.insert(previous, cook.cook_id.clone());
+        }
+        for cook in &mut self.cooks {
+            for dependency in &mut cook.depends_on {
+                if let Some(rekeyed) = ids.get(dependency) {
+                    *dependency = rekeyed.clone();
+                }
+            }
         }
         self.fanout_id = fanout_id;
+    }
+
+    fn dependency_nodes(&self) -> Vec<AgentTaskDependencyNode> {
+        self.cooks
+            .iter()
+            .map(|cook| AgentTaskDependencyNode {
+                id: cook.cook_id.clone(),
+                tracker_url: cook.task_url.clone(),
+                repository: cook.repo.clone(),
+                worktree: cook.workspace.clone().or_else(|| cook.cwd.clone()),
+                head: cook.head.clone(),
+                depends_on: cook.depends_on.clone(),
+            })
+            .collect()
+    }
+
+    fn resolve_dependencies(&mut self) -> Result<()> {
+        let (edges, _) = dependency_graph_readiness(&self.dependency_nodes(), &BTreeMap::new())?;
+        for edge in edges {
+            let parent = self
+                .cooks
+                .iter()
+                .find(|cook| cook.cook_id == edge.upstream_id)
+                .expect("validated graph parent");
+            let branch = parent.head.clone().ok_or_else(|| {
+                invalid_fanout(&format!(
+                    "upstream child '{}' must declare head for dependent '{}'",
+                    parent.cook_id, edge.downstream_id
+                ))
+            })?;
+            let child = self
+                .cooks
+                .iter_mut()
+                .find(|cook| cook.cook_id == edge.downstream_id)
+                .expect("validated graph child");
+            if child.depends_on.len() > 1 {
+                return Err(invalid_fanout(&format!(
+                    "child '{}' has multiple upstream candidates; declare one stack base per child",
+                    child.cook_id
+                )));
+            }
+            child.base = branch;
+        }
+        Ok(())
+    }
+
+    fn ready_plan(&self) -> Result<Self> {
+        let (_, readiness) =
+            dependency_graph_readiness(&self.dependency_nodes(), &BTreeMap::new())?;
+        let ready = readiness.ready.into_iter().collect::<HashSet<_>>();
+        Ok(Self {
+            cooks: self
+                .cooks
+                .iter()
+                .filter(|cook| ready.contains(&cook.cook_id))
+                .cloned()
+                .collect(),
+            ..self.clone()
+        })
+    }
+
+    fn dependency_graph_metadata(&self) -> Result<Value> {
+        let nodes = self.dependency_nodes();
+        let (edges, readiness) = dependency_graph_readiness(&nodes, &BTreeMap::new())?;
+        Ok(serde_json::json!({
+            "schema": "homeboy/agent-task-fanout-dependency-graph/v1",
+            "nodes": nodes,
+            "edges": edges,
+            "readiness": readiness,
+        }))
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct BatchCookSpec {
     cook_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    depends_on: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     prompt: Option<String>,
     #[serde(default)]
@@ -1037,6 +1459,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
         );
         cooks.push(BatchCookSpec {
             cook_id: format!("issue-{}", issue.number),
+            depends_on: Vec::new(),
             prompt: Some(prompt),
             tasks: Vec::new(),
             cwd: None,
@@ -1504,6 +1927,8 @@ mod tests {
     use crate::test_support::{env_lock, with_isolated_home};
     use clap::Parser;
     use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
 
     fn test_batch_plan() -> BatchCookFanoutPlan {
         BatchCookFanoutPlan::from_value(
@@ -1550,6 +1975,423 @@ mod tests {
         }
     }
 
+    fn command(path: &Path, program: &str, args: &[&str]) -> String {
+        let output = Command::new(program)
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|error| panic!("run {program} {args:?}: {error}"));
+        assert!(
+            output.status.success(),
+            "{program} {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn write_fake_gh(root: &Path) -> (PathBuf, PathBuf) {
+        let bin = root.join("bin");
+        std::fs::create_dir(&bin).expect("fake gh bin");
+        let log = root.join("gh.log");
+        let script = bin.join("gh");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$HOMEBOY_FAKE_GH_LOG"
+if [ "$1 $2" = "pr view" ]; then
+  case "$3" in
+    upstream) printf '%s\n' "$HOMEBOY_FAKE_UPSTREAM_PR" ;;
+    dependent) printf '%s\n' "$HOMEBOY_FAKE_DEPENDENT_PR" ;;
+    *) exit 2 ;;
+  esac
+elif [ "$1 $2" = "pr edit" ] && [ "${HOMEBOY_FAKE_GH_FAIL_EDIT:-}" = "1" ]; then
+  exit 1
+fi
+"#,
+        )
+        .expect("fake gh script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+                .expect("make fake gh executable");
+        }
+        (bin, log)
+    }
+
+    fn dependency_repo(root: &Path, conflict: bool) -> (PathBuf, String, String) {
+        let remote = root.join("remote.git");
+        let checkout = root.join("checkout");
+        command(
+            root,
+            "git",
+            &["init", "--bare", remote.to_str().expect("remote path")],
+        );
+        command(
+            root,
+            "git",
+            &[
+                "clone",
+                remote.to_str().expect("remote path"),
+                checkout.to_str().expect("checkout path"),
+            ],
+        );
+        command(
+            &checkout,
+            "git",
+            &["config", "user.email", "test@example.test"],
+        );
+        command(&checkout, "git", &["config", "user.name", "Fanout Test"]);
+        std::fs::write(checkout.join("shared.txt"), "base\n").expect("base file");
+        command(&checkout, "git", &["add", "."]);
+        command(&checkout, "git", &["commit", "-m", "base"]);
+        command(&checkout, "git", &["branch", "-M", "main"]);
+        command(&checkout, "git", &["push", "origin", "main"]);
+
+        command(&checkout, "git", &["checkout", "-b", "foundation"]);
+        if conflict {
+            std::fs::write(checkout.join("shared.txt"), "foundation\n").expect("foundation file");
+        } else {
+            std::fs::write(checkout.join("foundation.txt"), "foundation\n")
+                .expect("foundation file");
+        }
+        command(&checkout, "git", &["add", "."]);
+        command(&checkout, "git", &["commit", "-m", "foundation"]);
+        command(&checkout, "git", &["push", "origin", "foundation"]);
+
+        command(&checkout, "git", &["checkout", "-b", "dependent"]);
+        if conflict {
+            std::fs::write(checkout.join("shared.txt"), "dependent\n").expect("dependent file");
+        } else {
+            std::fs::write(checkout.join("dependent.txt"), "dependent\n").expect("dependent file");
+        }
+        command(&checkout, "git", &["add", "."]);
+        command(&checkout, "git", &["commit", "-m", "dependent"]);
+        command(&checkout, "git", &["push", "origin", "dependent"]);
+
+        command(&checkout, "git", &["checkout", "main"]);
+        command(
+            &checkout,
+            "git",
+            &["merge", "--no-ff", "foundation", "-m", "merge foundation"],
+        );
+        if conflict {
+            std::fs::write(checkout.join("shared.txt"), "main\n").expect("main conflict file");
+            command(&checkout, "git", &["add", "."]);
+            command(&checkout, "git", &["commit", "-m", "main conflict"]);
+        }
+        let merged = command(&checkout, "git", &["rev-parse", "HEAD"]);
+        command(&checkout, "git", &["push", "origin", "main"]);
+        command(&checkout, "git", &["checkout", "dependent"]);
+        let remote_dependent = command(&checkout, "git", &["rev-parse", "origin/dependent"]);
+        (checkout, merged, remote_dependent)
+    }
+
+    fn seed_dependency_batch(batch_id: &str, checkout: &Path) {
+        let run =
+            homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new("fanout-e2e", Vec::new());
+        for (run_id, pr) in [
+            ("upstream-run", Some("upstream")),
+            ("dependent-run", Some("dependent")),
+            ("sibling-run", None),
+        ] {
+            agent_task_lifecycle::submit_plan(&run, Some(run_id)).expect("durable child run");
+            if let Some(pr) = pr {
+                agent_task_lifecycle::record_cook_finalization(
+                    run_id,
+                    json!({ "status": "review_ready", "pr_url": pr }),
+                )
+                .expect("child PR finalization");
+                if run_id == "dependent-run" {
+                    agent_task_lifecycle::record_promotion(
+                        run_id,
+                        json!({ "status": "succeeded" }),
+                    )
+                    .expect("dependent promotion");
+                }
+            }
+        }
+        batch::persist_fanout_run_batch(
+            batch_id,
+            batch_id,
+            &[
+                batch::FanoutRunBatchChild { task_id: "upstream".into(), run_id: "upstream-run".into() },
+                batch::FanoutRunBatchChild { task_id: "sibling".into(), run_id: "sibling-run".into() },
+                batch::FanoutRunBatchChild { task_id: "dependent".into(), run_id: "dependent-run".into() },
+            ],
+            json!({ "dependency_graph": { "nodes": [
+                {"id":"upstream","repository":"repo","worktree":checkout,"head":"foundation","depends_on":[]},
+                {"id":"sibling","repository":"repo","worktree":checkout,"head":"sibling","depends_on":[]},
+                {"id":"dependent","repository":"repo","worktree":checkout,"head":"dependent","depends_on":["upstream"]}
+            ]}}),
+        )
+        .expect("durable fanout batch");
+    }
+
+    fn dependency_receipt(batch_id: &str, key: &str) -> Option<serde_json::Value> {
+        let batch = batch::read_batch_record(batch_id).expect("batch record");
+        batch.metadata["dependency_action_receipts"][key]
+            .as_object()
+            .map(|_| batch.metadata["dependency_action_receipts"][key].clone())
+    }
+
+    #[test]
+    fn fanout_resume_rebases_pushes_updates_pr_and_rearms_downstream_after_interruption() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("fanout tempdir");
+            let (checkout, merged, _) = dependency_repo(temp.path(), false);
+            let (bin, gh_log) = write_fake_gh(temp.path());
+            let path = format!("{}:{}", bin.display(), std::env::var("PATH").expect("PATH"));
+            let _env = EnvRestore::set(&[
+                ("PATH", Some(&path)),
+                (
+                    "HOMEBOY_FAKE_GH_LOG",
+                    Some(gh_log.to_str().expect("gh log path")),
+                ),
+                ("HOMEBOY_FAKE_GH_FAIL_EDIT", Some("1")),
+                (
+                    "HOMEBOY_FAKE_UPSTREAM_PR",
+                    Some(&format!(
+                        r#"{{"state":"MERGED","mergedAt":"2026-01-01T00:00:00Z","mergeCommit":{{"oid":"{merged}"}},"baseRefName":"main"}}"#
+                    )),
+                ),
+                (
+                    "HOMEBOY_FAKE_DEPENDENT_PR",
+                    Some(
+                        r#"{"state":"OPEN","mergedAt":null,"reviewDecision":"APPROVED","mergeCommit":null,"baseRefName":"foundation"}"#,
+                    ),
+                ),
+            ]);
+            seed_dependency_batch("fanout-e2e", &checkout);
+
+            // The first resume reaches the real force-with-lease push, then the
+            // fake PR adapter interrupts the process at the next durable step.
+            reconcile_fanout_pr_states("fanout-e2e", true)
+                .expect("push is journaled before PR edit");
+            let receipt =
+                dependency_receipt("fanout-e2e", &format!("upstream:dependent:{merged}:main"))
+                    .expect("receipt exists");
+            assert_eq!(receipt["steps"]["push"]["status"], "completed");
+            assert_eq!(receipt["blocked_step"], "pull_request_base_update");
+            let pushed = command(&checkout, "git", &["rev-parse", "origin/dependent"]);
+            assert_eq!(
+                command(
+                    &checkout,
+                    "git",
+                    &["merge-base", "--is-ancestor", &merged, &pushed]
+                ),
+                ""
+            );
+
+            std::env::remove_var("HOMEBOY_FAKE_GH_FAIL_EDIT");
+            reconcile_fanout_pr_states("fanout-e2e", true).expect("idempotent resume");
+            let receipt =
+                dependency_receipt("fanout-e2e", &format!("upstream:dependent:{merged}:main"))
+                    .expect("receipt exists");
+            assert_eq!(receipt["status"], "completed");
+            assert_eq!(receipt["steps"]["gates_invalidate"]["status"], "completed");
+            assert_eq!(receipt["steps"]["review_invalidate"]["status"], "completed");
+            let dependent =
+                agent_task_lifecycle::status("dependent-run").expect("dependent record");
+            assert!(dependent.metadata.get("cook_finalization").is_none());
+            assert_eq!(
+                dependent.metadata["cook_recovery_source_checkpoint"]["phase"],
+                "verification_pending"
+            );
+            let gh_calls = std::fs::read_to_string(gh_log).expect("gh calls");
+            assert_eq!(gh_calls.matches("pr edit dependent --base main").count(), 2);
+        });
+    }
+
+    #[test]
+    fn fanout_resume_rejection_and_rebase_conflict_block_without_later_mutations() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("fanout tempdir");
+            let (checkout, merged, before) = dependency_repo(temp.path(), true);
+            let (bin, gh_log) = write_fake_gh(temp.path());
+            let path = format!("{}:{}", bin.display(), std::env::var("PATH").expect("PATH"));
+            let _env = EnvRestore::set(&[
+                ("PATH", Some(&path)),
+                (
+                    "HOMEBOY_FAKE_GH_LOG",
+                    Some(gh_log.to_str().expect("gh log path")),
+                ),
+                (
+                    "HOMEBOY_FAKE_UPSTREAM_PR",
+                    Some(
+                        r#"{"state":"CLOSED","mergedAt":null,"mergeCommit":null,"baseRefName":"main"}"#,
+                    ),
+                ),
+                (
+                    "HOMEBOY_FAKE_DEPENDENT_PR",
+                    Some(
+                        r#"{"state":"OPEN","mergedAt":null,"mergeCommit":null,"baseRefName":"foundation"}"#,
+                    ),
+                ),
+            ]);
+            seed_dependency_batch("fanout-blocked", &checkout);
+
+            reconcile_fanout_pr_states("fanout-blocked", true).expect("rejection observation");
+            assert!(dependency_receipt("fanout-blocked", "upstream:dependent:missing").is_none());
+            assert_eq!(
+                command(&checkout, "git", &["rev-parse", "origin/dependent"]),
+                before
+            );
+
+            std::env::set_var(
+                "HOMEBOY_FAKE_UPSTREAM_PR",
+                format!(
+                    r#"{{"state":"MERGED","mergedAt":"2026-01-01T00:00:00Z","mergeCommit":{{"oid":"{merged}"}},"baseRefName":"main"}}"#
+                ),
+            );
+            reconcile_fanout_pr_states("fanout-blocked", true)
+                .expect("conflict becomes durable block");
+            let receipt = dependency_receipt(
+                "fanout-blocked",
+                &format!("upstream:dependent:{merged}:main"),
+            )
+            .expect("conflict receipt");
+            assert_eq!(receipt["blocked_step"], "rebase");
+            assert_eq!(receipt["steps"]["push"], serde_json::Value::Null);
+            assert_eq!(
+                command(&checkout, "git", &["rev-parse", "origin/dependent"]),
+                before
+            );
+            assert!(!std::fs::read_to_string(gh_log)
+                .expect("gh calls")
+                .contains("pr edit dependent"));
+        });
+    }
+
+    #[test]
+    fn fanout_stack_rebases_review_ready_heads_then_moves_to_target_after_merge() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("fanout tempdir");
+            let (checkout, _, _) = dependency_repo(temp.path(), false);
+            let (bin, gh_log) = write_fake_gh(temp.path());
+            let path = format!("{}:{}", bin.display(), std::env::var("PATH").expect("PATH"));
+            let _env = EnvRestore::set(&[
+                ("PATH", Some(&path)),
+                (
+                    "HOMEBOY_FAKE_GH_LOG",
+                    Some(gh_log.to_str().expect("gh log path")),
+                ),
+                (
+                    "HOMEBOY_FAKE_DEPENDENT_PR",
+                    Some(
+                        r#"{"state":"OPEN","mergedAt":null,"reviewDecision":"APPROVED","mergeCommit":null,"baseRefName":"foundation"}"#,
+                    ),
+                ),
+            ]);
+            seed_dependency_batch("fanout-stack", &checkout);
+
+            // The first accepted candidate releases the dependent against its
+            // branch, and the receipt binds the exact upstream head used.
+            let first = command(&checkout, "git", &["rev-parse", "origin/foundation"]);
+            std::env::set_var(
+                "HOMEBOY_FAKE_UPSTREAM_PR",
+                format!(
+                    r#"{{"state":"OPEN","mergedAt":null,"reviewDecision":"APPROVED","mergeCommit":null,"baseRefName":"main","headRefName":"foundation","headRefOid":"{first}"}}"#
+                ),
+            );
+            reconcile_fanout_pr_states("fanout-stack", true).expect("first stack transition");
+            let first_receipt = dependency_receipt(
+                "fanout-stack",
+                &format!("upstream:dependent:{first}:foundation"),
+            )
+            .expect("first candidate receipt");
+            assert_eq!(first_receipt["action"]["upstream_revision"], first);
+            assert_eq!(first_receipt["action"]["target_base"], "foundation");
+
+            // A new upstream head invalidates the dependent's prior review and
+            // produces a second rebase/reverification receipt rather than
+            // trusting the review of the old candidate.
+            command(&checkout, "git", &["checkout", "foundation"]);
+            std::fs::write(checkout.join("foundation-update.txt"), "updated\n").expect("update");
+            command(&checkout, "git", &["add", "."]);
+            command(&checkout, "git", &["commit", "-m", "update foundation"]);
+            command(&checkout, "git", &["push", "origin", "foundation"]);
+            let second = command(&checkout, "git", &["rev-parse", "HEAD"]);
+            std::env::set_var(
+                "HOMEBOY_FAKE_UPSTREAM_PR",
+                format!(
+                    r#"{{"state":"OPEN","mergedAt":null,"reviewDecision":"APPROVED","mergeCommit":null,"baseRefName":"main","headRefName":"foundation","headRefOid":"{second}"}}"#
+                ),
+            );
+            reconcile_fanout_pr_states("fanout-stack", true).expect("updated stack transition");
+            let second_receipt = dependency_receipt(
+                "fanout-stack",
+                &format!("upstream:dependent:{second}:foundation"),
+            )
+            .expect("updated candidate receipt");
+            assert_eq!(second_receipt["status"], "completed");
+            assert_eq!(
+                second_receipt["steps"]["gates_invalidate"]["status"],
+                "completed"
+            );
+            assert_eq!(
+                second_receipt["steps"]["review_invalidate"]["status"],
+                "completed"
+            );
+
+            command(&checkout, "git", &["checkout", "main"]);
+            command(
+                &checkout,
+                "git",
+                &[
+                    "merge",
+                    "--no-ff",
+                    "foundation",
+                    "-m",
+                    "merge updated foundation",
+                ],
+            );
+            let merged = command(&checkout, "git", &["rev-parse", "HEAD"]);
+            command(&checkout, "git", &["push", "origin", "main"]);
+            std::env::set_var(
+                "HOMEBOY_FAKE_UPSTREAM_PR",
+                format!(
+                    r#"{{"state":"MERGED","mergedAt":"2026-01-01T00:00:00Z","mergeCommit":{{"oid":"{merged}"}},"baseRefName":"main","headRefName":"foundation","headRefOid":"{second}"}}"#
+                ),
+            );
+            reconcile_fanout_pr_states("fanout-stack", true).expect("merge transition");
+            let merge_receipt =
+                dependency_receipt("fanout-stack", &format!("upstream:dependent:{merged}:main"))
+                    .expect("merge receipt");
+            assert_eq!(merge_receipt["action"]["target_base"], "main");
+            assert_eq!(merge_receipt["steps"]["rebase"]["status"], "completed");
+            assert!(std::fs::read_to_string(gh_log)
+                .expect("gh calls")
+                .contains("pr edit dependent --base main"));
+        });
+    }
+
+    #[test]
+    fn invalid_dependency_graph_does_not_mutate_a_real_repository() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("fanout tempdir");
+            let (checkout, _, before) = dependency_repo(temp.path(), false);
+            let error = BatchCookFanoutPlan::from_value(
+                json!({
+                    "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                    "fanout_id": "invalid",
+                    "cooks": [
+                        {"cook_id":"upstream","repo":"repo","prompt":"upstream","workspace":checkout,"to_worktree":"upstream","head":"upstream","verify":["true"]},
+                        {"cook_id":"dependent","repo":"repo","depends_on":["missing"],"prompt":"dependent","workspace":checkout,"to_worktree":"dependent","head":"dependent","verify":["true"]}
+                    ]
+                }),
+                &args(),
+            )
+            .expect_err("missing edge must fail validation");
+            assert!(error.message.contains("missing"));
+            assert_eq!(
+                command(&checkout, "git", &["rev-parse", "origin/dependent"]),
+                before
+            );
+            assert_eq!(command(&checkout, "git", &["status", "--porcelain"]), "");
+        });
+    }
+
     #[test]
     fn resolve_ai_tool_disclosure_preserves_an_explicit_operator_value() {
         // An operator-supplied disclosure is preserved verbatim regardless of
@@ -1561,6 +2403,32 @@ mod tests {
             Some("openai/gpt-5.6-terra"),
         );
         assert_eq!(resolved, "Custom Tool (v2)");
+    }
+
+    #[test]
+    fn pr_observation_distinguishes_merge_rejection_and_revision() {
+        let observation = |state: &str, merged_at: Option<&str>, review_decision: Option<&str>| {
+            FanoutPrObservation {
+                state: state.to_string(),
+                merged_at: merged_at.map(str::to_string),
+                review_decision: review_decision.map(str::to_string),
+                merge_state_status: None,
+                merge_commit: None,
+                base_ref_name: None,
+                head_ref_oid: None,
+                head_ref_name: None,
+            }
+        };
+
+        assert_eq!(
+            observation("CLOSED", Some("2026-07-30T00:00:00Z"), None).verdict(),
+            "merged"
+        );
+        assert_eq!(observation("CLOSED", None, None).verdict(), "rejected");
+        assert_eq!(
+            observation("OPEN", None, Some("CHANGES_REQUESTED")).verdict(),
+            "revision_requested"
+        );
     }
 
     #[test]
@@ -1689,6 +2557,54 @@ mod tests {
                 .expect("client context")
                 .contains("/Users/user/Developer/homeboy@5929-docs"));
         });
+    }
+
+    #[test]
+    fn batch_plan_persists_a_two_level_stack_and_schedules_ready_siblings() {
+        let plan = BatchCookFanoutPlan::from_value(
+            json!({
+                "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                "fanout_id": "stack",
+                "cooks": [
+                    {"cook_id": "foundation", "task_url": "https://github.com/Extra-Chill/homeboy/issues/1", "repo": "homeboy", "prompt": "foundation", "to_worktree": "homeboy@foundation", "head": "fix/foundation", "verify": ["true"]},
+                    {"cook_id": "sibling", "task_url": "https://github.com/Extra-Chill/homeboy/issues/2", "repo": "homeboy", "prompt": "sibling", "to_worktree": "homeboy@sibling", "head": "fix/sibling", "verify": ["true"]},
+                    {"cook_id": "dependent", "task_url": "https://github.com/Extra-Chill/homeboy/issues/3", "repo": "homeboy", "depends_on": ["https://github.com/Extra-Chill/homeboy/issues/1"], "prompt": "dependent", "to_worktree": "homeboy@dependent", "head": "fix/dependent", "verify": ["true"]}
+                ]
+            }),
+            &args(),
+        )
+        .expect("stack plan");
+        assert_eq!(plan.cooks[2].base, "fix/foundation");
+        assert_eq!(
+            plan.ready_plan()
+                .expect("ready frontier")
+                .cooks
+                .iter()
+                .map(|cook| cook.cook_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["fanout/refactor-foundation", "fanout/refactor-sibling"]
+        );
+        let graph = plan.dependency_graph_metadata().expect("durable graph");
+        assert_eq!(
+            graph["readiness"]["states"]["fanout/refactor-dependent"],
+            "blocked_by_dependency"
+        );
+    }
+
+    #[test]
+    fn batch_plan_rejects_missing_and_cross_repository_dependencies_before_mutation() {
+        let missing = BatchCookFanoutPlan::from_value(
+            json!({"schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA, "fanout_id": "missing", "cooks": [{"cook_id": "child", "depends_on": ["absent"], "prompt": "x", "to_worktree": "homeboy@child", "verify": ["true"]}]}),
+            &args(),
+        )
+        .expect_err("missing dependency");
+        assert!(missing.message.contains("missing"));
+        let cross_repo = BatchCookFanoutPlan::from_value(
+            json!({"schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA, "fanout_id": "cross", "cooks": [{"cook_id": "a", "repo": "one", "prompt": "x", "to_worktree": "one@a", "head": "fix/a", "verify": ["true"]}, {"cook_id": "b", "repo": "two", "depends_on": ["a"], "prompt": "x", "to_worktree": "two@b", "verify": ["true"]}]}),
+            &args(),
+        )
+        .expect_err("cross repository dependency");
+        assert!(cross_repo.message.contains("cross-repository"));
     }
 
     #[test]
@@ -2053,7 +2969,7 @@ mod tests {
     }
 
     #[test]
-    fn recipe_preflight_accepts_exact_replay_and_rejects_changed_inputs() {
+    fn recipe_preflight_accepts_safe_pre_execution_recipe_corrections() {
         with_isolated_home(|_| {
             let plan = test_batch_plan();
             let compiled = compile_batch_cooks(&plan, |_| {}).expect("compile batch cooks");
@@ -2071,9 +2987,8 @@ mod tests {
 
             let mut changed = plan;
             changed.cooks[0].title = Some("changed title".to_string());
-            let error = preflight_batch_cook_recipes(&changed, None)
-                .expect_err("changed execution inputs conflict");
-            assert!(error.message.contains("different execution inputs"));
+            preflight_batch_cook_recipes(&changed, None)
+                .expect("pre-execution finalization metadata can be corrected safely");
         });
     }
 

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -470,6 +470,12 @@ fn split_placement_coordinator_label(command: &Commands) -> Option<&'static str>
                     command: AgentTaskFanoutCommand::CookBatch(args),
                 }),
         }) if args.run_plan => Some("agent-task fanout cook-batch --run-plan"),
+        Commands::AgentTask(AgentTaskArgs {
+            command:
+                AgentTaskCommand::Fanout(AgentTaskFanoutArgs {
+                    command: AgentTaskFanoutCommand::SubmitBatch(_),
+                }),
+        }) => Some("agent-task fanout submit-batch"),
         _ => None,
     }
 }
@@ -524,7 +530,7 @@ fn split_placement_lab_runner_unavailable_error(
     Some(Error::validation_invalid_argument(
         "placement",
         format!(
-            "{label} accepts `--placement lab`, but no ready Lab runner could be selected (readiness: {state}); no provider attempt was dispatched"
+            "{label} accepts `--placement lab` but requires an eligible Lab runner; none could be selected (readiness: {state}), so no provider attempt was dispatched"
         ),
         Some("lab".to_string()),
         Some(hints),


### PR DESCRIPTION
## Summary

- add durable fanout dependency graphs with pre-mutation cycle/repository validation and readiness scheduling
- persist blocked child recipes so dependents can resume without replanning mutable input
- support review-ready stacked candidates, exact upstream revision invalidation, and post-merge target-base transitions
- journal fetch, rebase, push, PR-base update, gate invalidation, and review invalidation as restart-safe steps
- reconcile crash windows, conflicts, rejection, and aggregate state through the same durable graph

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-agents agent_task_dependency --lib`
- `cargo test -p homeboy-cli fanout --lib`
- real temp-Git and fake-GitHub E2E covers stack revisions, merge/rebase, PR updates, interrupted resume, rejection, and conflicts
- rebased onto current `origin/main`

Closes #10946.

## AI assistance

Substantive implementation and tests were drafted with OpenCode using `openai/gpt-5.6-sol`, with repeated independent coding-agent review and human-owned final responsibility.