### PR TITLE
Hydrate recoverable Lab patches before Cook continuation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -702,10 +702,15 @@ pub(crate) fn record_terminal_artifact_projection(
                     .insert("runner_id".to_string(), json!(runner_id));
             }
             Err(error) => {
+                let status = if error.retryable == Some(true) {
+                    "pending"
+                } else {
+                    "failed"
+                };
                 record.ensure_metadata_object().insert(
                     "artifact_projection".to_string(),
                     json!({
-                        "status": "pending",
+                        "status": status,
                         "error": error.message,
                         "recovery_action": {
                             "kind": "fetch_and_reconcile",
@@ -725,10 +730,15 @@ pub(crate) fn record_terminal_artifact_projection(
             );
         }
         Err(error) => {
+            let status = if error.retryable == Some(true) {
+                "pending"
+            } else {
+                "failed"
+            };
             record.ensure_metadata_object().insert(
                 "artifact_projection".to_string(),
                 json!({
-                    "status": "pending",
+                    "status": status,
                     "error": error.message,
                     "recovery_action": {
                         "kind": "fetch_and_reconcile",
@@ -882,16 +892,11 @@ fn runner_id_from_artifact_provenance(aggregate: &AgentTaskAggregate) -> Result<
         .flat_map(|outcome| &outcome.artifacts)
         .filter(|artifact| {
             crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
-                && artifact.path.as_deref().is_some_and(|path| Path::new(path).is_absolute())
                 && artifact.size_bytes.is_some()
                 && artifact.sha256.is_some()
         })
         .map(|artifact| {
-            artifact
-                .metadata
-                .pointer("/source_provenance/runner_id")
-                .and_then(Value::as_str)
-                .filter(|runner_id| !runner_id.trim().is_empty())
+            artifact_runner_id(artifact)
                 .map(str::to_string)
                 .ok_or_else(|| {
                     Error::validation_invalid_argument(
@@ -914,6 +919,33 @@ fn runner_id_from_artifact_provenance(aggregate: &AgentTaskAggregate) -> Result<
     }
 }
 
+fn artifact_runner_id(artifact: &AgentTaskArtifact) -> Option<&str> {
+    artifact
+        .metadata
+        .pointer("/source_provenance/runner_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|runner_id| !runner_id.is_empty())
+}
+
+fn validate_artifact_runner_binding(
+    artifact: &AgentTaskArtifact,
+    record_runner_id: &str,
+) -> Result<()> {
+    if artifact_runner_id(artifact).is_some_and(|runner_id| runner_id != record_runner_id) {
+        return Err(Error::validation_invalid_argument(
+            "artifact.metadata.source_provenance.runner_id",
+            format!(
+                "artifact '{}' runner provenance conflicts with lifecycle runner binding '{}'",
+                artifact.id, record_runner_id
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 fn aggregate_has_runner_backed_actionable_patch(aggregate: &AgentTaskAggregate) -> bool {
     aggregate
         .outcomes
@@ -921,7 +953,7 @@ fn aggregate_has_runner_backed_actionable_patch(aggregate: &AgentTaskAggregate) 
         .flat_map(|outcome| &outcome.artifacts)
         .any(|artifact| {
             crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
-                && artifact.path.as_deref().is_some_and(|path| {
+                && artifact.path.as_deref().is_none_or(|path| {
                     let path = Path::new(path);
                     path.is_absolute() && !path.is_file()
                 })
@@ -937,9 +969,9 @@ pub(crate) fn terminal_artifact_projection_is_verified(
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
             if requires_durable_lab_projection(artifact) {
-                if artifact.path.is_none()
-                    || artifact.size_bytes.is_none()
+                if artifact.size_bytes.is_none()
                     || artifact.sha256.is_none()
+                    || (artifact.path.is_none() && record.runner_id().is_none())
                 {
                     return Ok(false);
                 }
@@ -1054,6 +1086,19 @@ mod tests {
     }
 
     #[test]
+    fn artifact_runner_provenance_must_match_the_lifecycle_binding() {
+        let artifact = artifact("patch", "patch", Some("runner-a"));
+
+        validate_artifact_runner_binding(&artifact, "runner-a").expect("matching runner binding");
+        let error = validate_artifact_runner_binding(&artifact, "runner-b")
+            .expect_err("conflicting runner identity must fail closed");
+
+        assert!(error
+            .message
+            .contains("conflicts with lifecycle runner binding"));
+    }
+
+    #[test]
     fn reusable_artifact_rejects_conflicting_persisted_logical_identity() {
         homeboy_core::test_support::with_isolated_home(|home| {
             let store = homeboy_core::observation::ObservationStore::open_initialized()
@@ -1155,24 +1200,29 @@ pub(crate) fn project_terminal_artifacts(
     let mut projection_error = None;
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
-            if crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact)
-                && (artifact.path.is_none()
-                    || artifact.size_bytes.is_none()
-                    || artifact.sha256.is_none())
+            let actionable =
+                crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact);
+            let remote_runner = record.runner_id().filter(|runner_id| {
+                super::lifecycle_ops::execution_runner_id().as_deref() != Some(*runner_id)
+            });
+            if actionable
+                && (artifact.size_bytes.is_none()
+                    || artifact.sha256.is_none()
+                    || (artifact.path.is_none() && remote_runner.is_none()))
             {
                 return Err(Error::validation_invalid_argument(
                     "artifact_projection",
                     format!(
-                        "actionable patch for run '{}', task '{}', and artifact '{}' requires path, size, and SHA-256 before controller projection",
+                        "actionable patch for run '{}', task '{}', and artifact '{}' requires a local path or authenticated runner binding, plus size and SHA-256, before controller projection",
                         record.run_id, outcome.task_id, artifact.id
                     ),
                     Some(artifact.id.clone()),
                     None,
                 ));
             }
-            let Some(path) = artifact.path.as_deref() else {
+            if artifact.path.is_none() && remote_runner.is_none() {
                 continue;
-            };
+            }
             if artifact.size_bytes.is_none() || artifact.sha256.is_none() {
                 // Unreadable/remote declarations remain visible to review only.
                 continue;
@@ -1208,9 +1258,7 @@ pub(crate) fn project_terminal_artifacts(
             )? {
                 continue;
             }
-            if let Some(runner_id) = record.runner_id().filter(|runner_id| {
-                super::lifecycle_ops::execution_runner_id().as_deref() != Some(*runner_id)
-            }) {
+            if let Some(runner_id) = remote_runner {
                 if runner_id.trim().is_empty() {
                     return Err(Error::validation_invalid_argument(
                         "runner_id",
@@ -1219,6 +1267,7 @@ pub(crate) fn project_terminal_artifacts(
                         None,
                     ));
                 }
+                validate_artifact_runner_binding(artifact, runner_id)?;
                 match controller_finalized_artifact_path(artifact)? {
                     Some(path) => {
                         let mut controller_hash = sha2::Sha256::new();
@@ -1261,7 +1310,8 @@ pub(crate) fn project_terminal_artifacts(
                                             Some(mirror.path().to_path_buf()),
                                         )
                                     },
-                                )?;
+                                )
+                                .map_err(|error| error.with_retryable(true))?;
                                 let expected_size = artifact.size_bytes.expect("checked above");
                                 let expected_sha256 =
                                     artifact.sha256.as_deref().expect("checked above");
@@ -1338,6 +1388,7 @@ pub(crate) fn project_terminal_artifacts(
                     }
                 }
             } else {
+                let path = artifact.path.as_deref().expect("local path checked above");
                 store.record_verified_artifact_with_id(
                     &record.run_id,
                     &artifact.kind,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1569,6 +1569,36 @@ pub fn status_with_options(
                     &record,
                 ) {
                     Ok(()) => {
+                        if let Some(reason) =
+                            crate::agent_task_lifecycle::terminal_artifact_projection_readiness(
+                                &record.run_id,
+                            )?
+                        {
+                            let projection_status = record
+                                .metadata
+                                .pointer("/artifact_projection/status")
+                                .and_then(Value::as_str)
+                                .unwrap_or("pending")
+                                .to_string();
+                            let run_id = record.run_id.clone();
+                            let repair_command = format!("homeboy agent-task status {run_id}");
+                            record.ensure_metadata_object().insert(
+                                "cook_continuation_scheduler".to_string(),
+                                json!({
+                                    "status": format!("artifact_projection_{projection_status}"),
+                                    "cook_id": cook_id,
+                                    "run_id": run_id,
+                                    "phase": "artifact_projection",
+                                    "message": reason,
+                                    "repair_command": repair_command,
+                                }),
+                            );
+                            store::write_record(&record)?;
+                            return Ok(AgentTaskStatusOutcome {
+                                record,
+                                runner_probe,
+                            });
+                        }
                         let existing_scheduler_status = record
                             .metadata
                             .get("cook_continuation_scheduler")

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -1606,7 +1606,7 @@ fn terminal_reconciliation_rejects_conflicting_directly_imported_artifact() {
         record_run_aggregate(&submitted.run_id, &plan, &aggregate)
             .expect("terminal state is persisted");
         let record = store::read_record(&submitted.run_id).expect("terminal record");
-        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "failed");
         assert!(record.metadata["artifact_projection"]["error"]
             .as_str()
             .is_some_and(|error| error.contains("conflicts with terminal artifact projection")));

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1415,7 +1415,7 @@ fn terminal_executor_artifact_projection_rejects_mismatched_bytes() {
         record_run_aggregate("projection-tampered", &plan, &aggregate).expect("record aggregate");
 
         let record = status("projection-tampered").expect("terminal record");
-        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "failed");
         assert!(record.metadata["artifact_projection"]["error"]
             .as_str()
             .is_some_and(|error| error.contains("does not match")));
@@ -1540,7 +1540,7 @@ fn duplicate_runner_artifact_ids_fail_closed_before_projection() {
         record_run_aggregate(&submitted.run_id, &plan, &aggregate).expect("record aggregate");
 
         let record = status(&submitted.run_id).expect("terminal record");
-        assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+        assert_eq!(record.metadata["artifact_projection"]["status"], "failed");
         assert!(record.metadata["artifact_projection"]["error"]
             .as_str()
             .is_some_and(|error| error.contains("reuses artifact id 'patch'")));

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1535,7 +1535,7 @@ fn detached_lab_handoff_upgrades_existing_observation_record() {
 }
 
 #[test]
-fn status_backfills_legacy_runner_provenance_and_mirrors_a_verified_projection_idempotently() {
+fn timed_out_recoverable_lab_candidate_hydrates_a_pathless_patch_idempotently() {
     with_isolated_home(|_| {
         use sha2::Digest;
         use std::io::{Read, Write};
@@ -1681,6 +1681,10 @@ fn status_backfills_legacy_runner_provenance_and_mirrors_a_verified_projection_i
 
         let plan = test_plan();
         let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.status = AgentTaskAggregateStatus::PartialRecoverable;
+        aggregate.totals.succeeded = 0;
+        aggregate.totals.candidate_recoverable = 1;
+        aggregate.outcomes[0].status = AgentTaskOutcomeStatus::CandidateRecoverable;
         aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
             schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
             id: "patch".to_string(),
@@ -1689,7 +1693,9 @@ fn status_backfills_legacy_runner_provenance_and_mirrors_a_verified_projection_i
             label: None,
             role: None,
             semantic_key: None,
-            path: Some("/home/runner/.homeboy/executor-finalized/patch.diff".to_string()),
+            // The production #11006 aggregate retained the typed runner artifact
+            // identity and integrity fields but omitted its producer-local path.
+            path: None,
             url: None,
             mime: Some("text/x-patch".to_string()),
             size_bytes: Some(patch.len() as u64),
@@ -1725,8 +1731,14 @@ fn status_backfills_legacy_runner_provenance_and_mirrors_a_verified_projection_i
         }
 
         let record = status("detached-run").expect("status");
+        assert_eq!(record.state, AgentTaskRunState::PartialRecoverable);
         assert_eq!(record.metadata["runner_id"], "local");
         assert_eq!(record.metadata["artifact_projection"]["status"], "complete");
+        assert_eq!(
+            terminal_artifact_projection_readiness("detached-run").expect("projection readiness"),
+            None,
+            "a verified controller mirror makes a pathless runner declaration continuable"
+        );
         let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let artifact = homeboy_core::observation::runs_service::resolve_artifact_for_run(
             &store,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -41,7 +41,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
-fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending() {
+fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_failed() {
     homeboy_core::test_support::with_isolated_home(|_| {
         for (run_id, contents) in [
             ("recovered-missing-finalized", None),
@@ -82,10 +82,10 @@ fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending() {
                 None,
                 Some(&identity),
             )
-            .expect("bridge preserves aggregate while surfacing pending projection");
+            .expect("bridge preserves aggregate while surfacing failed projection");
 
             let record = crate::agent_task_lifecycle::status(run_id).expect("lifecycle status");
-            assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+            assert_eq!(record.metadata["artifact_projection"]["status"], "failed");
             assert!(record.metadata["artifact_projection"]["error"]
                 .as_str()
                 .expect("actionable error")

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -824,6 +824,37 @@ pub fn validate_recipe_attempt_record(
             ]),
         ));
     }
+    let controller_plan = agent_task_lifecycle::load_controller_plan(run_id)?;
+    let plan_identity_matches = controller_plan.tasks.len() == attempt.plan.tasks.len()
+        && attempt.plan.tasks.iter().all(|expected| {
+            controller_plan
+                .tasks
+                .iter()
+                .find(|observed| observed.task_id == expected.task_id)
+                .is_some_and(|observed| {
+                    observed.source_refs == expected.source_refs
+                        && observed.workspace.slug == expected.workspace.slug
+                        && observed.workspace.component_id == expected.workspace.component_id
+                        && observed.workspace.branch == expected.workspace.branch
+                        && observed.workspace.base_ref == expected.workspace.base_ref
+                        && observed.workspace.task_url == expected.workspace.task_url
+                        && observed.workspace.attempt == expected.workspace.attempt
+                })
+        });
+    if !plan_identity_matches {
+        return Err(Error::validation_invalid_argument(
+            "cook_recipe.attempts.plan",
+            format!(
+                "durable controller plan for Cook `{}` attempt `{run_id}` does not match the immutable recipe repository, base, and candidate inputs",
+                recipe.cook_id
+            ),
+            Some(run_id.to_string()),
+            Some(vec![
+                "Inspect the controller-owned recipe and run plan; do not continue across repository or base identities."
+                    .to_string(),
+            ]),
+        ));
+    }
     Ok(())
 }
 
@@ -1775,8 +1806,8 @@ fn reclaim_dead_claims(root: &std::path::Path) -> Result<()> {
 mod tests {
     use super::*;
     use crate::agent_task::{
-        AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
-        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+        AgentTaskArtifact, AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome,
+        AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
     };
     use crate::agent_task_scheduler::{
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
@@ -1895,6 +1926,22 @@ mod tests {
             assert!(error
                 .message
                 .contains("observed Cook `other-cook` run `run`"));
+        });
+    }
+
+    #[test]
+    fn recipe_attempt_identity_rejects_controller_plan_base_drift() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let (mut recipe, _) = persist_recipe_run();
+            let record = crate::agent_task_lifecycle::persisted_status("run").unwrap();
+            recipe.attempts[0].plan.tasks[0].workspace.base_ref = Some("other-base".to_string());
+
+            let error = validate_recipe_attempt_record(&recipe, "run", &record)
+                .expect_err("controller plan drift must fail closed");
+
+            assert!(error
+                .message
+                .contains("does not match the immutable recipe"));
         });
     }
 
@@ -2411,6 +2458,48 @@ mod tests {
                 Some(0)
             );
             assert_eq!(executions.load(Ordering::SeqCst), 1);
+        });
+    }
+
+    #[test]
+    fn status_exposes_failed_artifact_projection_as_a_continuation_phase() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let (_, plan) = persist_recipe_run();
+            let patch = home.path().join("candidate.patch");
+            fs::write(&patch, b"candidate").expect("write candidate patch");
+            let mut aggregate = succeeded_aggregate(&plan);
+            aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+                schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                name: None,
+                label: None,
+                role: None,
+                semantic_key: None,
+                path: Some(patch.display().to_string()),
+                url: None,
+                mime: Some("text/x-patch".to_string()),
+                size_bytes: Some(9),
+                sha256: Some("0".repeat(64)),
+                metadata: serde_json::json!({ "executor_artifact_finalized": true }),
+            });
+            crate::agent_task_lifecycle::record_run_aggregate("run", &plan, &aggregate).unwrap();
+
+            let record = crate::agent_task_lifecycle::status("run").unwrap();
+
+            assert_eq!(
+                record.metadata["cook_continuation_scheduler"]["status"],
+                "artifact_projection_failed"
+            );
+            assert_eq!(
+                record.metadata["cook_continuation_scheduler"]["phase"],
+                "artifact_projection"
+            );
+            assert_eq!(
+                record.metadata["cook_continuation_scheduler"]["repair_command"],
+                "homeboy agent-task status run"
+            );
+            assert!(claim_continuation().unwrap().is_none());
         });
     }
 

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -822,10 +822,9 @@ fn delegate_cook_continue_to_runner_pinned_runtime(
     Ok(exit_code)
 }
 
-/// A newer coordinator must repair a recipe-bound terminal attempt before an
-/// older pinned runtime can resume it. Provider execution remains pinned; this
-/// exception only covers terminal work already accepted by the current Cook
-/// scheduler, so it cannot redispatch the provider.
+/// A terminal recipe-bound continuation is controller-owned. Provider execution
+/// remains pinned, but harvest, artifact hydration, gates, and finalization must
+/// run where the immutable Cook recipe is stored rather than on Lab.
 fn current_runtime_owns_terminal_cook_continuation(run_id: &str) -> homeboy::core::Result<bool> {
     let Some(recipe) = crate::agents::agent_tasks::service::load_recipe_for_attempt(run_id)? else {
         return Ok(false);
@@ -840,26 +839,7 @@ fn current_runtime_owns_terminal_cook_continuation(run_id: &str) -> homeboy::cor
         return Ok(false);
     }
     crate::agents::agent_tasks::service::validate_recipe_attempt_record(&recipe, run_id, &record)?;
-    let scheduler_cook_id = record
-        .metadata
-        .get("cook_continuation_scheduler")
-        .and_then(|scheduler| scheduler.get("cook_id"))
-        .and_then(serde_json::Value::as_str);
-    let scheduler_build = record
-        .metadata
-        .get("cook_continuation_scheduler")
-        .and_then(|scheduler| scheduler.get("coordinator_build_identity"))
-        .and_then(serde_json::Value::as_str);
-    let originating_build = record
-        .metadata
-        .get("controller_runtime")
-        .and_then(|runtime| runtime.get("originating"))
-        .and_then(|originating| originating.get("build_identity"))
-        .and_then(serde_json::Value::as_str);
-    Ok(scheduler_cook_id == Some(recipe.cook_id.as_str())
-        && scheduler_build == Some(homeboy::core::build_identity::current().display.as_str())
-        && originating_build
-            .is_some_and(|build| build != homeboy::core::build_identity::current().display))
+    Ok(true)
 }
 
 /// Fanout coordination is controller-owned and may span children from distinct
@@ -2801,7 +2781,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn terminal_cook_without_a_current_scheduler_claim_reexecutes_the_origin_runtime() {
+    fn terminal_cook_with_a_controller_recipe_does_not_route_to_lab_or_origin_runtime() {
         crate::test_support::with_isolated_home(|home| {
             let target = home.path().join("active-task-worktree");
             std::fs::create_dir(&target).expect("create active task worktree");
@@ -2890,10 +2870,10 @@ mod tests {
             )
             .expect("current runtime delegates to verified runtime A");
 
-            assert_eq!(exit_code, Some(17));
-            assert_eq!(
-                std::fs::read_to_string(invocation).expect("runtime-A invocation"),
-                format!("agent-task\ncook-continue\n{cook_id}\n--full\n")
+            assert_eq!(exit_code, None);
+            assert!(
+                !invocation.exists(),
+                "controller continuation must not re-exec"
             );
             assert_eq!(
                 crate::agents::agent_tasks::service::resolve_cook_continuation_run_id(cook_id)


### PR DESCRIPTION
Closes #11006.

## Summary
- hydrate pathless recoverable Lab patch declarations from authenticated runner provenance and verify size, SHA-256, runner, task, run, and recipe plan identity
- classify deterministic projection defects as failed and transport availability as pending, with one controller-owned status repair phase
- keep terminal recipe-bound `cook-continue` coordination on the controller instead of routing it to Lab or an origin runtime
- preserve idempotent controller projections and reject contradictory runner provenance

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --locked`
- focused regressions for pathless candidate hydration, runner-binding mismatch, recipe-plan base drift, failed projection lifecycle phase, and controller-owned continuation routing

The full workspace suite was attempted twice. It is currently not a clean local gate: the first run reproducibly failed because isolated `cleanup_next_actions` detected unrelated host daemons, tracked with evidence in #11001; the existing reverse-Cook baseline is tracked in #11036. A second run with those tests skipped exposed broad concurrent baseline failures and exceeded 40 minutes, so no unrelated daemon processes were terminated and the run was not repeated.

## AI assistance
OpenCode using OpenAI GPT-5.6 Sol produced the initial Cook candidate, reviewed and tightened artifact identity validation, added regression coverage, and ran verification. Chris reviewed and owns every line.