### PR TITLE
fix(cli): stop argument provenance panicking on unresolvable ids

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/argument_provenance.rs
+++ b/crates/homeboy-cli/src/cli_surface/argument_provenance.rs
@@ -94,6 +94,19 @@ impl CommandArgumentProvenance {
 
     fn collect(&mut self, matches: &ArgMatches) {
         for id in matches.ids() {
+            // `ids()` yields ids that `value_source` cannot resolve, and it
+            // PANICS on them rather than returning `None`:
+            //
+            //   `"placement"` is not an id of an argument or a group.
+            //
+            // The runtime parses an extension-augmented command, whose global
+            // and flattened argument layout surfaces such ids, so any command
+            // reaching this collector aborted the process. `homeboy refactor
+            // rename` did exactly that. `try_get_raw` reports the same
+            // distinction as a recoverable error, so use it as the guard.
+            if matches.try_get_raw(id.as_str()).is_err() {
+                continue;
+            }
             if let Some(source) = matches.value_source(id.as_str()) {
                 self.set(id.as_str(), ArgumentSource::from_clap(source));
             }


### PR DESCRIPTION
`homeboy refactor rename` aborts the process on `main`.

```
thread 'main' panicked at crates/homeboy-cli/src/cli_surface/argument_provenance.rs:97:43:
`"placement"` is not an id of an argument or a group.
```

## Cause

```rust
for id in matches.ids() {
    if let Some(source) = matches.value_source(id.as_str()) { ... }
}
```

`ArgMatches::ids()` yields ids that `value_source` cannot resolve, and clap **panics** on those rather than returning `None`. The runtime parses an extension-augmented command, whose global and flattened argument layout surfaces such ids — so any command reaching this collector could abort.

`try_get_raw` reports the same distinction as a recoverable error, so it is the guard: skip ids clap cannot resolve, record the rest unchanged.

## How it was found — worth stating plainly

**CI caught this, I did not.** It failed in Test job `91030611025`. I had been attributing recent CI reds to this host's resource contention, and on that assumption I would have skipped past it. Checking whether the specific tests I saw flaking locally actually appeared in CI failures is what surfaced it — they did not, and this did.

## On the test

I did not add a unit test, deliberately.

A synthetic clap fixture with `conflicts_with` does **not** reproduce this. Neither does `Cli::command().try_get_matches_from([...])` parsed directly. I wrote both, and **both passed with the guard removed** — so both were worthless as regression tests.

The id only appears through the augmented runtime command, which means the existing integration test is the real one. Verified as a negative control:

| | `rename_defaults_to_cwd_git_worktree_without_component_metadata` |
|---|---|
| before | **FAILED** — `` `"placement"` is not an id of an argument or a group `` |
| after | **ok** |

A test that cannot fail is worse than no test, so the two that could not are not in this PR.

## Verification

`cargo fmt --check` clean, `cargo clippy -p homeboy-cli --lib` 0 errors, `refactor_transform_test` **3 passed**, `argument_provenance` unit tests **6 passed**.

Thirteen lines, twelve of which are the comment explaining why the guard exists.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
