### PR TITLE
Bound PR Test to the affected test closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # PR quality pipeline.
 #
-# Keep fast checks direct. Test uses Homeboy Action's restartable differential
-# DAG so candidate and baseline evidence survive independent runner retries.
+# Keep fast checks direct. Test uses Homeboy Action's changed-scope routing;
+# the workspace compile gate below covers every test target's wiring.
 
 name: CI
 
@@ -32,7 +32,7 @@ jobs:
         run: bash .github/validate-required-gates.sh --local
 
   # Non-differential safety net for crate-topology changes. The `review test`
-  # gate below is differentially scoped, so a crate extraction that orphans a
+  # gate below is changed-file scoped, so a crate extraction that orphans a
   # DONOR crate's test wiring (e.g. a test file left referencing a `super::foo`
   # module after `foo` moved to its own crate) can pass unnoticed — the donor
   # isn't in the changed scope. This job compiles EVERY crate's test target
@@ -139,8 +139,8 @@ jobs:
           comment-section-title: ${{ matrix.section_title }}
 
   # The caller job name plus the called reconciliation job name preserves the
-  # required `homeboy / Test` context. Candidate and baseline run independently;
-  # a cancelled phase can be rerun while the completed sibling artifact is reused.
+  # required `homeboy / Test` context. PRs execute the affected test closure;
+  # ambiguous source changes fail closed or use Homeboy's full-scope fallback.
   homeboy:
     name: homeboy
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
@@ -149,10 +149,11 @@ jobs:
       expected-commands: review audit,review lint,review test
       component: homeboy
       source: .
-      differential-gating: 'true'
-      baseline-commands: review test
-      execution-timeout-seconds: '3000'
-      test-timeout-seconds: '2700'
+      scope: auto
+      differential-gating: 'false'
+      baseline-commands: none
+      execution-timeout-seconds: '1800'
+      test-timeout-seconds: '1500'
       comment-section-key: test
       comment-section-title: Test
     secrets: inherit

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -68,6 +68,20 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
         !ci_workflow().contains("paths:"),
         "a required CI check cannot be path-filtered because unrelated PRs would wait forever"
     );
+
+    let test_gate = ci_workflow()
+        .split("  homeboy:\n")
+        .nth(1)
+        .expect("reusable Test gate");
+    assert!(test_gate.contains("      scope: auto"));
+    assert!(test_gate.contains("      differential-gating: 'false'"));
+    assert!(test_gate.contains("      baseline-commands: none"));
+    assert!(test_gate.contains("      execution-timeout-seconds: '1800'"));
+    assert!(test_gate.contains("      test-timeout-seconds: '1500'"));
+    assert!(
+        !test_gate.contains("baseline-commands: review test"),
+        "Test differential gating expands changed PRs to an unbounded full-workspace run"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- run the required PR Test gate with Homeboy changed-scope routing
- disable Test differential baseline execution that forced candidate and baseline across the full workspace
- retain the all-workspace test-target compile gate for crate topology and wiring coverage
- restore bounded 1500/1800 second Test budgets
- lock the bounded Test policy in the required-gates contract test

Closes #10992.

## Root cause

The required Test gate passed `differential-gating: true`. Homeboy Action deliberately removes changed-since scope from differential audit/test commands so candidate and baseline measurements are comparable. That converted every PR Test into a full `cargo test --workspace` execution.

Fresh proof run https://github.com/Extra-Chill/homeboy/actions/runs/30659016511 resolved the requested 3000/2700 second budgets and restored the candidate Cargo cache, but the full Test command still ran beyond 30 minutes. The hosted runner shut down with exit 143 before provenance upload.

The release Test in https://github.com/Extra-Chill/homeboy/actions/runs/30653091908 completed in about four minutes because changed-since routing selected only `required_gates_policy_test`. This PR gives normal PR Test runs the same affected-test closure while preserving `homeboy / Workspace Tests Compile` as the whole-workspace safety net.

Ambiguous or unmappable source changes retain Homeboy's existing fail-closed/full-fallback behavior.

## Verification

- `cargo test --test required_gates_policy_test` (2 passed; 2m13s cold compile)
- `actionlint .github/workflows/ci.yml`
- `bash .github/validate-required-gates.sh --local`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol correlated the failed full-scope PR command with the four-minute changed-scope release command, implemented the CI policy and regression contract, and ran verification. Chris Huber remains responsible for every line.