### PR TITLE
Preserve bench workspace identity for Lab retries

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -15,6 +15,8 @@ use homeboy_core::activity::{
     is_active, is_failure, ActivityCrossRefs, ActivityEvidenceRef, ActivityItem,
     ActivityNextAction, ActivityRunnerRefs, ActivityState,
 };
+
+use super::{load_controller_plan, plan_has_retry_materialization_identity};
 use homeboy_core::run_lifecycle_record::RunExecutionState;
 use homeboy_core::Result;
 
@@ -121,7 +123,14 @@ fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
             .collect(),
         source_projections: Vec::new(),
         state_conflicts: Vec::new(),
-        next_actions: actions_for_agent_task(&record.run_id, runner_id.as_deref(), state),
+        next_actions: actions_for_agent_task(
+            &record.run_id,
+            runner_id.as_deref(),
+            state,
+            load_controller_plan(&record.run_id)
+                .as_ref()
+                .is_ok_and(|plan| plan_has_retry_materialization_identity(plan)),
+        ),
     }
 }
 
@@ -129,6 +138,7 @@ fn actions_for_agent_task(
     run_id: &str,
     runner_id: Option<&str>,
     state: ActivityState,
+    retry_materializable: bool,
 ) -> Vec<ActivityNextAction> {
     let command_prefix = runner_id
         .map(|runner_id| format!("homeboy runner exec {runner_id} -- homeboy agent-task"))
@@ -140,7 +150,7 @@ fn actions_for_agent_task(
     ];
     if is_active(state) {
         actions.push(action("watch", format!("homeboy activity watch {run_id}")));
-    } else if is_failure(state) {
+    } else if is_failure(state) && retry_materializable {
         actions.push(action(
             "retry",
             format!("{command_prefix} retry --run {run_id}"),
@@ -180,12 +190,19 @@ mod tests {
 
     #[test]
     fn runner_backed_actions_execute_on_the_owning_runner() {
-        let actions = actions_for_agent_task("run-1", Some("lab-a"), ActivityState::Stale);
+        let actions = actions_for_agent_task("run-1", Some("lab-a"), ActivityState::Stale, true);
 
         assert!(actions.iter().any(|action| {
             action.command
                 == "homeboy runner exec lab-a -- homeboy agent-task reconcile run-1 --dry-run"
         }));
+    }
+
+    #[test]
+    fn failed_plan_without_materialization_identity_has_no_retry_action() {
+        let actions = actions_for_agent_task("run-1", None, ActivityState::Failed, false);
+
+        assert!(!actions.iter().any(|action| action.label == "retry"));
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1889,6 +1889,48 @@ pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRu
     retry_with_force_inner(run_id, requested_run_id, false, false)
 }
 
+/// Whether a persisted plan contains enough source identity to offer a retry
+/// that can be materialized without consulting the caller's current directory.
+pub fn plan_has_retry_materialization_identity(plan: &AgentTaskPlan) -> bool {
+    if plan.tasks.iter().any(|task| {
+        task.workspace
+            .root
+            .as_deref()
+            .or_else(|| {
+                task.executor
+                    .config
+                    .get("workspace_root")
+                    .and_then(Value::as_str)
+            })
+            .or_else(|| {
+                task.metadata
+                    .get("workspace")
+                    .and_then(|workspace| workspace.get("root"))
+                    .and_then(Value::as_str)
+            })
+            .is_some_and(|root| !root.trim().is_empty())
+    }) {
+        return true;
+    }
+
+    let Some(replay) = plan.metadata.get("generic_lab_command_replay") else {
+        return false;
+    };
+    replay.get("schema").and_then(Value::as_str) == Some("homeboy/generic-lab-command-replay/v1")
+        && replay
+            .get("normalized_args")
+            .and_then(Value::as_array)
+            .is_some_and(|args| !args.is_empty())
+        && replay
+            .pointer("/materialization/canonical_root")
+            .and_then(Value::as_str)
+            .is_some_and(|root| !root.trim().is_empty())
+        && replay
+            .pointer("/materialization/content_identity")
+            .and_then(Value::as_str)
+            .is_some_and(|identity| !identity.trim().is_empty())
+}
+
 pub(crate) fn record_metadata_value(run_id: &str, key: &str, value: Value) -> Result<()> {
     store::mutate_record(&sanitize_run_id(run_id), |record| {
         record

--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -125,6 +125,10 @@ impl BenchArgs {
             extension_overrides: run.extension_override.extensions.clone(),
         })
     }
+
+    pub(crate) fn portable_settings(&self) -> Option<&SettingArgs> {
+        self.run_args_for_lab_offload().map(|run| &run.setting_args)
+    }
 }
 
 #[derive(Subcommand)]

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -14,7 +14,7 @@ use homeboy::core::observation::{
 use homeboy::core::redaction::RedactionPolicy;
 use homeboy::core::Error;
 use homeboy::runner::runners::{self, RunnerExecOptions};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -127,7 +127,7 @@ pub fn route_after_parse_with_provenance(
     }
 
     let lab_command = lab_offload_command(&cli.command)?;
-    let normalized_args = inline_test_settings_profiles(cli, normalized_args)?;
+    let normalized_args = inline_portable_settings_profiles(cli, normalized_args)?;
 
     // Keep the readiness verdict, not just the selected id: when no runner is
     // eligible the reasons and remediation commands are the only thing that can
@@ -270,7 +270,11 @@ pub fn route_after_parse_with_provenance(
     // A controller-owned `run` becomes a portable `run-plan`. Route according
     // to that materialized command so Lab stages its workspace and rewrites the
     // structured plan instead of taking the original runner-resident path.
-    let lab_command = if run_handoff.is_some() {
+    let lab_command = if run_handoff.is_some()
+        || retry_handoff
+            .as_ref()
+            .is_some_and(|handoff| handoff.replays_generic_command)
+    {
         lab_offload_command_for_materialized_args(&normalized_args)?
     } else {
         lab_command
@@ -342,7 +346,14 @@ pub fn route_after_parse_with_provenance(
     )?;
     let generic_detached_handoff = needs_generic_detached_handoff
         .then(|| {
-            materialize_generic_detached_lab_handoff(&normalized_args, placement_decision.clone())
+            materialize_generic_detached_lab_handoff(
+                routed_args,
+                &routing_source_path,
+                lab_command
+                    .as_ref()
+                    .expect("generic detached handoff has a Lab command"),
+                placement_decision.clone(),
+            )
         })
         .transpose()?;
     // Only durable agent-task handoffs own placement outcomes. Dispatch
@@ -382,7 +393,13 @@ pub fn route_after_parse_with_provenance(
         .transpose()?;
     let durable_run_id = generic_detached_handoff
         .as_ref()
-        .map(|handoff| handoff.run_id.as_str());
+        .map(|handoff| handoff.run_id.as_str())
+        .or_else(|| {
+            retry_handoff
+                .as_ref()
+                .filter(|handoff| handoff.replays_generic_command)
+                .map(|handoff| handoff.run_id.as_str())
+        });
 
     let outcome = lab_routing::dispatch_lab_offload(
         LabRoutingRequest {
@@ -1658,11 +1675,20 @@ fn materialize_agent_task_cook_plan(
     Ok(Some(plan))
 }
 
-fn inline_test_settings_profiles(cli: &Cli, args: &[String]) -> homeboy::core::Result<Vec<String>> {
-    let settings = match &cli.command {
+fn inline_portable_settings_profiles(
+    cli: &Cli,
+    args: &[String],
+) -> homeboy::core::Result<Vec<String>> {
+    let (settings, command_token) = match &cli.command {
         Commands::Review(review) => match review.command.as_ref() {
-            Some(crate::commands::review::ReviewCommand::Test(test)) => &test.setting_args,
+            Some(crate::commands::review::ReviewCommand::Test(test)) => {
+                (&test.setting_args, "test")
+            }
             _ => return Ok(args.to_vec()),
+        },
+        Commands::Bench(bench) => match bench.portable_settings() {
+            Some(settings) => (settings, "bench"),
+            None => return Ok(args.to_vec()),
         },
         _ => return Ok(args.to_vec()),
     };
@@ -1706,12 +1732,10 @@ fn inline_test_settings_profiles(cli: &Cli, args: &[String]) -> homeboy::core::R
 
     let insertion = rewritten
         .iter()
-        .rposition(|arg| arg == "test")
+        .rposition(|arg| arg == command_token)
         .map(|index| index + 1)
         .ok_or_else(|| {
-            Error::internal_unexpected(
-                "test settings profile normalization lost the test subcommand",
-            )
+            Error::internal_unexpected("settings profile normalization lost the portable command")
         })?;
     let mut portable_profile_args = Vec::with_capacity(profile_values.len() * 2);
     for (key, value) in profile_values {
@@ -1860,20 +1884,109 @@ struct GenericDetachedLabHandoff {
     plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
 }
 
+const GENERIC_LAB_COMMAND_REPLAY_SCHEMA: &str = "homeboy/generic-lab-command-replay/v1";
+
+#[derive(Debug, serde::Deserialize)]
+struct GenericLabCommandReplay {
+    schema: String,
+    normalized_args: Vec<String>,
+    materialization: GenericLabMaterialization,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GenericLabMaterialization {
+    canonical_root: String,
+    content_identity: String,
+}
+
+fn structured_command_inputs(args: &[String]) -> serde_json::Value {
+    let mut options = BTreeMap::<String, Vec<serde_json::Value>>::new();
+    let mut positional = Vec::new();
+    let mut passthrough = Vec::new();
+    let mut iter = args.iter().skip(1).peekable();
+    let mut after_separator = false;
+    while let Some(arg) = iter.next() {
+        if after_separator {
+            passthrough.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            after_separator = true;
+            continue;
+        }
+        if let Some(option) = arg.strip_prefix("--") {
+            if let Some((name, value)) = option.split_once('=') {
+                options
+                    .entry(name.to_string())
+                    .or_default()
+                    .push(serde_json::Value::String(value.to_string()));
+            } else if iter.peek().is_some_and(|value| !value.starts_with('-')) {
+                options
+                    .entry(option.to_string())
+                    .or_default()
+                    .push(serde_json::Value::String(
+                        iter.next().expect("peeked value").clone(),
+                    ));
+            } else {
+                options
+                    .entry(option.to_string())
+                    .or_default()
+                    .push(serde_json::Value::Bool(true));
+            }
+        } else {
+            positional.push(arg.clone());
+        }
+    }
+    serde_json::json!({
+        "positional": positional,
+        "options": options,
+        "passthrough": passthrough,
+    })
+}
+
 /// Give detached portable commands a controller-owned identity before Lab
 /// admission. Agent-task commands retain their richer command-specific plans.
 fn materialize_generic_detached_lab_handoff(
     args: &[String],
+    source_path: &Path,
+    command: &runners::LabOffloadCommand,
     placement_decision: homeboy_lab_runner_contract::ExecutionPlacementDecision,
 ) -> homeboy::core::Result<GenericDetachedLabHandoff> {
     let run_id =
         explicit_run_id(args).unwrap_or_else(|| format!("lab-offload-{}", uuid::Uuid::new_v4()));
+    let canonical_root = source_path.canonicalize().map_err(|error| {
+        Error::validation_invalid_argument(
+            "workspace",
+            "detached Lab handoff could not canonicalize its source workspace",
+            Some(source_path.display().to_string()),
+            Some(vec![error.to_string()]),
+        )
+    })?;
+    let content_identity =
+        homeboy::runner::controller_workspace_materialization_identity(&canonical_root)?;
+    let repository_remote =
+        homeboy::core::git::release_download::detect_remote_url(&canonical_root);
+    let revision = homeboy::core::git::head_sha(&canonical_root);
+    let portable_args = portable_deferred_args(args);
+    let replay = serde_json::json!({
+        "schema": GENERIC_LAB_COMMAND_REPLAY_SCHEMA,
+        "normalized_args": portable_args,
+        "inputs": structured_command_inputs(args),
+        "lab_command": command,
+        "materialization": {
+            "canonical_root": canonical_root,
+            "content_identity": content_identity,
+            "repository_remote": repository_remote,
+            "revision": revision,
+        },
+    });
     let mut plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
         format!("lab-offload-{run_id}"),
         Vec::new(),
     );
     plan.metadata = serde_json::json!({
         "execution_placement_decision": placement_decision,
+        "generic_lab_command_replay": replay,
     });
     if agent_task_lifecycle::run_record_exists(&run_id)? {
         let persisted = agent_task_lifecycle::load_controller_plan(&run_id)?;
@@ -1893,6 +2006,8 @@ fn materialize_generic_detached_lab_handoff(
             })?;
         if persisted.plan_id != plan.plan_id
             || persisted_decision.as_ref() != Some(&placement_decision)
+            || persisted.metadata.get("generic_lab_command_replay")
+                != plan.metadata.get("generic_lab_command_replay")
         {
             return Err(Error::validation_invalid_argument(
                 "run_id",
@@ -1975,6 +2090,37 @@ struct AgentTaskRetryHandoff {
     run_id: String,
     plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
     primary_workspace: PathBuf,
+    replays_generic_command: bool,
+}
+
+fn generic_lab_command_replay(
+    plan: &homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+) -> homeboy::core::Result<Option<GenericLabCommandReplay>> {
+    let Some(value) = plan.metadata.get("generic_lab_command_replay") else {
+        return Ok(None);
+    };
+    let replay: GenericLabCommandReplay =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            Error::validation_invalid_argument(
+                "generic_lab_command_replay",
+                format!("persisted Lab replay plan is malformed: {error}"),
+                Some(plan.plan_id.clone()),
+                None,
+            )
+        })?;
+    if replay.schema != GENERIC_LAB_COMMAND_REPLAY_SCHEMA
+        || replay.normalized_args.is_empty()
+        || replay.materialization.canonical_root.trim().is_empty()
+        || replay.materialization.content_identity.trim().is_empty()
+    {
+        return Err(Error::validation_invalid_argument(
+            "generic_lab_command_replay",
+            "persisted Lab replay plan lacks required rematerialization identity",
+            Some(plan.plan_id.clone()),
+            None,
+        ));
+    }
+    Ok(Some(replay))
 }
 
 #[derive(Debug)]
@@ -2148,6 +2294,33 @@ fn materialize_agent_task_retry_handoff(
     }
     let record = retry_result.record;
     let plan = agent_task_lifecycle::load_plan(&record.run_id)?;
+    if let Some(replay) = generic_lab_command_replay(&plan)? {
+        let primary_workspace = PathBuf::from(&replay.materialization.canonical_root);
+        let current_identity =
+            homeboy::runner::controller_workspace_materialization_identity(&primary_workspace)?;
+        if current_identity != replay.materialization.content_identity {
+            let error = Error::validation_invalid_argument(
+                "workspace",
+                "agent-task retry refused a source workspace whose content no longer matches the persisted Lab replay identity",
+                Some(primary_workspace.display().to_string()),
+                Some(vec!["Restore the recorded workspace content or reissue the original command as a new run.".to_string()]),
+            );
+            agent_task_lifecycle::record_pre_execution_failure(
+                &record.run_id,
+                &plan,
+                "validate_retry_workspace_identity",
+                &error,
+            )?;
+            return Err(error);
+        }
+        return Ok(Some(AgentTaskRetryHandoff {
+            args: replay.normalized_args,
+            run_id: record.run_id,
+            plan,
+            primary_workspace,
+            replays_generic_command: true,
+        }));
+    }
     let primary_workspace = match retry_plan_primary_workspace(&plan) {
         Ok(workspace) => workspace,
         Err(error) => {
@@ -2190,6 +2363,7 @@ fn materialize_agent_task_retry_handoff(
         run_id: record.run_id,
         plan,
         primary_workspace,
+        replays_generic_command: false,
     }))
 }
 

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -45,6 +45,10 @@ fn detached_planless_handoff_persists_explicit_bench_label_before_handoff() {
                 "--run-id".to_string(),
                 "ssi-fixture-37-20260727-runtime-fixed".to_string(),
             ],
+            source.path(),
+            &lab_offload_command(&Cli::parse_from(["homeboy", "bench"]).command)
+                .expect("bench contract")
+                .expect("portable bench"),
             decision.clone(),
         )
         .expect("persist detached bench handoff");
@@ -79,14 +83,127 @@ fn detached_planless_handoff_reuses_the_same_explicit_bench_label() {
             Some(source.path()),
         )
         .expect("placement decision");
-        let first = materialize_generic_detached_lab_handoff(&args, decision.clone())
-            .expect("first handoff");
+        let command = lab_offload_command(&Cli::parse_from(["homeboy", "bench"]).command)
+            .expect("bench contract")
+            .expect("portable bench");
+        let first = materialize_generic_detached_lab_handoff(
+            &args,
+            source.path(),
+            &command,
+            decision.clone(),
+        )
+        .expect("first handoff");
         let second =
-            materialize_generic_detached_lab_handoff(&args, decision).expect("replayed handoff");
+            materialize_generic_detached_lab_handoff(&args, source.path(), &command, decision)
+                .expect("replayed handoff");
 
         assert_eq!(first.run_id, second.run_id);
         assert_eq!(first.plan.plan_id, second.plan.plan_id);
         assert!(agent_task_lifecycle::status(&first.run_id).is_ok());
+    });
+}
+
+#[test]
+fn failed_detached_bench_retry_replays_the_persisted_workspace_and_inputs() {
+    crate::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source workspace");
+        git_init(source.path());
+        let original = [
+            "homeboy",
+            "--placement",
+            "lab",
+            "--detach-after-handoff",
+            "bench",
+            "blocks-engine",
+            "--run-id",
+            "bench-pre-provider-failure",
+            "--rig",
+            "ssi-fixtures",
+            "--extension",
+            "blocks-engine=refs/pull/748/head",
+            "--setting-json",
+            "fixture={\"id\":37}",
+        ];
+        let cli = Cli::parse_from(original);
+        let args = original
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect::<Vec<_>>();
+        let command = lab_offload_command(&cli.command)
+            .expect("bench contract")
+            .expect("portable bench");
+        let decision = placement_decision(&cli, Some("homeboy-lab"), "bench", Some(source.path()))
+            .expect("placement decision");
+        let handoff =
+            materialize_generic_detached_lab_handoff(&args, source.path(), &command, decision)
+                .expect("persist detached bench handoff");
+        let persisted = agent_task_lifecycle::load_controller_plan(&handoff.run_id)
+            .expect("durable replay plan");
+        let replay = &persisted.metadata["generic_lab_command_replay"];
+        let expected_args = portable_deferred_args(&args);
+
+        assert_eq!(replay["normalized_args"], serde_json::json!(expected_args));
+        assert_eq!(replay["lab_command"], serde_json::json!(command));
+        assert_eq!(
+            replay["inputs"]["options"]["rig"],
+            serde_json::json!(["ssi-fixtures"])
+        );
+        assert_eq!(
+            replay["inputs"]["options"]["extension"],
+            serde_json::json!(["blocks-engine=refs/pull/748/head"])
+        );
+        assert_eq!(
+            replay["inputs"]["options"]["setting-json"],
+            serde_json::json!(["fixture={\"id\":37}"])
+        );
+        assert_eq!(
+            replay["materialization"]["canonical_root"],
+            serde_json::json!(source.path().canonicalize().expect("canonical source"))
+        );
+        assert!(replay["materialization"]["content_identity"]
+            .as_str()
+            .is_some_and(|identity| !identity.is_empty()));
+
+        agent_task_lifecycle::record_pre_execution_failure(
+            &handoff.run_id,
+            &persisted,
+            "lab_daemon_admission",
+            &Error::internal_unexpected("daemon unavailable"),
+        )
+        .expect("persist pre-provider failure");
+        let retry_args = [
+            "homeboy",
+            "agent-task",
+            "retry",
+            "bench-pre-provider-failure",
+            "--run",
+            "--new-run-id",
+            "bench-pre-provider-failure-retry1",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let retry_cli = Cli::parse_from(&retry_args);
+        let first = materialize_agent_task_retry_handoff(&retry_cli, &retry_args)
+            .expect("materialize retry")
+            .expect("retry handoff");
+        let second = materialize_agent_task_retry_handoff(&retry_cli, &retry_args)
+            .expect("idempotently rematerialize retry")
+            .expect("retry handoff");
+
+        assert!(first.replays_generic_command);
+        assert_eq!(first.run_id, "bench-pre-provider-failure-retry1");
+        assert_eq!(first.args, expected_args);
+        assert_eq!(second.args, first.args);
+        assert_eq!(second.run_id, first.run_id);
+        assert_eq!(
+            first.primary_workspace,
+            source.path().canonicalize().expect("canonical workspace")
+        );
+        assert_eq!(
+            first.plan.metadata["generic_lab_command_replay"],
+            persisted.metadata["generic_lab_command_replay"]
+        );
     });
 }
 
@@ -150,7 +267,7 @@ fn review_test_inlines_external_database_service_profile_before_lab_handoff() {
         "database_service={\"host\":\"db.lab\"}".to_string(),
     ];
 
-    let routed = inline_test_settings_profiles(&cli, &args).expect("portable settings args");
+    let routed = inline_portable_settings_profiles(&cli, &args).expect("portable settings args");
 
     assert!(!routed.iter().any(|arg| arg == "--settings-json-file"));
     let profile_setting = routed
@@ -196,7 +313,8 @@ fn credential_profile_is_rejected_without_persisting_plaintext() {
         settings.to_string_lossy().to_string(),
     ];
 
-    let error = inline_test_settings_profiles(&cli, &args).expect_err("credential profile refused");
+    let error =
+        inline_portable_settings_profiles(&cli, &args).expect_err("credential profile refused");
 
     assert!(error.message.contains("database_service.password"));
     assert!(error.message.contains("cannot be inlined"));

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -5,6 +5,18 @@ use super::*;
 use homeboy_core::build_identity;
 use homeboy_core::secret_env_plan::SECRET_ENV_PLAN_ENV_DELTA_SOURCE;
 
+pub(super) fn with_agent_task_retry_hint(
+    error: Error,
+    run_id: &str,
+    plan: Option<&homeboy_agents::agent_task_scheduler::AgentTaskPlan>,
+) -> Error {
+    if plan.is_some_and(agent_task_lifecycle::plan_has_retry_materialization_identity) {
+        error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))
+    } else {
+        error
+    }
+}
+
 /// Homeboy-owned Lab artifact directory for a given runner checkout root.
 ///
 /// Lab structured output is a Homeboy-owned artifact, not part of the synced
@@ -1168,9 +1180,11 @@ pub(crate) fn run_lab_offload_inner(
                         );
                     }
                 }
-                return Err(
-                    error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))
-                );
+                return Err(with_agent_task_retry_hint(
+                    error,
+                    run_id,
+                    request.durable_agent_task_plan,
+                ));
             }
         };
         let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
@@ -1656,9 +1670,11 @@ pub(crate) fn run_lab_offload_inner(
                         );
                     }
                 }
-                return Err(
-                    error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))
-                );
+                return Err(with_agent_task_retry_hint(
+                    error,
+                    run_id,
+                    request.durable_agent_task_plan,
+                ));
             }
         };
         let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
@@ -1712,7 +1728,7 @@ pub(crate) fn run_lab_offload_inner(
         Ok(stage) => stage,
         Err(error) => {
             let error = if let Some(run_id) = pre_acceptance_run_id.as_deref() {
-                error.with_hint(format!("Retry: homeboy agent-task retry {run_id} --run"))
+                with_agent_task_retry_hint(error, run_id, request.durable_agent_task_plan)
             } else {
                 error
             };

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -1,6 +1,36 @@
 use super::*;
 
 #[test]
+fn retry_hint_requires_persisted_materialization_identity() {
+    let missing =
+        homeboy_agents::agent_task_scheduler::AgentTaskPlan::new("missing-workspace", Vec::new());
+    let missing_error = super::super::inner::with_agent_task_retry_hint(
+        Error::internal_unexpected("admission failed"),
+        "missing-workspace",
+        Some(&missing),
+    );
+    assert!(missing_error.hints.is_empty());
+
+    let task = serde_json::from_value(serde_json::json!({
+        "task_id": "retryable",
+        "executor": { "backend": "fixture" },
+        "instructions": "retry",
+        "workspace": { "root": "/controller/worktree" }
+    }))
+    .expect("task");
+    let retryable =
+        homeboy_agents::agent_task_scheduler::AgentTaskPlan::new("retryable-workspace", vec![task]);
+    let retryable_error = super::super::inner::with_agent_task_retry_hint(
+        Error::internal_unexpected("admission failed"),
+        "retryable-workspace",
+        Some(&retryable),
+    );
+    assert!(retryable_error.hints.iter().any(|hint| hint
+        .message
+        .contains("agent-task retry retryable-workspace --run")));
+}
+
+#[test]
 fn apply_patch_step_accepts_noop_mutation_return() {
     let plan = base_lab_plan(Some(&portable_lab_command("refactor")));
 

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -109,6 +109,14 @@ mod workspace;
 pub(crate) use extension_materialization::materialize_lab_job_extension_overlays;
 pub(crate) use workspace::copy_snapshot_to_directory;
 pub use workspace::register_workspace_snapshot_provider;
+
+/// Compute the same controller workspace identity used by Lab snapshot
+/// materialization before a detached command is admitted.
+pub fn controller_workspace_materialization_identity(
+    path: &std::path::Path,
+) -> homeboy_core::error::Result<String> {
+    workspace::snapshot_identity(path, &[], &[])
+}
 // Only test code (extension::trace::canonicality) still calls verify_lab_workspace
 // directly; production goes through the LabWorkspaceProvenanceProvider hook.
 pub(crate) use workspace::update_workspace_resource_lifecycle;


### PR DESCRIPTION
## Summary

Make detached bench retries faithfully rematerialize the workspace and invocation persisted before Lab admission.

Closes #11003.

## What changed

- Persist a versioned generic Lab replay contract before detached bench admission, including normalized argv, structured inputs, Lab command, canonical workspace, content identity, repository remote, and revision.
- Inline portable bench settings profiles so replay retains the same effective settings without depending on controller-local profile files.
- Rebuild pre-provider retries from the persisted replay contract instead of controller cwd, reject changed workspace content, and preserve retry idempotency.
- Gate every pre-provider retry hint and activity action on sufficient rematerialization identity.
- Add deterministic coverage for rig, extension ref, settings, workspace identity, idempotent retry replay, and missing-identity hint suppression.

## Compatibility

Existing task-backed agent plans continue through their current workspace materialization path. The new replay metadata is additive and versioned. Legacy records without workspace identity remain readable, but no longer advertise a retry command that cannot execute.

## Verification

- `cargo fmt --all --check` passes.
- `cargo check --workspace --tests --locked` passes.
- `cargo test -p homeboy-cli failed_detached_bench_retry_replays_the_persisted_workspace_and_inputs --locked` passes.
- `cargo test -p homeboy-lab-runner retry_hint_requires_persisted_materialization_identity --locked` passes.
- `cargo test --workspace --locked` reaches one pre-existing failure in `pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_lifecycle`: `runner execution receipt has not been consumed for this claim`. The exact test fails identically on fresh `origin/main`, so it is not introduced by this branch.

## Control-plane follow-up

The original cook produced a valid recoverable patch but could not project its runner artifact back to the controller. That distinct regression is tracked in #11006 with run IDs, checksum evidence, and reproduction commands.

## AI assistance

- **Tool:** OpenCode
- **Model:** OpenAI GPT-5.6 Sol
- **Used for:** Investigated the Lab retry lifecycle, produced the initial implementation through Homeboy cook, recovered and checksum-verified the stranded candidate after the control-plane projection failure, completed regression coverage, and ran verification. Chris reviewed and owns every change.
