### PR TITLE
Fix adoption remediation observability

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -185,6 +185,8 @@ pub fn start_candidate_adoption_with_policy(
             terminal_error: None,
             completed_at: None,
             result: None,
+            remediation_run_id: None,
+            remediation_status_command: None,
         });
         record.updated_at = Some(now);
         true
@@ -217,6 +219,33 @@ pub fn start_candidate_adoption_with_policy(
         ));
     }
     Ok(record)
+}
+
+pub fn checkpoint_candidate_adoption_remediation(
+    run_id: &str,
+    remediation_run_id: &str,
+) -> Result<()> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let Some(attempt) = record.candidate_adoption.as_mut() else {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "candidate adoption remediation requires an active adoption",
+            Some(run_id.to_string()),
+            None,
+        ));
+    };
+    let now = now_timestamp();
+    attempt.state = "verification_running".to_string();
+    attempt.phase = "provider_remediation".to_string();
+    attempt.active_gate = "provider remediation".to_string();
+    attempt.updated_at = now.clone();
+    attempt.heartbeat_at = now;
+    attempt.remediation_run_id = Some(remediation_run_id.to_string());
+    attempt.remediation_status_command = Some(format!(
+        "homeboy agent-task status {remediation_run_id} --full"
+    ));
+    store::write_record(&record)?;
+    Ok(())
 }
 
 pub fn start_candidate_adoption_gate(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -275,6 +275,10 @@ pub struct AgentTaskCandidateAdoptionAttempt {
     /// adoption can legitimately be non-green when remediation was blocked.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remediation_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remediation_status_command: Option<String>,
 }
 
 impl AgentTaskCandidateAdoptionAttempt {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -340,6 +340,39 @@ fn candidate_adoption_gate_heartbeats_are_durable() {
     });
 }
 
+#[test]
+fn cook_alias_status_projects_active_adoption_remediation() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-adoption-remediation-status";
+        let source_run_id = "cook-adoption-remediation-status-attempt-1";
+        let remediation_run_id = "cook-adoption-remediation-status-attempt-2";
+        let plan = test_plan();
+        submit_plan(&plan, Some(source_run_id)).expect("source run");
+        submit_plan(&plan, Some(remediation_run_id)).expect("remediation run");
+        record_cook_attempt(cook_id, 1, source_run_id).expect("source attempt");
+        record_cook_attempt(cook_id, 2, remediation_run_id).expect("remediation attempt");
+        start_candidate_adoption(source_run_id, "candidate", "model", "cargo test")
+            .expect("active adoption");
+
+        checkpoint_candidate_adoption_remediation(source_run_id, remediation_run_id)
+            .expect("remediation checkpoint");
+
+        let projected = status(cook_id).expect("Cook alias status");
+        assert_eq!(projected.adoption_run_id.as_deref(), Some(source_run_id));
+        let adoption = projected.candidate_adoption.expect("projected adoption");
+        assert_eq!(adoption.state, "verification_running");
+        assert_eq!(adoption.phase, "provider_remediation");
+        assert_eq!(
+            adoption.remediation_run_id.as_deref(),
+            Some(remediation_run_id)
+        );
+        assert_eq!(
+            adoption.remediation_status_command.as_deref(),
+            Some("homeboy agent-task status cook-adoption-remediation-status-attempt-2 --full")
+        );
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn candidate_adoption_reconciles_and_cancels_an_orphaned_gate_group() {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1464,6 +1464,14 @@ where
         // Refresh the durable execution attestation before this plan can be
         // persisted or handed to a local or detached provider.
         bind_dispatch_workspace_attestations(&mut follow_up_plan)?;
+        agent_task_lifecycle::submit_plan(&follow_up_plan, Some(&next_run_id))?;
+        agent_task_lifecycle::record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
+        if budget_scope == CookFollowUpBudgetScope::CandidateAdoptionReview {
+            agent_task_lifecycle::checkpoint_candidate_adoption_remediation(
+                source_run_id,
+                &next_run_id,
+            )?;
+        }
         if let Some(dispatcher) = &options.attempt_dispatcher {
             // A detached dispatcher may return before any executor-side
             // lifecycle write, so a controller crash after the runner accepts
@@ -1475,7 +1483,6 @@ where
             // Persist the exact materialized plan first so a continuation resumes
             // this baseline-bound workspace contract, and so the run record the
             // claim is written onto exists.
-            agent_task_lifecycle::submit_plan(&follow_up_plan, Some(&next_run_id))?;
             let operation_key = retry_dispatch_operation_key(&next_run_id);
             match agent_task_lifecycle::claim_cook_operation(
                 &next_run_id,
@@ -1514,7 +1521,9 @@ where
     // The generated ID is random by design. Link the execution only after its
     // materialized plan is durable, so a resumed controller selects this exact
     // run without replacing its baseline-bound workspace contract.
-    agent_task_lifecycle::record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
+    if !attempt_needs_execution(&next_run_id) {
+        agent_task_lifecycle::record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
+    }
     if review_form_only {
         // A form-only retry deliberately makes no code changes. Carry the
         // already-authenticated candidate forward so its finalization path can


### PR DESCRIPTION
## Summary

- persist a remediation child plan and Cook index entry before provider execution blocks
- keep candidate adoption active in a `provider_remediation` phase with the exact child run ID
- expose an actionable `homeboy agent-task status <run-id> --full` command through Cook-alias status
- preserve existing bounded candidate-adoption review remediation

Closes #11092

## Verification

- `cargo +stable fmt --check`
- `cargo +stable test -p homeboy-agents cook_alias_status_projects_active_adoption_remediation`
- `cargo +stable test -p homeboy-agents adoption_review_uses_one_bounded_execution_after_the_source_budget_is_consumed`
- `git diff --check`

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-sol` diagnosed the lifecycle gap, implemented the durable remediation checkpoint and regression coverage, and ran the listed verification. Chris Huber reviewed the diff and remains responsible for the change.