### PR TITLE
fix: wire the disk budget to a decision, and keep cleanup runnable at zero inodes

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -140,7 +140,7 @@ pub fn run(args: CleanupArgs) -> CmdResult<Value> {
         Some(CleanupCommand::Resume(args)) => {
             cleanup_job_resume(&args.job_id).map(|output| (output, 0))
         }
-        None if args.apply => submit_cleanup(args).map(|output| (output, 0)),
+        None if args.apply => apply_cleanup(args).map(|output| (output, 0)),
         None => cleanup_inventory(args).map(|result| (result.output, result.exit_code)),
     }
 }
@@ -282,6 +282,58 @@ fn cleanup_job_parse_error(error: serde_json::Error) -> homeboy::core::Error {
         None,
         None,
     )
+}
+
+/// Apply cleanup, falling back to a store-free sweep when the durable path
+/// cannot start.
+///
+/// `--apply` normally runs through the daemon so the sweep is durable and
+/// recoverable. Reaching the daemon needs the controller's own persistent
+/// state, which needs the filesystem — so at zero free inodes the submission
+/// fails and the operator is left with no way to reclaim anything. That is the
+/// #10603 deadlock in its purest form: *the only tool that can free space
+/// cannot start.*
+///
+/// The fallback is deliberately narrow. It triggers only when the failure is
+/// positively identified as exhausted storage, either by the submission error
+/// itself or by an observation-store probe. A daemon that is merely down, or a
+/// database that is merely corrupt, still surfaces its own error — silently
+/// downgrading a durable `--apply` into a partial in-process sweep for an
+/// unrelated fault would be worse than failing.
+fn apply_cleanup(args: CleanupArgs) -> homeboy::core::Result<Value> {
+    // Captured before `args` is consumed. The subcommand is `None` on this
+    // path, so these are the only fields the degraded sweep needs.
+    let overrides = CleanupPolicyOverrides {
+        runtime_tmp_managed_days: args.runtime_tmp_managed_older_than_days,
+        limit: args.limit,
+        ..CleanupPolicyOverrides::default()
+    };
+    let error = match submit_cleanup(args) {
+        Ok(output) => return Ok(output),
+        Err(error) => error,
+    };
+
+    let store = cleanup::observation_store_availability();
+    if !error.is_storage_exhausted() && !store.is_storage_exhausted() {
+        return Err(error);
+    }
+
+    let policy =
+        cleanup::cleanup_policy_from_retention(&defaults::load_config().retention, overrides)?;
+    let outcome = cleanup::degraded_cleanup(
+        cleanup::DegradedCleanupOptions::from_policy(&policy, true),
+        store,
+        format!(
+            "durable cleanup could not be submitted because storage is exhausted: {}",
+            error.message
+        ),
+    );
+    serde_json::to_value(outcome).map_err(|error| {
+        homeboy::core::Error::internal_json(
+            error.to_string(),
+            Some("serialize degraded cleanup output".to_string()),
+        )
+    })
 }
 
 fn submit_cleanup(args: CleanupArgs) -> homeboy::core::Result<Value> {
@@ -973,6 +1025,9 @@ fn artifact_root_records(
         runner: None,
         run_id: None,
         limit: policy.scan_limit(),
+        // A read-only report has not probed the store, so it keeps the normal
+        // liveness path rather than defaulting itself into "retain everything".
+        ..RunnerDownloadCleanupOptions::default()
     })?;
     let downloads_root = downloads.root.display().to_string();
     if downloads.planned_count > 0 {
@@ -1485,6 +1540,14 @@ fn cleanup_inventory_with_deadline(
     )?;
     let terminal_run_days = policy.terminal_run_days;
     let limit = policy.limit;
+    // One probe for the whole sweep. Every database-backed category otherwise
+    // attempts its own `ObservationStore::open_initialized`, and each attempt
+    // is another `create_dir_all` plus WAL journal-file creation against a
+    // filesystem that may have no inode left to give — the exact state cleanup
+    // is being asked to recover from (#11127, #10603). Probing once turns N
+    // failing writes into one, and N generic per-category failures into one
+    // named degraded mode.
+    let store = cleanup::observation_store_availability();
     let mut categories = Vec::new();
 
     if selected.includes(CleanupCategoryArg::RepoArtifacts) {
@@ -1558,12 +1621,11 @@ fn cleanup_inventory_with_deadline(
     }
 
     if selected.includes(CleanupCategoryArg::TerminalRuns) {
-        isolate_cleanup_category(
+        isolate_store_backed_cleanup_category(
             &mut categories,
             TERMINAL_RUNS_METADATA,
             apply,
-            None,
-            None,
+            &store,
             || {
                 let output = runs_service::retain_terminal_runs(
                     runs_service::TerminalRunRetentionOptions {
@@ -1593,12 +1655,11 @@ fn cleanup_inventory_with_deadline(
     }
 
     if selected.includes(CleanupCategoryArg::PersistedRunArtifacts) {
-        isolate_cleanup_category(
+        isolate_store_backed_cleanup_category(
             &mut categories,
             PERSISTED_RUN_ARTIFACTS_METADATA,
             apply,
-            None,
-            None,
+            &store,
             || {
                 let persisted =
                     runs_service::cleanup_persisted_artifacts(PersistedArtifactCleanupOptions {
@@ -1682,6 +1743,11 @@ fn cleanup_inventory_with_deadline(
                         runner: None,
                         run_id: None,
                         limit: policy.scan_limit(),
+                        // Store-tolerant, not store-independent: with the
+                        // database shut its liveness veto fails closed and it
+                        // retains everything. Passing the probed answer keeps
+                        // that verdict without a second failing open.
+                        store_available: store.is_available(),
                     })?;
                 // `planned_count`, not `inspected_count`: a candidate is a resource
                 // selected for removal, not every entry the sweep walked past. Using
@@ -2033,6 +2099,70 @@ fn isolate_cleanup_category(
             specialist_command,
             error,
         )),
+    }
+}
+
+/// Run a category that cannot plan without the observation store, gating on a
+/// single probed availability answer.
+///
+/// When the store is unavailable the category is reported as skipped with a
+/// reason that names the store-independent categories, instead of attempting
+/// its own open and surfacing an undifferentiated failure. At zero free inodes
+/// that open cannot succeed and is itself another write against a filesystem
+/// with nothing left (#11127, #10603).
+fn isolate_store_backed_cleanup_category(
+    categories: &mut Vec<CleanupInventoryCategory>,
+    metadata: CleanupInventoryCategoryMetadata,
+    apply: bool,
+    store: &cleanup::StoreAvailability,
+    action: impl FnOnce() -> homeboy::core::Result<Vec<CleanupInventoryCategory>>,
+) {
+    match store.skip_reason() {
+        Some(reason) => categories.push(store_unavailable_category(metadata, apply, store, reason)),
+        None => isolate_cleanup_category(categories, metadata, apply, None, None, action),
+    }
+}
+
+/// A category skipped because the observation store could not be opened.
+///
+/// Reported as a failure, not a silent skip: the operator asked for cleanup and
+/// part of it did not happen. The `failure.code` carries the store's own error
+/// code, so `storage.exhausted` stays distinguishable all the way out to the
+/// command envelope.
+fn store_unavailable_category(
+    metadata: CleanupInventoryCategoryMetadata,
+    apply: bool,
+    store: &cleanup::StoreAvailability,
+    reason: String,
+) -> CleanupInventoryCategory {
+    let (code, retryable) = match store {
+        cleanup::StoreAvailability::Available => ("observation_store.unavailable", None),
+        // Retrying an exhausted filesystem changes nothing until capacity is
+        // reclaimed; any other fault might clear on its own.
+        cleanup::StoreAvailability::Unavailable {
+            code,
+            storage_exhausted,
+            ..
+        } => (code.as_str(), Some(!storage_exhausted)),
+    };
+    CleanupInventoryCategory {
+        category: metadata.category,
+        canonical_cleanup_command: metadata.canonical_cleanup_command(apply),
+        specialist_command: metadata.specialist_command(apply).to_string(),
+        included: true,
+        skipped: true,
+        skip_reason: Some(reason.clone()),
+        failure: Some(CleanupInventoryCategoryFailure {
+            code: code.to_string(),
+            message: reason,
+            retryable,
+        }),
+        candidate_count: 0,
+        applied_count: 0,
+        skipped_count: 1,
+        estimated_bytes: 0,
+        reclaimed_bytes: 0,
+        output: serde_json::to_value(store).unwrap_or(Value::Null),
     }
 }
 
@@ -2972,6 +3102,50 @@ mod count_unit_tests {
         ];
 
         assert_eq!(applied_category_count(&categories), 0);
+    }
+
+    /// A database-backed category skipped because the store will not open must
+    /// carry the store's own error code out to the envelope. Collapsing it into
+    /// an undifferentiated failure is what left #10603 unreadable, and the
+    /// remedy has to name the categories that still run — pointing a zero-inode
+    /// operator back at plain `homeboy cleanup --apply` is the loop.
+    #[test]
+    fn a_category_skipped_for_exhausted_storage_names_the_code_and_the_remedy() {
+        let store = cleanup::StoreAvailability::from_open_error(
+            &homeboy::core::Error::storage_exhausted("No space left on device (os error 28)", None),
+        );
+        let reason = store.skip_reason().expect("degraded skip reason");
+
+        let category = store_unavailable_category(TERMINAL_RUNS_METADATA, true, &store, reason);
+
+        assert!(category.skipped);
+        assert!(category
+            .skip_reason
+            .expect("skip reason")
+            .contains("orphaned-artifact-bytes"));
+        let failure = category.failure.expect("failure");
+        assert_eq!(failure.code, "storage.exhausted");
+        assert_eq!(
+            failure.retryable,
+            Some(false),
+            "retrying an exhausted filesystem changes nothing until capacity is reclaimed"
+        );
+    }
+
+    /// A corrupt database is not a full disk. It must stay retryable and must
+    /// not be laundered into a capacity story.
+    #[test]
+    fn a_category_skipped_for_a_non_capacity_store_fault_stays_retryable() {
+        let store = cleanup::StoreAvailability::from_open_error(
+            &homeboy::core::Error::internal_unexpected(
+                "SQLite observation store error: open: disk image is malformed",
+            ),
+        );
+        let reason = store.skip_reason().expect("degraded skip reason");
+
+        let category = store_unavailable_category(TERMINAL_RUNS_METADATA, true, &store, reason);
+
+        assert_eq!(category.failure.expect("failure").retryable, Some(true));
     }
 }
 

--- a/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
@@ -430,6 +430,9 @@ pub fn cleanup_downloads(args: RunsArtifactCleanupDownloadsArgs) -> CmdResult<Ru
         runner: args.runner,
         run_id: args.run_id,
         limit: policy.scan_limit(),
+        // The specialist has not probed the store, so it keeps the normal
+        // liveness path rather than defaulting itself into "retain everything".
+        ..RunnerDownloadCleanupOptions::default()
     })?;
 
     Ok((

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -473,6 +473,12 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
 
         ErrorCode::ObservationStoreBusy => 20,
 
+        // Exhausted storage is an environment fault, not a bug in the command
+        // that happened to be holding the pen when the filesystem gave out. It
+        // shares the operational exit code so a wrapper can distinguish it from
+        // an internal error and route to cleanup (#11127).
+        ErrorCode::StorageExhausted => 20,
+
         // A contended runtime promotion (another owner holds the lease) is a
         // transient "busy" condition, not a hard failure — map it to the
         // general error code alongside the other internal/unexpected states.

--- a/crates/homeboy-core/src/capacity.rs
+++ b/crates/homeboy-core/src/capacity.rs
@@ -1,0 +1,374 @@
+//! Capacity preflight: turn the disk budget into a decision.
+//!
+//! [`crate::observation::disk_budget`] already probes free bytes *and* free
+//! inodes in one `statvfs`, and it is correct. It was also, until this module,
+//! wired to nothing: both of its call sites are report-only. Nothing consulted
+//! it before materializing bytes. A measurement that no decision reads cannot
+//! change an outcome, which is why the #10603 fix did not prevent a recurrence
+//! (#11127).
+//!
+//! # The ladder is deliberately lopsided
+//!
+//! A preflight that fails closed can block legitimate work, and blocking work
+//! on a filesystem that is merely *tight* is worse than the failure it
+//! prevents. So:
+//!
+//! * **Exhausted** — hard error — only when a *measured* value is exactly zero.
+//!   Zero free bytes or zero free inodes means the next write fails; refusing
+//!   before writing is strictly better than a half-written artifact that then
+//!   has to be reaped.
+//! * **Warning** — never blocks — when a measured value is below the configured
+//!   reserve. The reserve keys already exist in
+//!   [`crate::defaults::RetentionConfig`] and are already default-on
+//!   (`shared_store_reserve_bytes` 5 GiB, `shared_store_reserve_inodes` 100k),
+//!   so this invents no new threshold.
+//! * **Unknown** — never blocks. A filesystem that does not report inodes, or a
+//!   `statvfs` that failed, must read as "not measured", never as exhaustion.
+//!
+//! Only a definite zero blocks. Everything uncertain proceeds.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::defaults::RetentionConfig;
+use crate::error::StorageExhaustedDetails;
+use crate::observation::disk_budget::{disk_budget, DiskBudget};
+use crate::{Error, Result};
+
+/// Free capacity a caller wants left over after its write.
+///
+/// Both keys already exist in [`RetentionConfig`] and are consulted today by
+/// exactly one consumer, the shared build-store admission check. Reusing them
+/// keeps one configured reserve rather than growing a second vocabulary for the
+/// same question.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CapacityReserve {
+    pub bytes: u64,
+    pub inodes: u64,
+}
+
+impl CapacityReserve {
+    /// No reserve. Only a measured zero is then treated as a problem.
+    pub const NONE: Self = Self {
+        bytes: 0,
+        inodes: 0,
+    };
+
+    pub fn from_retention(retention: &RetentionConfig) -> Self {
+        Self {
+            bytes: retention.shared_store_reserve_bytes,
+            inodes: retention.shared_store_reserve_inodes,
+        }
+    }
+
+    /// The configured reserve, resolved from the loaded configuration.
+    pub fn configured() -> Self {
+        Self::from_retention(&crate::defaults::load_config().retention)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapacityStatus {
+    /// Measured, and above every configured reserve.
+    Ok,
+    /// Measured, and below a configured reserve. Advisory: never blocks.
+    Warning,
+    /// A measured value is exactly zero. The next write fails.
+    Exhausted,
+    /// Not measurable here. Never blocks — see the module docs.
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapacityPreflight {
+    /// What the caller was about to do, used verbatim in the message.
+    pub subject: String,
+    pub path: String,
+    pub status: CapacityStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_inodes: Option<u64>,
+    pub reserve_bytes: u64,
+    pub reserve_inodes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+}
+
+impl CapacityPreflight {
+    pub fn is_exhausted(&self) -> bool {
+        self.status == CapacityStatus::Exhausted
+    }
+
+    /// The blocking error, when the filesystem has definitively run out.
+    ///
+    /// Carries the measured capacity and the reserve that was in force, so the
+    /// operator does not have to re-probe to understand the refusal.
+    pub fn error(&self) -> Option<Error> {
+        if !self.is_exhausted() {
+            return None;
+        }
+        Some(Error::storage_exhausted_detailed(StorageExhaustedDetails {
+            error: self
+                .warning
+                .clone()
+                .unwrap_or_else(|| format!("{} filesystem has no capacity left", self.subject)),
+            context: Some(format!("preflight before {}", self.subject)),
+            path: Some(self.path.clone()),
+            available_bytes: self.available_bytes,
+            available_inodes: self.available_inodes,
+            reserve_bytes: Some(self.reserve_bytes),
+            reserve_inodes: Some(self.reserve_inodes),
+        }))
+    }
+
+    /// `Err` when exhausted, otherwise the advisory warning, if any.
+    ///
+    /// The two arms are deliberately different types: a warning is data the
+    /// caller may surface, an exhaustion is a refusal it must propagate.
+    pub fn into_result(self) -> Result<Option<String>> {
+        match self.error() {
+            Some(error) => Err(error),
+            None => Ok(self.warning),
+        }
+    }
+}
+
+/// Probe `path` and decide whether a write may proceed.
+///
+/// One `statvfs`, through the same [`disk_budget`] the evidence reports use, so
+/// a preflight can never disagree with what the report shows.
+pub fn preflight_capacity(
+    path: &Path,
+    subject: &str,
+    reserve: CapacityReserve,
+) -> CapacityPreflight {
+    let budget = disk_budget(path, subject, "capacity is not measurable on this platform");
+    preflight_from_budget(budget, subject, reserve)
+}
+
+/// The decision, separated from the probe so every branch is reachable in a
+/// test without staging a full filesystem.
+fn preflight_from_budget(
+    budget: DiskBudget,
+    subject: &str,
+    reserve: CapacityReserve,
+) -> CapacityPreflight {
+    // A measured zero in either dimension. Inodes are checked independently of
+    // bytes because the #10603 state had ~34 GB free and zero free inodes: a
+    // byte-only test reads `ok` right up to hard ENOSPC.
+    let exhausted_bytes = budget.available_bytes == Some(0);
+    let exhausted_inodes = budget.available_inodes == Some(0);
+    let below_byte_reserve = reserve.bytes > 0
+        && budget
+            .available_bytes
+            .is_some_and(|available| available < reserve.bytes);
+    let below_inode_reserve = reserve.inodes > 0
+        && budget
+            .available_inodes
+            .is_some_and(|available| available < reserve.inodes);
+
+    let status = if exhausted_bytes || exhausted_inodes {
+        CapacityStatus::Exhausted
+    } else if below_byte_reserve || below_inode_reserve {
+        CapacityStatus::Warning
+    } else if budget.available_bytes.is_none() && budget.available_inodes.is_none() {
+        CapacityStatus::Unknown
+    } else {
+        CapacityStatus::Ok
+    };
+
+    let warning = match status {
+        CapacityStatus::Exhausted => Some(exhaustion_message(
+            subject,
+            exhausted_bytes,
+            exhausted_inodes,
+        )),
+        CapacityStatus::Warning => Some(reserve_message(
+            subject,
+            below_byte_reserve,
+            below_inode_reserve,
+            reserve,
+        )),
+        // Preserve whatever the probe itself had to say (an unavailable probe
+        // explains why), rather than manufacturing a second opinion.
+        CapacityStatus::Ok | CapacityStatus::Unknown => budget.warning.clone(),
+    };
+
+    CapacityPreflight {
+        subject: subject.to_string(),
+        path: budget.path,
+        status,
+        available_bytes: budget.available_bytes,
+        available_inodes: budget.available_inodes,
+        reserve_bytes: reserve.bytes,
+        reserve_inodes: reserve.inodes,
+        warning,
+    }
+}
+
+/// Name the dimension that ran out. "Disk full" with 34 GB free reads as a bug
+/// report against the tool rather than a fact about the filesystem.
+fn exhaustion_message(subject: &str, bytes: bool, inodes: bool) -> String {
+    match (bytes, inodes) {
+        (true, true) => format!("{subject} filesystem has no free bytes and no free inodes"),
+        (false, true) => format!(
+            "{subject} filesystem has NO free inodes; writes will fail regardless of free bytes"
+        ),
+        _ => format!("{subject} filesystem has no free bytes"),
+    }
+}
+
+fn reserve_message(subject: &str, bytes: bool, inodes: bool, reserve: CapacityReserve) -> String {
+    match (bytes, inodes) {
+        (true, true) => format!(
+            "{subject} filesystem is below both configured reserves ({} bytes, {} inodes)",
+            reserve.bytes, reserve.inodes
+        ),
+        (false, true) => format!(
+            "{subject} filesystem is below the configured inode reserve ({})",
+            reserve.inodes
+        ),
+        _ => format!(
+            "{subject} filesystem is below the configured free-space reserve ({} bytes)",
+            reserve.bytes
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn budget(available_bytes: Option<u64>, available_inodes: Option<u64>) -> DiskBudget {
+        DiskBudget {
+            path: "/fixture".to_string(),
+            available_bytes,
+            available_inodes,
+            ..DiskBudget::default()
+        }
+    }
+
+    fn reserve() -> CapacityReserve {
+        CapacityReserve {
+            bytes: 5 * 1024 * 1024 * 1024,
+            inodes: 100_000,
+        }
+    }
+
+    /// The #10603 state exactly: plenty of bytes, zero free inodes. A byte-only
+    /// gate reads `ok` here, which is how the outage reached hard ENOSPC with
+    /// nothing having warned.
+    #[test]
+    fn zero_free_inodes_blocks_even_with_tens_of_gigabytes_free() {
+        let preflight = preflight_from_budget(
+            budget(Some(34 * 1024 * 1024 * 1024), Some(0)),
+            "artifact publication",
+            reserve(),
+        );
+
+        assert_eq!(preflight.status, CapacityStatus::Exhausted);
+        let error = preflight.error().expect("exhaustion must block");
+        assert!(error.is_storage_exhausted());
+        assert_eq!(error.details["available_inodes"], 0);
+        assert_eq!(error.details["reserve_inodes"], 100_000);
+        assert!(
+            error.details["error"]
+                .as_str()
+                .expect("message")
+                .contains("regardless of free bytes"),
+            "the message must pre-empt the 'but there is plenty of space' reading"
+        );
+    }
+
+    #[test]
+    fn zero_free_bytes_blocks() {
+        let preflight = preflight_from_budget(
+            budget(Some(0), Some(500_000)),
+            "build",
+            CapacityReserve::NONE,
+        );
+
+        assert_eq!(preflight.status, CapacityStatus::Exhausted);
+        assert!(preflight.into_result().is_err());
+    }
+
+    /// A preflight that fails closed can block legitimate work. Breaching the
+    /// configured reserve is a warning, never a refusal — the reserve exists to
+    /// prompt cleanup, not to stop the machine at 5 GiB free.
+    #[test]
+    fn breaching_the_configured_reserve_warns_but_never_blocks() {
+        let preflight = preflight_from_budget(
+            budget(Some(1024 * 1024 * 1024), Some(50_000)),
+            "artifact publication",
+            reserve(),
+        );
+
+        assert_eq!(preflight.status, CapacityStatus::Warning);
+        assert!(preflight.error().is_none());
+        let warning = preflight.into_result().expect("a warning must not block");
+        let warning = warning.expect("a breached reserve must say so");
+        assert!(
+            warning.contains("below both configured reserves"),
+            "{warning}"
+        );
+    }
+
+    /// The reserve keys already exist and are already default-on. The preflight
+    /// must read them, not invent its own numbers.
+    #[test]
+    fn the_reserve_comes_from_the_keys_that_already_exist_in_retention_config() {
+        let configured = CapacityReserve::from_retention(&RetentionConfig::default());
+
+        assert_eq!(configured.bytes, 5 * 1024 * 1024 * 1024);
+        assert_eq!(configured.inodes, 100_000);
+    }
+
+    /// Filesystems that do not track inodes report none. That must read as "not
+    /// measured", never as total exhaustion — the inverse would block every
+    /// write on a network mount.
+    #[test]
+    fn an_unmeasurable_filesystem_never_blocks() {
+        let preflight = preflight_from_budget(budget(None, None), "build", reserve());
+
+        assert_eq!(preflight.status, CapacityStatus::Unknown);
+        assert!(preflight.error().is_none());
+    }
+
+    /// Bytes measured and healthy, inodes not reported at all: the byte
+    /// measurement still counts, and the missing one must not be read as zero.
+    #[test]
+    fn a_missing_inode_measurement_is_not_read_as_zero() {
+        let preflight = preflight_from_budget(
+            budget(Some(500 * 1024 * 1024 * 1024), None),
+            "build",
+            reserve(),
+        );
+
+        assert_eq!(preflight.status, CapacityStatus::Ok);
+        assert!(preflight.warning.is_none());
+    }
+
+    #[test]
+    fn a_healthy_filesystem_is_ok_and_silent() {
+        let preflight = preflight_from_budget(
+            budget(Some(500 * 1024 * 1024 * 1024), Some(9_000_000)),
+            "artifact publication",
+            reserve(),
+        );
+
+        assert_eq!(preflight.status, CapacityStatus::Ok);
+        assert_eq!(preflight.into_result().expect("no block"), None);
+    }
+
+    /// A real probe of a real path must not panic and must not block a machine
+    /// that is fine.
+    #[test]
+    fn probing_a_real_path_does_not_block_a_healthy_machine() {
+        let preflight = preflight_capacity(Path::new("/"), "root", CapacityReserve::NONE);
+
+        assert_ne!(preflight.status, CapacityStatus::Exhausted);
+    }
+}

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -23,6 +23,12 @@ pub use cargo_targets::{
 };
 mod automatic_retention;
 pub use automatic_retention::{run_automatic_cargo_retention, AutomaticRetentionOutput};
+pub mod degraded;
+pub use degraded::{
+    degraded_cleanup, observation_store_availability, DegradedCleanupCategory,
+    DegradedCleanupOptions, DegradedCleanupOutcome, StoreAvailability,
+    STORE_INDEPENDENT_CLEANUP_CATEGORIES,
+};
 mod extension_declarations;
 mod policy;
 pub use policy::{

--- a/crates/homeboy-core/src/cleanup/degraded.rs
+++ b/crates/homeboy-core/src/cleanup/degraded.rs
@@ -1,0 +1,485 @@
+//! Cleanup that still runs when the observation store cannot be opened.
+//!
+//! # The deadlock
+//!
+//! A workspace mount reached ZERO free inodes with ~34 GB still free. Every
+//! byte-only probe read `ok`, every write failed with a hard `ENOSPC`, and the
+//! recovery tool could not start: `ObservationStore::open_initialized` is a
+//! `create_dir_all`, a connection open that needs an inode for the WAL journal,
+//! the migration ladder, and an unfinished-publication reconciliation pass. At
+//! zero free inodes **the only tool that can free space cannot start** (#10603).
+//!
+//! #10603's fix added inode accounting to
+//! [`crate::observation::disk_budget`]. That measurement is correct, and it is
+//! wired to nothing: its only two call sites are report-only. A measurement
+//! that is never consulted by a decision does not change an outcome (#11127).
+//!
+//! # Which categories survive a closed database
+//!
+//! Three cleanup categories prove ownership by *name shape* rather than by
+//! joining against the `artifacts` table. Their docstrings are the primary
+//! source; what matters here is how each behaves when the store is gone, and
+//! the three are **not** equivalent:
+//!
+//! * [`crate::observation::runs_service::cleanup_orphaned_artifact_bytes`] —
+//!   genuinely store-free. Its removal decision is a pure function of (name
+//!   shape, entry type, age, symlink-freedom, containment), and it documents
+//!   that "the database is deliberately not consulted at all" because the paths
+//!   it reaps never get a row. This is the category that actually reclaims
+//!   bytes in a degraded sweep.
+//! * `crate::engine::temp::cleanup_runtime_tmp` — store-free *in effect*. It
+//!   opens the store in one place, `inspection_owner_protection`, to check
+//!   whether a named run is still `running`, and that check fails **open**
+//!   (`.ok().flatten().is_some_and(...)` — an unopenable store yields `false`,
+//!   so no protection is applied and the entry stays removable). Its real
+//!   liveness signals — the pin file's owner PID and the invocation lease — are
+//!   filesystem-local and unaffected.
+//! * [`crate::observation::runs_service::cleanup_runner_downloads`] — store
+//!   *tolerant*, not store-independent. Its liveness veto fails **closed** by
+//!   design: `LivenessVeto::read` returning `running: None` vetoes every
+//!   candidate, because these bytes are the operator's copy of something they
+//!   asked Homeboy to fetch and a wrong delete is not reversible. So it runs
+//!   safely with the database closed and reclaims exactly nothing. It is
+//!   reported here for visibility, flagged
+//!   [`DegradedCleanupCategory::reclaims_without_store`] `= false`, rather than
+//!   quietly omitted or dishonestly counted.
+//!
+//! # Why this is not just "let each category fail"
+//!
+//! The aggregate already isolates a failing category, so a degraded sweep was
+//! never a hard error. But every database-backed category independently
+//! attempts its own `open_initialized`, and each attempt is another
+//! `create_dir_all` plus journal-file creation against a filesystem that has
+//! nothing left to give. Probing once and gating on the answer replaces N
+//! failing writes with one, and turns N generic failures into one named
+//! degraded mode the operator can act on.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::engine::temp::{self, RuntimeTempCleanupOptions};
+use crate::observation::runs_service::{
+    self, OrphanedArtifactBytesCleanupOptions, RunnerDownloadCleanupOptions,
+};
+use crate::Error;
+
+/// Cleanup categories that can plan and apply with the observation store shut.
+///
+/// Ordered by how much they can actually reclaim in that state, so an operator
+/// reading the list top-down reaches the useful ones first.
+pub const STORE_INDEPENDENT_CLEANUP_CATEGORIES: &[&str] =
+    &["orphaned-artifact-bytes", "runtime-tmp", "runner-downloads"];
+
+/// Whether the observation store can be opened at all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum StoreAvailability {
+    Available,
+    Unavailable {
+        /// The failing error's code, so a consumer can branch without parsing
+        /// prose.
+        code: String,
+        reason: String,
+        /// True when the open failed specifically because the filesystem has
+        /// no capacity. This is the state that justifies degrading rather than
+        /// reporting a plain failure.
+        storage_exhausted: bool,
+    },
+}
+
+impl StoreAvailability {
+    pub fn is_available(&self) -> bool {
+        matches!(self, StoreAvailability::Available)
+    }
+
+    /// True only when the store is unavailable *and* the cause is exhausted
+    /// storage.
+    ///
+    /// Deliberately narrower than `!is_available()`: a corrupt database, a
+    /// permissions problem, or a migration failure must not silently reroute an
+    /// operator's `--apply` into a partial sweep.
+    pub fn is_storage_exhausted(&self) -> bool {
+        matches!(
+            self,
+            StoreAvailability::Unavailable {
+                storage_exhausted: true,
+                ..
+            }
+        )
+    }
+
+    /// Operator-facing explanation for a category skipped in degraded mode.
+    pub fn skip_reason(&self) -> Option<String> {
+        match self {
+            StoreAvailability::Available => None,
+            StoreAvailability::Unavailable { reason, .. } => Some(format!(
+                "observation store unavailable, so database-backed cleanup cannot plan: {reason}. \
+                 Store-independent categories still run: {}.",
+                STORE_INDEPENDENT_CLEANUP_CATEGORIES.join(", ")
+            )),
+        }
+    }
+
+    /// Classify an observation-store open failure.
+    pub fn from_open_error(error: &Error) -> Self {
+        StoreAvailability::Unavailable {
+            code: error.code.as_str().to_string(),
+            reason: error.message.clone(),
+            storage_exhausted: error.is_storage_exhausted(),
+        }
+    }
+}
+
+/// Probe the observation store once, for a whole sweep.
+///
+/// This is an open attempt rather than a capacity inference on purpose: the
+/// question a caller needs answered is "can the database be used", and the only
+/// honest answer comes from trying. Capacity is one reason it can fail; a
+/// corrupt file or a failed migration are others, and they must not be
+/// misreported as a full disk.
+pub fn observation_store_availability() -> StoreAvailability {
+    match crate::observation::ObservationStore::open_initialized() {
+        Ok(_) => StoreAvailability::Available,
+        Err(error) => StoreAvailability::from_open_error(&error),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DegradedCleanupOptions {
+    pub apply: bool,
+    /// Maximum candidate entries inspected per category. Callers resolve this
+    /// from [`super::CleanupPolicy::scan_limit`], which fails closed to zero.
+    pub limit: usize,
+    pub runtime_tmp_days: u64,
+    pub runtime_tmp_managed_days: Option<u64>,
+}
+
+impl DegradedCleanupOptions {
+    /// Degraded options resolved from the configured retention policy.
+    pub fn from_policy(policy: &super::CleanupPolicy, apply: bool) -> Self {
+        Self {
+            apply,
+            limit: policy.scan_limit(),
+            runtime_tmp_days: policy.runtime_tmp_days,
+            runtime_tmp_managed_days: Some(policy.runtime_tmp_managed_days),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DegradedCleanupCategory {
+    pub category: &'static str,
+    /// Whether this category can reclaim anything with the store closed.
+    ///
+    /// `false` for a category that runs safely but retains everything, so a
+    /// zero here reads as "structurally cannot", not "found nothing".
+    pub reclaims_without_store: bool,
+    pub planned_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub planned_count: usize,
+    pub removed_count: usize,
+    /// The category's own outcome, or its error details when it failed.
+    pub detail: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<Value>,
+}
+
+impl DegradedCleanupCategory {
+    fn failed(category: &'static str, reclaims_without_store: bool, error: Error) -> Self {
+        Self {
+            category,
+            reclaims_without_store,
+            planned_bytes: 0,
+            reclaimed_bytes: 0,
+            planned_count: 0,
+            removed_count: 0,
+            detail: error.details.clone(),
+            failure: Some(json!({
+                "code": error.code.as_str(),
+                "message": error.message,
+            })),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DegradedCleanupOutcome {
+    pub command: &'static str,
+    pub dry_run: bool,
+    /// Why the degraded path was taken.
+    pub reason: String,
+    pub store: StoreAvailability,
+    pub planned_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub categories: Vec<DegradedCleanupCategory>,
+    /// Categories deliberately not attempted because they cannot plan without
+    /// the database.
+    pub skipped_database_backed: bool,
+    pub next_command: &'static str,
+}
+
+/// Run every store-independent cleanup category with the database closed.
+///
+/// Never returns `Err`. A degraded sweep is the last recovery path available,
+/// so one failing category must not take the others down with it — the whole
+/// point is to reclaim whatever can still be reclaimed.
+pub fn degraded_cleanup(
+    options: DegradedCleanupOptions,
+    store: StoreAvailability,
+    reason: impl Into<String>,
+) -> DegradedCleanupOutcome {
+    let mut categories = Vec::new();
+
+    // The only category that genuinely reclaims with the store shut. It never
+    // consults the database in either direction.
+    categories.push(
+        match runs_service::cleanup_orphaned_artifact_bytes(OrphanedArtifactBytesCleanupOptions {
+            apply: options.apply,
+            limit: options.limit,
+        }) {
+            Ok(outcome) => DegradedCleanupCategory {
+                category: "orphaned-artifact-bytes",
+                reclaims_without_store: true,
+                planned_bytes: outcome.planned_size_bytes,
+                reclaimed_bytes: outcome.removed_size_bytes,
+                planned_count: outcome.planned_count,
+                removed_count: outcome.removed_count,
+                detail: serde_json::to_value(&outcome).unwrap_or(Value::Null),
+                failure: None,
+            },
+            Err(error) => DegradedCleanupCategory::failed("orphaned-artifact-bytes", true, error),
+        },
+    );
+
+    // Its store read is an advisory protection that fails open, and its real
+    // liveness signals (owner PID, invocation lease) are filesystem-local.
+    categories.push(
+        match temp::cleanup_runtime_tmp_bounded(RuntimeTempCleanupOptions {
+            apply: options.apply,
+            older_than_days: options.runtime_tmp_days,
+            managed_older_than_days: options.runtime_tmp_managed_days,
+            prefix: None,
+            limit: options.limit,
+            run_max_bytes: u64::MAX,
+            run_max_count: usize::MAX,
+            cursor: None,
+        }) {
+            Ok(outcome) => DegradedCleanupCategory {
+                category: "runtime-tmp",
+                reclaims_without_store: true,
+                planned_bytes: outcome.totals.planned_size_bytes,
+                reclaimed_bytes: outcome.totals.removed_size_bytes,
+                planned_count: outcome.planned_count,
+                removed_count: outcome.removed_count,
+                detail: serde_json::to_value(&outcome).unwrap_or(Value::Null),
+                failure: None,
+            },
+            Err(error) => DegradedCleanupCategory::failed("runtime-tmp", true, error),
+        },
+    );
+
+    // Runs safely, reclaims nothing: its liveness veto fails closed, so a
+    // closed store retains every candidate. Reported so the retained bytes stay
+    // visible instead of vanishing from the degraded report entirely.
+    categories.push(
+        match runs_service::cleanup_runner_downloads(RunnerDownloadCleanupOptions {
+            apply: options.apply,
+            runner: None,
+            run_id: None,
+            limit: options.limit,
+            store_available: store.is_available(),
+        }) {
+            Ok(outcome) => DegradedCleanupCategory {
+                category: "runner-downloads",
+                reclaims_without_store: false,
+                planned_bytes: outcome.planned_size_bytes,
+                reclaimed_bytes: outcome.removed_size_bytes,
+                planned_count: outcome.planned_count,
+                removed_count: outcome.removed_count,
+                detail: serde_json::to_value(&outcome).unwrap_or(Value::Null),
+                failure: None,
+            },
+            Err(error) => DegradedCleanupCategory::failed("runner-downloads", false, error),
+        },
+    );
+
+    DegradedCleanupOutcome {
+        command: "cleanup.degraded",
+        dry_run: !options.apply,
+        reason: reason.into(),
+        planned_bytes: categories.iter().map(|entry| entry.planned_bytes).sum(),
+        reclaimed_bytes: categories.iter().map(|entry| entry.reclaimed_bytes).sum(),
+        skipped_database_backed: !store.is_available(),
+        store,
+        categories,
+        next_command: "homeboy cleanup --apply",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exhausted() -> StoreAvailability {
+        StoreAvailability::from_open_error(&Error::storage_exhausted(
+            "No space left on device (os error 28)",
+            Some("open observation store".to_string()),
+        ))
+    }
+
+    /// The deadlock signal. An open that failed for lack of capacity is the one
+    /// condition that justifies rerouting to a partial, store-free sweep.
+    #[test]
+    fn an_open_that_failed_for_capacity_is_reported_as_storage_exhausted() {
+        let availability = exhausted();
+
+        assert!(!availability.is_available());
+        assert!(availability.is_storage_exhausted());
+        assert_eq!(
+            availability,
+            StoreAvailability::Unavailable {
+                code: "storage.exhausted".to_string(),
+                reason: "Filesystem capacity exhausted".to_string(),
+                storage_exhausted: true,
+            }
+        );
+    }
+
+    /// A corrupt database or a failed migration must not be laundered into
+    /// "the disk is full" — that would silently downgrade an operator's
+    /// `--apply` into a partial sweep for an unrelated fault.
+    #[test]
+    fn a_non_capacity_open_failure_is_not_treated_as_exhaustion() {
+        let availability = StoreAvailability::from_open_error(&Error::internal_unexpected(
+            "SQLite observation store error: apply migration 12: disk image is malformed",
+        ));
+
+        assert!(!availability.is_available());
+        assert!(!availability.is_storage_exhausted());
+    }
+
+    /// Pointing a zero-inode operator at plain `homeboy cleanup --apply` is the
+    /// loop #10603 could not escape. The skip reason has to name the categories
+    /// that still work.
+    #[test]
+    fn the_skip_reason_names_the_categories_that_still_run() {
+        let reason = exhausted().skip_reason().expect("degraded skip reason");
+
+        assert!(reason.contains("orphaned-artifact-bytes"), "{reason}");
+        assert!(reason.contains("runtime-tmp"), "{reason}");
+        assert!(
+            reason.contains("database-backed cleanup cannot plan"),
+            "{reason}"
+        );
+    }
+
+    #[test]
+    fn an_available_store_has_no_skip_reason() {
+        assert!(StoreAvailability::Available.skip_reason().is_none());
+        assert!(StoreAvailability::Available.is_available());
+        assert!(!StoreAvailability::Available.is_storage_exhausted());
+    }
+
+    /// The load-bearing claim: a degraded sweep completes **without ever
+    /// opening the observation store**.
+    ///
+    /// Proven directly rather than by inspection — the database file must not
+    /// exist afterwards. Opening it is a `create_dir_all` plus a connection
+    /// open that needs an inode for the WAL journal, which is precisely what
+    /// cannot happen at zero free inodes. If some category quietly opened one,
+    /// this fails.
+    #[test]
+    fn a_degraded_sweep_plans_every_category_without_opening_the_store() {
+        crate::test_support::with_isolated_home(|_| {
+            let database = crate::observation::store::database_path().expect("database path");
+            assert!(!database.exists(), "fixture must start with no database");
+
+            let outcome = degraded_cleanup(
+                DegradedCleanupOptions {
+                    apply: false,
+                    limit: 100,
+                    runtime_tmp_days: 7,
+                    runtime_tmp_managed_days: None,
+                },
+                exhausted(),
+                "test",
+            );
+
+            assert!(
+                !database.exists(),
+                "a degraded sweep must not create the observation store it cannot open"
+            );
+            assert!(outcome.skipped_database_backed);
+            assert!(outcome.dry_run);
+            let categories: Vec<_> = outcome
+                .categories
+                .iter()
+                .map(|entry| entry.category)
+                .collect();
+            assert_eq!(categories, STORE_INDEPENDENT_CLEANUP_CATEGORIES);
+            for entry in &outcome.categories {
+                assert!(
+                    entry.failure.is_none(),
+                    "{} failed in degraded mode: {:?}",
+                    entry.category,
+                    entry.failure
+                );
+            }
+        });
+    }
+
+    /// `runner-downloads` runs with the store shut but its liveness veto fails
+    /// closed, so it reclaims nothing. Reporting its zero exactly like the
+    /// others would misread a structural limit as an empty result, so the
+    /// distinction is carried in the payload rather than left to a reader.
+    #[test]
+    fn only_the_categories_that_can_reclaim_without_the_store_claim_to() {
+        crate::test_support::with_isolated_home(|_| {
+            let outcome = degraded_cleanup(
+                DegradedCleanupOptions {
+                    apply: false,
+                    limit: 100,
+                    runtime_tmp_days: 7,
+                    runtime_tmp_managed_days: None,
+                },
+                exhausted(),
+                "test",
+            );
+
+            let reclaiming: Vec<_> = outcome
+                .categories
+                .iter()
+                .filter(|entry| entry.reclaims_without_store)
+                .map(|entry| entry.category)
+                .collect();
+            assert_eq!(reclaiming, ["orphaned-artifact-bytes", "runtime-tmp"]);
+        });
+    }
+
+    /// A failing category must not take the rest of the sweep down with it.
+    /// A degraded pass is the last recovery path available.
+    #[test]
+    fn a_failed_category_is_reported_without_losing_its_error_code() {
+        let failed =
+            DegradedCleanupCategory::failed("orphaned-artifact-bytes", true, exhausted_error());
+
+        let failure = failed.failure.expect("failure detail");
+        assert_eq!(failure["code"], "storage.exhausted");
+        assert_eq!(failed.planned_bytes, 0);
+        assert_eq!(failed.reclaimed_bytes, 0);
+    }
+
+    /// The list is a contract, not a comment: the CLI gate and the degraded
+    /// fallback both render it to the operator.
+    #[test]
+    fn the_store_independent_category_list_matches_the_categories_that_run() {
+        assert_eq!(
+            STORE_INDEPENDENT_CLEANUP_CATEGORIES,
+            ["orphaned-artifact-bytes", "runtime-tmp", "runner-downloads"]
+        );
+    }
+
+    fn exhausted_error() -> Error {
+        Error::storage_exhausted("No space left on device (os error 28)", None)
+    }
+}

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -63,6 +63,7 @@ pub mod broker_auth;
 pub mod browser_evidence;
 pub mod browser_visual_compare;
 pub mod build_identity;
+pub mod capacity;
 pub mod change_artifact;
 pub mod ci_failure_log_triage;
 pub mod ci_gate;

--- a/crates/homeboy-core/src/observation/runs_service/runner_downloads.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_downloads.rs
@@ -142,6 +142,19 @@ pub struct RunnerDownloadCleanupOptions {
     /// callers from [`crate::cleanup::CleanupPolicy::scan_limit`], which fails
     /// closed to zero rather than widening to `usize::MAX`.
     pub limit: usize,
+    /// Whether the caller has already established that the observation store
+    /// can be opened.
+    ///
+    /// `false` skips the liveness open entirely and goes straight to the
+    /// fail-closed verdict this sweep would have reached anyway. That changes
+    /// no outcome — an unopenable store already vetoes every candidate — but it
+    /// avoids one more `create_dir_all` plus journal-file creation against a
+    /// filesystem that has no inode left to give, which is the exact condition
+    /// a degraded sweep is running under (#11127, #10603).
+    ///
+    /// Defaults to `true`: a caller that has not probed must not be silently
+    /// downgraded into retaining everything.
+    pub store_available: bool,
 }
 
 impl Default for RunnerDownloadCleanupOptions {
@@ -151,6 +164,7 @@ impl Default for RunnerDownloadCleanupOptions {
             runner: None,
             run_id: None,
             limit: DEFAULT_INSPECTION_LIMIT,
+            store_available: true,
         }
     }
 }
@@ -301,14 +315,16 @@ fn sweep(
     min_age: Duration,
     now: SystemTime,
 ) -> Result<RunnerDownloadCleanupOutcome> {
-    sweep_with(
-        artifact_root,
-        options,
-        filters,
-        min_age,
-        now,
-        LivenessVeto::read,
-    )
+    // A caller that already knows the store will not open gets the same
+    // fail-closed veto without paying for another failing open.
+    let store_available = options.store_available;
+    sweep_with(artifact_root, options, filters, min_age, now, move || {
+        if store_available {
+            LivenessVeto::read()
+        } else {
+            LivenessVeto::unavailable()
+        }
+    })
 }
 
 /// The sweep with its liveness source injected.
@@ -654,6 +670,13 @@ struct LivenessVeto {
 }
 
 impl LivenessVeto {
+    /// The veto a caller reaches when liveness cannot be established: retain
+    /// everything. Identical to what [`LivenessVeto::read`] returns on a failed
+    /// open, reachable without attempting one.
+    fn unavailable() -> Self {
+        Self { running: None }
+    }
+
     fn read() -> Self {
         let Ok(store) = ObservationStore::open_initialized() else {
             return Self { running: None };

--- a/crates/homeboy-core/src/observation/runs_service/runner_downloads/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_downloads/tests.rs
@@ -314,6 +314,49 @@ fn unavailable_liveness_retains_everything_instead_of_vetoing_nothing() {
     assert!(cache.exists());
 }
 
+/// A caller that has already established the store will not open reaches the
+/// same fail-closed verdict without attempting another one.
+///
+/// This routes through `sweep`, not `sweep_with`, so it exercises the real
+/// production wiring: with `store_available: false` no `open_initialized` is
+/// reachable at all. Under inode exhaustion every failing open is one more
+/// `create_dir_all` plus journal-file creation against a filesystem that has
+/// nothing left to give (#11127, #10603).
+#[test]
+fn a_declared_unavailable_store_fails_closed_without_attempting_an_open() {
+    let home = tempfile::tempdir().expect("home");
+    let cache = write_cached_download(home.path(), "lab", "run-1", "trace.zip", b"trace");
+    let degraded = RunnerDownloadCleanupOptions {
+        apply: true,
+        store_available: false,
+        ..RunnerDownloadCleanupOptions::default()
+    };
+
+    let outcome = sweep(
+        home.path(),
+        &degraded,
+        &filters(&degraded),
+        RUNNER_DOWNLOAD_MIN_AGE,
+        clock_past_the_floor(),
+    )
+    .expect("degraded sweep");
+
+    assert_eq!(outcome.liveness, RunnerDownloadLiveness::Unavailable);
+    assert_eq!(outcome.planned_count, 0);
+    assert_eq!(outcome.removed_count, 0);
+    assert!(
+        cache.exists(),
+        "a closed store must retain these bytes, never release them"
+    );
+}
+
+/// The gate defaults to "available" so a caller that never probed is not
+/// silently downgraded into retaining everything.
+#[test]
+fn the_default_assumes_the_store_is_available() {
+    assert!(RunnerDownloadCleanupOptions::default().store_available);
+}
+
 #[test]
 fn a_missing_run_row_does_not_by_itself_authorize_removal() {
     // Row absence is not a delete proof (#10284): runner-side run ids often

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -145,6 +145,7 @@ impl ObservationStore {
                     prepared.push((existing, None, None));
                     continue;
                 }
+                preflight_artifact_capacity(&stored_path)?;
                 let staged_path = staged_artifact_path(&stored_path, Uuid::new_v4());
                 staged_paths.push(staged_path.clone());
                 match publication.artifact_type {
@@ -696,6 +697,7 @@ impl ObservationStore {
             .map(str::to_string)
             .unwrap_or_else(|| Uuid::new_v4().to_string());
         let stored_path = persisted_artifact_path(run_id, &id, path)?;
+        preflight_artifact_capacity(&stored_path)?;
         let staged_path = staged_artifact_path(&stored_path, Uuid::new_v4());
         copy_artifact_file(path, &staged_path)?;
         let staged_metadata = fs::metadata(&staged_path).map_err(|error| {
@@ -942,6 +944,7 @@ impl ObservationStore {
         }
         let created_at = chrono::Utc::now().to_rfc3339();
         let stored_path = persisted_artifact_path(run_id, &id, path)?;
+        preflight_artifact_capacity(&stored_path)?;
         copy_artifact_directory(path, &stored_path)?;
         let path_string = stored_path.to_string_lossy().to_string();
 
@@ -1695,6 +1698,50 @@ fn remote_projection_identity_matches(
         && existing.metadata_json == incoming.metadata_json
 }
 
+/// Refuse to stage artifact bytes onto a filesystem that has definitively run
+/// out, and warn once when it is below the configured reserve.
+///
+/// Publication is the right place for this gate. It is the last moment before
+/// homeboy writes potentially very large bytes, and a copy that dies partway
+/// through `ENOSPC` leaves a `.artifact-<uuid>.staging` sibling behind — the
+/// crash residue `cleanup_orphaned_artifact_bytes` exists to reap. Refusing
+/// before the copy converts a leak plus an undifferentiated IO failure into one
+/// named `storage.exhausted` error the operator can act on (#11127, #10603).
+///
+/// Only a measured zero blocks; a breached reserve warns. See
+/// [`crate::capacity`] for why the ladder is lopsided.
+fn preflight_artifact_capacity(stored_path: &Path) -> Result<()> {
+    // Probe the nearest existing ancestor: the run directory is often created
+    // moments later, and a `statvfs` of a path that does not exist yet reports
+    // nothing at all.
+    let probe = stored_path
+        .ancestors()
+        .find(|candidate| candidate.exists())
+        .unwrap_or(stored_path);
+    let preflight = crate::capacity::preflight_capacity(
+        probe,
+        "artifact publication",
+        crate::capacity::CapacityReserve::configured(),
+    );
+    match preflight.into_result()? {
+        Some(warning) => {
+            warn_artifact_capacity_once(&warning);
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}
+
+/// A reserve breach is a standing condition, not a per-artifact event. Warning
+/// once per process keeps it visible without burying the run's real output
+/// under one line per published file.
+fn warn_artifact_capacity_once(warning: &str) {
+    static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    WARNED.get_or_init(|| {
+        eprintln!("Warning: {warning}. Reclaim capacity with `homeboy cleanup --apply`.");
+    });
+}
+
 fn staged_artifact_path(stored_path: &Path, staging_id: Uuid) -> std::path::PathBuf {
     // Keep sibling staging names well below common NAME_MAX limits regardless of
     // the content-addressed final artifact name.
@@ -1719,6 +1766,36 @@ mod tests {
     use crate::observation::{ArtifactViewerLink, NewRunRecord};
     use crate::test_support::with_isolated_home;
     use std::collections::BTreeSet;
+
+    /// The preflight gates every publication path, so a healthy filesystem must
+    /// stay silently healthy. A capacity gate that fails closed on a machine
+    /// with space would block more work than the exhaustion it prevents.
+    #[test]
+    fn the_capacity_preflight_admits_a_healthy_filesystem() {
+        with_isolated_home(|home| {
+            let target = home.path().join("run").join("artifact.bin");
+
+            preflight_artifact_capacity(&target).expect("a healthy filesystem must admit a write");
+        });
+    }
+
+    /// It must also resolve a target whose directory does not exist yet — the
+    /// run directory is frequently created moments after the path is computed,
+    /// and probing a non-existent path measures nothing at all.
+    #[test]
+    fn the_capacity_preflight_probes_the_nearest_existing_ancestor() {
+        with_isolated_home(|home| {
+            let unborn = home
+                .path()
+                .join("not")
+                .join("created")
+                .join("yet")
+                .join("artifact.bin");
+
+            preflight_artifact_capacity(&unborn)
+                .expect("an unborn target must not read as an unmeasurable filesystem");
+        });
+    }
 
     #[test]
     fn stable_artifact_id_publishes_copied_bytes_and_rejects_conflicts() {

--- a/crates/homeboy-core/src/observation/store/helpers.rs
+++ b/crates/homeboy-core/src/observation/store/helpers.rs
@@ -397,9 +397,39 @@ fn copy_artifact_directory_contents(source: &Path, target: &Path) -> Result<()> 
 pub(crate) fn sqlite_error(context: impl Into<String>) -> impl FnOnce(rusqlite::Error) -> Error {
     let context = context.into();
     move |error| {
+        // The observation store is the writer whose failure produced the
+        // #10603 deadlock: cleanup could not plan because opening the store
+        // needs an inode for its journal. Collapsing SQLITE_FULL into
+        // `internal.unexpected` is what made that unreadable, and what stopped
+        // any caller from degrading to a store-free path (#11127).
+        if sqlite_error_is_storage_exhausted(&error) {
+            return Error::storage_exhausted(
+                error.to_string(),
+                Some(format!("SQLite observation store: {context}")),
+            );
+        }
         Error::internal_unexpected(format!(
             "SQLite observation store error: {context}: {error}"
         ))
+    }
+}
+
+/// Whether a SQLite failure reports an out-of-capacity filesystem.
+///
+/// `SQLITE_FULL` is the direct signal. `SQLITE_IOERR` is checked through the
+/// message because SQLite reports an underlying `ENOSPC` from a journal or WAL
+/// write as a generic IO error with the operating-system text attached — which
+/// is exactly the write that fails first when inodes run out.
+pub(crate) fn sqlite_error_is_storage_exhausted(error: &rusqlite::Error) -> bool {
+    use rusqlite::ffi::ErrorCode;
+    match error {
+        rusqlite::Error::SqliteFailure(inner, message) => {
+            matches!(inner.code, ErrorCode::DiskFull)
+                || message
+                    .as_deref()
+                    .is_some_and(crate::error::message_reports_storage_exhaustion)
+        }
+        _ => false,
     }
 }
 

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -332,11 +332,50 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
     // WAL journaling lets readers and a single writer proceed concurrently,
     // which sharply reduces transient "database is locked" contention when
     // multiple homeboy processes touch the observation store at once.
-    // pragma_update may itself momentarily contend on the lock, so it is best
-    // effort: the busy_timeout above plus the write-retry wrapper still apply.
-    let _ = connection.pragma_update(None, "journal_mode", "WAL");
-    let _ = connection.pragma_update(None, "synchronous", "NORMAL");
+    // pragma_update may itself momentarily contend on the lock, so it stays
+    // best effort: the busy_timeout above plus the write-retry wrapper still
+    // apply.
+    //
+    // Best effort is not the same as silent. A discarded failure leaves the
+    // store running in rollback-journal mode with materially different
+    // concurrency behaviour and nobody told, so the next "database is locked"
+    // report has no way to reach its own cause.
+    for warning in apply_journal_pragmas(&connection) {
+        warn_pragma_once(&warning);
+    }
     Ok(connection)
+}
+
+/// Apply the concurrency pragmas, returning a warning per pragma that did not
+/// take. Pure so every branch is reachable without a contended database.
+fn apply_journal_pragmas(connection: &Connection) -> Vec<String> {
+    [("journal_mode", "WAL"), ("synchronous", "NORMAL")]
+        .into_iter()
+        .filter_map(|(pragma, value)| {
+            connection
+                .pragma_update(None, pragma, value)
+                .err()
+                .map(|error| pragma_warning(pragma, value, &error.to_string()))
+        })
+        .collect()
+}
+
+fn pragma_warning(pragma: &str, value: &str, error: &str) -> String {
+    format!(
+        "observation store could not set PRAGMA {pragma}={value}: {error}. The store keeps \
+         working with different concurrency behaviour; expect more transient \
+         `observation_store.busy` errors."
+    )
+}
+
+/// The condition is a property of the database, not of one open, and
+/// `open_connection` runs on nearly every command. Warning once per process
+/// keeps it visible without turning it into noise that gets filtered out.
+fn warn_pragma_once(warning: &str) {
+    static WARNED: OnceLock<()> = OnceLock::new();
+    WARNED.get_or_init(|| {
+        eprintln!("Warning: {warning}");
+    });
 }
 
 /// Open an existing observation store for a bounded metadata read.
@@ -513,6 +552,53 @@ fn column_exists(connection: &Connection, table: &str, column: &str) -> Result<b
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A real open must take both pragmas. Failure used to be discarded with
+    /// `let _ =`, so the store could silently fall back to rollback-journal
+    /// mode — different concurrency behaviour, nobody told, and the next
+    /// "database is locked" report unable to reach its own cause (#11127).
+    #[test]
+    fn a_healthy_connection_applies_both_concurrency_pragmas_without_warning() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let connection =
+            open_connection(&directory.path().join("observations.sqlite")).expect("open");
+
+        assert!(
+            apply_journal_pragmas(&connection).is_empty(),
+            "a healthy store must take both pragmas"
+        );
+        let mode: String = connection
+            .query_row("PRAGMA journal_mode;", [], |row| row.get(0))
+            .expect("read journal mode");
+        assert_eq!(mode.to_ascii_lowercase(), "wal");
+    }
+
+    /// The point of the change: a failure becomes words, not silence. The
+    /// warning has to name the pragma, the value, and the consequence.
+    #[test]
+    fn a_discarded_pragma_failure_becomes_an_actionable_warning() {
+        let warning = pragma_warning("journal_mode", "WAL", "database is locked");
+
+        assert!(warning.contains("journal_mode=WAL"), "{warning}");
+        assert!(warning.contains("database is locked"), "{warning}");
+        assert!(
+            warning.contains("observation_store.busy"),
+            "the warning must name what the operator will see instead: {warning}"
+        );
+    }
+
+    /// Every pragma that does not take produces exactly one warning, so a
+    /// second silent fallback cannot be introduced without a test noticing.
+    #[test]
+    fn one_warning_is_produced_per_pragma_that_did_not_take() {
+        let warnings: Vec<_> = [("journal_mode", "WAL"), ("synchronous", "NORMAL")]
+            .into_iter()
+            .map(|(pragma, value)| pragma_warning(pragma, value, "disk I/O error"))
+            .collect();
+
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().all(|warning| warning.contains("PRAGMA")));
+    }
 
     #[test]
     fn migration_12_adds_both_missing_columns() {

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -150,6 +150,12 @@ pub enum ErrorCode {
 
     ObservationStoreBusy,
 
+    /// The filesystem could not accept a write because it is out of bytes or
+    /// out of inodes. Distinct from [`ErrorCode::InternalIoError`] so callers
+    /// can degrade instead of retrying, and so an operator reads "disk full"
+    /// rather than "write failed" (#11127, #10603).
+    StorageExhausted,
+
     InternalIoError,
     InternalJsonError,
     InternalUnexpected,
@@ -213,6 +219,8 @@ impl ErrorCode {
             ErrorCode::GitCommandFailed => "git.command_failed",
 
             ErrorCode::ObservationStoreBusy => "observation_store.busy",
+
+            ErrorCode::StorageExhausted => "storage.exhausted",
 
             ErrorCode::InternalIoError => "internal.io_error",
             ErrorCode::InternalJsonError => "internal.json_error",
@@ -415,6 +423,85 @@ pub struct InternalIoErrorDetails {
     pub context: Option<String>,
 }
 
+/// Evidence for a write that failed because the filesystem had no capacity.
+///
+/// Every field beyond `error` is optional because the classifier is reachable
+/// from two very different places: a live `io::Error` at the moment a write
+/// failed (which knows nothing about reserves), and a deliberate capacity
+/// preflight (which knows all of it). Both must produce the same code.
+#[derive(Debug, Default, Serialize)]
+pub struct StorageExhaustedDetails {
+    pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+    /// Filesystem path the failing write targeted, when the caller knows it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_bytes: Option<u64>,
+    /// Free inodes. A filesystem with free bytes and none of these still fails
+    /// every write, which is precisely the state that produced #10603.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_inodes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reserve_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reserve_inodes: Option<u64>,
+}
+
+/// `ENOSPC` on every unix target homeboy builds for.
+///
+/// Checked alongside [`std::io::ErrorKind::StorageFull`] rather than instead of
+/// it: the mapped `ErrorKind` is the documented classification, and the raw
+/// errno is the fallback for any error value that was reconstructed without
+/// one (for example through `io::Error::from_raw_os_error` in a shim).
+#[cfg(unix)]
+const ENOSPC: i32 = 28;
+
+/// Whether a live `io::Error` reports an out-of-capacity filesystem.
+///
+/// Inode exhaustion also surfaces as `ENOSPC`, so this covers the #10603 state
+/// (free bytes, zero free inodes) without needing a separate probe.
+pub fn io_error_is_storage_exhausted(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::StorageFull {
+        return true;
+    }
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(ENOSPC) {
+        return true;
+    }
+    message_reports_storage_exhaustion(&error.to_string())
+}
+
+/// Whether an already-stringified io/SQLite error reports exhausted storage.
+///
+/// Most homeboy call sites stringify an `io::Error` before it ever reaches this
+/// crate — `Error::internal_io` takes `impl Into<String>`, and there is no
+/// `From<io::Error>` yet (#11134) — so the typed classifier above cannot see
+/// them. These markers are the stable operating-system and SQLite renderings of
+/// a filesystem that cannot accept another byte or another inode.
+pub fn message_reports_storage_exhaustion(message: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "no space left on device",
+        "database or disk is full",
+        "disk quota exceeded",
+        "enospc",
+        // `statvfs`-style phrasing used by homeboy's own capacity preflight.
+        "filesystem has no free inodes",
+    ];
+    let lowered = message.to_ascii_lowercase();
+    if MARKERS.iter().any(|marker| lowered.contains(marker)) {
+        return true;
+    }
+    // `io::Error`'s Display appends the raw errno. Errno 28 is ENOSPC on unix
+    // and something unrelated on Windows, so the numeric marker is unix-only.
+    #[cfg(unix)]
+    if lowered.contains("os error 28") {
+        return true;
+    }
+    false
+}
+
 #[derive(Debug, Serialize)]
 pub struct ObservationStoreBusyDetails {
     pub path: String,
@@ -513,6 +600,60 @@ impl Error {
             hints: Vec::new(),
             retryable: None,
         }
+    }
+
+    /// A write failed, or was refused, because the filesystem has no capacity.
+    ///
+    /// The hint names the degraded cleanup path on purpose. The reason #10603
+    /// deadlocked is that the only tool which can free capacity could not
+    /// start: opening the SQLite observation store needs an inode for its
+    /// journal, and there was none. The store-independent categories do not,
+    /// so they remain runnable in exactly the state that blocks everything
+    /// else.
+    pub fn storage_exhausted(error: impl Into<String>, context: Option<String>) -> Self {
+        Self::storage_exhausted_detailed(StorageExhaustedDetails {
+            error: error.into(),
+            context,
+            ..StorageExhaustedDetails::default()
+        })
+    }
+
+    /// [`Error::storage_exhausted`] carrying measured capacity evidence.
+    pub fn storage_exhausted_detailed(details: StorageExhaustedDetails) -> Self {
+        Self::new(
+            ErrorCode::StorageExhausted,
+            "Filesystem capacity exhausted",
+            to_details(details),
+        )
+        // Not retryable: the same write fails identically until capacity is
+        // reclaimed, so an automatic retry only burns the remaining budget.
+        .with_retryable(false)
+        .with_hint("Reclaim capacity with `homeboy cleanup --apply`.")
+        .with_hint(
+            "If cleanup cannot start because the observation store will not open, run the \
+             store-independent categories: `homeboy cleanup --include orphaned-artifact-bytes \
+             --include runtime-tmp --apply`.",
+        )
+    }
+
+    /// Classify a live `io::Error`, keeping storage exhaustion distinguishable.
+    ///
+    /// Deliberately *not* a `From<io::Error>` impl. Adding that conversion is
+    /// its own migration across ~1500 call sites and is tracked separately
+    /// (#11134); this constructor exists so the sites that matter can classify
+    /// today without waiting for it.
+    pub fn from_io_error(error: &std::io::Error, context: Option<String>) -> Self {
+        if io_error_is_storage_exhausted(error) {
+            return Self::storage_exhausted(error.to_string(), context);
+        }
+        Self::internal_io(error.to_string(), context)
+    }
+
+    /// Whether this error reports an out-of-capacity filesystem.
+    ///
+    /// The predicate callers use to decide between "retry" and "degrade".
+    pub fn is_storage_exhausted(&self) -> bool {
+        self.code == ErrorCode::StorageExhausted
     }
 
     pub fn observation_store_busy(
@@ -1231,11 +1372,21 @@ impl Error {
         Self::new(ErrorCode::ProjectNoActive, "No active project set", details)
     }
 
+    /// A generic IO failure.
+    ///
+    /// Storage exhaustion is split out here rather than at each of the ~1500
+    /// call sites that funnel into this constructor. Those sites hand over
+    /// `error.to_string()`, so this is the single place where an already
+    /// stringified `ENOSPC` is still recoverable. Leaving it collapsed into
+    /// `internal.io_error` is what made #10603 unreadable: every writer failed
+    /// with the same undifferentiated code, so no caller could degrade and the
+    /// operator was told "write failed" instead of "disk full" (#11127).
     pub fn internal_io(error: impl Into<String>, context: Option<String>) -> Self {
-        let details = to_details(InternalIoErrorDetails {
-            error: error.into(),
-            context,
-        });
+        let error = error.into();
+        if message_reports_storage_exhaustion(&error) {
+            return Self::storage_exhausted(error, context);
+        }
+        let details = to_details(InternalIoErrorDetails { error, context });
 
         Self::new(ErrorCode::InternalIoError, "IO error", details)
     }
@@ -1306,6 +1457,130 @@ impl Error {
             ),
             _ => self,
         }
+    }
+}
+
+/// Storage exhaustion must be distinguishable from every other IO failure.
+///
+/// #10603 was diagnosed only after the fact because every writer surfaced the
+/// same `internal.io_error`. These pin the classification, not the wording.
+#[cfg(test)]
+mod storage_exhaustion_tests {
+    use super::*;
+
+    #[test]
+    fn a_storage_full_io_error_does_not_collapse_into_a_generic_io_error() {
+        let full = std::io::Error::from(std::io::ErrorKind::StorageFull);
+
+        let error = Error::from_io_error(&full, Some("write evidence".to_string()));
+
+        assert_eq!(error.code, ErrorCode::StorageExhausted);
+        assert_eq!(error.code.as_str(), "storage.exhausted");
+        assert!(error.is_storage_exhausted());
+        assert_eq!(error.details["context"], "write evidence");
+    }
+
+    /// ENOSPC is what an out-of-*inodes* filesystem returns too, so the raw
+    /// errno path is the one that actually covers the #10603 state.
+    #[cfg(unix)]
+    #[test]
+    fn a_raw_enospc_errno_is_classified_as_storage_exhaustion() {
+        let raw = std::io::Error::from_raw_os_error(ENOSPC);
+
+        assert!(io_error_is_storage_exhausted(&raw));
+        assert!(Error::from_io_error(&raw, None).is_storage_exhausted());
+    }
+
+    /// The ~1500 existing call sites stringify before they reach this crate.
+    /// If the string form were not classified, the split would be invisible
+    /// everywhere it matters until #11134 lands `From<io::Error>`.
+    #[test]
+    fn an_already_stringified_enospc_is_still_classified() {
+        let error = Error::internal_io(
+            "No space left on device (os error 28)",
+            Some("persist artifact".to_string()),
+        );
+
+        assert_eq!(error.code, ErrorCode::StorageExhausted);
+        assert_eq!(error.details["context"], "persist artifact");
+    }
+
+    /// SQLite reports a full filesystem in its own words, and the observation
+    /// store is the writer whose failure produced the deadlock.
+    #[test]
+    fn the_sqlite_rendering_of_a_full_filesystem_is_classified() {
+        assert!(message_reports_storage_exhaustion(
+            "database or disk is full"
+        ));
+        assert!(message_reports_storage_exhaustion("Disk quota exceeded"));
+    }
+
+    #[test]
+    fn an_ordinary_io_failure_stays_a_generic_io_error() {
+        let missing = std::io::Error::from(std::io::ErrorKind::NotFound);
+
+        let typed = Error::from_io_error(&missing, None);
+        let stringified = Error::internal_io("permission denied (os error 13)", None);
+
+        assert_eq!(typed.code, ErrorCode::InternalIoError);
+        assert_eq!(stringified.code, ErrorCode::InternalIoError);
+        assert!(!typed.is_storage_exhausted());
+    }
+
+    /// A caller that sees this must degrade, not spin. The same write fails
+    /// identically until capacity is reclaimed.
+    #[test]
+    fn storage_exhaustion_is_reported_as_not_retryable() {
+        assert_eq!(
+            Error::storage_exhausted("full", None).retryable,
+            Some(false)
+        );
+    }
+
+    /// The remedy has to name the *store-independent* categories. Pointing a
+    /// zero-inode operator at plain `homeboy cleanup --apply` is the loop that
+    /// #10603 could not escape.
+    #[test]
+    fn the_hint_names_a_remedy_that_survives_a_closed_observation_store() {
+        let error = Error::storage_exhausted("full", None);
+
+        let hints = error
+            .hints
+            .iter()
+            .map(|hint| hint.message.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(hints.contains("orphaned-artifact-bytes"), "{hints}");
+        assert!(hints.contains("runtime-tmp"), "{hints}");
+    }
+
+    #[test]
+    fn measured_capacity_evidence_survives_into_the_details() {
+        let error = Error::storage_exhausted_detailed(StorageExhaustedDetails {
+            error: "reserve breached".to_string(),
+            context: Some("preflight".to_string()),
+            path: Some("/var/lib/homeboy".to_string()),
+            available_bytes: Some(1024),
+            available_inodes: Some(0),
+            reserve_bytes: Some(5 * 1024 * 1024 * 1024),
+            reserve_inodes: Some(100_000),
+        });
+
+        assert_eq!(error.details["available_inodes"], 0);
+        assert_eq!(error.details["reserve_inodes"], 100_000);
+        assert_eq!(error.details["path"], "/var/lib/homeboy");
+    }
+
+    /// Absent measurements must not serialize as nulls a consumer has to
+    /// special-case.
+    #[test]
+    fn unmeasured_capacity_fields_are_omitted_entirely() {
+        let error = Error::storage_exhausted("full", None);
+
+        let details = error.details.as_object().expect("object details");
+        assert!(!details.contains_key("available_bytes"));
+        assert!(!details.contains_key("reserve_inodes"));
+        assert!(!details.contains_key("context"));
     }
 }
 


### PR DESCRIPTION
Found during the 2026-08-01 consolidation investigation (#11151).

## The problem

`disk_budget()` (`crates/homeboy-core/src/observation/disk_budget.rs`) is correct, and it **does** check inodes — that was the fix for #10603. It has exactly two call sites, **both report-only** (`runs/evidence.rs`, `runs/loop_sync.rs`).

Nothing consulted it before a build, before Lab offload materialization, or before artifact publication. `RetentionConfig` already carries `shared_store_reserve_bytes` (5 GiB) and `shared_store_reserve_inodes` (100k) — reserves that, until this PR, only the cargo pruner read.

**The fix for the last outage was a measurement that was never wired to a decision.** A measurement no decision reads cannot change an outcome.

Grepping `ENOSPC|SQLITE_FULL|No space|StorageFull` across `crates/` returned three matches before this PR — all *comments* in `disk_budget.rs` describing the postmortem.

## The inode deadlock

At zero free inodes, `ObservationStore::open_initialized()` is a `create_dir_all`, a connection open that needs an inode for the WAL journal, the migration ladder, and a reconciliation pass. **The only tool that can free space cannot start.** Every database-backed cleanup category attempts its own open, so a filesystem with nothing left to give received N more failing writes and the operator received N undifferentiated failures.

And on ENOSPC every writer surfaced a generic `internal.io_error` (or `internal.unexpected` from the store), so no caller could distinguish "disk full" from "write failed" and degrade gracefully.

## What landed

### 1. A distinguishable error

`ErrorCode::StorageExhausted` (`storage.exhausted`) with `Error::storage_exhausted`, `Error::storage_exhausted_detailed` (carrying measured capacity evidence), `Error::from_io_error`, and `Error::is_storage_exhausted`.

Classification happens in two places rather than at ~1500 call sites:

- `Error::from_io_error` classifies a live `io::Error` from `ErrorKind::StorageFull` or a raw `ENOSPC`. Inode exhaustion also returns `ENOSPC`, so this covers the #10603 state directly.
- `Error::internal_io` classifies the already-stringified form. Every existing site hands over `error.to_string()`, so this is the only point at which an ENOSPC is still recoverable.

`From<io::Error>` is deliberately **not** added — that is #11134 and needs its own migration.

Also classifies `SQLITE_FULL` (and `SQLITE_IOERR` carrying the OS text) in the observation store's `sqlite_error`. The store is the writer whose failure produced the deadlock.

Storage exhaustion is reported non-retryable, exits `20` (operational, not internal), and its hints name the **store-independent** cleanup categories rather than plain `homeboy cleanup --apply` — which is the loop #10603 could not escape.

### 2. Store-free degraded cleanup

New `cleanup::degraded`:

- `observation_store_availability()` — one probe per sweep, distinguishing "out of capacity" from "corrupt database" so an unrelated fault is never laundered into a capacity story.
- `degraded_cleanup()` — runs the store-independent categories in process, never opening the database and never contacting the daemon. It cannot return `Err`: a degraded pass is the last recovery path, so one failing category must not take the others down.

`RunnerDownloadCleanupOptions::store_available` lets a caller that has already probed reach the same fail-closed verdict without a second failing open. Defaults to `true`, so an unprobed caller is never silently downgraded into retaining everything.

In the CLI, `cleanup_inventory` probes once and reports database-backed categories as skipped carrying the store's own error code, and `--apply` falls back to an in-process degraded sweep when the durable submission fails. That fallback is deliberately narrow — it triggers only on **positively identified** storage exhaustion, so a daemon that is merely down still surfaces its own error rather than silently becoming a partial sweep.

### 3. Capacity preflight

`capacity::preflight_capacity(path, subject, reserve)` over the existing `disk_budget`, with a deliberately lopsided ladder:

| status | trigger | blocks? |
| --- | --- | --- |
| `Exhausted` | a **measured** value is exactly zero | yes |
| `Warning` | below a configured reserve | no |
| `Unknown` | not measurable (no inode accounting, failed `statvfs`) | no |

Only a definite zero blocks. Inodes are checked independently of bytes, because a byte-only test reads `ok` at 34 GB free with zero inodes. `CapacityReserve::from_retention` reads the two keys that already exist and are already default-on — no new threshold is invented.

Wired into artifact publication — all three paths that stage bytes under the artifact root. That is the last moment before homeboy writes potentially very large files, and a copy that dies partway through ENOSPC leaves a `.artifact-<uuid>.staging` sibling behind: the exact crash residue `cleanup_orphaned_artifact_bytes` exists to reap.

Also stops discarding a failed WAL upgrade in `store/schema.rs`. `let _ = pragma_update(...)` left the store in rollback-journal mode with materially different concurrency behaviour and nobody told, so the next `observation_store.busy` report had no way to reach its own cause. Still best effort, but it now says so once per process, naming the pragma and the consequence. `PRAGMA foreign_keys` is untouched — that is #11129.

## Are the three categories really store-independent?

**No — and the difference matters.** This was the main surprise. Their docstrings were read directly rather than trusted:

| category | behaviour with the store shut | reclaims? |
| --- | --- | --- |
| `orphaned_artifact_bytes` | genuinely store-free; documents that the database is *deliberately* never consulted, because the paths it reaps never get a row | **yes** |
| `runtime_tmp` | store-free *in effect* — its one store read (`inspection_owner_protection`) fails **open**; its real liveness signals (pin owner PID, invocation lease) are filesystem-local | **yes** |
| `runner_downloads` | store **tolerant**, not store-independent — `LivenessVeto::read` returning `running: None` vetoes *every* candidate by design, because these bytes are the operator's copy of something they asked for | **no — exactly zero** |

So the degraded outcome carries `reclaims_without_store` per category. Reporting `runner-downloads`' zero exactly like the others would misread a structural limit as an empty result.

## Deferred

**Build and Lab offload materialization preflights.** `homeboy build` has four dispatch paths (`build::run`, `run_components_with_changed_since`, `run_component_with_changed_since`, and the `--all` fan-out) with the actual materialization living in extensions; `lab_offload.rs` is provider registration, with materialization in `homeboy-lab-runner`. Neither has a single entry point that could be gated with confidence, and the brief said to defer rather than guess at call sites. Artifact publication was identified with confidence and is wired.

Not touched, deliberately: `From<io::Error>` (#11134), `PRAGMA foreign_keys` (#11129).

## Testing

Hermetic unit tests throughout:

- `homeboy-error` — typed and stringified ENOSPC classification, SQLite phrasing, non-retryable, hints naming the store-independent remedy, capacity evidence serialization, and that an ordinary IO failure stays generic. All 13 run locally and pass.
- `cleanup::degraded` — a degraded sweep plans every category **and the observation database file does not exist afterwards**, which is a direct proof that no store was opened. Plus: a corrupt-database fault is not laundered into exhaustion, and only the categories that can reclaim claim to.
- `runner_downloads` — `store_available: false` routed through the real production `sweep` reaches the fail-closed verdict with no open reachable at all.
- `capacity` — the full ladder, including the 34-GB-free/zero-inode case and the "unmeasurable never blocks" case.
- `store/schema` — a healthy connection takes both pragmas and reports no warning; a failure becomes an actionable message.
- `store/artifacts` — the preflight admits a healthy filesystem and resolves a target whose directory does not exist yet.

`cargo fmt` clean. `cargo check -p homeboy-error --lib`, `-p homeboy-core --lib`, and `-p homeboy-cli --lib` all exit 0. Heavier compilation left to CI per the VPS build constraint.

Refs #10603, #11031, #11151. Companion: #11134, #11129.
