### PR TITLE
Fix help blocking on active controller state

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -40,11 +40,11 @@ impl ActivityAgentTaskProvider for AgentTaskActivityProvider {
             .map(item_from_agent_task))
     }
 
-    /// One pass over the durable records yields both the projected items and
-    /// the health summary for the same read, through the single-pass
-    /// `list_records_with_health` (#10308).
-    fn agent_task_activity(&self) -> Result<(Vec<ActivityItem>, Value)> {
-        let (records, health) = agent_task_lifecycle::list_records_with_health()?;
+    /// One bounded pass over the durable records yields both the projected
+    /// items and health summary. Activity is an observational surface, so it
+    /// must not reconcile runs, acquire lifecycle locks, or contact runners.
+    fn agent_task_activity(&self, limit: usize) -> Result<(Vec<ActivityItem>, Value)> {
+        let (records, health) = agent_task_lifecycle::read_records_with_health_bounded(limit)?;
         let items = records.into_iter().map(item_from_agent_task).collect();
         let health = serde_json::to_value(health).map_err(|error| {
             homeboy_core::Error::internal_json(
@@ -127,9 +127,10 @@ fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
             &record.run_id,
             runner_id.as_deref(),
             state,
-            load_controller_plan(&record.run_id)
-                .as_ref()
-                .is_ok_and(|plan| plan_has_retry_materialization_identity(plan)),
+            is_failure(state)
+                && load_controller_plan(&record.run_id)
+                    .as_ref()
+                    .is_ok_and(|plan| plan_has_retry_materialization_identity(plan)),
         ),
     }
 }
@@ -249,12 +250,18 @@ mod tests {
         with_isolated_home(|_| {
             register();
             let run_id = seed_record("run-report-health");
+            let before = agent_task_lifecycle::exact_record(&run_id).expect("record before list");
 
             let report = homeboy_core::activity::activity_report(ActivityScope::All, 50)
                 .expect("activity report");
 
             assert!(report.items.iter().any(|item| item.id == run_id));
             assert_eq!(report.agent_task_record_health["healthy"], 1);
+            assert_eq!(
+                agent_task_lifecycle::exact_record(&run_id).expect("record after list"),
+                before,
+                "activity list must not reconcile or rewrite lifecycle state"
+            );
 
             let shown = homeboy_core::activity::show_activity(&run_id).expect("show activity");
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1833,7 +1833,13 @@ pub fn list_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskR
 /// cannot delay access to controller-owned state.
 pub fn read_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)>
 {
-    let (mut records, health) = store::read_records_with_health()?;
+    read_records_with_health_bounded(1000)
+}
+
+pub fn read_records_with_health_bounded(
+    limit: usize,
+) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
+    let (mut records, health) = store::read_records_with_health_bounded(limit)?;
     records.sort_by(|left, right| {
         right
             .updated_at

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -378,9 +378,15 @@ pub(super) fn read_retry_successors(source_run_id: &str) -> Result<Vec<AgentTask
 
 pub(super) fn read_records_with_health(
 ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
+    read_records_with_health_bounded(1000)
+}
+
+pub(super) fn read_records_with_health_bounded(
+    limit: usize,
+) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
     let mut health = super::AgentTaskRecordHealthSummary::healthy();
     let mut records = Vec::new();
-    for run in observation_runs()? {
+    for run in observation_runs_bounded(limit)? {
         match super::health::diagnose_run(&run) {
             Ok(record) => {
                 health.healthy += 1;
@@ -393,10 +399,14 @@ pub(super) fn read_records_with_health(
 }
 
 pub(super) fn observation_runs() -> Result<Vec<RunRecord>> {
-    let store = ObservationStore::open_initialized()?;
+    observation_runs_bounded(1000)
+}
+
+fn observation_runs_bounded(limit: usize) -> Result<Vec<RunRecord>> {
+    let store = ObservationStore::open_readonly()?;
     let filter = RunListFilter {
         kind: Some("agent-task".to_string()),
-        limit: Some(1000),
+        limit: Some(i64::try_from(limit.clamp(1, 1000)).expect("bounded record limit")),
         ..Default::default()
     };
     store.list_runs(filter)

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -64,7 +64,7 @@ enum StartupFastPath {
 /// rendering help inline is why the root-help tests could only assert against a
 /// builder the binary never called.
 enum StartupFastPathOutput {
-    Help(Box<Command>),
+    Help(String),
     Version(String),
     Identity(serde_json::Value),
 }
@@ -78,7 +78,14 @@ fn startup_fast_path_output(args: &[String]) -> Option<StartupFastPathOutput> {
         // Rendered help never displays readiness, so probing it was pure cost
         // on the hottest command in the CLI (#10616).
         StartupFastPath::Help => {
-            StartupFastPathOutput::Help(Box::new(CliRuntime::new().build_augmented_command()))
+            let error = CliRuntime::new()
+                .build_augmented_command()
+                .try_get_matches_from(args)
+                .expect_err("an explicit help flag must stop argument parsing");
+            if error.kind() != clap::error::ErrorKind::DisplayHelp {
+                return None;
+            }
+            StartupFastPathOutput::Help(error.to_string())
         }
         StartupFastPath::Version => {
             StartupFastPathOutput::Version(upgrade::current_build_version())
@@ -92,10 +99,7 @@ fn startup_fast_path_output(args: &[String]) -> Option<StartupFastPathOutput> {
 
 pub fn run_startup_fast_path(args: &[String]) -> Option<std::process::ExitCode> {
     match startup_fast_path_output(args)? {
-        StartupFastPathOutput::Help(mut command) => {
-            command.print_help().expect("Failed to print help");
-            println!();
-        }
+        StartupFastPathOutput::Help(help) => print!("{help}"),
         StartupFastPathOutput::Version(version) => println!("{version}"),
         StartupFastPathOutput::Identity(identity) => {
             output_runtime::emit_json_result(Ok(identity), None, 0);
@@ -369,10 +373,12 @@ impl CliRuntime {
         }
         // Deferred records outlive their worker. Startup restarts the singleton
         // so expired claims recover without another deferral request.
-        if !matches!(
-            normalized.get(1..3),
-            Some([command, subcommand]) if command == "deferred-workload" && subcommand == "worker"
-        ) {
+        if command_capability == CommandCapability::Mutation
+            && !matches!(
+                normalized.get(1..3),
+                Some([command, subcommand]) if command == "deferred-workload" && subcommand == "worker"
+            )
+        {
             let _ = crate::commands::deferred_workload::restart_worker_if_pending();
         }
 
@@ -996,7 +1002,9 @@ fn startup_fast_path(args: &[String]) -> Option<StartupFastPath> {
     }
 
     match args {
-        [_, flag] if flag == "--help" || flag == "-h" => Some(StartupFastPath::Help),
+        [_, rest @ ..] if rest.iter().any(|arg| arg == "--help" || arg == "-h") => {
+            Some(StartupFastPath::Help)
+        }
         [_, flag] if flag == "--version" || flag == "-V" => Some(StartupFastPath::Version),
         [_, command, subcommand] if command == "self" && subcommand == "identity" => {
             Some(StartupFastPath::Identity)
@@ -2024,7 +2032,7 @@ mod tests {
     }
 
     #[test]
-    fn startup_fast_path_only_matches_root_help_and_version_flags() {
+    fn startup_fast_path_matches_explicit_help_at_every_command_depth() {
         assert_eq!(
             startup_fast_path(&argv(&["homeboy", "--help"])),
             Some(StartupFastPath::Help)
@@ -2043,31 +2051,35 @@ mod tests {
         );
         assert_eq!(
             startup_fast_path(&argv(&["homeboy", "status", "--help"])),
-            None
+            Some(StartupFastPath::Help)
         );
         assert_eq!(
-            startup_fast_path(&argv(&["homeboy", "sample-cli", "--help"])),
-            None
+            startup_fast_path(&argv(&["homeboy", "agent-task", "cook", "--help"])),
+            Some(StartupFastPath::Help)
         );
     }
 
-    /// Only root help pays for extension discovery. `<subcommand> --help`,
-    /// `help <subcommand>` and every other argv leave the fast path before any
-    /// discovery happens, so routing root help through the augmented command
-    /// cannot regress their startup cost.
+    /// Explicit help is rendered before runtime registration, config loading,
+    /// controller consultation, or deferred-worker recovery. Clap still decides
+    /// whether the flag is actually help rather than an option value.
     #[test]
-    fn subcommand_help_paths_stay_off_the_startup_fast_path() {
+    fn explicit_subcommand_help_uses_the_startup_fast_path() {
         for values in [
             &["homeboy", "status", "--help"][..],
             &["homeboy", "status", "-h"][..],
-            &["homeboy", "help", "status"][..],
             &["homeboy", "extension", "list", "--help"][..],
+            &["homeboy", "agent-task", "cook", "--help"][..],
         ] {
             assert!(
-                startup_fast_path_output(&argv(values)).is_none(),
-                "{values:?} should be parsed normally, not fast-pathed"
+                matches!(
+                    startup_fast_path_output(&argv(values)),
+                    Some(StartupFastPathOutput::Help(_))
+                ),
+                "{values:?} should render before runtime initialization"
             );
         }
+
+        assert!(startup_fast_path_output(&argv(&["homeboy", "help", "status"])).is_none());
     }
 
     #[test]
@@ -2113,7 +2125,7 @@ mod tests {
     /// these tests fail if root help ever regresses to the static command.
     fn root_help_for(argv_values: &[&str]) -> String {
         match startup_fast_path_output(&argv(argv_values)) {
-            Some(StartupFastPathOutput::Help(mut command)) => command.render_help().to_string(),
+            Some(StartupFastPathOutput::Help(help)) => help,
             _ => panic!("{argv_values:?} should resolve to the root-help startup fast path"),
         }
     }

--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -37,8 +37,9 @@ pub fn classify(args: &[String]) -> CommandCapability {
         {
             CommandCapability::ReadOnly
         }
+        [command, ..] if command == "activity" => CommandCapability::ReadOnly,
         [command, rest @ ..]
-            if matches!(command.as_str(), "activity" | "project" | "rig" | "server")
+            if matches!(command.as_str(), "project" | "rig" | "server")
                 && matches!(rest.first().map(String::as_str), None | Some("list")) =>
         {
             CommandCapability::ReadOnly
@@ -93,6 +94,9 @@ mod tests {
         for command in [
             args(&["homeboy", "activity"]),
             args(&["homeboy", "activity", "list"]),
+            args(&["homeboy", "activity", "list", "--limit", "1"]),
+            args(&["homeboy", "activity", "show", "run-1"]),
+            args(&["homeboy", "activity", "watch", "run-1"]),
             args(&["homeboy", "project", "list"]),
             args(&["homeboy", "rig", "list"]),
             args(&["homeboy", "server", "list"]),

--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -3,7 +3,7 @@ use fs4::fs_std::FileExt;
 use homeboy::core::deferred_workload;
 use serde::Serialize;
 use std::collections::BTreeSet;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
@@ -92,6 +92,12 @@ pub fn ensure_worker() -> homeboy::core::Result<()> {
             "--startup-token",
             &startup_token,
         ]);
+        // A detached worker must not keep an invoking client's capture pipes
+        // open after the foreground command exits.
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt;

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -1,11 +1,11 @@
 //! Activity reporting — aggregates in-flight and recent work from observation
-//! runs, agent-task records, daemon jobs, and runner sessions into a single
+//! runs, agent-task records, and daemon jobs into a single
 //! deduplicated report, and resolves individual items by id.
 //!
 //! The data model lives in [`model`], multi-source dedup/reconciliation in
 //! [`collector`], shared leaf helpers in [`action_helpers`], and each source
 //! adapter in its own submodule (`observation`, `daemon_jobs`,
-//! `runner_sessions`, `agent_task_provider`). This root retains only report
+//! `agent_task_provider`). This root retains only report
 //! assembly and id resolution (#9794).
 
 use std::collections::BTreeSet;
@@ -22,7 +22,6 @@ mod model;
 
 mod daemon_jobs;
 mod observation;
-mod runner_sessions;
 
 pub use model::*;
 
@@ -45,12 +44,12 @@ pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityRep
     observation::collect(&mut collector, limit)?;
     // Items and record health come from one pass over the durable agent-task
     // records. Reading them separately walked the corpus twice (#10308).
-    let (agent_task_items, agent_task_record_health) = agent_task_provider::agent_task_activity()?;
+    let (agent_task_items, agent_task_record_health) =
+        agent_task_provider::agent_task_activity(limit)?;
     for item in agent_task_items {
         collector.insert(item);
     }
     daemon_jobs::collect(&mut collector)?;
-    runner_sessions::collect(&mut collector);
     let mut report = report_from_items(collector.items(scope, limit), "activity");
     report.agent_task_record_health = agent_task_record_health;
     Ok(report)
@@ -62,7 +61,7 @@ pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityRep
 /// `activity show`/`watch` are called with a concrete id (an observation run id
 /// or a daemon/runner job UUID). Building the entire activity report just to
 /// find one item enumerated every observation, agent-task record, daemon job,
-/// runner session, and record-health probe — which timed out for active Lab
+/// and record-health probe — which timed out for active Lab
 /// jobs (#9762). This probes the cheap indexed lookups first; only when none
 /// resolve does it fall back to `resolve_item` over the bounded full report.
 ///

--- a/crates/homeboy-core/src/activity/agent_task_provider.rs
+++ b/crates/homeboy-core/src/activity/agent_task_provider.rs
@@ -34,13 +34,13 @@ pub trait ActivityAgentTaskProvider: Send + Sync {
     /// durable records. Asking for them separately made the activity report
     /// walk the corpus twice (#10308). The health summary is serialized as JSON
     /// so core does not depend on the agent-task health type.
-    fn agent_task_activity(&self) -> Result<(Vec<ActivityItem>, Value)>;
+    fn agent_task_activity(&self, limit: usize) -> Result<(Vec<ActivityItem>, Value)>;
 }
 
 struct NoopProvider;
 
 impl ActivityAgentTaskProvider for NoopProvider {
-    fn agent_task_activity(&self) -> Result<(Vec<ActivityItem>, Value)> {
+    fn agent_task_activity(&self, _limit: usize) -> Result<(Vec<ActivityItem>, Value)> {
         Ok((Vec::new(), Value::Null))
     }
 }
@@ -65,6 +65,6 @@ pub(crate) fn probe_by_id(id: &str) -> Result<Option<ActivityItem>> {
 /// The agent-task activity items and record-health summary via the registered
 /// provider (or no items and an empty summary when the agent-task subsystem is
 /// absent).
-pub(crate) fn agent_task_activity() -> Result<(Vec<ActivityItem>, Value)> {
-    with_provider(|p| p.agent_task_activity())
+pub(crate) fn agent_task_activity(limit: usize) -> Result<(Vec<ActivityItem>, Value)> {
+    with_provider(|p| p.agent_task_activity(limit))
 }

--- a/crates/homeboy-core/src/activity/observation.rs
+++ b/crates/homeboy-core/src/activity/observation.rs
@@ -11,7 +11,7 @@ use crate::Result;
 /// full corpus. Matches the persisted run id directly (indexed `get_run`),
 /// so `activity show <run-id>` returns immediately for a known run (#9762).
 pub(super) fn probe_by_id(id: &str) -> Result<Option<ActivityItem>> {
-    let store = ObservationStore::open_initialized()?;
+    let store = ObservationStore::open_readonly()?;
     match store.get_run(id)? {
         Some(run) => Ok(Some(item_from_run(&store, run)?)),
         None => Ok(None),
@@ -19,7 +19,7 @@ pub(super) fn probe_by_id(id: &str) -> Result<Option<ActivityItem>> {
 }
 
 pub(super) fn collect(collector: &mut ActivityCollector, limit: usize) -> Result<()> {
-    let store = ObservationStore::open_initialized()?;
+    let store = ObservationStore::open_readonly()?;
     let mut records = store.list_runs(RunListFilter {
         limit: Some(limit as i64),
         ..Default::default()
@@ -32,7 +32,7 @@ pub(super) fn collect(collector: &mut ActivityCollector, limit: usize) -> Result
     // always included before the canonical report applies its final limit.
     records.extend(
         store
-            .list_active_runs()?
+            .list_active_runs_bounded(limit as i64)?
             .into_iter()
             .filter(|record| !listed_ids.contains(&record.id)),
     );

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -402,6 +402,11 @@ impl ObservationStore {
     /// List every currently running run so callers can retain active work when
     /// applying a separate display limit to recent history.
     pub fn list_active_runs(&self) -> Result<Vec<RunRecord>> {
+        self.list_active_runs_bounded(i64::MAX)
+    }
+
+    /// List the newest active runs without scanning an unbounded stale corpus.
+    pub fn list_active_runs_bounded(&self, limit: i64) -> Result<Vec<RunRecord>> {
         let mut statement = self
             .connection
             .prepare(
@@ -411,11 +416,15 @@ impl ObservationStore {
                 FROM runs
                 WHERE status = ?1
                 ORDER BY started_at DESC, id DESC
+                LIMIT ?2
                 "#,
             )
             .map_err(sqlite_error("prepare list active run records"))?;
         let rows = statement
-            .query_map([RunStatus::Running.as_str()], row_to_run_record)
+            .query_map(
+                params![RunStatus::Running.as_str(), limit.max(1)],
+                row_to_run_record,
+            )
             .map_err(sqlite_error("list active run records"))?;
 
         collect_rows(rows, "collect active run records")

--- a/tests/readonly_cli_lock_test.rs
+++ b/tests/readonly_cli_lock_test.rs
@@ -10,6 +10,8 @@ use std::time::{Duration, Instant};
 fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let repository = create_repository(home.path());
+        homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("initialize observation store");
         let promotion_namespace = home.path().join("nested-promotion-gate-data");
         let _promotion_namespace = TestPromotionNamespace::new(&promotion_namespace);
         let git_before = git_metadata_snapshot(&repository);
@@ -22,6 +24,9 @@ fn read_only_cli_commands_complete_while_runtime_promotion_is_held() {
         for args in [
             vec!["--version"],
             vec!["--help"],
+            vec!["activity", "--help"],
+            vec!["agent-task", "cook", "--help"],
+            vec!["activity"],
             vec!["self", "identity"],
             vec!["self", "status"],
             vec!["status"],


### PR DESCRIPTION
## Summary

- render explicit nested `--help` before runtime registration, configuration loading, or controller recovery
- keep read-only activity paths out of reconciliation and remote runner probes
- bound observation and agent-task reads by the requested activity limit
- detach deferred worker stdio so captured commands can reach EOF

Closes #11079.

## Verification

- `cargo test -p homeboy-cli --lib command_capability::tests -- --nocapture`
- `cargo test -p homeboy-agents activity_provider -- --nocapture`
- `cargo test -p homeboy-core --lib activity:: -- --test-threads=1`
- `cargo test --test readonly_cli_lock_test -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- rebuilt binary with active workloads: nested cook help 0.08s; activity 3.31s

The broad `cargo test -p homeboy-cli --lib -- --test-threads=1` run was attempted but timed out after 10 minutes with existing current-main failures in CLI docs/flag snapshots and controller-run tests.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the contention paths, drafted the implementation and regression tests, and ran verification. Chris Huber reviewed and remains responsible for the change.