### PR TITLE
feat(audit): activate the layer_ownership architecture gate, drop stale baselines

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -538,6 +538,63 @@
       ]
     }
   },
+  "audit_rules": {
+    "layer_rules": [
+      {
+        "name": "contracts-own-no-process-execution",
+        "forbid": {
+          "glob": "crates/contracts/**",
+          "patterns": [
+            "std::process::Command",
+            "std::process::exit",
+            "reqwest::",
+            "tokio::spawn"
+          ]
+        }
+      },
+      {
+        "name": "engine-primitives-own-no-domain-crates",
+        "forbid": {
+          "glob": "crates/homeboy-engine-primitives/src/**",
+          "patterns": [
+            "homeboy_core::",
+            "homeboy_cli::",
+            "homeboy_agents::",
+            "homeboy_rig::"
+          ]
+        }
+      },
+      {
+        "name": "cli-surface-owns-no-process-execution",
+        "forbid": {
+          "glob": "crates/homeboy-cli/src/cli_surface/**",
+          "patterns": [
+            "std::process::Command",
+            "std::process::exit"
+          ]
+        }
+      },
+      {
+        "name": "command-contract-owns-no-process-execution",
+        "forbid": {
+          "glob": "crates/homeboy-cli/src/command_contract/**",
+          "patterns": [
+            "std::process::Command",
+            "std::process::exit"
+          ]
+        }
+      },
+      {
+        "name": "rig-owns-no-service-implementation",
+        "forbid": {
+          "glob": "crates/homeboy-rig/src/**",
+          "patterns": [
+            "http.server"
+          ]
+        }
+      }
+    ]
+  },
   "auto_cleanup": false,
   "autofix_verify": {
     "args": [
@@ -551,7 +608,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-07-27T04:11:26Z",
-      "item_count": 1515,
+      "item_count": 1517,
       "known_fingerprints": [
         "Commands::crates/homeboy-cli/src/commands/agent_task_dispatch.rs::MissingMethod",
         "Src::crates/contracts/homeboy-audit-contract/src/finding.rs::MissingMethod",
@@ -1624,6 +1681,8 @@
         "intra-method-duplication::crates/homeboy-tunnel/src/preview_ingress/http.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-tunnel/src/preview_ingress/serve.rs::IntraMethodDuplicate",
         "intra-method-duplication::tests/core/daemon/control_test.rs::IntraMethodDuplicate",
+        "layer_ownership::crates/homeboy-rig/src/service.rs::LayerOwnershipViolation",
+        "layer_ownership::crates/homeboy-rig/src/spec.rs::LayerOwnershipViolation",
         "near-duplication::crates/contracts/homeboy-lifecycle-contract/src/artifact_contract.rs::NearDuplicate",
         "near-duplication::crates/homeboy-agents/src/agent_task_controller_service/artifacts.rs::NearDuplicate",
         "near-duplication::crates/homeboy-agents/src/agent_task_controller_service/field_access.rs::NearDuplicate",

--- a/homeboy.json
+++ b/homeboy.json
@@ -551,7 +551,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-07-27T04:11:26Z",
-      "item_count": 1519,
+      "item_count": 1515,
       "known_fingerprints": [
         "Commands::crates/homeboy-cli/src/commands/agent_task_dispatch.rs::MissingMethod",
         "Src::crates/contracts/homeboy-audit-contract/src/finding.rs::MissingMethod",
@@ -563,10 +563,6 @@
         "Types::crates/homeboy-core/src/project/types/api.rs::MissingInterface",
         "Types::crates/homeboy-core/src/project/types/api.rs::MissingMethod",
         "Types::crates/homeboy-core/src/project/types/component.rs::NamingMismatch",
-        "artifact_portability::artifact_portability/local_artifact_path/$.artifact.commands[1].findings[0].metadata.source_sidecar_path::NonPortableArtifactPath",
-        "artifact_portability::artifact_portability/local_artifact_path/$.artifact.commands[1].findings[1].metadata.source_sidecar_path::NonPortableArtifactPath",
-        "artifact_portability::artifact_portability/local_artifact_path/$.artifact.commands[1].findings[2].metadata.source_sidecar_path::NonPortableArtifactPath",
-        "artifact_portability::artifact_portability/local_artifact_path/$.lab_offload.workspace_mapping.local_to_remote./Users/chubes/Developer/homeboy@cook-refactor-runner-evidence-lineage-fleet-20260621::NonPortableArtifactPath",
         "command_wrapper_bypass::crates/homeboy-agents/src/agent_task_finalization/backend.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-agents/src/agent_task_promotion/fingerprint.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-agents/src/agent_task_promotion/types.rs::CommandWrapperBypass",


### PR DESCRIPTION
Closes #11093
Partially addresses #11095 — see "corrections" below; that issue needs re-scoping, not closing.

## Commit 2 — #11093: the architecture gate is now live

`homeboy.json` had **no `audit_rules` key**, so `layer_ownership` — which is in the PR-blocking profile (`execution_plan.rs:68-77`) — returned `Vec::new()` on every run. Every PR ran an architecture gate structurally incapable of producing a finding.

Five rules added. Four produce **zero findings today** (regression guards); the fifth fires on a real violation and is baselined:

1. `contracts-own-no-process-execution` — `crates/contracts/**` ∤ `std::process::Command`, `std::process::exit`, `reqwest::`, `tokio::spawn`
2. `engine-primitives-own-no-domain-crates` — `homeboy-engine-primitives/src/**` ∤ `homeboy_core::`, `homeboy_cli::`, `homeboy_agents::`, `homeboy_rig::`
3. `cli-surface-owns-no-process-execution`
4. `command-contract-owns-no-process-execution`
5. `rig-owns-no-service-implementation` — `homeboy-rig/src/**` ∤ `http.server` → **2 findings** (`service.rs:284` hardcodes `python3 -m http.server`), both baselined

### Rule selection was measured, not guessed

Built an exact simulation of the detector — validated by reproducing its own Rust unit test — and ran candidates over all 2,148 scanned files. This caught false positives that would have turned main red:

`forbid.patterns` is a whole-file `content.contains()` substring test with **no regex and no comment stripping**, so `Command::new(` matches `CompiledCommand::new(` and `std::fs::` matches a doc comment.

Two candidate rules were **dropped** as a result:
- agent-runtime ids in `crates/**/src/**` — 41 hits, nearly all legitimate. The invariant doesn't hold as stated.
- `commands/**` process execution — 44 hits, and it duplicates the existing `thin_command_adapter` policy.

Verified with the **real binary** (`homeboy review audit --profile architecture`, v0.326.1, no cargo build): exactly the 2 expected findings, and `baseline_comparison.new_items` contains zero `layer_ownership` and zero `artifact_portability` entries.

## Commit 1 — #11095: only one of three deletions was safe

**My original issue was wrong on two of three counts.** Recording the corrections:

**(a) 678 duplicated fingerprints — fact verified, remedy rejected.** The duplication is real: diffed programmatically, 678 entries, byte-for-byte and order-identical. But **both proposed remedies break the repo**:
- `AuditBaselinePolicySection::known_fingerprints` (`baseline.rs:58`) has **no `#[serde(default)]`** — dropping the key fails deserialization of the entire baseline, so all 1,515 rows silently become "new findings"
- `tests/audit_source_policy_config_test.rs:198` hard-asserts the section exists *and* carries rows for four specific terms
- `policy_sections_from_fingerprints()` (`baseline.rs:489`) **regenerates** the section from the top-level array on every baseline save, so any deletion self-reverts on the next `--update-baseline`

**(b) `known_outliers` is consumed — kept.** My count was also off (13 of 20 have real fingerprints, not 10). It flows `run.rs:300` → `AuditCommandOutput::BaselineSaved` → `commands/audit.rs:358` as `outliers_found`, and is a required serde field. Folding the entries into `known_fingerprints` would have minted bogus fingerprints for the 7 with no finding.

**(c) 4 stale `artifact_portability` baselines — verified, deleted.** The detector scans recorded observation runs under `artifact_root()`, a machine-local runtime store. These were minted from one dev's Mac against a deleted worktree, so they are unmatchable in every environment including CI. `item_count` 1519 → 1515 → 1517 after adding the two layer rows.

## Two things flagged for follow-up

1. **Baselining is coarser than the rules.** The fingerprint (`baseline.rs:106`) is `convention::file::kind`, omitting rule name and pattern — so baselining a file silences it for *every* layer rule. This is a real detector weakness and the main reason the rules here are narrow.
2. **Main is already red on the architecture profile**, independent of this PR: 51 pre-existing new items (46 `structural`, 2 `docs`, 2 `thin_command_adapter`, 1 `command_status_contracts`). Only `homeboy.json` is touched here, so these are definitively not from this change — but the profile won't pass until they're triaged.

Also: my claim of "eleven detectors" reading `audit_rules` didn't hold up — it is **two** (`layer_ownership`, `wrapper_inference`). The latter is unaffected (`#[serde(default)]` + empty early-return). #11093 has been corrected accordingly.

Found during the 2026-08-01 consolidation investigation (#11151).