### PR TITLE
feat(runner): authenticate provider execution context

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -80,7 +80,8 @@ fn ensure_runner_exec_observation_run(
     let mut run = match store.get_run(&run_id)? {
         Some(run)
             if run.metadata_json.get("kind").and_then(Value::as_str)
-                == Some(RUNNER_EXEC_RUN_KIND) =>
+                == Some(RUNNER_EXEC_RUN_KIND)
+                || run.kind == "runner-exec" =>
         {
             run
         }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -75,6 +75,30 @@ fn runner_exec_run_id_creates_generic_run_on_demand() {
 }
 
 #[test]
+fn generic_runner_exec_adopts_and_reuses_a_direct_runner_exec_run() {
+    with_isolated_home(|_| {
+        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+        let direct = store
+            .start_run(
+                homeboy_core::observation::NewRunRecord::builder("runner-exec")
+                    .command("homeboy runner exec lab".to_string())
+                    .build(),
+            )
+            .expect("direct runner exec run");
+        let command = vec!["true".to_string()];
+
+        let adopted = ensure_generic_runner_exec_run(&direct.id, "lab", "/workspace", &command)
+            .expect("adopt direct runner exec run");
+        let reused = ensure_generic_runner_exec_run(&direct.id, "lab", "/workspace", &command)
+            .expect("repeat direct runner exec run");
+
+        assert_eq!(adopted.id, direct.id);
+        assert_eq!(reused.id, direct.id);
+        assert_eq!(reused.metadata_json["kind"], RUNNER_EXEC_RUN_KIND);
+    });
+}
+
+#[test]
 fn diagnostic_ssh_run_id_creates_generic_run_without_a_runner_job() {
     // #9485: the diagnostic-SSH transport executes synchronously and never
     // accepts a durable runner job, but `runner exec --ssh --run-id <new-id>`

--- a/crates/homeboy-cli/src/commands/infra/route/rig_source.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/rig_source.rs
@@ -77,6 +77,10 @@ pub(super) fn run_rig_source_management_on_runner(
     let (output, exit_code) = runners::exec(
         runner_id,
         RunnerExecOptions {
+            execution_context:
+                homeboy::core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
             cwd: runner.workspace_root.clone(),
             project_id: None,
             allow_diagnostic_ssh: false,

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -118,6 +118,10 @@ pub(super) fn exec(
     let (mut output, exit_code) = runner::exec(
         runner_id,
         runner::RunnerExecOptions {
+            execution_context:
+                homeboy::core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
             cwd,
             project_id,
             allow_diagnostic_ssh,

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -760,14 +760,21 @@ fn runner_exec_promotes_artifact_dir_children_to_run_store() {
             RunnerExecMode::Local,
             &workspace.path().display().to_string(),
         );
+        homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+            &run.id,
+            "lab-local",
+            &workspace.path().display().to_string(),
+            &["true".to_string()],
+        )
+        .expect("generic runner-exec run");
 
         let promoted =
             promote_runner_exec_artifact_dirs(&run.id, &output, &["outputs".to_string()])
                 .expect("promote artifact dir children");
 
-        assert_eq!(promoted.len(), 2);
+        assert_eq!(promoted.len(), 3);
         let artifacts = store.list_artifacts(&run.id).expect("artifacts");
-        assert_eq!(artifacts.len(), 2);
+        assert_eq!(artifacts.len(), 3);
         assert_eq!(artifacts[0].kind, "report");
         assert_eq!(artifacts[0].artifact_type, "directory");
         assert_eq!(artifacts[0].metadata_json["artifact_dir"], "outputs");
@@ -778,14 +785,22 @@ fn runner_exec_promotes_artifact_dir_children_to_run_store() {
         assert!(std::path::Path::new(&artifacts[0].path)
             .join("index.html")
             .is_file());
-        assert_eq!(artifacts[1].kind, "summary_json");
+        assert_eq!(artifacts[1].kind, "index_html");
         assert_eq!(artifacts[1].artifact_type, "file");
         assert_eq!(artifacts[1].metadata_json["artifact_dir"], "outputs");
         assert_eq!(
             artifacts[1].metadata_json["declared_path"],
-            "outputs/summary.json"
+            "outputs/report/index.html"
         );
         assert!(std::path::Path::new(&artifacts[1].path).is_file());
+        assert_eq!(artifacts[2].kind, "summary_json");
+        assert_eq!(artifacts[2].artifact_type, "file");
+        assert_eq!(artifacts[2].metadata_json["artifact_dir"], "outputs");
+        assert_eq!(
+            artifacts[2].metadata_json["declared_path"],
+            "outputs/summary.json"
+        );
+        assert!(std::path::Path::new(&artifacts[2].path).is_file());
     });
 }
 
@@ -946,6 +961,13 @@ fn runner_exec_promotes_artifact_dir_typed_schema_children() {
             RunnerExecMode::Local,
             &workspace.path().display().to_string(),
         );
+        homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+            &run.id,
+            "lab-local",
+            &workspace.path().display().to_string(),
+            &["true".to_string()],
+        )
+        .expect("generic runner-exec run");
 
         let promoted =
             promote_runner_exec_artifact_dirs(&run.id, &output, &["outputs".to_string()])

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -10,6 +10,7 @@ mod summary;
 // resolving. The job store / persistence / remote-runner behavior stays here.
 use homeboy_api_jobs_contract::types;
 
+pub use crate::runner_job_execution_context::RunnerJobExecutionContext;
 pub(crate) use persistence::timestamp_ms;
 pub use remote_runner::{
     JobArtifactMetadata, RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -573,6 +573,29 @@ pub(super) struct RemoteRunnerExecutionReceipt {
     pub(super) consumed_at_ms: u64,
 }
 
+fn execution_context_id_from_evidence(stored: &StoredJob) -> Result<Option<String>> {
+    let mut context_ids = HashSet::new();
+    for evidence in stored.events.iter().filter_map(|event| {
+        event
+            .data
+            .as_ref()
+            .and_then(|data| data.get("runner_job_execution_context"))
+    }) {
+        let context =
+            crate::runner_job_execution_context::RunnerJobExecutionContext::from_evidence_record(
+                evidence,
+            )?;
+        context_ids.insert(context.id().to_string());
+    }
+    match context_ids.len() {
+        0 => Ok(None),
+        1 => Ok(context_ids.into_iter().next()),
+        _ => Err(crate::runner_job_execution_context::rejected(
+            "durable claim has conflicting execution-context evidence",
+        )),
+    }
+}
+
 impl JobStore {
     pub fn lookup_remote_runner_submission(
         &self,
@@ -1054,14 +1077,19 @@ impl JobStore {
 
     fn ensure_remote_runner_execution_receipt(&self, job_id: Uuid) -> Result<()> {
         let inner = self.inner.lock().expect("job store mutex poisoned");
-        let remote_runner = inner
+        let stored = inner
             .jobs
             .get(&job_id)
-            .ok_or_else(|| job_not_found(job_id))?
+            .ok_or_else(|| job_not_found(job_id))?;
+        let remote_runner = stored
             .remote_runner
             .as_ref()
             .expect("finish only follows a validated remote runner claim");
-        let Some(context_id) = remote_runner.execution_context_id.as_deref() else {
+        let context_id = match remote_runner.execution_context_id.as_deref() {
+            Some(context_id) => Some(context_id.to_string()),
+            None => execution_context_id_from_evidence(stored)?,
+        };
+        let Some(context_id) = context_id else {
             return Ok(());
         };
         let Some(receipt) = remote_runner.execution_receipt.as_ref() else {

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -556,6 +556,11 @@ pub(super) struct StoredRemoteRunnerJob {
     #[serde(default, skip)]
     pub(super) execution_request: Option<RemoteRunnerJobRequest>,
     pub(super) request: RemoteRunnerJobRequest,
+    /// Presence records that this claim carried an authenticated execution
+    /// context. Its absence is the persisted compatibility signal for legacy
+    /// context-free claims.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) execution_context_id: Option<String>,
     /// One-time durable execution receipt. This is consumed only at the
     /// provider boundary after the worker has materialized its inputs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -751,6 +756,7 @@ impl JobStore {
                     // immediately before dispatch.
                     execution_request: None,
                     request: public_request,
+                    execution_context_id: None,
                     execution_receipt: None,
                 }),
                 local_runner: None,
@@ -921,6 +927,16 @@ impl JobStore {
                     }
                     None => None,
                 };
+                if let Some(context) = execution_context.as_ref() {
+                    inner
+                        .jobs
+                        .get_mut(&job_id)
+                        .expect("candidate exists")
+                        .remote_runner
+                        .as_mut()
+                        .expect("filtered remote runner job has request")
+                        .execution_context_id = Some(context.id().to_string());
+                }
                 Self::append_event_already_locked(
                     self,
                     inner,
@@ -976,6 +992,7 @@ impl JobStore {
         mut result: RemoteRunnerJobResult,
     ) -> Result<Job> {
         self.ensure_remote_runner_claim(job_id, runner_id, claim_id)?;
+        self.ensure_remote_runner_execution_receipt(job_id)?;
         result.validate_observation_run_details()?;
         result.observation_run_details_compatibility_degraded =
             !result.observation_run_ids.is_empty() && result.observation_run_details.is_empty();
@@ -1033,6 +1050,31 @@ impl JobStore {
                 )
             },
         )
+    }
+
+    fn ensure_remote_runner_execution_receipt(&self, job_id: Uuid) -> Result<()> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let remote_runner = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?
+            .remote_runner
+            .as_ref()
+            .expect("finish only follows a validated remote runner claim");
+        let Some(context_id) = remote_runner.execution_context_id.as_deref() else {
+            return Ok(());
+        };
+        let Some(receipt) = remote_runner.execution_receipt.as_ref() else {
+            return Err(crate::runner_job_execution_context::rejected(
+                "runner execution receipt has not been consumed for this claim",
+            ));
+        };
+        if receipt.context_id != context_id {
+            return Err(crate::runner_job_execution_context::rejected(
+                "runner execution receipt does not match the claimed execution context",
+            ));
+        }
+        Ok(())
     }
 
     pub(crate) fn renew_remote_runner_claim(

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -90,6 +90,13 @@ pub struct RemoteRunnerJobRequest {
 }
 
 impl RemoteRunnerJobRequest {
+    /// Provider environment resolution accepts only authenticated execution
+    /// contexts. Older workers can still receive ordinary runner jobs, but
+    /// must never be handed a job that would make this boundary fail open.
+    pub fn requires_execution_context(&self) -> bool {
+        !self.extension_env_providers.is_empty()
+    }
+
     /// A caller-owned identity makes a retried POST safe across a lost response.
     /// It deliberately lives in metadata so older clients can continue submitting
     /// anonymous jobs while durable handoffs opt into replayable ownership.
@@ -410,6 +417,14 @@ fn merge_metadata_value(mut metadata: Value, key: &str, value: Value) -> Value {
 pub struct RemoteRunnerJobClaim {
     pub job: Job,
     pub request: RemoteRunnerJobRequest,
+    /// Authenticated execution authority derived from this durable claim.
+    /// Older brokers omit it on the wire; workers refuse those claims rather
+    /// than reconstructing authority from environment or lifecycle projections.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_context: Option<crate::runner_job_execution_context::RunnerJobExecutionContext>,
+    /// Echoed by compatible workers and verified before they execute a claim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_protocol: Option<crate::runner_job_execution_context::RunnerJobExecutionProtocol>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -541,6 +556,16 @@ pub(super) struct StoredRemoteRunnerJob {
     #[serde(default, skip)]
     pub(super) execution_request: Option<RemoteRunnerJobRequest>,
     pub(super) request: RemoteRunnerJobRequest,
+    /// One-time durable execution receipt. This is consumed only at the
+    /// provider boundary after the worker has materialized its inputs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) execution_receipt: Option<RemoteRunnerExecutionReceipt>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct RemoteRunnerExecutionReceipt {
+    pub(super) context_id: String,
+    pub(super) consumed_at_ms: u64,
 }
 
 impl JobStore {
@@ -726,6 +751,7 @@ impl JobStore {
                     // immediately before dispatch.
                     execution_request: None,
                     request: public_request,
+                    execution_receipt: None,
                 }),
                 local_runner: None,
                 local_child: None,
@@ -781,6 +807,27 @@ impl JobStore {
         project_id: Option<&str>,
         lease_ms: u64,
         concurrency_limit: Option<usize>,
+    ) -> Result<Option<RemoteRunnerJobClaim>> {
+        self.claim_remote_runner_job_with_execution_protocol(
+            runner_id,
+            project_id,
+            lease_ms,
+            concurrency_limit,
+            Some(&crate::runner_job_execution_context::RunnerJobExecutionProtocol::current()),
+        )
+    }
+
+    /// Claim a reverse-runner job only after the worker has advertised support
+    /// for the context carried in the resulting claim.
+    pub fn claim_remote_runner_job_with_execution_protocol(
+        &self,
+        runner_id: &str,
+        project_id: Option<&str>,
+        lease_ms: u64,
+        concurrency_limit: Option<usize>,
+        execution_protocol: Option<
+            &crate::runner_job_execution_context::RunnerJobExecutionProtocol,
+        >,
     ) -> Result<Option<RemoteRunnerJobClaim>> {
         if runner_id.trim().is_empty() {
             return Err(Error::validation_invalid_argument(
@@ -858,23 +905,54 @@ impl JobStore {
                         .dispatch_request();
                     (stored.job.clone(), request)
                 };
+                let execution_context = match execution_protocol {
+                    Some(protocol) => {
+                        protocol.verify()?;
+                        Some(
+                            crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
+                                &job, &request,
+                            )?,
+                        )
+                    }
+                    None if request.requires_execution_context() => {
+                        return Err(crate::runner_job_execution_context::rejected(
+                            "worker did not advertise the required execution-context protocol",
+                        ));
+                    }
+                    None => None,
+                };
                 Self::append_event_already_locked(
                     self,
                     inner,
                     job_id,
                     JobEventKind::Status,
                     Some("remote runner job claimed".to_string()),
-                    Some(serde_json::json!({ "status": JobStatus::Running })),
+                    Some(match execution_context.as_ref() {
+                        Some(context) => serde_json::json!({
+                            "status": JobStatus::Running,
+                            "runner_job_execution_context": context.evidence_record()?,
+                        }),
+                        None => serde_json::json!({ "status": JobStatus::Running }),
+                    }),
                 )?;
-                return Ok(Some((job, request)));
+                return Ok(Some((job, request, execution_context)));
             }
             Ok(None)
         })?;
 
-        let Some((job, request)) = claimed else {
+        let Some((job, request, execution_context)) = claimed else {
             return Ok(None);
         };
-        Ok(Some(RemoteRunnerJobClaim { job, request }))
+        let execution_protocol = execution_context
+            .as_ref()
+            .map(|_| execution_protocol.cloned())
+            .flatten();
+        Ok(Some(RemoteRunnerJobClaim {
+            job,
+            request,
+            execution_context,
+            execution_protocol,
+        }))
     }
 
     pub fn append_remote_runner_event(
@@ -976,6 +1054,89 @@ impl JobStore {
             Ok(())
         })?;
         self.get(job_id)
+    }
+
+    /// Atomically revalidate and consume a claim immediately before provider
+    /// invocation. A receipt can only be consumed once, preventing a restarted
+    /// worker from replaying a materialized handoff.
+    pub fn consume_remote_runner_execution(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+        claim_id: &str,
+        context_id: &str,
+    ) -> Result<Job> {
+        self.durable_transaction(|inner| {
+            let now = timestamp_ms();
+            let job = {
+                let stored = inner
+                    .jobs
+                    .get_mut(&job_id)
+                    .ok_or_else(|| job_not_found(job_id))?;
+                if stored.remote_runner.is_none() {
+                    return Err(Error::validation_invalid_argument(
+                        "job_id",
+                        "job is not a remote runner job",
+                        Some(job_id.to_string()),
+                        None,
+                    ));
+                }
+                if stored.job.claimed_by_runner_id.as_deref() != Some(runner_id)
+                    || stored.job.claim_id.as_deref() != Some(claim_id)
+                    || stored.job.status != JobStatus::Running
+                    || stored
+                        .job
+                        .claim_expires_at_ms
+                        .is_none_or(|expires_at| expires_at <= now)
+                {
+                    return Err(crate::runner_job_execution_context::rejected(
+                        "durable runner claim is no longer live",
+                    ));
+                }
+                let remote_runner = stored
+                    .remote_runner
+                    .as_mut()
+                    .expect("checked remote runner");
+                if remote_runner.execution_receipt.is_some() {
+                    return Err(crate::runner_job_execution_context::rejected(
+                        "runner execution receipt was already consumed",
+                    ));
+                }
+                let request = remote_runner
+                    .execution_request
+                    .as_ref()
+                    .unwrap_or(&remote_runner.request);
+                let expected =
+                    crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
+                        &stored.job,
+                        request,
+                    )?;
+                if expected.id() != context_id {
+                    return Err(crate::runner_job_execution_context::rejected(
+                        "runner execution context does not match the live claim",
+                    ));
+                }
+                remote_runner.execution_receipt = Some(RemoteRunnerExecutionReceipt {
+                    context_id: context_id.to_string(),
+                    consumed_at_ms: now,
+                });
+                stored.job.updated_at_ms = now;
+                stored.job.clone()
+            };
+            Self::append_event_already_locked(
+                self,
+                inner,
+                job_id,
+                JobEventKind::Progress,
+                Some("remote runner execution receipt consumed".to_string()),
+                Some(serde_json::json!({
+                    "schema": "homeboy/remote-runner-execution-receipt/v1",
+                    "context_id": context_id,
+                    "consumed_at_ms": now,
+                })),
+            )?;
+            Ok(job)
+        })
     }
 
     pub(crate) fn cancel_remote_runner_job(
@@ -1092,7 +1253,7 @@ impl JobStore {
         })
     }
 
-    pub(crate) fn reconcile_expired_remote_runner_claims(&self, now_ms: u64) -> Result<Vec<Job>> {
+    pub fn reconcile_expired_remote_runner_claims(&self, now_ms: u64) -> Result<Vec<Job>> {
         self.reconcile_expired_remote_runner_claims_for_runner(now_ms, None)
     }
 

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1424,7 +1424,16 @@ fn remote_runner_submission_terminal_replay_returns_original_projection_without_
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, Some(1))
         .expect("claim")
         .expect("job claimed");
+    let context_id = claim
+        .execution_context
+        .as_ref()
+        .expect("execution context")
+        .id()
+        .to_string();
     let claim_id = claim.job.claim_id.expect("claim id");
+    store
+        .consume_remote_runner_execution(accepted.id, "homeboy-lab", &claim_id, &context_id)
+        .expect("consume execution receipt");
     let terminal = store
         .finish_remote_runner_job(
             accepted.id,

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -502,6 +502,75 @@ fn remote_runner_context_evidence_survives_controller_restart() {
 }
 
 #[test]
+fn old_persisted_context_claim_without_context_id_rejects_direct_finish() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let job = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .expect("remote runner job queues");
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim succeeds")
+        .expect("job is claimed");
+    let claim_id = claim.job.claim_id.expect("claim id");
+    drop(store);
+
+    // This is the durable shape written before execution_context_id was added.
+    let mut persisted: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("read durable store"))
+            .expect("decode durable store");
+    let stored = persisted["jobs"]
+        .as_array_mut()
+        .expect("persisted jobs")
+        .iter_mut()
+        .find(|stored| stored["job"]["id"] == job.id.to_string())
+        .expect("persisted job");
+    assert!(stored["remote_runner"]
+        .get("execution_context_id")
+        .is_some());
+    stored["remote_runner"]
+        .as_object_mut()
+        .expect("remote runner state")
+        .remove("execution_context_id");
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&persisted).expect("encode old durable store"),
+    )
+    .expect("write old durable store");
+
+    let reopened = JobStore::open_without_reconciliation(&path).expect("reopen old durable store");
+    let error = reopened
+        .finish_remote_runner_job(
+            job.id,
+            "homeboy-lab",
+            &claim_id,
+            RemoteRunnerJobResult {
+                exit_code: 0,
+                stdout: None,
+                stderr: None,
+                patch: None,
+                mutation_artifacts: None,
+                data: None,
+                observation_run_ids: Vec::new(),
+                observation_run_details: Vec::new(),
+                observation_run_details_compatibility_degraded: false,
+                artifacts: Vec::new(),
+                artifact_refs: Vec::new(),
+                metrics: None,
+                capture: None,
+            },
+        )
+        .expect_err("context evidence requires a consumed receipt");
+
+    assert!(error.message.contains("receipt has not been consumed"));
+    assert_eq!(
+        reopened.get(job.id).expect("job remains in flight").status,
+        JobStatus::Running
+    );
+}
+
+#[test]
 fn remote_runner_job_result_records_terminal_state_and_artifacts() {
     let store = JobStore::default();
     let job = store

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -180,8 +180,17 @@ fn remote_runner_job_claim_respects_concurrency_limit() {
         .claim_remote_runner_job("homeboy-lab", None, 30_000, Some(1))
         .expect("claim succeeds")
         .expect("first job is claimed");
+    let first_context_id = first_claim
+        .execution_context
+        .as_ref()
+        .expect("execution context")
+        .id()
+        .to_string();
     assert_eq!(first_claim.job.id, first.id);
     let first_claim_id = first_claim.job.claim_id.as_deref().expect("claim id");
+    store
+        .consume_remote_runner_execution(first.id, "homeboy-lab", first_claim_id, &first_context_id)
+        .expect("consume execution receipt");
 
     let saturated_claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, Some(1))
@@ -502,7 +511,16 @@ fn remote_runner_job_result_records_terminal_state_and_artifacts() {
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
         .expect("claim succeeds")
         .expect("job is claimed");
+    let context_id = claim
+        .execution_context
+        .as_ref()
+        .expect("execution context")
+        .id()
+        .to_string();
     let claim_id = claim.job.claim_id.expect("claim id");
+    store
+        .consume_remote_runner_execution(job.id, "homeboy-lab", &claim_id, &context_id)
+        .expect("consume execution receipt");
     store
         .append_remote_runner_event(
             job.id,
@@ -646,7 +664,16 @@ fn remote_runner_job_failed_result_records_error_and_terminal_state() {
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
         .expect("claim succeeds")
         .expect("job is claimed");
+    let context_id = claim
+        .execution_context
+        .as_ref()
+        .expect("execution context")
+        .id()
+        .to_string();
     let claim_id = claim.job.claim_id.expect("claim id");
+    store
+        .consume_remote_runner_execution(job.id, "homeboy-lab", &claim_id, &context_id)
+        .expect("consume execution receipt");
 
     let failed = store
         .finish_remote_runner_job(

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -245,6 +245,254 @@ fn remote_runner_job_claim_can_be_filtered_by_project() {
 }
 
 #[test]
+fn remote_runner_claim_persists_and_requires_authenticated_execution_context() {
+    let store = JobStore::default();
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.metadata = Some(json!({
+        "controller_run_id": "cook-42",
+        "controller_attempt_id": "cook-42:attempt-2",
+        "accepted_handoff_id": "reverse_broker:homeboy-lab:cook-42:attempt-2",
+    }));
+    let job = store
+        .submit_remote_runner_job(request)
+        .expect("remote runner job queues");
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+        .expect("claim succeeds")
+        .expect("job is claimed");
+    let context = claim.execution_context.as_ref().expect("execution context");
+    let serialized_context = serde_json::to_value(context).expect("serialize context");
+    assert_eq!(serialized_context["controller_run_id"], "cook-42");
+    assert_eq!(
+        serialized_context["controller_attempt_id"],
+        "cook-42:attempt-2"
+    );
+    assert_eq!(
+        serialized_context["accepted_handoff_id"],
+        "reverse_broker:homeboy-lab:cook-42:attempt-2"
+    );
+    let verified_context = context
+        .verify_claim(&claim.job, &claim.request)
+        .expect("context verifies claimed job");
+    assert!(verified_context.verify_integrity().is_ok());
+    let mut tampered_value = serde_json::to_value(context).expect("serialize context");
+    tampered_value["runner_job_id"] = serde_json::json!("different-job");
+    let tampered: crate::runner_job_execution_context::RunnerJobExecutionContext =
+        serde_json::from_value(tampered_value).expect("decode tampered context");
+    assert!(tampered.verify_claim(&claim.job, &claim.request).is_err());
+    assert!(store.events(job.id).expect("events").iter().any(|event| {
+        event
+            .data
+            .as_ref()
+            .and_then(|data| data.get("runner_job_execution_context"))
+            .and_then(|evidence| evidence.get("context"))
+            == Some(&serde_json::to_value(context).expect("serialize context"))
+    }));
+
+    let mut old_wire = serde_json::to_value(&claim).expect("serialize claim");
+    old_wire
+        .as_object_mut()
+        .expect("claim object")
+        .remove("execution_context");
+    let old_claim: RemoteRunnerJobClaim =
+        serde_json::from_value(old_wire).expect("decode old claim");
+    assert!(old_claim.execution_context.is_none());
+}
+
+#[test]
+fn remote_runner_context_rejects_expired_or_different_durable_claims() {
+    let store = JobStore::default();
+    let first = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("one")))
+        .expect("first job queues");
+    let second = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("two")))
+        .expect("second job queues");
+    let first_claim = store
+        .claim_remote_runner_job("homeboy-lab", Some("one"), 30_000, None)
+        .expect("first claim")
+        .expect("first job");
+    let second_claim = store
+        .claim_remote_runner_job("homeboy-lab", Some("two"), 30_000, None)
+        .expect("second claim")
+        .expect("second job");
+    let context = first_claim.execution_context.expect("first context");
+
+    assert_ne!(first.id, second.id);
+    assert!(context
+        .verify_claim(&second_claim.job, &second_claim.request)
+        .is_err());
+
+    let mut expired = first_claim.job.clone();
+    expired.claim_expires_at_ms = Some(crate::api_jobs::timestamp_ms().saturating_sub(1));
+    assert!(context
+        .verify_claim(&expired, &first_claim.request)
+        .is_err());
+}
+
+#[test]
+fn remote_runner_execution_receipt_is_one_time_and_revalidates_the_live_claim() {
+    let store = JobStore::default();
+    let job = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .expect("remote runner job queues");
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim succeeds")
+        .expect("job is claimed");
+    let context = claim.execution_context.expect("execution context");
+    let claim_id = claim.job.claim_id.as_deref().expect("claim id");
+
+    let consumed = store
+        .consume_remote_runner_execution(job.id, "homeboy-lab", claim_id, context.id())
+        .expect("live claim consumes once");
+    assert_eq!(consumed.id, job.id);
+    assert!(store
+        .consume_remote_runner_execution(job.id, "homeboy-lab", claim_id, context.id())
+        .is_err());
+    assert!(store.events(job.id).expect("events").iter().any(|event| {
+        event.message.as_deref() == Some("remote runner execution receipt consumed")
+            && event
+                .data
+                .as_ref()
+                .is_some_and(|data| data["context_id"] == context.id())
+    }));
+
+    let expired_job = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .expect("expired job queues");
+    let expired_claim = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("expired claim succeeds")
+        .expect("expired job is claimed");
+    let expired_context = expired_claim.execution_context.expect("expired context");
+    let expired_claim_id = expired_claim
+        .job
+        .claim_id
+        .as_deref()
+        .expect("expired claim id");
+    store
+        .inner
+        .lock()
+        .expect("job store")
+        .jobs
+        .get_mut(&expired_job.id)
+        .expect("expired job")
+        .job
+        .claim_expires_at_ms = Some(crate::api_jobs::timestamp_ms().saturating_sub(1));
+    assert!(store
+        .consume_remote_runner_execution(
+            expired_job.id,
+            "homeboy-lab",
+            expired_claim_id,
+            expired_context.id(),
+        )
+        .is_err());
+}
+
+#[test]
+fn remote_runner_claim_rejects_workers_without_the_context_protocol() {
+    let store = JobStore::default();
+    let mut request = remote_runner_request("homeboy-lab", None);
+    request.extension_env_providers = vec!["authenticated-provider".to_string()];
+    let job = store
+        .submit_remote_runner_job(request)
+        .expect("remote runner job queues");
+
+    let missing = store.claim_remote_runner_job_with_execution_protocol(
+        "homeboy-lab",
+        None,
+        30_000,
+        None,
+        None,
+    );
+    assert!(missing.is_err());
+    assert_eq!(
+        store.get(job.id).expect("job remains queued").status,
+        JobStatus::Queued
+    );
+
+    let old = crate::runner_job_execution_context::RunnerJobExecutionProtocol {
+        capability: crate::runner_job_execution_context::RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
+            .to_string(),
+        version: 0,
+    };
+    assert!(store
+        .claim_remote_runner_job_with_execution_protocol(
+            "homeboy-lab",
+            None,
+            30_000,
+            None,
+            Some(&old)
+        )
+        .is_err());
+    assert_eq!(
+        store.get(job.id).expect("job remains queued").status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
+fn remote_runner_legacy_claims_remain_available_only_for_context_free_jobs() {
+    let store = JobStore::default();
+    let job = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .expect("legacy job queues");
+
+    let claim = store
+        .claim_remote_runner_job_with_execution_protocol("homeboy-lab", None, 30_000, None, None)
+        .expect("legacy worker can claim context-free work")
+        .expect("legacy job is claimed");
+    assert_eq!(claim.job.id, job.id);
+    assert!(claim.execution_context.is_none());
+    assert!(claim.execution_protocol.is_none());
+    assert!(store.events(job.id).expect("events").iter().all(|event| {
+        event
+            .data
+            .as_ref()
+            .and_then(|data| data.get("runner_job_execution_context"))
+            .is_none()
+    }));
+}
+
+#[test]
+fn remote_runner_context_evidence_survives_controller_restart() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let job = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .expect("remote runner job queues");
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+        .expect("claim succeeds")
+        .expect("job is claimed");
+    let expected = claim.execution_context.expect("execution context");
+    drop(store);
+
+    let restarted = JobStore::open_without_reconciliation(&path).expect("restart store");
+    let evidence = restarted
+        .events(job.id)
+        .expect("events")
+        .into_iter()
+        .find_map(|event| {
+            event
+                .data
+                .and_then(|data| data.get("runner_job_execution_context").cloned())
+        })
+        .expect("durable context evidence");
+    let recovered =
+        crate::runner_job_execution_context::RunnerJobExecutionContext::from_evidence_record(
+            &evidence,
+        )
+        .expect("decode context");
+    assert_eq!(recovered, expected);
+    assert!(evidence["content_sha256"]
+        .as_str()
+        .is_some_and(|value| value.starts_with("sha256:")));
+}
+
+#[test]
 fn remote_runner_job_result_records_terminal_state_and_artifacts() {
     let store = JobStore::default();
     let job = store

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1899,6 +1899,9 @@ fn enqueue_exec_job(
         cwd: Some(plan.cwd.clone()),
         lifecycle: lifecycle.clone(),
     };
+    let execution_controller_run_id = lifecycle
+        .as_ref()
+        .and_then(|lifecycle| lifecycle.durable_run_id.clone());
     // Every runner process shares the runner's connection and declared process
     // capacity. Diagnostic commands are ordinary runner executions too, so
     // admitting them outside this queue can wedge the shared transport.
@@ -1928,6 +1931,30 @@ fn enqueue_exec_job(
                         return Err(error);
                     }
                 };
+                let execution_context = crate::runner_job_execution_context::RunnerJobExecutionContext::direct_daemon_with_dispatch_metadata(
+                    execution_controller_run_id.as_deref(),
+                    request
+                        .metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.get("controller_attempt_id"))
+                        .and_then(serde_json::Value::as_str),
+                    request
+                        .metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.get("accepted_handoff_id"))
+                        .and_then(serde_json::Value::as_str),
+                    &plan.runner_id,
+                    &job.job_id().to_string(),
+                    plan.command.first().map(String::as_str).unwrap_or_default(),
+                    &reservation_id,
+                )?;
+                let execution_context_evidence = execution_context.evidence_record()?;
+                // Durable progress makes the same receipt resolvable after a
+                // controller restart without consulting process environment.
+                job.progress(json!({
+                    "phase": "runner_job_execution_context_verified",
+                    "execution_context": execution_context_evidence,
+                }))?;
                 plan.env
                     .insert("HOMEBOY_RUNNER_CHILD_RESERVATION".to_string(), reservation_id);
                 let liveness = Arc::new(Mutex::new(ExecLiveness::new(Instant::now())));
@@ -2009,6 +2036,7 @@ fn enqueue_exec_job(
                 let driver_cancellation = Arc::clone(&cancellation_requested);
                 let process_output = runner_exec_driver::execute_exec(
                     &plan,
+                    &execution_context,
                     Box::new(move || {
                         driver_cancellation.load(Ordering::SeqCst) || cancel_job.is_cancelled()
                     }),
@@ -2040,6 +2068,7 @@ fn enqueue_exec_job(
                 let exit_code = process_output.exit_code;
                 let metrics = process_output.metrics.clone();
                 let capture = process_output.capture.clone();
+                let extension_env_provenance = process_output.extension_env_provenance.clone();
                 if cancellation_requested.load(Ordering::SeqCst) {
                     let evidence = stall_evidence
                         .lock()
@@ -2111,7 +2140,7 @@ fn enqueue_exec_job(
                     "patch": patch,
                     "metrics": metrics,
                     "capture": capture,
-                    "extension_env_providers": plan.extension_env_provenance,
+                    "extension_env_providers": extension_env_provenance,
                 });
                 if exit_code != 0 {
                     job.result(result.clone())?;
@@ -3186,6 +3215,7 @@ mod tests {
         fn execute(
             &self,
             prepared: &PreparedDaemonExec,
+            _execution_context: &crate::runner_job_execution_context::RunnerJobExecutionContext,
             _is_cancelled: runner_exec_driver::ExecCancellationProbe,
             _progress_sink: Option<runner_exec_driver::ExecProgressSink>,
             _require_child_identity_acknowledgement: bool,

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -1211,6 +1211,116 @@ mod auth_tests {
     }
 
     #[test]
+    fn context_claim_finish_requires_a_matching_consumed_receipt() {
+        let _home = HomeGuard::new();
+        let store = JobStore::default();
+        let submit = route(
+            "POST",
+            "/runner/jobs",
+            Some(submit_body()),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        let job_id = submit.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id")
+            .to_string();
+        let claim = route(
+            "POST",
+            "/runner/jobs/claim",
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "lease_ms": 30000,
+                "execution_protocol": crate::runner_job_execution_context::RunnerJobExecutionProtocol::current(),
+            })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(claim.status_code, 200, "claim body: {}", claim.body);
+        let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
+            .as_str()
+            .expect("claim id")
+            .to_string();
+        let context_id = claim.body["body"]["claim"]["execution_context"]["id"]
+            .as_str()
+            .expect("execution context id")
+            .to_string();
+        let finish_path = format!("/runner/jobs/{job_id}/finish");
+        let finish_body = || {
+            json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "result": { "exit_code": 0 },
+            })
+        };
+
+        let before_consumption = route(
+            "POST",
+            &finish_path,
+            Some(finish_body()),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(before_consumption.status_code, 400);
+        assert_eq!(
+            store
+                .get(Uuid::parse_str(&job_id).expect("valid job id"))
+                .expect("job remains running")
+                .status,
+            crate::api_jobs::JobStatus::Running
+        );
+
+        let consume_path = format!("/runner/jobs/{job_id}/consume");
+        let mismatch = route(
+            "POST",
+            &consume_path,
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "context_id": "rjec:mismatch",
+            })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(mismatch.status_code, 400);
+
+        let consumed = route(
+            "POST",
+            &consume_path,
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "context_id": context_id,
+            })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(consumed.status_code, 200, "consume body: {}", consumed.body);
+        let replay = route(
+            "POST",
+            &consume_path,
+            Some(json!({
+                "runner_id": "homeboy-lab",
+                "claim_id": claim_id,
+                "context_id": context_id,
+            })),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(replay.status_code, 400);
+
+        let finished = route(
+            "POST",
+            &finish_path,
+            Some(finish_body()),
+            &store,
+            &BrokerAuthContext::trusted_local(),
+        );
+        assert_eq!(finished.status_code, 200, "finish body: {}", finished.body);
+        assert_eq!(finished.body["body"]["job"]["status"], "succeeded");
+    }
+
+    #[test]
     fn broker_artifact_content_path_returns_worker_mirrored_bytes() {
         let _home = HomeGuard::new();
         let store = JobStore::default();

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -63,6 +63,8 @@ struct ClaimRequest {
     lease_ms: Option<u64>,
     #[serde(default)]
     concurrency_limit: Option<usize>,
+    #[serde(default)]
+    execution_protocol: Option<crate::runner_job_execution_context::RunnerJobExecutionProtocol>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -89,6 +91,13 @@ struct HeartbeatRequest {
     claim_id: String,
     #[serde(default)]
     lease_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ConsumeRequest {
+    runner_id: String,
+    claim_id: String,
+    context_id: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -146,7 +155,7 @@ pub(in crate::daemon) fn route(
                 "unknown remote runner broker path",
                 Some(path.to_string()),
                 Some(vec![
-                    "Use /runner/jobs, /runner/jobs/reconcile, /runner/jobs/claim, /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, /runner/jobs/<job-id>/cancel, or GET /runner/jobs/<job-id>/artifacts/<artifact-id>."
+                    "Use /runner/jobs, /runner/jobs/reconcile, /runner/jobs/claim, /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, /runner/jobs/<job-id>/consume, /runner/jobs/<job-id>/cancel, or GET /runner/jobs/<job-id>/artifacts/<artifact-id>."
                         .to_string(),
                     "Use /runner/sessions to register reverse runner sessions.".to_string(),
                 ]),
@@ -535,11 +544,12 @@ fn claim(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) ->
     let concurrency_limit = request
         .concurrency_limit
         .or_else(|| super::runner_workspace_root::runner_concurrency_limit(&request.runner_id));
-    let claim = job_store.claim_remote_runner_job(
+    let claim = job_store.claim_remote_runner_job_with_execution_protocol(
         &request.runner_id,
         request.project_id.as_deref(),
         request.lease_ms.unwrap_or(30_000),
         concurrency_limit,
+        request.execution_protocol.as_ref(),
     )?;
     Ok(json!({
         "command": "api.runner.jobs.claim",
@@ -561,7 +571,7 @@ fn update(
                 "unknown remote runner job path",
                 Some(path.to_string()),
                 Some(vec![
-                    "Use /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, or /runner/jobs/<job-id>/cancel.".to_string(),
+                    "Use /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, /runner/jobs/<job-id>/consume, or /runner/jobs/<job-id>/cancel.".to_string(),
                 ]),
             ),
         );
@@ -580,6 +590,10 @@ fn update(
             Ok(body) => daemon_endpoint_response("runner.jobs.heartbeat", body),
             Err(err) => auth_or_bad_request(err),
         },
+        "consume" => match consume(job_id, body, job_store, auth) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.consume", body),
+            Err(err) => auth_or_bad_request(err),
+        },
         "cancel" => match cancel(job_id, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.cancel", body),
             Err(err) => auth_or_bad_request(err),
@@ -591,7 +605,8 @@ fn update(
                 "unknown remote runner job operation",
                 Some(operation.to_string()),
                 Some(vec![
-                    "Supported operations are events, finish, heartbeat, and cancel.".to_string(),
+                    "Supported operations are events, finish, heartbeat, consume, and cancel."
+                        .to_string(),
                 ]),
             ),
         ),
@@ -687,6 +702,28 @@ fn heartbeat(
     Ok(json!({
         "command": "api.runner.jobs.heartbeat",
         "job": job,
+    }))
+}
+
+fn consume(
+    job_id: Uuid,
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    let request: ConsumeRequest = parse_body(body, "remote runner execution consume request")?;
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
+    touch_reverse_session(&request.runner_id)?;
+    let job = job_store.consume_remote_runner_execution(
+        job_id,
+        &request.runner_id,
+        &request.claim_id,
+        &request.context_id,
+    )?;
+    Ok(json!({
+        "command": "api.runner.jobs.consume",
+        "job": job,
+        "context_id": request.context_id,
     }))
 }
 

--- a/crates/homeboy-core/src/daemon/runner_exec_driver.rs
+++ b/crates/homeboy-core/src/daemon/runner_exec_driver.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use serde_json::Value;
 
 use crate::error::{Error, Result};
+use crate::runner_job_execution_context::RunnerJobExecutionContext;
 use crate::server::HeartbeatOnlyStallPolicy;
 use crate::source_snapshot::SourceSnapshot;
 
@@ -143,6 +144,7 @@ pub trait RunnerExecDriver: Send + Sync {
     fn execute(
         &self,
         prepared: &PreparedDaemonExec,
+        execution_context: &RunnerJobExecutionContext,
         is_cancelled: ExecCancellationProbe,
         progress_sink: Option<ExecProgressSink>,
         require_child_identity_acknowledgement: bool,
@@ -163,6 +165,7 @@ impl RunnerExecDriver for NoopRunnerExecDriver {
     fn execute(
         &self,
         _prepared: &PreparedDaemonExec,
+        _execution_context: &RunnerJobExecutionContext,
         _is_cancelled: ExecCancellationProbe,
         _progress_sink: Option<ExecProgressSink>,
         _require_child_identity_acknowledgement: bool,
@@ -191,6 +194,7 @@ pub(crate) fn prepare_exec(request: RunnerExecPrepareRequest) -> Result<Prepared
 /// is released before the child runs.
 pub(crate) fn execute_exec(
     prepared: &PreparedDaemonExec,
+    execution_context: &RunnerJobExecutionContext,
     is_cancelled: ExecCancellationProbe,
     progress_sink: Option<ExecProgressSink>,
     require_child_identity_acknowledgement: bool,
@@ -198,6 +202,7 @@ pub(crate) fn execute_exec(
 ) -> Result<DaemonExecOutput> {
     active_driver().execute(
         prepared,
+        execution_context,
         is_cancelled,
         progress_sink,
         require_child_identity_acknowledgement,

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -173,6 +173,7 @@ pub mod run_lifecycle_status;
 pub mod run_outcome_envelope;
 pub mod runner_download_cache;
 pub mod runner_execution_envelope;
+pub mod runner_job_execution_context;
 pub mod runtime_package;
 pub mod runtime_promotion;
 pub mod schedule;

--- a/crates/homeboy-core/src/runner_job_execution_context.rs
+++ b/crates/homeboy-core/src/runner_job_execution_context.rs
@@ -1,0 +1,564 @@
+//! Authenticated execution identity for a claimed runner job.
+//!
+//! This is deliberately built from the durable broker job and its live claim,
+//! not from environment or runner-local lifecycle projections. Consumers may
+//! project it into those surfaces for child-process compatibility, but cannot
+//! construct authority from them.
+
+use homeboy_engine_primitives::content_hash;
+use serde::{Deserialize, Serialize};
+
+use crate::api_jobs::{Job, RemoteRunnerJobRequest};
+use crate::error::{Error, ErrorCode, Result};
+
+pub const RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA: &str = "homeboy/runner-job-execution-context/v1";
+pub const RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA: &str =
+    "homeboy/runner-job-execution-context-evidence/v1";
+pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY: &str = "runner-job-execution-context";
+pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION: u32 = 1;
+const MAX_EVIDENCE_BYTES: usize = 8 * 1024;
+
+/// A worker must explicitly advertise this before the broker will hand it a
+/// context-bearing job. This prevents an older worker from ignoring the added
+/// claim field and executing an unauthenticated handoff.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobExecutionProtocol {
+    pub capability: String,
+    pub version: u32,
+}
+
+impl RunnerJobExecutionProtocol {
+    pub fn current() -> Self {
+        Self {
+            capability: RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY.to_string(),
+            version: RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION,
+        }
+    }
+
+    pub fn verify(&self) -> Result<()> {
+        if self.capability == RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
+            && self.version == RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION
+        {
+            return Ok(());
+        }
+        Err(rejected(
+            "worker does not advertise the required execution-context protocol",
+        ))
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobExecutionContext {
+    schema: String,
+    id: String,
+    controller_run_id: String,
+    controller_attempt_id: String,
+    runner_id: String,
+    runner_job_id: String,
+    accepted_handoff_id: String,
+    runtime_id: String,
+    /// Opaque reference to the broker claim/reservation. Raw claim material
+    /// never crosses a durable evidence or provider-process boundary.
+    claim_ref: String,
+    dispatch_receipt: String,
+    verification: RunnerJobExecutionVerification,
+    /// Authority is intentionally process-local. A wire value is only an
+    /// assertion until it has been recomputed from the live durable claim.
+    #[serde(skip)]
+    authenticated: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobExecutionVerification {
+    state: String,
+    verified_at_ms: u64,
+}
+
+impl std::fmt::Debug for RunnerJobExecutionContext {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RunnerJobExecutionContext")
+            .field("id", &self.id)
+            .field("runner_id", &self.runner_id)
+            .field("runner_job_id", &self.runner_job_id)
+            .field("runtime_id", &self.runtime_id)
+            .field("authenticated", &self.authenticated)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RunnerJobExecutionContext {
+    /// Construct the only remote context source: a durable accepted job with a
+    /// live broker claim. Generic runner jobs use their durable run/job identity
+    /// as their controller attempt; agent-task callers retain their explicit IDs.
+    pub fn from_claim(job: &Job, request: &RemoteRunnerJobRequest) -> Result<Self> {
+        let runner_id = required(&job.claimed_by_runner_id, "claimed runner")?;
+        let expected_runner_id = required(&job.target_runner_id, "target runner")?;
+        if runner_id != expected_runner_id || runner_id != request.runner_id.trim() {
+            return Err(rejected(
+                "runner identity does not match the accepted dispatch receipt",
+            ));
+        }
+        let claim_id = required(&job.claim_id, "claim")?;
+        let controller_run_id = metadata_id(request, "controller_run_id")
+            .or_else(|| {
+                request
+                    .lifecycle
+                    .as_ref()
+                    .and_then(|l| l.durable_run_id.clone())
+            })
+            .or_else(|| {
+                request
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("run_id"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| job.id.to_string());
+        let controller_attempt_id = metadata_id(request, "controller_attempt_id")
+            .unwrap_or_else(|| controller_run_id.clone());
+        let accepted_handoff_id = metadata_id(request, "accepted_handoff_id")
+            .unwrap_or_else(|| format!("{}:{}", controller_attempt_id, job.id));
+        let runtime_id = request
+            .command
+            .first()
+            .map(String::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| rejected("accepted dispatch has no runtime command"))?
+            .to_string();
+        let dispatch_receipt = receipt(
+            &controller_run_id,
+            &controller_attempt_id,
+            &runner_id,
+            &job.id.to_string(),
+            &accepted_handoff_id,
+            &runtime_id,
+            &claim_id,
+        );
+
+        Ok(Self {
+            schema: RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA.to_string(),
+            id: context_id(&dispatch_receipt),
+            controller_run_id,
+            controller_attempt_id,
+            runner_id,
+            runner_job_id: job.id.to_string(),
+            accepted_handoff_id,
+            runtime_id,
+            claim_ref: claim_ref(&claim_id),
+            dispatch_receipt,
+            verification: RunnerJobExecutionVerification {
+                state: "verified".to_string(),
+                verified_at_ms: job.updated_at_ms,
+            },
+            authenticated: false,
+        })
+    }
+
+    pub fn local(runtime_id: impl Into<String>) -> Self {
+        let runtime_id = runtime_id.into();
+        let dispatch_receipt = "local".to_string();
+        Self {
+            schema: RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA.to_string(),
+            id: context_id(&dispatch_receipt),
+            controller_run_id: "local".to_string(),
+            controller_attempt_id: "local".to_string(),
+            runner_id: "local".to_string(),
+            runner_job_id: "local".to_string(),
+            accepted_handoff_id: "local".to_string(),
+            runtime_id,
+            claim_ref: "local".to_string(),
+            dispatch_receipt,
+            verification: RunnerJobExecutionVerification {
+                state: "local".to_string(),
+                verified_at_ms: 0,
+            },
+            authenticated: true,
+        }
+    }
+
+    /// Direct-daemon jobs are accepted by the durable local-child reservation
+    /// rather than a reverse-broker claim. The reservation is the lease/receipt
+    /// that binds this context to the accepted daemon job.
+    pub fn direct_daemon(
+        controller_run_id: Option<&str>,
+        runner_id: &str,
+        runner_job_id: &str,
+        runtime_id: &str,
+        reservation_id: &str,
+    ) -> Result<Self> {
+        Self::direct_daemon_with_dispatch_metadata(
+            controller_run_id,
+            None,
+            None,
+            runner_id,
+            runner_job_id,
+            runtime_id,
+            reservation_id,
+        )
+    }
+
+    /// Construct a direct-daemon context from controller-generated dispatch
+    /// identities. The reservation remains the daemon-side acceptance proof.
+    pub fn direct_daemon_with_dispatch_metadata(
+        controller_run_id: Option<&str>,
+        controller_attempt_id: Option<&str>,
+        accepted_handoff_id: Option<&str>,
+        runner_id: &str,
+        runner_job_id: &str,
+        runtime_id: &str,
+        reservation_id: &str,
+    ) -> Result<Self> {
+        let runner_id = non_empty(runner_id, "runner")?;
+        let runner_job_id = non_empty(runner_job_id, "runner job")?;
+        let runtime_id = non_empty(runtime_id, "runtime")?;
+        let reservation_id = non_empty(reservation_id, "reservation")?;
+        let controller_run_id = controller_run_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(&runner_job_id)
+            .to_string();
+        let controller_attempt_id = controller_attempt_id
+            .map(|value| non_empty(value, "controller attempt"))
+            .transpose()?
+            .unwrap_or_else(|| controller_run_id.clone());
+        let accepted_handoff_id = accepted_handoff_id
+            .map(|value| non_empty(value, "accepted handoff"))
+            .transpose()?
+            .unwrap_or_else(|| format!("{controller_attempt_id}:{runner_job_id}"));
+        let dispatch_receipt = receipt(
+            &controller_run_id,
+            &controller_attempt_id,
+            &runner_id,
+            &runner_job_id,
+            &accepted_handoff_id,
+            &runtime_id,
+            &reservation_id,
+        );
+        Ok(Self {
+            schema: RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA.to_string(),
+            id: context_id(&dispatch_receipt),
+            controller_run_id,
+            controller_attempt_id,
+            runner_id,
+            runner_job_id,
+            accepted_handoff_id,
+            runtime_id,
+            claim_ref: claim_ref(&reservation_id),
+            dispatch_receipt,
+            verification: RunnerJobExecutionVerification {
+                state: "verified".to_string(),
+                verified_at_ms: 0,
+            },
+            authenticated: true,
+        })
+    }
+
+    /// Turn a received assertion into a capability after proving it against the
+    /// actual broker claim. The authentication bit is never serialized, so a
+    /// forged JSON payload cannot reach a provider entry point.
+    pub fn verify_claim(&self, job: &Job, request: &RemoteRunnerJobRequest) -> Result<Self> {
+        if job.status != crate::api_jobs::JobStatus::Running
+            || job
+                .claim_expires_at_ms
+                .is_none_or(|expires_at| expires_at <= crate::api_jobs::timestamp_ms())
+        {
+            return Err(rejected("durable runner claim is no longer live"));
+        }
+        let verified = Self::from_claim(job, request)?;
+        if self != &verified {
+            return Err(rejected(
+                "dispatch receipt does not match the accepted runner job",
+            ));
+        }
+        Ok(Self {
+            authenticated: true,
+            ..verified
+        })
+    }
+
+    /// Verify the self-contained form used by process-boundary consumers before
+    /// they serialize it into a provider command payload.
+    pub fn verify_integrity(&self) -> Result<()> {
+        if self.schema != RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA
+            || self.id != context_id(&self.dispatch_receipt)
+            || !matches!(self.verification.state.as_str(), "verified" | "local")
+            || !self.authenticated
+        {
+            return Err(rejected(
+                "execution context schema, identity, or verification is invalid",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn runner_id(&self) -> &str {
+        &self.runner_id
+    }
+
+    pub fn runner_job_id(&self) -> &str {
+        &self.runner_job_id
+    }
+
+    pub fn runtime_id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    pub fn is_local(&self) -> bool {
+        self.authenticated && self.verification.state == "local"
+    }
+
+    /// A single bounded, content-addressed durable record shared by controller
+    /// and runner recovery. The complete typed context is retained so a restart
+    /// never needs to infer authority from lifecycle or environment state.
+    pub fn evidence_record(&self) -> Result<serde_json::Value> {
+        let context = serde_json::to_value(self).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize runner context evidence".to_string()),
+            )
+        })?;
+        let bytes = serde_json::to_vec(&context).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("encode runner context evidence".to_string()),
+            )
+        })?;
+        if bytes.len() > MAX_EVIDENCE_BYTES {
+            return Err(rejected(
+                "accepted dispatch context evidence exceeds its bounded record",
+            ));
+        }
+        Ok(serde_json::json!({
+            "schema": RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA,
+            "content_sha256": format!("sha256:{}", content_hash::sha256_hex(&bytes)),
+            "context": context,
+        }))
+    }
+
+    pub fn from_evidence_record(evidence: &serde_json::Value) -> Result<Self> {
+        if evidence.get("schema").and_then(serde_json::Value::as_str)
+            != Some(RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA)
+        {
+            return Err(rejected("context evidence has an unsupported schema"));
+        }
+        let context = evidence
+            .get("context")
+            .ok_or_else(|| rejected("context evidence is missing its context"))?;
+        let bytes = serde_json::to_vec(context).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("encode runner context evidence".to_string()),
+            )
+        })?;
+        let expected = format!("sha256:{}", content_hash::sha256_hex(&bytes));
+        if evidence
+            .get("content_sha256")
+            .and_then(serde_json::Value::as_str)
+            != Some(&expected)
+        {
+            return Err(rejected(
+                "context evidence content address does not match its context",
+            ));
+        }
+        let context: Self = serde_json::from_value(context.clone()).map_err(|error| {
+            Error::new(
+                ErrorCode::RunnerLabTransportFailure,
+                format!("runner execution context rejected: invalid durable evidence: {error}"),
+                serde_json::json!({ "phase": "runner_job_execution_context" }),
+            )
+        })?;
+        // Evidence establishes durable identity, not runtime authority. A
+        // reverse worker must still call `verify_claim` with its broker payload.
+        if context.schema != RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA
+            || context.id != context_id(&context.dispatch_receipt)
+            || !matches!(context.verification.state.as_str(), "verified" | "local")
+        {
+            return Err(rejected("context evidence has invalid identity fields"));
+        }
+        Ok(context)
+    }
+}
+
+fn metadata_id(request: &RemoteRunnerJobRequest, key: &str) -> Option<String> {
+    request
+        .metadata
+        .as_ref()?
+        .get(key)?
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn required(value: &Option<String>, label: &str) -> Result<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| rejected(&format!("accepted dispatch is missing its {label} receipt")))
+}
+
+fn non_empty(value: &str, label: &str) -> Result<String> {
+    value
+        .trim()
+        .is_empty()
+        .then(|| rejected(&format!("accepted dispatch is missing its {label} receipt")))
+        .map_or_else(|| Ok(value.trim().to_string()), Err)
+}
+
+fn receipt(
+    run: &str,
+    attempt: &str,
+    runner: &str,
+    job: &str,
+    handoff: &str,
+    runtime: &str,
+    lease: &str,
+) -> String {
+    let payload = format!("{run}\n{attempt}\n{runner}\n{job}\n{handoff}\n{runtime}\n{lease}");
+    format!("sha256:{}", content_hash::sha256_hex(payload.as_bytes()))
+}
+
+fn claim_ref(claim_id: &str) -> String {
+    format!("sha256:{}", content_hash::sha256_hex(claim_id.as_bytes()))
+}
+
+fn context_id(dispatch_receipt: &str) -> String {
+    format!(
+        "rjec:{}",
+        content_hash::sha256_hex(dispatch_receipt.as_bytes())
+    )
+}
+
+pub(crate) fn rejected(reason: &str) -> Error {
+    Error::new(
+        ErrorCode::RunnerLabTransportFailure,
+        format!("runner execution context rejected: {reason}"),
+        serde_json::json!({ "phase": "runner_job_execution_context" }),
+    )
+    .with_hint("Claim a fresh runner job through the controller before retrying.".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_context_is_explicit_and_never_nullable() {
+        let context = RunnerJobExecutionContext::local("homeboy");
+        assert!(context.is_local());
+        assert_eq!(context.runner_id(), "local");
+    }
+
+    #[test]
+    fn serialized_context_preserves_direct_receipt() {
+        let context = RunnerJobExecutionContext::direct_daemon(
+            Some("run-1"),
+            "runner-1",
+            "job-1",
+            "homeboy",
+            "reservation-1",
+        )
+        .expect("context");
+        let decoded: RunnerJobExecutionContext =
+            serde_json::from_value(serde_json::to_value(context).expect("serialize"))
+                .expect("deserialize");
+
+        let expected = RunnerJobExecutionContext::direct_daemon(
+            Some("run-1"),
+            "runner-1",
+            "job-1",
+            "homeboy",
+            "reservation-1",
+        )
+        .expect("expected context");
+        assert_eq!(decoded.id(), expected.id());
+        assert!(decoded.verify_integrity().is_err());
+    }
+
+    #[test]
+    fn direct_context_preserves_controller_dispatch_metadata() {
+        let context = RunnerJobExecutionContext::direct_daemon_with_dispatch_metadata(
+            Some("run-1"),
+            Some("run-1:attempt-2"),
+            Some("daemon:runner-1:run-1:attempt-2"),
+            "runner-1",
+            "job-1",
+            "homeboy",
+            "reservation-1",
+        )
+        .expect("context");
+        let serialized = serde_json::to_value(context).expect("serialize context");
+
+        assert_eq!(serialized["controller_run_id"], "run-1");
+        assert_eq!(serialized["controller_attempt_id"], "run-1:attempt-2");
+        assert_eq!(
+            serialized["accepted_handoff_id"],
+            "daemon:runner-1:run-1:attempt-2"
+        );
+    }
+
+    #[test]
+    fn evidence_record_is_content_addressed_and_bounded() {
+        let context = RunnerJobExecutionContext::local("homeboy");
+        let mut evidence = context.evidence_record().expect("evidence");
+        assert_eq!(
+            evidence["schema"],
+            RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA
+        );
+        assert!(evidence["content_sha256"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("sha256:")));
+        assert_eq!(evidence["context"]["runner_id"], "local");
+        assert_eq!(
+            RunnerJobExecutionContext::from_evidence_record(&evidence)
+                .expect("recover evidence")
+                .id(),
+            context.id()
+        );
+        evidence["context"]["runner_id"] = serde_json::json!("tampered");
+        assert!(RunnerJobExecutionContext::from_evidence_record(&evidence).is_err());
+    }
+
+    #[test]
+    fn debug_redacts_claim_and_dispatch_receipts() {
+        let context = RunnerJobExecutionContext::direct_daemon(
+            Some("run-1"),
+            "runner-1",
+            "job-1",
+            "homeboy",
+            "reservation-secret",
+        )
+        .expect("context");
+        let debug = format!("{context:?}");
+        assert!(!debug.contains("reservation-secret"));
+        assert!(!debug.contains("dispatch_receipt"));
+    }
+
+    #[test]
+    fn serialized_evidence_and_context_redact_raw_claim_material() {
+        let secret = "reservation-secret";
+        let context = RunnerJobExecutionContext::direct_daemon(
+            Some("run-1"),
+            "runner-1",
+            "job-1",
+            "homeboy",
+            secret,
+        )
+        .expect("context");
+
+        let serialized = serde_json::to_string(&context).expect("serialize context");
+        let evidence = serde_json::to_string(&context.evidence_record().expect("evidence"))
+            .expect("serialize evidence");
+        assert!(!serialized.contains(secret));
+        assert!(!evidence.contains(secret));
+        assert!(serialized.contains("claim_ref"));
+    }
+}

--- a/crates/homeboy-extension/src/component_script.rs
+++ b/crates/homeboy-extension/src/component_script.rs
@@ -242,6 +242,9 @@ fn component_script_env(
             provider_env.extend(component_env.iter().cloned());
             provider_env.extend(extra_env.iter().cloned());
             env.extend(env_provider::env_vars(
+                &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
                 &extension,
                 source_path,
                 &provider_env,

--- a/crates/homeboy-extension/src/env_provider.rs
+++ b/crates/homeboy-extension/src/env_provider.rs
@@ -1,9 +1,23 @@
 use crate::manifest::ExtensionManifest;
 use homeboy_core::error::{Error, Result};
+use homeboy_core::runner_job_execution_context::RunnerJobExecutionContext;
 use homeboy_core::server::execute_local_command_in_dir;
 use homeboy_engine_primitives::shell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+
+pub const ENV_PROVIDER_COMMAND_PAYLOAD_ENV: &str = "HOMEBOY_ENV_PROVIDER_COMMAND_PAYLOAD";
+const ENV_PROVIDER_COMMAND_PAYLOAD_SCHEMA: &str = "homeboy/env-provider-command/v1";
+const MAX_PROVIDER_COMMAND_PAYLOAD_BYTES: usize = 8 * 1024;
+
+/// The explicit, bounded payload passed to every provider script. The typed
+/// context is duplicated here because scripts are process boundaries and
+/// cannot rely on Rust-side pre-validation.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EnvProviderCommandPayload<'a> {
+    pub schema: &'static str,
+    pub execution_context: &'a RunnerJobExecutionContext,
+}
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct EnvProviderContribution {
@@ -34,6 +48,7 @@ pub fn declared_secret_names(extension_id: &str) -> Result<Vec<String>> {
 /// that will execute the workload. The caller retains only this non-secret
 /// provenance; secret values remain in the runner's secret-env resolver.
 pub fn resolve_installed(
+    execution_context: &RunnerJobExecutionContext,
     extension_id: &str,
     component_path: &Path,
     base_env: &[(String, String)],
@@ -50,7 +65,7 @@ pub fn resolve_installed(
         ));
     };
     let secret_env_names = declared_secret_names(extension_id)?;
-    let public_env = env_vars(&extension, component_path, base_env)?;
+    let public_env = env_vars(execution_context, &extension, component_path, base_env)?;
     for (name, _) in &public_env {
         if secret_env_names.iter().any(|secret| secret == name)
             || homeboy_core::redaction::RedactionPolicy::default().is_sensitive_key(name)
@@ -75,10 +90,21 @@ pub fn resolve_installed(
 /// Resolve providers in request order and reject any ambiguous contribution
 /// before the workload can start. The returned values contain no secrets.
 pub fn resolve_installed_all(
+    execution_context: &RunnerJobExecutionContext,
     extension_ids: &[String],
     component_path: &Path,
     base_env: &[(String, String)],
 ) -> Result<Vec<EnvProviderContribution>> {
+    if execution_context.verify_integrity().is_err() {
+        return Err(Error::validation_invalid_argument(
+            "execution_context",
+            "extension environment providers require authenticated runner execution context",
+            None,
+            Some(vec![
+                "Claim a fresh runner job through the controller before retrying.".to_string(),
+            ]),
+        ));
+    }
     let mut effective_env = base_env.to_vec();
     let mut owners = HashMap::new();
     for (name, _) in base_env {
@@ -86,7 +112,12 @@ pub fn resolve_installed_all(
     }
     let mut contributions = Vec::new();
     for extension_id in extension_ids {
-        let contribution = resolve_installed(extension_id, component_path, &effective_env)?;
+        let contribution = resolve_installed(
+            execution_context,
+            extension_id,
+            component_path,
+            &effective_env,
+        )?;
         for (name, value) in &contribution.public_env {
             if let Some(owner) = owners.get(name) {
                 return Err(Error::validation_invalid_argument(
@@ -108,6 +139,7 @@ pub fn resolve_installed_all(
 }
 
 pub(crate) fn env_vars(
+    execution_context: &RunnerJobExecutionContext,
     extension: &ExtensionManifest,
     component_path: &Path,
     base_env: &[(String, String)],
@@ -117,7 +149,21 @@ pub(crate) fn env_vars(
     };
     let extension_path = extension_path(extension)?;
     let command = shell::quote_path(&extension_path.join(script_path).to_string_lossy());
-    let env_refs = base_env
+    let payload = provider_command_payload(execution_context)?;
+    if base_env
+        .iter()
+        .any(|(key, _)| key == ENV_PROVIDER_COMMAND_PAYLOAD_ENV)
+    {
+        return Err(Error::validation_invalid_argument(
+            "extension_env",
+            format!("request environment cannot override {ENV_PROVIDER_COMMAND_PAYLOAD_ENV}"),
+            None,
+            None,
+        ));
+    }
+    let mut provider_env = base_env.to_vec();
+    provider_env.push((ENV_PROVIDER_COMMAND_PAYLOAD_ENV.to_string(), payload));
+    let env_refs = provider_env
         .iter()
         .map(|(key, value)| (key.as_str(), value.as_str()))
         .collect::<Vec<_>>();
@@ -138,6 +184,36 @@ pub(crate) fn env_vars(
     }
 
     parse_env_provider_output(&output.stdout)
+}
+
+fn provider_command_payload(execution_context: &RunnerJobExecutionContext) -> Result<String> {
+    execution_context.verify_integrity().map_err(|_| {
+        Error::validation_invalid_argument(
+            "execution_context",
+            "extension environment providers require authenticated runner execution context",
+            None,
+            None,
+        )
+    })?;
+    let payload = serde_json::to_string(&EnvProviderCommandPayload {
+        schema: ENV_PROVIDER_COMMAND_PAYLOAD_SCHEMA,
+        execution_context,
+    })
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize env provider command payload".to_string()),
+        )
+    })?;
+    if payload.len() > MAX_PROVIDER_COMMAND_PAYLOAD_BYTES {
+        return Err(Error::validation_invalid_argument(
+            "execution_context",
+            "extension environment provider command payload exceeds its bounded record",
+            None,
+            None,
+        ));
+    }
+    Ok(payload)
 }
 
 pub(crate) fn load_manifest_from_dir(extension_path: &Path) -> Result<ExtensionManifest> {
@@ -201,5 +277,36 @@ mod tests {
                 ("B".to_string(), "two".to_string())
             ]
         );
+    }
+
+    #[test]
+    fn command_payload_carries_the_stable_verified_context_identity() {
+        let context = RunnerJobExecutionContext::local("homeboy");
+        let payload = provider_command_payload(&context).expect("payload");
+        let value: serde_json::Value = serde_json::from_str(&payload).expect("JSON payload");
+
+        assert_eq!(value["schema"], ENV_PROVIDER_COMMAND_PAYLOAD_SCHEMA);
+        assert_eq!(
+            value["execution_context"]["schema"],
+            homeboy_core::runner_job_execution_context::RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA
+        );
+        assert_eq!(value["execution_context"]["id"], context.id());
+    }
+
+    #[test]
+    fn command_payload_redacts_raw_execution_claim_material() {
+        let secret = "reservation-secret";
+        let context = RunnerJobExecutionContext::direct_daemon(
+            Some("run-1"),
+            "runner-1",
+            "job-1",
+            "homeboy",
+            secret,
+        )
+        .expect("context");
+
+        let payload = provider_command_payload(&context).expect("payload");
+        assert!(!payload.contains(secret));
+        assert!(payload.contains("claim_ref"));
     }
 }

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -159,7 +159,12 @@ fn persist_setup_runtime_env(extension: &ExtensionManifest, extension_id: &str) 
         None,
     );
 
-    match super::env_provider::env_vars(extension, extension_dir, &base_env) {
+    match super::env_provider::env_vars(
+        &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
+        extension,
+        extension_dir,
+        &base_env,
+    ) {
         Ok(discovered) if !discovered.is_empty() => {
             let _ = super::setup_env::persist(extension_id, &discovered);
         }
@@ -413,6 +418,9 @@ pub(crate) fn build_capability_env_with_additional_providers(
     provider_env.extend(extra_env.iter().cloned());
     if let Ok(extension) = env_provider::load_manifest_from_dir(extension_path) {
         env.extend(env_provider::env_vars(
+            &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                "homeboy",
+            ),
             &extension,
             component_path,
             &provider_env,
@@ -421,6 +429,9 @@ pub(crate) fn build_capability_env_with_additional_providers(
     for (_extension_id, provider_path) in additional_env_provider_paths {
         if let Ok(extension) = env_provider::load_manifest_from_dir(provider_path) {
             env.extend(env_provider::env_vars(
+                &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
                 &extension,
                 component_path,
                 &provider_env,

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -64,7 +64,8 @@ pub use homeboy_extension_contract::ExtensionCapability;
 pub use env_provider::{
     declared_secret_names as env_provider_secret_names,
     resolve_installed as resolve_installed_env_provider,
-    resolve_installed_all as resolve_installed_env_providers, EnvProviderContribution,
+    resolve_installed_all as resolve_installed_env_providers, EnvProviderCommandPayload,
+    EnvProviderContribution, ENV_PROVIDER_COMMAND_PAYLOAD_ENV,
 };
 pub(crate) use execution::build_settings_json_from_manifest;
 pub use execution::execute_action;

--- a/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
+++ b/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
@@ -14,6 +14,7 @@ use homeboy_core::daemon::runner_exec_driver::{
     PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
 };
 use homeboy_core::error::Result;
+use homeboy_core::runner_job_execution_context::RunnerJobExecutionContext;
 use homeboy_core::secret_env_plan::SecretEnvPlan;
 
 use super::execution::{
@@ -21,6 +22,11 @@ use super::execution::{
     PreparedRunnerProcess, RunnerProcessRequest,
 };
 use super::Runner;
+
+struct DaemonPreparedPlan {
+    plan: PreparedRunnerProcess,
+    extension_env_providers: Vec<String>,
+}
 
 /// The runner layer's `RunnerExecDriver`. Registered with core at startup.
 pub struct RunnerDaemonExecDriver;
@@ -65,7 +71,7 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
             &request.env,
             secret_env_plan,
         );
-        let mut plan = prepare_daemon_local_process(RunnerProcessRequest {
+        let plan = prepare_daemon_local_process(RunnerProcessRequest {
             runner_id: request.runner_id,
             runner,
             cwd: request.cwd,
@@ -80,8 +86,72 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
             require_paths: request.require_paths,
             validate_require_paths_on_host: request.validate_require_paths_on_host,
         })?;
-        let contributions = homeboy_extension::resolve_installed_env_providers(
-            &request.extension_env_providers,
+        Ok(PreparedDaemonExec::new(
+            plan.runner.id.clone(),
+            plan.cwd.clone(),
+            plan.command.clone(),
+            plan.env.clone(),
+            plan.secret_env_names.clone(),
+            plan.source_snapshot.clone(),
+            plan.require_paths.clone(),
+            plan.runner.settings.concurrency_limit,
+            plan.runner.settings.heartbeat_only_stall.clone(),
+            // This is a durable declaration, not provider output. The provider
+            // itself is resolved only after the authenticated context arrives
+            // at `execute`.
+            serde_json::json!({ "providers": request.extension_env_providers.clone() }),
+            Arc::new(DaemonPreparedPlan {
+                plan,
+                extension_env_providers: request.extension_env_providers,
+            }),
+        ))
+    }
+
+    fn execute(
+        &self,
+        prepared: &PreparedDaemonExec,
+        execution_context: &RunnerJobExecutionContext,
+        is_cancelled: ExecCancellationProbe,
+        progress_sink: Option<ExecProgressSink>,
+        require_child_identity_acknowledgement: bool,
+        child_started: Option<ExecChildStarted>,
+    ) -> Result<DaemonExecOutput> {
+        let base = prepared
+            .plan_token()
+            .downcast_ref::<DaemonPreparedPlan>()
+            .ok_or_else(|| {
+                homeboy_core::error::Error::internal_unexpected(
+                    "runner exec driver received a plan it did not prepare",
+                )
+            })?;
+
+        // The daemon may have mutated `prepared.env` (e.g. injecting the child
+        // reservation id) between prepare and execute, so run with that env.
+        if execution_context.verify_integrity().is_err()
+            || execution_context.runner_id() != prepared.runner_id
+            || execution_context.runtime_id()
+                != prepared
+                    .command
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or_default()
+        {
+            return Err(homeboy_core::error::Error::validation_invalid_argument(
+                "execution_context",
+                "daemon execution context does not match the accepted runner job",
+                Some(prepared.runner_id.clone()),
+                Some(vec![
+                    "Claim a fresh runner job through the controller before retrying.".to_string(),
+                ]),
+            ));
+        }
+        let mut plan = base.plan.clone();
+        plan.env = prepared.env.clone();
+        // Provider adapters execute only after the daemon supplied the verified
+        // typed context. No environment value participates in this decision.
+        let contributions = super::execution::resolve_provider_env_with_execution_context(
+            execution_context,
+            &base.extension_env_providers,
             std::path::Path::new(&plan.cwd),
             &plan
                 .env
@@ -100,43 +170,6 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
                 Some("serialize extension env provenance".to_string()),
             )
         })?;
-
-        Ok(PreparedDaemonExec::new(
-            plan.runner.id.clone(),
-            plan.cwd.clone(),
-            plan.command.clone(),
-            plan.env.clone(),
-            plan.secret_env_names.clone(),
-            plan.source_snapshot.clone(),
-            plan.require_paths.clone(),
-            plan.runner.settings.concurrency_limit,
-            plan.runner.settings.heartbeat_only_stall.clone(),
-            extension_env_provenance,
-            Arc::new(plan),
-        ))
-    }
-
-    fn execute(
-        &self,
-        prepared: &PreparedDaemonExec,
-        is_cancelled: ExecCancellationProbe,
-        progress_sink: Option<ExecProgressSink>,
-        require_child_identity_acknowledgement: bool,
-        child_started: Option<ExecChildStarted>,
-    ) -> Result<DaemonExecOutput> {
-        let base = prepared
-            .plan_token()
-            .downcast_ref::<PreparedRunnerProcess>()
-            .ok_or_else(|| {
-                homeboy_core::error::Error::internal_unexpected(
-                    "runner exec driver received a plan it did not prepare",
-                )
-            })?;
-
-        // The daemon may have mutated `prepared.env` (e.g. injecting the child
-        // reservation id) between prepare and execute, so run with that env.
-        let mut plan = base.clone();
-        plan.env = prepared.env.clone();
 
         let mut is_cancelled = is_cancelled;
         let output = execute_runner_process_until_cancelled_with_progress(
@@ -163,7 +196,7 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
             capture: output
                 .capture
                 .and_then(|capture| serde_json::to_value(capture).ok()),
-            extension_env_provenance: prepared.extension_env_provenance.clone(),
+            extension_env_provenance,
         })
     }
 }

--- a/crates/homeboy-lab-runner/src/dev_run.rs
+++ b/crates/homeboy-lab-runner/src/dev_run.rs
@@ -243,6 +243,10 @@ pub(crate) fn run_extension_dev_run_with(
     let (install, _) = exec(
         &plan.runner_id,
         RunnerExecOptions {
+            execution_context:
+                homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
             cwd: Some(synced.remote_path.clone()),
             project_id: None,
             allow_diagnostic_ssh: false,
@@ -309,6 +313,10 @@ pub(crate) fn run_extension_dev_run_with(
     let (command_output, command_exit_code) = exec(
         &plan.runner_id,
         RunnerExecOptions {
+            execution_context:
+                homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
             cwd: Some(synced.remote_path.clone()),
             project_id: None,
             allow_diagnostic_ssh: false,
@@ -576,6 +584,10 @@ fn probe_runner_extension_state(
     match exec(
         &plan.runner_id,
         RunnerExecOptions {
+            execution_context:
+                homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
             cwd: None,
             project_id: None,
             allow_diagnostic_ssh: false,

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -95,7 +95,8 @@ pub(super) fn exec_via_reverse_broker(
         path_materialization_plan: path_materialization_plan.clone(),
         lab_runner_workload: lab_runner_workload.clone(),
         metadata: Some({
-            let mut metadata = runner_exec_request_metadata(run_id.as_deref(), "reverse_broker");
+            let mut metadata =
+                runner_exec_request_metadata(run_id.as_deref(), "reverse_broker", &runner.id);
             if let Some(run_id) = run_id.as_deref() {
                 metadata["submission_key"] =
                     serde_json::json!(reverse_broker_submission_key(&runner.id, run_id));

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -110,7 +110,7 @@ pub(super) fn exec_via_daemon(
         "require_paths": require_paths.clone(),
         "extension_env_providers": extension_env_providers.clone(),
         "runner_workload": lab_runner_workload.clone(),
-        "metadata": runner_exec_request_metadata(run_id.as_deref(), "daemon"),
+        "metadata": runner_exec_request_metadata(run_id.as_deref(), "daemon", &runner.id),
         "lifecycle": lifecycle,
         // Explicit, first-class idempotency key the daemon dedupes `/exec` on.
         // The controller asserts it up front instead of the daemon having to

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -881,7 +881,10 @@ pub(crate) fn exec_with_status_snapshot(
                 plan.env.insert(key, value);
             }
         }
-        return exec_local(plan);
+        let (mut output, exit_code) = exec_local(plan)?;
+        append_runner_exec_binary_diagnostics(&mut output, &runner, None);
+        append_runner_exec_diagnostic_hint(&mut output, run_id_hint);
+        return Ok((output, exit_code));
     }
     // Extension parity uses daemon-backed runner commands. Recover the direct
     // session before that preparation so admission cannot fail before `/exec`.

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -135,6 +135,9 @@ pub fn reconcile_runner_generation_after_evidence(runner_id: &str) -> Result<()>
 
 #[derive(Debug, Clone)]
 pub struct RunnerExecOptions {
+    /// Typed execution authority supplied by the dispatch boundary. It is never
+    /// reconstructed from environment or runner-local lifecycle state.
+    pub execution_context: homeboy_core::runner_job_execution_context::RunnerJobExecutionContext,
     pub cwd: Option<String>,
     pub project_id: Option<String>,
     pub allow_diagnostic_ssh: bool,
@@ -176,9 +179,25 @@ pub struct RunnerExecOptions {
     pub read_only_artifact_access: bool,
 }
 
+/// The only provider-env adapter boundary for authenticated runner execution.
+/// The provider receives the typed context as an explicit argument to this
+/// boundary; environment remains only its eventual process projection.
+pub(crate) fn resolve_provider_env_with_execution_context(
+    execution_context: &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext,
+    provider_ids: &[String],
+    cwd: &std::path::Path,
+    env: &[(String, String)],
+) -> Result<Vec<homeboy_extension::EnvProviderContribution>> {
+    homeboy_extension::resolve_installed_env_providers(execution_context, provider_ids, cwd, env)
+}
+
 impl Default for RunnerExecOptions {
     fn default() -> Self {
         Self {
+            execution_context:
+                homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                    "homeboy",
+                ),
             cwd: None,
             project_id: None,
             allow_diagnostic_ssh: false,
@@ -848,6 +867,7 @@ pub(crate) fn exec_with_status_snapshot(
             validate_require_paths_on_host: false,
         })?;
         let contributions = homeboy_extension::resolve_installed_env_providers(
+            &options.execution_context,
             &options.extension_env_providers,
             std::path::Path::new(&plan.cwd),
             &plan
@@ -1230,9 +1250,19 @@ fn apply_explicit_runner_exec_run_id_env(
     })
 }
 
-fn runner_exec_request_metadata(run_id: Option<&str>, transport: &str) -> Value {
+fn runner_exec_request_metadata(run_id: Option<&str>, transport: &str, runner_id: &str) -> Value {
+    let controller_run_id = run_id
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or("runner-exec");
+    // This controller-created ID is stable in the persisted replay request and
+    // distinct for each new dispatch attempt.
+    let controller_attempt_id = format!("{controller_run_id}:{}", uuid::Uuid::new_v4());
+    let accepted_handoff_id = format!("{transport}:{runner_id}:{controller_attempt_id}");
     let mut metadata = serde_json::json!({
         "transport": transport,
+        "controller_run_id": controller_run_id,
+        "controller_attempt_id": controller_attempt_id,
+        "accepted_handoff_id": accepted_handoff_id,
     });
     if let Some(run_id) = run_id.filter(|id| !id.trim().is_empty()) {
         metadata["durable_run_id"] = serde_json::json!(run_id);

--- a/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
@@ -82,6 +82,18 @@ fn daemon_exec_does_not_require_runner_config_on_daemon_host() {
     assert_eq!(job.status, JobStatus::Succeeded);
 
     let events = store.events(job.id).expect("events");
+    assert!(events.iter().any(|event| {
+        event
+            .data
+            .as_ref()
+            .and_then(|data| data.get("execution_context"))
+            .is_some_and(|evidence| {
+                evidence["content_sha256"]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("sha256:"))
+                    && evidence["context"]["runner_job_id"] == serde_json::json!(job.id.to_string())
+            })
+    }));
     let result = events
         .iter()
         .find(|event| event.kind == JobEventKind::Result)
@@ -164,7 +176,7 @@ fn daemon_exec_injects_extension_env_and_redacts_provider_secret() {
     .expect("manifest");
     std::fs::write(
         extension.path().join("env.sh"),
-        "#!/bin/sh\nprintf '%s\\n' '{\"FIXTURE_RUNTIME\":\"runner-local\"}'\n",
+        "#!/bin/sh\ntest -n \"$HOMEBOY_ENV_PROVIDER_COMMAND_PAYLOAD\" || exit 23\nprintf '%s\\n' '{\"FIXTURE_RUNTIME\":\"runner-local\"}'\n",
     )
     .expect("provider");
     #[cfg(unix)]
@@ -197,6 +209,11 @@ fn daemon_exec_injects_extension_env_and_redacts_provider_secret() {
     );
 
     assert_eq!(response.status_code, 200);
+    assert_eq!(
+        response.body["body"]["request"]["extension_env_providers"]["providers"],
+        serde_json::json!(["fixture"]),
+        "enqueue retains only provider declarations; resolved output is produced after authenticated execution"
+    );
     let job_id = response.body["body"]["job"]["id"]
         .as_str()
         .expect("job id")

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -906,6 +906,10 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
         let (_output, exit_code) = super::super::worker::exec_worker_local_with_process_output(
             "lab-local",
             RunnerExecOptions {
+                execution_context:
+                    homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                        "homeboy",
+                    ),
                 cwd: Some(workspace.display().to_string()),
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -932,6 +936,7 @@ fn worker_local_workload_validation_uses_implicit_command_secret_names() {
                 print_handoff: true,
                 read_only_artifact_access: false,
             },
+            || Ok(()),
             |_plan| {
                 Ok(ProcessOutput {
                     stdout: "ok".to_string(),
@@ -957,6 +962,10 @@ fn test_exec_runs_local_runner_command() {
         let (output, exit_code) = exec(
             "lab-local",
             RunnerExecOptions {
+                execution_context:
+                    homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                        "homeboy",
+                    ),
                 cwd: None,
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -1036,6 +1045,10 @@ fn test_exec_does_not_leak_ambient_process_env() {
         let (output, exit_code) = exec(
             "lab-local",
             RunnerExecOptions {
+                execution_context:
+                    homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                        "homeboy",
+                    ),
                 cwd: None,
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -1083,6 +1096,10 @@ fn test_exec_preserves_explicit_request_env() {
         let (output, exit_code) = exec(
             "lab-local",
             RunnerExecOptions {
+                execution_context:
+                    homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                        "homeboy",
+                    ),
                 cwd: None,
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -1130,6 +1147,7 @@ fn runner_exec_explicit_run_id_overrides_conflicting_run_id_env() {
         let (output, exit_code) = exec(
             "lab-local",
             RunnerExecOptions {
+                execution_context: homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
                 cwd: None,
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -1212,6 +1230,10 @@ fn test_exec_rejects_missing_required_local_runner_path() {
         let err = exec(
             "lab-local",
             RunnerExecOptions {
+                execution_context:
+                    homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                        "homeboy",
+                    ),
                 cwd: None,
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -1270,6 +1292,10 @@ fn test_exec_reports_required_path_diagnostics() {
         let (output, exit_code) = exec(
             "lab-local",
             RunnerExecOptions {
+                execution_context:
+                    homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                        "homeboy",
+                    ),
                 cwd: None,
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -1339,6 +1365,10 @@ fn test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback() {
         let err = exec(
             "lab-server",
             RunnerExecOptions {
+                execution_context:
+                    homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
+                        "homeboy",
+                    ),
                 cwd: Some("/srv/homeboy/project".to_string()),
                 project_id: None,
                 allow_diagnostic_ssh: false,
@@ -1388,6 +1418,8 @@ fn test_diagnostic_ssh_mode_serializes_as_diagnostic_ssh() {
 #[test]
 fn explicit_diagnostic_ssh_wins_for_ssh_runners() {
     let mut options = RunnerExecOptions {
+        execution_context:
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
         cwd: Some("/srv/homeboy/project".to_string()),
         project_id: None,
         allow_diagnostic_ssh: true,

--- a/crates/homeboy-lab-runner/src/execution/tests/policy.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/policy.rs
@@ -26,6 +26,8 @@ fn test_required_extensions_for_command_reads_extension_flags() {
 fn test_runner_policy_denies_raw_ssh_exec_by_default() {
     let runner = ssh_runner();
     let options = RunnerExecOptions {
+        execution_context:
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
         cwd: Some("/srv/homeboy/project".to_string()),
         project_id: Some("extrachill".to_string()),
         allow_diagnostic_ssh: true,
@@ -73,6 +75,8 @@ fn test_runner_policy_enforces_projects_commands_workspace_and_artifacts() {
     };
 
     let allowed = RunnerExecOptions {
+        execution_context:
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
         cwd: Some("/srv/homeboy/extrachill/homeboy".to_string()),
         project_id: Some("extrachill".to_string()),
         allow_diagnostic_ssh: true,

--- a/crates/homeboy-lab-runner/src/execution/worker.rs
+++ b/crates/homeboy-lab-runner/src/execution/worker.rs
@@ -19,11 +19,12 @@ use super::*;
 pub(crate) fn exec_worker_local_until_cancelled_with_progress(
     runner_id: &str,
     options: RunnerExecOptions,
+    before_provider: impl FnOnce() -> Result<()>,
     is_cancelled: impl FnMut() -> bool,
     progress_sink: Option<super::super::RunnerCommandProgressSink>,
 ) -> Result<(RunnerExecOutput, i32)> {
     let mut is_cancelled = is_cancelled;
-    exec_worker_local_with_process_output(runner_id, options, |plan| {
+    exec_worker_local_with_process_output(runner_id, options, before_provider, |plan| {
         execute_runner_process_until_cancelled_with_progress(
             plan,
             &mut is_cancelled,
@@ -37,8 +38,22 @@ pub(crate) fn exec_worker_local_until_cancelled_with_progress(
 pub(super) fn exec_worker_local_with_process_output(
     runner_id: &str,
     options: RunnerExecOptions,
+    before_provider: impl FnOnce() -> Result<()>,
     execute: impl FnOnce(&PreparedRunnerProcess) -> Result<ProcessOutput>,
 ) -> Result<(RunnerExecOutput, i32)> {
+    let verified_remote = options.execution_context.verify_integrity().is_ok()
+        && options.execution_context.runner_id() == runner_id;
+    let explicit_local = options.execution_context.is_local();
+    if !verified_remote && !explicit_local {
+        return Err(homeboy_core::error::Error::validation_invalid_argument(
+            "execution_context",
+            "runner execution context is not verified for this runner",
+            Some(runner_id.to_string()),
+            Some(vec![
+                "Claim a fresh runner job through the controller before retrying.".to_string(),
+            ]),
+        ));
+    }
     let provider_secret_names = options
         .extension_env_providers
         .iter()
@@ -75,7 +90,10 @@ pub(super) fn exec_worker_local_with_process_output(
     })?;
     let run_id_hint =
         apply_explicit_runner_exec_run_id_env(&mut plan.env, options.run_id.as_deref());
-    let contributions = homeboy_extension::resolve_installed_env_providers(
+    // The final pre-provider boundary consumes a remote receipt exactly once.
+    before_provider()?;
+    let contributions = super::resolve_provider_env_with_execution_context(
+        &options.execution_context,
         &options.extension_env_providers,
         std::path::Path::new(&plan.cwd),
         &plan

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -441,6 +441,8 @@ fn lab_runner_exec_options(
     }
     env.extend(lab_rig_registry_env(context.rig_registry_root.as_deref()));
     RunnerExecOptions {
+        execution_context:
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
         cwd: Some(context.remote_cwd.clone()),
         project_id: None,
         allow_diagnostic_ssh: false,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -271,6 +271,8 @@ pub fn shell_arg(arg: &str) -> String {
 
 pub fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecOptions {
     RunnerExecOptions {
+        execution_context:
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
         cwd: None,
         project_id: None,
         allow_diagnostic_ssh: true,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/source_checkout.rs
@@ -106,6 +106,8 @@ pub fn runner_source_checkout_prepare_options(
     command: Vec<String>,
 ) -> RunnerExecOptions {
     RunnerExecOptions {
+        execution_context:
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local("homeboy"),
         cwd: None,
         project_id: None,
         allow_diagnostic_ssh: true,

--- a/crates/homeboy-lab-runner/src/worker/broker.rs
+++ b/crates/homeboy-lab-runner/src/worker/broker.rs
@@ -24,6 +24,7 @@ pub(super) fn claim_job(
             "project_id": options.project_id,
             "lease_ms": options.lease_ms.max(1),
             "concurrency_limit": options.concurrency_limit,
+            "execution_protocol": homeboy_core::runner_job_execution_context::RunnerJobExecutionProtocol::current(),
         }),
         "claim reverse runner job",
         options.broker_token.as_deref(),
@@ -38,30 +39,6 @@ pub(super) fn claim_job(
             Some("parse reverse runner job claim".to_string()),
         )
     })
-}
-
-pub(super) fn append_progress(
-    client: &Client,
-    broker_url: &str,
-    token: Option<&str>,
-    runner_id: &str,
-    job: &Job,
-) -> Result<()> {
-    let claim_id = remote_runner_claim_id(job)?;
-    broker_http::post_json(
-        client,
-        broker_url,
-        &format!("/runner/jobs/{}/events", job.id),
-        json!({
-            "runner_id": runner_id,
-            "claim_id": claim_id,
-            "kind": "progress",
-            "message": "reverse runner worker started execution",
-        }),
-        "append reverse runner progress event",
-        token,
-    )?;
-    Ok(())
 }
 
 pub(super) fn append_progress_data(
@@ -114,6 +91,35 @@ pub(super) fn finish_job(
         Error::internal_json(
             err.to_string(),
             Some("parse finished reverse runner job".to_string()),
+        )
+    })
+}
+
+pub(super) fn consume_execution(
+    client: &Client,
+    broker_url: &str,
+    token: Option<&str>,
+    runner_id: &str,
+    job: &Job,
+    context_id: &str,
+) -> Result<Job> {
+    let claim_id = remote_runner_claim_id(job)?;
+    let data = broker_http::post_json(
+        client,
+        broker_url,
+        &format!("/runner/jobs/{}/consume", job.id),
+        json!({
+            "runner_id": runner_id,
+            "claim_id": claim_id,
+            "context_id": context_id,
+        }),
+        "consume reverse runner execution receipt",
+        token,
+    )?;
+    serde_json::from_value(data["job"].clone()).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse consumed reverse runner job".to_string()),
         )
     })
 }

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -12,10 +12,11 @@ use serde_json::json;
 use homeboy_core::api_jobs::RemoteRunnerJobResult;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope;
+use homeboy_core::runner_job_execution_context::RunnerJobExecutionContext;
 
 use super::super::execution::{exec_worker_local_until_cancelled_with_progress, RunnerExecOptions};
 use super::broker::{
-    append_progress, append_progress_data, cancelled_job_snapshot, claim_job, finish_job,
+    append_progress_data, cancelled_job_snapshot, claim_job, consume_execution, finish_job,
     start_claim_heartbeat,
 };
 use super::result::{
@@ -241,6 +242,37 @@ fn run_once_output(
         ));
     };
 
+    // The broker claim is the execution boundary. Verify the typed receipt
+    // before materializing inputs or invoking any provider/runtime adapter.
+    let execution_context = claim.execution_context.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "execution_context",
+            "reverse runner claim predates authenticated execution context support",
+            Some(claim.job.id.to_string()),
+            Some(vec![
+                "Resubmit the handoff through a compatible controller before retrying.".to_string(),
+            ]),
+        )
+    })?;
+    claim
+        .execution_protocol
+        .as_ref()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "execution_protocol",
+                "reverse runner claim predates execution-context protocol negotiation",
+                Some(claim.job.id.to_string()),
+                None,
+            )
+        })?
+        .verify()?;
+    let execution_context = execution_context.verify_claim(&claim.job, &claim.request)?;
+
+    // Commit runner-owned evidence before materializing any broker input. The
+    // controller persists the same identity in its claim event; keeping both
+    // records lets either side recover after its own restart.
+    persist_runner_execution_context(&options.runner_id, &execution_context)?;
+
     if let Some(job) = poll_cancelled(&client, &options, &claim.job)? {
         return Ok(cancelled_output(
             options,
@@ -252,12 +284,19 @@ fn run_once_output(
         ));
     }
 
-    append_progress(
+    // This runner-authenticated record is persisted before inputs are
+    // materialized, so it and the claim event resolve the same receipt after a
+    // controller or runner restart.
+    append_progress_data(
         &client,
         &options.broker_url,
         options.broker_token.as_deref(),
         &options.runner_id,
         &claim.job,
+        serde_json::json!({
+            "phase": "runner_job_execution_context_verified",
+            "runner_job_execution_context": execution_context.evidence_record()?,
+        }),
     )?;
     let _heartbeat = start_claim_heartbeat(&client, &options, &claim.job)?;
     // Remote capability-parity preflight: validate that this runner can satisfy
@@ -305,7 +344,24 @@ fn run_once_output(
             execution_envelope.clone(),
             capability_preflight,
             claimed_run_id,
+            execution_context.clone(),
         )?,
+        || {
+            let recovered =
+                resolve_runner_execution_context(&options.runner_id, execution_context.id())?;
+            consume_execution(
+                &client,
+                &options.broker_url,
+                options.broker_token.as_deref(),
+                &options.runner_id,
+                &claim.job,
+                recovered.id(),
+            )?;
+            // Consumption atomically verifies the live claim and commits the
+            // one-time receipt. Its returned job has a newer timestamp, so it
+            // must not be used to recompute the pre-consumption receipt.
+            Ok(())
+        },
         || {
             if cancel_seen || last_cancel_poll.elapsed() < BROKER_CANCEL_POLL_INTERVAL {
                 return cancel_seen;
@@ -391,6 +447,77 @@ fn run_once_output(
         ),
         exit_code,
     ))
+}
+
+pub(super) fn persist_runner_execution_context(
+    runner_id: &str,
+    execution_context: &RunnerJobExecutionContext,
+) -> Result<()> {
+    let path = homeboy_core::paths::runner_job_execution_context_evidence_file(
+        runner_id,
+        execution_context.id(),
+    )?;
+    let parent = path.parent().expect("evidence file has parent");
+    std::fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", parent.display())),
+        )
+    })?;
+    let evidence = execution_context.evidence_record()?;
+    let bytes = serde_json::to_vec(&evidence).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("encode runner execution evidence".to_string()),
+        )
+    })?;
+    let temporary = path.with_extension("json.tmp");
+    std::fs::write(&temporary, bytes).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("write {}", temporary.display())),
+        )
+    })?;
+    std::fs::rename(&temporary, &path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("commit {}", path.display())),
+        )
+    })?;
+    let recovered = resolve_runner_execution_context(runner_id, execution_context.id())?;
+    if recovered.id() != execution_context.id() || recovered.runner_id() != runner_id {
+        return Err(Error::internal_unexpected(
+            "runner execution evidence resolved a different context",
+        ));
+    }
+    Ok(())
+}
+
+/// Recovery resolves only the exact runner-local context ID. This is
+/// diagnostic identity, never renewed authority: the broker still rejects a
+/// consumed receipt and fails the interrupted running job closed on expiry.
+pub(super) fn resolve_runner_execution_context(
+    runner_id: &str,
+    context_id: &str,
+) -> Result<RunnerJobExecutionContext> {
+    let path =
+        homeboy_core::paths::runner_job_execution_context_evidence_file(runner_id, context_id)?;
+    let bytes = std::fs::read(&path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+    })?;
+    let evidence: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("decode runner execution evidence".to_string()),
+        )
+    })?;
+    let context = RunnerJobExecutionContext::from_evidence_record(&evidence)?;
+    if context.id() != context_id || context.runner_id() != runner_id {
+        return Err(Error::internal_unexpected(
+            "runner execution evidence resolved a different context",
+        ));
+    }
+    Ok(context)
 }
 
 /// Private `@file` paths carry their SHA-256 in the runner-resident filename.
@@ -950,6 +1077,7 @@ fn runner_exec_options_from_envelope(
     envelope: RunnerExecutionEnvelope,
     capability_preflight: Option<crate::RunnerCapabilityPreflight>,
     run_id: Option<String>,
+    execution_context: homeboy_core::runner_job_execution_context::RunnerJobExecutionContext,
 ) -> Result<RunnerExecOptions> {
     let dispatch = envelope.dispatch.ok_or_else(|| {
         Error::internal_unexpected("runner execution envelope is missing dispatch payload")
@@ -963,6 +1091,7 @@ fn runner_exec_options_from_envelope(
         .unwrap_or_default();
 
     Ok(RunnerExecOptions {
+        execution_context,
         cwd: dispatch.cwd,
         project_id: dispatch.project_id,
         allow_diagnostic_ssh: false,

--- a/crates/homeboy-lab-runner/src/worker/tests/support.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/support.rs
@@ -71,6 +71,31 @@ pub(super) fn spawn_mock_broker_with_paths(
     (format!("http://{addr}"), handle)
 }
 
+/// Return a real store-backed claim while allowing a boundary test to corrupt
+/// its wire representation before the reverse worker receives it.
+pub(super) fn spawn_mock_broker_with_claim_mutation<F>(
+    store: JobStore,
+    mut mutate_claim: F,
+) -> (String, std::thread::JoinHandle<()>)
+where
+    F: FnMut(&mut Value) + Send + 'static,
+{
+    spawn_custom_broker(store, 1, None, move |store, request| {
+        if request.path == "/runner/jobs/claim" {
+            let claim = store
+                .claim_remote_runner_job("lab", None, 30_000, None)
+                .expect("claim job");
+            let mut claim = serde_json::to_value(claim).expect("serialize claim");
+            mutate_claim(&mut claim);
+            return serde_json::json!({
+                "success": true,
+                "data": { "body": { "claim": claim } }
+            });
+        }
+        handle_request(store, request)
+    })
+}
+
 pub(super) fn spawn_cancelling_after_claim_broker(
     store: JobStore,
     expected_requests: usize,
@@ -310,6 +335,27 @@ fn handle_request(store: &JobStore, request: &MockRequest) -> Value {
         return serde_json::json!({
             "success": true,
             "data": { "body": { "event": event } }
+        });
+    }
+    if let Some(job_id) = request
+        .path
+        .strip_prefix("/runner/jobs/")
+        .and_then(|tail| tail.strip_suffix("/consume"))
+    {
+        let job_id = uuid::Uuid::parse_str(job_id).expect("consume job id");
+        let job = store
+            .consume_remote_runner_execution(
+                job_id,
+                "lab",
+                request.body["claim_id"].as_str().expect("consume claim id"),
+                request.body["context_id"]
+                    .as_str()
+                    .expect("consume context id"),
+            )
+            .expect("consume execution receipt");
+        return serde_json::json!({
+            "success": true,
+            "data": { "body": { "job": job } }
         });
     }
     if let Some(job_id) = request

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -13,12 +13,14 @@ use homeboy_core::test_support;
 use sha2::{Digest, Sha256};
 
 use super::super::run::{
-    run_loop, run_reverse_worker, verify_private_at_files, write_private_at_file_snapshot,
+    persist_runner_execution_context, resolve_runner_execution_context, run_loop,
+    run_reverse_worker, verify_private_at_files, write_private_at_file_snapshot,
 };
 use super::support::{
     spawn_cancelling_after_claim_broker, spawn_cancelling_on_second_snapshot_broker,
     spawn_failing_broker, spawn_mock_broker, spawn_mock_broker_until_finish,
-    spawn_mock_broker_until_finish_with_paths, write_reverse_controller_session,
+    spawn_mock_broker_until_finish_with_paths, spawn_mock_broker_with_claim_mutation,
+    write_reverse_controller_session,
 };
 use super::worker_options;
 
@@ -88,6 +90,22 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
         assert!(serialized.get("last_claim").is_none());
         let job = output.job.clone().expect("job");
         let events = store.events(job.id).expect("events");
+        let runner_context_evidence = events
+            .iter()
+            .find_map(|event| {
+                event
+                    .data
+                    .as_ref()
+                    .filter(|data| {
+                        data["phase"] == serde_json::json!("runner_job_execution_context_verified")
+                    })
+                    .and_then(|data| data.get("runner_job_execution_context"))
+            })
+            .expect("runner persists verified context before execution");
+        assert_eq!(
+            runner_context_evidence["context"]["runner_job_id"],
+            serde_json::json!(job.id.to_string())
+        );
         let result = events
             .iter()
             .find(|event| event.kind == JobEventKind::Result)
@@ -106,6 +124,26 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
         }));
         assert!(result["metrics"]["duration_ms"].as_u64().is_some());
         let seen_paths = seen_paths.lock().expect("seen paths");
+        let consume_index = seen_paths
+            .iter()
+            .position(|path| path.ends_with("/consume"))
+            .expect("worker consumes execution receipt");
+        let finish_index = seen_paths
+            .iter()
+            .position(|path| path.ends_with("/finish"))
+            .expect("worker finishes claimed job");
+        assert_eq!(
+            seen_paths
+                .iter()
+                .filter(|path| path.ends_with("/consume"))
+                .count(),
+            1,
+            "execution receipt is consumed once"
+        );
+        assert!(
+            consume_index < finish_index,
+            "worker consumes its receipt before publishing the terminal result"
+        );
         assert!(
             !seen_paths.iter().any(|path| path == "/runner/jobs"),
             "claimed worker job must execute locally instead of submitting another reverse broker job"
@@ -117,6 +155,152 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
             );
             assert!(result["metrics"]["sample_count"].as_u64().is_some());
         }
+    });
+}
+
+#[test]
+fn reverse_worker_restart_cannot_replay_a_consumed_receipt_and_keeps_context_evidence() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let store = JobStore::default();
+        let job = store
+            .submit_remote_runner_job(run_id_echo_request())
+            .expect("queue job");
+        let claim = store
+            .claim_remote_runner_job("lab", None, 30_000, None)
+            .expect("claim job")
+            .expect("queued job");
+        let context = claim.execution_context.expect("execution context");
+        let claim_id = claim.job.claim_id.as_deref().expect("claim id");
+
+        // The first worker reaches the provider boundary, then is interrupted
+        // before it can report a terminal result.
+        persist_runner_execution_context("lab", &context).expect("persist runner evidence");
+        store
+            .consume_remote_runner_execution(job.id, "lab", claim_id, context.id())
+            .expect("consume receipt before interruption");
+        assert_eq!(
+            store.get(job.id).expect("running job").status,
+            JobStatus::Running
+        );
+
+        // A restarted worker sees no queued work and therefore cannot replay
+        // the consumed receipt or invoke the provider a second time.
+        let (broker_url, handle) = spawn_mock_broker(store.clone(), 1);
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("restarted worker");
+        assert_eq!(exit_code, 0);
+        assert!(!output.claimed);
+        handle.join().expect("restart broker joins");
+        assert!(store
+            .consume_remote_runner_execution(job.id, "lab", claim_id, context.id())
+            .is_err());
+
+        // Recovery retains runner-local identity for diagnostics, while the
+        // broker owns terminalization of the interrupted running job.
+        let recovered = resolve_runner_execution_context("lab", context.id())
+            .expect("read runner-local context evidence after restart");
+        assert_eq!(recovered.id(), context.id());
+        assert_eq!(recovered.runner_job_id(), job.id.to_string());
+        let reconciled = store
+            .reconcile_expired_remote_runner_claims(
+                claim.job.claim_expires_at_ms.expect("claim expiry") + 1,
+            )
+            .expect("broker fails interrupted execution closed");
+        assert_eq!(reconciled.len(), 1);
+        assert_eq!(reconciled[0].status, JobStatus::Failed);
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn reverse_provider_dispatch_rejects_runner_mismatch_before_provider_script() {
+    assert_tampered_claim_rejects_before_provider(|claim| {
+        claim["job"]["claimed_by_runner_id"] = serde_json::json!("other-runner");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn reverse_provider_dispatch_rejects_job_mismatch_before_provider_script() {
+    assert_tampered_claim_rejects_before_provider(|claim| {
+        claim["execution_context"]["runner_job_id"] =
+            serde_json::json!("00000000-0000-0000-0000-000000000000");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn reverse_provider_dispatch_rejects_tampered_context_before_provider_script() {
+    assert_tampered_claim_rejects_before_provider(|claim| {
+        claim["execution_context"]["dispatch_receipt"] = serde_json::json!("sha256:tampered");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn reverse_provider_dispatch_retry_keeps_controller_run_and_separates_attempt_jobs() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let directory = tempfile::tempdir().expect("provider fixture directory");
+        let provider = directory.path().join("provider.sh");
+        let marker = directory.path().join("provider-invocations");
+        std::fs::write(&provider, "#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$2\"\n")
+            .expect("write provider script");
+        let store = JobStore::default();
+        let controller_run_id = "cook-controller-run";
+        let first = store
+            .submit_remote_runner_job(provider_request(
+                &provider,
+                &marker,
+                "attempt-1",
+                controller_run_id,
+            ))
+            .expect("queue first provider attempt");
+        let second = store
+            .submit_remote_runner_job(provider_request(
+                &provider,
+                &marker,
+                "attempt-2",
+                controller_run_id,
+            ))
+            .expect("queue retry provider attempt");
+
+        for expected_job in [first.id, second.id] {
+            let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+            write_reverse_controller_session(&broker_url);
+            let (output, exit_code) =
+                run_reverse_worker(worker_options(broker_url)).expect("dispatch provider attempt");
+            assert_eq!(exit_code, 0);
+            assert_eq!(output.job.expect("completed job").id, expected_job);
+            handle.join().expect("broker joins");
+        }
+
+        assert_eq!(
+            std::fs::read_to_string(&marker).expect("provider invocations"),
+            "attempt-1\nattempt-2\n"
+        );
+        let contexts = [first.id, second.id].map(|job_id| {
+            store
+                .events(job_id)
+                .expect("broker events")
+                .into_iter()
+                .find_map(|event| {
+                    event.data.and_then(|data| {
+                        (data["phase"]
+                            == serde_json::json!("runner_job_execution_context_verified"))
+                        .then(|| data["runner_job_execution_context"]["context"].clone())
+                    })
+                })
+                .expect("verified context evidence")
+        });
+        assert_eq!(contexts[0]["controller_run_id"], controller_run_id);
+        assert_eq!(contexts[1]["controller_run_id"], controller_run_id);
+        assert_eq!(contexts[0]["controller_attempt_id"], "attempt-1");
+        assert_eq!(contexts[1]["controller_attempt_id"], "attempt-2");
+        assert_ne!(contexts[0]["runner_job_id"], contexts[1]["runner_job_id"]);
+        assert_eq!(contexts[0]["runner_job_id"], first.id.to_string());
+        assert_eq!(contexts[1]["runner_job_id"], second.id.to_string());
     });
 }
 
@@ -549,7 +733,7 @@ fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecy
         request.command[2] = "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"import\",\"current_item\":\"%s\",\"completed\":1,\"total\":2,\"metadata\":{\"api_key\":\"%s\"}}\\n' \"$TOKEN\" \"$TOKEN\"; printf 'HOMEBOY_RUNNER_PROGRESS {not-json}\\n'; printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"done\",\"status\":\"succeeded\"}\\n'; sleep 0.1; dd if=/dev/zero bs=1024 count=4097 2>/dev/null; printf tail".to_string();
         request.secret_env_names = vec!["TOKEN".to_string()];
         store.submit_remote_runner_job(request).expect("submit job");
-        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 9);
 
         let (output, exit_code) =
             run_reverse_worker(worker_options(broker_url)).expect("run worker");
@@ -798,7 +982,7 @@ fn reverse_worker_reports_execution_failure_to_broker() {
                 metadata: None,
             })
             .expect("submit job");
-        let (broker_url, handle) = spawn_mock_broker(store.clone(), 5);
+        let (broker_url, handle) = spawn_mock_broker(store.clone(), 6);
 
         let (output, exit_code) =
             run_reverse_worker(worker_options(broker_url)).expect("run worker");
@@ -843,7 +1027,7 @@ fn reverse_worker_loop_reports_failed_job_status() {
                 metadata: None,
             })
             .expect("submit job");
-        let (broker_url, handle) = spawn_mock_broker(store.clone(), 6);
+        let (broker_url, handle) = spawn_mock_broker(store.clone(), 7);
         let stop = Arc::new(AtomicBool::new(false));
         let stop_after_sleep = stop.clone();
         let mut options = worker_options(broker_url);
@@ -1130,6 +1314,84 @@ fn run_id_echo_request() -> RemoteRunnerJobRequest {
         lab_runner_workload: None,
         lifecycle: None,
         metadata: None,
+    }
+}
+
+#[cfg(unix)]
+fn assert_tampered_claim_rejects_before_provider(
+    mutate_claim: impl FnMut(&mut serde_json::Value) + Send + 'static,
+) {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let directory = tempfile::tempdir().expect("provider fixture directory");
+        let provider = directory.path().join("provider.sh");
+        let marker = directory.path().join("provider-invoked");
+        std::fs::write(&provider, "#!/bin/sh\ntouch \"$1\"\n").expect("write provider script");
+        let store = JobStore::default();
+        let job = store
+            .submit_remote_runner_job(provider_request(
+                &provider,
+                &marker,
+                "attempt-1",
+                "controller-run",
+            ))
+            .expect("queue provider job");
+        let (broker_url, handle) =
+            spawn_mock_broker_with_claim_mutation(store.clone(), mutate_claim);
+
+        let error = run_reverse_worker(worker_options(broker_url))
+            .expect_err("tampered broker claim must fail before provider dispatch");
+
+        assert!(
+            error.message.contains("runner execution context rejected"),
+            "unexpected error: {error:#?}"
+        );
+        assert!(
+            !marker.exists(),
+            "provider script ran despite rejected reverse broker claim"
+        );
+        assert_eq!(
+            store.get(job.id).expect("claimed job").status,
+            JobStatus::Running
+        );
+        handle.join().expect("broker joins");
+    });
+}
+
+#[cfg(unix)]
+fn provider_request(
+    provider: &std::path::Path,
+    marker: &std::path::Path,
+    attempt_id: &str,
+    controller_run_id: &str,
+) -> RemoteRunnerJobRequest {
+    RemoteRunnerJobRequest {
+        runner_id: "lab".to_string(),
+        project_id: None,
+        operation: "runner.exec".to_string(),
+        command: vec![
+            "sh".to_string(),
+            provider.display().to_string(),
+            attempt_id.to_string(),
+            marker.display().to_string(),
+        ],
+        cwd: Some("/tmp".to_string()),
+        env: Default::default(),
+        secret_env_names: Vec::new(),
+        secret_env_plan: Default::default(),
+        env_materialization: None,
+        capture_patch: false,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        require_paths: Vec::new(),
+        extension_env_providers: Vec::new(),
+        lab_runner_workload: None,
+        lifecycle: None,
+        metadata: Some(serde_json::json!({
+            "controller_run_id": controller_run_id,
+            "controller_attempt_id": attempt_id,
+            "accepted_handoff_id": format!("reverse:lab:{attempt_id}"),
+        })),
     }
 }
 

--- a/crates/homeboy-paths/src/runtime.rs
+++ b/crates/homeboy-paths/src/runtime.rs
@@ -77,6 +77,19 @@ pub(crate) fn runner_lease_evidence_file(runner_id: &str, lease_id: &str) -> Res
         .join(format!("{}.json", sanitize_path_segment(lease_id))))
 }
 
+/// Runner-owned durable reverse-execution evidence. This is distinct from the
+/// controller's job event record so a restarted runner can resolve the exact
+/// broker-issued context it persisted before starting a child process.
+pub fn runner_job_execution_context_evidence_file(
+    runner_id: &str,
+    context_id: &str,
+) -> Result<PathBuf> {
+    Ok(homeboy()?
+        .join("runner-job-execution-context")
+        .join(sanitize_path_segment(runner_id))
+        .join(format!("{}.json", sanitize_path_segment(context_id))))
+}
+
 /// Managed service tunnel runtime state directory (~/.local/share/homeboy/service-tunnels/{id}/).
 pub fn service_tunnel_runtime_dir(id: &str) -> Result<PathBuf> {
     Ok(homeboy_data()?

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2872,7 +2872,7 @@ fn routes_remote_runner_job_broker_lifecycle() {
 }
 
 #[test]
-fn remote_runner_broker_redacts_secret_env_from_public_surfaces() {
+fn remote_runner_broker_refuses_inline_secret_env_without_persisting_it() {
     let store = JobStore::default();
     let sentinel = "homeboy-secret-sentinel-do-not-echo";
     let submit = route_with_job_store_and_body(
@@ -2892,44 +2892,9 @@ fn remote_runner_broker_redacts_secret_env_from_public_surfaces() {
         &store,
     );
 
-    assert_eq!(submit.status_code, 200, "submit body: {}", submit.body);
+    assert_eq!(submit.status_code, 400, "submit body: {}", submit.body);
     assert!(!serialized_contains(&submit.body, sentinel));
-    assert_eq!(
-        submit.body["body"]["request"]["env"]["RUNNER_SECRET_TOKEN"],
-        "<redacted>"
-    );
-    let job_id = submit.body["body"]["job"]["id"]
-        .as_str()
-        .expect("job id")
-        .to_string();
-
-    let list = route_with_job_store("GET", "/jobs", &store);
-    assert_eq!(list.status_code, 200, "list body: {}", list.body);
-    assert!(!serialized_contains(&list.body, sentinel));
-
-    let show = route_with_job_store("GET", &format!("/jobs/{job_id}"), &store);
-    assert_eq!(show.status_code, 200, "show body: {}", show.body);
-    assert!(!serialized_contains(&show.body, sentinel));
-
-    let events = route_with_job_store("GET", &format!("/jobs/{job_id}/events"), &store);
-    assert_eq!(events.status_code, 200, "events body: {}", events.body);
-    assert!(!serialized_contains(&events.body, sentinel));
-
-    let claim = route_with_job_store_and_body(
-        "POST",
-        "/runner/jobs/claim",
-        Some(serde_json::json!({
-            "runner_id": "homeboy-lab",
-            "project_id": "sample-project",
-            "lease_ms": 30000
-        })),
-        &store,
-    );
-    assert_eq!(claim.status_code, 200, "claim body: {}", claim.body);
-    assert_eq!(
-        claim.body["body"]["claim"]["request"]["env"]["RUNNER_SECRET_TOKEN"],
-        sentinel
-    );
+    assert_eq!(store.list().len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- derive an opaque authenticated execution context from durable runner jobs and live claims
- deliver verified context through direct, reverse, and local provider paths with redacted durable evidence
- require one-time matching receipt consumption before context-bearing jobs can finish
- fail mixed-version in-flight claims closed by reconstructing context identity from verified durable evidence
- preserve direct runner-exec artifact and diagnostic lifecycle behavior

## Verification
- cargo test -p homeboy-core remote_runner
- cargo test -p homeboy-cli runner_exec --lib
- focused reverse-provider dispatch and restart/replay tests
- cargo check --workspace
- cargo fmt --check
- git diff --check origin/main...HEAD

Closes #10943

## AI assistance
OpenCode using openai/gpt-5.6-sol implemented and tested substantive portions of this change. Chris Huber reviewed and remains responsible for every line.