### PR TITLE
fix(extension): consolidate multi-extension ownership onto resolve_owner, add --capability-extension

### DIFF
--- a/crates/homeboy-cli/src/commands/component.rs
+++ b/crates/homeboy-cli/src/commands/component.rs
@@ -96,6 +96,18 @@ enum ComponentCommand {
         /// Extension(s) this component uses (e.g., a runtime/framework extension id). Repeatable.
         #[arg(long = "extension", value_name = "EXTENSION")]
         extensions: Vec<String>,
+
+        /// Owning extension for a contested capability, as
+        /// "<capability>=<extension>". Repeatable.
+        ///
+        /// Resolves the ambiguity reported when several linked extensions
+        /// provide the same thing. Accepts the capability labels (build, lint,
+        /// test, bench, fuzz, trace, deps) and the non-capability ownership
+        /// surfaces (remote_path, since_tag, provides.file_extensions).
+        ///
+        /// Example: --capability-extension build=wordpress
+        #[arg(long = "capability-extension", value_name = "CAPABILITY=EXTENSION")]
+        capability_extensions: Vec<String>,
     },
     /// Delete a component configuration
     Delete {
@@ -314,6 +326,7 @@ pub fn run(args: ComponentArgs) -> CmdResult<ComponentOutput> {
             changelog_target,
             version_targets,
             extensions,
+            capability_extensions,
         } => set(
             args,
             ComponentSetFlags {
@@ -325,6 +338,7 @@ pub fn run(args: ComponentArgs) -> CmdResult<ComponentOutput> {
             },
             version_targets,
             extensions,
+            capability_extensions,
         ),
         ComponentCommand::Delete { id } => delete(&id),
         ComponentCommand::Rename { id, new_id } => rename(&id, &new_id),
@@ -588,13 +602,19 @@ fn set(
     flags: ComponentSetFlags,
     version_targets: Vec<String>,
     extensions: Vec<String>,
+    capability_extensions: Vec<String>,
 ) -> CmdResult<ComponentOutput> {
     // Check if there's any input at all
     let has_dynamic = args.json_spec()?.is_some();
-    if !has_dynamic && !flags.has_any() && version_targets.is_empty() && extensions.is_empty() {
+    if !has_dynamic
+        && !flags.has_any()
+        && version_targets.is_empty()
+        && extensions.is_empty()
+        && capability_extensions.is_empty()
+    {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "spec",
-            "Provide a dedicated flag (e.g., --local-path), --json '<object>', --base64 <encoded-json>, --version-target, or --extension",
+            "Provide a dedicated flag (e.g., --local-path), --json '<object>', --base64 <encoded-json>, --version-target, --extension, or --capability-extension",
             None,
             Some(vec![
                 "Arbitrary field updates must use --json or --base64.".to_string(),
@@ -637,6 +657,26 @@ fn set(
                 "extensions".to_string(),
                 serde_json::Value::Object(extension_map),
             );
+        }
+    }
+
+    // Support --capability-extension. This is the runnable command the
+    // ownership-ambiguity error now points at (#11120), so it must land in the
+    // same `capability_extensions` map that `resolve_owner` reads.
+    if !capability_extensions.is_empty() {
+        let parsed = component::parse_capability_extensions(&capability_extensions)?;
+        if let serde_json::Value::Object(ref mut obj) = merged {
+            obj.insert(
+                "capability_extensions".to_string(),
+                serde_json::json!(parsed),
+            );
+        } else {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "spec",
+                "Merged spec must be a JSON object",
+                None,
+                None,
+            ));
         }
     }
 

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -57,7 +57,9 @@ pub use portable::{
     try_discover_from_portable, write_portable_config,
 };
 pub use relationships::{associated_projects, projects_using, rename_component, shared_components};
-pub use remote_path::{auto_resolve_remote_path, resolve_remote_path};
+pub use remote_path::{
+    auto_resolve_remote_path, resolve_remote_path, try_auto_resolve_remote_path,
+};
 pub use resolution::{
     local_path_is_relative, normalize_component_local_path, normalize_component_local_path_against,
     resolve, resolve_artifact, resolve_effective, resolve_target, resolve_target_from_component,

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -65,8 +65,8 @@ pub use resolution::{
 };
 pub use scope::{resolve_component_scope, EffectiveScope, ScopeCommand};
 pub use versioning::{
-    normalize_version_pattern, parse_version_targets, validate_version_pattern,
-    validate_version_target_conflict,
+    normalize_version_pattern, parse_capability_extensions, parse_version_targets,
+    validate_version_pattern, validate_version_target_conflict,
 };
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/component/remote_path.rs
+++ b/crates/homeboy-core/src/component/remote_path.rs
@@ -6,10 +6,13 @@
 //! `homeboy-component-contract` crate. They stay in core as free functions over
 //! `&Component` / `&mut Component`.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy_component_contract::model::render_remote_path_template;
 use homeboy_component_contract::Component;
+
+use crate::error::Result;
+use crate::extension_execution::{resolve_owner, REMOTE_PATH_SURFACE};
 
 /// Auto-resolve `remote_path` from linked extension deploy rules when not
 /// explicitly set.
@@ -24,39 +27,124 @@ use homeboy_component_contract::Component;
 ///
 /// Returns `Some(path)` if auto-resolved, `None` if not applicable or not
 /// detectable.
+///
+/// Infallible discovery form. Component discovery/probe paths (`resolve_target`,
+/// `prefer_cwd_for_component`, rig materialization) have no error channel and
+/// must degrade to "remote_path stays unset" rather than fail, so a genuine
+/// ownership conflict is swallowed here. Deploy takes the fallible
+/// [`try_auto_resolve_remote_path`] via
+/// [`crate::project::component_remote_path`], where an unresolved conflict is a
+/// hard error instead of an empty path.
 pub fn auto_resolve_remote_path(component: &Component) -> Option<String> {
+    try_auto_resolve_remote_path(component).ok().flatten()
+}
+
+/// Auto-resolve `remote_path`, surfacing genuine multi-extension ownership
+/// conflicts instead of silently returning `None`.
+///
+/// Rules were previously collected into a `HashSet<String>` of rendered paths
+/// and `if matches.len() == 1 { .. } else { None }` — so two extensions with
+/// conflicting `remote_path_inference` produced `None`, *indistinguishable from
+/// "no rule matched"*, and deploy then proceeded with an empty `remote_path`.
+/// That is the same silent-wrong-answer shape that
+/// [`crate::component::resolve_artifact`] documents as "a silent wrong-artifact
+/// deploy (#10281)", left unfixed here (#11119).
+///
+/// Now providers are collected per extension in a `BTreeMap` (deterministic,
+/// unlike `Component.extensions`' `HashMap`) and the distinct rendered paths
+/// decide:
+///
+/// - no rule matched → `Ok(None)`, as before
+/// - one distinct path → `Ok(Some(path))`, however many rules or extensions
+///   produced it (agreeing rules are not a conflict — WordPress's two
+///   plugin-detection rules both render `wp-content/plugins/{{dir_name}}`)
+/// - conflicting paths → [`resolve_owner`] on the `remote_path` surface:
+///   explicit `capability_extensions.remote_path`, then `composition.includes`
+///   primacy, then a hard error carrying a runnable fix command
+/// - conflicting paths *within the single owning extension* → hard error, since
+///   extension-level ownership cannot break a tie its own rules created
+pub fn try_auto_resolve_remote_path(component: &Component) -> Result<Option<String>> {
     // File components cannot auto-resolve — they must have explicit remote_path.
     if std::path::Path::new(&component.local_path).is_file() {
-        return None;
+        return Ok(None);
     }
 
     let local = std::path::Path::new(&component.local_path);
 
     // Use the directory basename as the remote directory name.
-    let dir_name = local.file_name()?.to_str()?;
+    let Some(dir_name) = local.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
 
-    let mut matches = HashSet::new();
-    for extension_id in component.extensions.as_ref()?.keys() {
+    let Some(extensions) = component.extensions.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut providers: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for extension_id in extensions.keys() {
         let Ok(extension) = crate::extension_store::load_extension(extension_id) else {
             continue;
         };
 
         for rule in extension.remote_path_inference_rules() {
             if remote_path_inference_rule_matches(component, rule, local, dir_name) {
-                matches.insert(render_remote_path_template(
-                    &rule.remote_path,
-                    &component.id,
-                    dir_name,
-                ));
+                providers.entry(extension_id.clone()).or_default().insert(
+                    render_remote_path_template(&rule.remote_path, &component.id, dir_name),
+                );
             }
         }
     }
 
-    if matches.len() == 1 {
-        matches.into_iter().next()
-    } else {
-        None
+    let distinct: BTreeSet<&str> = providers
+        .values()
+        .flatten()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+
+    match distinct.len() {
+        0 => Ok(None),
+        1 => Ok(distinct.into_iter().next().map(ToOwned::to_owned)),
+        _ => {
+            let candidates: Vec<String> = providers.keys().cloned().collect();
+            let owner = resolve_owner(component, REMOTE_PATH_SURFACE, &candidates)?;
+            let owned = providers.get(&owner).cloned().unwrap_or_default();
+
+            match owned.len() {
+                1 => Ok(owned.into_iter().next()),
+                // The winning extension's own rules disagree. Extension-level
+                // ownership cannot arbitrate that, so fail loudly rather than
+                // pick one and deploy somewhere arbitrary.
+                _ => Err(conflicting_rules_within_extension_error(
+                    component, &owner, &owned,
+                )),
+            }
+        }
     }
+}
+
+fn conflicting_rules_within_extension_error(
+    component: &Component,
+    owner: &str,
+    paths: &BTreeSet<String>,
+) -> crate::error::Error {
+    crate::error::Error::validation_invalid_argument(
+        "remotePath",
+        format!(
+            "Component '{}' matches conflicting remote_path_inference rules from extension '{}': {}",
+            component.id,
+            owner,
+            paths.iter().cloned().collect::<Vec<_>>().join(", ")
+        ),
+        None,
+        Some(vec![format!(
+            "Set an explicit remote_path: homeboy component set {} --remote-path <path>",
+            component.id
+        )]),
+    )
+    .with_hint(format!(
+        "Set an explicit remote_path: homeboy component set {} --remote-path <path>",
+        component.id
+    ))
 }
 
 fn remote_path_inference_rule_matches(

--- a/crates/homeboy-core/src/component/tests.rs
+++ b/crates/homeboy-core/src/component/tests.rs
@@ -495,12 +495,35 @@ fn auto_resolve_remote_path_returns_none_without_matching_extension_rule() {
     assert_eq!(crate::component::auto_resolve_remote_path(&component), None);
 }
 
-#[test]
-fn auto_resolve_remote_path_returns_none_on_conflicting_extension_rules() {
-    with_isolated_home(|home| {
-        let rule = |path: &str| {
-            format!(
-                r#"{{
+/// Like [`write_extension_fixture`] but also emits the top-level
+/// `composition.includes` block, so `composition.includes` primacy can be
+/// exercised. `write_extension_fixture`'s argument is nested under `deploy`.
+fn write_composing_extension_fixture(home: &Path, id: &str, includes: &[&str], deploy_json: &str) {
+    let dir = home.join(".config/homeboy/extensions").join(id);
+    std::fs::create_dir_all(&dir).expect("extension dir");
+    let includes_json = includes
+        .iter()
+        .map(|inc| format!("\"{}\"", inc))
+        .collect::<Vec<_>>()
+        .join(", ");
+    std::fs::write(
+        dir.join(format!("{}.json", id)),
+        format!(
+            r#"{{
+  "name": "{} extension",
+  "version": "1.0.0",
+  "composition": {{ "includes": [{}] }},
+  "deploy": {}
+}}"#,
+            id, includes_json, deploy_json
+        ),
+    )
+    .expect("extension manifest");
+}
+
+fn conflicting_remote_path_rule(path: &str) -> String {
+    format!(
+        r#"{{
 "remote_path_inference": [
   {{
     "when_file_contains": {{ "file": "marker.txt", "text": "Deployable" }},
@@ -508,25 +531,260 @@ fn auto_resolve_remote_path_returns_none_on_conflicting_extension_rules() {
   }}
 ]
   }}"#,
-                path
-            )
-        };
-        write_extension_fixture(home, "alpha", &rule("remote/alpha/{{dir_name}}"));
-        write_extension_fixture(home, "beta", &rule("remote/beta/{{dir_name}}"));
+        path
+    )
+}
+
+fn two_extension_conflict_component(home: &std::path::Path) -> Component {
+    let dir = home.join("my-component");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("marker.txt"), "Deployable component").unwrap();
+
+    Component {
+        id: "my-component".to_string(),
+        local_path: dir.to_string_lossy().to_string(),
+        extensions: Some(HashMap::from([
+            ("alpha".to_string(), ScopedExtensionConfig::default()),
+            ("beta".to_string(), ScopedExtensionConfig::default()),
+        ])),
+        ..Component::default()
+    }
+}
+
+/// #11119: conflicting `remote_path_inference` used to return `None`, which is
+/// indistinguishable from "no rule matched" — deploy then proceeded with an
+/// empty remote_path. It is a hard error now.
+#[test]
+fn try_auto_resolve_remote_path_errors_on_conflicting_extension_rules() {
+    with_isolated_home(|home| {
+        write_extension_fixture(
+            home,
+            "alpha",
+            &conflicting_remote_path_rule("remote/alpha/{{dir_name}}"),
+        );
+        write_extension_fixture(
+            home,
+            "beta",
+            &conflicting_remote_path_rule("remote/beta/{{dir_name}}"),
+        );
+
+        let component = two_extension_conflict_component(home);
+
+        let err = crate::component::try_auto_resolve_remote_path(&component)
+            .expect_err("conflicting remote_path rules must not resolve silently");
+        let message = err.to_string();
+
+        assert!(
+            message.contains("remote_path"),
+            "error must name the contested surface, got: {message}"
+        );
+        assert!(
+            message.contains("alpha") && message.contains("beta"),
+            "error must name both candidates, got: {message}"
+        );
+    });
+}
+
+/// #11120: the ambiguity error must hand back a command you can actually run.
+/// The old hint said only "Configure explicit <capability> extension ownership",
+/// naming neither `capability_extensions` nor any way to set it.
+#[test]
+fn ownership_ambiguity_error_names_a_runnable_command() {
+    with_isolated_home(|home| {
+        write_extension_fixture(
+            home,
+            "alpha",
+            &conflicting_remote_path_rule("remote/alpha/{{dir_name}}"),
+        );
+        write_extension_fixture(
+            home,
+            "beta",
+            &conflicting_remote_path_rule("remote/beta/{{dir_name}}"),
+        );
+
+        let component = two_extension_conflict_component(home);
+
+        let err = crate::component::try_auto_resolve_remote_path(&component)
+            .expect_err("conflicting rules must error");
+
+        let hint = err
+            .hints
+            .iter()
+            .map(|h| h.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            hint.contains(
+                "homeboy component set my-component --capability-extension remote_path=alpha"
+            ),
+            "hint must be a runnable disambiguation command, got: {hint}"
+        );
+
+        let tried: String = err.details["tried"]
+            .as_array()
+            .expect("tried hints")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            tried.contains("--capability-extension remote_path=alpha")
+                && tried.contains("--capability-extension remote_path=beta"),
+            "every candidate needs a runnable command, got: {tried}"
+        );
+    });
+}
+
+/// The conflict is resolvable through the same `capability_extensions` map the
+/// error now points at — including for a non-enum surface like `remote_path`,
+/// which has no `ExtensionCapability` variant.
+#[test]
+fn capability_extensions_resolves_remote_path_conflict() {
+    with_isolated_home(|home| {
+        write_extension_fixture(
+            home,
+            "alpha",
+            &conflicting_remote_path_rule("remote/alpha/{{dir_name}}"),
+        );
+        write_extension_fixture(
+            home,
+            "beta",
+            &conflicting_remote_path_rule("remote/beta/{{dir_name}}"),
+        );
+
+        let mut component = two_extension_conflict_component(home);
+        component
+            .capability_extensions
+            .insert("remote_path".to_string(), "beta".to_string());
+
+        assert_eq!(
+            crate::component::try_auto_resolve_remote_path(&component).expect("explicit owner"),
+            Some("remote/beta/my-component".to_string()),
+        );
+    });
+}
+
+/// `composition.includes` primacy applies to `remote_path` too, so the common
+/// WordPress-includes-nodejs shape resolves instead of erroring.
+#[test]
+fn composition_primacy_resolves_remote_path_conflict() {
+    with_isolated_home(|home| {
+        write_composing_extension_fixture(
+            home,
+            "alpha",
+            &["beta"],
+            &conflicting_remote_path_rule("remote/alpha/{{dir_name}}"),
+        );
+        write_extension_fixture(
+            home,
+            "beta",
+            &conflicting_remote_path_rule("remote/beta/{{dir_name}}"),
+        );
+
+        let component = two_extension_conflict_component(home);
+
+        assert_eq!(
+            crate::component::try_auto_resolve_remote_path(&component)
+                .expect("composition primacy resolves"),
+            Some("remote/alpha/my-component".to_string()),
+        );
+    });
+}
+
+/// Determinism guard for the `HashSet`/`HashMap` → `BTreeMap`/`BTreeSet`
+/// conversion. `Component.extensions` is a `HashMap` with `RandomState`, so
+/// iteration order differs per process *and* per instance. Resolution must not.
+#[test]
+fn remote_path_resolution_is_deterministic_across_repeated_resolution() {
+    with_isolated_home(|home| {
+        write_extension_fixture(
+            home,
+            "alpha",
+            &conflicting_remote_path_rule("remote/alpha/{{dir_name}}"),
+        );
+        write_extension_fixture(
+            home,
+            "beta",
+            &conflicting_remote_path_rule("remote/beta/{{dir_name}}"),
+        );
 
         let dir = home.join("my-component");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("marker.txt"), "Deployable component").unwrap();
 
-        let component = Component {
-            id: "my-component".to_string(),
-            local_path: dir.to_string_lossy().to_string(),
-            extensions: Some(HashMap::from([
-                ("alpha".to_string(), ScopedExtensionConfig::default()),
-                ("beta".to_string(), ScopedExtensionConfig::default()),
-            ])),
-            ..Component::default()
-        };
+        // Rebuild the component each iteration so the HashMap is freshly
+        // seeded, then assert the outcome never varies.
+        let mut observed = std::collections::BTreeSet::new();
+        for _ in 0..32 {
+            let mut component = Component {
+                id: "my-component".to_string(),
+                local_path: dir.to_string_lossy().to_string(),
+                extensions: Some(HashMap::from([
+                    ("alpha".to_string(), ScopedExtensionConfig::default()),
+                    ("beta".to_string(), ScopedExtensionConfig::default()),
+                ])),
+                ..Component::default()
+            };
+            component
+                .capability_extensions
+                .insert("remote_path".to_string(), "beta".to_string());
+
+            observed.insert(
+                crate::component::try_auto_resolve_remote_path(&component).expect("resolves"),
+            );
+        }
+
+        assert_eq!(
+            observed.len(),
+            1,
+            "resolution must not vary with HashMap iteration order, saw: {observed:?}"
+        );
+    });
+}
+
+/// Rules that agree are not a conflict, however many produce them. WordPress
+/// ships two plugin-detection rules that both render
+/// `wp-content/plugins/{{dir_name}}`.
+#[test]
+fn agreeing_remote_path_rules_are_not_ambiguous() {
+    with_isolated_home(|home| {
+        write_extension_fixture(
+            home,
+            "alpha",
+            &conflicting_remote_path_rule("remote/shared/{{dir_name}}"),
+        );
+        write_extension_fixture(
+            home,
+            "beta",
+            &conflicting_remote_path_rule("remote/shared/{{dir_name}}"),
+        );
+
+        let component = two_extension_conflict_component(home);
+
+        assert_eq!(
+            crate::component::try_auto_resolve_remote_path(&component).expect("agreeing rules"),
+            Some("remote/shared/my-component".to_string()),
+        );
+    });
+}
+
+/// Discovery callers have no error channel and must keep degrading to "unset"
+/// rather than fail — the infallible wrapper preserves the old return shape.
+#[test]
+fn auto_resolve_remote_path_still_degrades_to_none_on_conflict() {
+    with_isolated_home(|home| {
+        write_extension_fixture(
+            home,
+            "alpha",
+            &conflicting_remote_path_rule("remote/alpha/{{dir_name}}"),
+        );
+        write_extension_fixture(
+            home,
+            "beta",
+            &conflicting_remote_path_rule("remote/beta/{{dir_name}}"),
+        );
+
+        let component = two_extension_conflict_component(home);
 
         assert_eq!(crate::component::auto_resolve_remote_path(&component), None);
     });

--- a/crates/homeboy-core/src/component/versioning.rs
+++ b/crates/homeboy-core/src/component/versioning.rs
@@ -1,6 +1,81 @@
 use crate::component::VersionTarget;
 use crate::error::{Error, Result};
 use regex::Regex;
+use std::collections::BTreeMap;
+
+/// Parse repeatable `--capability-extension <surface>=<extension>` pairs into
+/// the `capability_extensions` map.
+///
+/// `capability_extensions` is the only way to resolve a contested ownership
+/// surface, but before #11120 it had no CLI flag at all — the sole route was
+/// `--json '{"capability_extensions":{...}}'`, which the ambiguity error did
+/// not mention either. Keyed by a `BTreeMap` so repeated flags serialize in a
+/// stable order.
+///
+/// The surface is any string key: the seven `ExtensionCapability` labels
+/// (`build`, `lint`, `test`, `bench`, `fuzz`, `trace`, `deps`) plus the
+/// non-enum surfaces (`remote_path`, `since_tag`, `provides.file_extensions`).
+/// Core deliberately does not validate the surface name here — the manifest
+/// declares far more contested surfaces than the enum knows about, and an
+/// unknown key is inert rather than harmful.
+pub fn parse_capability_extensions(pairs: &[String]) -> Result<BTreeMap<String, String>> {
+    let mut parsed = BTreeMap::new();
+
+    for pair in pairs {
+        let (surface, extension_id) = pair.split_once('=').ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "capability_extension",
+                format!(
+                    "Invalid capability extension '{}' (expected '<capability>=<extension>')",
+                    pair
+                ),
+                Some(pair.clone()),
+                Some(vec![
+                    "Example: --capability-extension build=wordpress".to_string()
+                ]),
+            )
+        })?;
+
+        let surface = surface.trim();
+        let extension_id = extension_id.trim();
+
+        if surface.is_empty() || extension_id.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "capability_extension",
+                format!(
+                    "Invalid capability extension '{}': both capability and extension are required",
+                    pair
+                ),
+                Some(pair.clone()),
+                Some(vec![
+                    "Example: --capability-extension build=wordpress".to_string()
+                ]),
+            ));
+        }
+
+        if let Some(existing) = parsed.get(surface) {
+            if existing != extension_id {
+                return Err(Error::validation_invalid_argument(
+                    "capability_extension",
+                    format!(
+                        "Conflicting owners for capability '{}': '{}' and '{}'",
+                        surface, existing, extension_id
+                    ),
+                    Some(pair.clone()),
+                    Some(vec![format!(
+                        "Pass --capability-extension {}=<extension> once",
+                        surface
+                    )]),
+                ));
+            }
+            continue;
+        }
+
+        parsed.insert(surface.to_string(), extension_id.to_string());
+    }
+
+    Ok(parsed)
+}
 
 /// Check if adding a new version target would conflict with existing targets.
 pub fn validate_version_target_conflict(
@@ -101,4 +176,69 @@ pub fn parse_version_targets(targets: &[String]) -> Result<Vec<VersionTarget>> {
         }
     }
     Ok(parsed)
+}
+
+#[cfg(test)]
+mod capability_extension_tests {
+    use super::parse_capability_extensions;
+
+    #[test]
+    fn parses_capability_and_non_capability_surfaces() {
+        let parsed = parse_capability_extensions(&[
+            "build=wordpress".to_string(),
+            "remote_path=wordpress".to_string(),
+            "provides.file_extensions=nodejs".to_string(),
+        ])
+        .expect("valid pairs");
+
+        assert_eq!(parsed.get("build").map(String::as_str), Some("wordpress"));
+        assert_eq!(
+            parsed.get("remote_path").map(String::as_str),
+            Some("wordpress")
+        );
+        assert_eq!(
+            parsed.get("provides.file_extensions").map(String::as_str),
+            Some("nodejs")
+        );
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        let parsed =
+            parse_capability_extensions(&[" build = wordpress ".to_string()]).expect("valid pair");
+        assert_eq!(parsed.get("build").map(String::as_str), Some("wordpress"));
+    }
+
+    #[test]
+    fn rejects_pair_without_equals() {
+        let err = parse_capability_extensions(&["build".to_string()])
+            .expect_err("missing '=' must be rejected");
+        assert!(err.to_string().contains("<capability>=<extension>"));
+    }
+
+    #[test]
+    fn rejects_empty_halves() {
+        assert!(parse_capability_extensions(&["=wordpress".to_string()]).is_err());
+        assert!(parse_capability_extensions(&["build=".to_string()]).is_err());
+    }
+
+    #[test]
+    fn repeating_the_same_owner_is_accepted() {
+        let parsed = parse_capability_extensions(&[
+            "build=wordpress".to_string(),
+            "build=wordpress".to_string(),
+        ])
+        .expect("identical repeats agree");
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn rejects_conflicting_owners_for_one_capability() {
+        let err = parse_capability_extensions(&[
+            "build=wordpress".to_string(),
+            "build=nodejs".to_string(),
+        ])
+        .expect_err("conflicting owners must be rejected");
+        assert!(err.to_string().contains("Conflicting owners"));
+    }
 }

--- a/crates/homeboy-core/src/extension_execution.rs
+++ b/crates/homeboy-core/src/extension_execution.rs
@@ -131,39 +131,71 @@ pub fn extension_guidance_hints(
     ]
 }
 
-fn capability_ambiguous_error(
-    component: &Component,
-    capability: ExtensionCapability,
-    matching: &[String],
-) -> Error {
-    let capability_name = capability.label();
+/// Ownership surface for `remote_path` auto-resolution.
+pub const REMOTE_PATH_SURFACE: &str = "remote_path";
+/// Ownership surface for `deploy.since_tag` placeholder rewriting.
+pub const SINCE_TAG_SURFACE: &str = "since_tag";
+/// Ownership surface for `provides.file_extensions` (fingerprint / refactor /
+/// audit file-type dispatch).
+pub const FILE_EXTENSIONS_SURFACE: &str = "provides.file_extensions";
+
+/// Ambiguity error for a contested ownership surface.
+///
+/// The hint must be a *runnable command*, not advice. Before #11120 this said
+/// "Configure explicit {capability} extension ownership before running this
+/// command", which named neither the config key (`capability_extensions`) nor
+/// any way to set it — while the validation errors a few dozen lines below
+/// correctly reported `capability_extensions.{label}`. A caller who hit the
+/// ambiguity had no discoverable route forward, because `--capability-extension`
+/// did not exist either. Both halves are fixed together: the flag exists now, so
+/// the hint names it with the surface and a concrete candidate filled in.
+fn ownership_ambiguous_error(component: &Component, surface: &str, matching: &[String]) -> Error {
+    let first = matching
+        .first()
+        .map(String::as_str)
+        .unwrap_or("<extension_id>");
+
     Error::validation_invalid_argument(
         "extension",
         format!(
-            "Component '{}' has multiple linked extensions with {} support: {}",
+            "Component '{}' has multiple linked extensions providing '{}': {}",
             component.id,
-            capability_name,
+            surface,
             matching.join(", ")
         ),
         None,
-        None,
+        Some(
+            matching
+                .iter()
+                .map(|candidate| {
+                    format!(
+                        "homeboy component set {} --capability-extension {}={}",
+                        component.id, surface, candidate
+                    )
+                })
+                .collect(),
+        ),
     )
     .with_hint(format!(
-        "Configure explicit {} extension ownership before running this command",
-        capability_name
+        "Pick the owning extension: homeboy component set {} --capability-extension {}={}",
+        component.id, surface, first
     ))
+}
+
+fn explicit_surface_extension<'a>(component: &'a Component, surface: &str) -> Option<&'a str> {
+    component
+        .capability_extensions
+        .get(surface)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|extension_id| !extension_id.is_empty())
 }
 
 fn explicit_capability_extension(
     component: &Component,
     capability: ExtensionCapability,
 ) -> Option<&str> {
-    component
-        .capability_extensions
-        .get(capability.label())
-        .map(String::as_str)
-        .map(str::trim)
-        .filter(|extension_id| !extension_id.is_empty())
+    explicit_surface_extension(component, capability.label())
 }
 
 pub fn extract_component_extension_settings(
@@ -295,7 +327,38 @@ pub(crate) fn disambiguate_capability_owner(
     capability: ExtensionCapability,
     candidates: &[String],
 ) -> Result<String> {
-    if let Some(explicit) = explicit_capability_extension(component, capability) {
+    resolve_owner(component, capability.label(), candidates)
+}
+
+/// Pick the owning extension for an arbitrary contested *surface*.
+///
+/// This is [`disambiguate_capability_owner`] with the seven-variant
+/// [`ExtensionCapability`] enum lifted off the front, so surfaces that have no
+/// enum variant — `remote_path`, `since_tag`, `provides.file_extensions` — can
+/// share the one ownership rule instead of inventing a seventh contradictory
+/// one (#11119). `Component.capability_extensions` is already
+/// `HashMap<String, String>` with arbitrary string keys, so an entry like
+/// `capability_extensions."remote_path"` needs no schema change.
+///
+/// The rule, unchanged:
+///
+/// 1. explicit `capability_extensions.<surface>` selection, when it names one
+///    of the candidates;
+/// 2. `composition.includes` primacy — when exactly one candidate composes all
+///    the others (WordPress declares `includes: ["nodejs"]`), it owns the
+///    surface;
+/// 3. otherwise the ambiguity is genuine → [`ownership_ambiguous_error`], which
+///    carries a runnable `homeboy component set --capability-extension` command.
+///
+/// `candidates` must be deterministically ordered — callers build them from a
+/// `BTreeMap`/`BTreeSet`, never from `Component.extensions` (a `HashMap` with
+/// `RandomState`, whose iteration order differs every process).
+pub fn resolve_owner(
+    component: &Component,
+    surface: &str,
+    candidates: &[String],
+) -> Result<String> {
+    if let Some(explicit) = explicit_surface_extension(component, surface) {
         if let Some(selected) = candidates.iter().find(|id| id.as_str() == explicit) {
             return Ok(selected.clone());
         }
@@ -305,9 +368,7 @@ pub(crate) fn disambiguate_capability_owner(
         return Ok(primary);
     }
 
-    Err(capability_ambiguous_error(
-        component, capability, candidates,
-    ))
+    Err(ownership_ambiguous_error(component, surface, candidates))
 }
 
 /// If exactly one of the ambiguous extensions composes all of the others via its

--- a/crates/homeboy-core/src/extension_store.rs
+++ b/crates/homeboy-core/src/extension_store.rs
@@ -113,6 +113,26 @@ pub fn find_extension_by_tool(tool: &str) -> Option<ExtensionManifest> {
 /// the given extension and whose `scripts` has the requested capability configured.
 ///
 /// Returns the extension manifest with `extension_path` populated.
+///
+/// # Known limitation (#11119)
+///
+/// This resolves over **every installed extension**, ignoring which extensions
+/// the component actually links, and takes the first match in
+/// `load_all_extensions()` order — which `config::list` sorts by id. So the
+/// winner is deterministic but *alphabetical*: `nodejs` beats `wordpress` for
+/// the five file extensions both manifests claim (`js`, `jsx`, `ts`, `tsx`,
+/// `json`), while [`crate::extension_execution::resolve_owner`] gives WordPress
+/// ownership via `composition.includes`. Two rules, opposite answers.
+///
+/// It is not routed through `resolve_owner` here because this function has no
+/// `&Component` in scope and neither do any of its nine callers (all returning
+/// `Option`, across homeboy-refactor / homeboy-extension / core's symbol
+/// graph). Threading component linkage through them is a separate change.
+///
+/// The contradiction is currently latent rather than live: among shipped
+/// extensions only `wordpress` declares `fingerprint`/`refactor` scripts for
+/// the contested file extensions, so the capability filter below eliminates
+/// `nodejs` before ordering matters.
 pub fn find_extension_for_file_ext(ext: &str, capability: &str) -> Option<ExtensionManifest> {
     load_all_extensions().ok().and_then(|extensions| {
         extensions.into_iter().find(|m| {

--- a/crates/homeboy-core/src/project/effective_remote_path.rs
+++ b/crates/homeboy-core/src/project/effective_remote_path.rs
@@ -10,12 +10,17 @@ use crate::server::SshClient;
 use homeboy_extension_contract::RemotePathRootRule;
 use std::collections::HashSet;
 
-pub fn component_remote_path(component: &Component) -> String {
+/// Effective deploy remote path for a component.
+///
+/// Fallible since #11119: this is the deploy-facing resolver, so an unresolved
+/// multi-extension `remote_path_inference` conflict must be a hard error here
+/// rather than the empty string that deploy would then treat as "not set".
+pub fn component_remote_path(component: &Component) -> Result<String> {
     if component.remote_path.trim().is_empty() {
-        component::auto_resolve_remote_path(component)
-            .unwrap_or_else(|| component.remote_path.clone())
+        Ok(component::try_auto_resolve_remote_path(component)?
+            .unwrap_or_else(|| component.remote_path.clone()))
     } else {
-        component.remote_path.clone()
+        Ok(component.remote_path.clone())
     }
 }
 
@@ -24,7 +29,7 @@ pub fn resolve_effective_remote_path(
     component: &Component,
     fallback_base_path: &str,
 ) -> Result<String> {
-    let remote_path = component_remote_path(component);
+    let remote_path = component_remote_path(component)?;
 
     if remote_path.trim_start().starts_with('/') {
         return base_path::join_remote_path(Some(fallback_base_path), &remote_path);
@@ -409,7 +414,7 @@ mod tests {
     #[test]
     fn test_component_remote_path() {
         assert_eq!(
-            component_remote_path(&component("explicit/path")),
+            component_remote_path(&component("explicit/path")).expect("explicit path"),
             "explicit/path"
         );
 
@@ -418,7 +423,7 @@ mod tests {
             let mut auto = component("");
             auto.local_path = std::env::temp_dir().to_string_lossy().to_string();
 
-            assert_eq!(component_remote_path(&auto), "");
+            assert_eq!(component_remote_path(&auto).expect("no rule matched"), "");
         });
     }
 

--- a/crates/homeboy-release/src/deploy/execution/prepare.rs
+++ b/crates/homeboy-release/src/deploy/execution/prepare.rs
@@ -144,7 +144,20 @@ pub(crate) fn prepare_component_deploy(
     // Auto-resolve remote_path from linked extension deploy policy when not explicitly set.
     // This is a deploy-time safety net; the primary resolution happens in
     // resolve_project_component (#812).
-    let effective_remote_path = component_remote_path(component);
+    //
+    // Fallible since #11119: an unresolved multi-extension `remote_path_inference`
+    // conflict used to collapse to an empty path and deploy anyway. Fail the
+    // component deploy instead.
+    let effective_remote_path = component_remote_path(component).map_err(|error| {
+        ComponentDeployResult::failed(
+            component,
+            base_path,
+            local_version.clone(),
+            remote_version.clone(),
+            error.to_string(),
+        )
+        .with_build_exit_code(build_exit_code)
+    })?;
     if component.remote_path.trim().is_empty() && !effective_remote_path.trim().is_empty() {
         homeboy_core::log_status!(
             "deploy",

--- a/crates/homeboy-release/src/release/version/default_pattern_for_file.rs
+++ b/crates/homeboy-release/src/release/version/default_pattern_for_file.rs
@@ -5,9 +5,11 @@ use homeboy_core::engine::codebase_scan;
 use homeboy_core::engine::local_files;
 use homeboy_core::engine::text;
 use homeboy_core::error::{Error, Result};
+use homeboy_core::extension_execution::{resolve_owner, SINCE_TAG_SURFACE};
 use homeboy_core::paths::resolve_path_string;
 use homeboy_extension::load_all_extensions;
 use regex::Regex;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
@@ -340,6 +342,66 @@ pub(crate) fn detect_unconfigured_patterns(component: &Component) -> Vec<Unconfi
     unconfigured
 }
 
+/// Resolve the single `deploy.since_tag` config that governs this component.
+///
+/// This used to be `component.extensions.keys().find_map(..)` — a first-match
+/// scan over a `HashMap<String, ScopedExtensionConfig>` built with
+/// `RandomState`. With two linked extensions both declaring `since_tag`, *which
+/// config won changed every process*, and this drives `@since` placeholder
+/// rewriting during release (#11119). Nothing about that failure was visible:
+/// the release simply rewrote a different set of file extensions on different
+/// runs.
+///
+/// Providers are now collected into a `BTreeMap` and resolved with the shared
+/// ownership rule:
+///
+/// - no provider → `Ok(None)` (no `@since` rewriting)
+/// - one distinct config → `Ok(Some(config))`, however many extensions declare
+///   it (agreeing extensions are not ambiguous)
+/// - conflicting configs → [`resolve_owner`] on the `since_tag` surface, then a
+///   hard error with a runnable fix command
+fn resolve_since_tag_config(
+    component: &Component,
+) -> Result<Option<homeboy_extension::SinceTagConfig>> {
+    use homeboy_extension::load_extension;
+
+    let Some(extensions) = component.extensions.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut providers: BTreeMap<String, homeboy_extension::SinceTagConfig> = BTreeMap::new();
+    for extension_id in extensions.keys() {
+        let Ok(manifest) = load_extension(extension_id) else {
+            continue;
+        };
+        if let Some(config) = manifest.since_tag() {
+            providers.insert(extension_id.clone(), config.clone());
+        }
+    }
+
+    // `SinceTagConfig` has no `PartialEq`, so distinctness is keyed on its
+    // observable fields — the two things that decide what gets rewritten.
+    let distinct: BTreeSet<(Vec<String>, Option<String>)> = providers
+        .values()
+        .map(|config| {
+            (
+                config.extensions.clone(),
+                config.placeholder_pattern.clone(),
+            )
+        })
+        .collect();
+
+    match distinct.len() {
+        0 => Ok(None),
+        1 => Ok(providers.into_values().next()),
+        _ => {
+            let candidates: Vec<String> = providers.keys().cloned().collect();
+            let owner = resolve_owner(component, SINCE_TAG_SURFACE, &candidates)?;
+            Ok(providers.get(&owner).cloned())
+        }
+    }
+}
+
 /// Replace `@since` placeholder tags in source files with the actual version.
 /// Returns the total number of replacements made across all files.
 ///
@@ -349,18 +411,7 @@ pub(crate) fn replace_since_tag_placeholders(
     component: &Component,
     new_version: &str,
 ) -> Result<usize> {
-    use homeboy_extension::load_extension;
-
-    // Find the extension's since_tag config
-    let since_tag = component.extensions.as_ref().and_then(|extensions| {
-        extensions.keys().find_map(|extension_id| {
-            load_extension(extension_id)
-                .ok()
-                .and_then(|m| m.since_tag().cloned())
-        })
-    });
-
-    let config = match since_tag {
+    let config = match resolve_since_tag_config(component)? {
         Some(c) => c,
         None => return Ok(0),
     };


### PR DESCRIPTION
Consolidates multi-extension ownership onto one rule and fixes the two live bugs that the divergence was hiding. Found during the 2026-08-01 extension-ownership consolidation investigation (#11151).

Closes #11120. Closes #11119.

## The contradiction

`disambiguate_capability_owner` documents the ownership rule — explicit selection, then `composition.includes` primacy, then a hard error — but it governed **only** capability-script and build-artifact resolution. Six other sites did something else: collect-distinct, merge-all-sorted-by-id, merge-all-with-hard-conflict, silent drop, nondeterministic HashMap first-match, and alphabetical-over-all-installed-extensions.

The sharpest case is `wordpress` + `nodejs`, which really do collide: `wordpress.json` claims `["php","css","ts","tsx","js","jsx","json"]` and `nodejs.json` claims `["js","jsx","ts","tsx","mjs","cjs","json"]` — **five overlap**. `config::list` sorts by id, so `nodejs` < `wordpress` wins `find_extension_for_file_ext`, while `wordpress` declares `composition.includes: ["nodejs"]` so `resolve_owner` gives it ownership. Two rules, opposite answers, same component.

**Verified against the shipped manifests, the contradiction is currently latent, not live.** `find_extension_for_file_ext` filters on capability-script presence, and among shipped extensions only `wordpress` declares `fingerprint`/`refactor` scripts for the contested file extensions — so `nodejs` is eliminated before ordering matters. The structural contradiction is real and one manifest edit away from firing; today it does not.

## The two live bugs

**Silent drop — `component/remote_path.rs`.** Rendered paths went into a `HashSet<String>` resolved by `if matches.len() == 1 { .. } else { None }`. Conflicting `remote_path_inference` returned `None`, *indistinguishable from "no rule matched"*, and deploy then proceeded with an empty `remote_path`. `component/resolution.rs:119-124` documents this exact shape as *"a silent wrong-artifact deploy (#10281)"* and fixed it for build artifacts — the same pattern was left unfixed here.

This one is reachable **with a single extension**: WordPress ships three `remote_path_inference` rules, and a component matching both a plugin rule and the theme rule renders two different paths. (No shipped extension pair conflicts, since only `wordpress` declares `remote_path_inference` at all.)

**Nondeterminism — `release/version/default_pattern_for_file.rs`.** `extensions.keys().find_map(..)` is a first-match scan over a `HashMap` with `RandomState`. With two linked extensions declaring `deploy.since_tag`, which config won changed **every process** — and this drives `@since` placeholder rewriting during release. Latent today (only `wordpress` declares `deploy.since_tag`, as `{"extensions": [".php"]}` under `deploy`, not top-level), but the failure mode is invisible when it fires: a release rewrites a different set of file extensions on different runs.

## What changed

`disambiguate_capability_owner` is generalized to `resolve_owner(component, surface: &str, candidates)`, lifting the seven-variant enum off the front so non-enum surfaces share the rule. `capability_extensions` is already `HashMap<String, String>`, so `remote_path` / `since_tag` need no schema change. Both converted sites collect providers into a **`BTreeMap`** and follow `resolve_artifact`'s shape: no provider → `None`; one distinct value → resolve however many produced it; conflict → explicit selection, then composition primacy, then hard error.

Net effect is not just "more errors" — the common WordPress-includes-nodejs shape now resolves **correctly** where it previously dropped the path.

`remote_path` is split by whether the caller has an error channel. `try_auto_resolve_remote_path` is fallible and backs the deploy-facing `project::component_remote_path`, so an unresolved conflict fails the deploy instead of deploying to an empty path. `auto_resolve_remote_path` keeps its `Option` signature for the ~14 discovery/probe callers (`resolve_target`, `prefer_cwd_for_component`, rig materialization) that have no error channel; converting those cascades across homeboy-rig and homeboy-cli and is deliberately not in this PR.

### Converted
- `component/remote_path.rs` — silent drop → `resolve_owner` on `remote_path`
- `release/version/default_pattern_for_file.rs` — nondeterministic first-match → `resolve_owner` on `since_tag`
- `extension_execution.rs` — `disambiguate_capability_owner` now delegates to `resolve_owner`

### Deferred (documented in-tree, not silently skipped)
- `extension_store::find_extension_for_file_ext` — **not clean.** No `&Component` in scope, and neither have any of its nine callers, all returning `Option`, across homeboy-refactor / homeboy-extension / core's symbol graph. Threading linkage through them is its own change. A doc comment on the function records the contradiction and why it is latent.
- `engine/hooks.rs`, `source_snapshot.rs`, `component_script.rs` (merge-all sorted by id) and `extension/env_provider.rs` (merge-all, hard conflict on duplicate key) — converting merge-all to single-owner is a behavior change deserving its own PR.

## New hard errors are intentional, and now recoverable

They replace answers that were wrong without saying so. That is only acceptable because #11120 lands in the same PR: `--capability-extension` did not exist before this, so the ambiguity error had nowhere to point. It now names the surface, the candidates, and a runnable command in both the hint and `tried`:

```
homeboy component set <id> --capability-extension <surface>=<candidate>
```

`component set --capability-extension <capability>=<extension>` is repeatable, parsed into a `BTreeMap`, and rejects a missing `=`, empty halves, and conflicting owners for one capability. It accepts the seven capability labels plus the non-enum surfaces.

## Tests

Hermetic, in `component/tests.rs` and `component/versioning.rs`:
- conflicting rules error instead of returning `None`
- the error names a **runnable command** (hint + every candidate in `tried`)
- `capability_extensions` resolves a `remote_path` conflict — a surface with no enum variant
- `composition.includes` primacy resolves it without an error
- **determinism guard** for the `BTreeMap` conversion: 32 freshly-seeded `HashMap` components, outcome must not vary
- agreeing rules are not ambiguous
- `auto_resolve_remote_path` still degrades to `None` for discovery callers
- `parse_capability_extensions` parse/trim/reject cases

The behavior-change test `auto_resolve_remote_path_returns_none_on_conflicting_extension_rules` was replaced by the erroring version plus an explicit test that the infallible wrapper still returns `None`.

## Verification

`cargo fmt` clean. `cargo check --lib` exit 0 on `homeboy-core`, `homeboy-cli`, `homeboy-release`, plus `homeboy-rig` and `homeboy-extension` as adjacent consumers. Per this VPS's build constraint, `--tests` was not compiled locally — CI validates the test targets.
