### PR TITLE
fix(agent-task): retain gate baseline artifacts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1,5 +1,6 @@
 use homeboy_engine_primitives::content_hash;
 use std::cell::RefCell;
+use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -971,7 +972,7 @@ fn gate_feedback_baseline_for_artifact(
 /// Replace a runner-local baseline path with the controller artifact-store
 /// identity before a follow-up can reuse a dirty destination. Older baselines
 /// without source identity retain their existing strict path/hash contract.
-fn bind_gate_feedback_baseline(baseline: Option<Value>) -> Result<Option<Value>> {
+pub(crate) fn bind_gate_feedback_baseline(baseline: Option<Value>) -> Result<Option<Value>> {
     let Some(mut baseline) = baseline else {
         return Ok(None);
     };
@@ -1264,6 +1265,9 @@ fn promote_committed_changes(
             None,
         ));
     }
+    let retained_patch_path =
+        retain_committed_changes_artifact(options, outcome, &patch, &committed_patch.sha256)?
+            .unwrap_or_else(|| committed_patch.patch_path.clone());
     let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
     // Keep committed-change promotion on the same atomic base-validation
     // boundary as artifact promotion: no apply or checkpoint may precede a
@@ -1321,7 +1325,7 @@ fn promote_committed_changes(
             AgentTaskPromotionArtifactRef {
                 id: "committed-changes".to_string(),
                 kind: "patch".to_string(),
-                path: committed_patch.patch_path.display().to_string(),
+                path: retained_patch_path.display().to_string(),
                 sha256: Some(committed_patch.sha256.clone()),
             },
             normalized_patch.changed_files.clone(),
@@ -1392,7 +1396,7 @@ fn promote_committed_changes(
         patch_artifact: AgentTaskPromotionArtifactRef {
             id: "committed-changes".to_string(),
             kind: "patch".to_string(),
-            path: committed_patch.patch_path.display().to_string(),
+            path: retained_patch_path.display().to_string(),
             sha256: Some(committed_patch.sha256),
         },
         changed_files: persisted_changed_files(normalized_patch.changed_files, candidate.as_ref()),
@@ -1419,6 +1423,67 @@ fn promote_committed_changes(
         }),
         operator_notification,
     })
+}
+
+/// Retain the controller-generated committed delta before its producer path can
+/// be cleaned up. Only an existing controller run may own this projection.
+fn retain_committed_changes_artifact(
+    options: &AgentTaskPromotionOptions,
+    outcome: &AgentTaskOutcome,
+    patch: &str,
+    sha256: &str,
+) -> Result<Option<PathBuf>> {
+    let Some(run_id) = options.source_run_id.as_deref() else {
+        return Ok(None);
+    };
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    if store.get_run(run_id)?.is_none() {
+        return Ok(None);
+    }
+    let mut snapshot = tempfile::NamedTempFile::new().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create committed changes artifact snapshot".to_string()),
+        )
+    })?;
+    snapshot
+        .as_file_mut()
+        .write_all(patch.as_bytes())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("write committed changes artifact snapshot".to_string()),
+            )
+        })?;
+    snapshot
+        .as_file_mut()
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("rewind committed changes artifact snapshot".to_string()),
+            )
+        })?;
+    let record_id = format!(
+        "agent-task-committed-changes-{}",
+        content_hash::sha256_hex(format!("{run_id}\0{}\0{sha256}", outcome.task_id).as_bytes())
+    );
+    let projection = store.record_verified_artifact_from_open_file_with_id(
+        run_id,
+        "patch",
+        snapshot.as_file_mut(),
+        &record_id,
+        i64::try_from(patch.len()).unwrap_or(i64::MAX),
+        sha256,
+        json!({
+            "agent_task": {
+                "task_id": outcome.task_id,
+                "logical_artifact_id": "committed-changes",
+                "projection": "committed_changes"
+            }
+        }),
+    )?;
+    Ok(Some(PathBuf::from(projection.path)))
 }
 
 fn run_promotion_gates(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -375,7 +375,7 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
 }
 
 #[test]
-fn committed_changes_bind_cleanup_safe_gate_feedback_baselines() {
+fn committed_changes_retain_a_controller_baseline_before_source_cleanup() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
@@ -390,34 +390,16 @@ fn committed_changes_bind_cleanup_safe_gate_feedback_baselines() {
         std::fs::write(repo.join("lib.rs"), "new\n").expect("candidate");
         git(&repo, &["commit", "-am", "candidate"]);
         let (source_path, source) = write_empty_patch_source(&temp);
-        let baseline_patch = VALID_PATCH;
-        let baseline_sha256 = sha256_hex(baseline_patch);
-        record_controller_projection("baseline-run", "baseline-task", "baseline", baseline_patch);
-        let mut source: Value = serde_json::from_str(&source).expect("source json");
-        source["artifacts"][0]["metadata"] = serde_json::json!({
-            "gate_feedback_baseline": {
-                "source_run_id": "baseline-run",
-                "source_task_id": "baseline-task",
-                "current_diff": baseline_patch,
-                "patch_artifact": {
-                    "id": "baseline",
-                    "kind": "patch",
-                    "path": "/lab/cleaned/baseline.patch",
-                    "sha256": baseline_sha256
-                }
-            }
-        });
-        let source = source.to_string();
-        std::fs::write(&source_path, &source).expect("write source");
+        record_controller_projection("baseline-run", "other-task", "other", VALID_PATCH);
         let mut provider = FakePromotionWorkspaceProvider {
             workspace_path: Some(repo.clone()),
             ..Default::default()
         };
 
-        promote_with_provider(
+        let report = promote_with_provider(
             AgentTaskPromotionOptions {
                 source,
-                source_run_id: Some("committed-follow-up".to_string()),
+                source_run_id: Some("baseline-run".to_string()),
                 source_path: Some(source_path),
                 source_worktree_path: Some(repo),
                 base_ref: None,
@@ -433,16 +415,65 @@ fn committed_changes_bind_cleanup_safe_gate_feedback_baselines() {
             },
             &mut provider,
         )
-        .expect("committed follow-up promotes after Lab cleanup");
-
-        let baseline = provider.apply_calls[0]
-            .gate_feedback_baseline
-            .as_ref()
-            .expect("baseline forwarded");
-        assert!(baseline["patch_artifact"].get("path").is_none());
+        .expect("committed changes promote");
+        let original_path = temp.path().join(format!(
+            "committed-changes-{}.patch",
+            report.patch_artifact.sha256.as_deref().expect("patch sha")
+        ));
+        assert_ne!(
+            report.patch_artifact.path,
+            original_path.display().to_string()
+        );
+        std::fs::remove_file(&original_path).expect("clean original promotion artifact");
+        crate::agent_task_lifecycle::verified_controller_artifact_projection(
+            "baseline-run",
+            "task-1",
+            "committed-changes",
+            "patch",
+            report.patch_artifact.sha256.as_deref().expect("patch sha"),
+            None,
+        )
+        .expect("retained projection lookup")
+        .expect("committed changes retained before cleanup");
+        let baseline = serde_json::json!({
+            "source_run_id": "baseline-run",
+            "source_task_id": "task-1",
+            "patch_artifact": report.patch_artifact,
+        });
+        let bound = super::super::promote::bind_gate_feedback_baseline(Some(baseline))
+            .expect("continuation resolves controller mirror")
+            .expect("bound baseline");
+        assert!(bound["patch_artifact"].get("path").is_none());
         assert_eq!(
-            baseline["patch_artifact"]["controller_artifact"]["run_id"],
-            "baseline-run"
+            bound["patch_artifact"]["controller_artifact"]["logical_artifact_id"],
+            "committed-changes"
+        );
+        let forged = serde_json::json!({
+            "source_run_id": "baseline-run",
+            "source_task_id": "forged-task",
+            "patch_artifact": {
+                "id": "forged",
+                "kind": "patch",
+                "path": temp.path().join("unbounded.patch"),
+                "sha256": sha256_hex(VALID_PATCH),
+            }
+        });
+        let error = super::super::promote::bind_gate_feedback_baseline(Some(forged))
+            .expect_err("unindexed baseline path cannot be imported");
+        assert!(error
+            .message
+            .contains("controller artifact mirror is missing"));
+        assert!(
+            crate::agent_task_lifecycle::verified_controller_artifact_projection(
+                "baseline-run",
+                "forged-task",
+                "forged",
+                "patch",
+                &sha256_hex(VALID_PATCH),
+                None,
+            )
+            .expect("forged lookup")
+            .is_none()
         );
     });
 }

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -473,6 +473,70 @@ impl ObservationStore {
         self.record_artifact_with_metadata(run_id, kind, snapshot.path(), metadata_json)
     }
 
+    /// Persist an opened file under a stable lifecycle identity after verifying
+    /// the exact descriptor-copied bytes against the supplied digest.
+    pub fn record_verified_artifact_from_open_file_with_id(
+        &self,
+        run_id: &str,
+        kind: &str,
+        source: &mut fs::File,
+        artifact_id: &str,
+        expected_size_bytes: i64,
+        expected_sha256: &str,
+        metadata_json: serde_json::Value,
+    ) -> Result<ArtifactRecord> {
+        let metadata = source.metadata().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("inspect opened verified artifact file".to_string()),
+            )
+        })?;
+        if !metadata.is_file() {
+            return Err(Error::validation_invalid_argument(
+                "artifact",
+                "opened verified artifact source is not a regular file",
+                None,
+                None,
+            ));
+        }
+        let mut snapshot = tempfile::NamedTempFile::new().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create verified artifact snapshot".to_string()),
+            )
+        })?;
+        std::io::copy(source, snapshot.as_file_mut()).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("copy opened verified artifact snapshot".to_string()),
+            )
+        })?;
+        snapshot.as_file_mut().flush().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("flush verified artifact snapshot".to_string()),
+            )
+        })?;
+        let actual_size_bytes = i64::try_from(
+            snapshot
+                .as_file()
+                .metadata()
+                .map_err(|error| Error::internal_io(error.to_string(), None))?
+                .len(),
+        )
+        .ok();
+        let actual_sha256 = crate::artifact_metadata::sha256_file(snapshot.path())?;
+        if actual_size_bytes != Some(expected_size_bytes) || actual_sha256 != expected_sha256 {
+            return Err(Error::validation_invalid_argument(
+                "artifact.sha256",
+                "opened artifact bytes do not match the published durable metadata",
+                Some(actual_sha256),
+                None,
+            ));
+        }
+        self.record_artifact_with_id(run_id, kind, snapshot.path(), artifact_id, metadata_json)
+    }
+
     /// Record verified file bytes under a caller-provided stable logical id.
     /// This is used when an owning lifecycle already defines artifact identity.
     pub fn record_artifact_with_id(
@@ -1695,6 +1759,71 @@ mod tests {
                 fs::read(&artifact.path).expect("persisted bytes"),
                 b"original bytes"
             );
+        });
+    }
+
+    #[test]
+    fn verified_opened_artifact_rejects_digest_mismatch_without_publishing() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("test").cwd_path(home.path()).build())
+                .expect("run");
+            let source = home.path().join("source.patch");
+            fs::write(&source, b"trusted bytes").expect("write source");
+            let mut opened = fs::File::open(&source).expect("open source");
+
+            let error = store
+                .record_verified_artifact_from_open_file_with_id(
+                    &run.id,
+                    "patch",
+                    &mut opened,
+                    "verified-patch",
+                    13,
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    serde_json::json!({}),
+                )
+                .expect_err("wrong digest rejects the descriptor bytes");
+            assert!(error.message.contains("do not match"));
+            assert!(store
+                .get_artifact("verified-patch")
+                .expect("lookup")
+                .is_none());
+        });
+    }
+
+    #[test]
+    fn verified_opened_artifact_uses_pre_replacement_descriptor_bytes() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("test").cwd_path(home.path()).build())
+                .expect("run");
+            let source = home.path().join("source.patch");
+            let replacement = home.path().join("replacement.patch");
+            let trusted = b"trusted bytes";
+            fs::write(&source, trusted).expect("write trusted source");
+            let expected_sha256 = crate::artifact_metadata::sha256_file(&source).expect("hash");
+            let mut opened = fs::File::open(&source).expect("open trusted source");
+            fs::write(&replacement, b"poison bytes").expect("write replacement");
+            fs::rename(&replacement, &source).expect("replace source pathname");
+
+            let artifact = store
+                .record_verified_artifact_from_open_file_with_id(
+                    &run.id,
+                    "patch",
+                    &mut opened,
+                    "verified-patch",
+                    i64::try_from(trusted.len()).expect("trusted size"),
+                    &expected_sha256,
+                    serde_json::json!({}),
+                )
+                .expect("publish trusted descriptor bytes");
+            assert_eq!(
+                fs::read(&source).expect("replacement bytes"),
+                b"poison bytes"
+            );
+            assert_eq!(fs::read(artifact.path).expect("stored bytes"), trusted);
         });
     }
 


### PR DESCRIPTION
## Summary

- Retain controller-generated `committed-changes` bytes before source cleanup can remove the baseline.
- Require continuation to resolve the retained controller projection with exact run, task, logical artifact, kind, record, and SHA-256 identity.
- Add a single-open verified snapshot primitive so pathname replacement cannot change retained bytes between verification and publication.
- Keep missing, forged, or mismatched baseline projections fail-closed.

Closes #10979.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents committed_changes_retain_a_controller_baseline_before_source_cleanup --lib`
- `cargo test -p homeboy-agents agent_task_candidate_baseline --lib` (4 passed)
- `cargo test -p homeboy-core verified_opened_artifact --lib` (2 passed)
- Independent security review found no remaining issues.

## AI Assistance

OpenCode general coding subagents using OpenAI GPT-5.6 Sol implemented and reviewed this change. Chris Huber remains responsible for every line.