### PR TITLE
fix(daemon): make the response envelope one contract, not two

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -157,10 +157,14 @@ pub struct LocalControllerJobClient {
     client: reqwest::blocking::Client,
 }
 
+/// Extract the `job` a controller-job endpoint returned.
+///
+/// Reaches the payload through [`daemon_endpoint_payload`] rather than spelling
+/// the wire path again, so this reader cannot drift away from the writer that
+/// produced it. Both the `/controller/jobs*` routes and the read-only
+/// `GET /jobs/<id>` route place the job at the same key inside that payload.
 fn controller_job_response(value: &serde_json::Value) -> Option<&serde_json::Value> {
-    value
-        .pointer("/data/body/job")
-        .or_else(|| value.pointer("/data/job"))
+    daemon_endpoint_payload(value)?.get("job")
 }
 
 impl LocalControllerJobClient {
@@ -1849,6 +1853,26 @@ fn daemon_freshness_report(job_store: &JobStore) -> Result<DaemonFreshnessReport
     Ok(freshness_report_from_validation(&validation, active_jobs))
 }
 
+/// JSON pointer to an endpoint payload inside a fully written daemon response.
+///
+/// This is the *one* place the wire path is spelled. Both producers of the
+/// envelope ([`daemon_endpoint_response`] and the read-only API's
+/// `HttpApiResponse`, which serializes to the same `{status, endpoint, body}`
+/// shape) sit beside it, and [`daemon_endpoint_payload`] is the only reader.
+/// A client that spells the path itself is how the durable controller-job
+/// submission shipped reading `/data/job` against a daemon that has only ever
+/// written `/data/body/job`. (#11032)
+const DAEMON_ENDPOINT_PAYLOAD_POINTER: &str = "/data/body";
+
+/// Read an endpoint payload back out of a written daemon response.
+///
+/// Deliberately has no fallback. Accepting a second shape would let the reader
+/// keep succeeding after the writer moved, which converts the next envelope
+/// drift from a loud failure into a silent one.
+pub(crate) fn daemon_endpoint_payload(response: &serde_json::Value) -> Option<&serde_json::Value> {
+    response.pointer(DAEMON_ENDPOINT_PAYLOAD_POINTER)
+}
+
 pub(super) fn daemon_endpoint_response(endpoint: &str, body: serde_json::Value) -> HttpResponse {
     HttpResponse {
         status_code: 200,
@@ -2852,16 +2876,81 @@ mod tests {
         self, DaemonExecOutput, PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
     };
 
+    /// Round-trip the envelope through the exact functions that build it on the
+    /// wire, then read it with the client's reader.
+    ///
+    /// This is the seam that shipped inverted in v0.326.1: the daemon wrote the
+    /// job at `data.body.job` while `LocalControllerJobClient` read `data.job`,
+    /// and every `homeboy cleanup --apply` failed with "local controller-job
+    /// submission response has no job". Both sides were individually covered —
+    /// the daemon test asserted its own output shape, the client had no test at
+    /// all — so nothing observed that they disagreed. Composing the real writer
+    /// with the real reader is what makes that disagreement a test failure
+    /// instead of a release. (#11032)
     #[test]
-    fn controller_job_client_accepts_endpoint_and_legacy_response_shapes() {
-        let endpoint = json!({ "data": { "body": { "job": { "id": "endpoint" } } } });
-        let legacy = json!({ "data": { "job": { "id": "legacy" } } });
+    fn controller_job_reader_recovers_the_job_the_daemon_writer_produced() {
+        let routed = daemon_endpoint_response(
+            "controller.jobs.create",
+            json!({ "job": { "id": "written-by-the-daemon" } }),
+        );
+        let wire = daemon_response_envelope(routed.status_code, &routed.body);
+
+        assert_eq!(wire["success"], true);
+        assert_eq!(
+            controller_job_response(&wire).expect("reader recovers the written job")["id"],
+            "written-by-the-daemon"
+        );
+    }
+
+    /// `LocalControllerJobClient::status` polls the read-only `GET /jobs/<id>`
+    /// route, which builds its envelope from `HttpApiResponse` rather than
+    /// [`daemon_endpoint_response`]. Two independent producers of one shape is
+    /// exactly how these drift, so pin the second one through the same reader.
+    #[test]
+    fn controller_job_reader_recovers_the_job_the_read_only_api_produced() {
+        let api = crate::http_api::HttpApiResponse {
+            status: 200,
+            endpoint: "jobs.show".to_string(),
+            body: json!({ "command": "api.jobs.show", "job": { "id": "read-only-api" } }),
+        };
+        let routed = serde_json::to_value(&api).expect("serialize read-only API response");
+        let wire = daemon_response_envelope(api.status, &routed);
 
         assert_eq!(
-            controller_job_response(&endpoint).unwrap()["id"],
-            "endpoint"
+            controller_job_response(&wire).expect("reader recovers the API-written job")["id"],
+            "read-only-api"
         );
-        assert_eq!(controller_job_response(&legacy).unwrap()["id"], "legacy");
+    }
+
+    /// The reader must fail closed on a shape no producer emits. A tolerant
+    /// reader that also accepted `data.job` would keep returning `Some` after a
+    /// writer moved, turning the next envelope drift into silent wrong data
+    /// rather than the loud error that surfaced this bug.
+    #[test]
+    fn controller_job_reader_rejects_shapes_no_producer_writes() {
+        for foreign in [
+            json!({ "data": { "job": { "id": "never-written-by-any-route" } } }),
+            json!({ "job": { "id": "unwrapped" } }),
+            json!({ "data": { "body": { "not_a_job": {} } } }),
+            json!({ "success": true }),
+        ] {
+            assert!(
+                controller_job_response(&foreign).is_none(),
+                "reader accepted a shape no daemon route produces: {foreign}"
+            );
+        }
+    }
+
+    /// A failed response carries its payload at the same pointer, so a client
+    /// reading a 4xx envelope sees "no job" rather than a decode panic.
+    #[test]
+    fn failed_daemon_responses_keep_the_payload_pointer_stable() {
+        let wire = daemon_response_envelope(400, &json!({ "error": "bad_request" }));
+
+        assert_eq!(wire["success"], false);
+        assert_eq!(wire["error"], wire["data"]);
+        assert_eq!(daemon_endpoint_payload(&wire), None);
+        assert!(controller_job_response(&wire).is_none());
     }
 
     /// Polling cadence is independent of any schedule's own cadence, and an
@@ -4265,19 +4354,30 @@ fn http_content_length(headers: &str) -> Option<usize> {
     })
 }
 
+/// Wrap a routed [`HttpResponse`] body in the outer transport envelope written
+/// to the socket.
+///
+/// Extracted from [`write_http_response`] so the shape a client actually
+/// receives is reachable from a test without a TCP listener. The `data` key
+/// added here is the first segment of [`DAEMON_ENDPOINT_PAYLOAD_POINTER`].
+fn daemon_response_envelope(status_code: u16, body: &serde_json::Value) -> serde_json::Value {
+    let success = (200..300).contains(&status_code);
+    let mut envelope = json!({
+        "success": success,
+        "data": body,
+    });
+    if !success {
+        envelope["error"] = envelope["data"].clone();
+    }
+    envelope
+}
+
 fn write_http_response(mut stream: TcpStream, response: &HttpResponse) -> std::io::Result<()> {
     if let Some(artifact) = response.artifact.clone() {
         return artifact_download::write_response(stream, response.status_code, artifact);
     }
 
-    let success = (200..300).contains(&response.status_code);
-    let mut envelope = json!({
-        "success": success,
-        "data": response.body,
-    });
-    if !success {
-        envelope["error"] = envelope["data"].clone();
-    }
+    let envelope = daemon_response_envelope(response.status_code, &response.body);
     let body = serde_json::to_string_pretty(&envelope)
         .unwrap_or_else(|_| "{\"success\":false}".to_string());
     let status_text = match response.status_code {


### PR DESCRIPTION
Refs #11032

## The bug, stated precisely

`homeboy cleanup --apply` fails on **every** v0.326.1 install:

```
$ homeboy cleanup --apply
"summary": "local controller-job submission response has no job"
"code": "internal.unexpected"
```

Not slow, not flaky — deterministic. And not a regression: **there has never
been a release where this worked.**

The disagreement lives inside a single released commit,
`crates/homeboy-core/src/daemon/mod.rs`. The daemon writes the job two levels
down:

```rust
body: json!({ "status": 200, "endpoint": endpoint, "body": body }),
```

and `write_http_response` wraps that in `data`, so the job lands at
`data.body.job`. The client, in the same file, read one level down:

```rust
value.pointer("/data/job")
```

Five call sites — cancel, submit, start, status, resume — all reading the same
wrong pointer.

### Timeline (2026-07-31 UTC)

| time | event |
|---|---|
| 18:28 | `v0.326.0` tagged — no durable submission path yet |
| 20:49 | `868872f39` lands `LocalControllerJobClient` reading `/data/job` |
| 22:47 | **`v0.326.1` tagged — ships it broken** |
| 00:15 | `84fa510c6` adds the `controller_job_response()` fallback |

The fix missed the release by ~90 minutes.

## Why the existing fix is not sufficient

`84fa510c6` corrected the pointer by making the reader accept **both** shapes:

```rust
value.pointer("/data/body/job").or_else(|| value.pointer("/data/job"))
```

That unblocks the symptom but widens the reader instead of restoring the
contract. A reader that tolerates the shape its writer abandoned keeps returning
`Some` after the *next* drift — converting a loud, immediately-diagnosable
failure into silent wrong data. The error message in this issue is the good
outcome; the tolerant reader trades it away.

It also enshrines a shape that **no route has ever produced**. I checked all
three ways it could be reachable:

- `/controller/jobs*` has gone through `daemon_endpoint_response` since durable
  controller jobs were introduced in `4e2327566` (Jul 21).
- `GET /jobs/<id>` — which `LocalControllerJobClient::status` polls — goes
  through `route_read_only_api` → `HttpApiResponse { status, endpoint, body }`,
  the same three fields.
- Cross-version skew is structurally impossible: `daemon_lease.rs` marks a lease
  stale on both build-identity and `binary_sha256` mismatch, so a client never
  talks to a daemon built from a different binary.

The `/data/job` branch is dead code. The unit test that covered it called the
shape "legacy", which is aspirational — there is no legacy producer.

## The fix

**Spell the wire path once.** `DAEMON_ENDPOINT_PAYLOAD_POINTER` and its only
reader `daemon_endpoint_payload` sit directly beside the writer that produces
the shape. `controller_job_response` reaches through them instead of naming the
path a second time. The fallback is deleted.

**Make the wire reachable from a test.** `daemon_response_envelope` is extracted
out of `write_http_response`, so the bytes a client actually receives can be
built without a TCP listener.

## Why nothing caught this

`tests/cleanup_next_actions.rs` at `v0.326.1` asserted only the advertised
string:

```rust
assert_eq!(next_command, "homeboy cleanup --include repo-artifacts --apply");
```

It never executed it. The test verified that homeboy *tells operators* to run
`--apply`; not that running it does anything.

`tests/core/daemon_test.rs` did read `data.body.job` correctly — but over raw
HTTP, so it covered the daemon's **output** while never touching the client's
**input** assumption. Both sides were covered. The seam between them was not.

The new tests compose the real writer with the real reader, which is what turns
that disagreement into a test failure instead of a release.

## Verification

Mutation-tested both directions, not just asserted green:

```
# reader mutated back to the v0.326.1 bug (pointer -> "/data")
test result: FAILED. 0 passed; 4 failed
  ✗ controller_job_reader_recovers_the_job_the_daemon_writer_produced
  ✗ controller_job_reader_recovers_the_job_the_read_only_api_produced
  ✗ controller_job_reader_rejects_shapes_no_producer_writes
  ✗ failed_daemon_responses_keep_the_payload_pointer_stable

# writer mutated ("body" -> "payload"), reader untouched
test result: FAILED. 1 passed; 1 failed
  ✗ controller_job_reader_recovers_the_job_the_daemon_writer_produced

# unmutated
test result: ok. 23 passed (full daemon::tests)
```

```
cargo fmt --check
cargo check -p homeboy-core --lib --tests          # clean
cargo clippy -p homeboy-core --lib --tests         # no new findings
homeboy review audit homeboy --path .              # 2897 findings, unchanged
```

Full-suite execution left to CI per this host's build policy.

## Note for release

This does not change behavior relative to current `main` — `main` already
decodes correctly via the fallback. The operator-visible breakage is confined to
`v0.326.1`, and **will not self-heal until a release ships containing
`84fa510c6`.** Worth confirming that lands before anyone else burns time on a
`cleanup --apply` that cannot succeed.
