### PR TITLE
fix(storage): put runtime temp on the data volume and probe the config volume in retained-storage

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -414,7 +414,14 @@ struct RetainedStorageSqlite {
 
 #[derive(Debug, Serialize)]
 struct RetainedStorageFilesystem {
+    /// The Homeboy **data** root. `reconciliation` balances this walk against
+    /// the non-external `top_level` entries.
     root: RetainedStorageFilesystemUsage,
+    /// The Homeboy **config** root (#11126). Frequently a different volume from
+    /// the data root, and previously never probed at all, so the one report
+    /// whose job is "where did my disk go" could describe a healthy system
+    /// while the volume holding it was full.
+    config_root: RetainedStorageFilesystemUsage,
     top_level: Vec<RetainedStorageFilesystemEntry>,
     reconciliation: RetainedStorageReconciliation,
     accounting_notes: Vec<&'static str>,
@@ -650,17 +657,20 @@ fn runtime_tmp_retained_record(row: engine::temp::RuntimeTempCleanupRow) -> Reta
 
 fn retained_storage_filesystem_inventory() -> homeboy::core::Result<RetainedStorageFilesystem> {
     let root = homeboy::core::paths::homeboy_data()?;
+    let config_root = homeboy::core::paths::homeboy()?;
     let artifact_root = homeboy::core::artifacts::root()?;
     let cargo_target_root = cleanup::shared_cargo_target_root()?;
-    retained_storage_filesystem_inventory_for(root, artifact_root, cargo_target_root)
+    retained_storage_filesystem_inventory_for(root, config_root, artifact_root, cargo_target_root)
 }
 
 fn retained_storage_filesystem_inventory_for(
     root: PathBuf,
+    config_root: PathBuf,
     artifact_root: PathBuf,
     cargo_target_root: PathBuf,
 ) -> homeboy::core::Result<RetainedStorageFilesystem> {
     let root_usage = filesystem_usage(&root)?;
+    let config_root_usage = filesystem_usage(&config_root)?;
     let mut top_level = Vec::new();
     if root.exists() {
         for entry in std::fs::read_dir(&root).map_err(|error| {
@@ -677,6 +687,28 @@ fn retained_storage_filesystem_inventory_for(
             })?;
             top_level.push(filesystem_entry(entry.path())?);
         }
+    }
+
+    // The config root is a second Homeboy volume, not a second copy of the
+    // first. It holds `rigs/{id}.state/logs/` (unbounded append), `backups/`,
+    // `rig-packages/`, `agent-runtimes/`, `runner-sessions/`,
+    // `runner-lease-evidence/`, `runner-job-execution-context/`, and
+    // `preview-ingress/routes/`. Before #11126 it was never probed, so this
+    // report described a healthy system during the 2026-07-29 outage.
+    //
+    // Double-counting is a containment question, not a same-filesystem
+    // question: two roots sharing a device still occupy disjoint inodes, so the
+    // guard is the same `starts_with` containment test the other external roots
+    // below already use, applied in both directions (`HOMEBOY_DATA_DIR` can be
+    // pointed at, or inside, the config root).
+    let config_root_is_nested = config_root.starts_with(&root) || root.starts_with(&config_root);
+    if !config_root_is_nested {
+        top_level.push(filesystem_entry_with_category(
+            config_root.clone(),
+            "config_root",
+            "managed/external",
+            "homeboy cleanup",
+        )?);
     }
 
     // An explicit artifact root can live on a separate volume. It is still a
@@ -716,6 +748,12 @@ fn retained_storage_filesystem_inventory_for(
             apparent_bytes: root_usage.apparent_bytes,
             physical_bytes: root_usage.physical_bytes,
         },
+        config_root: RetainedStorageFilesystemUsage {
+            path: config_root.display().to_string(),
+            exists: config_root.exists(),
+            apparent_bytes: config_root_usage.apparent_bytes,
+            physical_bytes: config_root_usage.physical_bytes,
+        },
         top_level,
         reconciliation: RetainedStorageReconciliation {
             top_level_apparent_bytes: apparent_total,
@@ -731,6 +769,8 @@ fn retained_storage_filesystem_inventory_for(
             "Root totals de-duplicate hard-linked inodes; independently measured top-level stores can count a cross-store hard link more than once.",
             "The root directory's own metadata and filesystem allocation granularity can leave a small reconciliation difference.",
             "Symlinks are measured as links and are not followed.",
+            "`reconciliation` balances the data root only. `managed/external` entries — including the config root — are measured and listed but are deliberately excluded from those totals, because they are not part of the data-root walk they would be reconciled against.",
+            "The config root is probed as a separate volume. It is omitted from `top_level` only when it contains, or is contained by, the data root; roots that merely share a filesystem occupy disjoint inodes and are not double-counted.",
         ],
     })
 }
@@ -3159,6 +3199,12 @@ mod tests {
                 apparent_bytes: 0,
                 physical_bytes: 0,
             },
+            config_root: RetainedStorageFilesystemUsage {
+                path: "/homeboy-config".to_string(),
+                exists: true,
+                apparent_bytes: 0,
+                physical_bytes: 0,
+            },
             top_level: Vec::new(),
             reconciliation: RetainedStorageReconciliation {
                 top_level_apparent_bytes: 0,
@@ -3213,12 +3259,14 @@ mod tests {
     #[test]
     fn retained_storage_filesystem_inventory_reports_configured_external_cargo_root() {
         let data = TempDir::new().expect("data root");
+        let config = TempDir::new().expect("config root");
         let cargo_root = TempDir::new().expect("cargo root");
         std::fs::write(cargo_root.path().join("artifact"), b"cargo output")
             .expect("cargo artifact");
 
         let inventory = retained_storage_filesystem_inventory_for(
             data.path().to_path_buf(),
+            config.path().to_path_buf(),
             data.path().join("artifacts"),
             cargo_root.path().to_path_buf(),
         )
@@ -3234,6 +3282,116 @@ mod tests {
         assert_eq!(
             cargo.cleanup_or_status_command,
             "homeboy cleanup --include shared-cargo-targets"
+        );
+    }
+
+    #[test]
+    fn retained_storage_probes_the_config_volume_the_data_root_cannot_see() {
+        // During the 2026-07-29 outage the config volume was full and this
+        // report said the system was healthy, because `homeboy()` was never
+        // probed. Every byte below lives on a root the data-root walk cannot
+        // reach.
+        let data = TempDir::new().expect("data root");
+        let config = TempDir::new().expect("config root");
+        let rig_logs = config.path().join("rigs").join("demo.state").join("logs");
+        std::fs::create_dir_all(&rig_logs).expect("rig log dir");
+        std::fs::write(rig_logs.join("runner.log"), vec![b'l'; 64 * 1024]).expect("rig log");
+        std::fs::create_dir_all(config.path().join("backups")).expect("backups");
+        std::fs::write(config.path().join("backups").join("homeboy.json"), b"{}")
+            .expect("backup file");
+
+        let inventory = retained_storage_filesystem_inventory_for(
+            data.path().to_path_buf(),
+            config.path().to_path_buf(),
+            data.path().join("artifacts"),
+            data.path().join("cargo-targets"),
+        )
+        .expect("filesystem inventory");
+
+        assert!(inventory.config_root.exists);
+        assert_eq!(
+            inventory.config_root.path,
+            config.path().display().to_string()
+        );
+        assert!(
+            inventory.config_root.apparent_bytes >= 64 * 1024,
+            "the config volume must be measured, not assumed empty"
+        );
+
+        let entry = inventory
+            .top_level
+            .iter()
+            .find(|entry| entry.category == "config_root")
+            .expect("config root is a probed top-level root");
+        assert_eq!(entry.classification, "managed/external");
+        assert_eq!(entry.cleanup_or_status_command, "homeboy cleanup");
+        assert!(
+            entry
+                .largest_examples
+                .iter()
+                .any(|child| child.path.ends_with("rigs")),
+            "the operator gets a drill-down into the volume that filled"
+        );
+
+        // `managed/external` roots are excluded from the data-root
+        // reconciliation on purpose: they are not part of the walk those
+        // totals balance against. The config volume is therefore reported
+        // without corrupting the data-root balance.
+        assert_eq!(inventory.reconciliation.top_level_apparent_bytes, 0);
+        assert!(
+            inventory.reconciliation.top_level_apparent_bytes
+                < inventory.config_root.apparent_bytes
+        );
+    }
+
+    #[test]
+    fn a_config_root_nested_in_the_data_root_is_never_listed_twice() {
+        // `HOMEBOY_DATA_DIR` can legally be pointed at the config root. Sharing
+        // a filesystem is not double-counting; sharing a subtree is.
+        let root = TempDir::new().expect("shared root");
+        std::fs::write(root.path().join("homeboy.json"), b"{}").expect("config file");
+
+        let inventory = retained_storage_filesystem_inventory_for(
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            root.path().join("artifacts"),
+            root.path().join("cargo-targets"),
+        )
+        .expect("filesystem inventory");
+
+        assert_eq!(
+            inventory
+                .top_level
+                .iter()
+                .filter(|entry| entry.category == "config_root")
+                .count(),
+            0,
+            "a config root already covered by the data-root walk must not be re-added"
+        );
+        assert_eq!(inventory.config_root.path, inventory.root.path);
+        assert!(inventory.config_root.exists);
+    }
+
+    #[test]
+    fn a_config_root_containing_the_data_root_is_not_double_counted() {
+        let config = TempDir::new().expect("config root");
+        let data = config.path().join("data");
+        std::fs::create_dir_all(&data).expect("nested data root");
+
+        let inventory = retained_storage_filesystem_inventory_for(
+            data.clone(),
+            config.path().to_path_buf(),
+            data.join("artifacts"),
+            data.join("cargo-targets"),
+        )
+        .expect("filesystem inventory");
+
+        assert!(
+            !inventory
+                .top_level
+                .iter()
+                .any(|entry| entry.category == "config_root"),
+            "a config root that contains the data root would count the data root twice"
         );
     }
 

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -600,15 +600,74 @@ mod owner_support {
         }
     }
 
+    /// The explicit runtime-temp root, when the operator pinned one.
+    pub(super) fn runtime_root_override() -> Option<PathBuf> {
+        let value = env::var(runtime_tmpdir_env()).ok()?;
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+    }
+
+    /// The active runtime-temp root: where new allocations land, and the
+    /// directory exported to every child process as `TMPDIR`.
+    ///
+    /// This resolves under the **data** root, not the config root. Runtime temp
+    /// is high-churn, machine-local, reconstructable bytes — a compiler
+    /// launched by a Homeboy workload writes its intermediates here — so it
+    /// belongs on the same volume an operator moves with `HOMEBOY_DATA_DIR`.
+    ///
+    /// It also makes the local resolver agree with the remote-shell protocol
+    /// this same file already ships in [`RuntimeTempOwner::remote_shell_command`],
+    /// which has always resolved `$HOMEBOY_DATA_DIR/runtime/tmp` ->
+    /// `$XDG_DATA_HOME/homeboy/runtime/tmp` -> `$HOME/.local/share/homeboy/runtime/tmp`.
+    /// The two resolvers disagreeing is the mechanism behind #11125: moving
+    /// storage to a large volume moved everything except the bytes that
+    /// actually grow.
     pub(super) fn runtime_root() -> Result<PathBuf> {
-        if let Ok(override_dir) = env::var(runtime_tmpdir_env()) {
-            let trimmed = override_dir.trim();
-            if !trimmed.is_empty() {
-                return Ok(PathBuf::from(trimmed));
-            }
+        if let Some(override_dir) = runtime_root_override() {
+            return Ok(override_dir);
         }
 
+        Ok(paths::homeboy_data()?.join("runtime").join("tmp"))
+    }
+
+    /// The pre-#11125 default runtime-temp root, under the **config** root.
+    ///
+    /// Nothing allocates here anymore. It is still swept so entries written by
+    /// an older binary keep being reclaimed instead of leaking forever.
+    pub(super) fn legacy_runtime_root() -> Result<PathBuf> {
         Ok(paths::homeboy()?.join("runtime").join("tmp"))
+    }
+
+    /// Superseded roots a full sweep must still drain, in sweep order.
+    ///
+    /// Only populated when the active root came from default resolution. An
+    /// explicit `HOMEBOY_RUNTIME_TMPDIR` is the operator naming exactly one
+    /// root, and under the old resolver that override also won — so there is no
+    /// superseded default in play for that process to inherit.
+    pub(super) fn superseded_runtime_roots() -> Vec<PathBuf> {
+        if runtime_root_override().is_some() {
+            return Vec::new();
+        }
+        let Ok(active) = runtime_root() else {
+            return Vec::new();
+        };
+        let Ok(legacy) = legacy_runtime_root() else {
+            return Vec::new();
+        };
+        // `is_dir` first: the sweep acquires a cleanup lock, which creates the
+        // root it is handed. Probing a root that was never used must not
+        // resurrect it on the volume this fix exists to keep clean.
+        if legacy.is_dir() && !same_runtime_root(&legacy, &active) {
+            vec![legacy]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn same_runtime_root(left: &Path, right: &Path) -> bool {
+        let left = fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf());
+        let right = fs::canonicalize(right).unwrap_or_else(|_| right.to_path_buf());
+        left == right
     }
 
     pub(super) fn runtime_tmpdir_env() -> String {
@@ -851,11 +910,76 @@ pub fn cleanup_runtime_tmp_bounded(
     cleanup_runtime_tmp_bounded_with_remover(options, remove_runtime_tmp_entry)
 }
 
+/// Sweep the active runtime-temp root, then drain every superseded root.
+///
+/// #11125 moved the default root from the config volume to the data volume.
+/// Entries written by an older binary are tracked by owner metadata and are
+/// only ever reclaimed by this sweep, so abandoning the old root would leak
+/// disk permanently. The superseded drain is therefore part of the normal
+/// sweep — there is no flag, no environment variable, and no separate command
+/// that has to be discovered before the bytes come back.
 fn cleanup_runtime_tmp_bounded_with_remover(
     options: RuntimeTempCleanupOptions<'_>,
     remover: RuntimeTempEntryRemover,
 ) -> Result<RuntimeTempCleanupOutput> {
-    let root = runtime_root()?;
+    let mut output = cleanup_runtime_tmp_root(runtime_root()?, options, remover)?;
+
+    for superseded in superseded_runtime_roots() {
+        // The bound is shared across roots so an aggregate sweep still returns
+        // a bounded report. Exhausting it here defers the drain to the next
+        // invocation rather than silently dropping it.
+        let remaining = options.limit.max(1).saturating_sub(output.rows.len());
+        if remaining == 0 {
+            output.has_more = true;
+            break;
+        }
+        // The superseded root is drain-only: nothing allocates into it, so it
+        // is restarted from the beginning every invocation and never
+        // participates in the caller's cursor. Repeated invocations converge.
+        let mut superseded_options = options;
+        superseded_options.cursor = None;
+        superseded_options.limit = remaining;
+        let drained = cleanup_runtime_tmp_root(superseded.clone(), superseded_options, remover)?;
+        merge_runtime_temp_cleanup(&mut output, drained);
+        if options.apply {
+            // Best effort, and only ever succeeds once the root is genuinely
+            // empty. Leaves nothing behind on the config volume after the last
+            // legacy entry is reclaimed.
+            let _ = fs::remove_dir(&superseded);
+        }
+    }
+
+    Ok(output)
+}
+
+/// Fold a superseded-root sweep into the active-root report.
+///
+/// Row order is preserved (active root first) and the reported
+/// `runtime_tmp_root` stays the active root, so the primary contract is
+/// unchanged. `next_cursor` also stays the active root's, because the
+/// superseded drain restarts each invocation and has no page to resume.
+fn merge_runtime_temp_cleanup(
+    output: &mut RuntimeTempCleanupOutput,
+    drained: RuntimeTempCleanupOutput,
+) {
+    output.totals.inspected_count += drained.totals.inspected_count;
+    output.totals.planned_size_bytes += drained.totals.planned_size_bytes;
+    output.totals.removed_size_bytes += drained.totals.removed_size_bytes;
+    output.planned_count += drained.planned_count;
+    output.removed_count += drained.removed_count;
+    output.skipped_count += drained.skipped_count;
+    output.planned_allocated_bytes += drained.planned_allocated_bytes;
+    output.removed_allocated_bytes += drained.removed_allocated_bytes;
+    output.verified_reclaimed_bytes += drained.verified_reclaimed_bytes;
+    output.has_more |= drained.has_more;
+    output.rows.extend(drained.rows);
+}
+
+fn cleanup_runtime_tmp_root(
+    root: PathBuf,
+    options: RuntimeTempCleanupOptions<'_>,
+    remover: RuntimeTempEntryRemover,
+) -> Result<RuntimeTempCleanupOutput> {
     let lock = acquire_cleanup_lock(&root)?;
     let mut output = RuntimeTempCleanupOutput {
         command: "self.cleanup-runtime-tmp",
@@ -1668,6 +1792,206 @@ mod tests {
             run_max_count: 100,
             cursor: None,
         }
+    }
+
+    /// Pin `HOMEBOY_DATA_DIR` for one test so data-root resolution never
+    /// depends on the ambient environment of the host running the suite.
+    struct DataDirGuard(Option<String>);
+
+    impl DataDirGuard {
+        fn set(path: &Path) -> Self {
+            let prior = env::var(paths::HOMEBOY_DATA_DIR_ENV).ok();
+            env::set_var(paths::HOMEBOY_DATA_DIR_ENV, path);
+            Self(prior)
+        }
+    }
+
+    impl Drop for DataDirGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(prior) => env::set_var(paths::HOMEBOY_DATA_DIR_ENV, prior),
+                None => env::remove_var(paths::HOMEBOY_DATA_DIR_ENV),
+            }
+        }
+    }
+
+    /// Put a superseded-root run directory on disk exactly as an older binary
+    /// would have left it: owner metadata, no pin, a dead owner PID.
+    fn seed_superseded_run(root: &Path, name: &str, state: &str) -> PathBuf {
+        let path = root.join(name);
+        fs::create_dir_all(&path).expect("superseded run dir");
+        let now = chrono::Utc::now().to_rfc3339();
+        let owner = RuntimeRunOwner {
+            schema: RUN_OWNER_SCHEMA.to_string(),
+            owner_id: uuid::Uuid::new_v4().to_string(),
+            owner_pid: u32::MAX,
+            linux_starttime_ticks: None,
+            run_id: None,
+            invocation_ids: Vec::new(),
+            state: state.to_string(),
+            created_at: now.clone(),
+            completed_at: Some(now),
+            reason: None,
+            producer: Some("legacy_producer".to_string()),
+        };
+        write_run_owner(&path, &owner).expect("superseded owner record");
+        fs::write(path.join("evidence.bin"), vec![b'x'; 64]).expect("superseded evidence");
+        path
+    }
+
+    #[test]
+    fn runtime_root_resolves_on_the_data_volume_and_names_the_config_volume_as_superseded() {
+        with_isolated_home(|home| {
+            env::remove_var(runtime_tmpdir_env());
+            let data = home.path().join("data-volume");
+            let _data_guard = DataDirGuard::set(&data);
+
+            assert_eq!(
+                runtime_root().expect("runtime root"),
+                data.join("runtime").join("tmp"),
+                "new allocations must land on the volume HOMEBOY_DATA_DIR moves"
+            );
+            assert_eq!(
+                legacy_runtime_root().expect("legacy runtime root"),
+                home.path()
+                    .join(".config")
+                    .join("homeboy")
+                    .join("runtime")
+                    .join("tmp"),
+                "the superseded root stays addressable so it can still be drained"
+            );
+        });
+    }
+
+    #[test]
+    fn runtime_tmpdir_override_outranks_the_data_volume_default() {
+        with_isolated_home(|home| {
+            let pinned = home.path().join("pinned-runtime-tmp");
+            env::set_var(runtime_tmpdir_env(), &pinned);
+            let _data_guard = DataDirGuard::set(&home.path().join("data-volume"));
+
+            assert_eq!(runtime_root().expect("runtime root"), pinned);
+        });
+    }
+
+    #[test]
+    fn an_explicit_runtime_tmpdir_scopes_the_sweep_to_that_one_root() {
+        with_isolated_home(|home| {
+            let legacy = home
+                .path()
+                .join(".config")
+                .join("homeboy")
+                .join("runtime")
+                .join("tmp");
+            fs::create_dir_all(&legacy).expect("superseded root");
+            env::set_var(runtime_tmpdir_env(), home.path().join("pinned-runtime-tmp"));
+
+            assert!(
+                superseded_runtime_roots().is_empty(),
+                "an operator-pinned root is the only root; the old resolver honored the same override"
+            );
+        });
+    }
+
+    #[test]
+    fn probing_a_superseded_root_never_creates_it() {
+        with_isolated_home(|home| {
+            env::remove_var(runtime_tmpdir_env());
+            let data = home.path().join("data-volume");
+            let _data_guard = DataDirGuard::set(&data);
+            let legacy = legacy_runtime_root().expect("legacy runtime root");
+
+            assert!(superseded_runtime_roots().is_empty());
+            let mut options = bounded_options(true, None);
+            options.managed_older_than_days = Some(0);
+            options.older_than_days = 0;
+            cleanup_runtime_tmp_bounded(options).expect("sweep with no superseded root");
+
+            assert!(
+                !legacy.exists(),
+                "the sweep acquires a lock that creates its root; it must not resurrect the config volume"
+            );
+        });
+    }
+
+    #[test]
+    fn superseded_config_root_entries_are_drained_by_the_normal_sweep() {
+        with_isolated_home(|home| {
+            env::remove_var(runtime_tmpdir_env());
+            let data = home.path().join("data-volume");
+            let _data_guard = DataDirGuard::set(&data);
+
+            let legacy = legacy_runtime_root().expect("legacy runtime root");
+            fs::create_dir_all(&legacy).expect("superseded root");
+            let stranded = seed_superseded_run(&legacy, "legacy-run-a-1", "succeeded");
+
+            let active = runtime_temp_dir("active-run").expect("active allocation");
+            assert!(
+                active.starts_with(&data),
+                "allocations go to the data volume only"
+            );
+
+            let mut options = bounded_options(false, None);
+            options.older_than_days = 0;
+            options.managed_older_than_days = Some(0);
+            let dry = cleanup_runtime_tmp_bounded(options).expect("dry run");
+            assert_eq!(
+                dry.runtime_tmp_root,
+                runtime_root().expect("runtime root").display().to_string(),
+                "the reported root stays the active root"
+            );
+            assert!(
+                dry.rows
+                    .iter()
+                    .any(|row| row.path == stranded.display().to_string()
+                        && row.action == "remove"),
+                "the superseded root is inspected without being asked for"
+            );
+
+            options.apply = true;
+            let applied = cleanup_runtime_tmp_bounded(options).expect("apply");
+            assert!(applied.removed_count >= 1);
+            assert!(!stranded.exists(), "superseded bytes are reclaimed");
+            assert!(
+                !legacy.exists(),
+                "a fully drained superseded root leaves nothing on the config volume"
+            );
+        });
+    }
+
+    #[test]
+    fn a_live_owner_in_the_superseded_root_is_protected_from_the_drain() {
+        with_isolated_home(|home| {
+            env::remove_var(runtime_tmpdir_env());
+            let _data_guard = DataDirGuard::set(&home.path().join("data-volume"));
+
+            let legacy = legacy_runtime_root().expect("legacy runtime root");
+            fs::create_dir_all(&legacy).expect("superseded root");
+            let held = seed_superseded_run(&legacy, "legacy-run-live-1", "succeeded");
+            let pin = pin_runtime_temp_dir(&held).expect("pin held by this process");
+
+            let mut options = bounded_options(true, None);
+            options.older_than_days = 0;
+            options.managed_older_than_days = Some(0);
+            let output = cleanup_runtime_tmp_bounded(options).expect("apply");
+
+            let row = output
+                .rows
+                .iter()
+                .find(|row| row.path == held.display().to_string())
+                .expect("held superseded row");
+            assert!(
+                row.reason.contains("pin owner PID"),
+                "the drain reuses the ownership protocol, not a blind delete: {}",
+                row.reason
+            );
+            assert!(held.exists());
+
+            drop(pin);
+            let released = cleanup_runtime_tmp_bounded(options).expect("release");
+            assert!(released.removed_count >= 1);
+            assert!(!held.exists());
+        });
     }
 
     #[test]

--- a/docs/cleanup-retention.md
+++ b/docs/cleanup-retention.md
@@ -227,6 +227,27 @@ granularity can make the top-level sum differ from root physical usage; the
 report states the direction and byte difference rather than hiding it. Existing
 `retained_bytes` and lifecycle aggregates remain unchanged for consumers.
 
+Since #11126 the **config root** (`~/.config/homeboy`) is probed as a fourth
+root, exposed as `filesystem.config_root` and as a `config_root` entry in
+`top_level`. It is usually a different volume from the data root and holds
+`rigs/{id}.state/logs/` (unbounded append), `rig-packages/`, `backups/`,
+`agent-runtimes/`, `runner-sessions/`, `runner-lease-evidence/`,
+`runner-job-execution-context/`, and `preview-ingress/routes/`. It was never
+probed before, so during the 2026-07-29 outage this report described a healthy
+system while the volume it omitted was full. Like the artifact and Cargo roots,
+it is classified `managed/external` and excluded from the data-root
+reconciliation totals, because it is not part of the walk those totals balance
+against. Double-counting is prevented by the same `starts_with` containment test
+the other external roots use, applied in both directions: two roots that merely
+share a filesystem occupy disjoint inodes and are not double-counted, but a
+config root nested in the data root (or a data root nested in the config root)
+is listed once.
+
+`runtime/tmp` used to live on the config root and no longer does (#11125), so
+after that change the config root should be small. It is still probed: an
+unprobed volume is an invisible one, and everything else in the list above
+still lives there.
+
 ## Remaining Scope
 
 The following Issue #8648 portions remain independently owned and are not

--- a/docs/cleanup-retention.md
+++ b/docs/cleanup-retention.md
@@ -160,6 +160,38 @@ symlinks, malformed or partial layouts, and candidates that change identity are
 retained. Apply revalidates selection, inode identity, layout, symlink state,
 and process ownership immediately before removal.
 
+## Runtime Temp Root Relocation
+
+The runtime temp root is what Homeboy exports as `TMPDIR`, `TMP`, and `TEMP` to
+every child process it launches, so it absorbs build intermediates from
+workloads such as `cargo build`. Through #11125 it defaulted to
+`<config root>/runtime/tmp` while the remote-shell protocol in the same module
+resolved `$HOMEBOY_DATA_DIR/runtime/tmp`. The two resolvers disagreeing meant an
+operator who moved storage to a large volume moved everything except the bytes
+that actually grow. It now defaults to `<data root>/runtime/tmp`, matching the
+remote protocol. `HOMEBOY_RUNTIME_TMPDIR` remains the highest-precedence
+override; see [Configuration Reference](reference/configuration.md#storage-locations).
+
+Entries an older binary left under the config root are not orphaned. They are
+tracked by owner metadata and are only ever reclaimed by the runtime-temp sweep,
+so `homeboy cleanup --include runtime-tmp` — and the aggregate `homeboy cleanup`
+— drains the superseded root as part of its normal pass. There is no flag and no
+separate command. The drain reuses the full ownership protocol rather than
+deleting blindly: active pins, live owner PIDs, active invocation leases, running
+persisted runs, and the corrupt-metadata quarantine grace all protect a
+superseded entry exactly as they protect an active one, and the configured
+retention window still applies. The sweep shares one bounded row budget across
+roots, restarts the superseded root from the beginning each invocation (nothing
+allocates there, so it needs no cursor), and removes the superseded root
+directory once it is empty. It never creates that directory: a root that was
+never used is left alone.
+
+The drain is scoped to default resolution. If `HOMEBOY_RUNTIME_TMPDIR` is set,
+that root is the only one swept, because the old resolver honored the same
+override and there is no superseded default in play. Residue under the config
+root from before an override was adopted is reported by
+`homeboy cleanup retained-storage`.
+
 ## Retained Storage Accounting
 
 `homeboy cleanup retained-storage` explains where disk went without deleting

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -49,6 +49,36 @@ required together. Explicit `--notification-transport` and
 `--notification-route` CLI values take precedence over these environment
 variables.
 
+## Storage Locations
+
+Homeboy writes to two base directories, and three of its largest stores can be
+relocated independently. An operator moving Homeboy onto a larger volume needs
+all of these, not just the first — see `homeboy cleanup retained-storage`, which
+probes every root listed here.
+
+| Root | Default | Override | Holds |
+| --- | --- | --- | --- |
+| Config root | `~/.config/homeboy` (`%APPDATA%\homeboy` on Windows) | `HOME` / `APPDATA` only | `homeboy.json`, component/project/server/extension declarations, `daemon/`, `rigs/`, `runner-sessions/`, `backups/`, `agent-runtimes/`, `preview-ingress/routes/` |
+| Data root | `$XDG_DATA_HOME/homeboy`, else `~/.local/share/homeboy` (`%LOCALAPPDATA%\homeboy` on Windows) | `HOMEBOY_DATA_DIR` | `homeboy.sqlite`, `artifacts/`, `cargo-targets/`, `controller-runtimes/`, `controller-scratch/`, `runtime/tmp/` |
+| Artifact root | `<data root>/artifacts` | `homeboy --artifact-root <dir>`, `HOMEBOY_ARTIFACT_ROOT`, or config `artifact_root` | Persisted run artifacts |
+| Shared Cargo target root | `<data root>/cargo-targets` | `HOMEBOY_CARGO_TARGET_ROOT` or config `cargo_target_root` | Reconstructable shared Cargo target directories |
+| Runtime temp root | `<data root>/runtime/tmp` | `HOMEBOY_RUNTIME_TMPDIR` | Per-workload scratch, exported to every child process as `TMPDIR`/`TMP`/`TEMP` |
+
+`HOMEBOY_RUNTIME_TMPDIR` is the highest-precedence runtime-temp setting and is
+worth knowing about: the runtime temp root is what Homeboy exports as `TMPDIR`,
+`TMP`, and `TEMP` to every child process it launches, so it absorbs build
+intermediates from workloads such as `cargo build`. It is the fastest-growing
+store on a busy controller. Before Homeboy 0.328 this root defaulted under the
+**config** root, so `HOMEBOY_DATA_DIR` did not move it; it now defaults under
+the data root, matching the resolution Homeboy has always used for remote
+shell workloads. A runtime temp root left behind under the config root by an
+older binary is drained automatically by `homeboy cleanup --include runtime-tmp`
+(and by the aggregate `homeboy cleanup`) using the same ownership and retention
+protocol as the active root — no flag required. That automatic drain is scoped
+to default resolution: if `HOMEBOY_RUNTIME_TMPDIR` is set, that root is the only
+one swept, and any residue under the config root is reported by
+`homeboy cleanup retained-storage`.
+
 ### `BenchConfig`
 
 - `local_execution` — Local benchmark execution policy: `allowed` (default) or `denied`.


### PR DESCRIPTION
Two fixes for one failure mode: Homeboy writes its fastest-growing store onto a volume the operator did not choose, and then the command whose job is to explain disk usage cannot see that volume.

Found during the 2026-08-01 consolidation investigation (#11151). Related: #11031, #10603.

## Two outages, one mechanism

- **2026-07-29** — 24 GB of build output filled the root filesystem. extrachill.com returned HTTP 500, Kimaki entered an ENOSPC restart loop. The workspace volume the operator had provisioned for exactly this had 54 GB free (#11032, #10732).
- **2026-07-31** — recurrence, noted in #11031.

Both times storage had been moved to a large volume. Both times the bytes went to the root filesystem anyway.

## Fix 1 — #11125: the local and remote resolvers disagree about which volume holds runtime temp

`crates/homeboy-core/src/engine/temp/implementation.rs` ships two resolvers for one logical store.

The **local** one:

```rust
pub(super) fn runtime_root() -> Result<PathBuf> {
    if let Ok(override_dir) = env::var(runtime_tmpdir_env()) { ... }
    Ok(paths::homeboy()?.join("runtime").join("tmp"))   // ~/.config/homeboy
}
```

The **remote-shell** one, ~500 lines above it in the same file:

```sh
elif [ -n "${HOMEBOY_DATA_DIR:-}" ]; then
  runtime_tmp_root="$HOMEBOY_DATA_DIR/runtime/tmp"
elif [ -n "${XDG_DATA_HOME:-}" ]; then
  runtime_tmp_root="$XDG_DATA_HOME/homeboy/runtime/tmp"
else
  runtime_tmp_root="$HOME/.local/share/homeboy/runtime/tmp"
fi
```

The remote one is correct. The local one is the bug, and it is not a cosmetic disagreement, because `RuntimeTempOwner::child_env_vars()` exports that local path as `TMPDIR`, `TMP`, and `TEMP` to **every child process Homeboy launches**. Every compiler invocation under a Homeboy workload writes its intermediates there.

So an operator moves storage to a large volume by setting `HOMEBOY_DATA_DIR` and/or `artifact_root` — and neither moves the store that actually grows. Only `HOMEBOY_RUNTIME_TMPDIR` did, it was undocumented, and it had to be set separately from every other storage knob. That is the mechanism behind both outages.

Reproduced on the affected host with released 0.327.0:

```
$ homeboy cleanup --include runtime-tmp   # runtime_tmp_root
/root/.config/homeboy/runtime/tmp
```

`runtime_root()` now falls back to `homeboy_data()?.join("runtime").join("tmp")`, matching the remote protocol this same file already ships. `HOMEBOY_RUNTIME_TMPDIR` stays the highest-precedence path.

### Migration design: drain, do not move

This changes an on-disk location, so existing entries must not be orphaned — they are tracked by owner metadata and reclaimed only by `cleanup --include runtime-tmp`, so silently abandoning them leaks disk forever.

**I took the second option offered in the issue: new allocations use the new root, and the cleanup path unconditionally sweeps the legacy root.** Saying so explicitly, with the reasoning, because the alternative was to relocate in place and I rejected it:

1. **A live workload holds the old path as an absolute string.** `TMPDIR` was already exported to running children. POSIX `rename(2)` keeps open file descriptors valid, but the path itself stops existing — so every subsequent *creation* under `$TMPDIR` in that child fails. `RuntimeTempOwner` explicitly supports concurrent live entries (pins, PID liveness, invocation leases, run liveness), so "a concurrent process holds an entry" is the normal case, not the edge case.
2. **A cross-filesystem move is the disease.** These two roots being on different volumes is the entire point of the fix. `rename` returns `EXDEV`, and the copy fallback would write potentially many GB *onto the volume this change exists to relieve*, at exactly the moment the operator is trying to drain it.
3. **The safe primitive already exists.** Runtime temp is reclaimable by an ownership protocol that is designed to run against live directories. Reusing it is safe by construction; a bespoke relocation is not.

So `cleanup_runtime_tmp_bounded` now sweeps the active root and then drains `<config root>/runtime/tmp` in the same pass. **Unconditional: no flag, no environment variable, no separate command to discover.** The aggregate `homeboy cleanup` gets it too.

Properties of the drain:

- **Reuses the full protocol, not a blind delete.** Active pins, live owner PIDs, active invocation leases, running persisted runs, and the corrupt-metadata quarantine grace protect a superseded entry exactly as they protect an active one. The configured retention window still applies, so failure evidence keeps its diagnostic value regardless of which root it landed in. Covered by a test that pins a legacy entry from the test process and asserts it survives, then releases the pin and asserts it is reclaimed.
- **Bounded.** One row budget is shared across roots. If the active root exhausts it, the drain sets `has_more` and defers rather than blowing the bound or silently dropping work.
- **No cursor.** Nothing allocates into the superseded root, so it is restarted from the beginning each invocation and never participates in the caller's cursor. Repeated invocations converge. `runtime_tmp_root` and `next_cursor` in the output still describe the active root, so the existing contract is unchanged.
- **Never resurrects a dead root.** `acquire_cleanup_lock` does `create_dir_all` on whatever root it is handed, so the sweep would otherwise re-create `~/.config/homeboy/runtime/tmp` on a machine that never had one. Guarded with an `is_dir()` probe first, and tested.
- **Removes the root directory once empty**, so a fully drained config volume is left clean.

### Failure modes considered

| Case | Behavior |
| --- | --- |
| Both roots exist | Both swept, active first |
| Legacy root empty | Swept (no-op), then `remove_dir` succeeds and it disappears |
| Legacy root absent | Not probed, not created |
| Legacy and active resolve to the same path | Canonicalized comparison; swept once |
| Cross-filesystem | Never a factor — nothing is copied or renamed |
| Concurrent process holds an entry | Protected by pin/PID/lease/run liveness, same as the active root |
| Corrupt owner metadata | 24h quarantine grace, same as the active root |
| Removal fails mid-drain | Reported as a `failed` row; the sweep continues |

### Scope of the drain

The drain is scoped to default resolution. If `HOMEBOY_RUNTIME_TMPDIR` is set, that root is the only one swept — the operator has named exactly one root, and the *old* resolver honored that same override, so there is no superseded default in play for that process to inherit. This is a scope, not an opt-in: there is no flag or variable that turns the drain on.

The residual gap is an operator who adopted `HOMEBOY_RUNTIME_TMPDIR` as a workaround *after* accumulating config-root entries. Fix 2 closes it: those bytes are now reported by `cleanup retained-storage` with a named command. It also keeps the whole existing runtime-temp test suite hermetic, since `HomeGuard` sets `HOMEBOY_RUNTIME_TMPDIR` for every isolated-home test — an unscoped drain would reach into the developer's real `~/.config/homeboy` and make count assertions non-deterministic.

### Documentation

`HOMEBOY_RUNTIME_TMPDIR` was undocumented, which is half the reason the outage was hard to diagnose. `docs/reference/configuration.md` gains a **Storage Locations** section: one table covering the config root, data root (`HOMEBOY_DATA_DIR`), artifact root (`HOMEBOY_ARTIFACT_ROOT`), shared Cargo target root (`HOMEBOY_CARGO_TARGET_ROOT`), and runtime temp root (`HOMEBOY_RUNTIME_TMPDIR`), with what each holds and the explicit warning that an operator relocating storage needs all of them. `docs/cleanup-retention.md` documents the relocation and the drain contract.

## Fix 2 — #11126: `cleanup retained-storage` never probes the config volume

```rust
fn retained_storage_filesystem_inventory() -> Result<RetainedStorageFilesystem> {
    let root = homeboy::core::paths::homeboy_data()?;
    let artifact_root = homeboy::core::artifacts::root()?;
    let cargo_target_root = cleanup::shared_cargo_target_root()?;
```

`homeboy_paths::homeboy()` is never probed. The `filesystem_usage`, the `top_level` walk, and the reconciliation totals describe the data root plus the artifact and Cargo roots when external — and nothing else.

So the command whose entire job is "explain retained Homeboy storage" omits the volume holding `runtime/tmp`, `rigs/{id}.state/logs/` (unbounded append), `rig-packages/`, `backups/`, `agent-runtimes/`, `runner-sessions/`, `runner-lease-evidence/`, `runner-job-execution-context/`, and `preview-ingress/routes/`.

**During the 2026-07-29 outage this report would have shown a healthy system.** Confirmed on the affected host with released 0.327.0 — the `filesystem` object has no config-root key at all, while `~/.config/homeboy` holds bytes the report never mentions:

```
top_level categories: [controller_runtimes, sqlite_observation_store, artifacts,
                       controller_scratch, unknown_storage ×12, shared_cargo_targets]
config_root present:  False
```

The config root is now a fourth probed root, via the existing `filesystem_entry_with_category` primitive, with the same `managed`/`external` classification already used for out-of-root artifact and Cargo roots, plus a dedicated `filesystem.config_root` usage object so the volume is visible in the JSON even when it is not listed in `top_level`.

### The double-counting decision

**The same-filesystem double-count case does not exist, and I did not add a device check.** Two roots sharing a device still occupy disjoint inodes, and the reconciliation totals sum measured per-path usage, not device usage. Sharing a filesystem is not double-counting.

The real hazard is **subtree containment**, which is exactly what the existing external roots already guard with `starts_with`. The config root uses the same test, applied in **both directions**, because `HOMEBOY_DATA_DIR` can legally be pointed at the config root or at a directory inside it:

- config root inside data root → already covered by the `read_dir` walk → entry omitted
- data root inside config root → the config-root entry would swallow the whole data root → entry omitted
- identical paths → omitted (`starts_with` is reflexive)
- disjoint paths, same device → **listed**, this is the normal case

Both containment directions have tests.

Classification is `managed/external`, which is also the *exclusion* key for the reconciliation totals. That is correct and deliberate: `reconciliation` balances the data-root walk against its own top-level children, and the config root is not part of that walk. Adding it would corrupt the balance the report exists to state. A test asserts the config volume's bytes are reported while `top_level_apparent_bytes` stays at the data-root value.

Cross-root hard links are still counted once per root. That limitation was already in `accounting_notes`; the notes now say so about the config root explicitly, and state the containment-vs-same-filesystem rule so the next reader does not have to re-derive it.

Fix 1 moves `runtime/tmp` off this volume, so after both changes the config root should be small. It is probed anyway — the other stores still live there, and an unprobed volume is an invisible one.

## Verification

- `cargo fmt` clean.
- `cargo check -p homeboy-core --lib` exit 0, no new warnings from the changed file.
- `cargo check -p homeboy-cli --lib` exit 0, no new warnings from the changed file.
- Full build/test deliberately left to CI: this host OOMs on a workspace build.
- New unit tests are hermetic — tempdir fixtures and `with_isolated_home`, with `HOMEBOY_DATA_DIR` pinned per test via an RAII guard so data-root resolution never reads the host environment. No test touches a real home.
- Every existing runtime-temp test sets `HOMEBOY_RUNTIME_TMPDIR`, so none of them change behavior under the new resolver or see the drain.
- Comments were checked against the `core-agnostic-source` forbidden-terms policy; no new ecosystem tokens outside `#[cfg(test)]`.

### Tests added

Core (`engine/temp/implementation.rs`):
- `runtime_root_resolves_on_the_data_volume_and_names_the_config_volume_as_superseded`
- `runtime_tmpdir_override_outranks_the_data_volume_default`
- `an_explicit_runtime_tmpdir_scopes_the_sweep_to_that_one_root`
- `probing_a_superseded_root_never_creates_it`
- `superseded_config_root_entries_are_drained_by_the_normal_sweep`
- `a_live_owner_in_the_superseded_root_is_protected_from_the_drain`

CLI (`commands/cleanup.rs`):
- `retained_storage_probes_the_config_volume_the_data_root_cannot_see`
- `a_config_root_nested_in_the_data_root_is_never_listed_twice`
- `a_config_root_containing_the_data_root_is_not_double_counted`

Closes #11125
Closes #11126
