### PR TITLE
test(provider-registry): fail the build when a provider registry is never wired

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ version = "0.1.0"
 dependencies = [
  "homeboy-error",
  "homeboy-paths",
+ "inventory",
  "libc",
  "regex",
  "serde",

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -119,6 +119,220 @@ pub fn current_augmented_command_safety_manifest() -> CommandSafetyManifest {
     )
 }
 
+/// Register every provider hook the CLI wires before the startup terminal-run
+/// reconcile.
+///
+/// Split out of [`CliRuntime::run_from_args`] so the set of registrations is a
+/// named, callable list instead of an inline sequence no test could reach. An
+/// omission here is silent at runtime — a boxed provider registry with an empty
+/// slot dispatches to its no-op — so `register_all_providers` exists to give the
+/// completeness test the exact startup wiring the binary performs.
+///
+/// Order is load-bearing and preserved verbatim from the original inline block.
+pub fn register_startup_providers_before_reconcile() {
+    // Register the config-level artifact_root resolver before any command runs
+    // so paths::artifact_root() can honor global config without paths depending
+    // on the defaults layer (breaks the paths <-> defaults dependency cycle).
+    crate::core::paths::set_config_artifact_root_resolver(|| {
+        crate::core::defaults::load_config().artifact_root
+    });
+    // Register optional feature crates' config entities with core so their
+    // IDs/aliases participate in cross-entity collision detection. Core owns
+    // the collision invariant but must not depend on these optional features.
+    homeboy_tunnel::register();
+    // Register the audit manifest provider so code_audit can read extension
+    // manifests (detector rules, test mappings, provided extensions) without
+    // depending on the extension layer's loader — the seam that lets audit
+    // become its own crate.
+    // Register the in-core release provider so core's status mechanics
+    // (fleet/project/context/git change reporting/tag-gap) get deploy+release
+    // behavior through the hook. Moves out with deploy/release when they
+    // become the homeboy-release crate.
+    crate::release::provider_impl::register();
+    homeboy_extension::audit_manifest_provider::register();
+    homeboy_extension::component_script::register_component_script_runner();
+    homeboy_extension::build::register_component_build_runner();
+    homeboy_extension::lifecycle::register_component_install_runner();
+    // Register extension-backed audit providers so code_audit can load
+    // grammars and run fallback fingerprint scripts without depending on the
+    // extension registry or script runner.
+    homeboy_extension::audit_fingerprint_script_provider::register();
+    homeboy_extension::audit_grammar_source_provider::register();
+    // Register the audit recorded-artifact provider so the artifact-portability
+    // detector can read past runs' artifacts from the observation store without
+    // code_audit depending on observation — the last seam before audit becomes
+    // its own crate.
+    crate::core::observation::audit_artifact_provider::register();
+    // Register the audit fixability provider so code_audit can report how
+    // fixable its findings are without calling up into the refactor engine's
+    // fix planner — the seam that removes the last code_audit->refactor edge.
+    // Register the rig toolchain provider so core's extension exec-env
+    // builder can prepend the rig toolchain PATH.
+    crate::rig::provider::register();
+    crate::stack::provider::register();
+    crate::refactor::audit_fixability_provider::register();
+    // Register the refactor transform provider so core's extension
+    // test-drift auto-fixer can apply generated transform rules.
+    crate::refactor::transform_provider::register();
+    // Register the audit component provider so code_audit can resolve the
+    // component under audit (path, extension ids, audit rules, scope excludes)
+    // without depending on the component layer — the last cross-layer seam
+    // before audit becomes its own crate.
+    crate::core::component::audit_provider::register();
+    // Register the runner-evidence provider so observation::runs_service can
+    // enrich run/artifact lookups with live runner + daemon evidence without
+    // core depending on runner behavior. (Runner is still in-crate today;
+    // this registration is the seam that lets it become its own crate.)
+    crate::runner::register_runner_evidence_provider();
+    // Register the runner job-preparation provider so api_jobs can compute
+    // the secret-env plan and validate workload dispatch for remote-runner
+    // jobs without core depending on runner behavior.
+    crate::runner::register_runner_job_preparation_provider();
+    // Register the lab-workspace provenance provider so the agent-task
+    // scheduler can verify lab-materialized workspaces without core depending
+    // on runner behavior.
+    crate::runner::register_lab_workspace_provenance_provider();
+    // Register the runner-continuation provider so the agent-task lifecycle
+    // can reconcile and resume runs dispatched to a remote runner without
+    // core depending on runner behavior.
+    crate::runner::register_runner_continuation_provider();
+}
+
+/// Register every provider hook the CLI wires after the startup terminal-run
+/// reconcile.
+///
+/// Takes the agent-task config rather than loading it so the completeness test
+/// can drive the full registration sequence without touching the ambient home
+/// directory.
+pub fn register_startup_providers_after_reconcile(
+    agent_task: &crate::core::defaults::AgentTaskConfig,
+) -> Result<(), crate::core::error::Error> {
+    // Register the runner daemon-exec driver so the daemon's /exec endpoint
+    // can prepare and run a runner job as a local child without core
+    // depending on runner process-execution behavior.
+    crate::runner::register_runner_daemon_exec_driver();
+    // Lab owns its durable staging/dispatch controller-job interpretation;
+    // core only owns the generic daemon lifecycle.
+    crate::runner::register_lab_staging_controller_driver();
+    crate::agents::agent_task_service::register_promotion_job_driver();
+    crate::commands::cleanup::register_cleanup_job_driver();
+    // The configured acceptance verifier is the one registration that is
+    // conditional: `register_acceptance_verifier_from_config` is a no-op when
+    // no verifier is configured, which is why the completeness test treats
+    // that registry as deliberately optional.
+    crate::agents::agent_task_lifecycle::register_acceptance_verifier_from_config(agent_task)?;
+    crate::runner::enable_production_lab_staging();
+    // Register the runner workspace-root provider so the daemon file API can
+    // resolve a runner's configured workspace_root without core depending on
+    // the runner config registry.
+    crate::runner::register_runner_workspace_root_provider();
+    // Register Runner as a config entity so it participates in config
+    // id/alias collision detection, mirroring how feature crates register
+    // their own entities (moves into the runner crate once extracted).
+    crate::runner::register_runner_config_entity();
+    // Register the runner-upgrade provider so the core upgrade flow can
+    // refresh configured runners without depending on runner behavior.
+    crate::runner::register_runner_upgrade();
+    // Register the runner-availability provider so the controller action loop
+    // can gate execution on a runner's live status.
+    crate::runner::register_runner_availability_provider();
+    // Register the Lab-offload provider so core's lab_routing can execute an
+    // offload without depending on runner behavior.
+    crate::runner::register_runner_lab_offload_provider();
+    // Register the workspace-snapshot provider so core's hygiene subsystem
+    // can materialize an isolated validation-dependency workspace without
+    // depending on runner behavior.
+    crate::runner::register_workspace_snapshot_provider();
+    // Register the agent-task controller pin-reference provider so core's
+    // controller-runtime retention report can discover which pinned
+    // executables are still referenced by nonterminal durable agent-task
+    // records without core depending on the agent-task subsystem. (This is
+    // the seam that lets agent-task become its own crate.)
+    crate::agents::agent_task_lifecycle::controller_pin_reference_provider::register();
+    // Register the loop-spec validation provider so core's proof validator
+    // can validate a materialized agent-task loop-spec artifact without
+    // depending on the agent-task subsystem.
+    crate::agents::agent_task_controller_service::loop_spec_validation_provider::register();
+    // Register the gate-feedback candidate-baseline provider so core's
+    // worktree-safety logic can accept a dirty worktree that is a verified
+    // agent-task gate-feedback candidate without depending on the agent-task
+    // subsystem.
+    crate::agents::agent_task_candidate_baseline::register();
+    // Register the agent-task activity provider so core's activity report
+    // includes durable agent-task records and their health summary without
+    // depending on the agent-task subsystem.
+    crate::agents::agent_task_lifecycle::activity_provider::register();
+    // Register the bench agent-task matrix provider so core's cross-rig
+    // bench comparison can project rig entries into an agent-task matrix
+    // without depending on the agent-task subsystem.
+    crate::agents::agent_task::bench_matrix_provider::register();
+    // Register the agent-task terminal-recovery provider so core's job store
+    // can recover terminal jobs from durable agent-task runs.
+    crate::agents::api_jobs_terminal_recovery::register();
+    // Register the agent-task secret provider so core's trace secret
+    // resolution can consult the agent-task secret store.
+    crate::agents::agent_task_secrets::register();
+    // Register the extension provider-discovery validator so core's
+    // extension install/repair can verify declared agent-runtime providers.
+    crate::agents::agent_task_provider::discovery::register();
+    // Register the command-label resolver so core::runner can map dispatched
+    // argv to a hot-command label without depending on the full CLI parser.
+    crate::runner::set_command_label_resolver(|argv| {
+        let cli = <crate::cli_surface::Cli as clap::Parser>::try_parse_from(argv).ok()?;
+        let route_contract = cli.command.lab_route_contract().ok()??;
+        Some(route_contract.command.hot_label.to_string())
+    });
+    // Register the agent-task dispatch resolver so core::runner can extract a
+    // cook dispatch command from argv without depending on the CLI parser.
+    crate::runner::set_agent_task_dispatch_resolver(|argv| {
+        let cli =
+            <crate::cli_surface::Cli as clap::Parser>::try_parse_from(argv).map_err(|error| {
+                crate::core::error::Error::validation_invalid_argument(
+                    "agent-task",
+                    "failed to parse agent-task arguments while compiling Lab provider policy",
+                    Some(error.to_string()),
+                    None,
+                )
+            })?;
+        Ok(match cli.command {
+            crate::cli_surface::Commands::AgentTask(agent_task) => match agent_task.command {
+                crate::commands::agent_task::AgentTaskCommand::Cook(cook) => {
+                    Some(cook.dispatch.into())
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+    });
+    // Register the Lab-runner hint provider so core::runner can compose
+    // `--runner`/`--placement` unsupported errors from the command-spec table
+    // without depending on `command_contract`.
+    crate::runner::set_lab_runner_hint_provider(|| {
+        let summary = crate::command_contract::lab_runner_support_summary();
+        crate::runner::LabRunnerHint {
+            hint: summary.hint,
+            unsupported_message: summary.unsupported_message,
+        }
+    });
+
+    Ok(())
+}
+
+/// Every provider registration the CLI performs at startup, in the exact order
+/// [`CliRuntime::run_from_args`] performs them.
+///
+/// `run_from_args` calls the two halves separately because it interleaves a
+/// terminal-run reconcile between them. This is the entry point the
+/// registration-completeness test drives; keeping it as the sole other caller is
+/// what makes "every declared provider registry is populated afterwards" a
+/// meaningful assertion about the real binary.
+pub fn register_all_providers(
+    agent_task: &crate::core::defaults::AgentTaskConfig,
+) -> Result<(), crate::core::error::Error> {
+    register_startup_providers_before_reconcile();
+    register_startup_providers_after_reconcile(agent_task)
+}
+
 impl CliRuntime {
     pub fn new() -> Self {
         Self {
@@ -134,72 +348,7 @@ impl CliRuntime {
             return std::process::ExitCode::from(2);
         }
 
-        // Register the config-level artifact_root resolver before any command runs
-        // so paths::artifact_root() can honor global config without paths depending
-        // on the defaults layer (breaks the paths <-> defaults dependency cycle).
-        crate::core::paths::set_config_artifact_root_resolver(|| {
-            crate::core::defaults::load_config().artifact_root
-        });
-        // Register optional feature crates' config entities with core so their
-        // IDs/aliases participate in cross-entity collision detection. Core owns
-        // the collision invariant but must not depend on these optional features.
-        homeboy_tunnel::register();
-        // Register the audit manifest provider so code_audit can read extension
-        // manifests (detector rules, test mappings, provided extensions) without
-        // depending on the extension layer's loader — the seam that lets audit
-        // become its own crate.
-        // Register the in-core release provider so core's status mechanics
-        // (fleet/project/context/git change reporting/tag-gap) get deploy+release
-        // behavior through the hook. Moves out with deploy/release when they
-        // become the homeboy-release crate.
-        crate::release::provider_impl::register();
-        homeboy_extension::audit_manifest_provider::register();
-        homeboy_extension::component_script::register_component_script_runner();
-        homeboy_extension::build::register_component_build_runner();
-        homeboy_extension::lifecycle::register_component_install_runner();
-        // Register extension-backed audit providers so code_audit can load
-        // grammars and run fallback fingerprint scripts without depending on the
-        // extension registry or script runner.
-        homeboy_extension::audit_fingerprint_script_provider::register();
-        homeboy_extension::audit_grammar_source_provider::register();
-        // Register the audit recorded-artifact provider so the artifact-portability
-        // detector can read past runs' artifacts from the observation store without
-        // code_audit depending on observation — the last seam before audit becomes
-        // its own crate.
-        crate::core::observation::audit_artifact_provider::register();
-        // Register the audit fixability provider so code_audit can report how
-        // fixable its findings are without calling up into the refactor engine's
-        // fix planner — the seam that removes the last code_audit->refactor edge.
-        // Register the rig toolchain provider so core's extension exec-env
-        // builder can prepend the rig toolchain PATH.
-        crate::rig::provider::register();
-        crate::stack::provider::register();
-        crate::refactor::audit_fixability_provider::register();
-        // Register the refactor transform provider so core's extension
-        // test-drift auto-fixer can apply generated transform rules.
-        crate::refactor::transform_provider::register();
-        // Register the audit component provider so code_audit can resolve the
-        // component under audit (path, extension ids, audit rules, scope excludes)
-        // without depending on the component layer — the last cross-layer seam
-        // before audit becomes its own crate.
-        crate::core::component::audit_provider::register();
-        // Register the runner-evidence provider so observation::runs_service can
-        // enrich run/artifact lookups with live runner + daemon evidence without
-        // core depending on runner behavior. (Runner is still in-crate today;
-        // this registration is the seam that lets it become its own crate.)
-        crate::runner::register_runner_evidence_provider();
-        // Register the runner job-preparation provider so api_jobs can compute
-        // the secret-env plan and validate workload dispatch for remote-runner
-        // jobs without core depending on runner behavior.
-        crate::runner::register_runner_job_preparation_provider();
-        // Register the lab-workspace provenance provider so the agent-task
-        // scheduler can verify lab-materialized workspaces without core depending
-        // on runner behavior.
-        crate::runner::register_lab_workspace_provenance_provider();
-        // Register the runner-continuation provider so the agent-task lifecycle
-        // can reconcile and resume runs dispatched to a remote runner without
-        // core depending on runner behavior.
-        crate::runner::register_runner_continuation_provider();
+        register_startup_providers_before_reconcile();
         // Recover completed generic runner-exec jobs before a mutating invocation
         // can evict their evidence. Read-only commands must not mutate durable
         // state during startup.
@@ -213,118 +362,11 @@ impl CliRuntime {
         {
             let _ = crate::runner::reconcile_terminal_runner_exec_runs();
         }
-        // Register the runner daemon-exec driver so the daemon's /exec endpoint
-        // can prepare and run a runner job as a local child without core
-        // depending on runner process-execution behavior.
-        crate::runner::register_runner_daemon_exec_driver();
-        // Lab owns its durable staging/dispatch controller-job interpretation;
-        // core only owns the generic daemon lifecycle.
-        crate::runner::register_lab_staging_controller_driver();
-        crate::agents::agent_task_service::register_promotion_job_driver();
-        crate::commands::cleanup::register_cleanup_job_driver();
         let config = crate::core::defaults::load_config();
-        if let Err(error) =
-            crate::agents::agent_task_lifecycle::register_acceptance_verifier_from_config(
-                &config.agent_task,
-            )
-        {
+        if let Err(error) = register_startup_providers_after_reconcile(&config.agent_task) {
             eprintln!("error: {error}");
             return std::process::ExitCode::from(2);
         }
-        crate::runner::enable_production_lab_staging();
-        // Register the runner workspace-root provider so the daemon file API can
-        // resolve a runner's configured workspace_root without core depending on
-        // the runner config registry.
-        crate::runner::register_runner_workspace_root_provider();
-        // Register Runner as a config entity so it participates in config
-        // id/alias collision detection, mirroring how feature crates register
-        // their own entities (moves into the runner crate once extracted).
-        crate::runner::register_runner_config_entity();
-        // Register the runner-upgrade provider so the core upgrade flow can
-        // refresh configured runners without depending on runner behavior.
-        crate::runner::register_runner_upgrade();
-        // Register the runner-availability provider so the controller action loop
-        // can gate execution on a runner's live status.
-        crate::runner::register_runner_availability_provider();
-        // Register the Lab-offload provider so core's lab_routing can execute an
-        // offload without depending on runner behavior.
-        crate::runner::register_runner_lab_offload_provider();
-        // Register the workspace-snapshot provider so core's hygiene subsystem
-        // can materialize an isolated validation-dependency workspace without
-        // depending on runner behavior.
-        crate::runner::register_workspace_snapshot_provider();
-        // Register the agent-task controller pin-reference provider so core's
-        // controller-runtime retention report can discover which pinned
-        // executables are still referenced by nonterminal durable agent-task
-        // records without core depending on the agent-task subsystem. (This is
-        // the seam that lets agent-task become its own crate.)
-        crate::agents::agent_task_lifecycle::controller_pin_reference_provider::register();
-        // Register the loop-spec validation provider so core's proof validator
-        // can validate a materialized agent-task loop-spec artifact without
-        // depending on the agent-task subsystem.
-        crate::agents::agent_task_controller_service::loop_spec_validation_provider::register();
-        // Register the gate-feedback candidate-baseline provider so core's
-        // worktree-safety logic can accept a dirty worktree that is a verified
-        // agent-task gate-feedback candidate without depending on the agent-task
-        // subsystem.
-        crate::agents::agent_task_candidate_baseline::register();
-        // Register the agent-task activity provider so core's activity report
-        // includes durable agent-task records and their health summary without
-        // depending on the agent-task subsystem.
-        crate::agents::agent_task_lifecycle::activity_provider::register();
-        // Register the bench agent-task matrix provider so core's cross-rig
-        // bench comparison can project rig entries into an agent-task matrix
-        // without depending on the agent-task subsystem.
-        crate::agents::agent_task::bench_matrix_provider::register();
-        // Register the agent-task terminal-recovery provider so core's job store
-        // can recover terminal jobs from durable agent-task runs.
-        crate::agents::api_jobs_terminal_recovery::register();
-        // Register the agent-task secret provider so core's trace secret
-        // resolution can consult the agent-task secret store.
-        crate::agents::agent_task_secrets::register();
-        // Register the extension provider-discovery validator so core's
-        // extension install/repair can verify declared agent-runtime providers.
-        crate::agents::agent_task_provider::discovery::register();
-        // Register the command-label resolver so core::runner can map dispatched
-        // argv to a hot-command label without depending on the full CLI parser.
-        crate::runner::set_command_label_resolver(|argv| {
-            let cli = <crate::cli_surface::Cli as clap::Parser>::try_parse_from(argv).ok()?;
-            let route_contract = cli.command.lab_route_contract().ok()??;
-            Some(route_contract.command.hot_label.to_string())
-        });
-        // Register the agent-task dispatch resolver so core::runner can extract a
-        // cook dispatch command from argv without depending on the CLI parser.
-        crate::runner::set_agent_task_dispatch_resolver(|argv| {
-            let cli = <crate::cli_surface::Cli as clap::Parser>::try_parse_from(argv).map_err(
-                |error| {
-                    crate::core::error::Error::validation_invalid_argument(
-                        "agent-task",
-                        "failed to parse agent-task arguments while compiling Lab provider policy",
-                        Some(error.to_string()),
-                        None,
-                    )
-                },
-            )?;
-            Ok(match cli.command {
-                crate::cli_surface::Commands::AgentTask(agent_task) => match agent_task.command {
-                    crate::commands::agent_task::AgentTaskCommand::Cook(cook) => {
-                        Some(cook.dispatch.into())
-                    }
-                    _ => None,
-                },
-                _ => None,
-            })
-        });
-        // Register the Lab-runner hint provider so core::runner can compose
-        // `--runner`/`--placement` unsupported errors from the command-spec table
-        // without depending on `command_contract`.
-        crate::runner::set_lab_runner_hint_provider(|| {
-            let summary = crate::command_contract::lab_runner_support_summary();
-            crate::runner::LabRunnerHint {
-                hint: summary.hint,
-                unsupported_message: summary.unsupported_message,
-            }
-        });
         // Deferred records outlive their worker. Startup restarts the singleton
         // so expired claims recover without another deferral request.
         if !matches!(

--- a/crates/homeboy-cli/tests/provider_registry_completeness.rs
+++ b/crates/homeboy-cli/tests/provider_registry_completeness.rs
@@ -1,0 +1,152 @@
+//! Startup provider-registration completeness.
+//!
+//! Homeboy inverts most subsystem behavior behind `provider_registry!` hooks: a
+//! leaf layer declares a trait plus a no-op, an owning layer registers the real
+//! implementation at CLI startup, and the leaf dispatches through a
+//! process-global slot. When the slot is empty the accessor falls back to the
+//! no-op, which means **deleting a `register_*()` line at startup produces no
+//! error, no log, and no failing test** — the subsystem just stops doing
+//! anything. Adding a brand-new registry and forgetting to wire it is the same
+//! failure with the same silence.
+//!
+//! Every `provider_registry!` / `provider_registry_arc!` expansion now submits a
+//! descriptor to a link-time inventory, so the set of registries is derived from
+//! the declaration sites rather than hand-listed here. This test drives the
+//! binary's real startup wiring (`register_all_providers`, the same sequence
+//! `CliRuntime::run_from_args` performs) and then asserts every declared
+//! registry is populated.
+//!
+//! It lives in its own integration-test binary on purpose: registration is
+//! process-global and irreversible, so wiring every production provider inside
+//! the shared lib-test process would leak into unrelated tests.
+
+use std::collections::BTreeSet;
+
+use homeboy_engine_primitives::provider_registry::{
+    declared_provider_registries, unregistered_provider_registry_ids,
+};
+
+/// A registry that a full startup pass is allowed to leave empty, with the
+/// reason it is allowed.
+struct OptionalRegistry {
+    id: &'static str,
+    reason: &'static str,
+}
+
+/// The only registries permitted to be empty after `register_all_providers`.
+///
+/// The completeness assertion is a subset check, so removing an entry here is
+/// how a registry graduates to "must be wired", and wiring one of these up later
+/// shrinks the unregistered set without breaking the test. Adding an entry is
+/// the deliberate, reviewable act of accepting an inert subsystem.
+const OPTIONAL_REGISTRIES: &[OptionalRegistry] = &[
+    OptionalRegistry {
+        id: "homeboy_agents::agent_task_lifecycle::acceptance_verifier::register_acceptance_verifier",
+        reason: "Conditional by design. `register_acceptance_verifier_from_config` returns \
+                 Ok(()) without registering when `agent_task.acceptance_verifier` is unset, \
+                 which is the default. Tests inject their own verifier through the registry.",
+    },
+    OptionalRegistry {
+        id: "homeboy_code_audit::compiler_warning_provider::register_compiler_warning_provider",
+        reason: "NOT WIRED (found while closing #11133). \
+                 `homeboy_extension::audit_compiler_warning_provider::register` exists and its \
+                 doc comment claims it is \"called once at binary startup by the CLI\", but no \
+                 caller exists anywhere in the workspace, so audit's compiler-warning provider \
+                 is inert in production and silently returns the no-op. Recorded here rather \
+                 than fixed because wiring it changes audit behavior, which is out of scope for \
+                 the detection fix. Removing this entry is the fix.",
+    },
+];
+
+/// A registry that must exist in the inventory for this test to mean anything.
+/// The inventory is collected at link time; a collection that silently yielded
+/// nothing would make the completeness assertion vacuously true.
+const SENTINEL_REGISTRY: &str = "homeboy_core::stack_provider::register_stack_provider";
+
+/// Floor on the number of declared registries. Deliberately far below the real
+/// count so crate extraction does not churn it — this only has to catch an
+/// inventory that collected nothing or almost nothing.
+const MINIMUM_DECLARED_REGISTRIES: usize = 20;
+
+#[test]
+fn cli_startup_registers_every_declared_provider_registry() {
+    homeboy_core::test_support::with_isolated_home(|_home| {
+        let declared = declared_provider_registries();
+        let declared_ids = declared
+            .iter()
+            .map(|registry| registry.id())
+            .collect::<Vec<_>>();
+
+        assert!(
+            declared.len() >= MINIMUM_DECLARED_REGISTRIES,
+            "the link-time provider-registry inventory collected only {} descriptor(s); \
+             expected at least {}. Either the inventory is no longer being linked in or the \
+             macros stopped submitting descriptors — every assertion below is vacuous until \
+             this holds. Collected: {declared_ids:?}",
+            declared.len(),
+            MINIMUM_DECLARED_REGISTRIES,
+        );
+        assert!(
+            declared_ids.iter().any(|id| id == SENTINEL_REGISTRY),
+            "expected the inventory to contain {SENTINEL_REGISTRY}; collected {declared_ids:?}",
+        );
+
+        let mut unique = declared_ids.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            declared_ids.len(),
+            "provider-registry ids must be unique; a module hosts at most one registry",
+        );
+
+        // Nothing has registered yet, so whatever is populated after the call
+        // below is populated *because of* the call.
+        assert!(
+            unregistered_provider_registry_ids()
+                .iter()
+                .any(|id| id == SENTINEL_REGISTRY),
+            "expected {SENTINEL_REGISTRY} to be empty before startup wiring runs",
+        );
+
+        homeboy_cli::cli_runtime::register_all_providers(
+            &homeboy_core::defaults::AgentTaskConfig::default(),
+        )
+        .expect("startup provider registration succeeds under the default agent-task config");
+
+        let optional = OPTIONAL_REGISTRIES
+            .iter()
+            .map(|registry| registry.id)
+            .collect::<BTreeSet<_>>();
+        let inert = unregistered_provider_registry_ids()
+            .into_iter()
+            .filter(|id| !optional.contains(id.as_str()))
+            .collect::<Vec<_>>();
+
+        assert!(
+            inert.is_empty(),
+            "{} provider registr{} declared but never registered by \
+             `cli_runtime::register_all_providers`:\n  {}\n\n\
+             An empty registry is not an error at runtime — the accessor falls back to the \
+             no-op and the subsystem silently does nothing. Either add the missing \
+             `register_*()` call to `register_all_providers` (in the order the subsystem \
+             needs), or, if the registry is intentionally conditional, add it to \
+             OPTIONAL_REGISTRIES in this file with the reason.",
+            inert.len(),
+            if inert.len() == 1 { "y is" } else { "ies are" },
+            inert.join("\n  "),
+        );
+
+        // Every allowlist entry must still name a real registry, so the list
+        // cannot rot into a set of ids nothing declares anymore.
+        for registry in OPTIONAL_REGISTRIES {
+            assert!(
+                declared_ids.iter().any(|id| id == registry.id),
+                "OPTIONAL_REGISTRIES names {}, which no registry declares anymore. \
+                 Recorded reason: {} Remove the entry.",
+                registry.id,
+                registry.reason,
+            );
+        }
+    });
+}

--- a/crates/homeboy-engine-primitives/Cargo.toml
+++ b/crates/homeboy-engine-primitives/Cargo.toml
@@ -17,6 +17,11 @@ homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 homeboy-paths = { version = "0.1.0", path = "../homeboy-paths" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# Link-time inventory of every declared provider registry. Each
+# `provider_registry!` expansion submits a descriptor so the CLI's
+# registration completeness test can enumerate registries it was never told
+# about, instead of the subsystem silently degrading to its no-op.
+inventory = "0.3"
 toml = "1.0.3"
 regex = "1.11"
 libc = "0.2"

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -30,3 +30,13 @@ pub mod template;
 pub mod test_path;
 pub mod text;
 pub mod validation;
+
+// Re-exported so the `provider_registry!` / `provider_registry_arc!` expansions
+// can reach `inventory` as `$crate::inventory` from any crate in the workspace
+// without every one of them taking a direct dependency on it.
+#[doc(hidden)]
+pub use inventory;
+
+pub use provider_registry::{
+    declared_provider_registries, unregistered_provider_registry_ids, DeclaredProviderRegistry,
+};

--- a/crates/homeboy-engine-primitives/src/provider_registry.rs
+++ b/crates/homeboy-engine-primitives/src/provider_registry.rs
@@ -56,6 +56,125 @@
 //! call. Used where holding the lock across the call would serialize real work.
 //! Its `optional:` form is the `Arc` counterpart of `with_optional:`: no no-op,
 //! accessor yields `Option<Arc<dyn Trait>>`.
+//!
+//! # Declaration inventory
+//!
+//! Every expansion also submits a [`DeclaredProviderRegistry`] descriptor to a
+//! link-time inventory. That closes the pattern's one genuinely silent failure
+//! mode: an unregistered boxed registry dispatches to its no-op, so deleting a
+//! `register_*()` call at startup produces no error, no log, and no test
+//! failure — the subsystem just stops doing anything. Because the descriptors
+//! are contributed by the declaration site rather than hand-listed, a registry
+//! that nobody ever wired up is visible to
+//! [`unregistered_provider_registry_ids`] the moment it exists.
+//!
+//! The inventory is pure metadata: it does not change what an unregistered
+//! registry *does*, only whether anything can notice. `homeboy-cli`'s
+//! `register_all_providers` completeness test is the consumer that turns
+//! noticing into a failing build.
+
+/// One declared provider registry, contributed to a link-time inventory by
+/// every `provider_registry!` / `provider_registry_arc!` expansion in the
+/// process.
+///
+/// The descriptor is metadata plus one probe. It exists so that "was this
+/// registry ever wired up?" is an answerable question: without it, an
+/// unregistered boxed registry is indistinguishable at runtime from one whose
+/// provider happens to do nothing.
+#[derive(Clone, Copy)]
+pub struct DeclaredProviderRegistry {
+    /// `module_path!()` of the declaration site. Unique per registry: two
+    /// registries in one module would collide on the generated slot accessor,
+    /// so a module hosts at most one.
+    pub module_path: &'static str,
+    /// The name of the generated registration entry point, e.g.
+    /// `register_stack_provider`.
+    pub register_fn: &'static str,
+    /// Whether the slot currently holds a provider. Takes the registry lock,
+    /// recovering from poisoning exactly like the accessors do.
+    pub is_registered: fn() -> bool,
+}
+
+impl DeclaredProviderRegistry {
+    /// Stable identifier: the declaration site's module path joined to the
+    /// registration entry point's name.
+    pub fn id(&self) -> String {
+        format!("{}::{}", self.module_path, self.register_fn)
+    }
+
+    /// Whether a provider has been registered into this registry.
+    pub fn registered(&self) -> bool {
+        (self.is_registered)()
+    }
+}
+
+impl std::fmt::Debug for DeclaredProviderRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeclaredProviderRegistry")
+            .field("id", &self.id())
+            .finish()
+    }
+}
+
+inventory::collect!(DeclaredProviderRegistry);
+
+/// Every provider registry declared by any crate linked into the current
+/// binary, sorted by [`DeclaredProviderRegistry::id`].
+///
+/// Only registries whose declaring crate is linked in are visible, which is
+/// exactly the set that binary can be expected to register.
+pub fn declared_provider_registries() -> Vec<&'static DeclaredProviderRegistry> {
+    let mut declared = inventory::iter::<DeclaredProviderRegistry>
+        .into_iter()
+        .collect::<Vec<_>>();
+    // Sorted by `id()` rather than by the `(module_path, register_fn)` tuple:
+    // the two orders differ (a parent module sorts before its child under the
+    // tuple, after it once `::` is part of the string), and `id()` is what
+    // callers report and diff against.
+    declared.sort_by_key(|registry| registry.id());
+    declared
+}
+
+/// The ids of every declared registry whose slot is still empty.
+///
+/// An empty boxed registry silently dispatches to its no-op, so this is the
+/// list of subsystems that are currently inert. A completeness test asserts it
+/// contains nothing but the registries that are deliberately conditional.
+pub fn unregistered_provider_registry_ids() -> Vec<String> {
+    declared_provider_registries()
+        .into_iter()
+        .filter(|registry| !registry.registered())
+        .map(DeclaredProviderRegistry::id)
+        .collect()
+}
+
+/// Internal: submit the declaration-site descriptor for the registry whose
+/// slot accessor was just generated. Shared by all four macro forms.
+///
+/// The probe closes over the enclosing module's generated `provider_slot()`,
+/// so it reports the live state of that specific registry.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __provider_registry_declare {
+    ($register:ident) => {
+        const _: () = {
+            fn is_registered() -> bool {
+                provider_slot()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .is_some()
+            }
+
+            $crate::inventory::submit! {
+                $crate::provider_registry::DeclaredProviderRegistry {
+                    module_path: ::std::module_path!(),
+                    register_fn: ::std::stringify!($register),
+                    is_registered: is_registered,
+                }
+            }
+        };
+    };
+}
 
 /// Declare a process-global boxed provider registry.
 ///
@@ -78,6 +197,7 @@ macro_rules! provider_registry {
         with: $with_vis:vis fn $with:ident $(,)?
     ) => {
         $crate::__provider_registry_slot!($provider);
+        $crate::__provider_registry_declare!($register);
 
         $(#[$register_meta])*
         $register_vis fn $register(provider: ::std::boxed::Box<dyn $provider>) {
@@ -109,6 +229,7 @@ macro_rules! provider_registry {
         with_optional: $with_vis:vis fn $with:ident $(,)?
     ) => {
         $crate::__provider_registry_slot!($provider);
+        $crate::__provider_registry_declare!($register);
 
         $(#[$register_meta])*
         $register_vis fn $register(provider: ::std::boxed::Box<dyn $provider>) {
@@ -155,6 +276,7 @@ macro_rules! provider_registry_arc {
         active: $active_vis:vis fn $active:ident $(,)?
     ) => {
         $crate::__provider_registry_arc_slot!($provider);
+        $crate::__provider_registry_declare!($register);
 
         $(#[$register_meta])*
         $register_vis fn $register(provider: ::std::sync::Arc<dyn $provider>) {
@@ -184,6 +306,7 @@ macro_rules! provider_registry_arc {
         optional: $active_vis:vis fn $active:ident $(,)?
     ) => {
         $crate::__provider_registry_arc_slot!($provider);
+        $crate::__provider_registry_declare!($register);
 
         $(#[$register_meta])*
         $register_vis fn $register(provider: ::std::sync::Arc<dyn $provider>) {
@@ -332,6 +455,78 @@ mod tests {
                 active_greeter().map(|g| g.greet()),
                 Some("real".to_string())
             );
+        }
+    }
+
+    // The declaration inventory is what turns "nobody registered this" from
+    // silence into an assertable fact. Its own registry lives in a dedicated
+    // module so no other test can register into it and mask the transition.
+    mod declaration_inventory {
+        use super::Greeter;
+        use crate::provider_registry::{
+            declared_provider_registries, unregistered_provider_registry_ids,
+        };
+
+        struct RealGreeter;
+
+        impl Greeter for RealGreeter {
+            fn greet(&self) -> String {
+                "real".to_string()
+            }
+        }
+
+        crate::provider_registry! {
+            provider: dyn Greeter,
+            noop: super::NoopGreeter,
+            /// Register the greeter used by this test module.
+            register: pub(crate) fn register_inventoried_greeter,
+            with: fn with_greeter,
+        }
+
+        const ID: &str = concat!(
+            module_path!(),
+            "::",
+            // Kept literal on purpose: the id is a contract the completeness
+            // test reads, so a rename has to be a deliberate edit here too.
+            "register_inventoried_greeter"
+        );
+
+        // One test: registration is a process-global one-way transition, so
+        // splitting the before/after halves would make them order-dependent.
+        #[test]
+        fn declares_itself_and_reports_the_registration_transition() {
+            // Declared without anyone having to list it anywhere.
+            let declared = declared_provider_registries();
+            let this = declared
+                .iter()
+                .find(|registry| registry.id() == ID)
+                .expect("the expansion submits its own descriptor");
+            assert_eq!(this.register_fn, "register_inventoried_greeter");
+
+            // Ids are sorted and unique, so the completeness test's diff of
+            // "declared but unregistered" is stable across runs.
+            let ids = declared
+                .iter()
+                .map(|registry| registry.id())
+                .collect::<Vec<_>>();
+            let mut sorted = ids.clone();
+            sorted.sort();
+            sorted.dedup();
+            assert_eq!(ids, sorted, "descriptors are sorted and unique by id");
+
+            // Before: inert, and the accessor silently yields the no-op. That
+            // pairing is the bug this inventory exists to make visible.
+            assert!(!this.registered());
+            assert!(unregistered_provider_registry_ids().contains(&ID.to_string()));
+            assert_eq!(with_greeter(|greeter| greeter.greet()), "noop");
+
+            register_inventoried_greeter(Box::new(RealGreeter));
+
+            // After: the same probe flips, so deleting the registration above
+            // is a test failure rather than a subsystem that quietly stops.
+            assert!(this.registered());
+            assert!(!unregistered_provider_registry_ids().contains(&ID.to_string()));
+            assert_eq!(with_greeter(|greeter| greeter.greet()), "real");
         }
     }
 }


### PR DESCRIPTION
Closes #11133

## The silent failure

`provider_registry.rs:97-101` returns a no-op when a slot is unregistered:

```rust
match slot.as_deref() {
    Some(provider) => f(provider),
    None => f(&$noop),          // omission = silently does nothing
}
```

35 `provider_registry!` invocations across five crates, ~36 `register*()` calls hand-listed inline in `run_from_args`. **Delete one line and the subsystem degrades to a no-op — no error, no log, no test.** The macro's own doc admits: *"hand-copied across ~35 modules in five crates. The copies drifted."*

## The change

Extends the existing macro — no parallel system, no call-site churn:

- `DeclaredProviderRegistry { module_path, register_fn, is_registered }` + `inventory::collect!`
- A new internal `__provider_registry_declare!` invoked by all four macro forms. **All 35 existing invocations are untouched.**
- `declared_provider_registries()` / `unregistered_provider_registry_ids()`
- The no-op fallback itself is byte-for-byte unchanged — this detects omissions, it does not change what happens on one.
- `inventory = "0.3"` was **already in Cargo.lock** as a transitive dep of `serde_json_path`, so no new compilation unit enters the graph.

`cli_runtime.rs`: the inline registration block is extracted into `register_all_providers`, split into before/after-reconcile halves because `run_from_args` interleaves the terminal runner-exec reconcile between them. **Call order is verbatim** — diffed old vs new, only the reconcile block and `load_config` moved out.

New test lives in its own binary (`tests/provider_registry_completeness.rs`) because registration is process-global and irreversible; in the shared lib-test process it would leak production providers into unrelated tests.

## Verified it actually catches the bug

Two ways, since the full integration test can't run on the dev VPS:

1. **Unit test** — deleting a registration line: `FAILED ... assertion failed: this.registered()`. Restored → passes.
2. **Cross-crate proof** (the real risk, since `inventory` is link-section based across rlibs). Throwaway 2-crate project against the real `homeboy-engine-primitives`:
   - line deleted → `unregistered after: ["donor::register_donor_greeter"]`, `dispatch yields: noop`
   - line present → `unregistered after: []`, `dispatch yields: real`

`cargo check` clean on `homeboy-engine-primitives --lib`, `homeboy-cli --lib`, and the new test target.

## ⚠️ Found a real bug while writing the allowlist

`homeboy_extension::audit_compiler_warning_provider::register()` has a doc comment saying *"Called once at binary startup by the CLI"* — and **no caller anywhere in the workspace.** Audit's compiler-warning provider has been silently serving its no-op in production.

That is precisely the failure mode this issue describes, found by the fix. **Not fixed here** — wiring it changes audit behavior and is out of scope for a detection change. Recorded in `OPTIONAL_REGISTRIES` with that reason; filed separately.

The only other unpopulated registry is `register_acceptance_verifier`, legitimately conditional (returns `Ok(())` without registering when `agent_task.acceptance_verifier` is unset, which is the default). The other 33 are correctly wired.

The allowlist is a **subset** check, so wiring the compiler-warning provider later shrinks the list rather than breaking the test; each entry is also staleness-checked, and a sentinel-id + count-floor guard makes an empty inventory fail loudly instead of passing vacuously.

Found during the 2026-08-01 consolidation investigation (#11151).