### PR TITLE
fix(test): share immutable controller runtime pins

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -3455,7 +3455,11 @@ mod tests {
 
             let temporary = tempfile::tempdir().expect("temporary executable directory");
             let source = temporary.path().join("homeboy");
-            fs::write(&source, b"controller bytes").expect("write controller");
+            fs::write(
+                &source,
+                "#!/bin/sh\nif [ \"$1\" = self ] && [ \"$2\" = identity ]; then\n  printf '%s\\n' '{\"data\":{\"display\":\"homeboy 0.0.0+fixture\"}}'\n  exit 0\nfi\nexit 1\n",
+            )
+            .expect("write controller");
             fs::set_permissions(&source, fs::Permissions::from_mode(0o755))
                 .expect("make controller executable");
 
@@ -3960,27 +3964,16 @@ mod tests {
 
             let (a_enqueued, a_enqueued_result) = std::sync::mpsc::channel();
             let (a_release, a_release_result) = std::sync::mpsc::channel();
-            let seal_a =
-                std::thread::spawn(move || match pin_current_queued("seal-a", || Ok(false)) {
-                    Ok(_runtime) => {
-                        let _ = a_enqueued.send(Ok(()));
-                        let _ = a_release_result.recv();
-                    }
-                    Err(error) => {
-                        let _ = a_enqueued.send(Err(error.message));
-                    }
-                });
-
-            let (b_enqueued, b_enqueued_result) = std::sync::mpsc::channel();
-            let b_handle =
-                std::thread::spawn(move || match pin_current_queued("seal-b", || Ok(false)) {
-                    Ok(_runtime) => {
-                        let _ = b_enqueued.send(Ok(()));
-                    }
-                    Err(error) => {
-                        let _ = b_enqueued.send(Err(error.message));
-                    }
-                });
+            let seal_a = std::thread::spawn(move || match admit_current_for("seal-a") {
+                Ok(admission) => {
+                    let _ = a_enqueued.send(Ok(()));
+                    let _ = a_release_result.recv();
+                    drop(admission);
+                }
+                Err(error) => {
+                    let _ = a_enqueued.send(Err(error.message));
+                }
+            });
 
             let waiting_a = (0..40)
                 .map(|_| {
@@ -3995,6 +3988,21 @@ mod tests {
                 .find_map(|status| status)
                 .expect("seal-a queues behind existing owner");
             assert_eq!(waiting_a["position"], 2);
+
+            // Enqueue B only after A is durably visible, so this asserts FIFO
+            // order rather than scheduler order between two spawned threads.
+            let (b_enqueued, b_enqueued_result) = std::sync::mpsc::channel();
+            let (b_release, b_release_result) = std::sync::mpsc::channel();
+            let b_handle = std::thread::spawn(move || match admit_current_for("seal-b") {
+                Ok(admission) => {
+                    let _ = b_enqueued.send(Ok(()));
+                    let _ = b_release_result.recv();
+                    drop(admission);
+                }
+                Err(error) => {
+                    let _ = b_enqueued.send(Err(error.message));
+                }
+            });
 
             let waiting_b = (0..40)
                 .map(|_| {
@@ -4035,6 +4043,7 @@ mod tests {
                 admission_status("seal-b").expect("seal-b admitted")["state"],
                 "admitted"
             );
+            b_release.send(()).expect("release seal-b");
             b_handle.join().expect("seal-b thread exits");
         });
     }

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -20,6 +20,8 @@ pub const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
 pub(crate) const TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV: &str =
     "HOMEBOY_TEST_CONTROLLER_RUNTIME_EXECUTABLE";
 #[cfg(any(test, feature = "test-support"))]
+pub(crate) const TEST_CONTROLLER_RUNTIME_STORE_ENV: &str = "HOMEBOY_TEST_CONTROLLER_RUNTIME_STORE";
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) const TEST_CONTROLLER_RUNTIME_IDENTITY_ENV: &str =
     "HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY";
 
@@ -2303,7 +2305,7 @@ fn is_executable(metadata: &fs::Metadata) -> bool {
 }
 
 fn pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?
+    Ok(controller_runtime_store_root()?
         .join("controller-runtimes")
         .join(format!(
             "{}-{}",
@@ -2314,7 +2316,7 @@ fn pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
 }
 
 fn recovered_pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?
+    Ok(controller_runtime_store_root()?
         .join("controller-runtimes")
         .join(format!(
             "{}-{}",
@@ -2323,6 +2325,15 @@ fn recovered_pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
         ))
         .join(format!("recovery-{}", uuid::Uuid::new_v4()))
         .join("homeboy"))
+}
+
+fn controller_runtime_store_root() -> Result<PathBuf> {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Some(path) = std::env::var_os(TEST_CONTROLLER_RUNTIME_STORE_ENV) {
+        return Ok(PathBuf::from(path));
+    }
+
+    paths::homeboy_data()
 }
 
 fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Result<()> {

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -12,6 +12,8 @@ use crate::api_jobs::{Job, JobEventKind, JobStore, RemoteRunnerJobRequest, Remot
 static SHARED_EMPTY_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_COMMITTED_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_CONTROLLER_RUNTIME_FIXTURE: OnceLock<TempDir> = OnceLock::new();
+static SHARED_HOMEBOY_CONTROLLER_RUNTIME_FIXTURE: OnceLock<TempDir> = OnceLock::new();
+static SHARED_CONTROLLER_RUNTIME_STORE: OnceLock<TempDir> = OnceLock::new();
 static EXEC_CAPABLE_TEMP_BASE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 static SHORT_EXEC_CAPABLE_TEMP_BASE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 /// Runs the leaked-tempdir sweep exactly once per test process.
@@ -138,11 +140,17 @@ impl HermeticTestContext {
             )
             .env(
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
-                test_controller_fixture(),
+                test_controller_fixture(binary),
             )
             .env(
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
                 crate::build_identity::current().display,
+            )
+            // Runtime pins are immutable content-addressed files, so tests can
+            // share them without sharing mutable Homeboy state.
+            .env(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_STORE_ENV,
+                test_controller_runtime_store(),
             );
         command
     }
@@ -271,7 +279,7 @@ impl HomeGuard {
         );
         std::env::set_var(
             crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
-            test_controller_fixture(),
+            test_controller_fixture(TestBinary::CurrentTest),
         );
         std::env::set_var(
             crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
@@ -597,13 +605,25 @@ impl Drop for HomeGuard {
     }
 }
 
-fn test_controller_fixture() -> PathBuf {
-    SHARED_CONTROLLER_RUNTIME_FIXTURE
+fn test_controller_fixture(binary: TestBinary) -> PathBuf {
+    let fixture = match binary {
+        TestBinary::CurrentTest => &SHARED_CONTROLLER_RUNTIME_FIXTURE,
+        TestBinary::HomeboyFixture => &SHARED_HOMEBOY_CONTROLLER_RUNTIME_FIXTURE,
+    };
+    fixture
         .get_or_init(|| {
             let directory = exec_capable_tempdir();
             let path = directory.path().join("homeboy-controller-fixture");
             fs::copy(
-                std::env::current_exe().expect("current test executable"),
+                match binary {
+                    TestBinary::CurrentTest => {
+                        std::env::current_exe().expect("current test executable")
+                    }
+                    TestBinary::HomeboyFixture => PathBuf::from(
+                        std::env::var_os("CARGO_BIN_EXE_homeboy")
+                            .expect("CARGO_BIN_EXE_homeboy fixture binary"),
+                    ),
+                },
                 &path,
             )
             .expect("copy controller fixture");
@@ -612,6 +632,12 @@ fn test_controller_fixture() -> PathBuf {
         })
         .path()
         .join("homeboy-controller-fixture")
+}
+
+fn test_controller_runtime_store() -> &'static Path {
+    SHARED_CONTROLLER_RUNTIME_STORE
+        .get_or_init(exec_capable_tempdir)
+        .path()
 }
 
 fn make_test_controller_fixture_read_only(path: &Path) {

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -58,7 +58,7 @@ fn contradictory_cook_arguments_survive_controller_transport_context() {
     let cook = |args: &[&str]| {
         let context = HermeticTestContext::new();
         context
-            .command(TestBinary::HomeboyFixture)
+            .controller_runtime_command(TestBinary::HomeboyFixture)
             .env(
                 homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV,
                 r#"{"runner_id":"homeboy-lab"}"#,


### PR DESCRIPTION
## Summary

Reuses a sealed, content-addressed controller-runtime pin for hermetic subprocess tests that intentionally exercise controller routing. The selected fixture binary remains executable and each test retains isolated HOME, config, data, artifacts, and invocation runtime state.

Fixes #10687
Refs #11000

## Root Cause

The post-merge workflow for #11000 at `6e219dd602f995daafbfb223eca369060e33828e` timed out in `contradictory_cook_arguments_survive_controller_transport_context`. Its two hermetic CLI invocations each cold-copied the 666 MB debug controller binary into separate runtime-pin stores before validation completed.

## Compatibility

The shared test store contains only immutable content-addressed controller pins. Production storage remains unchanged, and ordinary isolated-home tests retain separate pins.

## Verification

- `cargo fmt --check`
- `cargo test --test cook_lab_handoff_test -- --exact contradictory_cook_arguments_survive_controller_transport_context`
- `cargo test --test cook_lab_handoff_test`
- `cargo test -p homeboy-core controller_runtime::tests::pin_current_uses_the_explicit_test_controller_fixture`
- `cargo test -p homeboy-core test_support::tests::isolated_homes_share_the_read_only_controller_fixture_and_not_pins`
- `cargo check --workspace`
- `cargo clippy -p homeboy-core --all-targets`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the CI artifact, implemented and verified substantive portions of this change. Chris Huber remains responsible for every line.