### PR TITLE
Verify intentional no-change agent results

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -235,7 +235,8 @@ fn provider_executions_for_task(
                 Some("running") => ProviderRuntimeState::Running,
                 Some("succeeded") => ProviderRuntimeState::Succeeded,
                 Some("cancelled") => ProviderRuntimeState::Cancelled,
-                Some("timed_out") | Some("candidate_recoverable") => ProviderRuntimeState::TimedOut,
+                Some("timed_out") => ProviderRuntimeState::TimedOut,
+                Some("candidate_recoverable") => ProviderRuntimeState::Failed,
                 _ => ProviderRuntimeState::Failed,
             };
             Some(ProviderRuntimeLifecycle {
@@ -305,7 +306,7 @@ pub(crate) fn provider_runtime_state_for_task_state(
         }
         Some(AgentTaskState::Running) => ProviderRuntimeState::Running,
         Some(AgentTaskState::Succeeded) => ProviderRuntimeState::Succeeded,
-        Some(AgentTaskState::CandidateRecoverable) => ProviderRuntimeState::TimedOut,
+        Some(AgentTaskState::CandidateRecoverable) => ProviderRuntimeState::Failed,
         Some(AgentTaskState::Failed) => ProviderRuntimeState::Failed,
         Some(AgentTaskState::Cancelled) => ProviderRuntimeState::Cancelled,
         Some(AgentTaskState::TimedOut) => ProviderRuntimeState::TimedOut,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -18,6 +18,14 @@ use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
 #[test]
+fn candidate_recoverable_provider_projection_is_failed_not_timed_out() {
+    assert_eq!(
+        provider_runtime_state_for_task_state(Some(AgentTaskState::CandidateRecoverable)),
+        ProviderRuntimeState::Failed
+    );
+}
+
+#[test]
 fn cook_alias_status_projects_active_adoption_from_earlier_attempt() {
     with_isolated_home(|_| {
         let cook_id = "cook-issue-9168-active";

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -620,6 +620,12 @@ pub(super) fn run_materialized_provider_command_once(
                 &mut outcome,
                 &request.artifacts_path,
                 &request.artifacts_path_provenance,
+                request
+                    .request
+                    .workspace
+                    .root
+                    .as_deref()
+                    .map(std::path::Path::new),
             );
             validate_declared_outputs(&mut outcome, request);
             surface_provider_process_failure(

--- a/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
@@ -39,6 +39,7 @@ pub(super) fn normalize_homeboy_local_artifact_sizes(
     outcome: &mut AgentTaskOutcome,
     artifact_root: &std::path::Path,
     provenance: &AgentTaskArtifactsPathProvenance,
+    workspace_root: Option<&std::path::Path>,
 ) {
     if provenance.owner != "homeboy" || provenance.locality != "runner" {
         return;
@@ -63,23 +64,124 @@ pub(super) fn normalize_homeboy_local_artifact_sizes(
     }
 
     if outcome.status == AgentTaskOutcomeStatus::Succeeded && has_known_empty_change_set(outcome) {
-        if has_substantive_non_change_evidence(outcome) {
-            // An empty change artifact next to substantive work evidence
-            // (a transcript, report, log, or other content-bearing artifact)
-            // is not a clean "nothing happened" — it is a patch-capture
-            // failure that would otherwise silently discard real changes,
-            // including committed ones (#7719). Surface it for controller
-            // review/salvage instead of collapsing it to NoOp.
-            outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
-            outcome.summary = Some(
+        match intentional_no_change_verdict(outcome, workspace_root) {
+            IntentionalNoChangeVerdict::Verified => {
+                // Preserve Succeeded so promotion follows the empty-patch gate
+                // path and records a verified no-op rather than attempting a
+                // candidate recovery.
+                outcome.summary = Some(
+                    "provider declared an intentional no-change review verdict bound to the verified workspace revision"
+                        .to_string(),
+                );
+            }
+            IntentionalNoChangeVerdict::Invalid(message) => {
+                outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
+                outcome.summary = Some(message);
+            }
+            IntentionalNoChangeVerdict::Absent if has_substantive_non_change_evidence(outcome) => {
+                // An empty change artifact next to substantive work evidence
+                // (a transcript, report, log, or other content-bearing artifact)
+                // is not a clean "nothing happened" — it is a patch-capture
+                // failure that would otherwise silently discard real changes,
+                // including committed ones (#7719). Surface it for controller
+                // review/salvage instead of collapsing it to NoOp.
+                outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
+                outcome.summary = Some(
                 "provider reported success with an empty change artifact but produced substantive work evidence; the patch may have failed to capture real changes and needs review"
                     .to_string(),
             );
-        } else {
-            outcome.status = AgentTaskOutcomeStatus::NoOp;
-            outcome.summary = Some("provider produced an empty change artifact".to_string());
+            }
+            IntentionalNoChangeVerdict::Absent => {
+                outcome.status = AgentTaskOutcomeStatus::NoOp;
+                outcome.summary = Some("provider produced an empty change artifact".to_string());
+            }
         }
     }
+}
+
+const INTENTIONAL_NO_CHANGE_SCHEMA: &str = "homeboy/intentional-no-change/v1";
+
+enum IntentionalNoChangeVerdict {
+    Absent,
+    Verified,
+    Invalid(String),
+}
+
+#[derive(serde::Deserialize)]
+struct IntentionalNoChangeDeclaration {
+    schema: String,
+    verdict: String,
+    inspected_revision: String,
+}
+
+/// A provider may declare a no-change review only through this versioned result
+/// field. Homeboy, rather than the provider, verifies the declared revision and
+/// the complete checkout state before allowing transcript evidence to be a
+/// successful no-op.
+fn intentional_no_change_verdict(
+    outcome: &AgentTaskOutcome,
+    workspace_root: Option<&std::path::Path>,
+) -> IntentionalNoChangeVerdict {
+    let Some(verdict) = outcome
+        .outputs
+        .get("provider_run_result")
+        .and_then(|result| result.get("intentional_no_change"))
+    else {
+        return IntentionalNoChangeVerdict::Absent;
+    };
+    let Ok(declaration) = serde_json::from_value::<IntentionalNoChangeDeclaration>(verdict.clone())
+    else {
+        return IntentionalNoChangeVerdict::Invalid(
+            "provider declared an intentional no-change verdict without a valid schema, no_change verdict, and inspected workspace revision; changes require recovery review"
+                .to_string(),
+        );
+    };
+    if declaration.schema != INTENTIONAL_NO_CHANGE_SCHEMA
+        || declaration.verdict != "no_change"
+        || declaration.inspected_revision.trim().is_empty()
+    {
+        return IntentionalNoChangeVerdict::Invalid(
+            "provider declared an invalid intentional no-change verdict; changes require recovery review"
+                .to_string(),
+        );
+    }
+    let Some(workspace_root) = workspace_root else {
+        return IntentionalNoChangeVerdict::Invalid(
+            "provider declared an intentional no-change verdict but Homeboy has no workspace checkout to verify; changes require recovery review"
+                .to_string(),
+        );
+    };
+    let head = git_output(workspace_root, &["rev-parse", "HEAD"]);
+    if head.as_deref() != Some(declaration.inspected_revision.as_str()) {
+        return IntentionalNoChangeVerdict::Invalid(
+            "provider declared an intentional no-change verdict for a revision that does not match the workspace checkout; changes require recovery review"
+                .to_string(),
+        );
+    }
+    if git_output(
+        workspace_root,
+        &["status", "--porcelain", "--untracked-files=all"],
+    )
+    .is_none_or(|status| !status.is_empty())
+    {
+        return IntentionalNoChangeVerdict::Invalid(
+            "provider declared an intentional no-change verdict but the workspace checkout changed; changes require recovery review"
+                .to_string(),
+        );
+    }
+    IntentionalNoChangeVerdict::Verified
+}
+
+fn git_output(workspace_root: &std::path::Path, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(workspace_root)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Evidence that the executor did real work even though its change artifact is

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -313,7 +313,7 @@ fn homeboy_local_artifact_normalization_measures_empty_nonempty_and_unavailable_
         artifact: Some(empty),
         metadata: Value::Null,
     }];
-    normalize_homeboy_local_artifact_sizes(&mut empty_outcome, root.path(), &provenance);
+    normalize_homeboy_local_artifact_sizes(&mut empty_outcome, root.path(), &provenance, None);
 
     assert_eq!(empty_outcome.status, AgentTaskOutcomeStatus::NoOp);
     assert_eq!(empty_outcome.artifacts[0].size_bytes, Some(0));
@@ -330,7 +330,7 @@ fn homeboy_local_artifact_normalization_measures_empty_nonempty_and_unavailable_
     nonempty_outcome.status = AgentTaskOutcomeStatus::Succeeded;
     nonempty_outcome.failure_classification = None;
     nonempty_outcome.artifacts = vec![nonempty];
-    normalize_homeboy_local_artifact_sizes(&mut nonempty_outcome, root.path(), &provenance);
+    normalize_homeboy_local_artifact_sizes(&mut nonempty_outcome, root.path(), &provenance, None);
     assert_eq!(nonempty_outcome.status, AgentTaskOutcomeStatus::Succeeded);
     assert!(nonempty_outcome.artifacts[0].size_bytes.unwrap_or_default() > 0);
 
@@ -338,7 +338,12 @@ fn homeboy_local_artifact_normalization_measures_empty_nonempty_and_unavailable_
     unavailable_outcome.status = AgentTaskOutcomeStatus::Succeeded;
     unavailable_outcome.failure_classification = None;
     unavailable_outcome.artifacts = vec![unavailable];
-    normalize_homeboy_local_artifact_sizes(&mut unavailable_outcome, root.path(), &provenance);
+    normalize_homeboy_local_artifact_sizes(
+        &mut unavailable_outcome,
+        root.path(),
+        &provenance,
+        None,
+    );
     assert_eq!(
         unavailable_outcome.status,
         AgentTaskOutcomeStatus::Succeeded
@@ -386,7 +391,7 @@ fn empty_patch_with_substantive_evidence_is_flagged_for_review_not_noop() {
     outcome.status = AgentTaskOutcomeStatus::Succeeded;
     outcome.failure_classification = None;
     outcome.artifacts = vec![empty_patch, transcript];
-    normalize_homeboy_local_artifact_sizes(&mut outcome, root.path(), &provenance);
+    normalize_homeboy_local_artifact_sizes(&mut outcome, root.path(), &provenance, None);
 
     assert_eq!(
         outcome.status,
@@ -400,6 +405,108 @@ fn empty_patch_with_substantive_evidence_is_flagged_for_review_not_noop() {
         .as_deref()
         .unwrap_or_default()
         .contains("needs review"));
+}
+
+#[test]
+fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_checkout() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let artifacts = tempfile::tempdir().expect("artifact root");
+    for args in [
+        ["init"].as_slice(),
+        ["config", "user.email", "homeboy@example.test"].as_slice(),
+        ["config", "user.name", "Homeboy Test"].as_slice(),
+    ] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(workspace.path())
+            .status()
+            .expect("run git")
+            .success());
+    }
+    fs::write(workspace.path().join("reviewed.rs"), "reviewed\n").expect("source");
+    assert!(std::process::Command::new("git")
+        .args(["add", "reviewed.rs"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("stage source")
+        .success());
+    assert!(std::process::Command::new("git")
+        .args(["commit", "-m", "review base"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("commit source")
+        .success());
+    let revision = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(workspace.path())
+            .output()
+            .expect("read revision")
+            .stdout,
+    )
+    .expect("UTF-8 revision")
+    .trim()
+    .to_string();
+    let empty_patch_path = artifacts.path().join("review.patch");
+    let transcript_path = artifacts.path().join("review.md");
+    fs::write(&empty_patch_path, "").expect("empty patch");
+    fs::write(&transcript_path, "No findings.\n".repeat(1024)).expect("large transcript");
+    let provenance = AgentTaskArtifactsPathProvenance {
+        owner: "homeboy".to_string(),
+        locality: "runner".to_string(),
+        plan_id: "plan".to_string(),
+        run_id: None,
+        task_id: "review".to_string(),
+        attempt: 1,
+    };
+    let mut patch = fixture_artifact("patch", "patch", &empty_patch_path, Some("text/x-patch"));
+    patch.size_bytes = None;
+    let mut transcript = fixture_artifact(
+        "transcript",
+        "transcript",
+        &transcript_path,
+        Some("text/markdown"),
+    );
+    transcript.size_bytes = None;
+    let mut outcome = failed_outcome_with_run_result(json!({
+        "status": "succeeded",
+        "intentional_no_change": {
+            "schema": "homeboy/intentional-no-change/v1",
+            "verdict": "no_change",
+            "inspected_revision": revision,
+        }
+    }));
+    outcome.status = AgentTaskOutcomeStatus::Succeeded;
+    outcome.failure_classification = None;
+    outcome.artifacts = vec![patch, transcript];
+
+    normalize_homeboy_local_artifact_sizes(
+        &mut outcome,
+        artifacts.path(),
+        &provenance,
+        Some(workspace.path()),
+    );
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert!(outcome
+        .summary
+        .as_deref()
+        .unwrap_or_default()
+        .contains("intentional no-change"));
+
+    fs::write(workspace.path().join("uncaptured.rs"), "must recover\n").expect("untracked source");
+    normalize_homeboy_local_artifact_sizes(
+        &mut outcome,
+        artifacts.path(),
+        &provenance,
+        Some(workspace.path()),
+    );
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::CandidateRecoverable);
+    assert!(outcome
+        .summary
+        .as_deref()
+        .unwrap_or_default()
+        .contains("checkout changed"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- accept an explicit revision-bound intentional no-change provider verdict only for a clean inspected checkout
- preserve fail-closed candidate recovery when no valid no-change declaration exists
- stop projecting non-timeout recoverable candidates as timed-out provider runtimes
- restore deterministic gates for verified no-op reviews

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-agents revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_checkout --lib`
- `cargo test -p homeboy-agents candidate_recoverable_provider_projection_is_failed_not_timed_out --lib`
- `cargo test -p homeboy-agents empty_patch_runs_public_and_private_gates_against_destination --lib`
- `cargo test -p homeboy-agents empty_patch_failing_gate_is_reported_against_destination --lib`

Closes #11042

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode implemented the change and regression coverage under Chris Huber direction. Chris remains responsible for the resulting code.