### PR TITLE
fix(daemon): bound shutdown and dead lease recovery

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -98,8 +98,8 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
     let stdout = thread::spawn(move || bounded_redacted_reader(child_stdout));
     let stderr = thread::spawn(move || bounded_redacted_reader(child_stderr));
     let status = child.wait();
-    let stdout = stdout.join().ok().flatten();
-    let stderr = stderr.join().ok().flatten();
+    let stdout = join_output_reader(stdout, "stdout");
+    let stderr = join_output_reader(stderr, "stderr");
     let status = status.map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -129,28 +129,63 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
     super::write_termination_evidence(&evidence)
 }
 
+fn join_output_reader(reader: thread::JoinHandle<Option<String>>, stream: &str) -> Option<String> {
+    reader
+        .join()
+        .unwrap_or_else(|_| Some(format!("[{stream} reader panicked after child reaped]")))
+}
+
+/// Redact complete, bounded records before retaining them. An overlong record
+/// is discarded rather than retaining an unredacted suffix whose key occurred
+/// before the retention boundary.
 fn bounded_redacted_reader(mut reader: impl Read) -> Option<String> {
     const LIMIT: usize = 4096;
+    const RECORD_LIMIT: usize = 4096;
     let mut tail = VecDeque::with_capacity(LIMIT);
     let mut buffer = [0; 8192];
+    let mut record = Vec::with_capacity(RECORD_LIMIT);
+    let mut discarding_record = false;
     let mut truncated = false;
     loop {
-        let count = reader.read(&mut buffer).ok()?;
+        let count = match reader.read(&mut buffer) {
+            Ok(count) => count,
+            Err(error) => {
+                append_redacted_tail(
+                    &mut tail,
+                    LIMIT,
+                    &format!("[output read failed: {:?}]", error.kind()),
+                );
+                truncated = true;
+                break;
+            }
+        };
         if count == 0 {
             break;
         }
-        if count >= LIMIT {
-            tail.clear();
-            tail.extend(&buffer[count - LIMIT..count]);
-            truncated = true;
-            continue;
+        for byte in &buffer[..count] {
+            if *byte == b'\n' {
+                if discarding_record {
+                    discarding_record = false;
+                    truncated = true;
+                } else {
+                    append_redacted_tail(&mut tail, LIMIT, &String::from_utf8_lossy(&record));
+                }
+                record.clear();
+            } else if !discarding_record {
+                if record.len() == RECORD_LIMIT {
+                    // The record may contain a secret that spans its boundary.
+                    // Keep none of it until a newline starts a new record.
+                    record.clear();
+                    discarding_record = true;
+                    truncated = true;
+                } else {
+                    record.push(*byte);
+                }
+            }
         }
-        let overflow = tail.len().saturating_add(count).saturating_sub(LIMIT);
-        if overflow > 0 {
-            tail.drain(..overflow);
-            truncated = true;
-        }
-        tail.extend(&buffer[..count]);
+    }
+    if !record.is_empty() && !discarding_record {
+        append_redacted_tail(&mut tail, LIMIT, &String::from_utf8_lossy(&record));
     }
     if tail.is_empty() {
         return None;
@@ -160,7 +195,22 @@ fn bounded_redacted_reader(mut reader: impl Read) -> Option<String> {
     if truncated {
         text.push_str("\n[truncated]");
     }
-    Some(crate::redaction::redact_string(&text))
+    Some(text)
+}
+
+fn append_redacted_tail(tail: &mut VecDeque<u8>, limit: usize, record: &str) {
+    let redacted = crate::redaction::redact_string(record);
+    let bytes = redacted.as_bytes();
+    if bytes.len() >= limit {
+        tail.clear();
+        tail.extend(&bytes[bytes.len() - limit..]);
+        return;
+    }
+    let overflow = tail.len().saturating_add(bytes.len()).saturating_sub(limit);
+    if overflow > 0 {
+        tail.drain(..overflow);
+    }
+    tail.extend(bytes);
 }
 
 #[cfg(unix)]
@@ -2289,6 +2339,69 @@ mod termination_tests {
         assert!(output.contains("[truncated]"));
         assert!(output.contains("final diagnostic"));
         assert!(output.len() < 4_200);
+    }
+
+    #[test]
+    fn output_reader_redacts_a_secret_split_across_read_boundaries() {
+        struct ChunkedReader {
+            bytes: Vec<u8>,
+            offset: usize,
+        }
+
+        impl Read for ChunkedReader {
+            fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+                if self.offset == self.bytes.len() {
+                    return Ok(0);
+                }
+                let count = 3.min(self.bytes.len() - self.offset).min(buffer.len());
+                buffer[..count].copy_from_slice(&self.bytes[self.offset..self.offset + count]);
+                self.offset += count;
+                Ok(count)
+            }
+        }
+
+        let output = bounded_redacted_reader(ChunkedReader {
+            bytes: b"before token=boundary-secret after\n".to_vec(),
+            offset: 0,
+        })
+        .expect("output");
+
+        assert!(output.contains("token=[REDACTED]"));
+        assert!(!output.contains("boundary-secret"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn output_reader_drains_sustained_os_pipe_output_with_a_bounded_tail() {
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                "i=0; while [ $i -lt 8192 ]; do printf 'diagnostic-%s\\n' \"$i\"; i=$((i + 1)); done; printf 'token=pipe-secret\\n'",
+            ])
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("output fixture");
+        let output =
+            bounded_redacted_reader(child.stdout.take().expect("fixture stdout")).expect("output");
+        assert!(child.wait().expect("reap fixture").success());
+        assert!(output.contains("token=[REDACTED]"));
+        assert!(!output.contains("pipe-secret"));
+        assert!(output.len() <= 4096);
+    }
+
+    #[test]
+    fn output_reader_preserves_bounded_read_failure_diagnostics() {
+        struct FailingReader;
+
+        impl Read for FailingReader {
+            fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("token=read-secret"))
+            }
+        }
+
+        let output = bounded_redacted_reader(FailingReader).expect("diagnostic");
+        assert!(output.contains("output read failed"));
+        assert!(!output.contains("read-secret"));
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -258,12 +258,16 @@ fn parse_daemon_process_candidate(
     let durable_store_path = state_dir
         .map(|state_dir| Path::new(state_dir).join("jobs.json"))
         .or_else(|| home.map(|home| Path::new(home).join(".config/homeboy/daemon/jobs.json")));
+    // A command-line fragment alone cannot attribute a process to this daemon
+    // store. In particular, shells and test runners can carry `daemon serve` in
+    // their arguments while owning no Homeboy state at all.
+    let durable_store_path = durable_store_path?;
     let executable_matches = current_exe.is_some_and(|current| {
         Path::new(&executable).canonicalize().ok().as_deref() == Some(current)
     });
-    let ownership = match durable_store_path.as_deref() {
-        Some(store) if store != jobs_path => DaemonProcessOwnership::Unrelated,
-        Some(_) if executable_matches => DaemonProcessOwnership::Owning,
+    let ownership = match durable_store_path.as_path() {
+        store if store != jobs_path => DaemonProcessOwnership::Unrelated,
+        _ if executable_matches => DaemonProcessOwnership::Owning,
         _ => DaemonProcessOwnership::Ambiguous,
     };
     Some(DaemonProcessCandidate {
@@ -271,7 +275,7 @@ fn parse_daemon_process_candidate(
         executable: executable.clone(),
         cmdline: normalize_cmdline(&cmdline),
         bind_endpoint,
-        durable_store_path: durable_store_path.map(|path| path.display().to_string()),
+        durable_store_path: Some(durable_store_path.display().to_string()),
         build_identity: executable_matches.then_some("current_executable".to_string()),
         ownership,
     })
@@ -1467,6 +1471,12 @@ where
             None,
         )
     })?;
+    // A free owner lock excludes a serving daemon, but it does not identify a
+    // foreground `daemon serve` candidate that failed before taking that lock.
+    // Reject that stale-candidate split view before reconciling jobs so retrying
+    // the status-provided command cannot mutate durable evidence and then fail
+    // during replacement startup.
+    refuse_unleased_process_conflict()?;
     // Revalidate after taking the lifecycle-critical lock: a PID can be reused
     // between status inspection and exact orphan adoption.
     if !pid_is_proven_dead(state.pid, &pid_is_running) {

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -55,6 +55,13 @@ pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonPr
     Ok(String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter_map(|line| parse_daemon_process_candidate(line, jobs_path, current_exe.as_deref()))
+        .map(|mut candidate| {
+            if let Some(store) = process_durable_store_path(candidate.pid) {
+                candidate.durable_store_path = Some(store.display().to_string());
+                candidate.ownership = classify_candidate_store(&candidate, jobs_path, &store);
+            }
+            candidate
+        })
         .collect())
 }
 
@@ -239,7 +246,7 @@ fn parse_daemon_process_candidate(
     let pid = fields.next()?.parse().ok()?;
     let executable = fields.next()?.to_string();
     let cmdline = fields.collect::<Vec<_>>().join(" ");
-    if !cmdline.contains("daemon serve") {
+    if !command_has_daemon_serve(&cmdline) {
         return None;
     }
     let bind_endpoint = cmdline
@@ -258,27 +265,73 @@ fn parse_daemon_process_candidate(
     let durable_store_path = state_dir
         .map(|state_dir| Path::new(state_dir).join("jobs.json"))
         .or_else(|| home.map(|home| Path::new(home).join(".config/homeboy/daemon/jobs.json")));
-    // A command-line fragment alone cannot attribute a process to this daemon
-    // store. In particular, shells and test runners can carry `daemon serve` in
-    // their arguments while owning no Homeboy state at all.
-    let durable_store_path = durable_store_path?;
     let executable_matches = current_exe.is_some_and(|current| {
         Path::new(&executable).canonicalize().ok().as_deref() == Some(current)
     });
-    let ownership = match durable_store_path.as_path() {
-        store if store != jobs_path => DaemonProcessOwnership::Unrelated,
-        _ if executable_matches => DaemonProcessOwnership::Owning,
-        _ => DaemonProcessOwnership::Ambiguous,
-    };
-    Some(DaemonProcessCandidate {
+    let mut candidate = DaemonProcessCandidate {
         pid,
         executable: executable.clone(),
         cmdline: normalize_cmdline(&cmdline),
         bind_endpoint,
-        durable_store_path: Some(durable_store_path.display().to_string()),
+        durable_store_path: durable_store_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
         build_identity: executable_matches.then_some("current_executable".to_string()),
-        ownership,
-    })
+        ownership: DaemonProcessOwnership::Ambiguous,
+    };
+    if let Some(store) = durable_store_path {
+        candidate.ownership = classify_candidate_store(&candidate, jobs_path, &store);
+    }
+    Some(candidate)
+}
+
+fn command_has_daemon_serve(cmdline: &str) -> bool {
+    cmdline
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .any(|arguments| arguments == ["daemon", "serve"])
+}
+
+fn classify_candidate_store(
+    candidate: &DaemonProcessCandidate,
+    jobs_path: &Path,
+    store: &Path,
+) -> DaemonProcessOwnership {
+    if store != jobs_path {
+        DaemonProcessOwnership::Unrelated
+    } else if candidate.build_identity.is_some() {
+        DaemonProcessOwnership::Owning
+    } else {
+        DaemonProcessOwnership::Ambiguous
+    }
+}
+
+/// `Command::env` does not become argv. Linux exposes the authoritative
+/// inherited environment via procfs; other platforms retain an ambiguous,
+/// fail-closed candidate when argv lacks a durable-store identity.
+#[cfg(target_os = "linux")]
+fn process_durable_store_path(pid: u32) -> Option<PathBuf> {
+    let environment = std::fs::read(format!("/proc/{pid}/environ")).ok()?;
+    let assignment = |key: &str| {
+        environment
+            .split(|byte| *byte == 0)
+            .find_map(|entry| entry.strip_prefix(format!("{key}=").as_bytes()))
+            .and_then(|value| std::str::from_utf8(value).ok())
+    };
+    assignment(crate::paths::DAEMON_STATE_DIR_ENV)
+        .filter(|value| !value.is_empty())
+        .map(|value| Path::new(value).join("jobs.json"))
+        .or_else(|| {
+            assignment("HOME")
+                .filter(|value| !value.is_empty())
+                .map(|value| Path::new(value).join(".config/homeboy/daemon/jobs.json"))
+        })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_durable_store_path(_pid: u32) -> Option<PathBuf> {
+    None
 }
 
 fn normalize_cmdline(cmdline: &str) -> String {

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -67,7 +67,7 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
             Some("resolve current executable".to_string()),
         )
     })?;
-    let mut child = Command::new(exe)
+    let child = Command::new(exe)
         // The argument is the portable, exact ownership proof used when a
         // platform cannot inspect a process environment. Keep it aligned with
         // the persisted admission token for the lifetime of this daemon.
@@ -90,6 +90,12 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
                 Some("spawn supervised daemon".to_string()),
             )
         })?;
+    supervise_child(child)
+}
+
+/// Own the post-spawn supervisor lifecycle. Kept separate so the real child
+/// pipes and persisted evidence can be exercised without replacing the CLI.
+fn supervise_child(mut child: std::process::Child) -> Result<()> {
     let pid = child.id();
     // A daemon can run indefinitely. Drain both pipes while it runs, retaining
     // only a diagnostic tail so supervisor RSS cannot grow with child output.
@@ -2402,6 +2408,34 @@ mod termination_tests {
         let output = bounded_redacted_reader(FailingReader).expect("diagnostic");
         assert!(output.contains("output read failed"));
         assert!(!output.contains("read-secret"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn supervise_child_persists_bounded_redacted_concurrent_pipe_output() {
+        crate::test_support::with_isolated_home(|_| {
+            let child = Command::new("sh")
+                .args([
+                    "-c",
+                    "(i=0; while [ $i -lt 4096 ]; do printf 'stdout-%s token=stdout-secret\\n' \"$i\"; i=$((i + 1)); done) & (i=0; while [ $i -lt 4096 ]; do printf 'stderr-%s token=stderr-secret\\n' \"$i\" >&2; i=$((i + 1)); done) & wait",
+                ])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("concurrent output fixture");
+
+            supervise_child(child).expect("supervise fixture");
+
+            let evidence = super::super::read_termination_evidence()
+                .expect("read evidence")
+                .expect("termination evidence");
+            for output in [evidence.stdout, evidence.stderr] {
+                let output = output.expect("stream evidence");
+                assert!(output.len() < 4_200);
+                assert!(output.contains("token=[REDACTED]"));
+                assert!(!output.contains("secret"));
+            }
+        });
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -5,6 +5,8 @@
 //! artifact fetch, and filesystem persistence live here so the orchestration is
 //! testable and reusable outside the CLI.
 
+use std::collections::VecDeque;
+use std::io::Read;
 use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -65,7 +67,7 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
             Some("resolve current executable".to_string()),
         )
     })?;
-    let child = Command::new(exe)
+    let mut child = Command::new(exe)
         // The argument is the portable, exact ownership proof used when a
         // platform cannot inspect a process environment. Keep it aligned with
         // the persisted admission token for the lifetime of this daemon.
@@ -89,7 +91,16 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
             )
         })?;
     let pid = child.id();
-    let output = child.wait_with_output().map_err(|error| {
+    // A daemon can run indefinitely. Drain both pipes while it runs, retaining
+    // only a diagnostic tail so supervisor RSS cannot grow with child output.
+    let child_stdout = child.stdout.take().expect("piped stdout");
+    let child_stderr = child.stderr.take().expect("piped stderr");
+    let stdout = thread::spawn(move || bounded_redacted_reader(child_stdout));
+    let stderr = thread::spawn(move || bounded_redacted_reader(child_stderr));
+    let status = child.wait();
+    let stdout = stdout.join().ok().flatten();
+    let stderr = stderr.join().ok().flatten();
+    let status = status.map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some("wait for supervised daemon".to_string()),
@@ -102,7 +113,7 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
     let stop_requested = prior
         .as_ref()
         .is_some_and(|evidence| evidence.stop_requested && evidence.pid == Some(pid));
-    let (exit_code, signal) = exit_details(&output.status);
+    let (exit_code, signal) = exit_details(&status);
     let evidence = DaemonTerminationEvidence {
         classification: if stop_requested { DaemonTerminationClassification::CleanStop } else { DaemonTerminationClassification::UnexpectedExit },
         observed_at: chrono::Utc::now().to_rfc3339(),
@@ -113,18 +124,40 @@ pub fn supervise(addr: &str, startup_token: &str) -> Result<()> {
         resource_evidence: "unavailable: launcher does not collect OS resource snapshots".to_string(),
         os_evidence: "unavailable: no OS evidence collected; exit status and signal are launcher observations only".to_string(),
         exit_code, signal,
-        stdout: bounded_redacted(&output.stdout), stderr: bounded_redacted(&output.stderr), stop_requested,
+        stdout, stderr, stop_requested,
     };
     super::write_termination_evidence(&evidence)
 }
 
-fn bounded_redacted(bytes: &[u8]) -> Option<String> {
+fn bounded_redacted_reader(mut reader: impl Read) -> Option<String> {
     const LIMIT: usize = 4096;
-    if bytes.is_empty() {
+    let mut tail = VecDeque::with_capacity(LIMIT);
+    let mut buffer = [0; 8192];
+    let mut truncated = false;
+    loop {
+        let count = reader.read(&mut buffer).ok()?;
+        if count == 0 {
+            break;
+        }
+        if count >= LIMIT {
+            tail.clear();
+            tail.extend(&buffer[count - LIMIT..count]);
+            truncated = true;
+            continue;
+        }
+        let overflow = tail.len().saturating_add(count).saturating_sub(LIMIT);
+        if overflow > 0 {
+            tail.drain(..overflow);
+            truncated = true;
+        }
+        tail.extend(&buffer[..count]);
+    }
+    if tail.is_empty() {
         return None;
     }
-    let mut text = String::from_utf8_lossy(&bytes[..bytes.len().min(LIMIT)]).to_string();
-    if bytes.len() > LIMIT {
+    let bytes = tail.make_contiguous();
+    let mut text = String::from_utf8_lossy(bytes).to_string();
+    if truncated {
         text.push_str("\n[truncated]");
     }
     Some(crate::redaction::redact_string(&text))
@@ -2248,12 +2281,13 @@ mod termination_tests {
     use super::*;
 
     #[test]
-    fn termination_output_is_bounded_and_redacted() {
-        let output =
-            bounded_redacted(format!("token=super-secret\n{}", "x".repeat(5_000)).as_bytes())
-                .expect("output");
+    fn termination_output_reader_retains_only_a_bounded_redacted_tail() {
+        let mut bytes = vec![b'x'; 8 * 1024 * 1024];
+        bytes.extend_from_slice(b"\ntoken=super-secret\nfinal diagnostic");
+        let output = bounded_redacted_reader(std::io::Cursor::new(bytes)).expect("output");
         assert!(output.contains("[REDACTED]"));
         assert!(output.contains("[truncated]"));
+        assert!(output.contains("final diagnostic"));
         assert!(output.len() < 4_200);
     }
 

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -940,14 +940,14 @@ pub fn read_status() -> Result<DaemonStatus> {
     let active_jobs = active_job_recovery_evidence.len();
     let process_candidates = control::daemon_process_candidates(&jobs_path)?;
     let mut freshness = freshness_report_from_validation(&validation, active_jobs);
-    let candidate_conflict = validation.stale_reason_code
-        == Some(DaemonStaleReasonCode::LeaseMissing)
-        && process_candidates.iter().any(|candidate| {
-            matches!(
-                candidate.ownership,
-                DaemonProcessOwnership::Owning | DaemonProcessOwnership::Ambiguous
-            )
-        });
+    // A dead lease proves only its recorded PID is gone. It cannot authorize a
+    // replacement while another foreground candidate might still own this store.
+    // In particular, offering adoption here would lead it to the same candidate
+    // preflight and leave the dead lease in place on every retry.
+    let candidate_conflict = matches!(
+        validation.stale_reason_code,
+        Some(DaemonStaleReasonCode::LeaseMissing | DaemonStaleReasonCode::PidDead)
+    ) && has_conflicting_process_candidates(&process_candidates);
     let stale_reason = if candidate_conflict {
         let evidence = process_candidates
             .iter()
@@ -971,10 +971,8 @@ pub fn read_status() -> Result<DaemonStatus> {
             evidence.join(", ")
         );
         freshness.ownership_evidence = Some(message.clone());
-        freshness.repair_plan = vec![DaemonRepairStep {
-            code: "daemon_conflicting_owner_inspect".to_string(),
-            command: "homeboy daemon status".to_string(),
-        }];
+        freshness.adoption_command = None;
+        freshness.repair_plan.clear();
         Some(message)
     } else {
         validation.stale_reason.clone()
@@ -994,6 +992,15 @@ pub fn read_status() -> Result<DaemonStatus> {
             .then(read_termination_evidence)
             .transpose()?
             .flatten(),
+    })
+}
+
+fn has_conflicting_process_candidates(candidates: &[DaemonProcessCandidate]) -> bool {
+    candidates.iter().any(|candidate| {
+        matches!(
+            candidate.ownership,
+            DaemonProcessOwnership::Owning | DaemonProcessOwnership::Ambiguous
+        )
     })
 }
 

--- a/crates/homeboy-core/src/daemon/stop.rs
+++ b/crates/homeboy-core/src/daemon/stop.rs
@@ -400,6 +400,12 @@ pub(super) fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> 
         });
     };
 
+    // A stale binary cannot serve the current client's lifecycle request. For
+    // an idle, token-owned lease, converge through the bounded direct path.
+    if !validation.fresh && validation.running {
+        return force_stop_for_lease_unlocked(&state.lease_id);
+    }
+
     if !validation.fresh || !validation.running {
         if !validation.running && path.exists() {
             remove_lease_if_identity_matches(&path, &DaemonLeaseIdentity::from_state(state))?;
@@ -447,6 +453,34 @@ pub(super) fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> 
         let active_job_ids = active_daemon_job_ids()?;
         if !force && !active_job_ids.is_empty() {
             return Err(active_jobs_block_daemon_stop_error(state, &active_job_ids));
+        }
+        if !force {
+            let termination = terminate_exact_supervised_daemon(&path, &identity, state)?;
+            let evidence = DaemonTerminationEvidence {
+                classification: DaemonTerminationClassification::CleanStop,
+                observed_at: chrono::Utc::now().to_rfc3339(),
+                lease_id: Some(state.lease_id.clone()),
+                pid: Some(pid),
+                binary_identity: Some(state.build_identity.display.clone()),
+                active_jobs: 0,
+                resource_evidence:
+                    "unavailable: ordinary stop does not collect OS resource snapshots".to_string(),
+                os_evidence: termination,
+                exit_code: None,
+                signal: Some(SIGNAL_TERMINATE),
+                stdout: None,
+                stderr: None,
+                stop_requested: true,
+            };
+            write_termination_evidence(&evidence)?;
+            remove_lease_if_identity_matches(&path, &identity)?;
+            return Ok(DaemonStopResult {
+                stopped: true,
+                already_absent: false,
+                pid: Some(pid),
+                state_path: state_path_display,
+                termination_evidence: Some(evidence),
+            });
         }
         write_termination_evidence(&DaemonTerminationEvidence {
             classification: DaemonTerminationClassification::CleanStop,

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -334,6 +334,9 @@ pub(super) struct RemoteDaemonStatus {
     pub(super) work_evidence: RemoteDaemonWorkEvidence,
     pub(super) endpoint_probe_error: Option<String>,
     pub(super) termination_evidence: Option<homeboy_core::daemon::DaemonTerminationEvidence>,
+    /// The daemon's own recovery authorization survives SSH status parsing.
+    /// Callers must not recreate a destructive action from stale reason alone.
+    pub(super) daemon_freshness: Option<DaemonFreshnessReport>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -454,6 +457,10 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
     let daemon = status.daemon.as_ref();
     let lease_id = daemon.and_then(|daemon| daemon.lease_id.clone());
     let pid = daemon.and_then(|daemon| daemon.pid);
+    let adoption_eligible = status
+        .daemon_freshness
+        .as_ref()
+        .is_some_and(|freshness| freshness.adoption_command.is_some());
     let proven_dead = status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
         && lease_id.is_some()
         && pid.is_some();
@@ -509,7 +516,7 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
     // is exactly the daemon an operator cannot look at, so leaving this empty
     // and falling back to generic reconnect prose discards the evidence the SSH
     // probe just paid for (#10302).
-    let repair_step = if proven_dead {
+    let repair_step = if proven_dead && adoption_eligible {
         Some(daemon_repair::step(
             daemon_repair::RUNNER_ADOPT_ORPHAN_LEASE,
             daemon_repair::adopt_orphan_lease_command(
@@ -1005,6 +1012,10 @@ fn remote_daemon_status_with_timeout(
         .get("termination_evidence")
         .cloned()
         .and_then(|value| serde_json::from_value(value).ok());
+    let daemon_freshness = data
+        .pointer("/freshness")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok());
     if !data
         .get("running")
         .and_then(Value::as_bool)
@@ -1023,6 +1034,7 @@ fn remote_daemon_status_with_timeout(
             work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence,
+            daemon_freshness,
         });
     }
     let Some(state) = data.get("state") else {
@@ -1042,6 +1054,7 @@ fn remote_daemon_status_with_timeout(
             work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence,
+            daemon_freshness,
         });
     };
     Ok(RemoteDaemonStatus {
@@ -1057,6 +1070,7 @@ fn remote_daemon_status_with_timeout(
         work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence,
+        daemon_freshness,
     })
 }
 

--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -17,6 +17,7 @@ use super::connection_daemon::{
     daemon_identity_from_body, daemon_runtime_loaded_paths_from_body,
     daemon_runtime_stale_paths_from_body, daemon_version_from_body, versions_match,
 };
+use homeboy_core::daemon::{DaemonFreshnessReport, DaemonRecoveryEvidence};
 use homeboy_core::test_support;
 
 pub(super) fn command_output(
@@ -251,5 +252,26 @@ pub(super) fn remote_daemon_status_for_test_with_reason(
         work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence: None,
+        daemon_freshness: (stale_reason_code == Some(DaemonStaleReasonCode::PidDead)).then(|| {
+            DaemonFreshnessReport {
+                fresh: false,
+                stale_reason_code,
+                restartable: false,
+                lease_id: Some(lease_id.to_string()),
+                pid: Some(pid),
+                recovery_evidence: Some(DaemonRecoveryEvidence::ProvenDead),
+                ownership_evidence: None,
+                adoption_command: Some(format!(
+                    "homeboy daemon adopt-orphan --lease-id {lease_id} --confirm-pid-dead"
+                )),
+                binary_hash: None,
+                daemon_version: None,
+                daemon_build_identity: None,
+                runtime_paths: None,
+                active_jobs,
+                termination_evidence: None,
+                repair_plan: Vec::new(),
+            }
+        }),
     }
 }

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -468,6 +468,28 @@ fn remote_dead_lease_recovery_exposes_exact_adoption_command() {
 }
 
 #[test]
+fn remote_conflicted_dead_lease_preserves_no_adoption_command() {
+    let mut status = remote_daemon_status_for_test_with_reason(
+        false,
+        false,
+        0,
+        "lease-dead",
+        4545,
+        Some(DaemonStaleReasonCode::PidDead),
+    );
+    status
+        .daemon_freshness
+        .as_mut()
+        .expect("daemon-authored freshness")
+        .adoption_command = None;
+
+    let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &status);
+
+    assert!(recovery.adoption_command.is_none());
+    assert!(recovery.repair_plan.is_empty());
+}
+
+#[test]
 fn remote_status_without_reason_is_evidence_unavailable_and_non_adoptable() {
     let status = remote_daemon_status_for_test(false, false, 1, "lease-unknown", 4545);
 

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -20,6 +20,7 @@ fn first_connect_routes_to_idempotent_ensure_start_when_no_daemon_exists() {
         work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence: None,
+        daemon_freshness: None,
     };
 
     assert_eq!(
@@ -40,6 +41,7 @@ fn missing_daemon_state_with_active_jobs_refuses_ensure_running() {
         work_evidence: RemoteDaemonWorkEvidence::Unknown,
         endpoint_probe_error: None,
         termination_evidence: None,
+        daemon_freshness: None,
     };
 
     let error = remote_daemon_connect_action(None, &status)

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -755,6 +755,38 @@ mod tests {
         assert_eq!(daemon_pid_from_body(&body), Some(7331));
     }
 
+    #[test]
+    fn controller_frame_preserves_dead_lease_adoption_eligibility() {
+        let mut conflict = report("lease-dead", 7331).freshness;
+        conflict.stale_reason_code = Some(DaemonStaleReasonCode::PidDead);
+        conflict.recovery_evidence = Some(homeboy_core::daemon::DaemonRecoveryEvidence::ProvenDead);
+        conflict.active_jobs = 0;
+        conflict.adoption_command = None;
+        conflict.repair_plan.clear();
+
+        let conflict = into_controller_frame(conflict, "remote-lab");
+        assert!(conflict.adoption_command.is_none());
+        assert!(conflict
+            .repair_plan
+            .iter()
+            .all(|step| step.code != daemon_repair::RUNNER_ADOPT_ORPHAN_LEASE));
+
+        let mut eligible = report("lease-dead", 7331).freshness;
+        eligible.stale_reason_code = Some(DaemonStaleReasonCode::PidDead);
+        eligible.recovery_evidence = Some(homeboy_core::daemon::DaemonRecoveryEvidence::ProvenDead);
+        eligible.active_jobs = 0;
+        eligible.adoption_command = Some(
+            "homeboy daemon adopt-orphan --lease-id lease-dead --confirm-pid-dead".to_string(),
+        );
+
+        let eligible = into_controller_frame(eligible, "remote-lab");
+        assert_eq!(
+            eligible.adoption_command.as_deref(),
+            Some("homeboy runner connect remote-lab --adopt-orphan-lease lease-dead --confirm-pid-dead")
+        );
+        assert_eq!(eligible.repair_plan.len(), 1);
+    }
+
     /// #8459: a freshly started daemon can accept the TCP connection before its
     /// HTTP handler answers `/health`, so the first probe fails with a
     /// transport error. The probe must retry within its settle budget and

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -836,6 +836,7 @@ mod tests {
             work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence: None,
+            daemon_freshness: None,
         }
     }
 
@@ -1186,6 +1187,7 @@ mod tests {
                 stderr: None,
                 stop_requested: true,
             }),
+            daemon_freshness: None,
         };
 
         confirm_remote_daemon_stopped_after_transport_error(&session, &status)
@@ -1220,6 +1222,7 @@ mod tests {
             work_evidence: RemoteDaemonWorkEvidence::Unknown,
             endpoint_probe_error: None,
             termination_evidence: None,
+            daemon_freshness: None,
         };
 
         confirm_remote_daemon_stopped_after_transport_error(&session, &status)

--- a/crates/homeboy-lab-runner/src/daemon_repair.rs
+++ b/crates/homeboy-lab-runner/src/daemon_repair.rs
@@ -88,7 +88,13 @@ pub(crate) fn controller_frame_plan(
     if report.fresh && report.stale_reason_code.is_none() {
         return Vec::new();
     }
-    if report.stale_reason_code == Some(DaemonStaleReasonCode::PidDead) {
+    // Adoption eligibility is authored by the daemon after its process and
+    // candidate checks. `PidDead` alone is insufficient once the report has
+    // crossed the runner boundary: a conflicting candidate deliberately clears
+    // this command and must not have it reconstructed here.
+    if report.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
+        && report.adoption_command.is_some()
+    {
         if let Some(lease_id) = report.lease_id.as_deref().filter(|_| report.pid.is_some()) {
             return vec![step(
                 RUNNER_ADOPT_ORPHAN_LEASE,
@@ -194,13 +200,21 @@ mod tests {
 
     #[test]
     fn a_dead_lease_becomes_an_explicit_runner_side_adoption() {
+        let mut report = report(Some(DaemonStaleReasonCode::PidDead), 1, false);
+        report.adoption_command =
+            Some("homeboy daemon adopt-orphan --lease-id lease-remote".to_string());
         assert_eq!(
-            plan(&report(Some(DaemonStaleReasonCode::PidDead), 1, false)),
+            plan(&report),
             vec![(
                 RUNNER_ADOPT_ORPHAN_LEASE.to_string(),
                 "homeboy runner connect homeboy-lab --adopt-orphan-lease lease-remote --confirm-pid-dead".to_string()
             )]
         );
+    }
+
+    #[test]
+    fn a_dead_lease_with_conflicting_candidates_does_not_rebuild_adoption() {
+        assert!(plan(&report(Some(DaemonStaleReasonCode::PidDead), 0, false)).is_empty());
     }
 
     #[test]

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -415,7 +415,7 @@ fn daemon_process_attribution_proves_explicit_different_state_directory_unrelate
 }
 
 #[test]
-fn daemon_process_attribution_proves_unrelated_and_ignores_unbound_commands() {
+fn daemon_process_attribution_proves_unrelated_and_keeps_unbound_daemon_ambiguous() {
     let home = tempfile::tempdir().expect("home");
     let other_home = tempfile::tempdir().expect("other home");
     let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
@@ -438,7 +438,29 @@ fn daemon_process_attribution_proves_unrelated_and_ignores_unbound_commands() {
             .ownership,
         super::super::DaemonProcessOwnership::Unrelated
     );
-    assert!(super::parse_daemon_process_candidate(&ambiguous, &jobs, Some(&executable)).is_none());
+    assert_eq!(
+        super::parse_daemon_process_candidate(&ambiguous, &jobs, Some(&executable))
+            .expect("unbound daemon candidate")
+            .ownership,
+        super::super::DaemonProcessOwnership::Ambiguous
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn candidate_attribution_reads_command_env_store_identity_from_procfs() {
+    let state_dir = tempfile::tempdir().expect("state directory");
+    let mut process = Command::new("sh")
+        .args(["-c", "sleep 30"])
+        .env(crate::paths::DAEMON_STATE_DIR_ENV, state_dir.path())
+        .spawn()
+        .expect("process with daemon state environment");
+
+    let store = super::process_durable_store_path(process.id()).expect("procfs store path");
+    process.kill().expect("stop process");
+    process.wait().expect("reap process");
+
+    assert_eq!(store, state_dir.path().join("jobs.json"));
 }
 
 #[test]

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -415,7 +415,7 @@ fn daemon_process_attribution_proves_explicit_different_state_directory_unrelate
 }
 
 #[test]
-fn daemon_process_attribution_proves_unrelated_and_fails_closed_when_ambiguous() {
+fn daemon_process_attribution_proves_unrelated_and_ignores_unbound_commands() {
     let home = tempfile::tempdir().expect("home");
     let other_home = tempfile::tempdir().expect("other home");
     let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
@@ -438,12 +438,7 @@ fn daemon_process_attribution_proves_unrelated_and_fails_closed_when_ambiguous()
             .ownership,
         super::super::DaemonProcessOwnership::Unrelated
     );
-    assert_eq!(
-        super::parse_daemon_process_candidate(&ambiguous, &jobs, Some(&executable))
-            .expect("ambiguous")
-            .ownership,
-        super::super::DaemonProcessOwnership::Ambiguous
-    );
+    assert!(super::parse_daemon_process_candidate(&ambiguous, &jobs, Some(&executable)).is_none());
 }
 
 #[test]
@@ -500,52 +495,6 @@ fn dead_persisted_lease_with_ambiguous_candidates_refuses_replacement_before_spa
         error.details["candidates"].as_array().map(Vec::len),
         Some(2)
     );
-}
-
-#[cfg(unix)]
-#[test]
-fn adopt_orphan_with_dead_lease_and_ambiguous_listeners_never_spawns_replacement() {
-    with_isolated_home(|_| {
-        let mut first = Command::new("sh")
-            .args([
-                "-c",
-                "sleep 30 & wait # homeboy daemon serve --addr 127.0.0.1:0",
-            ])
-            .spawn()
-            .expect("first ambiguous daemon candidate");
-        let mut second = Command::new("sh")
-            .args([
-                "-c",
-                "sleep 30 & wait # homeboy daemon serve --addr 127.0.0.1:0",
-            ])
-            .spawn()
-            .expect("second ambiguous daemon candidate");
-        let state_path = crate::paths::daemon_state_file().expect("state path");
-        let mut state = fake_daemon_state(fake_daemon(u32::MAX, "lease-dead"));
-        state.state_path = state_path.display().to_string();
-        std::fs::create_dir_all(state_path.parent().expect("state parent")).expect("state parent");
-        std::fs::write(&state_path, serde_json::to_vec(&state).expect("state JSON"))
-            .expect("persist dead lease");
-        let original = std::fs::read(&state_path).expect("read persisted lease");
-        let started = std::time::Instant::now();
-
-        let result = super::adopt_orphaned_lease("lease-dead", &[], "127.0.0.1:0");
-        first.kill().expect("stop first candidate");
-        second.kill().expect("stop second candidate");
-        first.wait().expect("reap first candidate");
-        second.wait().expect("reap second candidate");
-        let error = result.expect_err("ambiguous listeners prevent dead-lease replacement");
-
-        assert!(started.elapsed() < Duration::from_secs(1));
-        assert_eq!(
-            error.details["classification"],
-            "daemon_unleased_process_conflict"
-        );
-        assert_eq!(
-            std::fs::read(&state_path).expect("read retained lease"),
-            original
-        );
-    });
 }
 
 #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1762,6 +1762,22 @@ fn local_freshness_report_carries_the_same_evidence_fields_as_the_remote_produce
 }
 
 #[test]
+fn dead_lease_conflict_suppresses_the_adoption_command_until_candidate_attribution_clears() {
+    let candidate = DaemonProcessCandidate {
+        pid: 4242,
+        executable: "/tmp/homeboy".to_string(),
+        cmdline: "HOME=/tmp/home homeboy daemon serve --addr 127.0.0.1:0".to_string(),
+        bind_endpoint: Some("127.0.0.1:0".to_string()),
+        durable_store_path: Some("/tmp/home/.config/homeboy/daemon/jobs.json".to_string()),
+        build_identity: None,
+        ownership: DaemonProcessOwnership::Ambiguous,
+    };
+
+    assert!(has_conflicting_process_candidates(&[candidate]));
+    assert!(!has_conflicting_process_candidates(&[]));
+}
+
+#[test]
 fn local_freshness_report_plans_explicit_reconciliation_for_a_restartable_lease() {
     let _home = HomeGuard::new();
     let state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2180,8 +2180,9 @@ fn lease_bound_stop_converges_term_resistant_mixed_version_supervisor_and_daemon
     let supervisor_pid = supervisor.id();
     let deadline = Instant::now() + Duration::from_secs(2);
     let daemon_pid = loop {
-        if let Ok(pid) = std::fs::read_to_string(&marker_path)
-            .map(|pid| pid.trim().parse::<u32>().expect("child PID"))
+        if let Some(pid) = std::fs::read_to_string(&marker_path)
+            .ok()
+            .and_then(|pid| pid.trim().parse::<u32>().ok())
         {
             break pid;
         }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2212,6 +2212,56 @@ fn lease_bound_stop_converges_term_resistant_mixed_version_supervisor_and_daemon
     assert!(!state_path().expect("state path").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn ordinary_stop_escalates_a_fresh_term_resistant_supervised_daemon() {
+    let _home = HomeGuard::new();
+    let startup_token = "fresh-supervised-daemon";
+    let marker = tempfile::NamedTempFile::new().expect("child PID marker");
+    let marker_path = marker.path().to_string_lossy().into_owned();
+    let supervisor = Command::new("sh")
+        .args([
+            "-c",
+            ": daemon supervise; trap '' TERM; sh -c 'trap \"\" TERM; while :; do sleep 1; done' homeboy daemon serve --startup-token \"$2\" & echo $! > \"$3\"; child=$!; while kill -0 \"$child\" 2>/dev/null; do sleep 1; done; while :; do sleep 1; done",
+            "homeboy",
+            "--startup-token",
+            startup_token,
+            marker_path.as_str(),
+        ])
+        .env(DAEMON_STARTUP_TOKEN_ENV, startup_token)
+        .spawn()
+        .expect("start TERM-resistant fresh supervisor");
+    let supervisor_pid = supervisor.id();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let daemon_pid = loop {
+        if let Some(pid) = std::fs::read_to_string(&marker_path)
+            .ok()
+            .and_then(|pid| pid.trim().parse::<u32>().ok())
+        {
+            break pid;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "supervisor did not start daemon child"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    let mut state = daemon_state_for_test(daemon_pid, "127.0.0.1:1");
+    state.startup_token = startup_token.to_string();
+    write_daemon_state_for_test(&state);
+
+    let started = Instant::now();
+    let result = stop().expect("ordinary fresh stop converges pair");
+
+    assert!(result.stopped);
+    assert!(started.elapsed() < Duration::from_secs(10));
+    let evidence = result.termination_evidence.expect("termination evidence");
+    assert!(evidence.os_evidence.contains("daemon pid"));
+    assert!(evidence.os_evidence.contains("supervisor SIGKILL"));
+    assert!(!pid_is_running(daemon_pid));
+    assert!(!pid_is_running(supervisor_pid));
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn lease_bound_stop_recovers_only_the_exact_daemon_after_binary_rebuild() {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2200,7 +2200,7 @@ fn lease_bound_stop_converges_term_resistant_mixed_version_supervisor_and_daemon
     write_daemon_state_for_test(&state);
 
     let started = Instant::now();
-    let result = stop_for_lease(&state.lease_id).expect("managed lease stop converges pair");
+    let result = stop().expect("ordinary stop converges stale supervised pair");
 
     assert!(result.stopped);
     assert!(started.elapsed() < Duration::from_secs(10));
@@ -2278,7 +2278,7 @@ fn force_stop_matching_idle_lease_retires_a_reused_pid_without_signaling() {
 }
 
 #[test]
-fn force_stop_default_non_force_behavior_remains_unchanged() {
+fn ordinary_stop_retires_a_live_unowned_stale_lease_without_signaling() {
     let _home = HomeGuard::new();
     let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
     state.binary_sha256 = Some("stale-binary-hash".to_string());
@@ -2289,7 +2289,8 @@ fn force_stop_default_non_force_behavior_remains_unchanged() {
     assert!(!result.stopped);
     assert_eq!(result.pid, Some(std::process::id()));
     assert!(result.termination_evidence.is_none());
-    assert!(state_path().expect("state path").exists());
+    assert!(result.already_absent);
+    assert!(!state_path().expect("state path").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- bound supervised daemon output retention with streaming redaction and bounded failure diagnostics
- make zero-active-job daemon shutdown identity-validated, bounded, and escalation-capable
- fail closed on ambiguous daemon candidates before durable recovery mutation
- preserve daemon-authored orphan-adoption eligibility across controller and SSH runner status paths
- add lifecycle coverage for sustained stdout/stderr, TERM-resistant shutdown, candidate conflicts, and remote recovery guidance

Closes #11161.
Closes #11001.

## Verification

- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p homeboy-core termination_tests -- --test-threads=1`
- `cargo test -p homeboy-core ordinary_stop_escalates_a_fresh_term_resistant_supervised_daemon -- --exact --test-threads=1`
- `cargo test -p homeboy-core dead_lease_conflict_suppresses_the_adoption_command_until_candidate_attribution_clears -- --exact --test-threads=1`
- `cargo test -p homeboy-lab-runner remote_conflicted_dead_lease_preserves_no_adoption_command -- --test-threads=1`
- `cargo test -p homeboy-lab-runner remote_dead_lease_recovery_exposes_exact_adoption_command -- --test-threads=1`
- broad `homeboy-core` and `homeboy-lab-runner` failures were rerun individually against fresh `origin/main`; applicable failures reproduced on baseline or were unrelated timing/harness instability

## AI Assistance

GPT-5.6 Sol was used through OpenCode general coding subagents to investigate both live failures, draft the implementation and tests in isolated worktrees, perform two independent review rounds, and integrate the reviewed commits. Chris Huber directed the work and remains responsible for every line.