### PR TITLE
fix(lab): retain reviewer artifacts durably

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/bench_artifact.rs
+++ b/crates/contracts/homeboy-extension-contract/src/bench_artifact.rs
@@ -4,6 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use homeboy_lifecycle_contract::ArtifactViewerLink;
 
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
 /// Viewer pointers shared by bench artifact records and the compact
 /// artifact index. Embedded via `#[serde(flatten)]` so the on-wire JSON
 /// keeps `viewer_url` / `viewer_links` at the parent level — identical
@@ -43,6 +47,10 @@ pub struct BenchArtifact {
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observation_artifact_id: Option<String>,
+    /// Makes this reviewer-facing artifact part of the terminal durability
+    /// contract. The producer must provide bytes that Homeboy can retain.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub required_durable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/contracts/homeboy-extension-contract/src/bench_artifact_test.rs
+++ b/crates/contracts/homeboy-extension-contract/src/bench_artifact_test.rs
@@ -58,6 +58,20 @@ fn bench_artifact_serializes_url_fields_when_present() {
 }
 
 #[test]
+fn bench_artifact_serializes_required_durable_contract() {
+    let artifact = BenchArtifact {
+        path: Some("artifacts/run-1/diff.png".to_string()),
+        required_durable: true,
+        ..BenchArtifact::default()
+    };
+
+    assert_eq!(
+        serde_json::to_string(&artifact).unwrap(),
+        r#"{"path":"artifacts/run-1/diff.png","required_durable":true}"#
+    );
+}
+
+#[test]
 fn bench_artifact_serializes_preview_metadata_when_present() {
     let artifact = BenchArtifact {
         path: Some("artifacts/preview.json".to_string()),

--- a/crates/contracts/homeboy-extension-contract/src/bench_artifact_test.rs
+++ b/crates/contracts/homeboy-extension-contract/src/bench_artifact_test.rs
@@ -72,6 +72,18 @@ fn bench_artifact_serializes_required_durable_contract() {
 }
 
 #[test]
+fn bench_artifact_accepts_mixed_legacy_and_durable_records() {
+    let legacy: BenchArtifact =
+        serde_json::from_str(r#"{"path":"artifacts/legacy.png"}"#).expect("legacy artifact");
+    let durable: BenchArtifact =
+        serde_json::from_str(r#"{"path":"artifacts/current.png","required_durable":true}"#)
+            .expect("durable artifact");
+
+    assert!(!legacy.required_durable);
+    assert!(durable.required_durable);
+}
+
+#[test]
 fn bench_artifact_serializes_preview_metadata_when_present() {
     let artifact = BenchArtifact {
         path: Some("artifacts/preview.json".to_string()),

--- a/crates/homeboy-cli/src/commands/bench/observation/artifacts.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/artifacts.rs
@@ -10,8 +10,8 @@ pub(super) fn record_bench_observation_artifacts(
     observation: &BenchObservation,
     workflow: &mut homeboy_extension::bench::BenchRunWorkflowResult,
     run_dir: &RunDir,
-) {
-    bench::record_bench_observation_artifacts(&observation.0, workflow, run_dir);
+) -> bool {
+    bench::record_bench_observation_artifacts(&observation.0, workflow, run_dir)
 }
 
 pub(super) fn record_if_exists(observation: &BenchObservation, kind: &str, path: PathBuf) {

--- a/crates/homeboy-cli/src/commands/bench/observation/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/lifecycle.rs
@@ -4,6 +4,7 @@ use homeboy::core::engine::run_dir::{self, RunDir};
 use homeboy::core::git::short_head_revision_at;
 use homeboy::core::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::rig::RigStateSnapshot;
+use homeboy_extension::bench::run::BenchRunFailure;
 use homeboy_extension::bench::BenchRunWorkflowResult;
 
 use super::artifacts::{
@@ -85,7 +86,21 @@ pub(in crate::commands::bench) fn finish_success(
 ) -> Option<BenchObservationSummary> {
     let observation = observation?;
 
-    record_bench_observation_artifacts(&observation, workflow, run_dir);
+    if !record_bench_observation_artifacts(&observation, workflow, run_dir) {
+        workflow.status = "failed".to_string();
+        workflow.exit_code = 1;
+        workflow.failure = Some(BenchRunFailure {
+            component_id: workflow.component.clone(),
+            component_path: None,
+            scenario_id: None,
+            exit_code: 1,
+            stderr_tail: "declared reviewer-facing artifacts were not durably promoted".to_string(),
+            failure_classification: None,
+            responsiveness: None,
+            memory_sample: None,
+            diagnostics: workflow.diagnostics.clone(),
+        });
+    }
     let metadata =
         bench_observation_finish_metadata(observation.0.initial_metadata().clone(), workflow);
     let status = if workflow.exit_code == 0 {

--- a/crates/homeboy-core/src/observation/mod.rs
+++ b/crates/homeboy-core/src/observation/mod.rs
@@ -59,9 +59,9 @@ pub use records::{
 };
 pub use run_failure_causes::{nested_failure_causes_from_run_detail, RunFailureCause};
 pub use store::{
-    directory_tree_sha256, ArtifactPublication, ObservationDbStatus, ObservationStore,
-    CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
-    SOURCE_SNAPSHOT_METADATA_ENV,
+    directory_tree_sha256, ArtifactPublication, ArtifactPublicationType, ObservationDbStatus,
+    ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV,
+    PREVIEW_PUBLIC_URL_ENV, SOURCE_SNAPSHOT_METADATA_ENV,
 };
 pub use test_findings::{
     finding_records_from_failure_clusters, finding_records_from_test_analysis_input,

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -12,8 +12,14 @@ use super::*;
 const PUBLICATION_LEASE_MS: i64 = 5 * 60 * 1000;
 const PUBLICATION_ARTIFACT_FILENAME_LIMIT: usize = 240;
 
-/// A file staged by a caller for atomic publication with its run record.
+/// A filesystem artifact staged by a caller for atomic publication with its run record.
 /// The store computes controller-owned integrity metadata from `source_path`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactPublicationType {
+    File,
+    Directory,
+}
+
 #[derive(Debug, Clone)]
 pub struct ArtifactPublication {
     pub id: String,
@@ -25,10 +31,11 @@ pub struct ArtifactPublication {
     /// both fields; other store callers may omit them for local files.
     pub expected_size_bytes: Option<i64>,
     pub expected_sha256: Option<String>,
+    pub artifact_type: ArtifactPublicationType,
 }
 
 impl ObservationStore {
-    /// Publish a run and all of its file artifacts as one reader-visible unit.
+    /// Publish a run and all of its filesystem artifacts as one reader-visible unit.
     ///
     /// Files are copied and verified before the SQLite transaction begins. The
     /// rows become visible together at commit; files created for a failed
@@ -66,10 +73,14 @@ impl ObservationStore {
                         Some(format!("inspect staged artifact {}", source.display())),
                     )
                 })?;
-                if !metadata.is_file() {
+                let is_expected_type = match publication.artifact_type {
+                    ArtifactPublicationType::File => metadata.is_file(),
+                    ArtifactPublicationType::Directory => metadata.is_dir(),
+                };
+                if !is_expected_type {
                     return Err(Error::validation_invalid_argument(
                         "artifact.path",
-                        "atomic artifact publication requires a regular file",
+                        "atomic artifact publication source has the wrong filesystem type",
                         Some(source.display().to_string()),
                         None,
                     ));
@@ -79,9 +90,15 @@ impl ObservationStore {
                 // bytes must therefore be owned by this publication token.
                 let stored_path =
                     publication_artifact_path(&run.id, &publication.id, source, &publication_id)?;
-                let size_bytes = i64::try_from(metadata.len()).ok();
-                let sha256 = crate::artifact_metadata::sha256_file(source)?;
-                if publication.expected_size_bytes.is_some()
+                let size_bytes = (publication.artifact_type == ArtifactPublicationType::File)
+                    .then(|| i64::try_from(metadata.len()).ok())
+                    .flatten();
+                let sha256 = match publication.artifact_type {
+                    ArtifactPublicationType::File => crate::artifact_metadata::sha256_file(source)?,
+                    ArtifactPublicationType::Directory => directory_tree_sha256(source)?,
+                };
+                if publication.artifact_type == ArtifactPublicationType::File
+                    && publication.expected_size_bytes.is_some()
                     && publication.expected_size_bytes != size_bytes
                 {
                     return Err(Error::validation_invalid_argument(
@@ -104,10 +121,19 @@ impl ObservationStore {
                 if let Some(existing) = self.get_artifact(&publication.id)? {
                     let matches = existing.run_id == run.id
                         && existing.kind == publication.kind
-                        && existing.artifact_type == "file"
+                        && existing.artifact_type
+                            == match publication.artifact_type {
+                                ArtifactPublicationType::File => "file",
+                                ArtifactPublicationType::Directory => "directory",
+                            }
                         && existing.size_bytes == size_bytes
                         && existing.sha256.as_deref() == Some(sha256.as_str())
-                        && Path::new(&existing.path).is_file();
+                        && match publication.artifact_type {
+                            ArtifactPublicationType::File => Path::new(&existing.path).is_file(),
+                            ArtifactPublicationType::Directory => {
+                                Path::new(&existing.path).is_dir()
+                            }
+                        };
                     if !matches {
                         return Err(Error::validation_invalid_argument(
                             "artifact.id",
@@ -121,8 +147,19 @@ impl ObservationStore {
                 }
                 let staged_path = staged_artifact_path(&stored_path, Uuid::new_v4());
                 staged_paths.push(staged_path.clone());
-                copy_artifact_file(source, &staged_path)?;
-                if crate::artifact_metadata::sha256_file(&staged_path)? != sha256 {
+                match publication.artifact_type {
+                    ArtifactPublicationType::File => copy_artifact_file(source, &staged_path)?,
+                    ArtifactPublicationType::Directory => {
+                        copy_artifact_directory(source, &staged_path)?
+                    }
+                }
+                let staged_sha256 = match publication.artifact_type {
+                    ArtifactPublicationType::File => {
+                        crate::artifact_metadata::sha256_file(&staged_path)?
+                    }
+                    ArtifactPublicationType::Directory => directory_tree_sha256(&staged_path)?,
+                };
+                if staged_sha256 != sha256 {
                     return Err(Error::internal_unexpected(
                         "staged artifact checksum changed before publication",
                     ));
@@ -131,7 +168,10 @@ impl ObservationStore {
                     id: publication.id.clone(),
                     run_id: run.id.clone(),
                     kind: publication.kind.clone(),
-                    artifact_type: "file".to_string(),
+                    artifact_type: match publication.artifact_type {
+                        ArtifactPublicationType::File => "file".to_string(),
+                        ArtifactPublicationType::Directory => "directory".to_string(),
+                    },
                     path: stored_path.display().to_string(),
                     url: None,
                     public_url: None,
@@ -139,14 +179,19 @@ impl ObservationStore {
                     viewer_links: Vec::new(),
                     sha256: Some(sha256),
                     size_bytes,
-                    mime: publication
-                        .mime
-                        .clone()
-                        .or_else(|| crate::artifact_metadata::content_type_from_path(source)),
+                    mime: (publication.artifact_type == ArtifactPublicationType::File)
+                        .then(|| {
+                            publication.mime.clone().or_else(|| {
+                                crate::artifact_metadata::content_type_from_path(source)
+                            })
+                        })
+                        .flatten(),
                     metadata_json: publication.metadata_json.clone(),
                     created_at: chrono::Utc::now().to_rfc3339(),
                 };
-                crate::artifact_links::annotate_public_artifact_url_validation(&mut artifact);
+                if publication.artifact_type == ArtifactPublicationType::File {
+                    crate::artifact_links::annotate_public_artifact_url_validation(&mut artifact);
+                }
                 prepared.push((artifact, Some(staged_path), Some(stored_path)));
             }
             // Copying can be slow. Journal only after all staging completes so
@@ -223,7 +268,7 @@ impl ObservationStore {
         })();
         if let Err(error) = result {
             for path in staged_paths {
-                fs::remove_file(path).ok();
+                remove_publication_path(&path);
             }
             self.reconcile_artifact_publication(&publication_id, &owner_token)
                 .ok();
@@ -278,8 +323,8 @@ impl ObservationStore {
                 params![publication_id, artifact_id, owner_token, lease_expires_at, now],
             ).map_err(sqlite_error("claim expired artifact publication"))?;
             if claimed == 1 {
-                fs::remove_file(staging_path).ok();
-                fs::remove_file(final_path).ok();
+                remove_publication_path(Path::new(&staging_path));
+                remove_publication_path(Path::new(&final_path));
             }
         }
         Ok(())
@@ -300,8 +345,8 @@ impl ObservationStore {
             .map_err(sqlite_error("query owned artifact publication"))?;
         for (staging_path, final_path) in collect_rows(paths, "collect owned artifact publication")?
         {
-            fs::remove_file(staging_path).ok();
-            fs::remove_file(final_path).ok();
+            remove_publication_path(Path::new(&staging_path));
+            remove_publication_path(Path::new(&final_path));
         }
         self.connection.execute(
             "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND owner_token = ?2",
@@ -914,11 +959,11 @@ impl ObservationStore {
                     kind,
                     "directory",
                     path_string,
-                    Some(tree_sha256.clone()),
+                    Option::<String>::None,
                     Option::<String>::None,
                     Option::<String>::None,
                     viewer_links_json,
-                    Option::<String>::None,
+                    Some(tree_sha256.clone()),
                     Option::<i64>::None,
                     Option::<String>::None,
                     metadata_json_str,
@@ -1656,6 +1701,18 @@ fn staged_artifact_path(stored_path: &Path, staging_id: Uuid) -> std::path::Path
     stored_path.with_file_name(format!(".artifact-{staging_id}.staging"))
 }
 
+fn remove_publication_path(path: &Path) {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => {
+            fs::remove_dir_all(path).ok();
+        }
+        Ok(_) => {
+            fs::remove_file(path).ok();
+        }
+        Err(_) => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1846,6 +1903,7 @@ mod tests {
                 metadata_json: serde_json::json!({}),
                 expected_size_bytes: None,
                 expected_sha256: None,
+                artifact_type: ArtifactPublicationType::File,
             };
 
             let error = store
@@ -1874,6 +1932,105 @@ mod tests {
     }
 
     #[test]
+    fn atomic_publication_keeps_mixed_artifacts_invisible_until_complete() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let seed = store
+                .start_run(NewRunRecord::builder("test").cwd_path(home.path()).build())
+                .expect("seed run");
+            let mut run = seed.clone();
+            run.id = "mixed-atomic-run".to_string();
+            let file = home.path().join("evidence.json");
+            let directory = home.path().join("visuals");
+            fs::write(&file, b"evidence").expect("file");
+            fs::create_dir_all(&directory).expect("directory");
+            fs::write(directory.join("diff.png"), b"diff").expect("directory file");
+            let file_hash = crate::artifact_metadata::sha256_file(&file).expect("file hash");
+            let tree_hash = directory_tree_sha256(&directory).expect("tree hash");
+            let publication = |id: &str, source_path: PathBuf, artifact_type| ArtifactPublication {
+                id: id.to_string(),
+                kind: "evidence".to_string(),
+                source_path,
+                mime: None,
+                metadata_json: serde_json::json!({}),
+                expected_size_bytes: None,
+                expected_sha256: None,
+                artifact_type,
+            };
+
+            store
+                .publish_run_artifacts_atomically(
+                    &run,
+                    &[
+                        publication("file", file.clone(), ArtifactPublicationType::File),
+                        publication(
+                            "missing-directory",
+                            home.path().join("missing-directory"),
+                            ArtifactPublicationType::Directory,
+                        ),
+                    ],
+                )
+                .expect_err("mixed staging failure");
+            assert!(store.get_run(&run.id).expect("run lookup").is_none());
+            assert!(store.get_artifact("file").expect("file lookup").is_none());
+
+            let directory_only = RunRecord {
+                id: "directory-only-run".to_string(),
+                ..run.clone()
+            };
+            let directory_records = store
+                .publish_run_artifacts_atomically(
+                    &directory_only,
+                    &[ArtifactPublication {
+                        expected_sha256: Some(tree_hash.clone()),
+                        ..publication(
+                            "directory",
+                            directory.clone(),
+                            ArtifactPublicationType::Directory,
+                        )
+                    }],
+                )
+                .expect("directory-only publication");
+            assert_eq!(directory_records[0].artifact_type, "directory");
+            assert_eq!(
+                directory_records[0].sha256.as_deref(),
+                Some(tree_hash.as_str())
+            );
+
+            let mixed = RunRecord {
+                id: "mixed-success-run".to_string(),
+                ..run
+            };
+            let records = store
+                .publish_run_artifacts_atomically(
+                    &mixed,
+                    &[
+                        ArtifactPublication {
+                            expected_sha256: Some(file_hash),
+                            ..publication("mixed-file", file, ArtifactPublicationType::File)
+                        },
+                        ArtifactPublication {
+                            expected_sha256: Some(tree_hash.clone()),
+                            ..publication(
+                                "mixed-directory",
+                                directory,
+                                ArtifactPublicationType::Directory,
+                            )
+                        },
+                    ],
+                )
+                .expect("mixed publication");
+            assert_eq!(records.len(), 2);
+            assert!(records
+                .iter()
+                .any(|artifact| artifact.artifact_type == "file"));
+            assert!(records
+                .iter()
+                .any(|artifact| artifact.sha256.as_deref() == Some(tree_hash.as_str())));
+        });
+    }
+
+    #[test]
     fn atomic_publication_bounds_oversized_final_filename() {
         with_isolated_home(|home| {
             let store = ObservationStore::open_initialized().expect("store");
@@ -1898,6 +2055,7 @@ mod tests {
                         metadata_json: serde_json::json!({}),
                         expected_size_bytes: None,
                         expected_sha256: None,
+                        artifact_type: ArtifactPublicationType::File,
                     }],
                 )
                 .expect("publish oversized private artifact");

--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -23,7 +23,7 @@ use super::records::{
 };
 use crate::{paths, Error, Result};
 pub use artifacts::directory_tree_sha256;
-pub use artifacts::ArtifactPublication;
+pub use artifacts::{ArtifactPublication, ArtifactPublicationType};
 
 pub(crate) use helpers::*;
 

--- a/crates/homeboy-extension/src/bench/artifact_persistence.rs
+++ b/crates/homeboy-extension/src/bench/artifact_persistence.rs
@@ -249,6 +249,10 @@ fn persist_bench_artifact(
 
     match record {
         Ok(record) => {
+            // The source URL can be a tunnel or runner-local address. Keep it
+            // in the persisted provenance metadata, but never present it as a
+            // reviewer-facing reference after durable promotion.
+            artifact.url = None;
             artifact.path = Some(record.path.clone());
             apply_recorded_bench_artifact_links(scenario_id, run_index, name, artifact, &record)
         }

--- a/crates/homeboy-extension/src/bench/artifact_persistence.rs
+++ b/crates/homeboy-extension/src/bench/artifact_persistence.rs
@@ -26,7 +26,7 @@ pub fn record_bench_observation_artifacts(
     observation: &ActiveObservation,
     workflow: &mut BenchRunWorkflowResult,
     run_dir: &RunDir,
-) {
+) -> bool {
     if let Some(results) = workflow.results.as_mut() {
         workflow
             .diagnostics
@@ -51,12 +51,30 @@ pub fn record_bench_observation_artifacts(
     record_memory_timeline_artifacts(observation, run_dir);
 
     let Some(results) = workflow.results.as_ref() else {
-        return;
+        return true;
     };
     observation.record_findings(&finding_records_from_budget(
         observation.run_id(),
         &results.budget_findings,
     ));
+    all_bench_artifacts_are_promoted(results)
+}
+
+fn all_bench_artifacts_are_promoted(results: &BenchResults) -> bool {
+    results.scenarios.iter().all(|scenario| {
+        scenario
+            .artifacts
+            .values()
+            .chain(
+                scenario
+                    .runs
+                    .iter()
+                    .flatten()
+                    .flat_map(|run| run.artifacts.values()),
+            )
+            .filter(|artifact| artifact.required_durable)
+            .all(|artifact| artifact.observation_artifact_id.is_some())
+    })
 }
 
 /// Record an artifact when the file at `path` exists.
@@ -136,7 +154,9 @@ fn persist_bench_artifact(
     run_dir: &RunDir,
     shared_state: Option<&str>,
 ) -> Option<BenchDiagnostic> {
-    let kind = artifact.kind.clone().unwrap_or_else(|| name.to_string());
+    // Results can be retried or hydrated from a prior run. Only this attempt's
+    // persisted record may satisfy the current durability declaration.
+    artifact.observation_artifact_id = None;
     let metadata = bench_artifact_metadata(scenario_id, run_index, name, artifact);
 
     let original_path = artifact.path.clone();
@@ -160,28 +180,40 @@ fn persist_bench_artifact(
         shared_state,
     ) else {
         if let Some(url) = artifact.url.clone() {
-            return match observation.store().record_url_artifact_with_metadata(
-                observation.run_id(),
-                &kind,
-                &url,
-                metadata,
-            ) {
-                Ok(record) => apply_recorded_bench_artifact_links(
-                    scenario_id,
-                    run_index,
-                    name,
-                    artifact,
-                    &record,
+            if !artifact.required_durable {
+                return match observation.store().record_url_artifact_with_metadata(
+                    observation.run_id(),
+                    artifact.kind.as_deref().unwrap_or(name),
+                    &url,
+                    metadata,
+                ) {
+                    Ok(record) => apply_recorded_bench_artifact_links(
+                        scenario_id,
+                        run_index,
+                        name,
+                        artifact,
+                        &record,
+                    ),
+                    Err(error) => Some(bench_artifact_diagnostic(
+                        scenario_id,
+                        run_index,
+                        name,
+                        "bench_artifact_url_record_failed",
+                        format!("failed to record bench URL artifact `{name}`: {error}"),
+                        serde_json::json!({ "url": url }),
+                    )),
+                };
+            }
+            return Some(bench_artifact_diagnostic(
+                scenario_id,
+                run_index,
+                name,
+                "bench_artifact_durable_source_missing",
+                format!(
+                    "bench artifact `{name}` has only URL source `{url}`; reviewer-facing artifacts require a local file or directory for durable promotion"
                 ),
-                Err(error) => Some(bench_artifact_diagnostic(
-                    scenario_id,
-                    run_index,
-                    name,
-                    "bench_artifact_url_record_failed",
-                    format!("failed to record bench URL artifact `{name}`: {error}"),
-                    serde_json::json!({ "url": url }),
-                )),
-            };
+                serde_json::json!({ "url": url }),
+            ));
         }
 
         let original_path = original_path?;

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -15,7 +15,8 @@ use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::execution_contract::encode_uri_component;
 use homeboy_core::notification_route::NotificationRoute;
 use homeboy_core::observation::{
-    ArtifactPublication, ArtifactRecord, ObservationStore, RunRecord, RunStatus,
+    ArtifactPublication, ArtifactPublicationType, ArtifactRecord, ObservationStore, RunRecord,
+    RunStatus,
 };
 use homeboy_core::redaction::redact_argv_shell_display;
 use homeboy_core::runner_download_cache::RunnerDownloadIntent;
@@ -1346,6 +1347,7 @@ where
             }),
             expected_size_bytes: size_bytes,
             expected_sha256: sha256,
+            artifact_type: ArtifactPublicationType::File,
         });
         staged.push(file);
     }
@@ -1448,32 +1450,75 @@ where
         if let Some(notification_route) = notification_route {
             notification_route.insert_into_metadata(&mut run.metadata_json);
         }
-        let publications = remote_detail_artifacts(&detail, runner, &run.id)?
-            .into_iter()
-            .map(|artifact| {
-                if artifact.size_bytes.is_none()
-                    || artifact.sha256.as_deref().is_none_or(str::is_empty)
-                {
-                    return Err(Error::validation_invalid_argument(
-                        "artifact.provenance",
-                        "declared terminal artifact is missing required size_bytes or sha256 provenance",
-                        Some(artifact.id),
-                        None,
+        let mut publications = Vec::new();
+        for artifact in remote_detail_artifacts(&detail, runner, &run.id)? {
+            match artifact.artifact_type.as_str() {
+                "remote_file" => {
+                    if artifact.size_bytes.is_none()
+                        || artifact.sha256.as_deref().is_none_or(str::is_empty)
+                    {
+                        return Err(artifact_projection_error(
+                            runner,
+                            job,
+                            run_id,
+                            Error::validation_invalid_argument(
+                                "artifact.provenance",
+                                "declared terminal file artifact is missing required size_bytes or sha256 provenance",
+                                Some(artifact.id),
+                                None,
+                            ),
+                        ));
+                    }
+                    let source_path = download(&artifact.path)
+                        .map_err(|error| artifact_projection_error(runner, job, run_id, error))?;
+                    publications.push(ArtifactPublication {
+                        id: artifact.id,
+                        kind: artifact.kind,
+                        source_path,
+                        mime: artifact.mime,
+                        metadata_json: artifact.metadata_json,
+                        expected_size_bytes: artifact.size_bytes,
+                        expected_sha256: artifact.sha256,
+                        artifact_type: ArtifactPublicationType::File,
+                    });
+                }
+                "directory" => {
+                    let expected_tree_sha256 = artifact.sha256.as_deref().filter(|hash| !hash.is_empty()).ok_or_else(|| {
+                        artifact_projection_error(runner, job, run_id, Error::validation_invalid_argument(
+                            "artifact.sha256",
+                            "declared terminal directory artifact is missing its tree SHA-256",
+                            Some(artifact.id.clone()),
+                            None,
+                        ))
+                    })?;
+                    let source_path = download(&artifact.path)
+                        .map_err(|error| artifact_projection_error(runner, job, run_id, error))?;
+                    publications.push(ArtifactPublication {
+                        id: artifact.id,
+                        kind: artifact.kind,
+                        source_path,
+                        mime: None,
+                        metadata_json: artifact.metadata_json,
+                        expected_size_bytes: None,
+                        expected_sha256: Some(expected_tree_sha256.to_string()),
+                        artifact_type: ArtifactPublicationType::Directory,
+                    });
+                }
+                _ => {
+                    return Err(artifact_projection_error(
+                        runner,
+                        job,
+                        run_id,
+                        Error::validation_invalid_argument(
+                            "artifact.type",
+                            "declared terminal artifact must provide downloadable file or directory bytes, not a URL or live runner reference",
+                            Some(artifact.id),
+                            None,
+                        ),
                     ));
                 }
-                let source_path = download(&artifact.path)?;
-                Ok(ArtifactPublication {
-                    id: artifact.id,
-                    kind: artifact.kind,
-                    source_path,
-                    mime: artifact.mime,
-                    metadata_json: artifact.metadata_json,
-                    expected_size_bytes: artifact.size_bytes,
-                    expected_sha256: artifact.sha256,
-                })
-            })
-            .collect::<Result<Vec<_>>>()
-            .map_err(|error| artifact_projection_error(runner, job, run_id, error))?;
+            }
+        }
         store
             .publish_run_artifacts_atomically(&run, &publications)
             .map_err(|error| artifact_projection_error(runner, job, run_id, error))?;

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -1539,6 +1539,151 @@ fn terminal_mirroring_persists_declared_run_and_artifact_for_controller_review()
 }
 
 #[test]
+fn terminal_mirroring_keeps_every_declared_visual_artifact_after_runner_cleanup() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("controller store");
+        let run_id = "bench-visual-review".to_string();
+        let workspace = tempfile::tempdir().expect("runner workspace");
+        let artifacts = (0..21)
+            .map(|index| {
+                let id = format!("visual-{index:02}");
+                let bytes = format!("png-{index}").into_bytes();
+                let path = workspace.path().join(format!("{id}.png"));
+                fs::write(&path, &bytes).expect("runner artifact");
+                json!({
+                    "id": id,
+                    "kind": "visual_compare",
+                    "type": "file",
+                    "size_bytes": bytes.len(),
+                    "sha256": format!("{:x}", Sha256::digest(&bytes)),
+                    "mime": "image/png"
+                })
+            })
+            .collect::<Vec<_>>();
+        let job = terminal_runner_job();
+
+        mirror_remote_observation_runs_by_id_with_downloader(
+            &store,
+            &ssh_runner(),
+            &job,
+            std::slice::from_ref(&run_id),
+            None,
+            |_| {
+                Ok(Some(json!({
+                    "id": run_id,
+                    "kind": "bench",
+                    "started_at": "2023-11-14T22:13:20Z",
+                    "finished_at": "2023-11-14T22:13:21Z",
+                    "status": "pass",
+                    "artifacts": artifacts,
+                })))
+            },
+            |artifact_path| {
+                let id = artifact_path.rsplit('/').next().expect("artifact id");
+                Ok(workspace.path().join(format!("{id}.png")))
+            },
+        )
+        .expect("all declared visual artifacts are durably mirrored");
+
+        workspace.close().expect("runner workspace cleanup");
+        let persisted = store.list_artifacts(&run_id).expect("persisted artifacts");
+        assert_eq!(persisted.len(), 21);
+        for artifact in persisted {
+            assert_eq!(artifact.artifact_type, "file");
+            assert!(artifact.sha256.is_some());
+            assert!(!fs::read(&artifact.path)
+                .expect("controller artifact")
+                .is_empty());
+        }
+    });
+}
+
+#[test]
+fn terminal_mirroring_copies_declared_directory_with_tree_hash() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("controller store");
+        let run_id = "bench-directory-review".to_string();
+        let workspace = tempfile::tempdir().expect("runner workspace");
+        let directory = workspace.path().join("visuals");
+        fs::create_dir_all(directory.join("nested")).expect("directory");
+        fs::write(directory.join("baseline.png"), b"baseline").expect("baseline");
+        fs::write(directory.join("nested/diff.png"), b"diff").expect("diff");
+        let tree_sha256 =
+            homeboy_core::observation::directory_tree_sha256(&directory).expect("tree hash");
+
+        mirror_remote_observation_runs_by_id_with_downloader(
+            &store,
+            &ssh_runner(),
+            &terminal_runner_job(),
+            std::slice::from_ref(&run_id),
+            None,
+            |_| {
+                Ok(Some(json!({
+                    "id": run_id,
+                    "kind": "bench",
+                    "started_at": "2023-11-14T22:13:20Z",
+                    "finished_at": "2023-11-14T22:13:21Z",
+                    "status": "pass",
+                    "artifacts": [{
+                        "id": "visual-directory",
+                        "kind": "visual_compare",
+                        "type": "directory",
+                        "path": "runner-artifact://lab/bench-directory-review/visual-directory",
+                        "sha256": tree_sha256.clone()
+                    }]
+                })))
+            },
+            |_| Ok(directory.clone()),
+        )
+        .expect("directory is durably mirrored");
+
+        workspace.close().expect("runner workspace cleanup");
+        let artifact = store
+            .get_artifact("visual-directory")
+            .expect("artifact lookup")
+            .expect("artifact");
+        assert_eq!(artifact.artifact_type, "directory");
+        assert_eq!(artifact.sha256.as_deref(), Some(tree_sha256.as_str()));
+        assert!(std::path::Path::new(&artifact.path).is_dir());
+    });
+}
+
+#[test]
+fn terminal_mirroring_rejects_url_only_declared_artifacts() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("controller store");
+        let run_id = "bench-expired-tunnel".to_string();
+        let error = mirror_remote_observation_runs_by_id_with_downloader(
+            &store,
+            &ssh_runner(),
+            &terminal_runner_job(),
+            std::slice::from_ref(&run_id),
+            None,
+            |_| {
+                Ok(Some(json!({
+                    "id": run_id,
+                    "kind": "bench",
+                    "started_at": "2023-11-14T22:13:20Z",
+                    "finished_at": "2023-11-14T22:13:21Z",
+                    "status": "pass",
+                    "artifacts": [{
+                        "id": "expired-tunnel",
+                        "kind": "visual_compare",
+                        "type": "url",
+                        "url": "https://expired.example/visual.png"
+                    }]
+                })))
+            },
+            |_| unreachable!("URL artifacts must not be downloaded as terminal evidence"),
+        )
+        .expect_err("URL-only artifact must fail terminal projection");
+
+        assert!(error.message.contains("durably project all artifacts"));
+        assert!(store.get_run(&run_id).expect("run lookup").is_none());
+    });
+}
+
+#[test]
 fn reverse_broker_lookup_projects_only_embedded_typed_run_details() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let job = terminal_runner_job();

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -15,7 +15,9 @@ use homeboy_core::api_jobs::{
     RunnerJobLifecycleMetadata, RunnerJobProjection,
 };
 use homeboy_core::error::{Error, ErrorCode};
-use homeboy_core::observation::{ArtifactRecord, NewRunRecord, ObservationStore, RunRecord};
+use homeboy_core::observation::{
+    runs_service, ArtifactRecord, NewRunRecord, ObservationStore, RunRecord,
+};
 use homeboy_core::server::{RunnerPolicy, RunnerSettings};
 
 use super::detail::{
@@ -1586,7 +1588,12 @@ fn terminal_mirroring_keeps_every_declared_visual_artifact_after_runner_cleanup(
         .expect("all declared visual artifacts are durably mirrored");
 
         workspace.close().expect("runner workspace cleanup");
-        let persisted = store.list_artifacts(&run_id).expect("persisted artifacts");
+        drop(store);
+
+        // A reviewer opens the controller store after the runner is gone and
+        // retrieves bytes by the stable run/artifact reference alone.
+        let reader = ObservationStore::open_initialized().expect("reviewer store");
+        let persisted = reader.list_artifacts(&run_id).expect("persisted artifacts");
         assert_eq!(persisted.len(), 21);
         for artifact in persisted {
             assert_eq!(artifact.artifact_type, "file");
@@ -1595,6 +1602,20 @@ fn terminal_mirroring_keeps_every_declared_visual_artifact_after_runner_cleanup(
                 .expect("controller artifact")
                 .is_empty());
         }
+        let artifact = runs_service::resolve_artifact_for_run(&reader, &run_id, "visual-00")
+            .expect("reviewer resolves durable artifact");
+        let reviewer_copy = tempfile::NamedTempFile::new().expect("reviewer output");
+        let outcome = runs_service::copy_local_file_artifact(
+            artifact,
+            Some(reviewer_copy.path().to_path_buf()),
+        )
+        .expect("reviewer retrieves durable artifact");
+        assert_eq!(outcome.run_id, run_id);
+        assert_eq!(outcome.artifact_id, "visual-00");
+        assert_eq!(
+            fs::read(reviewer_copy.path()).expect("reviewer bytes"),
+            b"png-0"
+        );
     });
 }
 

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -15,8 +15,17 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
         let _xdg = XdgGuard::unset();
         let run_dir = RunDir::create().expect("run dir");
         fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+        fs::write(run_dir.path().join("promoted.json"), b"{}").expect("promoted artifact");
 
         let mut results = bench_results("homeboy", "cold", 42.0);
+        results.scenarios[0].artifacts.insert(
+            "promoted".to_string(),
+            BenchArtifact {
+                path: Some("promoted.json".to_string()),
+                required_durable: true,
+                ..BenchArtifact::default()
+            },
+        );
         results.scenarios[0].artifacts.insert(
             "missing".to_string(),
             BenchArtifact {
@@ -25,7 +34,8 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
                 artifact_type: None,
                 kind: Some("json".to_string()),
                 label: Some("Missing".to_string()),
-                observation_artifact_id: None,
+                observation_artifact_id: Some("stale-artifact-id".to_string()),
+                required_durable: true,
                 ..BenchArtifact::default()
             },
         );
@@ -37,7 +47,8 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
                 artifact_type: None,
                 kind: Some("json".to_string()),
                 label: Some("Escape".to_string()),
-                observation_artifact_id: None,
+                observation_artifact_id: Some("stale-url-id".to_string()),
+                required_durable: true,
                 ..BenchArtifact::default()
             },
         );
@@ -77,6 +88,14 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
             .collect();
         assert!(classes.contains(&"bench_artifact_path_missing"));
         assert!(classes.contains(&"bench_artifact_path_blocked"));
+        assert_eq!(workflow.status, "failed");
+        assert_eq!(workflow.exit_code, 1);
+        assert!(workflow.failure.is_some());
+        assert!(
+            workflow.results.as_ref().unwrap().scenarios[0].artifacts["promoted"]
+                .observation_artifact_id
+                .is_some()
+        );
         assert!(
             workflow.results.as_ref().unwrap().scenarios[0].artifacts["missing"]
                 .observation_artifact_id
@@ -87,6 +106,134 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
                 .observation_artifact_id
                 .is_none()
         );
+    });
+}
+
+#[test]
+fn bench_observation_rejects_url_only_artifacts_as_terminal_evidence() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let run_dir = RunDir::create().expect("run dir");
+        fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+        let mut results = bench_results("homeboy", "cold", 42.0);
+        results.scenarios[0].artifacts.insert(
+            "visual".to_string(),
+            BenchArtifact {
+                path: None,
+                url: Some("https://tunnel.example/visual.png".to_string()),
+                artifact_type: Some("image/png".to_string()),
+                kind: Some("visual".to_string()),
+                label: Some("Visual comparison".to_string()),
+                observation_artifact_id: None,
+                required_durable: true,
+                ..BenchArtifact::default()
+            },
+        );
+        let mut workflow = BenchRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "homeboy".to_string(),
+            exit_code: 0,
+            iterations: 1,
+            results: Some(results),
+            gate_results: Vec::new(),
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        };
+        let args = bench_args();
+        let observation = start(BenchObservationStart {
+            component_id: "homeboy",
+            component_label: "homeboy",
+            source_path: home.path(),
+            args: &args,
+            selected_scenarios: &["cold".to_string()],
+            rig_id: None,
+            rig_snapshot: None,
+            run_dir: &run_dir,
+        })
+        .expect("start observation");
+
+        finish_success(Some(observation), &mut workflow, &run_dir).expect("observation summary");
+
+        assert_eq!(workflow.status, "failed");
+        assert!(workflow
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.class == "bench_artifact_durable_source_missing" }));
+        assert!(
+            workflow.results.as_ref().unwrap().scenarios[0].artifacts["visual"]
+                .observation_artifact_id
+                .is_none()
+        );
+    });
+}
+
+#[test]
+fn bench_observation_promotes_required_directory_with_tree_identity() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let run_dir = RunDir::create().expect("run dir");
+        fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+        let directory = run_dir.path().join("artifacts/visual");
+        fs::create_dir_all(directory.join("nested")).expect("artifact directory");
+        fs::write(directory.join("baseline.png"), b"baseline").expect("baseline");
+        fs::write(directory.join("nested/diff.png"), b"diff").expect("diff");
+        let expected_tree =
+            homeboy::core::observation::directory_tree_sha256(&directory).expect("tree hash");
+        let mut results = bench_results("homeboy", "cold", 42.0);
+        results.scenarios[0].artifacts.insert(
+            "visuals".to_string(),
+            BenchArtifact {
+                path: Some("artifacts/visual".to_string()),
+                required_durable: true,
+                ..BenchArtifact::default()
+            },
+        );
+        let mut workflow = BenchRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "homeboy".to_string(),
+            exit_code: 0,
+            iterations: 1,
+            results: Some(results),
+            gate_results: Vec::new(),
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        };
+        let args = bench_args();
+        let observation = start(BenchObservationStart {
+            component_id: "homeboy",
+            component_label: "homeboy",
+            source_path: home.path(),
+            args: &args,
+            selected_scenarios: &["cold".to_string()],
+            rig_id: None,
+            rig_snapshot: None,
+            run_dir: &run_dir,
+        })
+        .expect("observation");
+        let run_id = observation.run_id().to_string();
+        finish_success(Some(observation), &mut workflow, &run_dir).expect("summary");
+
+        assert_eq!(workflow.status, "passed");
+        let store =
+            homeboy::core::observation::ObservationStore::open_initialized().expect("store");
+        let artifact_id = workflow.results.as_ref().unwrap().scenarios[0].artifacts["visuals"]
+            .observation_artifact_id
+            .clone()
+            .expect("artifact id");
+        let artifact = store
+            .get_artifact(&artifact_id)
+            .expect("artifact lookup")
+            .expect("artifact");
+        assert_eq!(artifact.run_id, run_id);
+        assert_eq!(artifact.artifact_type, "directory");
+        assert_eq!(artifact.sha256.as_deref(), Some(expected_tree.as_str()));
+        assert!(std::path::Path::new(&artifact.path).is_dir());
     });
 }
 

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -22,6 +22,7 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
             "promoted".to_string(),
             BenchArtifact {
                 path: Some("promoted.json".to_string()),
+                url: Some("https://expired-runner.example/promoted.json".to_string()),
                 required_durable: true,
                 ..BenchArtifact::default()
             },
@@ -91,6 +92,10 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
         assert_eq!(workflow.status, "failed");
         assert_eq!(workflow.exit_code, 1);
         assert!(workflow.failure.is_some());
+        assert_eq!(
+            workflow.results.as_ref().unwrap().scenarios[0].artifacts["promoted"].url,
+            None
+        );
         assert!(
             workflow.results.as_ref().unwrap().scenarios[0].artifacts["promoted"]
                 .observation_artifact_id

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -169,6 +169,7 @@ mod fixtures {
             kind: Some("preview".to_string()),
             label: Some("Public preview".to_string()),
             observation_artifact_id: Some("obs-preview".to_string()),
+            required_durable: false,
             role: role.map(str::to_string),
             preview_url: Some(preview_url.to_string()),
             public_url: Some(preview_url.to_string()),


### PR DESCRIPTION
## Summary

Promotes required reviewer artifacts into the controller-owned observation store before terminal success, with file and directory integrity verification. Terminal output is withheld when declared evidence cannot be promoted, and promoted bench artifacts no longer expose expired runner URLs.

Fixes #11000

## Reproduction

Run `2d788144-6209-4b5c-b39e-d6798e2b49fe` reported source/candidate/diff screenshot paths under a generation-time Homeboy runtime directory. Those paths expired after terminal completion; the bytes were recoverable only by manually spelunking the persisted artifact store. This change makes the durable run/artifact references the reviewer-facing result.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-extension-contract bench_artifact`
- `cargo test -p homeboy-core atomic_publication`
- `cargo test -p homeboy-cli bench_observation`
- `cargo test -p homeboy-lab-runner terminal_mirroring`

The full workspace test gate was not run; the focused changed scopes above cover contract compatibility, atomic store publication, terminal evidence failure, runner cleanup, separate-reader retrieval, and lab mirroring.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode drafted and verified substantive portions of this change. Chris Huber remains responsible for every line.