### PR TITLE
fix(test): complete reverse broker receipt fixture

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -150,7 +150,7 @@ impl HermeticTestContext {
             // share them without sharing mutable Homeboy state.
             .env(
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_STORE_ENV,
-                test_controller_runtime_store(),
+                shared_controller_runtime_store(),
             );
         command
     }
@@ -634,7 +634,9 @@ fn test_controller_fixture(binary: TestBinary) -> PathBuf {
         .join("homeboy-controller-fixture")
 }
 
-fn test_controller_runtime_store() -> &'static Path {
+/// Return the process-wide immutable controller-runtime pin store for tests
+/// that spawn controller subprocesses outside `controller_runtime_command`.
+pub fn shared_controller_runtime_store() -> &'static Path {
     SHARED_CONTROLLER_RUNTIME_STORE
         .get_or_init(exec_capable_tempdir)
         .path()
@@ -1240,6 +1242,16 @@ fn handle_reverse_broker_request(
                 .map(|event| json!({ "event": event })),
             "heartbeat" => store
                 .renew_remote_runner_claim(job_id, runner_id, claim_id, 30_000)
+                .map(|job| json!({ "job": job })),
+            "consume" => store
+                .consume_remote_runner_execution(
+                    job_id,
+                    runner_id,
+                    claim_id,
+                    request.body["context_id"]
+                        .as_str()
+                        .expect("broker execution context id"),
+                )
                 .map(|job| json!({ "job": job })),
             "finish" => store
                 .finish_remote_runner_job(

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -58,7 +58,7 @@ fn contradictory_cook_arguments_survive_controller_transport_context() {
     let cook = |args: &[&str]| {
         let context = HermeticTestContext::new();
         context
-            .controller_runtime_command(TestBinary::HomeboyFixture)
+            .command(TestBinary::HomeboyFixture)
             .env(
                 homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV,
                 r#"{"runner_id":"homeboy-lab"}"#,

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -190,6 +190,12 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
         "HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY",
         homeboy_core::build_identity::current().display,
     );
+    // The daemon, submitting CLI, and detached worker all pin the same
+    // immutable controller binary while retaining independent mutable state.
+    std::env::set_var(
+        "HOMEBOY_TEST_CONTROLLER_RUNTIME_STORE",
+        homeboy_core::test_support::shared_controller_runtime_store(),
+    );
     ledger.mark("hermetic_context");
     let broker = ReverseBrokerFixture::start("lab");
     let (_checkout_guard, checkout) =


### PR DESCRIPTION
## Summary\n\nCompletes the reverse-broker fixture's authenticated execution-receipt endpoint and shares immutable controller-runtime pins across the detached reverse Cook lifecycle test.\n\n## Root Cause\n\n#11185 was merged before its final Test job reconciled a 1500-second candidate timeout. The retained artifact identified : its subprocesses did not inherit the shared controller runtime store, repeatedly pinning the debug binary. Once that path is exercised quickly, the fixture was also missing , which correctly caused the production finish guard to reject an unconsumed receipt.\n\n## Verification\n\n- \n- 
running 1 test
phase timings (seconds):
  hermetic_context: 0.29
  git_fixtures: 1.24
  daemon_ready: 1.86
  server_and_runner_configured: 0.21
  detached_cook_cli: 7.22
  controller_enqueued_reverse_job: 4.52
  reverse_worker_first_wave: 11.63
  reverse_worker_duplicate_wave: 0.01
  controller_terminal_projection: 2.64
  TOTAL: 29.65
test pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_lifecycle ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 29.69s\n- 
running 1 test
test worker::tests::worker_tests::reverse_worker_restart_cannot_replay_a_consumed_receipt_and_keeps_context_evidence ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1567 filtered out; finished in 0.37s\n- 
running 54 tests
test api_jobs::tests::part_b::remote_runner_job_submit_targets_runner_and_project ... ok
test api_jobs::tests::part_b::remote_runner_submission_lookup_is_non_mutating ... ok
test api_jobs::tests::part_b::remote_runner_submission_key_concurrent_replay_creates_one_job ... ok
test api_jobs::tests::part_c::cancelled_remote_runner_job_cannot_be_claimed ... ok
test api_jobs::tests::part_c::expired_remote_runner_claims_are_reconciled_as_failed ... ok
test api_jobs::tests::part_c::remote_runner_context_rejects_expired_or_different_durable_claims ... ok
test api_jobs::tests::part_c::remote_runner_claim_heartbeat_extends_matching_unexpired_claim ... ok
test api_jobs::tests::part_c::remote_runner_claim_rejects_workers_without_the_context_protocol ... ok
test api_jobs::tests::part_c::remote_runner_execution_receipt_is_one_time_and_revalidates_the_live_claim ... ok
test api_jobs::tests::part_c::remote_runner_claim_heartbeat_rejects_wrong_or_expired_claim ... ok
test api_jobs::tests::part_b::remote_runner_job_env_is_scoped_to_submitted_job ... ok
test api_jobs::tests::part_c::remote_runner_job_claim_can_be_filtered_by_project ... ok
test api_jobs::tests::part_c::remote_runner_job_enqueue_persists_run_ref_metadata ... ok
test api_jobs::tests::part_b::remote_runner_submission_key_conflicts_on_all_execution_semantic_inputs ... ok
test api_jobs::tests::part_c::remote_runner_job_writes_require_matching_claim_id ... ok
test api_jobs::tests::part_c::remote_runner_job_writes_reject_expired_claims ... ok
test api_jobs::tests::part_c::remote_runner_job_failed_result_records_error_and_terminal_state ... ok
test api_jobs::tests::part_c::remote_runner_legacy_claims_remain_available_only_for_context_free_jobs ... ok
test api_jobs::tests::part_c::remote_runner_job_claim_respects_concurrency_limit ... ok
test api_jobs::tests::part_c::remote_runner_job_result_records_terminal_state_and_artifacts ... ok
test api_jobs::tests::part_c::running_remote_runner_job_can_be_cancelled_by_broker ... ok
test artifact_address::tests::remote_runner_refs_are_reviewer_visible_tokens ... ok
test daemon::daemon_test::remote_runner_broker_refuses_inline_secret_env_without_persisting_it ... ok
test api_jobs::tests::part_c::remote_runner_result_observation_details_are_additive_and_validate_declared_runs ... ok
test daemon::daemon_test::routes_remote_runner_job_broker_lifecycle ... ok
test api_jobs::tests::part_c::remote_runner_claim_persists_and_requires_authenticated_execution_context ... ok
test daemon::daemon_test::routes_remote_runner_job_updates_require_live_matching_claim_id ... ok
test api_jobs::tests::part_c::remote_runner_job_claim_returns_oldest_matching_job ... ok
test api_jobs::tests::part_b::remote_runner_job_rejects_inline_secret_env_before_durable_persistence ... ok
test api_jobs::tests::part_c::durable_remote_runner_restart_failure_moves_to_stale_runner_jobs ... ok
test api_jobs::tests::part_c::remote_runner_jobs_persist_request_and_claim_state ... ok
test api_jobs::tests::part_b::remote_runner_submission_key_concurrent_independent_stores_create_one_job ... ok
test api_jobs::tests::part_c::remote_runner_context_evidence_survives_controller_restart ... ok
test daemon::remote_runner::auth_tests::artifact_routes_require_the_owning_work_bearer_and_preserve_not_found ... ok
test api_jobs::tests::part_b::remote_runner_submission_key_replays_one_redacted_durable_job ... ok
test daemon::remote_runner::auth_tests::broker_artifact_content_path_returns_worker_mirrored_bytes ... ok
test daemon::remote_runner::auth_tests::broker_retains_every_declared_run_artifact_after_reverse_worker_completion ... ok
test daemon::remote_runner::auth_tests::context_claim_finish_requires_a_matching_consumed_receipt ... ok
test api_jobs::tests::part_b::remote_runner_submission_key_survives_restart_and_rejects_conflicts ... ok
test api_jobs::tests::part_b::remote_runner_submit_and_claim_roll_back_after_a_durable_write_failure ... ok
test daemon::remote_runner::auth_tests::paired_runner_can_register_claim_progress_and_finish ... ok
test daemon::remote_runner::auth_tests::run_detail_rejects_a_valid_token_for_a_different_runner ... ok
test api_jobs::tests::part_b::remote_runner_submission_retry_preserves_concurrent_claim ... ok
test daemon::remote_runner::auth_tests::run_detail_rejects_an_invalid_bearer_token ... ok
test daemon::remote_runner::auth_tests::run_detail_reports_malformed_persisted_details_as_a_server_error ... ok
test daemon::remote_runner::auth_tests::run_detail_requires_a_bearer_token ... ok
test api_jobs::tests::part_b::remote_runner_submission_terminal_replay_returns_original_projection_without_progress ... ok
test daemon::remote_runner::auth_tests::run_detail_returns_not_found_for_a_missing_job_or_run ... ok
test daemon::remote_runner::auth_tests::run_detail_returns_typed_details_to_the_owning_runner ... ok
test daemon::remote_runner::auth_tests::submit_token_reads_its_own_job_but_not_another_runners_job ... ok
test daemon::remote_runner::auth_tests::unauthenticated_broker_route_is_rejected ... ok
test daemon::remote_runner::auth_tests::work_token_cannot_submit_jobs ... ok
test daemon::remote_runner::auth_tests::wrong_runner_id_cannot_claim_anothers_jobs ... ok
test daemon::remote_runner::auth_tests::wrong_runner_id_cannot_finish_anothers_job ... ok

test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 2077 filtered out; finished in 0.43s\n- \n\n## AI Assistance\n\nOpenAI GPT-5.6 Terra via OpenCode investigated the retained CI artifact, implemented the test-fixture correction, and ran the listed verification. Chris Huber remains responsible for every line.