### PR TITLE
test: pin the durable cleanup submission receipt contract

### DIFF
--- a/tests/cleanup_next_actions.rs
+++ b/tests/cleanup_next_actions.rs
@@ -77,6 +77,24 @@ fn aggregate_repo_artifact_next_action_runs_outside_a_checkout() {
         .pointer("/data/job_id")
         .and_then(Value::as_str)
         .expect("cleanup job ID");
+
+    // The submission receipt is the operator's only handle on work that has not
+    // finished yet. Assert it names the job and hands back the exact commands
+    // that reach its status and evidence, so a durable handoff can never return
+    // an unfollowable job.
+    assert!(!job_id.is_empty());
+    assert_eq!(applied["data"]["status"], "running", "{applied:#}");
+    assert_eq!(
+        applied["data"]["status_command"],
+        format!("homeboy cleanup status {job_id}"),
+        "{applied:#}"
+    );
+    assert_eq!(
+        applied["data"]["evidence_command"],
+        format!("homeboy cleanup status {job_id} --full"),
+        "{applied:#}"
+    );
+
     let completed = wait_for_cleanup_job(fixture.path(), &invocation_dir, job_id, &path);
     assert_eq!(completed["data"]["status"], "succeeded", "{completed:#}");
     let artifact_removed = !repository.join("target").exists();

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -901,6 +901,8 @@ fn controller_job_outlives_tcp_client_after_durable_response_handoff() {
         .expect("submit durable job")
         .json()
         .expect("parse durable job response");
+    assert_eq!(submitted["success"], true);
+    assert_eq!(submitted["data"]["endpoint"], "controller.jobs.create");
     let job_id = submitted["data"]["body"]["job"]["id"]
         .as_str()
         .expect("durable job ID")


### PR DESCRIPTION
Rebased onto `main`. Both conflicts resolved in favor of `main`, which had
independently landed the substance of this branch:

- **`crates/homeboy-core/src/daemon/mod.rs`** — this branch changed five call
  sites from an inline pointer to `/data/body/job`. `main` now routes all five
  through `controller_job_response()`, which tries `/data/body/job` and falls
  back to `/data/job`. That is a strict superset of this branch's fix, so the
  branch's version was dropped entirely.
- **`tests/cleanup_next_actions.rs`** — the "wait for asynchronous cleanup
  completion" commit became empty. `main` already waits via
  `wait_for_cleanup_job`, asserts the terminal status is `succeeded`, and stops
  the daemon before asserting the filesystem effect. That is the stronger form
  of what this branch's second commit did, so it was dropped.

## What survives

Only the coverage that `main` does not already have:

- `aggregate_repo_artifact_next_action_runs_outside_a_checkout` now asserts the
  **submission receipt** before waiting — non-empty `job_id`, `status ==
  "running"`, and that `status_command` / `evidence_command` are exactly
  `homeboy cleanup status {job_id}` and `homeboy cleanup status {job_id} --full`.
  A durable handoff cannot return a job the operator has no command to follow.
  This pins acceptance criterion 4 of #11032 ("Expose status/evidence/resume
  commands for the run").
- `controller_job_outlives_tcp_client_after_durable_response_handoff` now
  asserts the response envelope itself (`success == true`,
  `data.endpoint == "controller.jobs.create"`) rather than only reaching through
  it for the job ID. The decoding bug this branch was opened for was a
  disagreement about that envelope's shape; the test that covers the boundary
  now describes it.

## Scope change

This no longer closes #11032 — the decoding defect is already fixed on `main`,
and #11032 is a broader contract issue with seven requirements. Retitled from
"Fix durable cleanup submission response" accordingly. Refs #11032.

## Verification

```
cargo fmt --check
cargo check -p homeboy --lib --tests        # clean
cargo check -p homeboy --test cleanup_next_actions
```

Execution of these two tests needs a built binary and a live daemon, so it is
left to CI per this host's build policy.

## AI Assistance

Original change prepared with OpenCode using `openai/gpt-5.6-sol`. Conflict
resolution and rescoping performed by Claude. Chris Huber reviewed the diff and
remains responsible for the change.
