### PR TITLE
Make aggregate cleanup bounded and resumable

### DIFF
--- a/crates/contracts/homeboy-command-contract/src/cleanup.rs
+++ b/crates/contracts/homeboy-command-contract/src/cleanup.rs
@@ -6,8 +6,9 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
 
-#[derive(Args, Debug, PartialEq, Eq)]
+#[derive(Args, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CleanupArgs {
     /// Apply cleanup across the selected categories. Omit for inventory dry-run output.
     #[arg(long)]
@@ -46,10 +47,11 @@ pub struct CleanupArgs {
     pub cursor: Option<String>,
 
     #[command(subcommand)]
+    #[serde(skip)]
     pub command: Option<CleanupCommand>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum, Serialize, Deserialize)]
 #[value(rename_all = "kebab-case")]
 pub enum CleanupCategoryArg {
     RepoArtifacts,
@@ -80,6 +82,19 @@ pub enum CleanupCommand {
     RetainedStorage(CleanupRetainedStorageArgs),
     /// Run one configured, bounded retention pass
     AutomaticRetention,
+    /// Read compact durable progress for an asynchronous cleanup apply
+    Status(CleanupJobArgs),
+    /// Re-submit a queued durable cleanup job after an interrupted client
+    Resume(CleanupJobArgs),
+}
+
+#[derive(Args, Debug, PartialEq, Eq, Clone)]
+pub struct CleanupJobArgs {
+    /// Durable controller job identifier printed by cleanup --apply.
+    pub job_id: String,
+    /// Include the daemon's durable job record, including completed cleanup evidence.
+    #[arg(long)]
+    pub full: bool,
 }
 
 #[derive(Args, Debug, PartialEq, Eq)]
@@ -235,6 +250,14 @@ mod tests {
         ]);
         assert_eq!(parsed.cleanup.include, vec![CleanupCategoryArg::RuntimeTmp]);
         assert_eq!(parsed.cleanup.runtime_tmp_managed_older_than_days, Some(0));
+
+        let parsed =
+            CleanupParserTest::parse_from(["cleanup", "status", "cleanup-job-id", "--full"]);
+        let Some(CleanupCommand::Status(args)) = parsed.cleanup.command else {
+            panic!("expected cleanup status command");
+        };
+        assert_eq!(args.job_id, "cleanup-job-id");
+        assert!(args.full);
 
         let parsed = CleanupParserTest::parse_from([
             "cleanup",

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -221,6 +221,7 @@ impl CliRuntime {
         // core only owns the generic daemon lifecycle.
         crate::runner::register_lab_staging_controller_driver();
         crate::agents::agent_task_service::register_promotion_job_driver();
+        crate::commands::cleanup::register_cleanup_job_driver();
         let config = crate::core::defaults::load_config();
         if let Err(error) =
             crate::agents::agent_task_lifecycle::register_acceptance_verifier_from_config(

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use fs4::fs_std::FileExt;
 use homeboy::core::cleanup::{
@@ -9,6 +9,10 @@ use homeboy::core::cleanup::{
     ResourceCleanupOptions,
 };
 use homeboy::core::controller_runtime::{self, ControllerRuntimeRetentionOverrides};
+use homeboy::core::daemon::controller_job_driver::{
+    self, ControllerJobDriver, ControllerJobHandle, ControllerJobPublicError,
+};
+use homeboy::core::daemon::LocalControllerJobClient;
 use homeboy::core::defaults;
 use homeboy::core::engine;
 use homeboy::core::engine::shell::quote_arg;
@@ -127,8 +131,199 @@ pub fn run(args: CleanupArgs) -> CmdResult<Value> {
             })
             .map(|output| (output, 0)),
         Some(CleanupCommand::AutomaticRetention) => automatic_retention(),
+        Some(CleanupCommand::Status(args)) => {
+            cleanup_job_status(&args.job_id, args.full).map(|output| (output, 0))
+        }
+        Some(CleanupCommand::Resume(args)) => {
+            cleanup_job_resume(&args.job_id).map(|output| (output, 0))
+        }
+        None if args.apply => submit_cleanup(args).map(|output| (output, 0)),
         None => cleanup_inventory(args).map(|result| (result.output, result.exit_code)),
     }
+}
+
+const CLEANUP_JOB_TYPE: &str = "cleanup.inventory";
+const CLEANUP_JOB_VERSION: u32 = 1;
+
+/// Registers cleanup with the daemon's generic durable-job infrastructure. The
+/// command owns cleanup semantics; the daemon only owns process-independent
+/// admission, recovery, and durable progress.
+pub fn register_cleanup_job_driver() {
+    static REGISTERED: OnceLock<()> = OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        controller_job_driver::register_controller_job_driver(Arc::new(CleanupJobDriver))
+            .expect("register cleanup controller job driver");
+    });
+}
+
+struct CleanupJobDriver;
+
+impl ControllerJobDriver for CleanupJobDriver {
+    fn job_type(&self) -> &'static str {
+        CLEANUP_JOB_TYPE
+    }
+    fn version(&self) -> u32 {
+        CLEANUP_JOB_VERSION
+    }
+
+    fn public_request(&self, request: &Value) -> homeboy::core::Result<Value> {
+        let args: CleanupArgs =
+            serde_json::from_value(request.clone()).map_err(cleanup_job_parse_error)?;
+        Ok(serde_json::json!({
+            "mode": "apply",
+            "include_count": args.include.len(),
+            "exclude_count": args.exclude.len(),
+            "full_evidence": args.full,
+        }))
+    }
+
+    fn public_progress(&self, progress: &Value) -> homeboy::core::Result<Value> {
+        Ok(serde_json::json!({ "phase": progress.get("phase").cloned().unwrap_or(Value::Null) }))
+    }
+
+    fn public_result(&self, result: &Value) -> homeboy::core::Result<Value> {
+        Ok(compact_cleanup_result(result))
+    }
+
+    fn public_error(&self, error: &homeboy::core::Error) -> ControllerJobPublicError {
+        ControllerJobPublicError {
+            message: "durable cleanup failed; inspect cleanup status for retained evidence"
+                .to_string(),
+            data: serde_json::json!({ "code": error.code.as_str() }),
+        }
+    }
+
+    fn validate_secret_references(&self, request: &Value) -> homeboy::core::Result<()> {
+        let args: CleanupArgs =
+            serde_json::from_value(request.clone()).map_err(cleanup_job_parse_error)?;
+        if !args.apply || args.command.is_some() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "cleanup_job",
+                "durable cleanup jobs must contain an aggregate apply request",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    fn execute(
+        &self,
+        prepared: Value,
+        handle: ControllerJobHandle,
+    ) -> homeboy::core::Result<Value> {
+        self.run(prepared, handle)
+    }
+
+    fn resume(
+        &self,
+        checkpoint: Value,
+        handle: ControllerJobHandle,
+    ) -> homeboy::core::Result<Value> {
+        self.run(checkpoint, handle)
+    }
+
+    fn cancel(&self, _prepared: &Value) -> homeboy::core::Result<()> {
+        Ok(())
+    }
+}
+
+impl CleanupJobDriver {
+    fn run(&self, request: Value, handle: ControllerJobHandle) -> homeboy::core::Result<Value> {
+        let args: CleanupArgs = serde_json::from_value(request).map_err(cleanup_job_parse_error)?;
+        if handle.is_cancelled() {
+            return Ok(serde_json::json!({ "phase": "cancelled" }));
+        }
+        handle.checkpoint(serde_json::to_value(&args).map_err(|error| {
+            homeboy::core::Error::internal_json(
+                error.to_string(),
+                Some("serialize cleanup checkpoint".to_string()),
+            )
+        })?)?;
+        handle.progress(serde_json::json!({ "phase": "running" }))?;
+        let result = cleanup_inventory(args)?;
+        let output = serde_json::json!({
+            "phase": "completed",
+            "exit_code": result.exit_code,
+            "evidence": result.output,
+        });
+        handle.checkpoint(output.clone())?;
+        handle.progress(serde_json::json!({ "phase": "completed" }))?;
+        Ok(output)
+    }
+}
+
+fn cleanup_job_parse_error(error: serde_json::Error) -> homeboy::core::Error {
+    homeboy::core::Error::validation_invalid_argument(
+        "cleanup_job",
+        format!("invalid durable cleanup request: {error}"),
+        None,
+        None,
+    )
+}
+
+fn submit_cleanup(args: CleanupArgs) -> homeboy::core::Result<Value> {
+    let request = serde_json::to_value(&args).map_err(|error| {
+        homeboy::core::Error::internal_json(
+            error.to_string(),
+            Some("serialize cleanup job request".to_string()),
+        )
+    })?;
+    let digest = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, request.to_string().as_bytes());
+    let job = LocalControllerJobClient::connect()?.submit(serde_json::json!({
+        "type": CLEANUP_JOB_TYPE,
+        "version": CLEANUP_JOB_VERSION,
+        "idempotency_key": format!("cleanup-inventory-{digest}"),
+        "request": request,
+    }))?;
+    Ok(compact_cleanup_job(&job, "submitted"))
+}
+
+fn cleanup_job_status(job_id: &str, full: bool) -> homeboy::core::Result<Value> {
+    let job = LocalControllerJobClient::connect()?.status(job_id)?;
+    if full {
+        return serde_json::to_value(job).map_err(|error| {
+            homeboy::core::Error::internal_json(
+                error.to_string(),
+                Some("serialize cleanup job evidence".to_string()),
+            )
+        });
+    }
+    Ok(compact_cleanup_job(&job, "status"))
+}
+
+fn cleanup_job_resume(job_id: &str) -> homeboy::core::Result<Value> {
+    // Starting is idempotent: a running or terminal job returns its durable state.
+    Ok(compact_cleanup_job(
+        &LocalControllerJobClient::connect()?.start(job_id)?,
+        "resume",
+    ))
+}
+
+fn compact_cleanup_job(job: &homeboy::core::api_jobs::Job, command: &'static str) -> Value {
+    let job = serde_json::to_value(job).unwrap_or(Value::Null);
+    serde_json::json!({
+        "command": format!("cleanup.{command}"),
+        "job_id": job.get("id").cloned().unwrap_or(Value::Null),
+        "status": job.get("status").cloned().unwrap_or(Value::Null),
+        "progress": job.pointer("/metadata/progress").cloned().unwrap_or(Value::Null),
+        "status_command": format!("homeboy cleanup status {}", job.get("id").and_then(Value::as_str).unwrap_or("<job-id>")),
+        "evidence_command": format!("homeboy cleanup status {} --full", job.get("id").and_then(Value::as_str).unwrap_or("<job-id>")),
+    })
+}
+
+fn compact_cleanup_result(result: &Value) -> Value {
+    let evidence = result.get("evidence").unwrap_or(&Value::Null);
+    serde_json::json!({
+        "phase": result.get("phase").cloned().unwrap_or(Value::Null),
+        "exit_code": result.get("exit_code").cloned().unwrap_or(Value::Null),
+        "status": evidence.get("status").cloned().unwrap_or(Value::Null),
+        "category_count": evidence.get("category_count").cloned().unwrap_or(Value::Null),
+        "failed_category_count": evidence.get("failed_category_count").cloned().unwrap_or(Value::Null),
+        "candidate_count": evidence.get("candidate_count").cloned().unwrap_or(Value::Null),
+        "applied_count": evidence.get("applied_count").cloned().unwrap_or(Value::Null),
+        "reclaimed_bytes": evidence.get("reclaimed_bytes").cloned().unwrap_or(Value::Null),
+    })
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -218,6 +218,147 @@ impl LocalControllerJobClient {
         }
         Ok(job)
     }
+
+    /// Admit and start a typed durable controller job. The daemon, rather than
+    /// the submitting CLI process, owns execution after this method returns.
+    pub fn submit(&self, request: serde_json::Value) -> Result<crate::api_jobs::Job> {
+        let response = self
+            .client
+            .post(format!("{}/controller/jobs", self.endpoint))
+            .json(&request)
+            .send()
+            .map_err(|error| {
+                Error::internal_unexpected(format!("submit local controller job: {error}"))
+            })?;
+        let status = response.status();
+        let value: serde_json::Value = response.json().map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller-job submission".to_string()),
+            )
+        })?;
+        if !status.is_success()
+            || value.get("success").and_then(serde_json::Value::as_bool) != Some(true)
+        {
+            return Err(Error::internal_unexpected(format!(
+                "local controller job submission failed: {value}"
+            )));
+        }
+        let job: crate::api_jobs::Job =
+            serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+                Error::internal_unexpected("local controller-job submission response has no job")
+            })?)
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse local controller job".to_string()),
+                )
+            })?;
+        let response = self
+            .client
+            .post(format!(
+                "{}/controller/jobs/{}/start",
+                self.endpoint, job.id
+            ))
+            .send()
+            .map_err(|error| {
+                Error::internal_unexpected(format!(
+                    "start local controller job `{}`: {error}",
+                    job.id
+                ))
+            })?;
+        let status = response.status();
+        let value: serde_json::Value = response.json().map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller-job start".to_string()),
+            )
+        })?;
+        if !status.is_success()
+            || value.get("success").and_then(serde_json::Value::as_bool) != Some(true)
+        {
+            return Err(Error::internal_unexpected(format!(
+                "local controller job start failed: {value}"
+            )));
+        }
+        serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+            Error::internal_unexpected("local controller-job start response has no job")
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller job".to_string()),
+            )
+        })
+    }
+
+    pub fn status(&self, job_id: &str) -> Result<crate::api_jobs::Job> {
+        let response = self
+            .client
+            .get(format!("{}/jobs/{job_id}", self.endpoint))
+            .send()
+            .map_err(|error| {
+                Error::internal_unexpected(format!("read local controller job `{job_id}`: {error}"))
+            })?;
+        let status = response.status();
+        let value: serde_json::Value = response.json().map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller-job status".to_string()),
+            )
+        })?;
+        if !status.is_success()
+            || value.get("success").and_then(serde_json::Value::as_bool) != Some(true)
+        {
+            return Err(Error::internal_unexpected(format!(
+                "local controller job status failed: {value}"
+            )));
+        }
+        serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+            Error::internal_unexpected("local controller-job status response has no job")
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller job".to_string()),
+            )
+        })
+    }
+
+    pub fn start(&self, job_id: &str) -> Result<crate::api_jobs::Job> {
+        let response = self
+            .client
+            .post(format!("{}/controller/jobs/{job_id}/start", self.endpoint))
+            .send()
+            .map_err(|error| {
+                Error::internal_unexpected(format!(
+                    "start local controller job `{job_id}`: {error}"
+                ))
+            })?;
+        let status = response.status();
+        let value: serde_json::Value = response.json().map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller-job start".to_string()),
+            )
+        })?;
+        if !status.is_success()
+            || value.get("success").and_then(serde_json::Value::as_bool) != Some(true)
+        {
+            return Err(Error::internal_unexpected(format!(
+                "local controller job start failed: {value}"
+            )));
+        }
+        serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+            Error::internal_unexpected("local controller-job start response has no job")
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse local controller job".to_string()),
+            )
+        })
+    }
 }
 
 static DAEMON_JOB_STORE: OnceLock<JobStore> = OnceLock::new();

--- a/docs/cleanup-retention.md
+++ b/docs/cleanup-retention.md
@@ -12,6 +12,18 @@ Unsafe existing local artifact paths keep the run and its lifecycle directory.
 The existing cleanup inventory remains the only planner. This change does not
 add a second cleanup engine.
 
+## Durable Aggregate Apply
+
+`homeboy cleanup --apply` submits the existing aggregate inventory to the local
+controller's durable job queue and returns a compact receipt immediately. The
+daemon continues the apply if the submitting terminal disconnects. Use
+`homeboy cleanup status <job-id>` for compact progress,
+`homeboy cleanup status <job-id> --full` for the durable job evidence, and
+`homeboy cleanup resume <job-id>` to start a queued recovered job. The durable
+controller job retains the full category evidence; normal submission and status
+responses deliberately report only totals and retrieval commands. The
+`runner-downloads` category remains explicit opt-in in durable applies.
+
 Retention resolves the observation store and the artifact root once per sweep.
 Both used to be re-derived inside every per-run artifact plan, so a default
 `--limit 1000` sweep opened thousands of SQLite connections and re-ran the


### PR DESCRIPTION
## Summary
Implemented durable daemon-backed submission for \`homeboy cleanup --apply\` (#11032), returning a compact job receipt while the controller owns execution and durable result storage.

## What changed
- Added a typed \`cleanup.inventory\` controller-job driver using existing daemon admission, checkpoint, recovery, and cancellation infrastructure.
- Changed aggregate cleanup apply to submit and start a durable controller job; dry-run remains synchronous.
- Added compact \`homeboy cleanup status \<job-id\>\`, full durable evidence via \`--full\`, and idempotent \`cleanup resume \<job-id\>\`.
- Added daemon client submit, status, and start helpers.
- Preserved existing cleanup inventory, classifiers, retention rules, and runner-download opt-in behavior.
- Documented durable aggregate apply and added command-contract parsing coverage.

## How to test
1. Run `cargo +stable fmt --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo +stable test cleanup`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Aggregate apply is now asynchronous and returns a durable job receipt instead of inline category evidence. Existing dry-run and specialist cleanup behavior is unchanged. Full evidence remains retrievable through \`homeboy cleanup status \<job-id\> --full\`. Verified with \`cargo check -p homeboy-cli\`, \`cargo test -p homeboy-command-contract cleanup --lib\`, \`cargo fmt\`, and \`git diff --check\`.

## Evidence
- Base unchanged since verification: main remains at 602168bb2aff1d9dba426964d7c36077b2a379eb.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 2 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/11032
- Task objective: Implement https://github.com/Extra-Chill/homeboy/issues/11032 in a fresh candidate. A prior candidate merely persisted an observation run and then called cleanup\_inventory synchronously; that does not satisfy the issue and must not be repeated.
- Verified candidate scope: 5 changed file(s): crates/contracts/homeboy-command-contract/src/cleanup.rs, crates/homeboy-cli/src/cli\_runtime.rs, crates/homeboy-cli/src/commands/cleanup.rs, crates/homeboy-core/src/daemon/mod.rs, docs/cleanup-retention.md.
- Verified finalization base: main at 602168bb2aff1d9dba426964d7c36077b2a379eb
- deterministic gate passed: sh -lc cargo +stable fmt --check (Passed)
- deterministic gate passed: sh -lc cargo +stable test cleanup (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Inspected the existing cleanup inventory and generic controller-job lifecycle first, then reused the daemon-owned durable execution path rather than introducing a parallel cleanup engine. Evidence boundary: this change establishes durable submission, recovery checkpoints, compact output, and full result retrieval; targeted slow-child deadline and interrupted-client integration tests remain required before PR eligibility.
