### PR TITLE
fix: confirm terminal status before reporting a run completed

### DIFF
--- a/crates/homeboy-core/src/daemon/completion_tracker.rs
+++ b/crates/homeboy-core/src/daemon/completion_tracker.rs
@@ -7,11 +7,33 @@
 //! so the daemon can fire exactly one completion notification per run instead
 //! of re-notifying every poll.
 //!
-//! This is pure state-diff logic with no I/O, clock, or notifier coupling, so
-//! it is deterministic and unit-testable. The daemon owns the polling cadence,
-//! the store reads, and the notification dispatch around it.
+//! Absence from a poll is **not** proof of completion. The running set arrives
+//! as a query result, and any bound or ordering churn in that query can evict a
+//! live run from the page. A false completion is not a harmless extra ping: the
+//! daemon marks the notification delivered before dispatching, so a run that is
+//! wrongly reported burns its exactly-once marker while still running, and the
+//! real completion is then suppressed on every path. Departure is therefore a
+//! *candidate*, confirmed against the run's actual status by the caller-supplied
+//! resolver before it is reported.
+//!
+//! The diff itself has no I/O, clock, or notifier coupling — the store read is
+//! injected — so it stays deterministic and unit-testable. The daemon owns the
+//! polling cadence, the store reads, and the notification dispatch around it.
 
 use std::collections::BTreeSet;
+
+/// The confirmed state of a run that disappeared from the running set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunTerminality {
+    /// The store confirms the run reached a terminal status. Report it.
+    Terminal,
+    /// The run is still running, carries a status Homeboy does not own, or the
+    /// store could not be read. Keep tracking it and re-check on a later poll.
+    Unresolved,
+    /// The run no longer exists in the store (reaped by retention). Stop
+    /// tracking it without reporting: there is nothing left to notify about.
+    Vanished,
+}
 
 /// Tracks the set of run ids observed running on the previous poll.
 #[derive(Debug, Default)]
@@ -21,19 +43,37 @@ pub struct CompletionTracker {
 
 impl CompletionTracker {
     /// Record the currently-running run ids and return the ids that completed
-    /// since the last call (were running before, are not running now).
+    /// since the last call.
+    ///
+    /// An id that was running before and is absent now is only *reported* when
+    /// `resolve` confirms [`RunTerminality::Terminal`]. An [`RunTerminality::Unresolved`]
+    /// id is retained in the tracked set, so a run evicted from a truncated or
+    /// re-ordered page is re-checked next poll and still reported when it truly
+    /// finishes.
     ///
     /// The first call seeds the baseline and reports nothing: the daemon only
     /// pings for runs it actually observed in flight, never for runs that were
     /// already settled when it started watching. Returned ids are sorted and
     /// de-duplicated.
-    pub fn observe<I>(&mut self, current_running: I) -> Vec<String>
+    pub fn observe<I, F>(&mut self, current_running: I, mut resolve: F) -> Vec<String>
     where
         I: IntoIterator<Item = String>,
+        F: FnMut(&str) -> RunTerminality,
     {
         let current: BTreeSet<String> = current_running.into_iter().collect();
-        let completed: Vec<String> = self.running.difference(&current).cloned().collect();
+        let mut completed = Vec::new();
+        let mut unresolved = BTreeSet::new();
+        for candidate in self.running.difference(&current) {
+            match resolve(candidate) {
+                RunTerminality::Terminal => completed.push(candidate.clone()),
+                RunTerminality::Unresolved => {
+                    unresolved.insert(candidate.clone());
+                }
+                RunTerminality::Vanished => {}
+            }
+        }
         self.running = current;
+        self.running.extend(unresolved);
         completed
     }
 }
@@ -41,55 +81,136 @@ impl CompletionTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
 
     fn ids(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
     }
 
+    /// Resolver for the cases where the running set is authoritative: every
+    /// departure really is a completion.
+    fn terminal(_run_id: &str) -> RunTerminality {
+        RunTerminality::Terminal
+    }
+
     #[test]
     fn first_observation_seeds_without_reporting_completions() {
         let mut tracker = CompletionTracker::default();
-        let completed = tracker.observe(ids(&["a", "b"]));
+        let completed = tracker.observe(ids(&["a", "b"]), terminal);
         assert!(completed.is_empty());
         // The seeded ids are now tracked: completing them reports them.
-        assert_eq!(tracker.observe(Vec::new()), ids(&["a", "b"]));
+        assert_eq!(tracker.observe(Vec::new(), terminal), ids(&["a", "b"]));
     }
 
     #[test]
     fn reports_runs_that_left_the_running_set() {
         let mut tracker = CompletionTracker::default();
-        tracker.observe(ids(&["a", "b", "c"]));
-        let completed = tracker.observe(ids(&["a"]));
+        tracker.observe(ids(&["a", "b", "c"]), terminal);
+        let completed = tracker.observe(ids(&["a"]), terminal);
         assert_eq!(completed, ids(&["b", "c"]));
     }
 
     #[test]
     fn newly_appearing_runs_are_tracked_then_reported_on_departure() {
         let mut tracker = CompletionTracker::default();
-        tracker.observe(ids(&["a"]));
+        tracker.observe(ids(&["a"]), terminal);
         // `d` appears mid-flight; nothing completed yet.
-        assert!(tracker.observe(ids(&["a", "d"])).is_empty());
+        assert!(tracker.observe(ids(&["a", "d"]), terminal).is_empty());
         // `a` finishes; `d` still running.
-        assert_eq!(tracker.observe(ids(&["d"])), ids(&["a"]));
+        assert_eq!(tracker.observe(ids(&["d"]), terminal), ids(&["a"]));
         // `d` finishes.
-        assert_eq!(tracker.observe(Vec::new()), ids(&["d"]));
+        assert_eq!(tracker.observe(Vec::new(), terminal), ids(&["d"]));
     }
 
     #[test]
     fn a_run_is_reported_only_once() {
         let mut tracker = CompletionTracker::default();
-        tracker.observe(ids(&["a"]));
-        assert_eq!(tracker.observe(Vec::new()), ids(&["a"]));
+        tracker.observe(ids(&["a"]), terminal);
+        assert_eq!(tracker.observe(Vec::new(), terminal), ids(&["a"]));
         // Subsequent polls without `a` running must not re-report it.
-        assert!(tracker.observe(Vec::new()).is_empty());
+        assert!(tracker.observe(Vec::new(), terminal).is_empty());
     }
 
     #[test]
     fn duplicate_running_ids_collapse() {
         let mut tracker = CompletionTracker::default();
-        let completed = tracker.observe(ids(&["a", "a", "b"]));
+        let completed = tracker.observe(ids(&["a", "a", "b"]), terminal);
         assert!(completed.is_empty());
         // Despite the duplicate, each id is reported at most once on departure.
-        assert_eq!(tracker.observe(Vec::new()), ids(&["a", "b"]));
+        assert_eq!(tracker.observe(Vec::new(), terminal), ids(&["a", "b"]));
+    }
+
+    #[test]
+    fn a_run_truncated_out_of_the_page_is_not_reported_completed() {
+        let mut tracker = CompletionTracker::default();
+        tracker.observe(ids(&["a", "b"]), terminal);
+        // The page drops `b` — bound hit, ordering churn — but `b` is still
+        // running. Reporting it here would burn its exactly-once delivery
+        // marker and permanently suppress the real completion.
+        let completed = tracker.observe(ids(&["a"]), |_| RunTerminality::Unresolved);
+        assert!(completed.is_empty());
+    }
+
+    #[test]
+    fn a_truncated_run_is_still_reported_when_it_actually_completes() {
+        let mut tracker = CompletionTracker::default();
+        tracker.observe(ids(&["a", "b"]), terminal);
+        // `b` is evicted from the page for two polls while still running.
+        assert!(tracker
+            .observe(ids(&["a"]), |_| RunTerminality::Unresolved)
+            .is_empty());
+        assert!(tracker
+            .observe(ids(&["a"]), |_| RunTerminality::Unresolved)
+            .is_empty());
+        // It never came back to the page, but the tracker kept it: once the
+        // store confirms terminality it is reported exactly once.
+        assert_eq!(tracker.observe(ids(&["a"]), terminal), ids(&["b"]));
+        assert!(tracker.observe(ids(&["a"]), terminal).is_empty());
+    }
+
+    #[test]
+    fn a_truncated_run_that_returns_to_the_page_is_not_double_tracked() {
+        let mut tracker = CompletionTracker::default();
+        tracker.observe(ids(&["a", "b"]), terminal);
+        assert!(tracker
+            .observe(ids(&["a"]), |_| RunTerminality::Unresolved)
+            .is_empty());
+        // `b` re-appears in the next page, then genuinely completes.
+        assert!(tracker.observe(ids(&["a", "b"]), terminal).is_empty());
+        assert_eq!(tracker.observe(ids(&["a"]), terminal), ids(&["b"]));
+    }
+
+    #[test]
+    fn only_the_departed_ids_are_resolved() {
+        let resolved = RefCell::new(Vec::new());
+        let mut tracker = CompletionTracker::default();
+        tracker.observe(ids(&["a", "b", "c"]), terminal);
+        resolved.borrow_mut().clear();
+        tracker.observe(ids(&["a"]), |run_id| {
+            resolved.borrow_mut().push(run_id.to_string());
+            RunTerminality::Terminal
+        });
+        // Runs still present in the page are never re-read from the store.
+        assert_eq!(*resolved.borrow(), ids(&["b", "c"]));
+    }
+
+    #[test]
+    fn a_vanished_run_is_dropped_without_being_reported() {
+        let mut tracker = CompletionTracker::default();
+        tracker.observe(ids(&["a"]), terminal);
+        // The record was reaped by retention: nothing to notify about, and it
+        // must not be retained forever either.
+        assert!(tracker
+            .observe(Vec::new(), |_| RunTerminality::Vanished)
+            .is_empty());
+        // Dropped, not retained: a later poll does not re-resolve it.
+        let mut resolved = 0_usize;
+        assert!(tracker
+            .observe(Vec::new(), |_| {
+                resolved += 1;
+                RunTerminality::Terminal
+            })
+            .is_empty());
+        assert_eq!(resolved, 0);
     }
 }

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1254,14 +1254,37 @@ fn completion_notify_loop(interval: std::time::Duration, shutdown: mpsc::Receive
                 );
             }
             let running_after = list_running_run_ids(&store);
-            for completed_id in tracker.observe(running_after) {
+            // Departure from the running set is only a *candidate* completion.
+            // Confirm terminality against the record itself before reporting:
+            // marking delivery is irreversible, so a run wrongly reported here
+            // would consume its exactly-once marker while still in flight and
+            // silence its real completion on every path.
+            let mut terminal_runs: HashMap<String, crate::observation::RunRecord> = HashMap::new();
+            let completed = tracker.observe(running_after, |run_id| match store.get_run(run_id) {
+                Ok(Some(run)) => {
+                    match crate::observation::RunStatus::from_label(&run.status) {
+                        Some(status) if status.is_terminal() => {
+                            terminal_runs.insert(run_id.to_string(), run);
+                            completion_tracker::RunTerminality::Terminal
+                        }
+                        // Still running, or a status label Homeboy does not
+                        // own: keep watching rather than guessing terminality.
+                        _ => completion_tracker::RunTerminality::Unresolved,
+                    }
+                }
+                Ok(None) => completion_tracker::RunTerminality::Vanished,
+                // A transient store error is not evidence of completion.
+                Err(_) => completion_tracker::RunTerminality::Unresolved,
+            });
+            for completed_id in completed {
                 let already_delivered = store
                     .is_notification_delivered(&completed_id)
                     .unwrap_or(false);
                 if already_delivered {
                     continue;
                 }
-                let run = store.get_run(&completed_id).ok().flatten();
+                // Loaded by the terminality resolver above; no second read.
+                let run = terminal_runs.remove(&completed_id);
                 let status = run
                     .as_ref()
                     .map(|run| run.status.as_str())
@@ -1295,13 +1318,15 @@ fn completion_notify_loop(interval: std::time::Duration, shutdown: mpsc::Receive
     }
 }
 
+/// Every run currently marked running — exhaustively, not a page of them.
+///
+/// A bounded page here is a silent truncation, not a guard: the completion
+/// notifier's only signal is presence in this set, so any run the bound cuts off
+/// reads as "gone". `list_active_runs` is the unbounded query that exists for
+/// exactly this reason.
 fn list_running_run_ids(store: &crate::observation::ObservationStore) -> Vec<String> {
     store
-        .list_runs(crate::observation::RunListFilter {
-            status: Some(crate::observation::RunStatus::Running.as_str().to_string()),
-            limit: Some(1000),
-            ..Default::default()
-        })
+        .list_active_runs()
         .unwrap_or_default()
         .into_iter()
         .map(|run| run.id)


### PR DESCRIPTION
Closes #11116. Found during the 2026-08-01 consolidation investigation (#11151).

## The bug

The daemon's completion notifier treated **absence from one page of running runs as proof of completion**. It was not proof — and the damage is not a spurious ping, it is permanent suppression of the real one.

### The chain

**1. The page is a truncation, not a guard.**

`list_running_run_ids` asked for `limit: Some(1000)`, and `list_runs` clamps to 1000 and orders by `started_at DESC, id DESC`. Above 1000 concurrent running runs the query silently drops rows, and ordering churn between polls evicts *arbitrary* ids. `fanout submit-batch` exists specifically to launch batches that large, so this is reachable in ordinary use, not a synthetic edge case.

**2. The tracker's sole definition of "completed" was departure from that page.**

```rust
let current: BTreeSet<String> = current_running.into_iter().collect();
let completed: Vec<String> = self.running.difference(&current).cloned().collect();
```

A truncated-out run is indistinguishable from a finished one.

**3. The false completion wins the exactly-once race.**

The loop called `mark_notification_delivered(&completed_id, "controller")` — the single coordination point that prevents duplicate notifications. It set the delivery marker on a run that was **still running**.

**4. The real completion is then dropped by every path.**

When the run actually finishes, `fire_runner_direct_notification` (`homeboy-lab-runner/src/execution/mod.rs`) returns early on `already_delivered`, and this loop's own `is_notification_delivered` check skips it too.

Net observable behavior: **the orchestrator receives a completion notice carrying `status: "running"`, and then silence.** No further notification is ever sent for that run.

### Why this is worse than a spurious ping

A spurious ping is noisy but recoverable — the consumer sees an event, can re-read the run, and the real completion still arrives. Here the spurious event *consumes the exactly-once token*, so it converts a duplicate-delivery problem into a **lost-delivery** problem. The completion notifier exists precisely so a detached or offloaded run never becomes a ghost; under truncation it was the thing manufacturing ghosts. And it fails silently: no error, no log, a green-looking event with the wrong status.

## The fix

### Correctness — gate the diff on confirmed terminality

`CompletionTracker::observe` now takes a resolver and only reports an id the store confirms terminal. Critically, a departed id that is **not** confirmed terminal is *retained* in the tracked running set rather than dropped — so a run evicted from a truncated or re-ordered page is re-checked on subsequent polls and is still reported exactly once when it genuinely finishes. Simply skipping it would have traded a false completion for a missed one.

`RunTerminality` makes the three outcomes explicit:

| variant | meaning | action |
|---|---|---|
| `Terminal` | store confirms a terminal status | report |
| `Unresolved` | still running, a status label Homeboy does not own, or a store read error | retain, re-check next poll |
| `Vanished` | record no longer exists (reaped by retention) | drop without reporting |

`Unresolved` deliberately covers unknown status labels and transient store errors — neither is evidence of completion, matching the existing convention in `RunStatus::from_label` ("callers can treat an unknown status conservatively rather than guessing terminality") and `terminal_run_ids_before` ("Unknown statuses are deliberately retained rather than guessed terminal"). `Vanished` exists so retained ids cannot accumulate without bound in a long-lived daemon.

The resolver hands the loaded `RunRecord` back to the loop, so confirmation costs **no extra store read** — the loop consumes the record the resolver already fetched.

### Defense in depth — remove the magic 1000

`list_running_run_ids` now calls `list_active_runs()`, the already-existing unbounded running-set query whose doc comment says it exists for exactly this reason ("List every currently running run so callers can retain active work when applying a separate display limit"). No new SQL, and the magic constant is gone.

The gate alone is sufficient for correctness; the exhaustive query additionally ensures runs launched beyond the old bound are *seeded* into the tracker in the first place, so the controller backstop can see them at all.

## Tests

Extended `completion_tracker.rs` with the truncation case and its follow-through — all hermetic, no I/O, sub-millisecond:

- `a_run_truncated_out_of_the_page_is_not_reported_completed` — the core regression: a page drops a still-running id, nothing is reported.
- `a_truncated_run_is_still_reported_when_it_actually_completes` — retained across two evicted polls, then reported exactly once on real terminality. This is the test that would fail if the fix were "skip it" instead of "retain it".
- `a_truncated_run_that_returns_to_the_page_is_not_double_tracked`
- `a_vanished_run_is_dropped_without_being_reported` — asserts the id is not re-resolved on a later poll, pinning the no-leak property.
- `only_the_departed_ids_are_resolved` — runs still present in the page are never re-read from the store.

Existing tests are preserved, passing an always-terminal resolver (the case where the running set really is authoritative).

## Verification

- `cargo fmt -p homeboy-core` clean.
- `cargo check -p homeboy-core --lib` exits 0, no new warnings.
- The tracker module is std-only, so its test module was compiled and run in isolation (10/10 pass, `cargo clippy --all-targets -- -D warnings` clean) rather than building homeboy-core's full test target locally. CI is the gate for the rest.
