### PR TITLE
fix(release): gate declared test secrets before dependency hydration

### DIFF
--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -117,6 +117,43 @@ fn looks_like_secret_env_name(name: &str) -> bool {
     .any(|marker| name.contains(marker))
 }
 
+/// Resolve the secret identity *names* the component's test capability
+/// declares, composing static `test.secret_env` with settings-conditional
+/// `test.secret_env_projections` against the merged effective settings.
+///
+/// This is the same declaration the test runner resolves immediately before it
+/// spawns the extension child, exposed so callers can validate resolvability
+/// ahead of expensive work (release dependency hydration) instead of
+/// discovering an unresolvable declaration as a test-gate failure. Only names
+/// are produced here; no secret value is ever read.
+///
+/// Returns an empty list when the component runs its own `scripts.test` (the
+/// extension runner, and therefore the declaration, is bypassed) or when no
+/// test extension resolves.
+pub fn declared_secret_env_names(component: &Component) -> homeboy_core::Result<Vec<String>> {
+    if component.has_script(ExtensionCapability::Test) {
+        return Ok(Vec::new());
+    }
+
+    let Ok(context) = resolve_test_command(component) else {
+        return Ok(Vec::new());
+    };
+    let Some(test) = crate::load_extension(&context.extension_id)?.test else {
+        return Ok(Vec::new());
+    };
+
+    let static_names = test.secret_env.into_keys().collect::<Vec<_>>();
+    let projections = test.secret_env_projections;
+    if static_names.is_empty() && projections.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let prepared =
+        crate::execution::prepare_capability_run(&context, Some(component), None, &[], &[], false)?;
+
+    effective_secret_env_names(&static_names, &projections, &prepared.settings_json)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn build_test_runner(
     component: &Component,

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -1489,6 +1489,41 @@ mod tests {
         });
     }
 
+    /// The names callers can resolve ahead of a run must match what the runner
+    /// itself would require, so a pre-run gate cannot disagree with the gate it
+    /// is meant to front. (#10402)
+    #[test]
+    fn declared_secret_env_names_match_the_runner_requirement_without_spawning() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = conditional_secret_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            let marker = source.path().join("declared-names-child-ran");
+
+            let matching = conditional_test_component(home.path(), source.path(), "remote");
+            std::fs::write(
+                home.path()
+                    .join(".config/homeboy/extensions/conditional-secret-fixture/test.sh"),
+                format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            )
+            .expect("marker script");
+
+            assert_eq!(
+                crate::test::declared_secret_env_names(&matching).expect("matching declaration"),
+                vec!["FIRST_PROJECTED_SECRET", "SECOND_PROJECTED_SECRET"]
+            );
+
+            let local = conditional_test_component(home.path(), source.path(), "local");
+            assert!(crate::test::declared_secret_env_names(&local)
+                .expect("non-matching declaration")
+                .is_empty());
+
+            assert!(
+                !marker.exists(),
+                "resolving declared names must not spawn the test child"
+            );
+        });
+    }
+
     #[test]
     fn review_test_missing_projected_secret_fails_before_spawn() {
         homeboy_core::test_support::with_isolated_home(|home| {

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -35,6 +35,7 @@ pub(super) fn execute_release_plan_step(
         "preflight.recovery_artifacts" => Ok(Some(run_recovery_artifacts_preflight(step, context))),
         "preflight.remote_sync" => Ok(Some(run_remote_sync_preflight(step, context, None))),
         "preflight.bump_policy" => Ok(Some(run_bump_policy_preflight(step))),
+        "preflight.test_secret_env" => Ok(Some(run_test_secret_env_preflight(step, context))),
         "preflight.dependencies" => Ok(Some(run_dependencies_preflight(step, context))),
         "preflight.lint" => Ok(Some(run_lint_preflight(step, context))),
         "preflight.test" => Ok(Some(run_test_preflight(step, context))),
@@ -289,6 +290,7 @@ fn release_step_is_plan_only(step: &PlanStep) -> bool {
         && step.kind != "preflight.recovery_artifacts"
         && step.kind != "preflight.remote_sync"
         && step.kind != "preflight.bump_policy"
+        && step.kind != "preflight.test_secret_env"
         && step.kind != "preflight.dependencies"
         && step.kind != "preflight.lint"
         && step.kind != "preflight.test"
@@ -645,6 +647,32 @@ fn run_test_preflight(step: &PlanStep, context: &ReleaseExecutionContext) -> Rel
     }
 }
 
+/// Resolve the test capability's declared secret identities before dependency
+/// hydration, so a missing runner/service credential is reported as the
+/// configuration failure it is instead of a downstream test-gate failure.
+/// (#10402)
+fn run_test_secret_env_preflight(
+    step: &PlanStep,
+    context: &ReleaseExecutionContext,
+) -> ReleaseStepResult {
+    match super::planning_quality::validate_test_secret_env(context.component) {
+        // Identity names are declarations, not values, so they are safe to
+        // record as step evidence.
+        Ok(names) => ReleaseStepResult {
+            id: step.id.clone(),
+            step_type: step.kind.clone(),
+            status: ReleaseStepStatus::Success,
+            data: Some(serde_json::json!({
+                "ran": !names.is_empty(),
+                "declared_count": names.len(),
+                "declared": names,
+            })),
+            ..Default::default()
+        },
+        Err(err) => failed_result(&step.id, &step.kind, err),
+    }
+}
+
 fn successful_quality_result(step: &PlanStep, ran: bool) -> ReleaseStepResult {
     ReleaseStepResult {
         id: step.id.clone(),
@@ -721,6 +749,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
             | "preflight.recovery_artifacts"
             | "preflight.remote_sync"
             | "preflight.bump_policy"
+            | "preflight.test_secret_env"
             | "preflight.dependencies"
             | "preflight.lint"
             | "preflight.test"
@@ -980,6 +1009,9 @@ mod tests {
         )));
         assert!(!release_step_is_plan_only(&plan_step(
             "preflight.bump_policy"
+        )));
+        assert!(!release_step_is_plan_only(&plan_step(
+            "preflight.test_secret_env"
         )));
         assert!(!release_step_is_plan_only(&plan_step(
             "preflight.dependencies"

--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -24,9 +24,14 @@ pub(super) fn build_initial_preflight_plan(
         .collect();
 
     if let Some(tag_step) = early_tag_availability_step(options, false) {
+        // Tag availability is the cheapest gate and must fail before any other
+        // preflight work, including the declared-test-secret gate that now
+        // precedes dependency hydration.
         let insert_at = steps
             .iter()
-            .position(|step| step.id == "preflight.dependencies")
+            .position(|step| {
+                step.id == "preflight.test_secret_env" || step.id == "preflight.dependencies"
+            })
             .unwrap_or(steps.len());
         steps.insert(insert_at, tag_step);
     }
@@ -59,6 +64,7 @@ pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {
         "preflight.recovery_artifacts",
         "preflight.remote_sync",
         "preflight.tag_availability",
+        "preflight.test_secret_env",
         "preflight.dependencies",
         "preflight.lint",
         "preflight.test",
@@ -431,6 +437,7 @@ mod tests {
                 "preflight.recovery_artifacts",
                 "preflight.remote_sync",
                 "preflight.tag_availability",
+                "preflight.test_secret_env",
                 "preflight.dependencies",
                 "preflight.lint",
                 "preflight.test",
@@ -460,9 +467,44 @@ mod tests {
             .position(|step| step.id == "preflight.test")
             .expect("test preflight");
 
+        let secret_env = steps
+            .iter()
+            .position(|step| step.id == "preflight.test_secret_env")
+            .expect("declared test secret preflight");
+
         assert!(tag < lint, "tag availability must fail before lint runs");
         assert!(tag < test, "tag availability must fail before tests run");
+        assert!(
+            tag < secret_env,
+            "tag availability must fail before the declared-test-secret gate runs"
+        );
         assert_eq!(steps[tag].needs, vec!["preflight.remote_sync"]);
+    }
+
+    /// A missing runner/service credential must be diagnosed before dependency
+    /// hydration spends time on a release whose test gate cannot pass. (#10402)
+    #[test]
+    fn initial_preflight_plan_validates_declared_test_secrets_before_hydration() {
+        let options = ReleaseOptions {
+            bump_type: "none".to_string(),
+            ..Default::default()
+        };
+        let plan = super::build_initial_preflight_plan("fixture", &options);
+        let steps = plan.plan.steps;
+        let secret_env = steps
+            .iter()
+            .position(|step| step.id == "preflight.test_secret_env")
+            .expect("declared test secret preflight");
+        let deps = steps
+            .iter()
+            .position(|step| step.id == "preflight.dependencies")
+            .expect("dependency preflight");
+
+        assert!(
+            secret_env < deps,
+            "declared test secrets must resolve before dependencies hydrate"
+        );
+        assert_eq!(steps[deps].needs, vec!["preflight.test_secret_env"]);
     }
 
     #[test]
@@ -513,6 +555,7 @@ mod tests {
                 "preflight.head_identity",
                 "preflight.recovery_artifacts",
                 "preflight.remote_sync",
+                "preflight.test_secret_env",
                 "preflight.dependencies",
                 "preflight.lint",
                 "preflight.test",

--- a/crates/homeboy-release/src/release/plan_steps/preflight.rs
+++ b/crates/homeboy-release/src/release/plan_steps/preflight.rs
@@ -101,6 +101,13 @@ pub(in crate::release) fn build_preflight_steps(
 
     steps.extend(build_extension_release_preflight_steps(extensions));
 
+    // The test gate resolves its declared secret identities immediately before
+    // spawning the extension child. Resolving them here instead means a missing
+    // runner/service credential is diagnosed as the configuration failure it is,
+    // before dependency hydration spends time on a release that cannot pass its
+    // test gate. (#10402)
+    steps.push(build_test_secret_env_step(options));
+
     let dependencies_step = if options.skip_deps_hydration {
         disabled_step(
             "preflight.dependencies",
@@ -113,7 +120,7 @@ pub(in crate::release) fn build_preflight_steps(
             "preflight.dependencies",
             "preflight.dependencies",
             "Hydrate release dependencies",
-            vec!["preflight.bump_policy".to_string()],
+            vec!["preflight.test_secret_env".to_string()],
             StepConfig::new(),
         )
     };
@@ -157,6 +164,45 @@ pub(in crate::release) fn build_preflight_steps(
     steps
 }
 
+/// Build the declared-test-secret gate.
+///
+/// Disabled whenever the test gate itself is skipped: a release that never runs
+/// tests never resolves their secret declarations, so requiring them would block
+/// releases that are explicitly opting out of the gate. The skip decision is
+/// read back out of the shared quality planner rather than re-derived here, so
+/// this gate can never disagree with whether `preflight.test` actually runs.
+fn build_test_secret_env_step(options: &ReleaseOptions) -> PlanStep {
+    let quality = quality_plan_options(options);
+    let skip_reason = if quality.skip_checks {
+        Some(quality.skip_reason)
+    } else if quality.skip_test {
+        Some(quality.granular_skip_reason)
+    } else {
+        None
+    };
+
+    match skip_reason {
+        Some(reason) => disabled_step(
+            "preflight.test_secret_env",
+            "preflight.test_secret_env",
+            "Validate declared test secret environment",
+            string_config("reason", reason),
+        ),
+        None => ready_step(
+            "preflight.test_secret_env",
+            "preflight.test_secret_env",
+            "Validate declared test secret environment",
+            vec!["preflight.bump_policy".to_string()],
+            StepConfig::new(),
+        ),
+    }
+}
+
+fn quality_plan_options(options: &ReleaseOptions) -> QualityPlanOptions {
+    QualityPlanOptions::release_preflight("release", options.skip_checks)
+        .with_granular_skips(&options.skip_checks_granular)
+}
+
 fn build_extension_release_preflight_steps(extensions: &[ExtensionManifest]) -> Vec<PlanStep> {
     extensions
         .iter()
@@ -179,8 +225,7 @@ fn build_extension_release_preflight_steps(extensions: &[ExtensionManifest]) -> 
 }
 
 fn build_quality_steps(options: &ReleaseOptions) -> Vec<PlanStep> {
-    let mut quality_options = QualityPlanOptions::release_preflight("release", options.skip_checks)
-        .with_granular_skips(&options.skip_checks_granular);
+    let mut quality_options = quality_plan_options(options);
     quality_options.lint_needs = vec![if options.skip_deps_hydration {
         "preflight.bump_policy".to_string()
     } else {

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -30,6 +30,7 @@ fn test_build_preflight_steps() {
             "preflight.recovery_artifacts",
             "preflight.remote_sync",
             "preflight.bump_policy",
+            "preflight.test_secret_env",
             "preflight.dependencies",
             "preflight.audit",
             "preflight.lint",
@@ -226,12 +227,86 @@ fn release_plan_records_explicit_quality_preflights() {
         Some("no-release-audit-policy")
     );
     assert_eq!(dependencies.status, PlanStepStatus::Ready);
-    assert_eq!(dependencies.needs, vec!["preflight.bump_policy"]);
+    assert_eq!(dependencies.needs, vec!["preflight.test_secret_env"]);
     assert_eq!(lint.status, PlanStepStatus::Ready);
     assert_eq!(lint.needs, vec!["preflight.dependencies"]);
     assert_eq!(test.status, PlanStepStatus::Ready);
     assert_eq!(test.needs, vec!["preflight.lint"]);
     assert_eq!(changelog_bootstrap.needs, vec!["preflight.test"]);
+}
+
+/// The declared-test-secret gate resolves the identities the test child needs
+/// before hydration runs, and is disabled whenever the test gate itself is
+/// skipped. (#10402)
+#[test]
+fn release_plan_gates_declared_test_secrets_before_dependency_hydration() {
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        ..Default::default()
+    };
+
+    let steps = build_preflight_steps(&options, None, &[]);
+    let secret_env = steps
+        .iter()
+        .position(|step| step.id == "preflight.test_secret_env")
+        .expect("declared test secret step");
+    let dependencies = steps
+        .iter()
+        .position(|step| step.id == "preflight.dependencies")
+        .expect("dependencies step");
+
+    assert!(secret_env < dependencies);
+    assert_eq!(steps[secret_env].status, PlanStepStatus::Ready);
+    assert_eq!(steps[secret_env].needs, vec!["preflight.bump_policy"]);
+    assert_eq!(
+        steps[secret_env].label.as_deref(),
+        Some("Validate declared test secret environment")
+    );
+}
+
+#[test]
+fn release_plan_disables_declared_test_secret_gate_when_test_gate_is_skipped() {
+    for (options, reason) in [
+        (
+            ReleaseOptions {
+                bump_type: "patch".to_string(),
+                skip_checks: true,
+                ..Default::default()
+            },
+            "--skip-checks",
+        ),
+        (
+            ReleaseOptions {
+                bump_type: "patch".to_string(),
+                skip_checks_granular: vec!["Tests".to_string()],
+                ..Default::default()
+            },
+            "--skip-checks=<check>",
+        ),
+    ] {
+        let steps = build_preflight_steps(&options, None, &[]);
+        let secret_env = steps
+            .iter()
+            .find(|step| step.id == "preflight.test_secret_env")
+            .expect("declared test secret step");
+        let test = steps
+            .iter()
+            .find(|step| step.id == "preflight.test")
+            .expect("test step");
+
+        assert_eq!(secret_env.status, PlanStepStatus::Disabled);
+        assert_eq!(
+            secret_env
+                .inputs
+                .get("reason")
+                .and_then(|value| value.as_str()),
+            Some(reason)
+        );
+        // The gate exists only to front `preflight.test`; it must never be
+        // enabled while the gate it fronts is disabled.
+        assert_eq!(test.status, secret_env.status);
+        assert_eq!(test.inputs.get("reason"), secret_env.inputs.get("reason"));
+    }
 }
 
 #[test]

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -269,6 +269,33 @@ fn lint_workflow_failure(
     error
 }
 
+/// Validate that every secret identity the component's test capability declares
+/// can be resolved from an authorized controller source.
+///
+/// The test runner resolves these immediately before spawning the extension
+/// child, so an unresolvable declaration surfaces as a test-gate failure after
+/// dependency hydration has already run — and reads like a component test
+/// failure rather than the runner/service misconfiguration it is. Running the
+/// same resolver ahead of hydration fails closed at the point of diagnosis
+/// instead. (#10402)
+///
+/// Returns the declared identity names, which are safe to report. Resolved
+/// values are discarded here; only the test child ever receives them.
+pub(super) fn validate_test_secret_env(component: &Component) -> Result<Vec<String>> {
+    let names = extension::test::declared_secret_env_names(component)?;
+    if names.is_empty() {
+        return Ok(names);
+    }
+
+    homeboy_core::secret_env::resolve_local_required(
+        names.clone(),
+        "test.secret_env",
+        "extension child",
+    )?;
+
+    Ok(names)
+}
+
 /// Run release tests via the component's extension.
 ///
 /// Returns whether a test command was available and executed. Missing test
@@ -470,7 +497,7 @@ fn is_runner_infrastructure_failure(output: &extension::RunnerOutput) -> bool {
 mod tests {
     use super::{
         code_quality_failure_message, is_runner_infrastructure_failure, validate_lint_quality,
-        validate_test_quality, LintQualityOutcome,
+        validate_test_quality, validate_test_secret_env, LintQualityOutcome,
     };
     use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
     use homeboy_core::error::Error;
@@ -932,6 +959,104 @@ mod tests {
             assert!(error.message.contains("PROJECTED_RELEASE_SECRET"));
             assert!(!error.to_string().contains("available-static-secret"));
             assert!(!marker.exists());
+        });
+    }
+
+    /// The declared-test-secret gate must reach the same verdict the test
+    /// runner would, without hydrating dependencies or spawning the child, and
+    /// must report identity names rather than a test failure. (#10402)
+    #[test]
+    fn validate_test_secret_env_rejects_missing_conditional_identity_without_spawning() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = test_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            let marker = source.path().join("preflight-child-ran");
+            let component = conditional_extension_test_component(
+                home.path(),
+                source.path(),
+                &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            );
+            std::env::set_var("DECLARED_RELEASE_SECRET", "available-static-secret");
+            std::env::remove_var("PROJECTED_RELEASE_SECRET");
+
+            let error = validate_test_secret_env(&component)
+                .expect_err("missing projected identity blocks the release before hydration");
+            std::env::remove_var("DECLARED_RELEASE_SECRET");
+
+            assert_eq!(error.details["field"], "test.secret_env");
+            assert!(error.message.contains("PROJECTED_RELEASE_SECRET"));
+            assert!(
+                !error.to_string().contains("available-static-secret"),
+                "resolved values must never reach the diagnostic"
+            );
+            assert!(
+                !marker.exists(),
+                "the gate must not spawn the extension test child"
+            );
+        });
+    }
+
+    #[test]
+    fn validate_test_secret_env_reports_resolvable_identities_by_name() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = test_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            let marker = source.path().join("preflight-child-ran");
+            let component = conditional_extension_test_component(
+                home.path(),
+                source.path(),
+                &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+            );
+            std::env::set_var("DECLARED_RELEASE_SECRET", "available-static-secret");
+            std::env::set_var("PROJECTED_RELEASE_SECRET", "available-projected-secret");
+
+            let names =
+                validate_test_secret_env(&component).expect("declared identities all resolve");
+            std::env::remove_var("DECLARED_RELEASE_SECRET");
+            std::env::remove_var("PROJECTED_RELEASE_SECRET");
+
+            assert_eq!(
+                names,
+                vec!["DECLARED_RELEASE_SECRET", "PROJECTED_RELEASE_SECRET"]
+            );
+            assert!(!marker.exists());
+        });
+    }
+
+    /// A component with no declared test secrets must stay releasable, and a
+    /// non-matching projection must not manufacture a requirement.
+    #[test]
+    fn validate_test_secret_env_is_inert_without_matching_declarations() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let _guard = test_env_guard();
+            let source = tempfile::tempdir().expect("source dir");
+            let mut component = conditional_extension_test_component(
+                home.path(),
+                source.path(),
+                "#!/bin/sh\nexit 0\n",
+            );
+            component
+                .extensions
+                .as_mut()
+                .and_then(|extensions| extensions.get_mut("release-test-fixture"))
+                .expect("release extension")
+                .settings
+                .insert("service".to_string(), serde_json::json!({"mode":"local"}));
+            std::env::set_var("DECLARED_RELEASE_SECRET", "available-static-secret");
+            std::env::remove_var("PROJECTED_RELEASE_SECRET");
+
+            assert_eq!(
+                validate_test_secret_env(&component)
+                    .expect("non-matching projection requires no conditional identity"),
+                vec!["DECLARED_RELEASE_SECRET"]
+            );
+            std::env::remove_var("DECLARED_RELEASE_SECRET");
+
+            assert!(
+                validate_test_secret_env(&component_without_quality_runners())
+                    .expect("a component without a test extension declares nothing")
+                    .is_empty()
+            );
         });
     }
 

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -33,6 +33,7 @@ Common executable step kinds include:
 - `preflight.working_tree`
 - `preflight.remote_sync`
 - `preflight.bump_policy`
+- `preflight.test_secret_env`
 - `preflight.lint`
 - `preflight.test`
 - `preflight.changelog_bootstrap`
@@ -51,6 +52,15 @@ Common executable step kinds include:
 
 Some preflight and changelog planning steps are plan-only. They appear in the
 release plan for visibility but are not executed as mutating steps.
+
+`preflight.test_secret_env` resolves the secret identities the component's test
+extension declares — static `test.secret_env` plus any settings-conditional
+`test.secret_env_projections` — against the merged effective settings. It runs
+before `preflight.dependencies` so an unresolvable runner/service credential is
+reported as the configuration failure it is, rather than as a test-gate failure
+after hydration has already run. Only identity names are recorded as step
+evidence; resolved values reach the test child and nothing else. The step is
+disabled whenever the test gate itself is skipped.
 
 ## Extension Boundary
 


### PR DESCRIPTION
Closes #10402

## What was already fixed

The reported failure — the WordPress PHPUnit adapter throwing
`wp_codebox_database_service secret environment variable is unavailable: WP_CODEBOX_DB_HOST`
straight out of `wp-codebox-phpunit-adapter.mjs` — is closed on current main by
the `test.secret_env_projections` contract (#10852) plus the WordPress
extension's declaration of it (homeboy-extensions #2494, shipped in
`wordpress-v3.34.22`).

Verified on this host against the installed binary (`homeboy 0.326.0`, which
contains `c594c55da`) with a fixture component configured for
`wp_codebox_database_service.provider = external`:

```
$ homeboy review test wpdbsecret-fixture
"summary": "Invalid argument 'test.secret_env': missing required extension child
            secret env: WP_CODEBOX_DB_HOST, WP_CODEBOX_DB_PASSWORD,
            WP_CODEBOX_DB_PORT, WP_CODEBOX_DB_USER"
"tried": ["Export each declared variable in the controller environment, or
          configure an authorized Homeboy secret mapping with
          `homeboy agent-task auth map-env` / `homeboy agent-task auth set-keychain`.", ...]
```

With the four identities exported the adapter proceeds past
`resolveDatabaseService` and reaches PHPUnit discovery. No raw JS stack trace,
and the child never starts when an identity is missing.

## What this PR fixes

The issue's second expectation is not yet met:

> If the service is unavailable, preflight should diagnose the missing
> runner/service configuration **before dependency hydration** rather than
> presenting it as a component test failure.

`ExtensionRunner::run` resolves the declaration immediately before it spawns the
child, so on the release path that verdict lands inside `preflight.test` — after
`preflight.dependencies` has already hydrated npm/composer, and under the step
an operator reads as "this component's tests failed". A missing runner/service
credential is neither of those things.

This adds `preflight.test_secret_env`:

- ordered after `preflight.bump_policy`, before `preflight.dependencies`, which
  now `needs` it
- `preflight.tag_availability` still precedes it, so the cheapest gate stays first
- resolves the *same* declaration through the *same* resolver
  (`secret_env::resolve_local_required`) and does nothing else — no hydration,
  no child spawn
- executable and a show-stopper, so a failure halts the pipeline rather than
  degrading into a plan-only note

The gate reads its skip decision back out of `QualityPlanOptions` instead of
re-deriving `--skip-checks` / `--skip-checks=test` handling locally, so it can
never be enabled while the `preflight.test` gate it fronts is disabled. A test
pins that parity.

Identity names are recorded as step evidence (they are declarations, not
values). Resolved values are dropped here; only the test child ever receives
them, and the existing redaction path is untouched.

`homeboy_extension::test::declared_secret_env_names` exposes the composition —
static `test.secret_env` plus any matching `secret_env_projections` evaluated
against merged effective settings — without preparing a run. It returns empty
for components that run their own `scripts.test`, since those bypass the
extension runner and therefore the declaration entirely.

Nothing WordPress- or WP-Codebox-specific enters homeboy: the gate only knows
about the generic `test.secret_env` / `test.secret_env_projections` contract.

## Verification

```
cargo fmt
cargo check -p homeboy-extension -p homeboy-release --lib --tests     # clean
cargo clippy -p homeboy-extension -p homeboy-release --lib --tests    # no new findings
cargo test -p homeboy-release --lib -- release::planning_quality::tests::validate_test_secret_env \
    release::execution_plan::tests release::plan_steps::tests release::execution_dispatch::tests
cargo test -p homeboy-extension --lib -- test::run::tests::declared_secret_env_names \
    test::run::tests::review_test_ test::tests::conditional
homeboy review audit homeboy --path .                                  # 2903 -> 2897 findings
```

New tests:

- `validate_test_secret_env_rejects_missing_conditional_identity_without_spawning`
  — asserts `error_details.field == "test.secret_env"`, that the missing
  identity is named, that no resolved value reaches the diagnostic, and that the
  child marker file is never created
- `validate_test_secret_env_reports_resolvable_identities_by_name`
- `validate_test_secret_env_is_inert_without_matching_declarations`
- `declared_secret_env_names_match_the_runner_requirement_without_spawning` —
  parity between the pre-run gate and the runner's own requirement
- `initial_preflight_plan_validates_declared_test_secrets_before_hydration`
- `release_plan_gates_declared_test_secrets_before_dependency_hydration`
- `release_plan_disables_declared_test_secret_gate_when_test_gate_is_skipped`

Per this host's build policy the full suite is left to CI. One unrelated
pre-existing flake was observed under parallel execution
(`release_plan_warns_when_configured_extensions_have_no_publish_action` races on
`with_isolated_home` and fails with `ExtensionNotFound: wordpress`); it passes
in isolation and touches `build_release_steps`, not this change.
