### PR TITLE
fix(lab): run workspace shell programs under a pipefail-capable interpreter

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -411,6 +411,47 @@ fn snapshot_git_falls_back_to_filesystem_snapshot_when_git_closure_is_unavailabl
     });
 }
 
+/// A failing producer must fail the materialization even when the consumer
+/// succeeds.
+///
+/// The archive pipeline is `(cd src && prepare && tar -cf - .) | ssh runner
+/// 'tar -xf -'`. Under a plain POSIX shell the status is the *consumer's*, and
+/// `tar -xf -` exits 0 on a truncated or empty stream — so a local `tar` that
+/// died on a full disk or an unreadable file shipped a partial workspace and
+/// reported success (#11100).
+#[test]
+fn a_failing_pipeline_producer_fails_the_command() {
+    let error = super::super::util::run_shell_command(
+        "sh -c 'printf partial; exit 19' | cat",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("a failing pipeline producer must fail the command");
+
+    assert!(
+        error.message.contains("exit status 19"),
+        "the producer's status must be the reported status, not the consumer's: {}",
+        error.message
+    );
+}
+
+/// The consumer's failure must still win when it is the one that fails, so
+/// `pipefail` does not mask the SSH-side transport errors that
+/// `classify_transport_failure` depends on (#8803).
+#[test]
+fn a_failing_pipeline_consumer_still_fails_the_command() {
+    let error = super::super::util::run_shell_command(
+        "printf whole | sh -c 'exit 26'",
+        "materialize SSH workspace snapshot",
+    )
+    .expect_err("a failing pipeline consumer must fail the command");
+
+    assert!(
+        error.message.contains("exit status 26"),
+        "the consumer's status must survive: {}",
+        error.message
+    );
+}
+
 #[test]
 fn snapshot_command_failure_keeps_exit_status_and_silent_transport_cause() {
     let error =

--- a/crates/homeboy-lab-runner/src/workspace/util.rs
+++ b/crates/homeboy-lab-runner/src/workspace/util.rs
@@ -9,6 +9,47 @@ use homeboy_core::server::{self, Server, SshClient};
 
 use super::super::Runner;
 
+/// Interpreter used for every workspace shell program, chosen so a pipeline's
+/// exit status reflects *every* stage rather than only the last one.
+///
+/// Snapshot materialization hands the shell a program shaped like
+/// `(cd src && prepare && tar -cf - .) | ssh runner 'tar -xf -'`, with two
+/// further pipelines nested inside `prepare`. A POSIX shell reports only the
+/// last element's status, so a failing local `tar` — disk full, an unreadable
+/// file, a failed `mktemp`, a bad exclude — produced a truncated stream that
+/// the remote `tar -xf -` consumed happily and exited 0. The materialization
+/// was reported successful and the loss surfaced minutes later on the runner as
+/// an unrelated build or test failure, which is the most expensive shape a
+/// failure can take: the evidence points at the wrong subsystem (#11100).
+///
+/// `pipefail` cannot live in the program text. It is not POSIX, `dash` rejects
+/// it at runtime, and the materialization command is held to a
+/// `dash`-parseable contract precisely because a shell-syntax regression once
+/// reached `sh -c` unobserved (#10399). Selecting the interpreter keeps the
+/// emitted program byte-identical and portable.
+const PIPEFAIL_SHELL: &str = "bash";
+
+/// Fallback for hosts without `bash`. Pipelines then report last-stage status
+/// only, which is the pre-#11100 behavior — degraded, not broken.
+const POSIX_SHELL: &str = "sh";
+
+/// Run one shell program under a pipefail-capable interpreter.
+///
+/// Falls back to `sh` only when `bash` is genuinely absent, so a missing
+/// interpreter degrades to the historical behavior instead of failing the
+/// operation outright.
+fn shell_output(command: &str) -> std::io::Result<std::process::Output> {
+    match Command::new(PIPEFAIL_SHELL)
+        .args(["-o", "pipefail", "-c", command])
+        .output()
+    {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Command::new(POSIX_SHELL).args(["-c", command]).output()
+        }
+        other => other,
+    }
+}
+
 pub(super) fn validate_absolute_path(field: &str, path: &str) -> Result<()> {
     if path.starts_with('/') {
         return Ok(());
@@ -99,7 +140,7 @@ pub(crate) fn ssh_client_for_runner(runner: &Runner) -> Result<(Server, SshClien
 /// reading a synthetic snapshot checkout's HEAD over SSH) where a failure must
 /// not abort the surrounding operation.
 pub(crate) fn run_shell_capture(command: &str) -> Option<String> {
-    let output = Command::new("sh").args(["-c", command]).output().ok()?;
+    let output = shell_output(command).ok()?;
     if !output.status.success() {
         return None;
     }
@@ -112,9 +153,7 @@ pub(crate) fn run_shell_capture(command: &str) -> Option<String> {
 }
 
 pub(crate) fn run_shell_command(command: &str, action: &str) -> Result<()> {
-    let output = Command::new("sh")
-        .args(["-c", command])
-        .output()
+    let output = shell_output(command)
         .map_err(|err| Error::internal_io(err.to_string(), Some(action.to_string())))?;
     if output.status.success() {
         return Ok(());


### PR DESCRIPTION
Closes #11100

## The bug

Snapshot materialization hands the shell a program shaped like:

```
(cd src && prepare && tar -cf - .) | ssh runner 'tar -xf -'
```

with two further pipelines nested inside `prepare` (`workspace/snapshot.rs:1747-1800`), executed via `Command::new("sh").args(["-c", ...])` (`workspace/util.rs:114-118`).

**A POSIX shell reports only the last element's status.** So a failing local `tar` — disk full, an unreadable file, a failed `mktemp`, a bad exclude — produced a truncated stream that the remote `tar -xf -` consumed happily and exited 0.

The materialization was reported successful, and the loss surfaced minutes later on the runner as an unrelated build or test failure. That is the most expensive shape a failure can take: **the evidence points at the wrong subsystem.**

Repo-wide, `pipefail` appears in 60+ `.sh` files and every GitHub workflow — and in zero Rust-constructed shell programs.

## Why the option is not in the program text

It cannot be. `pipefail` is not POSIX, `dash` rejects it at runtime, and the materialization command is held to a dash-parseable contract precisely because a shell-syntax regression once reached `sh -c` unobserved (#10399):

```
$ dash -c 'set -o pipefail; echo reached'
dash: 1: set: Illegal option -o pipefail
```

Selecting the interpreter keeps the emitted program **byte-identical**, so every existing construction test (`snapshot_materialization_command_parses_under_posix_shells` and friends) still asserts the same string.

## Verification

| case | `sh -c` | `bash -o pipefail -c` |
|---|---|---|
| producer fails, consumer succeeds | **0 (masked)** | **19** |
| consumer fails | 26 | 26 |
| signal death (`kill -PIPE $$`) | SIGPIPE, no exit code | SIGPIPE, no exit code |

Row 3 matters: the #8803 transport classification depends on signal death surfacing with no exit code, and that is unchanged.

Two tests added covering rows 1 and 2.

## Risk

This will surface previously-hidden failures — that is the point. Falls back to `sh` only when `bash` is genuinely absent (`ErrorKind::NotFound`), degrading to the historical behavior rather than failing the operation.

Found during the 2026-08-01 consolidation investigation (#11151).