### PR TITLE
Fix durable cleanup response decoding

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -157,6 +157,12 @@ pub struct LocalControllerJobClient {
     client: reqwest::blocking::Client,
 }
 
+fn controller_job_response(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    value
+        .pointer("/data/body/job")
+        .or_else(|| value.pointer("/data/job"))
+}
+
 impl LocalControllerJobClient {
     pub fn connect() -> Result<Self> {
         let daemon = ensure_running(DEFAULT_ADDR)?;
@@ -201,7 +207,7 @@ impl LocalControllerJobClient {
             )));
         }
         let job: crate::api_jobs::Job =
-            serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+            serde_json::from_value(controller_job_response(&value).cloned().ok_or_else(|| {
                 Error::internal_unexpected("local controller-job cancellation response has no job")
             })?)
             .map_err(|error| {
@@ -245,7 +251,7 @@ impl LocalControllerJobClient {
             )));
         }
         let job: crate::api_jobs::Job =
-            serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+            serde_json::from_value(controller_job_response(&value).cloned().ok_or_else(|| {
                 Error::internal_unexpected("local controller-job submission response has no job")
             })?)
             .map_err(|error| {
@@ -281,7 +287,7 @@ impl LocalControllerJobClient {
                 "local controller job start failed: {value}"
             )));
         }
-        serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+        serde_json::from_value(controller_job_response(&value).cloned().ok_or_else(|| {
             Error::internal_unexpected("local controller-job start response has no job")
         })?)
         .map_err(|error| {
@@ -314,7 +320,7 @@ impl LocalControllerJobClient {
                 "local controller job status failed: {value}"
             )));
         }
-        serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+        serde_json::from_value(controller_job_response(&value).cloned().ok_or_else(|| {
             Error::internal_unexpected("local controller-job status response has no job")
         })?)
         .map_err(|error| {
@@ -349,7 +355,7 @@ impl LocalControllerJobClient {
                 "local controller job start failed: {value}"
             )));
         }
-        serde_json::from_value(value.pointer("/data/job").cloned().ok_or_else(|| {
+        serde_json::from_value(controller_job_response(&value).cloned().ok_or_else(|| {
             Error::internal_unexpected("local controller-job start response has no job")
         })?)
         .map_err(|error| {
@@ -2845,6 +2851,18 @@ mod tests {
     use crate::daemon::runner_exec_driver::{
         self, DaemonExecOutput, PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
     };
+
+    #[test]
+    fn controller_job_client_accepts_endpoint_and_legacy_response_shapes() {
+        let endpoint = json!({ "data": { "body": { "job": { "id": "endpoint" } } } });
+        let legacy = json!({ "data": { "job": { "id": "legacy" } } });
+
+        assert_eq!(
+            controller_job_response(&endpoint).unwrap()["id"],
+            "endpoint"
+        );
+        assert_eq!(controller_job_response(&legacy).unwrap()["id"], "legacy");
+    }
 
     /// Polling cadence is independent of any schedule's own cadence, and an
     /// operator can opt out of daemon-driven scheduling entirely.

--- a/tests/cleanup_next_actions.rs
+++ b/tests/cleanup_next_actions.rs
@@ -3,14 +3,23 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
+#[cfg(unix)]
 fn aggregate_repo_artifact_next_action_runs_outside_a_checkout() {
     let fixture = tempfile::tempdir().expect("fixture");
     let repository = fixture.path().join("repository");
     let invocation_dir = fixture.path().join("operator-cwd");
     let components_dir = fixture.path().join(".config/homeboy/components");
+    let tools = fixture.path().join("tools");
     std::fs::create_dir_all(repository.join("target/debug")).expect("target directory");
     std::fs::create_dir_all(&invocation_dir).expect("operator directory");
     std::fs::create_dir_all(&components_dir).expect("components directory");
+    std::fs::create_dir_all(&tools).expect("tools directory");
+    write_executable(&tools.join("ps"), "#!/bin/sh\nexit 0\n");
+    let path = format!(
+        "{}:{}",
+        tools.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
     std::fs::write(repository.join(".gitignore"), "target/\n").expect("target ignore rule");
     std::fs::write(repository.join("target/debug/app"), "artifact").expect("target artifact");
     run_git(&repository, &["init", "-b", "main"]);
@@ -37,10 +46,11 @@ fn aggregate_repo_artifact_next_action_runs_outside_a_checkout() {
     )
     .expect("component registration");
 
-    let inventory = run_cleanup(
+    let inventory = run_cleanup_with_path(
         fixture.path(),
         &invocation_dir,
         &["--include", "repo-artifacts"],
+        &path,
     );
     assert_eq!(inventory["success"], true, "{inventory:#}");
     assert_eq!(
@@ -61,9 +71,18 @@ fn aggregate_repo_artifact_next_action_runs_outside_a_checkout() {
     );
 
     let args: Vec<_> = next_command.split_whitespace().skip(2).collect();
-    let applied = run_cleanup(fixture.path(), &invocation_dir, &args);
+    let applied = run_cleanup_with_path(fixture.path(), &invocation_dir, &args, &path);
     assert_eq!(applied["success"], true, "{applied:#}");
-    assert!(!repository.join("target").exists());
+    let job_id = applied
+        .pointer("/data/job_id")
+        .and_then(Value::as_str)
+        .expect("cleanup job ID");
+    let completed = wait_for_cleanup_job(fixture.path(), &invocation_dir, job_id, &path);
+    assert_eq!(completed["data"]["status"], "succeeded", "{completed:#}");
+    let artifact_removed = !repository.join("target").exists();
+    let stopped = run_homeboy(fixture.path(), &invocation_dir, &["daemon", "stop"], &path);
+    assert_eq!(stopped["success"], true, "{stopped:#}");
+    assert!(artifact_removed);
 }
 
 #[test]
@@ -186,6 +205,22 @@ fn run_homeboy(home: &Path, cwd: &Path, args: &[&str], path: &str) -> Value {
             String::from_utf8_lossy(&output.stderr)
         )
     })
+}
+
+fn wait_for_cleanup_job(home: &Path, cwd: &Path, job_id: &str, path: &str) -> Value {
+    let mut latest = Value::Null;
+    for _ in 0..100 {
+        latest = run_cleanup_with_path(home, cwd, &["status", job_id], path);
+        if latest
+            .pointer("/data/status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| matches!(status, "succeeded" | "failed" | "cancelled"))
+        {
+            return latest;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("cleanup job did not finish: {latest:#}");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Decode controller-job responses from the daemon endpoint envelope while retaining the legacy direct response shape.
- Make the aggregate cleanup integration fixture independent of host-wide daemon processes.
- Poll the submitted durable cleanup job to terminal success and explicitly stop the fixture daemon.

Closes #11038.

## Root cause
`LocalControllerJobClient` expected jobs at `/data/job`, but mutating daemon endpoints return the standard endpoint envelope at `/data/body/job`. The existing integration test also read the host process table and leaked its isolated daemon, allowing unrelated daemon processes to mask the response bug and contaminate later tests.

## Verification
- `cargo test --test cleanup_next_actions` (passed twice consecutively)
- `cargo test -p homeboy-core controller_job_client_accepts_endpoint_and_legacy_response_shapes`
- `cargo test cleanup`
- `cargo check --workspace --tests --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

Reproduction evidence: https://github.com/Extra-Chill/homeboy/actions/runs/30671988569

## AI assistance
OpenCode with OpenAI GPT-5.6 Sol diagnosed the daemon response-envelope mismatch, implemented the shared decoder and lifecycle test repair, and ran the listed verification. Chris Huber reviewed and remains responsible for the change.