### PR TITLE
fix(agent-task): recover manual finalization intent

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::agent_task_promotion::AgentTaskPromotionReport;
@@ -151,6 +150,25 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
             ));
         }
     };
+    let candidate_changed_files = normalize_changed_files(&changed_files);
+    if options.expected_candidate_sha.is_some() && (commit_required || push_required) {
+        return Err(Error::validation_invalid_argument(
+            "publication_intent",
+            "recovered manual finalization requires the already-pushed candidate validated by preflight",
+            None,
+            None,
+        ));
+    }
+    if options.expected_candidate_sha.is_some()
+        && normalize_changed_files(&options.changed_files) != candidate_changed_files
+    {
+        return Err(Error::validation_invalid_argument(
+            "publication_intent.changed_files",
+            "recovered manual finalization changed files no longer match the preflight-validated candidate",
+            None,
+            None,
+        ));
+    }
     if !options.manual_finalization {
         changed_files = durable_changed_files;
     } else if !options.changed_files.is_empty() {
@@ -260,6 +278,16 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
             None,
         )
     })?;
+    if let Some(expected_candidate_sha) = options.expected_candidate_sha.as_deref() {
+        if expected_candidate_sha != commit_sha {
+            return Err(Error::validation_invalid_argument(
+                "publication_intent",
+                "recovered manual finalization candidate no longer matches the preflight-validated commit",
+                Some(commit_sha.to_string()),
+                None,
+            ));
+        }
+    }
     let git_tracking = if push_required {
         Some(backend.push_branch(&options.path, commit_sha, &head)?)
     } else {
@@ -733,6 +761,7 @@ fn report(
         path: options.path.clone(),
         base: options.base.clone(),
         head: head.to_string(),
+        title: options.title.clone(),
         pr_action: pr_action.to_string(),
         pr_number,
         pr_url,

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -2093,6 +2093,7 @@ fn options() -> AgentTaskPrFinalizationOptions {
         },
         review_profile: crate::agent_task_review_dossier::default_profile(),
         manual_finalization: true,
+        expected_candidate_sha: None,
         protected_branches: vec![
             "main".to_string(),
             "master".to_string(),

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -12,7 +12,7 @@ pub struct AgentTaskGateResult {
     pub detail: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskPrFinalizationReport {
     pub schema: String,
     pub run_id: String,
@@ -20,6 +20,8 @@ pub struct AgentTaskPrFinalizationReport {
     pub path: String,
     pub base: String,
     pub head: String,
+    #[serde(default)]
+    pub title: String,
     pub pr_action: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_number: Option<u64>,
@@ -250,6 +252,8 @@ pub struct AgentTaskPrFinalizationOptions {
     pub review_profile: AgentTaskReviewProfile,
     /// Manual finalization is an explicit migration mode for work not produced by a durable run.
     pub manual_finalization: bool,
+    /// A recovered manual preflight may only publish the immutable candidate it validated.
+    pub expected_candidate_sha: Option<String>,
     pub protected_branches: Vec<String>,
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2544,6 +2544,69 @@ pub fn record_cook_finalization(run_id: &str, finalization: Value) -> Result<Age
     }
 }
 
+/// Persist a validated manual publication intent without claiming Cook completion.
+pub(crate) fn record_manual_finalization_intent(
+    run_id: &str,
+    intent: Value,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let digest = manual_finalization_intent_digest(&intent);
+    let record = store::mutate_record(&run_id, |record| {
+        if record.metadata.get("manual_finalization_intent") == Some(&intent)
+            && record.metadata.get("manual_finalization_intent_digest") == Some(&json!(digest))
+        {
+            return false;
+        }
+        record.updated_at = Some(now_timestamp());
+        record
+            .ensure_metadata_object()
+            .insert("manual_finalization_intent".to_string(), intent.clone());
+        record.ensure_metadata_object().insert(
+            "manual_finalization_intent_digest".to_string(),
+            json!(digest),
+        );
+        true
+    })?;
+    match record {
+        Some(record) => Ok(record),
+        None => store::read_record(&run_id),
+    }
+}
+
+/// Stable digest of the exact validated manual dossier persisted for recovery.
+pub(crate) fn manual_finalization_intent_digest(intent: &Value) -> String {
+    content_hash::sha256_hex(
+        &serde_json::to_vec(intent).expect("JSON values always serialize into a manual intent"),
+    )
+}
+
+/// Persist a completed manual receipt and bind it to the validated intent digest.
+pub(crate) fn record_manual_finalization_receipt(
+    run_id: &str,
+    receipt: Value,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let intent_digest = record.metadata["manual_finalization_intent_digest"].clone();
+        record.updated_at = Some(now_timestamp());
+        let metadata = record.ensure_metadata_object();
+        metadata.insert("cook_finalization".to_string(), receipt.clone());
+        metadata.insert(
+            "manual_finalization_receipt_digest".to_string(),
+            json!(manual_finalization_intent_digest(&receipt)),
+        );
+        metadata.insert(
+            "manual_finalization_receipt_intent_digest".to_string(),
+            intent_digest,
+        );
+        true
+    })?;
+    match record {
+        Some(record) => Ok(record),
+        None => store::read_record(&run_id),
+    }
+}
+
 /// Checkpoint controller-owned recovery after a promoted, green candidate loses
 /// its publication base. The terminal provider result remains untouched.
 pub fn record_cook_moving_base_recovery(

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -13,9 +13,10 @@ use serde_json::Value;
 use std::path::PathBuf;
 
 use crate::agent_task_finalization::{
-    finalize_pr_with_backend, preflight_pr_with_backend, AgentTaskPrEvidence,
-    AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions, AgentTaskPrRuntimeGuardrails,
-    AgentTaskPrSourceRelationship, AgentTaskPrVerification, RealAgentTaskPrFinalizationBackend,
+    finalize_pr_with_backend, preflight_pr_with_backend, validate_publication_intent,
+    AgentTaskPrEvidence, AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions,
+    AgentTaskPrFinalizationReport, AgentTaskPrRuntimeGuardrails, AgentTaskPrSourceRelationship,
+    AgentTaskPrVerification, RealAgentTaskPrFinalizationBackend,
 };
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::{
@@ -1139,7 +1140,7 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         .map(|report| serde_json::to_value(report).unwrap_or(Value::Null))
 }
 
-fn cook_finalization_options(
+pub(crate) fn cook_finalization_options(
     options: &AgentTaskCookServiceOptions,
     successful_run_id: &str,
     promotion: &AgentTaskPromotionReport,
@@ -1219,8 +1220,42 @@ fn cook_finalization_options(
         review_dossier,
         review_profile: resolve_review_profile(&path)?,
         manual_finalization: false,
+        expected_candidate_sha: None,
         protected_branches: options.protected_branches.clone(),
     })
+}
+
+/// Persist only a controller-validated manual preflight dossier for recovery.
+pub fn persist_manual_finalization_intent(
+    run_id: &str,
+    report: &AgentTaskPrFinalizationReport,
+) -> Result<crate::agent_task_lifecycle::AgentTaskRunRecord> {
+    validate_manual_preflight_report(report, run_id)?;
+    agent_task_lifecycle::record_manual_finalization_intent(
+        run_id,
+        serde_json::to_value(report).expect("finalization report serializes"),
+    )
+}
+
+/// Persist only a controller-published manual receipt bound to its preflight dossier.
+pub fn persist_manual_finalization_receipt(
+    run_id: &str,
+    report: &AgentTaskPrFinalizationReport,
+) -> Result<crate::agent_task_lifecycle::AgentTaskRunRecord> {
+    let record = agent_task_lifecycle::status(run_id)?;
+    let intent = manual_finalization_intent_for_run(&record, run_id)?;
+    if !valid_manual_finalization_receipt(report, &intent, &record, run_id, false) {
+        return Err(Error::validation_invalid_argument(
+            "cook_finalization",
+            "manual finalization receipt failed controller validation",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    agent_task_lifecycle::record_manual_finalization_receipt(
+        run_id,
+        serde_json::to_value(report).expect("finalization report serializes"),
+    )
 }
 
 /// Recover publication from the durable Cook recipe and applied promotion.
@@ -1255,6 +1290,33 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             )
         })?
     };
+    if let Some(receipt) = completed_finalization_receipt_for_recovery(&recipe, run_or_cook_id)? {
+        return Ok(receipt);
+    }
+    if let Some(report) = manual_finalization_intent_for_recovery(&recipe, run_or_cook_id)? {
+        if !overrides.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "review_overrides",
+                "recovered manual finalization must execute the preflight-validated dossier unchanged",
+                None,
+                None,
+            ));
+        }
+        let finalization = manual_finalization_options(report)?;
+        let report = if preflight {
+            preflight_pr_with_backend(finalization, backend)?
+        } else {
+            finalize_pr_with_backend(finalization, backend)?
+        };
+        let value = serde_json::to_value(&report).unwrap_or(Value::Null);
+        if !preflight {
+            persist_manual_finalization_receipt(
+                value["run_id"].as_str().unwrap_or_default(),
+                &report,
+            )?;
+        }
+        return Ok(value);
+    }
     let run_id = if recipe
         .attempts
         .iter()
@@ -1314,6 +1376,425 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         agent_task_lifecycle::record_cook_finalization(&run_id, value.clone())?;
     }
     Ok(value)
+}
+
+fn manual_finalization_run_ids<'a>(
+    recipe: &'a super::cook_recipe::AgentTaskCookRecipe,
+) -> Vec<&'a str> {
+    recipe
+        .attempts
+        .iter()
+        .rev()
+        .map(|attempt| attempt.run_id.as_str())
+        .collect()
+}
+
+fn completed_finalization_receipt_for_recovery(
+    recipe: &super::cook_recipe::AgentTaskCookRecipe,
+    run_or_cook_id: &str,
+) -> Result<Option<Value>> {
+    let run_ids = if recipe
+        .attempts
+        .iter()
+        .any(|attempt| attempt.run_id == run_or_cook_id)
+    {
+        vec![run_or_cook_id]
+    } else {
+        manual_finalization_run_ids(recipe)
+    };
+    for run_id in run_ids {
+        let record = agent_task_lifecycle::status(run_id)?;
+        let Some(value) = record.metadata.get("cook_finalization") else {
+            continue;
+        };
+        if value["status"] != "review_ready" {
+            continue;
+        }
+        // Normal Cook finalization receipts intentionally have a lightweight,
+        // generic shape. Only the explicit manual receipt schema requires the
+        // additional recovery integrity contract.
+        if value["manual_finalization"] == true {
+            let report: AgentTaskPrFinalizationReport = serde_json::from_value(value.clone())
+                .map_err(|_| {
+                    Error::validation_invalid_argument(
+                        "cook_finalization",
+                        "persisted manual finalization receipt is invalid",
+                        Some(run_id.to_string()),
+                        None,
+                    )
+                })?;
+            let intent = manual_finalization_intent_for_run(&record, run_id)?;
+            if !valid_manual_finalization_receipt(&report, &intent, &record, run_id, true) {
+                return Err(Error::validation_invalid_argument(
+                    "cook_finalization",
+                    "persisted manual finalization receipt failed integrity validation",
+                    Some(run_id.to_string()),
+                    None,
+                ));
+            }
+        }
+        return Ok(Some(value.clone()));
+    }
+    Ok(None)
+}
+
+fn manual_finalization_intent_for_recovery(
+    recipe: &super::cook_recipe::AgentTaskCookRecipe,
+    run_or_cook_id: &str,
+) -> Result<Option<AgentTaskPrFinalizationReport>> {
+    let run_ids = if recipe
+        .attempts
+        .iter()
+        .any(|attempt| attempt.run_id == run_or_cook_id)
+    {
+        vec![run_or_cook_id]
+    } else {
+        manual_finalization_run_ids(recipe)
+    };
+    for run_id in run_ids {
+        let record = agent_task_lifecycle::status(run_id)?;
+        let Some(_) = record.metadata.get("manual_finalization_intent") else {
+            continue;
+        };
+        let report = manual_finalization_intent_for_run(&record, run_id)?;
+        return Ok(Some(report));
+    }
+    Ok(None)
+}
+
+fn manual_finalization_intent_for_run(
+    record: &crate::agent_task_lifecycle::AgentTaskRunRecord,
+    run_id: &str,
+) -> Result<AgentTaskPrFinalizationReport> {
+    let value = record
+        .metadata
+        .get("manual_finalization_intent")
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "manual_finalization_intent",
+                "manual finalization receipt has no persisted validated intent",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    let expected_digest = record
+        .metadata
+        .get("manual_finalization_intent_digest")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if expected_digest != agent_task_lifecycle::manual_finalization_intent_digest(value) {
+        return Err(Error::validation_invalid_argument(
+            "manual_finalization_intent",
+            "persisted manual finalization intent failed integrity validation",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    let report: AgentTaskPrFinalizationReport =
+        serde_json::from_value(value.clone()).map_err(|_| {
+            Error::validation_invalid_argument(
+                "manual_finalization_intent",
+                "persisted manual finalization intent is invalid",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    if report.run_id != run_id {
+        return Err(Error::validation_invalid_argument(
+            "manual_finalization_intent.run_id",
+            "persisted manual finalization intent belongs to a different durable run",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    Ok(report)
+}
+
+fn valid_manual_finalization_receipt(
+    report: &AgentTaskPrFinalizationReport,
+    intent: &AgentTaskPrFinalizationReport,
+    record: &crate::agent_task_lifecycle::AgentTaskRunRecord,
+    run_id: &str,
+    require_persisted_digest: bool,
+) -> bool {
+    let Some(binding) = report.publication_proof.binding.as_ref() else {
+        return false;
+    };
+    let Some(git_identity) = report.publication_proof.git_identity.as_ref() else {
+        return false;
+    };
+    let Some(intent_git_identity) = intent.publication_proof.git_identity.as_ref() else {
+        return false;
+    };
+    report.schema == crate::agent_task_finalization::AGENT_TASK_PR_FINALIZATION_SCHEMA
+        && report.run_id == run_id
+        && intent.status == "validated"
+        && intent.manual_finalization
+        && receipt_matches_manual_preflight(
+            report,
+            intent,
+            binding,
+            git_identity,
+            intent_git_identity,
+        )
+        && (!require_persisted_digest
+            || (record.metadata["manual_finalization_receipt_digest"]
+                == serde_json::json!(agent_task_lifecycle::manual_finalization_intent_digest(
+                    &serde_json::to_value(report).expect("finalization report serializes"),
+                ))
+                && record.metadata["manual_finalization_receipt_intent_digest"]
+                    == record.metadata["manual_finalization_intent_digest"]))
+        && validate_publication_intent(&report.publication_intent).is_ok()
+        && report.publication_intent.run_id == run_id
+        && report.publication_proof.run_id == run_id
+        && report.finalization_outcome.run_id == run_id
+        && report.publication_proof.schema
+            == crate::agent_task_finalization::AGENT_TASK_PUBLICATION_PROOF_SCHEMA
+        && report.publication_proof.intent_schema == report.publication_intent.schema
+        && report.publication_proof.status == "review_ready"
+        && report.finalization_outcome.schema
+            == crate::agent_task_finalization::AGENT_TASK_PR_FINALIZATION_OUTCOME_SCHEMA
+        && matches!(report.pr_action.as_str(), "created" | "updated")
+        && report.publication_proof.adapter_action.as_deref() == Some(report.pr_action.as_str())
+        && report.publication_proof.adapter_ref == report.pr_url
+        && report.pr_number.is_some()
+        && report.pr_url.is_some()
+        && same_publication_target(
+            &report.publication_proof.target,
+            &report.publication_intent.target,
+        )
+        && report.finalization_outcome.target == report.publication_proof.target
+        && report.publication_proof.target.url == report.pr_url
+        && report.finalization_outcome.pr_number == report.pr_number
+        && report.finalization_outcome.pr_url == report.pr_url
+        && report.finalization_outcome.status == "review_ready"
+        && report.finalization_outcome.publication_action == report.pr_action
+        && report.finalization_outcome.publication_status == "review_ready"
+        && report.finalization_outcome.published
+        && !report.finalization_outcome.committed
+        && !report.finalization_outcome.pushed
+        && binding.candidate_sha == binding.remote_sha
+        && binding.candidate_sha == binding.pr_head_sha
+        && git_identity.commit_sha.as_deref() == Some(binding.candidate_sha.as_str())
+        && report
+            .publication_proof
+            .git_tracking
+            .as_ref()
+            .is_none_or(|tracking| tracking.verified_remote_sha == binding.candidate_sha)
+        && binding.repository == binding.head_repository
+        && binding.changed_files == report.changed_files
+        && report.publication_intent.changed_files == report.changed_files
+        && report.finalization_outcome.changed_files == report.changed_files
+}
+
+fn receipt_matches_manual_preflight(
+    receipt: &AgentTaskPrFinalizationReport,
+    intent: &AgentTaskPrFinalizationReport,
+    binding: &crate::agent_task_finalization::AgentTaskPublicationBinding,
+    git_identity: &homeboy_core::git::GitIdentityProof,
+    intent_git_identity: &homeboy_core::git::GitIdentityProof,
+) -> bool {
+    let mut receipt_dossier = receipt.review_dossier.clone();
+    receipt_dossier
+        .evidence
+        .retain(|evidence| intent.review_dossier.evidence.contains(evidence));
+    receipt.path == intent.path
+        && receipt.base == intent.base
+        && receipt.head == intent.head
+        && receipt.title == intent.title
+        && receipt.changed_files == intent.changed_files
+        && receipt.proof == intent.proof
+        && receipt_dossier == intent.review_dossier
+        && receipt.review_dossier.evidence.iter().all(|evidence| {
+            intent.review_dossier.evidence.contains(evidence)
+                || is_publication_base_observation(evidence, receipt)
+        })
+        && intent
+            .review_dossier
+            .evidence
+            .iter()
+            .all(|evidence| receipt.review_dossier.evidence.contains(evidence))
+        && receipt.publication_intent.proof == intent.publication_intent.proof
+        && same_preflight_publication_target(
+            &receipt.publication_intent.target,
+            &intent.publication_intent.target,
+        )
+        && intent_git_identity.commit_sha.is_some()
+        && git_identity.commit_sha == intent_git_identity.commit_sha
+        && binding.candidate_sha
+            == intent_git_identity
+                .commit_sha
+                .as_deref()
+                .unwrap_or_default()
+}
+
+fn is_publication_base_observation(
+    evidence: &AgentTaskReviewEvidence,
+    receipt: &AgentTaskPrFinalizationReport,
+) -> bool {
+    if evidence.url.is_some() {
+        return false;
+    }
+    let target = &receipt.publication_intent.target;
+    let verified_base_sha = target.verified_base_sha.as_deref().unwrap_or_default();
+    if verified_base_sha.is_empty() {
+        return false;
+    }
+    let expected = match target.publication_base_sha.as_deref() {
+        Some(publication_base_sha) if publication_base_sha == verified_base_sha => format!(
+            "Base unchanged since verification: {} remains at {}.",
+            receipt.base, verified_base_sha
+        ),
+        Some(publication_base_sha) => format!(
+            "Base advanced after verification: verified {} at {}; publication observed {}. Candidate ancestry was validated against the verified snapshot.",
+            receipt.base, verified_base_sha, publication_base_sha
+        ),
+        None => format!(
+            "Base observation unavailable immediately before publication; candidate ancestry was validated against verified {} at {}.",
+            receipt.base, verified_base_sha
+        ),
+    };
+    evidence.summary == expected
+}
+
+fn same_publication_target(
+    published: &crate::agent_task_finalization::AgentTaskPublicationTarget,
+    intent: &crate::agent_task_finalization::AgentTaskPublicationTarget,
+) -> bool {
+    let mut published = published.clone();
+    published.url = None;
+    published == *intent
+}
+
+/// Publication can add a PR URL and a live-base observation; all preflight
+/// target fields remain immutable.
+fn same_preflight_publication_target(
+    receipt: &crate::agent_task_finalization::AgentTaskPublicationTarget,
+    intent: &crate::agent_task_finalization::AgentTaskPublicationTarget,
+) -> bool {
+    let mut receipt = receipt.clone();
+    let mut intent = intent.clone();
+    receipt.url = None;
+    receipt.publication_base_sha = None;
+    intent.url = None;
+    intent.publication_base_sha = None;
+    receipt == intent
+}
+
+fn manual_finalization_options(
+    report: AgentTaskPrFinalizationReport,
+) -> Result<AgentTaskPrFinalizationOptions> {
+    validate_manual_preflight_report(&report, &report.run_id)?;
+    let target = &report.publication_intent.target;
+    let path = target.path.clone().filter(|path| path == &report.path);
+    let base = target.base.clone().filter(|base| base == &report.base);
+    let head = target.head.clone().filter(|head| head == &report.head);
+    let verified_base_sha = target.verified_base_sha.clone();
+    let expected_candidate_sha = report
+        .publication_proof
+        .git_identity
+        .as_ref()
+        .and_then(|identity| identity.commit_sha.clone());
+    if path.is_none()
+        || base.is_none()
+        || head.is_none()
+        || verified_base_sha.as_deref().unwrap_or_default().is_empty()
+        || expected_candidate_sha
+            .as_deref()
+            .unwrap_or_default()
+            .is_empty()
+    {
+        return Err(Error::validation_invalid_argument(
+            "cook_finalization",
+            "persisted manual finalization dossier is missing its immutable publication target",
+            None,
+            None,
+        ));
+    }
+    let path = path.expect("validated path");
+    Ok(AgentTaskPrFinalizationOptions {
+        path: path.clone(),
+        run_id: report.run_id,
+        base: base.expect("validated base"),
+        verified_base_sha,
+        head,
+        title: report.title,
+        // An immutable recovered candidate must never reach commit mutation.
+        commit_message: "recovered manual finalization".to_string(),
+        gate_results: report.gate_results,
+        normalized_gate_results: report.normalized_gate_results,
+        changed_files: report.changed_files,
+        evidence: report.evidence,
+        ai_used_for: report.review_dossier.ai_assistance.used_for.clone(),
+        review_dossier: report.review_dossier,
+        review_profile: resolve_review_profile(&path)?,
+        manual_finalization: true,
+        expected_candidate_sha,
+        protected_branches: vec![
+            "main".to_string(),
+            "master".to_string(),
+            "trunk".to_string(),
+        ],
+    })
+}
+
+fn validate_manual_preflight_report(
+    report: &AgentTaskPrFinalizationReport,
+    run_id: &str,
+) -> Result<()> {
+    if report.run_id != run_id {
+        return Err(Error::validation_invalid_argument(
+            "manual_finalization_intent.run_id",
+            "manual finalization dossier belongs to a different durable run",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    if report.schema != crate::agent_task_finalization::AGENT_TASK_PR_FINALIZATION_SCHEMA
+        || report.status != "validated"
+        || !report.manual_finalization
+        || report.title.trim().is_empty()
+        || report.publication_proof.schema
+            != crate::agent_task_finalization::AGENT_TASK_PUBLICATION_PROOF_SCHEMA
+        || report.publication_proof.status != "validated"
+        || report.publication_proof.intent_schema != report.publication_intent.schema
+        || report.publication_proof.adapter_action.is_some()
+        || report.publication_proof.adapter_ref.is_some()
+        || report.proof != report.publication_intent.proof
+        || report.proof != report.publication_proof.proof
+        || report.run_id != report.publication_intent.run_id
+        || report.run_id != report.publication_proof.run_id
+        || report.changed_files != report.publication_intent.changed_files
+        || report.changed_files != report.finalization_outcome.changed_files
+        || report.publication_intent.target != report.publication_proof.target
+        || report.publication_intent.target != report.finalization_outcome.target
+        || report.finalization_outcome.schema
+            != crate::agent_task_finalization::AGENT_TASK_PR_FINALIZATION_OUTCOME_SCHEMA
+        || report.finalization_outcome.run_id != report.run_id
+        || report.finalization_outcome.status != "validated"
+        || report.finalization_outcome.publication_status != "validated"
+        || report.finalization_outcome.publication_action != "none"
+        || report.finalization_outcome.base != report.base
+        || report.finalization_outcome.head != report.head
+        || report.finalization_outcome.published
+        || report.finalization_outcome.committed
+        || report.finalization_outcome.pushed
+    {
+        return Err(Error::validation_invalid_argument(
+            "cook_finalization",
+            "persisted manual finalization dossier failed integrity validation",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    validate_publication_intent(&report.publication_intent).map_err(|_| {
+        Error::validation_invalid_argument(
+            "cook_finalization",
+            "persisted manual finalization dossier has an invalid publication intent",
+            None,
+            None,
+        )
+    })
 }
 
 fn cook_review_dossier(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -9,9 +9,11 @@ use super::super::cook_adoption::{
 };
 use super::super::cook_baseline::git_output;
 use super::super::cook_promotion::{
-    cook_report, finalize_cook_pr_with_backend, finalize_or_load_cook_pr_with_backend,
-    moving_base_recovery_for_run, moving_base_recovery_from_promotion, moving_base_recovery_report,
-    next_moving_base_recovery, persisted_promotion_for_attempt, recover_cook_pr_with_backend,
+    cook_finalization_options, cook_report, finalize_cook_pr_with_backend,
+    finalize_or_load_cook_pr_with_backend, moving_base_recovery_for_run,
+    moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
+    persist_manual_finalization_intent, persist_manual_finalization_receipt,
+    persisted_promotion_for_attempt, recover_cook_pr_with_backend,
     recover_moving_base_cook_candidate, refreshed_moving_base_recovery, selected_candidate_task_id,
     MovingBaseCookRecovery,
 };
@@ -21,8 +23,8 @@ use crate::agent_task::{
     AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
 };
 use crate::agent_task_finalization::{
-    AgentTaskPrDurableGateProof, AgentTaskPrFinalizationBackend, AgentTaskPrRef,
-    AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
+    AgentTaskPrDurableGateProof, AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationReport,
+    AgentTaskPrRef, AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
     RealAgentTaskPrFinalizationBackend,
 };
 use crate::agent_task_scheduler::AgentTaskState;
@@ -5522,6 +5524,8 @@ struct CaptureBackend {
     committed: bool,
     pushed: bool,
     created: bool,
+    candidate_state: Option<crate::agent_task_finalization::AgentTaskPrCandidateState>,
+    committed_sha: Option<String>,
     hydrate_run_id: Option<String>,
     hydrate_gate_proof_run_id: Option<String>,
     synthetic_gate_proof: Option<AgentTaskPromotionReport>,
@@ -5577,6 +5581,18 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
     fn changed_files(&mut self, _path: &str) -> Result<Vec<String>> {
         Ok(vec!["src/lib.rs".to_string()])
     }
+    fn candidate_state(
+        &mut self,
+        _path: &str,
+        _base: &crate::agent_task_finalization::AgentTaskPrResolvedBase,
+        _head: &str,
+    ) -> Result<crate::agent_task_finalization::AgentTaskPrCandidateState> {
+        Ok(self.candidate_state.clone().unwrap_or(
+            crate::agent_task_finalization::AgentTaskPrCandidateState::Dirty {
+                changed_files: vec!["src/lib.rs".to_string()],
+            },
+        ))
+    }
     fn validate_publication_identity(
         &mut self,
         _path: &str,
@@ -5607,7 +5623,11 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
                 commit_sha: None,
                 scope: "commit_host_policy".to_string(),
             });
-        proof.commit_sha = Some("candidate-sha".to_string());
+        proof.commit_sha = Some(
+            self.committed_sha
+                .clone()
+                .unwrap_or_else(|| "candidate-sha".to_string()),
+        );
         proof.scope = "commit_host_policy".to_string();
         Ok(proof)
     }
@@ -6468,6 +6488,289 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
             );
         }
         assert!(backend.committed && backend.pushed && backend.created);
+    });
+}
+
+#[test]
+fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-10980-normal";
+        let run_id = "cook-10980-normal-attempt-1";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.head = Some("fix/8058".to_string());
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        options.gates = VerifyGateOptions {
+            verify: vec!["cargo test --locked agent_task_promotion --lib".to_string()],
+            ..Default::default()
+        };
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
+        seed_review_form_aggregate(run_id, &options.initial_plan);
+
+        let mut manual =
+            cook_finalization_options(&options, run_id, &promotion(run_id), Vec::new())
+                .expect("manual options");
+        manual.manual_finalization = true;
+        let mut preflight_backend = CaptureBackend {
+            candidate_state: Some(
+                crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
+                    changed_files: vec!["src/lib.rs".to_string()],
+                    push_required: false,
+                },
+            ),
+            ..Default::default()
+        };
+        let intent = crate::agent_task_finalization::preflight_pr_with_backend(
+            manual,
+            &mut preflight_backend,
+        )
+        .expect("manual preflight");
+        persist_manual_finalization_intent(run_id, &intent).expect("persist intent");
+        assert!(agent_task_lifecycle::status(run_id)
+            .expect("status")
+            .metadata["cook_finalization"]
+            .is_null());
+
+        let mut normal_backend = CaptureBackend::default();
+        let receipt = finalize_or_load_cook_pr_with_backend(
+            &options,
+            run_id,
+            &promotion(run_id),
+            &mut normal_backend,
+        )
+        .expect("normal Cook finalization continues");
+        assert_eq!(receipt["status"], "review_ready");
+        assert!(normal_backend.created);
+
+        let generic_receipt =
+            serde_json::json!({ "status": "review_ready", "pr": { "number": 42 } });
+        agent_task_lifecycle::record_cook_finalization(run_id, generic_receipt.clone())
+            .expect("persist generic normal receipt");
+        let mut recovery_backend = CaptureBackend::default();
+        let recovered =
+            recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut recovery_backend)
+                .expect("normal finalization receipt takes precedence over stale manual intent");
+        assert_eq!(recovered, generic_receipt);
+        assert!(!recovery_backend.created);
+    });
+}
+
+#[test]
+fn manual_preflight_recovers_without_a_persisted_promotion_and_rejects_tampering() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-10980";
+        let run_id = "cook-10980-attempt-1";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.head = Some("fix/8058".to_string());
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        options.gates = VerifyGateOptions {
+            verify: vec!["cargo test --locked agent_task_promotion --lib".to_string()],
+            ..Default::default()
+        };
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
+        seed_review_form_aggregate(run_id, &options.initial_plan);
+
+        let mut finalization =
+            cook_finalization_options(&options, run_id, &promotion(run_id), Vec::new())
+                .expect("manual finalization options");
+        finalization.manual_finalization = true;
+        let clean_candidate =
+            crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
+                changed_files: vec!["src/lib.rs".to_string()],
+                push_required: false,
+            };
+        let mut preflight_backend = CaptureBackend {
+            candidate_state: Some(clean_candidate.clone()),
+            ..Default::default()
+        };
+        let preflight = crate::agent_task_finalization::preflight_pr_with_backend(
+            finalization,
+            &mut preflight_backend,
+        )
+        .expect("manual preflight");
+        assert_eq!(preflight.status, "validated");
+        assert!(
+            !preflight_backend.committed && !preflight_backend.pushed && !preflight_backend.created
+        );
+        let mut copied_from_another_run = preflight.clone();
+        copied_from_another_run.run_id = "another-cook-attempt".to_string();
+        let error = persist_manual_finalization_intent(run_id, &copied_from_another_run)
+            .expect_err("a dossier copied from another run cannot be persisted");
+        assert!(error.message.contains("different durable run"));
+        assert!(agent_task_lifecycle::status(run_id)
+            .expect("status")
+            .metadata["manual_finalization_intent"]
+            .is_null());
+
+        let mut malformed = preflight.clone();
+        malformed.status = "review_ready".to_string();
+        let error = persist_manual_finalization_intent(run_id, &malformed)
+            .expect_err("a non-preflight dossier cannot be persisted");
+        assert!(error
+            .message
+            .contains("dossier failed integrity validation"));
+        assert!(agent_task_lifecycle::status(run_id)
+            .expect("status")
+            .metadata["manual_finalization_intent"]
+            .is_null());
+
+        let preflight = serde_json::to_value(preflight).expect("serialize preflight");
+
+        let mut coherently_tampered = preflight.clone();
+        for pointer in [
+            "/changed_files",
+            "/publication_intent/changed_files",
+            "/finalization_outcome/changed_files",
+        ] {
+            *coherently_tampered
+                .pointer_mut(pointer)
+                .expect("changed-files field") = serde_json::json!(["tampered.rs"]);
+        }
+        agent_task_lifecycle::record_manual_finalization_intent(run_id, coherently_tampered)
+            .expect("persist coherent tampering");
+        let error = recover_cook_pr_with_backend(
+            cook_id,
+            Vec::new(),
+            false,
+            &mut CaptureBackend {
+                candidate_state: Some(clean_candidate.clone()),
+                ..Default::default()
+            },
+        )
+        .expect_err("candidate scope tampering fails closed");
+        assert!(error.message.contains("changed files no longer match"));
+
+        let preflight_report = serde_json::from_value(preflight.clone()).expect("parse preflight");
+        persist_manual_finalization_intent(run_id, &preflight_report)
+            .expect("persist manual dossier");
+        let error = recover_cook_pr_with_backend(
+            cook_id,
+            Vec::new(),
+            false,
+            &mut CaptureBackend {
+                candidate_state: Some(clean_candidate.clone()),
+                committed_sha: Some("different-candidate-sha".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect_err("candidate SHA mismatch fails closed");
+        assert!(error.message.contains("no longer matches"));
+
+        let mut publish_backend = CaptureBackend {
+            candidate_state: Some(clean_candidate),
+            ..Default::default()
+        };
+        let published =
+            recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut publish_backend)
+                .expect("recover manual publication");
+        assert_eq!(published["status"], "review_ready");
+        assert!(publish_backend.created);
+        assert!(!publish_backend.committed && !publish_backend.pushed);
+        let mut repeated_backend = CaptureBackend::default();
+        let repeated =
+            recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut repeated_backend)
+                .expect("completed manual recovery is idempotent");
+        assert_eq!(repeated, published);
+        assert!(!repeated_backend.created);
+
+        let mut different_candidate: AgentTaskPrFinalizationReport =
+            serde_json::from_value(published.clone()).expect("parse receipt");
+        different_candidate.changed_files = vec!["different.rs".to_string()];
+        different_candidate.path = "/different-worktree".to_string();
+        different_candidate.base = "different-base".to_string();
+        different_candidate.head = "different-head".to_string();
+        different_candidate.publication_intent.changed_files =
+            different_candidate.changed_files.clone();
+        different_candidate.publication_intent.target.path = Some(different_candidate.path.clone());
+        different_candidate.publication_intent.target.base = Some(different_candidate.base.clone());
+        different_candidate.publication_intent.target.head = Some(different_candidate.head.clone());
+        different_candidate.publication_proof.target =
+            different_candidate.publication_intent.target.clone();
+        different_candidate.finalization_outcome.target =
+            different_candidate.publication_intent.target.clone();
+        different_candidate.publication_proof.target.url = different_candidate.pr_url.clone();
+        different_candidate.finalization_outcome.target.url = different_candidate.pr_url.clone();
+        different_candidate.finalization_outcome.base = different_candidate.base.clone();
+        different_candidate.finalization_outcome.head = different_candidate.head.clone();
+        different_candidate.finalization_outcome.changed_files =
+            different_candidate.changed_files.clone();
+        let binding = different_candidate
+            .publication_proof
+            .binding
+            .as_mut()
+            .expect("publication binding");
+        binding.candidate_sha = "different-candidate-sha".to_string();
+        binding.remote_sha = binding.candidate_sha.clone();
+        binding.pr_head_sha = binding.candidate_sha.clone();
+        binding.changed_files = different_candidate.changed_files.clone();
+        different_candidate
+            .publication_proof
+            .git_identity
+            .as_mut()
+            .expect("Git identity")
+            .commit_sha = Some("different-candidate-sha".to_string());
+        let before = agent_task_lifecycle::status(run_id).expect("receipt before rejection");
+        let error = persist_manual_finalization_receipt(run_id, &different_candidate)
+            .expect_err("a self-consistent receipt for a different candidate cannot persist");
+        assert!(error.message.contains("controller validation"));
+        assert_eq!(
+            agent_task_lifecycle::status(run_id)
+                .expect("receipt after rejection")
+                .metadata,
+            before.metadata
+        );
+
+        for (pointer, replacement) in [
+            ("/path", serde_json::json!("/tampered")),
+            ("/base", serde_json::json!("tampered-base")),
+            ("/head", serde_json::json!("tampered-head")),
+            ("/proof", serde_json::json!({"tampered": true})),
+            ("/review_dossier", serde_json::json!({"tampered": true})),
+        ] {
+            let mut tampered = published.clone();
+            *tampered
+                .pointer_mut(pointer)
+                .expect("authoritative receipt field") = replacement;
+            agent_task_lifecycle::record_cook_finalization(run_id, tampered)
+                .expect("persist coherent receipt tampering");
+            let error = recover_cook_pr_with_backend(
+                run_id,
+                Vec::new(),
+                false,
+                &mut CaptureBackend::default(),
+            )
+            .expect_err("receipt tampering fails closed");
+            assert!(error.message.contains("finalization"));
+        }
+
+        let mut reassigned_receipt: AgentTaskPrFinalizationReport =
+            serde_json::from_value(published.clone()).expect("parse receipt");
+        reassigned_receipt.run_id = "another-cook-attempt".to_string();
+        let error = persist_manual_finalization_receipt(run_id, &reassigned_receipt)
+            .expect_err("a reassigned receipt cannot be persisted");
+        assert!(error.message.contains("controller validation"));
+
+        let mut malformed_receipt: AgentTaskPrFinalizationReport =
+            serde_json::from_value(published.clone()).expect("parse receipt");
+        malformed_receipt.pr_action = "none".to_string();
+        let error = persist_manual_finalization_receipt(run_id, &malformed_receipt)
+            .expect_err("a non-publication receipt cannot be persisted");
+        assert!(error.message.contains("controller validation"));
+
+        let published_report = serde_json::from_value(published.clone()).expect("parse receipt");
+        persist_manual_finalization_receipt(run_id, &published_report)
+            .expect("restore valid manual receipt");
+        let mut tampered = published;
+        tampered["changed_files"] = serde_json::json!(["tampered.rs"]);
+        agent_task_lifecycle::record_cook_finalization(run_id, tampered)
+            .expect("persist tampering");
+        let error =
+            recover_cook_pr_with_backend(run_id, Vec::new(), false, &mut CaptureBackend::default())
+                .expect_err("tampered dossier fails closed");
+        assert!(error.message.contains("integrity validation"));
     });
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -417,7 +417,7 @@ pub mod service {
         consume_claimed_with_dispatcher, discover_runs, enqueue_terminal_continuation,
         evidence_ref_task_id, execute_promotion, hydrate_evidence_ref, hydrate_evidence_summary,
         load_recipe, load_recipe_for_attempt, logs, normalize_plan_workspaces,
-        offloaded_status_remediation, persist_initial_recipe,
+        offloaded_status_remediation, persist_initial_recipe, persist_manual_finalization_intent,
         persist_provider_boundary_replay_evidence, persisted_status, promotion_is_resumable,
         promotion_source, read_plan, rearm_failed_terminal_continuation,
         reconcile_recipe_attempt_for_continuation, reconcile_terminal_artifact_projection,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -505,6 +505,7 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         review_dossier,
         review_profile,
         manual_finalization: args.manual_finalization,
+        expected_candidate_sha: None,
         protected_branches: args.protected_branches,
     };
     let report = if args.preflight {
@@ -519,6 +520,9 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     };
 
     let mut value = serde_json::to_value(&report).unwrap_or(Value::Null);
+    if args.manual_finalization && args.preflight && report.status == "validated" {
+        agent_task_service::persist_manual_finalization_intent(&handoff_run_id, &report)?;
+    }
     value["handoff"] = finalization_handoff(
         &report.status,
         report.pr_url.as_deref(),


### PR DESCRIPTION
## Summary

- Persist validated manual-finalization preflight as a separate typed lifecycle intent rather than a completed Cook finalization.
- Recover that intent without requiring a promotion, while requiring the exact clean, already-pushed candidate SHA and live changed-file scope.
- Bind manual intent and completed receipt to durable run ownership, publication target, proof, review dossier, and immutable candidate identity.
- Preserve lightweight normal Cook receipts, prioritize completed normal finalization over stale manual intent, and return completed manual publication idempotently.
- Reject reassigned, malformed, coherently altered, or cross-candidate intents and receipts before publication.

Closes #10980.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents manual_preflight --lib` (2 passed)
- `cargo test -p homeboy-agents agent_task_finalization --lib` (55 passed)
- `cargo check -p homeboy-cli`
- Independent adversarial review found no remaining issues.

GitHub publication is mocked in tests; no external mutation occurs during recovery coverage.

## AI Assistance

OpenCode general coding subagents using OpenAI GPT-5.6 Sol implemented and reviewed this change. Chris Huber remains responsible for every line.