### PR TITLE
fix: stop cook reports naming a prior session's run, and keep the default report actionable

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -39,7 +39,8 @@ use super::cook_promotion::{
     is_moving_base_finalization_error, moving_base_recovery_for_run,
     moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
     persisted_promotion_for_attempt, promote_or_load_attempt, recover_moving_base_cook_candidate,
-    refreshed_moving_base_recovery, retryable_provider_discovery_failure, MovingBaseCookRecovery,
+    refreshed_moving_base_recovery, retryable_provider_discovery_failure, CookReportInput,
+    MovingBaseCookRecovery,
 };
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
@@ -129,15 +130,15 @@ fn pre_artifact_interruption_report(
     reason: String,
     exit_code: i32,
 ) -> AgentTaskRunResult<AgentTaskCookReport> {
-    let mut report = cook_report(
+    let mut report = cook_report(CookReportInput {
         cook_id,
-        "pre_artifact_interruption",
+        status: "pre_artifact_interruption",
         attempts,
-        None,
-        Some(reason),
+        finalization: None,
+        stop_reason: Some(reason),
         exit_code,
-        Some(run_id),
-    );
+        invocation_latest_run_id: Some(run_id),
+    });
     report.value.terminal_phase = Some(phase.name().to_string());
     report.value.terminal_failure_classification = Some("pre_artifact_interruption".to_string());
     report
@@ -1773,15 +1774,23 @@ fn durable_cook_error_report(
     error: Error,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     if super::recipe_exists(&options.cook_id)? {
-        let mut report = cook_report(
-            options.cook_id.clone(),
-            "durable_failure",
-            Vec::new(),
-            None,
-            Some("Cook stopped after durable creation; use the recovery actions in failure_context to inspect or continue it.".to_string()),
-            1,
-            None,
-        );
+        let mut report = cook_report(CookReportInput {
+            cook_id: options.cook_id.clone(),
+            status: "durable_failure",
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: Some(
+                "Cook stopped after durable creation; use the recovery actions in \
+                 failure_context to inspect or continue it."
+                    .to_string(),
+            ),
+            exit_code: 1,
+            // A controller failure still belongs to THIS invocation. Without
+            // this, the report — and every recovery command
+            // `cook_failure_context` stamps with it — falls back to the
+            // cross-invocation Cook index and can name a prior session's run.
+            invocation_latest_run_id: Some(&options.initial_run_id),
+        });
         if let Some(context) = &mut report.value.failure_context {
             // This is a controller failure, not a provider attempt. Keep a
             // bounded, redacted cause so continuation never needs redispatch.
@@ -2312,15 +2321,15 @@ where
                     ));
                 }
                 if attempt == max_attempts {
-                    return Ok(cook_report(
+                    return Ok(cook_report(CookReportInput {
                         cook_id,
-                        "retries_exhausted",
+                        status: "retries_exhausted",
                         attempts,
-                        None,
-                        Some(error.to_string()),
-                        1,
-                        Some(&run_id),
-                    ));
+                        finalization: None,
+                        stop_reason: Some(error.to_string()),
+                        exit_code: 1,
+                        invocation_latest_run_id: Some(&run_id),
+                    }));
                 }
                 let next_attempt = attempt + 1;
                 let next_run_id = agent_task_lifecycle::cook_attempt_run_id(&cook_id, next_attempt);
@@ -2366,15 +2375,15 @@ where
                 promotion: None,
                 feedback: None,
             });
-            return Ok(cook_report(
+            return Ok(cook_report(CookReportInput {
                 cook_id,
-                "in_flight",
+                status: "in_flight",
                 attempts,
-                None,
-                Some("provider attempt accepted by the runner daemon".to_string()),
-                0,
-                Some(&run_id),
-            ));
+                finalization: None,
+                stop_reason: Some("provider attempt accepted by the runner daemon".to_string()),
+                exit_code: 0,
+                invocation_latest_run_id: Some(&run_id),
+            }));
         }
         let plan = agent_task_lifecycle::load_plan_for_execution(&run_id)?;
         budget_limit.get_or_insert_with(|| plan.options.execution_budget.clone());
@@ -2460,15 +2469,17 @@ where
             .provider_rotations
             .saturating_add(remediation_category_usage.provider_rotations);
         let Some(source_request) = plan.tasks.first().cloned() else {
-            return Ok(cook_report(
+            return Ok(cook_report(CookReportInput {
                 cook_id,
-                "policy_failure",
+                status: "policy_failure",
                 attempts,
-                None,
-                Some("agent-task cook requires a plan with one source task".to_string()),
-                1,
-                Some(&run_id),
-            ));
+                finalization: None,
+                stop_reason: Some(
+                    "agent-task cook requires a plan with one source task".to_string(),
+                ),
+                exit_code: 1,
+                invocation_latest_run_id: Some(&run_id),
+            }));
         };
         validate_cook_candidate_group(&plan)?;
 
@@ -2488,18 +2499,18 @@ where
                 promotion: None,
                 feedback: None,
             });
-            return Ok(cook_report(
+            return Ok(cook_report(CookReportInput {
                 cook_id,
-                "provider_failure",
+                status: "provider_failure",
                 attempts,
-                None,
-                Some(format!(
+                finalization: None,
+                stop_reason: Some(format!(
                     "agent-task run {run_id} ended in state {:?}",
                     record.state
                 )),
-                1,
-                Some(&run_id),
-            ));
+                exit_code: 1,
+                invocation_latest_run_id: Some(&run_id),
+            }));
         }
 
         if let Some(finalization) = record
@@ -2524,15 +2535,15 @@ where
                 promotion: None,
                 feedback: None,
             });
-            return Ok(cook_report(
+            return Ok(cook_report(CookReportInput {
                 cook_id,
-                &status,
+                status: &status,
                 attempts,
-                Some(finalization),
-                None,
+                finalization: Some(finalization),
+                stop_reason: None,
                 exit_code,
-                Some(&run_id),
-            ));
+                invocation_latest_run_id: Some(&run_id),
+            }));
         }
 
         report_cook_progress(
@@ -2555,15 +2566,15 @@ where
                     feedback: None,
                 });
                 let recovery = "promotion provider response was rejected. The successful candidate remains durable; use failure_context to inspect or continue the Cook.".to_string();
-                return Ok(cook_report(
+                return Ok(cook_report(CookReportInput {
                     cook_id,
-                    "policy_failure",
+                    status: "policy_failure",
                     attempts,
-                    None,
-                    Some(recovery),
-                    1,
-                    Some(&run_id),
-                ));
+                    finalization: None,
+                    stop_reason: Some(recovery),
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(&run_id),
+                }));
             }
         };
 
@@ -2602,18 +2613,19 @@ where
         match feedback_status {
             AgentTaskCookLoopStatus::GreenCompleted => {
                 if options.no_finalize {
-                    return Ok(cook_report(
+                    return Ok(cook_report(CookReportInput {
                         cook_id,
-                        "green_no_finalize",
+                        status: "green_no_finalize",
                         attempts,
-                        None,
-                        Some(
-                            "deterministic gates completed green; --no-finalize skipped commit, push, and PR finalization"
+                        finalization: None,
+                        stop_reason: Some(
+                            "deterministic gates completed green; --no-finalize skipped \
+     commit, push, and PR finalization"
                                 .to_string(),
                         ),
-                        0,
-                        Some(&run_id),
-                    ));
+                        exit_code: 0,
+                        invocation_latest_run_id: Some(&run_id),
+                    }));
                 }
                 let mut active_moving_base_recovery = None;
                 let promotion = match moving_base_recovery_for_run(&run_id)? {
@@ -2718,20 +2730,26 @@ where
                         ));
                     }
                     Err(error) if error.message.contains("awaiting_acceptance") => {
-                        return Ok(cook_report(
+                        return Ok(cook_report(CookReportInput {
                             cook_id,
-                            "awaiting_acceptance",
+                            status: "awaiting_acceptance",
                             attempts,
-                            Some(serde_json::json!({
+                            finalization: Some(serde_json::json!({
                                 "status": "awaiting_acceptance",
                                 "reason": error.message,
                                 "run_id": run_id,
-                                "status_command": format!("homeboy agent-task status {run_id} --full"),
+                                "status_command": format!(
+                                    "homeboy agent-task status {run_id} --full"
+                                ),
                             })),
-                            Some("deterministic gates passed; an independent acceptance verdict is required before PR finalization".to_string()),
-                            1,
-                            Some(&run_id),
-                        ));
+                            stop_reason: Some(
+                                "deterministic gates passed; an independent acceptance verdict \
+     is required before PR finalization"
+                                    .to_string(),
+                            ),
+                            exit_code: 1,
+                            invocation_latest_run_id: Some(&run_id),
+                        }));
                     }
                     Err(error) => return Err(error),
                 };
@@ -2743,57 +2761,59 @@ where
                 let stop_reason = (final_status == "no_changes").then(|| {
                     "cook completed provider execution and gates, but finalization found no changed files; task likely still requires review or retry".to_string()
                 });
-                return Ok(cook_report(
+                return Ok(cook_report(CookReportInput {
                     cook_id,
-                    &final_status,
+                    status: &final_status,
                     attempts,
-                    Some(finalization),
+                    finalization: Some(finalization),
                     stop_reason,
                     exit_code,
-                    Some(&run_id),
-                ));
+                    invocation_latest_run_id: Some(&run_id),
+                }));
             }
             AgentTaskCookLoopStatus::NoChanges => {
-                return Ok(cook_report(
+                return Ok(cook_report(CookReportInput {
                     cook_id,
-                    "no_changes",
+                    status: "no_changes",
                     attempts,
-                    None,
-                    Some(
-                        "cook completed provider execution but produced no changed files; task likely still requires review or retry"
+                    finalization: None,
+                    stop_reason: Some(
+                        "cook completed provider execution but produced no changed \
+     files; task likely still requires review or retry"
                             .to_string(),
                     ),
-                    1,
-                    Some(&run_id),
-                ));
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(&run_id),
+                }));
             }
             AgentTaskCookLoopStatus::NoOpGateFailed => {
-                return Ok(cook_report(
+                return Ok(cook_report(CookReportInput {
                     cook_id,
-                    "no_op_gate_failed",
+                    status: "no_op_gate_failed",
                     attempts,
-                    None,
-                    Some(
-                        "provider produced no patch and the pinned candidate failed deterministic verification"
+                    finalization: None,
+                    stop_reason: Some(
+                        "provider produced no patch and the pinned candidate failed \
+     deterministic verification"
                             .to_string(),
                     ),
-                    1,
-                    Some(&run_id),
-                ));
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(&run_id),
+                }));
             }
             AgentTaskCookLoopStatus::RetryRequested => {
                 let Some(follow_up_request) = follow_up_request else {
-                    return Ok(cook_report(
+                    return Ok(cook_report(CookReportInput {
                         cook_id,
-                        "policy_failure",
+                        status: "policy_failure",
                         attempts,
-                        None,
-                        Some(
+                        finalization: None,
+                        stop_reason: Some(
                             "cook feedback requested retry without a follow-up request".to_string(),
                         ),
-                        1,
-                        Some(&run_id),
-                    ));
+                        exit_code: 1,
+                        invocation_latest_run_id: Some(&run_id),
+                    }));
                 };
                 let budget_limit = budget_limit
                     .as_ref()
@@ -2819,57 +2839,57 @@ where
                         run_id: next_run_id,
                     } => run_id = next_run_id,
                     CookFollowUpDispatch::BudgetExhausted { reason } => {
-                        return Ok(cook_report(
+                        return Ok(cook_report(CookReportInput {
                             cook_id,
-                            "execution_budget_exhausted",
+                            status: "execution_budget_exhausted",
                             attempts,
-                            None,
-                            Some(format!(
+                            finalization: None,
+                            stop_reason: Some(format!(
                                 "provider execution stopped because {reason} was exhausted"
                             )),
-                            1,
-                            Some(&run_id),
-                        ));
+                            exit_code: 1,
+                            invocation_latest_run_id: Some(&run_id),
+                        }));
                     }
                     CookFollowUpDispatch::PolicyFailure { reason } => {
-                        return Ok(cook_report(
+                        return Ok(cook_report(CookReportInput {
                             cook_id,
-                            "policy_failure",
+                            status: "policy_failure",
                             attempts,
-                            None,
-                            Some(reason),
-                            1,
-                            Some(&run_id),
-                        ));
+                            finalization: None,
+                            stop_reason: Some(reason),
+                            exit_code: 1,
+                            invocation_latest_run_id: Some(&run_id),
+                        }));
                     }
                 }
             }
             AgentTaskCookLoopStatus::RetriesExhausted => {
-                return Ok(cook_report(
+                return Ok(cook_report(CookReportInput {
                     cook_id,
-                    "retries_exhausted",
+                    status: "retries_exhausted",
                     attempts,
-                    None,
-                    Some(
+                    finalization: None,
+                    stop_reason: Some(
                         "deterministic gates stayed red after the configured attempt budget"
                             .to_string(),
                     ),
-                    1,
-                    Some(&run_id),
-                ));
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(&run_id),
+                }));
             }
         }
     }
 
-    Ok(cook_report(
+    Ok(cook_report(CookReportInput {
         cook_id,
-        "retries_exhausted",
+        status: "retries_exhausted",
         attempts,
-        None,
-        Some("cook attempt budget exhausted".to_string()),
-        1,
-        Some(&run_id),
-    ))
+        finalization: None,
+        stop_reason: Some("cook attempt budget exhausted".to_string()),
+        exit_code: 1,
+        invocation_latest_run_id: Some(&run_id),
+    }))
 }
 
 fn resumable_cook_run_id(

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -40,7 +40,7 @@ use super::cook::{
 };
 use super::cook_promotion::{
     cook_report, finalize_or_load_cook_pr_with_backend, persisted_promotion_for_attempt,
-    promotion_source,
+    promotion_source, CookReportInput,
 };
 use super::AgentTaskRunResult;
 
@@ -327,15 +327,29 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 } else {
                     1
                 };
-            return Ok(cook_report(
-                cook_id.to_string(),
-                &result.status,
-                Vec::new(),
-                None,
-                result.stop_reason,
+            // Replaying an already-completed adoption is exactly the path an
+            // orchestrator hits when it re-polls a Cook it already ran, so it
+            // is the path that must not fall back to the cross-invocation Cook
+            // index. Every sibling return in this file already reports the
+            // adopted record's run id; this one did not.
+            return Ok(cook_report(CookReportInput {
+                cook_id: cook_id.to_string(),
+                status: &result.status,
+                attempts: vec![AgentTaskCookAttemptReport {
+                    attempt: 1,
+                    run_id: record.run_id.clone(),
+                    run_state: format!("{:?}", record.state),
+                    aggregate_path: record.aggregate_path.clone(),
+                    promotion: persisted_promotion_for_attempt(&record.run_id)
+                        .ok()
+                        .flatten(),
+                    feedback: None,
+                }],
+                finalization: None,
+                stop_reason: result.stop_reason,
                 exit_code,
-                None,
-            ));
+                invocation_latest_run_id: Some(record.run_id.as_str()),
+            }));
         }
         let promotion = persisted_promotion_for_attempt(&record.run_id)?.ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -362,10 +376,10 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             .and_then(|value| value["status"].as_str())
             .unwrap_or("green_no_finalize")
             .to_string();
-        return Ok(cook_report(
-            cook_id.to_string(),
-            &status,
-            vec![AgentTaskCookAttemptReport {
+        return Ok(cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: &status,
+            attempts: vec![AgentTaskCookAttemptReport {
                 attempt: 1,
                 run_id: record.run_id.clone(),
                 run_state: format!("{:?}", record.state),
@@ -374,10 +388,18 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 feedback: Some(feedback),
             }],
             finalization,
-            Some("reused the completed candidate adoption result; set rerun_completed_gates to rerun its gates".to_string()),
-            if status == "review_ready" || status == "green_no_finalize" { 0 } else { 1 },
-            Some(record.run_id.as_str()),
-        ));
+            stop_reason: Some(
+                "reused the completed candidate adoption result; set \
+     rerun_completed_gates to rerun its gates"
+                    .to_string(),
+            ),
+            exit_code: if status == "review_ready" || status == "green_no_finalize" {
+                0
+            } else {
+                1
+            },
+            invocation_latest_run_id: Some(record.run_id.as_str()),
+        }));
     }
     let attempt_dispatcher =
         reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
@@ -544,18 +566,18 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                         .to_string(),
                 ),
             )?;
-            let report = cook_report(
-                cook_id.to_string(),
-                "policy_failure",
-                vec![attempt],
-                None,
-                Some(
+            let report = cook_report(CookReportInput {
+                cook_id: cook_id.to_string(),
+                status: "policy_failure",
+                attempts: vec![attempt],
+                finalization: None,
+                stop_reason: Some(
                     "candidate adoption feedback requested retry without a follow-up request"
                         .to_string(),
                 ),
-                1,
-                Some(record.run_id.as_str()),
-            );
+                exit_code: 1,
+                invocation_latest_run_id: Some(record.run_id.as_str()),
+            });
             persist_adoption_terminal_result(&record.run_id, &report.value)?;
             return Ok(report);
         };
@@ -629,17 +651,17 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 Ok(result)
             }
             CookFollowUpDispatch::BudgetExhausted { reason } => {
-                let report = cook_report(
-                    cook_id.to_string(),
-                    "execution_budget_exhausted",
-                    vec![attempt],
-                    None,
-                    Some(format!(
+                let report = cook_report(CookReportInput {
+                    cook_id: cook_id.to_string(),
+                    status: "execution_budget_exhausted",
+                    attempts: vec![attempt],
+                    finalization: None,
+                    stop_reason: Some(format!(
                         "provider execution stopped because {reason} was exhausted"
                     )),
-                    1,
-                    Some(record.run_id.as_str()),
-                );
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(record.run_id.as_str()),
+                });
                 persist_adoption_terminal_result(&record.run_id, &report.value)?;
                 agent_task_lifecycle::finish_candidate_adoption(
                     &record.run_id,
@@ -648,15 +670,15 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 Ok(report)
             }
             CookFollowUpDispatch::PolicyFailure { reason } => {
-                let report = cook_report(
-                    cook_id.to_string(),
-                    "policy_failure",
-                    vec![attempt],
-                    None,
-                    Some(reason.clone()),
-                    1,
-                    Some(record.run_id.as_str()),
-                );
+                let report = cook_report(CookReportInput {
+                    cook_id: cook_id.to_string(),
+                    status: "policy_failure",
+                    attempts: vec![attempt],
+                    finalization: None,
+                    stop_reason: Some(reason.clone()),
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(record.run_id.as_str()),
+                });
                 persist_adoption_terminal_result(&record.run_id, &report.value)?;
                 agent_task_lifecycle::finish_candidate_adoption(&record.run_id, Some(reason))?;
                 Ok(report)
@@ -668,30 +690,32 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             &record.run_id,
             Some("adopted candidate did not pass the original deterministic gates".to_string()),
         )?;
-        return Ok(cook_report(
-            cook_id.to_string(),
-            "gate_failed",
-            vec![attempt],
-            None,
-            Some("adopted candidate did not pass the original deterministic gates".to_string()),
-            1,
-            Some(record.run_id.as_str()),
-        ));
+        return Ok(cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "gate_failed",
+            attempts: vec![attempt],
+            finalization: None,
+            stop_reason: Some(
+                "adopted candidate did not pass the original deterministic gates".to_string(),
+            ),
+            exit_code: 1,
+            invocation_latest_run_id: Some(record.run_id.as_str()),
+        }));
     }
     if options.no_finalize {
         agent_task_lifecycle::finish_candidate_adoption(&record.run_id, None)?;
-        return Ok(cook_report(
-            cook_id.to_string(),
-            "green_no_finalize",
-            vec![attempt],
-            None,
-            Some(
+        return Ok(cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "green_no_finalize",
+            attempts: vec![attempt],
+            finalization: None,
+            stop_reason: Some(
                 "adopted candidate passed deterministic gates; recipe skips finalization"
                     .to_string(),
             ),
-            0,
-            Some(record.run_id.as_str()),
-        ));
+            exit_code: 0,
+            invocation_latest_run_id: Some(record.run_id.as_str()),
+        }));
     }
     agent_task_lifecycle::checkpoint_candidate_adoption(
         &record.run_id,
@@ -720,15 +744,15 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         .unwrap_or("unknown")
         .to_string();
     let exit_code = if status == "review_ready" { 0 } else { 1 };
-    Ok(cook_report(
-        cook_id.to_string(),
-        &status,
-        vec![attempt],
-        Some(finalization),
-        None,
+    Ok(cook_report(CookReportInput {
+        cook_id: cook_id.to_string(),
+        status: &status,
+        attempts: vec![attempt],
+        finalization: Some(finalization),
+        stop_reason: None,
         exit_code,
-        Some(record.run_id.as_str()),
-    ))
+        invocation_latest_run_id: Some(record.run_id.as_str()),
+    }))
 }
 
 /// PR/finalization evidence is a projection of the durable decision, never a

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -23,7 +23,7 @@ use super::cook::{
     AgentTaskCookAttemptDispatcher, AgentTaskCookAttemptReport, AgentTaskCookReport,
     AgentTaskCookServiceOptions,
 };
-use super::cook_promotion::cook_report;
+use super::cook_promotion::{cook_report, CookReportInput};
 use super::AgentTaskRunResult;
 
 /// Persist the controller-owned initial attempt before transport preparation so
@@ -169,17 +169,17 @@ pub(crate) fn pre_execution_failure_report(
 ) -> AgentTaskRunResult<AgentTaskCookReport> {
     let phase = failure.phase.as_deref().unwrap_or("cook_pre_execution");
     let classification = failure.classification.as_deref().unwrap_or("unknown");
-    let mut report = cook_report(
+    let mut report = cook_report(CookReportInput {
         cook_id,
-        "pre_execution_failure",
+        status: "pre_execution_failure",
         attempts,
-        None,
-        Some(format!(
+        finalization: None,
+        stop_reason: Some(format!(
             "pre-provider failure in phase `{phase}` classified as `{classification}`: {error}"
         )),
-        1,
+        exit_code: 1,
         invocation_latest_run_id,
-    );
+    });
     report.value.terminal_phase = failure.phase;
     report.value.terminal_failure_classification = failure.classification;
     report

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -493,15 +493,15 @@ pub(crate) fn moving_base_recovery_report(
             recovery.blocker, recovery.continuation
         ))
     };
-    let mut report = cook_report(
+    let mut report = cook_report(CookReportInput {
         cook_id,
-        "candidate_recoverable",
+        status: "candidate_recoverable",
         attempts,
-        None,
+        finalization: None,
         stop_reason,
-        1,
+        exit_code: 1,
         invocation_latest_run_id,
-    );
+    });
     report.value.moving_base_recovery = Some(recovery);
     report
 }
@@ -2198,15 +2198,39 @@ fn review_form_for_finalization(
     Ok(form)
 }
 
-pub(crate) fn cook_report(
-    cook_id: String,
-    status: &str,
-    attempts: Vec<AgentTaskCookAttemptReport>,
-    finalization: Option<Value>,
-    stop_reason: Option<String>,
-    exit_code: i32,
-    invocation_latest_run_id: Option<&str>,
-) -> AgentTaskRunResult<AgentTaskCookReport> {
+/// Every field a Cook report is built from, named at the call site.
+///
+/// This is a struct input rather than a positional argument list because
+/// `invocation_latest_run_id` is the field that decides whether the report —
+/// and every recovery command derived from it — points at THIS invocation's
+/// run or at some prior session's run recorded in the cross-invocation Cook
+/// index. When it was an optional trailing positional argument, two call sites
+/// silently passed `None` and reported a stale run id to the orchestrator. A
+/// required named field makes that class of mistake a compile error.
+#[non_exhaustive]
+pub(crate) struct CookReportInput<'a> {
+    pub cook_id: String,
+    pub status: &'a str,
+    pub attempts: Vec<AgentTaskCookAttemptReport>,
+    pub finalization: Option<Value>,
+    pub stop_reason: Option<String>,
+    pub exit_code: i32,
+    /// The run this invocation is reporting on. `None` is legal only when the
+    /// caller genuinely has no invocation-scoped run id — it falls back to the
+    /// cross-invocation Cook index, which may name a prior session's run.
+    pub invocation_latest_run_id: Option<&'a str>,
+}
+
+pub(crate) fn cook_report(input: CookReportInput<'_>) -> AgentTaskRunResult<AgentTaskCookReport> {
+    let CookReportInput {
+        cook_id,
+        status,
+        attempts,
+        finalization,
+        stop_reason,
+        exit_code,
+        invocation_latest_run_id,
+    } = input;
     let history_run_ids = agent_task_lifecycle::cook_index(&cook_id)
         .map(|index| {
             index
@@ -2241,14 +2265,22 @@ pub(crate) fn cook_report(
                 .ok()
                 .and_then(|recipe| recipe.attempts.last().map(|attempt| attempt.run_id.clone()))
         });
-    let invocation_run_ids: Vec<String> = attempts
+    // A controller failure produces no attempt report, but its run id is still
+    // part of THIS invocation. Union it in so invocation scope is never empty
+    // just because the failure happened outside an attempt.
+    let mut invocation_run_ids: Vec<String> = attempts
         .iter()
         .map(|attempt| attempt.run_id.clone())
         .collect();
+    if let Some(run_id) = invocation_latest_run_id {
+        if !invocation_run_ids.iter().any(|known| known == run_id) {
+            invocation_run_ids.push(run_id.to_string());
+        }
+    }
     let failure_context = (exit_code != 0)
         .then(|| cook_failure_context(&cook_id, latest_run_id.as_deref()))
         .flatten();
-    let selected_candidate = cook_selected_candidate_provenance(&cook_id);
+    let selected_candidate = cook_selected_candidate_provenance(&cook_id, &invocation_run_ids);
     AgentTaskRunResult {
         value: AgentTaskCookReport {
             schema: "homeboy/agent-task-cook/v1",
@@ -2270,9 +2302,25 @@ pub(crate) fn cook_report(
     }
 }
 
-fn cook_selected_candidate_provenance(cook_id: &str) -> Option<Value> {
+/// `select_cook_candidate` deliberately selects across the whole Cook index
+/// with no invocation scope — adopting the best candidate across attempts is
+/// what a Cook is for. But a report can therefore say `latest_run_id: <this
+/// run>` while `selected_candidate.run_id` names a prior session's run, and
+/// `cook_failure_context` prefers that cross-invocation id when it builds
+/// recovery commands. The orchestrator could not previously tell the two apart.
+/// `invocation_scoped` states it explicitly. The selection itself is unchanged.
+fn cook_selected_candidate_provenance(
+    cook_id: &str,
+    invocation_run_ids: &[String],
+) -> Option<Value> {
     let selection = agent_task_lifecycle::select_cook_candidate(cook_id).ok()?;
     let mut value = serde_json::to_value(&selection).ok()?;
+    value["invocation_scoped"] = serde_json::json!(
+        !selection.run_id.is_empty()
+            && invocation_run_ids
+                .iter()
+                .any(|run_id| run_id == &selection.run_id)
+    );
     if selection.incomplete || selection.run_id.is_empty() {
         return Some(value);
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -15,7 +15,7 @@ use super::super::cook_promotion::{
     persist_manual_finalization_intent, persist_manual_finalization_receipt,
     persisted_promotion_for_attempt, recover_cook_pr_with_backend,
     recover_moving_base_cook_candidate, refreshed_moving_base_recovery, selected_candidate_task_id,
-    MovingBaseCookRecovery,
+    CookReportInput, MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::persist_initial_recipe;
 use super::*;
@@ -5154,15 +5154,15 @@ fn cook_report_emits_selected_candidate_provenance_without_redefining_latest_run
         })
         .expect("persist promotion provenance");
 
-        let report = cook_report(
-            cook_id.to_string(),
-            "completed",
-            Vec::new(),
-            None,
-            None,
-            0,
-            Some(latest_run_id),
-        );
+        let report = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "completed",
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: None,
+            exit_code: 0,
+            invocation_latest_run_id: Some(latest_run_id),
+        });
         assert_eq!(report.value.latest_run_id.as_deref(), Some(latest_run_id));
         let provenance = report
             .value
@@ -5268,18 +5268,18 @@ fn resume_promoted_patch_guidance_keeps_the_exhausted_zero_byte_attempt_as_lates
         assert_eq!(pointer.run_id, candidate_run_id);
         assert_eq!(pointer.attempt, 1);
 
-        let report = cook_report(
-            cook_id.to_string(),
-            "execution_budget_exhausted",
-            Vec::new(),
-            None,
-            Some(
+        let report = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "execution_budget_exhausted",
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: Some(
                 "provider execution stopped because max_provider_executions was exhausted"
                     .to_string(),
             ),
-            1,
-            Some(&latest_empty_run_id),
-        );
+            exit_code: 1,
+            invocation_latest_run_id: Some(&latest_empty_run_id),
+        });
 
         assert_eq!(
             report.value.latest_run_id.as_deref(),
@@ -5322,15 +5322,15 @@ fn resume_promoted_patch_guidance_keeps_the_exhausted_zero_byte_attempt_as_lates
                 serde_json::json!(1);
         })
         .expect("remove destination proof");
-        let unproven = cook_report(
-            cook_id.to_string(),
-            "execution_budget_exhausted",
-            Vec::new(),
-            None,
-            None,
-            1,
-            Some(&latest_empty_run_id),
-        )
+        let unproven = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "execution_budget_exhausted",
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: None,
+            exit_code: 1,
+            invocation_latest_run_id: Some(&latest_empty_run_id),
+        })
         .value
         .failure_context
         .expect("unproven destination context");
@@ -7726,10 +7726,10 @@ fn cook_report_latest_run_id_prefers_invocation_over_stale_cook_index() {
         let fresh_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 2);
         let invocation_run_ids = vec![fresh_run_id.clone()];
 
-        let report = cook_report(
-            cook_id.to_string(),
-            "execution_budget_exhausted",
-            vec![AgentTaskCookAttemptReport {
+        let report = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "execution_budget_exhausted",
+            attempts: vec![AgentTaskCookAttemptReport {
                 attempt: 2,
                 run_id: fresh_run_id.clone(),
                 run_state: "Running".to_string(),
@@ -7737,11 +7737,13 @@ fn cook_report_latest_run_id_prefers_invocation_over_stale_cook_index() {
                 promotion: None,
                 feedback: None,
             }],
-            None,
-            Some("provider execution stopped because budget was exhausted".to_string()),
-            1,
-            Some(&fresh_run_id),
-        );
+            finalization: None,
+            stop_reason: Some(
+                "provider execution stopped because budget was exhausted".to_string(),
+            ),
+            exit_code: 1,
+            invocation_latest_run_id: Some(&fresh_run_id),
+        });
 
         assert_eq!(
             report.value.latest_run_id.as_deref(),
@@ -7764,6 +7766,154 @@ fn cook_report_latest_run_id_prefers_invocation_over_stale_cook_index() {
         assert!(
             report.value.history_run_ids.contains(&fresh_run_id),
             "history_run_ids should include the current invocation's run"
+        );
+    });
+}
+
+/// #11114 (a): the controller-failure path passed `None` for the invocation run
+/// id, so it reported whatever the cross-invocation Cook index happened to name
+/// — and `cook_failure_context` stamped that same stale id into every recovery
+/// command it emitted. The orchestrator was handed `status`/`diagnose` commands
+/// for a prior session's run.
+#[test]
+fn durable_controller_failure_reports_this_invocation_run_not_the_stale_cook_index() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-11114-controller-failure";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        persist_initial_recipe(&options).expect("persist durable recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .expect("materialize this invocation's run");
+
+        // A prior session left the cross-invocation Cook index pointing at its
+        // own run. That is the value this path used to report.
+        let stale_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&stale_run_id))
+            .expect("materialize the prior session's run");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, &stale_run_id)
+            .expect("index the prior session's run");
+        assert_eq!(
+            agent_task_lifecycle::cook_index(cook_id)
+                .expect("cook index")
+                .latest_run_id,
+            stale_run_id,
+            "fixture must leave the cross-invocation index on the prior session's run"
+        );
+
+        let report = durable_cook_error_report(
+            &options,
+            Error::internal_unexpected("controller failed after durable creation"),
+        )
+        .expect("controller failure converts into the Cook result contract");
+
+        assert_eq!(
+            report.value.latest_run_id.as_deref(),
+            Some(options.initial_run_id.as_str()),
+            "a controller failure must report THIS invocation's run"
+        );
+        assert!(
+            report
+                .value
+                .invocation_run_ids
+                .contains(&options.initial_run_id),
+            "invocation scope must not be empty just because no attempt report exists"
+        );
+        assert!(
+            !report.value.invocation_run_ids.contains(&stale_run_id),
+            "the prior session's run is history, not this invocation"
+        );
+
+        let context = report
+            .value
+            .failure_context
+            .expect("durable failure context");
+        assert_eq!(context.phase, "controller");
+        assert_eq!(context.latest_run_id, options.initial_run_id);
+        for action in context.legal_actions.iter().chain(&context.next_actions) {
+            // Candidate-selection actions intentionally address the selected
+            // cross-invocation candidate; the run-addressed diagnostics must not.
+            if !matches!(action.action.as_str(), "status" | "diagnose" | "reconcile") {
+                continue;
+            }
+            assert!(
+                action.command.contains(&options.initial_run_id),
+                "recovery command must address this invocation's run: {}",
+                action.command
+            );
+            assert!(
+                !action.command.contains(&stale_run_id),
+                "recovery command must not address the prior session's run: {}",
+                action.command
+            );
+        }
+    });
+}
+
+/// #11114: `select_cook_candidate` deliberately spans invocations, so a report
+/// can name this invocation's `latest_run_id` while `selected_candidate` names a
+/// prior attempt. `invocation_scoped` makes that difference legible instead of
+/// leaving the orchestrator to guess.
+#[test]
+fn selected_candidate_provenance_flags_cross_invocation_selection() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let cook_id = "cook-11114-selection-scope";
+        let selected_run_id = "cook-11114-selection-scope-1";
+        let latest_run_id = "cook-11114-selection-scope-2";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        for (attempt, run_id) in [(1, selected_run_id), (2, latest_run_id)] {
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("persist lifecycle record");
+            agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id)
+                .expect("persist attempt index entry");
+        }
+        seed_substantive_candidate_aggregate(
+            selected_run_id,
+            &options.initial_plan,
+            &temp.path().join("selected.patch"),
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+        seed_substantive_candidate_aggregate(
+            latest_run_id,
+            &options.initial_plan,
+            &temp.path().join("malformed.patch"),
+            "nonempty malformed newer artifact\n",
+        );
+
+        let cross_invocation = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "completed",
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: None,
+            exit_code: 0,
+            invocation_latest_run_id: Some(latest_run_id),
+        })
+        .value
+        .selected_candidate
+        .expect("selected candidate provenance");
+        assert_eq!(cross_invocation["run_id"], selected_run_id);
+        assert_eq!(
+            cross_invocation["invocation_scoped"],
+            serde_json::json!(false),
+            "a candidate selected from a prior attempt must be flagged as out of invocation scope"
+        );
+
+        let in_invocation = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "completed",
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: None,
+            exit_code: 0,
+            invocation_latest_run_id: Some(selected_run_id),
+        })
+        .value
+        .selected_candidate
+        .expect("selected candidate provenance");
+        assert_eq!(
+            in_invocation["invocation_scoped"],
+            serde_json::json!(true),
+            "a candidate this invocation produced must be flagged as invocation scoped"
         );
     });
 }
@@ -7791,15 +7941,17 @@ fn post_materialization_failure_families_expose_only_durable_identity_and_legal_
             "follow_up_materialization_failure",
             "finalization_failure",
         ] {
-            let report = cook_report(
-                cook_id.to_string(),
+            let report = cook_report(CookReportInput {
+                cook_id: cook_id.to_string(),
                 status,
-                Vec::new(),
-                None,
-                Some("private provider evidence remains in durable diagnostics".to_string()),
-                1,
-                Some(&options.initial_run_id),
-            );
+                attempts: Vec::new(),
+                finalization: None,
+                stop_reason: Some(
+                    "private provider evidence remains in durable diagnostics".to_string(),
+                ),
+                exit_code: 1,
+                invocation_latest_run_id: Some(&options.initial_run_id),
+            });
             let value = serde_json::to_value(report.value).expect("serialize command data");
             let context = &value["failure_context"];
 
@@ -7970,10 +8122,10 @@ fn re_materialize_follow_up_baseline_recovers_after_worktree_deletion() {
 fn cook_report_invocation_run_ids_populated_for_policy_failure() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let fresh_run_id = "agent-task-fresh-abc123".to_string();
-        let report = cook_report(
-            "cook-test".to_string(),
-            "policy_failure",
-            vec![AgentTaskCookAttemptReport {
+        let report = cook_report(CookReportInput {
+            cook_id: "cook-test".to_string(),
+            status: "policy_failure",
+            attempts: vec![AgentTaskCookAttemptReport {
                 attempt: 1,
                 run_id: fresh_run_id.clone(),
                 run_state: "Succeeded".to_string(),
@@ -7981,11 +8133,11 @@ fn cook_report_invocation_run_ids_populated_for_policy_failure() {
                 promotion: None,
                 feedback: None,
             }],
-            None,
-            Some("policy failure".to_string()),
-            1,
-            Some(&fresh_run_id),
-        );
+            finalization: None,
+            stop_reason: Some("policy failure".to_string()),
+            exit_code: 1,
+            invocation_latest_run_id: Some(&fresh_run_id),
+        });
 
         assert_eq!(report.value.invocation_run_ids, vec![fresh_run_id.clone()]);
         assert_eq!(

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -2456,6 +2456,18 @@ pub(crate) fn compact_aggregate_summary(
     summary
 }
 
+/// The default view for `homeboy agent-task cook`. `--full` is opt-in, so this
+/// is what an external orchestrator actually receives back from a cook.
+///
+/// "Compact" must still mean "actionable". `cook_failure_context` already
+/// computes the exact runnable recovery commands for the failed Cook state, and
+/// the notification path forwards them verbatim — the pull channel has no reason
+/// to be poorer than the push channel from the same computation. Only the
+/// runnable/classification fields are surfaced here; `diagnostic` and
+/// `blocking_claim` stay behind `--full` because they carry provider and gate
+/// evidence that `cook_failure_context` deliberately keeps out of a command
+/// envelope. Output only grows on the failure path: `failure_context` is `None`
+/// whenever `exit_code == 0`.
 pub(crate) fn compact_cook_report(value: Value, full: bool) -> Value {
     if full {
         return value;
@@ -2478,8 +2490,49 @@ pub(crate) fn compact_cook_report(value: Value, full: bool) -> Value {
         "attempts": attempts.iter().take(COMPACT_TASK_LIMIT).map(|attempt| compact_fields(attempt, &["attempt", "run_id", "run_state", "aggregate_path"])).collect::<Vec<_>>(),
         "attempts_omitted": attempts.len().saturating_sub(COMPACT_TASK_LIMIT),
         "finalization": value.get("finalization").map(|finalization| compact_fields(finalization, &["schema", "status", "pr_number", "pr_url", "updated_at", "created_at"])),
-        "selected_candidate": value.get("selected_candidate").map(|candidate| compact_fields(candidate, &["latest_attempt_run_id", "run_id", "attempt", "selected_task_id", "selected_artifact_id", "reason", "incomplete", "skipped_newer_attempts", "applied_promotion"])),
+        "selected_candidate": value.get("selected_candidate").map(|candidate| compact_fields(candidate, &["latest_attempt_run_id", "run_id", "attempt", "invocation_scoped", "selected_task_id", "selected_artifact_id", "reason", "incomplete", "skipped_newer_attempts", "applied_promotion"])),
     });
+    // The run ids this invocation actually dispatched, so a caller can tell them
+    // apart from the cross-invocation history `latest_run_id` may be drawn from.
+    if let Some(invocation_run_ids) = value.get("invocation_run_ids") {
+        summary["invocation_run_ids"] = invocation_run_ids.clone();
+    }
+    // The recovery commands the Cook already computed for its own failed state.
+    // `diagnostic` and `blocking_claim` are deliberately absent: they carry
+    // provider and gate evidence that stays behind `--full` and `diagnose`.
+    if let Some(failure_context) = value.get("failure_context") {
+        summary["failure_context"] = compact_fields(
+            failure_context,
+            &[
+                "latest_run_id",
+                "selected_run_id",
+                "durable_recipe_ref",
+                "lifecycle_state",
+                "phase",
+                "reason_code",
+                "provider_budget_consumed",
+                "provider_executions_consumed",
+                "recovery_legal",
+                "recovery_reason",
+                "legal_actions",
+                "next_actions",
+            ],
+        );
+    }
+    // The promotion report this carries is full evidence, so keep only the
+    // blocker and the continuation the caller is expected to act on.
+    if let Some(moving_base_recovery) = value.get("moving_base_recovery") {
+        summary["moving_base_recovery"] = compact_fields(
+            moving_base_recovery,
+            &[
+                "run_id",
+                "prior_verified_base",
+                "blocker",
+                "continuation",
+                "base_movements",
+            ],
+        );
+    }
     if let Some(run_id) = latest_run_id {
         summary["full_command"] = json!(format!("homeboy agent-task status {run_id} --full"));
         summary["evidence_command"] = json!(format!("homeboy agent-task evidence {run_id}"));
@@ -3571,6 +3624,127 @@ mod tests {
             compact["full_command"],
             "homeboy agent-task status run-14 --full"
         );
+        assert!(
+            compact.get("failure_context").is_none(),
+            "a report without failure_context must not grow one"
+        );
+        assert_eq!(compact_cook_report(report.clone(), true), report);
+    }
+
+    /// #11113: `cook_failure_context` already computes the runnable recovery
+    /// commands, and the notification path forwards them. The default (compact)
+    /// view discarded the whole thing, so the pull channel was strictly poorer
+    /// than the push channel from the same computation.
+    #[test]
+    fn compact_cook_report_keeps_failure_context_actionable() {
+        let report = json!({
+            "schema": "homeboy/agent-task-cook/v1",
+            "cook_id": "cook-11113",
+            "latest_run_id": "run-2",
+            "history_run_ids": ["run-1", "run-2"],
+            "invocation_run_ids": ["run-2"],
+            "status": "durable_failure",
+            "attempts": [],
+            "failure_context": {
+                "cook_id": "cook-11113",
+                "latest_run_id": "run-2",
+                "selected_run_id": "run-1",
+                "durable_recipe_ref": "homeboy://agent-task/cooks/cook-11113/recipe",
+                "lifecycle_state": "Failed",
+                "phase": "promotion",
+                "reason_code": "operation_in_progress",
+                "provider_budget_consumed": true,
+                "provider_executions_consumed": 3,
+                "recovery_legal": true,
+                "recovery_reason": "y".repeat(COMPACT_TEXT_LIMIT + 1),
+                "legal_actions": [
+                    { "action": "status", "command": "homeboy agent-task status run-2 --full" },
+                    { "action": "diagnose", "command": "homeboy agent-task diagnose run-2" }
+                ],
+                "next_actions": [
+                    { "action": "status", "command": "homeboy agent-task status run-2 --full" }
+                ],
+                "diagnostic": { "code": "promotion_rejected", "evidence": "private gate output" },
+                "blocking_claim": { "state": "Running", "evidence": "private claim payload" }
+            }
+        });
+
+        let compact = compact_cook_report(report.clone(), false);
+        let context = &compact["failure_context"];
+
+        assert_eq!(context["phase"], "promotion");
+        assert_eq!(context["reason_code"], "operation_in_progress");
+        assert_eq!(context["recovery_legal"], true);
+        assert_eq!(context["provider_executions_consumed"], 3);
+        assert_eq!(
+            context["legal_actions"][1]["command"],
+            "homeboy agent-task diagnose run-2"
+        );
+        assert_eq!(
+            context["next_actions"][0]["command"],
+            "homeboy agent-task status run-2 --full"
+        );
+        assert_eq!(compact["invocation_run_ids"], json!(["run-2"]));
+
+        // Private evidence stays behind --full and `diagnose`.
+        assert!(
+            context.get("diagnostic").is_none(),
+            "diagnostic carries provider and gate evidence"
+        );
+        assert!(
+            context.get("blocking_claim").is_none(),
+            "blocking_claim carries claim payload evidence"
+        );
+
+        // The compact text budget still applies to the fields that are kept.
+        assert_eq!(
+            context["recovery_reason"]
+                .as_str()
+                .expect("recovery_reason")
+                .chars()
+                .count(),
+            COMPACT_TEXT_LIMIT + 3,
+            "long prose must still be truncated to the compact budget"
+        );
+
+        assert_eq!(compact_cook_report(report.clone(), true), report);
+    }
+
+    /// The moving-base recovery carries a full promotion report. Compact keeps
+    /// the blocker and the continuation, not the evidence.
+    #[test]
+    fn compact_cook_report_keeps_moving_base_continuation_without_promotion_evidence() {
+        let report = json!({
+            "schema": "homeboy/agent-task-cook/v1",
+            "cook_id": "cook-11113-moving-base",
+            "latest_run_id": "run-3",
+            "status": "candidate_recoverable",
+            "attempts": [],
+            "moving_base_recovery": {
+                "schema": "homeboy/agent-task-cook-moving-base-recovery/v1",
+                "cook_id": "cook-11113-moving-base",
+                "run_id": "run-3",
+                "prior_verified_base": "abc123",
+                "blocker": "base moved during promotion",
+                "continuation": "homeboy agent-task cook-continue run-3",
+                "base_movements": 2,
+                "promotion": { "nested_evidence": "x".repeat(COMPACT_TEXT_LIMIT + 1) },
+                "passed_gates": { "nested_evidence": "x".repeat(COMPACT_TEXT_LIMIT + 1) }
+            }
+        });
+
+        let compact = compact_cook_report(report.clone(), false);
+        let recovery = &compact["moving_base_recovery"];
+
+        assert_eq!(recovery["blocker"], "base moved during promotion");
+        assert_eq!(
+            recovery["continuation"],
+            "homeboy agent-task cook-continue run-3"
+        );
+        assert_eq!(recovery["base_movements"], 2);
+        assert!(recovery.get("promotion").is_none());
+        assert!(recovery.get("passed_gates").is_none());
+
         assert_eq!(compact_cook_report(report.clone(), true), report);
     }
 

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -362,10 +362,11 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
     let cook_stdout = std::fs::read(&cook_stdout_path).expect("read Cook stdout");
     let cook_stderr = std::fs::read(&cook_stderr_path).expect("read Cook stderr");
     if !cook_status.success() {
-        // The summary Cook view carries no `failure_context`, so the exit
-        // status alone names no cause (#10237). A failing Cook is exactly when
-        // the controller's own record and the daemon it delegated to are worth
-        // reading, so hydrate both before panicking.
+        // The summary Cook view now carries `failure_context` (#11113), but it
+        // deliberately withholds the provider and gate evidence behind
+        // `--full`/`diagnose`. A failing Cook is exactly when the controller's
+        // own record and the daemon it delegated to are worth reading, so
+        // hydrate both before panicking.
         let reported_run_id = serde_json::from_slice::<serde_json::Value>(&cook_stdout)
             .ok()
             .and_then(|report| {


### PR DESCRIPTION
Found during the 2026-08-01 consolidation investigation (#11151). Two related fixes to what an external orchestrator (a chat agent like OpenCode) actually receives back from a cook. Two commits, structural fix first.

Closes #11114. Closes #11113.

---

## Commit 1 — #11114: `cook_report` correctness was opt-in, and two call sites returned a prior session's run id

`cook_report` took `invocation_latest_run_id` as an **optional trailing positional argument**. When it was `None`, it fell back to `cook_index(&cook_id).latest_run_id` — the **cross-invocation persistent index** — so the Cook reported whatever run a *previous* session had left there. Of 28 non-test call sites, two passed `None`, and they were the two that matter.

### (a) `cook.rs` `durable_cook_error_report` — the controller-failure path

Blast radius is larger than one field:

- `cook_failure_context(&cook_id, latest_run_id)` derives `chronological_latest_run_id` from the same value and **stamps it into every recovery command it emits** — `agent-task status <run> --full`, `agent-task diagnose <run>`, and `agent-task reconcile <run> --dry-run`.
- `cook_status_is_terminal("durable_failure")` is true, so `cook_terminal` fires and `terminal_payload` reads `report.latest_run_id`.

Net effect: on a controller failure the orchestrator was **pushed a terminal notification naming the wrong run, carrying diagnose commands for the wrong run**. `options.initial_run_id` was already in scope. Now passed.

### (b) `cook_adoption.rs` — the completed-adoption replay branch

The `"reused the completed candidate adoption result"` return, which is hit **exactly when an orchestrator re-polls a cook it already ran** — the highest-traffic path for the stale-id bug. `record.run_id` was in scope and used ten lines later, and *every sibling return in the same file* already passed it correctly. This branch also returned `Vec::new()` for `attempts`, so `invocation_run_ids` came back empty; it now reports the adopted attempt the same way its sibling branch does.

### Root cause fix

`cook_report` now takes a `CookReportInput<'_>` struct with `#[non_exhaustive]`. `invocation_latest_run_id` is a **required named field**, so the compiler enumerates every call site and this class of bug cannot be reintroduced by omission. Matches the struct-input pattern already used in the crate (`LabOffloadProxyPlan<'_>`, `DetachedLabRunRecord<'_>`, `AgentTaskCookLoopOptions`).

**34 call sites converted** — 28 production (18 `cook.rs`, 8 `cook_adoption.rs`, 1 `cook_pre_execution.rs`, 1 `cook_promotion.rs`) and 6 in `cook_tests.rs`.

### Two supporting corrections

- **`invocation_run_ids` unions in `invocation_latest_run_id`.** A controller failure produces no attempt report, but its run still belongs to this invocation. Invocation scope should not be empty merely because the failure happened outside an attempt.
- **`selected_candidate` gains `invocation_scoped: bool`.** `select_cook_candidate` selects across the whole cook index with **no invocation scope**, so a report could say `latest_run_id: <this run>` while `selected_candidate.run_id` named a prior session's run — and `cook_failure_context` *prefers that cross-invocation id* when building recovery commands. That is probably intentional (adopting the best candidate across attempts is the cook's purpose), but the orchestrator could not tell. It is now explicit. **The selection logic itself is unchanged**; only its provenance is.

The existing pinning test `cook_report_latest_run_id_prefers_invocation_over_stale_cook_index` still passes (adapted to the struct input). Two new hermetic tests:

- `durable_controller_failure_reports_this_invocation_run_not_the_stale_cook_index` — drives `durable_cook_error_report` with a stale cook index in place and asserts both the reported run id and every run-addressed recovery command target this invocation. This fails on `main`.
- `selected_candidate_provenance_flags_cross_invocation_selection` — asserts `invocation_scoped` is `false` for a candidate selected from a prior attempt and `true` otherwise.

---

## Commit 2 — #11113: the default cook report discarded `failure_context`

`cook_failure_context` computes ~180 lines of exactly what an orchestrator needs — `phase`, `reason_code`, `recovery_legal`, `recovery_reason`, `provider_executions_consumed`, and a computed `legal_actions`/`next_actions` list of **runnable commands** — and attaches it to the report. `compact_cook_report` then rebuilt a fixed `json!({...})` and threw all of it away, along with `invocation_run_ids` and `moving_base_recovery`.

**This is the default.** `homeboy agent-task cook` renders through this path (`run.rs`, `review.rs`); `--full` is opt-in. So the thing an orchestrator actually receives told it a cook failed and nothing about what to do next.

### The asymmetry that proves it is a bug

`agent_task_notify.rs` **already** forwards `failure_context.next_actions` and `legal_actions` verbatim into the terminal notification. The push channel was strictly richer than the pull channel, from the same computation.

### What stays behind `--full`

- **`failure_context.diagnostic` and `failure_context.blocking_claim`.** `cook_failure_context` is documented as building recovery coordinates *"from durable controller records only. Provider output, gate output, and filesystem paths stay behind `diagnose` so a failed command envelope cannot disclose private evidence."* Those two fields are precisely the private-evidence carriers. They remain reachable via `--full` and `agent-task diagnose`.
- **`moving_base_recovery.promotion` and `.passed_gates`**, which are whole promotion reports. Compact keeps `run_id`, `prior_verified_base`, `blocker`, `continuation`, `base_movements` — the blocker and the command the caller is expected to act on.

### On the tension with #9676 / #9654

Both ask for *compact* cook output, so this deliberately does not reopen them. The budget is preserved:

- every kept field goes through the existing `compact_fields` / `bounded_value` helpers, so text is still capped at `COMPACT_TEXT_LIMIT` (512);
- the recovery-action lists are bounded by construction (at most ~5 short command strings);
- `failure_context` is `None` whenever `exit_code == 0`, so **output grows only on the failure path** — the green path is byte-for-byte unchanged.

The point of those issues is that a cook report should not dump evidence. It is not that it should be unactionable. Compact must still mean actionable.

Three tests: the existing bounded-output test gains an assertion that a green report does not grow a `failure_context`; `compact_cook_report_keeps_failure_context_actionable` pins the forwarded fields, the `COMPACT_TEXT_LIMIT` truncation, and the **absence** of `diagnostic`/`blocking_claim`; `compact_cook_report_keeps_moving_base_continuation_without_promotion_evidence` pins the same shape for moving-base recovery.

A now-stale comment in `tests/reverse_cook_queue_acceptance.rs` (which cited #10237, another duplicate of this) was corrected.

---

## Verification

`cargo fmt --all -- --check`, `cargo check -p homeboy-agents --lib`, and `cargo check -p homeboy-cli --lib` all exit 0. Full build and test are left to CI per this host's build constraints.
