### PR TITLE
Make a cook's id and its route usable from outside the launching process

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -16,7 +16,7 @@ use homeboy_core::activity::{
     ActivityNextAction, ActivityRunnerRefs, ActivityState,
 };
 
-use super::{load_controller_plan, plan_has_retry_materialization_identity};
+use super::{load_controller_plan, plan_has_retry_materialization_identity, resolve_run_id};
 use homeboy_core::run_lifecycle_record::RunExecutionState;
 use homeboy_core::Result;
 
@@ -35,9 +35,7 @@ impl ActivityAgentTaskProvider for AgentTaskActivityProvider {
     /// daemon job UUID, a malformed record — is `None`, not an error, so id
     /// resolution falls through to the next provider.
     fn probe_by_id(&self, id: &str) -> Result<Option<ActivityItem>> {
-        Ok(agent_task_lifecycle::exact_record(id)
-            .ok()
-            .map(item_from_agent_task))
+        Ok(record_for_id(id).map(item_from_agent_task))
     }
 
     /// One pass over the durable records yields both the projected items and
@@ -54,6 +52,35 @@ impl ActivityAgentTaskProvider for AgentTaskActivityProvider {
         })?;
         Ok((items, health))
     }
+}
+
+/// Resolve an id the way every operator-facing action already claims to.
+///
+/// A durable run id resolves directly. A **Cook id** does not: attempts are
+/// stored under `{cook_id}-attempt-{n}-{suffix}`, so `exact_record(cook_id)`
+/// is always a miss and `activity watch <cook_id>` reported
+/// `activity item not found` — even though the cook notification that handed
+/// the operator that command emitted it next to `agent-task status <cook_id>`,
+/// which *does* resolve because it routes through the same Cook alias index
+/// (#11112). The two actions disagreed about what a cook id is.
+///
+/// The fallback is additive: run ids keep their existing single-read
+/// behaviour and only an id that missed pays for the alias lookup.
+///
+/// Both steps are pure reads. `resolve_run_id` is an indexed
+/// `read_cook_index`, not the reconciling `status()` — resolving one id must
+/// still never mutate persisted state (#10308).
+fn record_for_id(id: &str) -> Option<AgentTaskRunRecord> {
+    if let Ok(record) = agent_task_lifecycle::exact_record(id) {
+        return Some(record);
+    }
+    let resolved = resolve_run_id(id).ok()?;
+    if resolved == id {
+        // Not a Cook alias: `resolve_run_id` echoed the id back, so a second
+        // `exact_record` would repeat the miss above.
+        return None;
+    }
+    agent_task_lifecycle::exact_record(&resolved).ok()
 }
 
 fn metadata_string(value: &Value, keys: &[&str]) -> Option<String> {
@@ -260,6 +287,78 @@ mod tests {
 
             assert_eq!(shown.schema, report.schema);
             assert!(shown.agent_task_record_health.is_null());
+        });
+    }
+
+    #[test]
+    fn probe_by_id_resolves_a_cook_id_through_its_alias_index_without_writing() {
+        // #11112: a cook notification hands the operator
+        // `homeboy activity watch <cook_id>`, but attempts are stored under
+        // `{cook_id}-attempt-{n}-{suffix}`, so the exact read always missed and
+        // the command reported `activity item not found`. The alias must
+        // resolve to the latest attempt — and, like every other activity read,
+        // must not mutate persisted state (#10308).
+        with_isolated_home(|_| {
+            let cook_id = "cook-alias";
+            let attempt = seed_record("cook-alias-attempt-1-aaaa");
+            agent_task_lifecycle::replace_cook_index_for_test(
+                &crate::agent_task_lifecycle::AgentTaskCookIndex {
+                    schema: crate::agent_task_lifecycle::schemas::COOK_INDEX.to_string(),
+                    cook_id: cook_id.to_string(),
+                    latest_run_id: attempt.clone(),
+                    latest_substantive_candidate: None,
+                    attempts: vec![crate::agent_task_lifecycle::AgentTaskCookIndexAttempt {
+                        attempt: 1,
+                        run_id: attempt.clone(),
+                        recorded_at: "2026-01-01T00:00:00Z".to_string(),
+                    }],
+                },
+            )
+            .expect("durable cook index");
+            let before = agent_task_lifecycle::exact_record(&attempt).expect("attempt record");
+
+            let item = AgentTaskActivityProvider
+                .probe_by_id(cook_id)
+                .expect("probe")
+                .expect("cook id resolves to its latest attempt");
+
+            assert_eq!(item.id, attempt);
+            assert_eq!(item.source_store, "agent-task.lifecycle");
+            assert_eq!(
+                item.refs.agent_task_run_id.as_deref(),
+                Some(attempt.as_str())
+            );
+            assert_eq!(
+                agent_task_lifecycle::exact_record(&attempt).expect("record remains readable"),
+                before
+            );
+        });
+    }
+
+    #[test]
+    fn probe_by_id_still_prefers_an_exact_run_id_over_the_alias_fallback() {
+        // The fallback is additive. A run id that resolves directly must never
+        // be redirected to whatever a same-named cook index happens to point at.
+        with_isolated_home(|_| {
+            let direct = seed_record("cook-alias-attempt-2-bbbb");
+            let other = seed_record("cook-alias-attempt-9-cccc");
+            agent_task_lifecycle::replace_cook_index_for_test(
+                &crate::agent_task_lifecycle::AgentTaskCookIndex {
+                    schema: crate::agent_task_lifecycle::schemas::COOK_INDEX.to_string(),
+                    cook_id: direct.clone(),
+                    latest_run_id: other,
+                    latest_substantive_candidate: None,
+                    attempts: Vec::new(),
+                },
+            )
+            .expect("durable cook index");
+
+            let item = AgentTaskActivityProvider
+                .probe_by_id(&direct)
+                .expect("probe")
+                .expect("run id resolves exactly");
+
+            assert_eq!(item.id, direct);
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2748,7 +2748,18 @@ pub fn exact_record(run_id: &str) -> Result<AgentTaskRunRecord> {
     store::read_record(&sanitize_run_id(run_id))
 }
 
-fn resolve_run_id(run_id: &str) -> Result<String> {
+/// Resolve a caller-supplied identifier to the durable run it addresses.
+///
+/// A Cook id is an alias, not a record: attempts are stored under
+/// `{cook_id}-attempt-{n}-{suffix}`, so `exact_record(cook_id)` always misses.
+/// This maps the alias through the durable Cook index and returns the id
+/// unchanged when it is not an alias.
+///
+/// This is a **pure read**: `store::read_cook_index` is a single
+/// `fs::read_to_string` of `agent-task-cooks/<id>/index.json` and writes
+/// nothing. Read models that must not mutate persisted state (`activity`,
+/// #10308) may use it; `status()` may not, because it reconciles.
+pub(crate) fn resolve_run_id(run_id: &str) -> Result<String> {
     let run_id = sanitize_run_id(run_id);
     match store::read_cook_index(&run_id) {
         Ok(index) => Ok(index.latest_run_id),

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -738,6 +738,51 @@ pub fn persist_notification_route(
     store::write_record(&record)
 }
 
+/// Read back the route a run was launched with.
+///
+/// The route a caller supplied is bound to the launching *thread*
+/// (`notification_route::current`), which a process that did not launch the
+/// cook — `cook --continue`, controller adoption, claimed continuation — never
+/// inherits. It is also persisted on the durable record by
+/// [`persist_notification_route`], and that copy survives the process. This is
+/// the same durable read the daemon completion backstop and `runs watch`
+/// already perform (#11115).
+///
+/// A missing record, a record without a route, or a malformed route is `None`:
+/// notification routing is observability and must never fail a cook.
+pub fn durable_notification_route(
+    run_id: &str,
+) -> Option<homeboy_core::notification_route::NotificationRoute> {
+    if run_id.trim().is_empty() {
+        return None;
+    }
+    let record = store::read_record(&resolve_run_id(run_id).ok()?).ok()?;
+    homeboy_core::notification_route::NotificationRoute::from_metadata(&record.metadata)
+}
+
+/// Claim the single terminal notification a Cook is allowed to deliver.
+///
+/// Returns `Ok(true)` for the caller that won the claim and `Ok(false)` for
+/// every later one, mirroring `ObservationStore::mark_notification_delivered`
+/// — same `{at, by}` marker, same only-if-absent semantics, same
+/// "the winner dispatches" contract. It differs only in its key: that marker
+/// is a column on one `runs` row, and a Cook spans many runs
+/// (`{cook_id}-attempt-{n}-{suffix}`), so a per-run marker cannot dedupe a
+/// per-cook event. Durable route rehydration (#11115) lets a second process
+/// reach the same cook's terminal boundary, so the cook needs its own claim.
+pub fn claim_cook_terminal_notification(cook_id: &str, delivered_by: &str) -> Result<bool> {
+    if cook_id.trim().is_empty() {
+        return Ok(false);
+    }
+    store::claim_cook_notification(
+        cook_id,
+        &json!({
+            "at": now_timestamp(),
+            "by": delivered_by,
+        }),
+    )
+}
+
 pub fn record_completed_run(
     plan: &AgentTaskPlan,
     aggregate: &AgentTaskAggregate,

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -24,13 +24,16 @@
 use homeboy_core::notification_payload::{
     NotifyAction, NotifyEventKind, NotifyLink, NotifyPayload, NotifySubject,
 };
-use homeboy_core::notification_route;
+use homeboy_core::notification_route::{self, NotificationRoute};
 use homeboy_core::notify::{self, NotifyEvent};
 
 use crate::agent_task_service::AgentTaskCookReport;
 
 /// Generic subject class for every cook lifecycle notification.
 const COOK_SUBJECT_KIND: &str = "agent_task_cook";
+
+/// Attribution recorded on the cook-level exactly-once marker.
+const COOK_TERMINAL_DELIVERED_BY: &str = "cook-controller";
 
 /// Whether a cook lifecycle event is delivered.
 ///
@@ -44,8 +47,28 @@ fn should_deliver(kind: NotifyEventKind, has_explicit_route: bool) -> bool {
     kind.is_terminal() || has_explicit_route
 }
 
-fn deliver(event: NotifyEvent) {
-    let route = notification_route::current();
+/// The destination this cook's events belong to.
+///
+/// `notification_route::current()` is a **thread-local**, so it only answers in
+/// the process and on the thread that accepted `--notification-route`. A cook
+/// resumed elsewhere — `cook --continue`, controller adoption, a claimed
+/// continuation — starts with an empty one, which silently downgraded the whole
+/// arc: `Started`/`Progress` were dropped by `should_deliver`, and the terminal
+/// event went to the ambient default transport instead of the thread that
+/// launched the work. The route is already persisted on the durable record, and
+/// both the daemon completion backstop and `runs watch` already read it back
+/// from there; this closes the same gap for cook lifecycle events (#11115).
+///
+/// In-process thread hops are still covered by
+/// `notification_route::capture`/`bind`; the thread-local deliberately wins so
+/// an explicitly bound route is never overridden by durable metadata.
+fn effective_route(run_id: &str) -> Option<NotificationRoute> {
+    notification_route::current()
+        .or_else(|| crate::agent_task_lifecycle::durable_notification_route(run_id))
+}
+
+fn deliver(event: NotifyEvent, run_id: &str) {
+    let route = effective_route(run_id);
     if !should_deliver(event.kind, route.is_some()) {
         return;
     }
@@ -122,6 +145,7 @@ pub(crate) fn cook_started(
         NotifyEvent::lifecycle(NotifyEventKind::Started, cook_id, "started")
             .with_title(format!("cook started — {title}"))
             .with_payload(payload),
+        run_id,
     );
 }
 
@@ -158,6 +182,7 @@ pub(crate) fn cook_retrying(
         NotifyEvent::lifecycle(NotifyEventKind::Progress, cook_id, "retrying")
             .with_title(format!("cook attempt {attempt} of {max_attempts}"))
             .with_payload(payload),
+        run_id,
     );
 }
 
@@ -232,8 +257,35 @@ fn terminal_payload(
 }
 
 /// The cook reached a terminal outcome.
+///
+/// Delivered at most once per *cook*. The pre-existing exactly-once marker is
+/// keyed on a `runs` row, which dedupes one attempt against the runner-direct
+/// and daemon-backstop paths but cannot dedupe an event whose subject is the
+/// cook. That was tolerable while only the launching thread could deliver;
+/// durable route rehydration (#11115) means a second process reaching the same
+/// terminal boundary — a `--continue` over an already-terminal cook, an adopted
+/// controller — would now re-announce an outcome the operator already has.
 pub(crate) fn cook_terminal(report: &AgentTaskCookReport, component: Option<&str>, exit_code: i32) {
+    // Claim before building the payload, and treat a failed claim the same as a
+    // lost one: the runner-direct and daemon-backstop paths also decline to
+    // dispatch when their marker cannot be established, because a duplicated
+    // terminal notification is worse than a missing one.
+    let claimed = crate::agent_task_lifecycle::claim_cook_terminal_notification(
+        &report.cook_id,
+        COOK_TERMINAL_DELIVERED_BY,
+    )
+    .unwrap_or(false);
+    if !claimed {
+        return;
+    }
     let succeeded = exit_code == 0;
+    // The cook id resolves through the same alias index when a report carries
+    // no latest attempt, so a terminal event is never left unroutable.
+    let route_run_id = report
+        .latest_run_id
+        .clone()
+        .filter(|run_id| !run_id.trim().is_empty())
+        .unwrap_or_else(|| report.cook_id.clone());
     let payload = terminal_payload(report, component, exit_code);
     deliver(
         NotifyEvent::lifecycle(payload.kind, &report.cook_id, &report.status)
@@ -247,6 +299,7 @@ pub(crate) fn cook_terminal(report: &AgentTaskCookReport, component: Option<&str
                 report.cook_id
             ))
             .with_payload(payload),
+        &route_run_id,
     );
 }
 
@@ -412,7 +465,87 @@ mod tests {
             cook_started("cook-abc", "run-1", "task", None, "main", 3, "claude");
             cook_retrying("cook-abc", "run-1", None, 2, 3);
             cook_terminal(&report("succeeded", None), None, 0);
-            cook_terminal(&report("durable_failure", None), None, 1);
+            // A distinct cook: the terminal event is now claimed once per cook,
+            // so reusing `cook-abc` would exercise the dedupe rather than the
+            // failure path.
+            let mut failed = report("durable_failure", None);
+            failed.cook_id = "cook-def".to_string();
+            cook_terminal(&failed, None, 1);
+        });
+    }
+
+    fn route(destination: &str) -> NotificationRoute {
+        NotificationRoute::new("extension", destination).expect("route")
+    }
+
+    fn seed_run_with_route(run_id: &str, destination: &str) {
+        let plan = crate::agent_task_scheduler::AgentTaskPlan::new("notify-plan", Vec::new());
+        crate::agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("durable run");
+        crate::agent_task_lifecycle::persist_notification_route(run_id, &route(destination))
+            .expect("persist route");
+    }
+
+    #[test]
+    fn a_cook_resumed_in_a_new_process_recovers_its_route_from_the_durable_record() {
+        // #11115: `notification_route::current()` is a thread-local, so a
+        // process that did not launch the cook (`cook --continue`, controller
+        // adoption, claimed continuation) has none. Without the durable
+        // fallback the whole arc degrades: Started/Progress are dropped and the
+        // terminal event lands on the ambient default transport instead of the
+        // thread that asked for this work. No route is bound here — that is the
+        // resumed process.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            seed_run_with_route("cook-resumed-attempt-1-aaaa", "thread-42");
+            assert!(notification_route::current().is_none());
+
+            let resolved = effective_route("cook-resumed-attempt-1-aaaa");
+
+            assert_eq!(resolved, Some(route("thread-42")));
+        });
+    }
+
+    #[test]
+    fn an_explicitly_bound_route_still_wins_over_durable_metadata() {
+        // The thread-local is the caller's live intent; durable metadata is
+        // only the fallback for a process that has none. In-process thread hops
+        // keep using capture/bind and must not be overridden.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            seed_run_with_route("cook-bound-attempt-1-aaaa", "durable-thread");
+
+            let resolved = notification_route::with_current(Some(route("live-thread")), || {
+                effective_route("cook-bound-attempt-1-aaaa")
+            });
+
+            assert_eq!(resolved, Some(route("live-thread")));
+        });
+    }
+
+    #[test]
+    fn an_unroutable_run_is_silent_rather_than_a_cook_failure() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            assert!(effective_route("no-such-run").is_none());
+            assert!(effective_route("").is_none());
+        });
+    }
+
+    #[test]
+    fn the_terminal_event_is_claimed_once_per_cook_not_once_per_attempt() {
+        // The pre-existing exactly-once marker is a column on one `runs` row,
+        // so it cannot dedupe an event whose subject is the cook. Durable route
+        // rehydration lets a second process reach the same terminal boundary,
+        // so the claim has to be keyed the way the event is.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let claim = |cook_id: &str| {
+                crate::agent_task_lifecycle::claim_cook_terminal_notification(cook_id, "test")
+                    .expect("claim")
+            };
+
+            assert!(claim("cook-once"));
+            assert!(!claim("cook-once"));
+            // Every other cook still gets its one delivery.
+            assert!(claim("cook-other"));
+            // An empty id is never claimable, so it can never suppress a real one.
+            assert!(!claim(""));
         });
     }
 }

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -334,6 +334,44 @@ pub(super) fn cook_index_exists(cook_id: &str) -> Result<bool> {
     Ok(cook_index_path(cook_id)?.exists())
 }
 
+/// Claim the one terminal notification a Cook is allowed to deliver.
+///
+/// The claim is the creation of the marker file itself: `create_new` is
+/// `O_EXCL`, so exactly one caller — in any process, on any thread — observes
+/// `Ok(true)`. This is the cook-scoped counterpart of
+/// `ObservationStore::mark_notification_delivered`, which cannot serve here
+/// because it is keyed on a `runs` row and a Cook id is an alias with no row
+/// of its own.
+pub(super) fn claim_cook_notification(cook_id: &str, marker: &Value) -> Result<bool> {
+    let path = cook_index_path(&sanitize_run_id(cook_id))?.with_file_name("notification.json");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+    }
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            use std::io::Write;
+            let bytes = serde_json::to_vec(marker).map_err(|error| {
+                Error::internal_json(error.to_string(), Some(path.display().to_string()))
+            })?;
+            file.write_all(&bytes).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(path.display().to_string()))
+            })?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(path.display().to_string()),
+        )),
+    }
+}
+
 pub(super) fn update_cook_index(
     cook_id: &str,
     mutate: impl FnOnce(&mut AgentTaskCookIndex) -> bool,


### PR DESCRIPTION
Two fixes for the same failure mode, found during the 2026-08-01 consolidation investigation (#11151): an external orchestration plane — an OpenCode/chat agent that fans out cooks and reports back to a thread — cannot use what a cook hands it.

## #11112 — `activity watch <cook_id>` could never resolve

A cook notification attaches two actions built from the same id in the same payload:

```
homeboy agent-task status <cook_id>     # works
homeboy activity watch <cook_id>        # activity item not found: <cook_id>
```

`status()` routes through `resolve_run_id`, which maps a Cook id through its durable index. The activity provider's `probe_by_id` called `exact_record`, which explicitly documents that it refuses Cook-id resolution. Since attempts are stored as `{cook_id}-attempt-{n}-{suffix}`, that read always missed, and `activity.rs`'s fallback only matches `item.id` / `refs.run_id` / `refs.agent_task_run_id` / `refs.runner_job_id` — all run ids. The two actions disagreed about what a cook id is.

`probe_by_id` now falls back to the alias index when the exact read misses. Additive: a run id keeps its existing single indexed read, and only a miss pays for the lookup.

### The #10308 non-mutation constraint

`activity` is a read model that must not mutate persisted state, which is why `probe_by_id` was written against `exact_record` and not `status()`. That is preserved. `resolve_run_id` was read and confirmed to be a pure read before it was used here:

```
resolve_run_id -> store::read_cook_index -> read_json -> fs::read_to_string
                 (path from paths::homeboy_data(), pure env/path joins)
```

No write, no directory creation, no lock, no reconciliation. `status()` is still not on this path and must not be. The existing `probe_by_id_resolves_one_record_without_scanning_or_writing` before/after assertions are extended to the new alias path.

## #11115 — the notification route was thread-local-only, never rehydrated

`deliver` read the route from `notification_route::current()` alone — a thread-local. A cook resumed in a process that did not launch it (`cook --continue`, controller adoption, the claimed continuation in `run.rs`) has none, and the whole arc silently degrades: `Started`/`Progress` are dropped unconditionally by `should_deliver`, and the terminal event goes to the **ambient global default transport instead of the thread that launched the cook**. For an orchestrator, that is the difference between "my cook reported back" and "the outcome went somewhere else".

The route is already durable — `persist_notification_route` writes it from `run_plan_projection` — and two subsystems already read it back with `NotificationRoute::from_metadata`: the daemon completion backstop (`daemon/mod.rs`) and `runs watch`. Cook lifecycle events were the outlier.

`deliver` now takes the run id every emitter already has and falls back:

```rust
notification_route::current().or_else(|| durable_notification_route(run_id))
```

`from_metadata` is reused verbatim — no contract change. The thread-local still wins, so an explicitly bound route (including one propagated to a worker thread via `capture`/`bind`) is never overridden by durable metadata. In-process thread hops were already handled; this closes the cross-process case. `cook_terminal` uses `report.latest_run_id` and falls back to the Cook id, which resolves through the same alias index fixed above.

### Cook-level dedupe

Rehydration means a second process can now reach the same cook's terminal boundary, so the terminal event is claimed **once per cook**.

The pre-existing marker, `ObservationStore::mark_notification_delivered`, is a conditional `UPDATE ... WHERE json_extract(...) IS NULL` on **one `runs` row**. It dedupes the runner-direct path against the daemon backstop for a single attempt, but it cannot dedupe an event whose subject spans every attempt of a cook — and a Cook id is an alias with no `runs` row of its own, so it cannot even be called with one.

`claim_cook_terminal_notification` is the same contract keyed by Cook id: same `{at, by}` marker payload, same only-if-absent semantics, same "the winner dispatches, a failed claim declines" behaviour as both existing callers. Atomicity comes from `O_EXCL` creation of `agent-task-cooks/<cook_id>/notification.json` — exactly one caller in any process on any thread observes `Ok(true)`.

## Verification

`cargo fmt -p homeboy-agents`; `cargo check -p homeboy-agents --lib` and `cargo check -p homeboy-core --lib` both exit 0 with no new warnings against the pre-change baseline. Unit tests are added for both fixes (alias resolution + non-mutation, exact-id precedence, cross-process rehydration, thread-local precedence, unroutable-is-silent, once-per-cook claim); they were written but not executed locally — this host cannot run the agents suite, so CI is the gate.
