### PR TITLE
fix(agent-task): resolve Cook aliases to selected attempts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1148,15 +1148,15 @@ pub fn reconstruct_adoption_options(
 /// owns continuation. Both the CLI re-exec boundary and the Cook handler use
 /// this so an upgraded controller cannot select different attempts.
 pub fn resolve_cook_continuation_run_id(cook_or_attempt_id: &str) -> Result<String> {
-    let recipe = load_recipe(cook_or_attempt_id)
-        .or_else(|cook_error| load_recipe_for_attempt(cook_or_attempt_id)?.ok_or(cook_error))?;
-    if recipe
-        .attempts
-        .iter()
-        .any(|attempt| attempt.run_id == cook_or_attempt_id)
-    {
-        return Ok(cook_or_attempt_id.to_string());
-    }
+    let recipe = match load_recipe(cook_or_attempt_id) {
+        // A Cook ID can also be its original attempt's run ID. In that case the
+        // Cook alias remains authoritative and must select the current candidate.
+        Ok(recipe) => recipe,
+        Err(cook_error) => {
+            load_recipe_for_attempt(cook_or_attempt_id)?.ok_or(cook_error)?;
+            return Ok(cook_or_attempt_id.to_string());
+        }
+    };
     if !agent_task_lifecycle::cook_index_exists(&recipe.cook_id)? {
         let attempts = recipe
             .attempts

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4956,6 +4956,88 @@ fn adoption_by_cook_id_selects_the_latest_substantive_candidate_not_a_newer_empt
 }
 
 #[test]
+fn cook_alias_continuation_uses_the_candidate_selected_after_adoption_and_gate_feedback() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let cook_id = "cook-alias-selected-attempt";
+        // Attempt one deliberately shares the Cook ID, matching the durable
+        // identity shape that previously bypassed candidate selection.
+        let original_run_id = cook_id;
+        let adoption_run_id = "cook-alias-selected-attempt-attempt-2-adoption";
+        let gate_feedback_run_id = "cook-alias-selected-attempt-attempt-3-gate-feedback";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = original_run_id.to_string();
+        super::super::persist_initial_recipe(&options).expect("persist recipe");
+        super::super::record_recipe_attempt(cook_id, 2, adoption_run_id, &options.initial_plan)
+            .expect("persist adoption recipe attempt");
+        super::super::record_recipe_attempt(
+            cook_id,
+            3,
+            gate_feedback_run_id,
+            &options.initial_plan,
+        )
+        .expect("persist gate-feedback recipe attempt");
+        for (attempt, run_id) in [
+            (1, original_run_id),
+            (2, adoption_run_id),
+            (3, gate_feedback_run_id),
+        ] {
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("persist lifecycle record");
+            agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id)
+                .expect("persist Cook attempt");
+        }
+        let patch = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        for (run_id, name) in [
+            (original_run_id, "original.patch"),
+            (adoption_run_id, "adoption.patch"),
+            (gate_feedback_run_id, "gate-feedback.patch"),
+        ] {
+            seed_substantive_candidate_aggregate(
+                run_id,
+                &options.initial_plan,
+                &temp.path().join(name),
+                patch,
+            );
+        }
+
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
+            .expect("select advanced durable candidate");
+        assert_eq!(selection.run_id, gate_feedback_run_id);
+        assert_eq!(selection.attempt, 3);
+        assert_eq!(selection.reason, "latest_substantive_candidate_pointer");
+
+        let selected_run_id = super::super::resolve_cook_continuation_run_id(cook_id)
+            .expect("Cook alias resolves selected candidate");
+        assert_eq!(selected_run_id, gate_feedback_run_id);
+        assert_eq!(
+            super::super::resolve_cook_continuation_run_id(adoption_run_id)
+                .expect("exact distinct attempt remains addressable"),
+            adoption_run_id
+        );
+        let recipe = super::super::load_recipe(cook_id).expect("load recipe");
+        let record =
+            super::super::reconcile_recipe_attempt_for_continuation(&recipe, &selected_run_id)
+                .expect("selected candidate passes strict Cook identity fence");
+        assert_eq!(record.run_id, gate_feedback_run_id);
+        super::super::validate_recipe_attempt_record(&recipe, &selected_run_id, &record)
+            .expect("matching Cook metadata passes the identity fence");
+        let mut cross_cook_record = record;
+        cross_cook_record.ensure_metadata_object().insert(
+            "cook_id".to_string(),
+            Value::String("other-cook".to_string()),
+        );
+        let error = super::super::validate_recipe_attempt_record(
+            &recipe,
+            &selected_run_id,
+            &cross_cook_record,
+        )
+        .expect_err("cross-Cook metadata must fail the identity fence");
+        assert!(error.message.contains("observed Cook `other-cook`"));
+    });
+}
+
+#[test]
 fn record_cook_attempt_recovers_an_aggregate_completed_before_attempt_registration() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("candidate artifacts");


### PR DESCRIPTION
## Summary

- Treat a persisted Cook recipe ID as the Cook alias before considering exact-attempt resolution.
- Resolve that alias to the current durable candidate selected after adoption or gate feedback.
- Preserve exact non-alias attempt resolution and strict cross-Cook lifecycle fencing.

Closes #10978.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents cook_alias_continuation_uses_the_candidate_selected_after_adoption_and_gate_feedback --lib`
- Independent adversarial review found no correctness issues.

## AI Assistance

OpenCode general coding subagents using OpenAI GPT-5.6 Sol implemented and reviewed this change. Chris Huber remains responsible for every line.