### PR TITLE
fix(error): add io/json From impls and a cause chain, and stop discarding the errno at five deploy sites

### DIFF
--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -331,6 +331,7 @@ fn identity_error(message: &str, details: serde_json::Value) -> crate::error::Er
         details,
         hints: Vec::new(),
         retryable: Some(false),
+        source: None,
     }
 }
 

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -615,9 +615,35 @@ pub struct SshIdentityFileNotFoundDetails {
     pub identity_file: String,
 }
 
-/// Serialize a details struct to JSON Value, falling back to empty object on failure.
+/// Present in `details` when the details struct itself failed to serialize.
+///
+/// A consumer that finds this key is reading an error whose evidence was lost
+/// in transit, and should say so rather than reporting "no details".
+pub const DETAILS_SERIALIZATION_ERROR_KEY: &str = "_homeboy_details_serialization_error";
+
+/// Serialize a details struct to a JSON `Value`, reporting its own failures.
+///
+/// This used to swallow the error and return an empty object, which is
+/// indistinguishable from an error that legitimately carries no details — so a
+/// details struct that could not serialize produced a *silently* evidence-free
+/// error, and the reason was gone. Now the failure lands in the payload under
+/// [`DETAILS_SERIALIZATION_ERROR_KEY`].
+///
+/// Still infallible on purpose: this runs while an error is being constructed,
+/// frequently on a failure path, and panicking or returning a `Result` here
+/// would replace a reportable problem with an unreportable one.
 fn to_details(details: impl Serialize) -> Value {
-    serde_json::to_value(details).unwrap_or_else(|_| Value::Object(serde_json::Map::new()))
+    match serde_json::to_value(details) {
+        Ok(value) => value,
+        Err(error) => {
+            let mut map = serde_json::Map::new();
+            map.insert(
+                DETAILS_SERIALIZATION_ERROR_KEY.to_string(),
+                Value::String(error.to_string()),
+            );
+            Value::Object(map)
+        }
+    }
 }
 
 impl Error {
@@ -1772,6 +1798,77 @@ mod conversion_tests {
         );
 
         assert_eq!(error.details["context"], "read deployment provider policy");
+    }
+}
+
+/// A details struct that fails to serialize must not look like an error that
+/// simply had no details (#11134).
+#[cfg(test)]
+mod details_serialization_tests {
+    use super::*;
+
+    /// Serialization fails the way a real details struct fails: a map keyed by
+    /// something JSON cannot use as an object key.
+    struct UnserializableDetails;
+
+    impl Serialize for UnserializableDetails {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            use serde::ser::SerializeMap;
+            let mut map = serializer.serialize_map(Some(1))?;
+            map.serialize_key(&[1u8, 2, 3])?;
+            map.serialize_value(&"value")?;
+            map.end()
+        }
+    }
+
+    #[test]
+    fn a_details_struct_that_cannot_serialize_says_so_instead_of_vanishing() {
+        let details = to_details(UnserializableDetails);
+
+        let object = details.as_object().expect("object details");
+        assert_eq!(
+            object.len(),
+            1,
+            "a failure must not be indistinguishable from an empty object"
+        );
+        let reported = object[DETAILS_SERIALIZATION_ERROR_KEY]
+            .as_str()
+            .expect("the serialization failure is reported as a string");
+        assert!(!reported.is_empty(), "the reason must survive");
+    }
+
+    /// The marker only appears on failure — an error with genuinely no details
+    /// must stay a clean empty object.
+    #[test]
+    fn a_successful_serialization_carries_no_failure_marker() {
+        let error = Error::internal_unexpected("plain");
+
+        assert!(!error
+            .details
+            .as_object()
+            .expect("object details")
+            .contains_key(DETAILS_SERIALIZATION_ERROR_KEY));
+        assert_eq!(
+            to_details(serde_json::json!({})),
+            Value::Object(serde_json::Map::new())
+        );
+    }
+
+    /// Construction must survive the failure: this runs on a failure path, so
+    /// replacing a reportable error with a panic would be strictly worse.
+    #[test]
+    fn constructing_an_error_survives_a_failed_details_serialization() {
+        let error = Error::new(
+            ErrorCode::InternalUnexpected,
+            "fixture",
+            to_details(UnserializableDetails),
+        );
+
+        assert_eq!(error.code, ErrorCode::InternalUnexpected);
+        assert!(error.details[DETAILS_SERIALIZATION_ERROR_KEY].is_string());
     }
 }
 

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -281,6 +281,25 @@ pub struct Error {
     pub details: Value,
     pub hints: Vec<Hint>,
     pub retryable: Option<bool>,
+    /// The error this one was built from, when the constructor had it.
+    ///
+    /// `code`/`message`/`details` are homeboy's *reported* view of a failure:
+    /// stable, structured, and safe to render. This is the original value,
+    /// kept so `std::error::Error::source` can walk the chain and so a caller
+    /// can downcast to (for example) `io::Error` to read an `ErrorKind`
+    /// instead of pattern-matching a rendered string.
+    ///
+    /// `Arc` rather than `Box` because `Error` is `Clone`, and a boxed trait
+    /// object is not. Clones therefore share one source, which is correct:
+    /// the cause is a fact about the failure, not about a copy of the report.
+    ///
+    /// Deliberately not serialized. `Error` is projected into
+    /// `homeboy/command-result/v3` envelopes field by field — it derives
+    /// neither `Serialize` nor `Deserialize` — so the wire contract is
+    /// unchanged and a round-tripped error simply has no source. Anything an
+    /// operator or a machine consumer must see belongs in `details`, which is
+    /// serialized; this field is for in-process inspection.
+    pub source: Option<std::sync::Arc<dyn std::error::Error + Send + Sync>>,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -291,7 +310,13 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| &**source as &(dyn std::error::Error + 'static))
+    }
+}
 
 /// Let `?` carry a real `io::Error` instead of forcing a manual stringify.
 ///
@@ -306,7 +331,7 @@ impl std::error::Error for Error {}
 /// least resistance again.
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {
-        Self::from_io_error(&error, None)
+        Self::from_io_error(&error, None).with_source(error)
     }
 }
 
@@ -317,7 +342,7 @@ impl From<std::io::Error> for Error {
 /// storage exhaustion) rather than as a JSON failure.
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
-        Self::from_json_error(&error, None)
+        Self::from_json_error(&error, None).with_source(error)
     }
 }
 
@@ -654,7 +679,18 @@ impl Error {
             details,
             hints: Vec::new(),
             retryable: None,
+            source: None,
         }
+    }
+
+    /// Attach the error this one was built from.
+    ///
+    /// Additive: it changes neither `code`, `message`, nor `details`, so the
+    /// reported contract is untouched and only `std::error::Error::source`
+    /// (and downcasting) gain anything.
+    pub fn with_source(mut self, source: impl std::error::Error + Send + Sync + 'static) -> Self {
+        self.source = Some(std::sync::Arc::new(source));
+        self
     }
 
     /// A write failed, or was refused, because the filesystem has no capacity.
@@ -1786,6 +1822,101 @@ mod conversion_tests {
             .as_str()
             .expect("io error text")
             .contains("provider closed stdin"));
+    }
+
+    /// `source()` is what lets a caller reach the typed cause instead of
+    /// re-parsing a rendered string (#11134).
+    #[test]
+    fn the_question_mark_conversion_exposes_the_cause_through_source() {
+        use std::error::Error as _;
+
+        let error = io_via_question_mark(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "keyfile is not readable",
+        ))
+        .expect_err("io failure converts");
+
+        let source = error.source().expect("the cause is reachable");
+        assert!(source.to_string().contains("keyfile is not readable"));
+    }
+
+    /// The point of keeping the *typed* cause rather than its text: a caller
+    /// can read an `ErrorKind` instead of matching on a message.
+    #[test]
+    fn the_cause_can_be_downcast_back_to_the_original_io_error() {
+        use std::error::Error as _;
+
+        let error = Error::from(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+
+        let cause = error
+            .source()
+            .expect("cause")
+            .downcast_ref::<std::io::Error>()
+            .expect("the original io error survives");
+        assert_eq!(cause.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn a_json_conversion_also_carries_its_cause() {
+        use std::error::Error as _;
+
+        let error = json_via_question_mark("{ not json").expect_err("syntax failure converts");
+
+        assert!(error
+            .source()
+            .expect("cause")
+            .downcast_ref::<serde_json::Error>()
+            .is_some());
+    }
+
+    /// An error built without a cause must report none, not an empty stand-in.
+    #[test]
+    fn an_error_constructed_without_a_cause_reports_no_source() {
+        use std::error::Error as _;
+
+        assert!(Error::internal_unexpected("no cause").source().is_none());
+    }
+
+    /// `Error` is `Clone`, so the source is `Arc`-shared rather than boxed.
+    /// A clone must still see the cause.
+    #[test]
+    fn cloning_an_error_preserves_its_cause() {
+        use std::error::Error as _;
+
+        let error = Error::from(std::io::Error::from(std::io::ErrorKind::StorageFull));
+        let clone = error.clone();
+
+        assert!(clone.source().is_some());
+        assert_eq!(clone.code, ErrorCode::StorageExhausted);
+    }
+
+    /// Attaching a cause must not disturb the reported contract, which is what
+    /// every consumer and every envelope actually reads.
+    #[test]
+    fn attaching_a_cause_does_not_change_the_reported_contract() {
+        let plain = Error::internal_io("boom", Some("context".to_string()));
+        let sourced = Error::internal_io("boom", Some("context".to_string()))
+            .with_source(std::io::Error::from(std::io::ErrorKind::NotFound));
+
+        assert_eq!(plain.code, sourced.code);
+        assert_eq!(plain.message, sourced.message);
+        assert_eq!(plain.details, sourced.details);
+        assert_eq!(plain.retryable, sourced.retryable);
+    }
+
+    /// The cause is in-process state, not wire state. `Error` derives no
+    /// serde impls, so the envelope projection is unchanged by definition —
+    /// this pins that `details` (which *is* serialized) stays clean.
+    #[test]
+    fn the_cause_does_not_leak_into_the_serialized_details() {
+        let error = Error::from(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "secret-path-detail",
+        ));
+
+        let details = error.details.as_object().expect("object details");
+        assert!(!details.contains_key("source"));
+        assert!(!details.contains_key("cause"));
     }
 
     /// `?` cannot attach context, so the contextful constructors must stay the

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -293,6 +293,34 @@ impl std::fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
+/// Let `?` carry a real `io::Error` instead of forcing a manual stringify.
+///
+/// Routed through [`Error::from_io_error`] on purpose: that is where #11188's
+/// storage-exhaustion classification lives, and a conversion that bypassed it
+/// would silently re-collapse every `ENOSPC` back into `internal.io_error`.
+///
+/// The conversion cannot attach context — `?` has nowhere to put it — so a
+/// site that knows which file or which operation failed should still call
+/// [`Error::from_io_error`] with a context string. This impl exists so that
+/// *discarding the error entirely* (`.map_err(|_| ...)`) is never the path of
+/// least resistance again.
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Self::from_io_error(&error, None)
+    }
+}
+
+/// Let `?` carry a real `serde_json::Error`.
+///
+/// Delegates to [`Error::from_json_error`], so a serialization failure that is
+/// really a failed *write* is reported as an IO failure (and classified for
+/// storage exhaustion) rather than as a JSON failure.
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::from_json_error(&error, None)
+    }
+}
+
 #[derive(Debug, Serialize)]
 
 pub struct NotFoundDetails {
@@ -476,10 +504,11 @@ pub fn io_error_is_storage_exhausted(error: &std::io::Error) -> bool {
 /// Whether an already-stringified io/SQLite error reports exhausted storage.
 ///
 /// Most homeboy call sites stringify an `io::Error` before it ever reaches this
-/// crate — `Error::internal_io` takes `impl Into<String>`, and there is no
-/// `From<io::Error>` yet (#11134) — so the typed classifier above cannot see
-/// them. These markers are the stable operating-system and SQLite renderings of
-/// a filesystem that cannot accept another byte or another inode.
+/// crate — `Error::internal_io` takes `impl Into<String>`, and the typed
+/// [`From<std::io::Error>`] conversion added in #11134 only covers sites that
+/// have been migrated onto `?` — so the typed classifier above cannot see them.
+/// These markers are the stable operating-system and SQLite renderings of a
+/// filesystem that cannot accept another byte or another inode.
 pub fn message_reports_storage_exhaustion(message: &str) -> bool {
     const MARKERS: &[&str] = &[
         "no space left on device",
@@ -638,15 +667,38 @@ impl Error {
 
     /// Classify a live `io::Error`, keeping storage exhaustion distinguishable.
     ///
-    /// Deliberately *not* a `From<io::Error>` impl. Adding that conversion is
-    /// its own migration across ~1500 call sites and is tracked separately
-    /// (#11134); this constructor exists so the sites that matter can classify
-    /// today without waiting for it.
+    /// This is the contextful form. [`From<std::io::Error>`] delegates here
+    /// with `None`, so every conversion — explicit or via `?` — goes through
+    /// the same ENOSPC classification (#11188). Prefer this constructor
+    /// wherever the call site knows *what it was doing*: a bare `?` yields a
+    /// correctly coded error with no operation attached, which is enough to
+    /// act on but not enough to locate.
     pub fn from_io_error(error: &std::io::Error, context: Option<String>) -> Self {
         if io_error_is_storage_exhausted(error) {
             return Self::storage_exhausted(error.to_string(), context);
         }
         Self::internal_io(error.to_string(), context)
+    }
+
+    /// Classify a `serde_json` failure, keeping storage exhaustion visible.
+    ///
+    /// `serde_json`'s writer-side entry points (`to_writer`,
+    /// `to_writer_pretty`) wrap the underlying `io::Error` rather than
+    /// returning it, so a full filesystem reaches a caller as a
+    /// `serde_json::Error`. Reporting that as `internal.json_error` is how a
+    /// disk-full write comes to look like malformed JSON — the exact
+    /// misdirection #10603 was diagnosed through. Io-category failures are
+    /// therefore routed to [`Error::internal_io`], which carries #11188's
+    /// ENOSPC classification; only genuine syntax/data/EOF failures stay
+    /// `internal.json_error`.
+    pub fn from_json_error(error: &serde_json::Error, context: Option<String>) -> Self {
+        if error.is_io() {
+            if error.io_error_kind() == Some(std::io::ErrorKind::StorageFull) {
+                return Self::storage_exhausted(error.to_string(), context);
+            }
+            return Self::internal_io(error.to_string(), context);
+        }
+        Self::internal_json(error.to_string(), context)
     }
 
     /// Whether this error reports an out-of-capacity filesystem.
@@ -1581,6 +1633,145 @@ mod storage_exhaustion_tests {
         assert!(!details.contains_key("available_bytes"));
         assert!(!details.contains_key("reserve_inodes"));
         assert!(!details.contains_key("context"));
+    }
+}
+
+/// `?` must be able to carry a real error, and must not lose the #11188
+/// storage classification on the way through (#11134).
+#[cfg(test)]
+mod conversion_tests {
+    use super::*;
+
+    fn io_via_question_mark(error: std::io::Error) -> Result<()> {
+        Err(error)?;
+        Ok(())
+    }
+
+    fn json_via_question_mark(text: &str) -> Result<Value> {
+        Ok(serde_json::from_str(text)?)
+    }
+
+    /// A writer that fails the way a full or severed destination fails.
+    ///
+    /// Used instead of `serde_json::Error::io`, which is `#[doc(hidden)]` and
+    /// documented as "Not public API". This produces a genuine io-category
+    /// `serde_json::Error` through the same public path production code takes.
+    struct FailingWriter {
+        kind: std::io::ErrorKind,
+        message: &'static str,
+    }
+
+    impl std::io::Write for FailingWriter {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(self.kind, self.message))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn json_write_failure(kind: std::io::ErrorKind, message: &'static str) -> serde_json::Error {
+        serde_json::to_writer(
+            FailingWriter { kind, message },
+            &serde_json::json!({ "payload": true }),
+        )
+        .expect_err("the writer always fails")
+    }
+
+    /// The whole point: a bare `?` keeps the errno-derived text that
+    /// `.map_err(|_| ...)` throws away.
+    #[test]
+    fn the_question_mark_conversion_preserves_the_underlying_io_message() {
+        let error = io_via_question_mark(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "keyfile is not readable",
+        ))
+        .expect_err("io failure converts");
+
+        assert_eq!(error.code, ErrorCode::InternalIoError);
+        assert!(
+            error.details["error"]
+                .as_str()
+                .expect("io error text")
+                .contains("keyfile is not readable"),
+            "{:?}",
+            error.details
+        );
+    }
+
+    /// A conversion that bypassed `from_io_error` would re-collapse ENOSPC
+    /// into `internal.io_error` and undo #11188 everywhere `?` is used.
+    #[test]
+    fn the_question_mark_conversion_still_classifies_storage_exhaustion() {
+        let error = io_via_question_mark(std::io::Error::from(std::io::ErrorKind::StorageFull))
+            .expect_err("storage failure converts");
+
+        assert_eq!(error.code, ErrorCode::StorageExhausted);
+        assert!(error.is_storage_exhausted());
+        assert_eq!(error.retryable, Some(false));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_raw_enospc_survives_the_question_mark_conversion() {
+        let error = io_via_question_mark(std::io::Error::from_raw_os_error(ENOSPC))
+            .expect_err("enospc converts");
+
+        assert!(error.is_storage_exhausted());
+    }
+
+    #[test]
+    fn a_json_syntax_failure_converts_to_a_json_error() {
+        let error = json_via_question_mark("{ not json").expect_err("syntax failure converts");
+
+        assert_eq!(error.code, ErrorCode::InternalJsonError);
+        assert!(!error.details["error"]
+            .as_str()
+            .expect("json error text")
+            .is_empty());
+    }
+
+    /// `serde_json::to_writer` on a full disk returns a `serde_json::Error`
+    /// wrapping the `io::Error`. Calling that "JSON error" is how a disk-full
+    /// deploy gets misread as malformed payload.
+    #[test]
+    fn a_json_error_wrapping_a_full_disk_is_reported_as_storage_exhaustion() {
+        let wrapped =
+            json_write_failure(std::io::ErrorKind::StorageFull, "no space left on device");
+
+        assert!(wrapped.is_io(), "expected an io-category json error");
+        let error = Error::from(wrapped);
+
+        assert_eq!(error.code, ErrorCode::StorageExhausted);
+        assert!(error.is_storage_exhausted());
+    }
+
+    /// An io-category `serde_json::Error` is a failed write, not bad JSON.
+    #[test]
+    fn a_json_error_wrapping_an_ordinary_io_failure_is_reported_as_an_io_error() {
+        let wrapped = json_write_failure(std::io::ErrorKind::BrokenPipe, "provider closed stdin");
+
+        let error = Error::from_json_error(&wrapped, Some("write provider input".to_string()));
+
+        assert_eq!(error.code, ErrorCode::InternalIoError);
+        assert_eq!(error.details["context"], "write provider input");
+        assert!(error.details["error"]
+            .as_str()
+            .expect("io error text")
+            .contains("provider closed stdin"));
+    }
+
+    /// `?` cannot attach context, so the contextful constructors must stay the
+    /// preferred form for sites that know which operation failed.
+    #[test]
+    fn the_contextful_constructor_records_what_the_caller_was_doing() {
+        let error = Error::from_io_error(
+            &std::io::Error::from(std::io::ErrorKind::NotFound),
+            Some("read deployment provider policy".to_string()),
+        );
+
+        assert_eq!(error.details["context"], "read deployment provider policy");
     }
 }
 

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -325,6 +325,7 @@ mod tests {
                 details: json!({ "http_status": 404 }),
                 hints: Vec::new(),
                 retryable: None,
+                source: None,
             };
             record_evicted_evidence_loss(&store, &run, &error).expect("eviction recorded");
             let terminal = store.get_run(run_id).expect("read").expect("terminal run");

--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -433,7 +433,7 @@ pub(super) fn run_lint_stage(
         // fixers and skips its own validation pass (the engine validates
         // separately via the diagnose phase). Auto-fixing lives exclusively
         // under `homeboy refactor` — there is no other entry point.
-        let fix_output = (|| {
+        let fix_output = (|| -> std::result::Result<(), Error> {
             for route in &fix_routes {
                 let route_glob = lint_scope_glob(&root_str, &route.files);
                 build_lint_runner(route_glob.as_deref(), route.step.as_deref())?

--- a/crates/homeboy-release/src/deploy/provider.rs
+++ b/crates/homeboy-release/src/deploy/provider.rs
@@ -232,13 +232,27 @@ fn layered_provider_evidence(stdout: &str, expected_schema: &str) -> serde_json:
     }
 }
 
+/// What `layered_payload` was doing when a step failed.
+///
+/// Named rather than inlined because three of these steps used to emit the
+/// same literal — `"Could not prepare deployment provider input"` — which made
+/// a failure unattributable to a line. `distinct_payload_step_contexts` pins
+/// that they stay distinguishable (#11134).
+const ENCODE_POLICY_CONTEXT: &str =
+    "canonically encode the deployment provider policy for its digest";
+const CREATE_INPUT_CONTEXT: &str = "create the deployment provider input tempfile";
+#[cfg(unix)]
+const SECURE_INPUT_CONTEXT: &str = "restrict the deployment provider input tempfile to mode 0600";
+const WRITE_INPUT_CONTEXT: &str = "write the deployment provider payload to its input tempfile";
+const FLUSH_INPUT_CONTEXT: &str = "flush the deployment provider input tempfile";
+
 fn layered_payload(
     component: &Component,
     policy: &serde_json::Value,
     target: Option<&serde_json::Value>,
 ) -> Result<tempfile::NamedTempFile> {
     let policy_bytes = homeboy_engine_primitives::canonical_json::canonical_json_bytes(policy)
-        .map_err(|_| Error::internal_io("Could not serialize deployment provider policy", None))?;
+        .map_err(|error| Error::from_json_error(&error, Some(ENCODE_POLICY_CONTEXT.to_string())))?;
     let revision = clean_head_revision(component)?;
     let payload = serde_json::json!({
         "schema": homeboy_extension::DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA,
@@ -253,19 +267,28 @@ fn layered_payload(
         "target": target,
         "source": { "component": component.id, "revision": revision },
     });
+    // Each step below reports its own operation and hands over the real error.
+    // Discarding it with `|_|` cost the errno, the path, and the kind — which
+    // is how an out-of-space or read-only /tmp reached an operator as the
+    // unactionable sentence "Could not prepare deployment provider input".
+    // Routing through `from_io_error`/`from_json_error` also keeps #11188's
+    // ENOSPC classification, so a full disk here is `storage.exhausted` rather
+    // than a generic `internal.io_error` the caller cannot degrade on.
     let mut file = tempfile::NamedTempFile::new()
-        .map_err(|_| Error::internal_io("Could not prepare deployment provider input", None))?;
+        .map_err(|error| Error::from_io_error(&error, Some(CREATE_INPUT_CONTEXT.to_string())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         file.as_file()
             .set_permissions(std::fs::Permissions::from_mode(0o600))
-            .map_err(|_| Error::internal_io("Could not secure deployment provider input", None))?;
+            .map_err(|error| {
+                Error::from_io_error(&error, Some(SECURE_INPUT_CONTEXT.to_string()))
+            })?;
     }
     serde_json::to_writer(&mut file, &payload)
-        .map_err(|_| Error::internal_io("Could not prepare deployment provider input", None))?;
+        .map_err(|error| Error::from_json_error(&error, Some(WRITE_INPUT_CONTEXT.to_string())))?;
     file.flush()
-        .map_err(|_| Error::internal_io("Could not prepare deployment provider input", None))?;
+        .map_err(|error| Error::from_io_error(&error, Some(FLUSH_INPUT_CONTEXT.to_string())))?;
     Ok(file)
 }
 
@@ -362,12 +385,60 @@ fn repository_contract(component: &Component, contract: &str) -> Result<PathBuf>
 mod tests {
     use super::{
         layered_payload, layered_provider_evidence, repository_contract, run_if_configured,
-        validate_repository_policy,
+        validate_repository_policy, CREATE_INPUT_CONTEXT, ENCODE_POLICY_CONTEXT,
+        FLUSH_INPUT_CONTEXT, WRITE_INPUT_CONTEXT,
     };
     use crate::deploy::DeployConfig;
     use homeboy_core::component::{Component, DeploymentProviderAttachment};
+    use homeboy_core::error::Error;
     use homeboy_core::project::{Project, ProjectComponentAttachment};
     use std::process::Command;
+
+    /// Three of these steps used to emit the identical literal
+    /// `"Could not prepare deployment provider input"`, so a report named the
+    /// function but not the line (#11134).
+    #[test]
+    fn every_payload_step_reports_a_distinct_operation() {
+        let mut contexts = vec![
+            ENCODE_POLICY_CONTEXT,
+            CREATE_INPUT_CONTEXT,
+            WRITE_INPUT_CONTEXT,
+            FLUSH_INPUT_CONTEXT,
+        ];
+        #[cfg(unix)]
+        contexts.push(super::SECURE_INPUT_CONTEXT);
+
+        let total = contexts.len();
+        contexts.sort_unstable();
+        contexts.dedup();
+
+        assert_eq!(
+            contexts.len(),
+            total,
+            "payload steps must stay individually attributable: {contexts:?}"
+        );
+        assert!(contexts.iter().all(|context| !context.is_empty()));
+    }
+
+    /// `.map_err(|_| ...)` discarded the `io::Error` outright, so the report
+    /// carried no errno, no path, and no kind. The classifying constructors
+    /// must keep all of it alongside the operation.
+    #[test]
+    fn a_failed_payload_step_reports_the_underlying_io_error() {
+        let io_error = std::fs::File::create(
+            std::path::Path::new("/homeboy-nonexistent-root").join("provider-input"),
+        )
+        .expect_err("creating under a missing root fails");
+
+        let error = Error::from_io_error(&io_error, Some(CREATE_INPUT_CONTEXT.to_string()));
+
+        assert_eq!(error.details["context"], CREATE_INPUT_CONTEXT);
+        let reported = error.details["error"].as_str().expect("io error text");
+        assert!(
+            reported.contains("os error"),
+            "the errno must survive: {reported}"
+        );
+    }
 
     #[test]
     fn requires_a_repository_contained_contract_file() {

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -585,7 +585,7 @@ fn clear_path(path: &Path) -> Result<()> {
 fn contained_path(root: &Path, path: impl AsRef<Path>) -> Result<PathBuf> {
     let path =
         homeboy_paths::resolve_contained_local_path(root, path, "dependency_materialization")
-            .map_err(Into::into)?;
+            .map_err(Error::from)?;
     let root =
         fs::canonicalize(root).map_err(|error| io_error("resolve dependency workspace", error))?;
     let mut ancestor = path.as_path();

--- a/crates/homeboy-rig/src/local_artifact.rs
+++ b/crates/homeboy-rig/src/local_artifact.rs
@@ -97,7 +97,7 @@ pub fn register_current_run_artifact(
                 .as_ref()
                 .map(|context| (context.run_id.clone(), context.manifest_path.clone()))
         })
-        .map(Ok)
+        .map(Ok::<_, Error>)
         .unwrap_or_else(|| {
             Ok((
                 required_env(homeboy_core::observation::ACTIVE_RUN_ID_ENV)?,

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -206,7 +206,7 @@ pub fn run_upgrade_with_method(
                 // Validate before the release gate and any extension or runner
                 // work. A dirty source tree is never an acceptable controller.
                 prepare_source_workspace_for_upgrade(source_path)?;
-                Ok(source_upgrade_decision(
+                Ok::<_, Error>(source_upgrade_decision(
                     &target_version,
                     &target_identity,
                     source_path,


### PR DESCRIPTION
Found during the 2026-08-01 consolidation investigation (#11151). Companion to #11135.

Closes #11134.

## What was wrong

`homeboy_error::Error` had a bare `impl std::error::Error for Error {}`, no `From<std::io::Error>`, and no `From<serde_json::Error>`. There was no way to hand a real error to the type system, so every I/O failure had to be stringified by hand — and the cheapest expression that satisfies the borrow checker is the one that throws the error away:

```rust
.map_err(|_| Error::internal_io("Could not prepare deployment provider input", None))?;
```

`|_|` does not summarize the `io::Error`. It **destroys** it. No errno, no path, no `ErrorKind`, no `raw_os_error`. What reaches the operator is a fixed sentence that would be byte-identical whether `/tmp` was full, read-only, missing, or mounted `noexec`.

Five of these sit in one production function, `layered_payload` in `crates/homeboy-release/src/deploy/provider.rs`, and **three of the five emitted the same literal string** for three different operations:

| step | old message |
|---|---|
| `NamedTempFile::new()` | `Could not prepare deployment provider input` |
| `serde_json::to_writer(...)` | `Could not prepare deployment provider input` |
| `file.flush()` | `Could not prepare deployment provider input` |

So the report identified the *function* but not the *line*, and those three causes are not interchangeable — a missing TMPDIR, a serializer failure, and a failed flush want different responses.

Separately, `to_details()` was `serde_json::to_value(details).unwrap_or_else(|_| {})`. A serialization failure produced an empty details object, **byte-for-byte identical to an error that legitimately carries no details**. The error still surfaced with the right code and message, and its evidence was silently gone.

## What landed

Four commits, one per part.

### 1. `From<io::Error>` and `From<serde_json::Error>` (`5244918a6`)

Both route through classifying constructors rather than building an `Error` directly, so **#11188's ENOSPC classification is preserved on the `?` path**:

- `From<io::Error>` → the existing `Error::from_io_error`, which checks `ErrorKind::StorageFull`, the raw errno, and the rendered message before falling back to `internal.io_error`. A conversion that bypassed it would silently re-collapse every ENOSPC back into a generic IO error, undoing #11188 everywhere `?` is used. Tested directly.
- `From<serde_json::Error>` → a new `Error::from_json_error`. This one is worth reading: **`serde_json::to_writer` wraps the underlying `io::Error` rather than returning it**, so a full filesystem reaches a caller as a `serde_json::Error`. Reporting that as `internal.json_error` is how a disk-full write comes to look like malformed JSON. Io-category failures now route to `internal_io` (and to `storage.exhausted` when the kind is `StorageFull`); only genuine syntax/data/EOF failures stay `internal.json_error`.

Neither impl can attach context — `?` has nowhere to put it — so `from_io_error`/`from_json_error` remain the preferred form where the call site knows which operation failed. The point of the impls is that *discarding the error is no longer the path of least resistance*.

### 2. Fixed the five `|_|` sites (`3065ad525`)

Each step now names its own operation via a named constant, and hands the real error to a classifying constructor. `every_payload_step_reports_a_distinct_operation` pins that the five stay pairwise distinct, so the three-identical-strings state cannot come back. `a_failed_payload_step_reports_the_underlying_io_error` asserts the errno survives into `details.error` — the specific thing `|_|` was throwing away.

This is also where the ENOSPC preservation pays off concretely: the payload tempfile lives in TMPDIR, which is exactly the filesystem #10603 and #11127 exhausted. A full disk here is now `storage.exhausted` (not retryable, with the store-independent cleanup hint) instead of a generic `internal.io_error` a caller cannot degrade on. Under the old closures that signal was destroyed before any classifier could see it.

### 3. `to_details` reports its own failures (`f542b20a1`)

The failure now lands in the payload under `DETAILS_SERIALIZATION_ERROR_KEY`, so a consumer can distinguish "this error has no details" from "this error's details did not survive, and here is why". Kept infallible on purpose: it runs while an error is being constructed, almost always on a failure path already, so panicking or returning a `Result` would replace a reportable problem with an unreportable one. The marker is additive and only present on failure — an error with genuinely no details still serializes as `{}`.

### 4. Cause chain (`d1a2f2fb6`)

`Error` now carries `Option<Arc<dyn std::error::Error + Send + Sync>>` and implements `source()`. The `From` impls attach it, so `?` gets the typed cause for free and a caller can downcast back to the original `io::Error` to read an `ErrorKind` — instead of substring-matching a rendered message, which is the technique `message_reports_storage_exhaustion` is still forced to use for the ~1500 already-stringified sites.

## The derive constraints, checked rather than assumed

The issue anticipated trouble with `Clone`, `PartialEq`, `Serialize`, and `Deserialize`. Against the real code:

- **`Arc`, not `Box`** — `Error` derives `Clone`, and a boxed trait object is not `Clone`. `Arc` is. Clones share one source, which is correct: the cause is a fact about the failure, not about a copy of the report. Pinned by `cloning_an_error_preserves_its_cause`.
- **No `#[serde(skip)]` was needed.** `Error` derives *neither* `Serialize` nor `Deserialize`. It is projected into `homeboy/command-result/v3` envelopes **field by field** (`err.code.as_str()`, `message`, `details`, `hints`) at each consumer. The wire contract is therefore untouched by construction, and a round-tripped error simply has no source. `the_cause_does_not_leak_into_the_serialized_details` pins that `details` — which *is* serialized — stays clean.
- **No `PartialEq` to preserve.** `Error` never derived it, and nothing in the workspace compares two `Error` values. The "preserve `PartialEq` while ignoring `source`" tradeoff never had to be made.
- `Debug` and `Clone` are both still derived, unchanged. `Error` remains `Send + Sync`.

`with_source` is additive — it touches neither `code`, `message`, nor `details`, so nothing reading the reported contract can observe it. `attaching_a_cause_does_not_change_the_reported_contract` pins that.

## Did the blanket `From` cause breakage?

Yes, but narrowly, and it is worth recording the exact shape.

There were **no pre-existing `From` impls for `Error` anywhere**, so nothing could conflict by duplicate impl. The real cost is inference: `?` requires `Error: From<_>`, and until now the reflexive `impl<T> From<T> for T` was the *only* candidate, so the error type was pinned for free. With three candidates, sites that relied on that pinning become ambiguous:

```
note: multiple `impl`s satisfying `homeboy_core::Error: From<_>` found:
        - impl From<serde_json::Error> for homeboy_core::Error;
        - impl From<std::io::Error> for homeboy_core::Error;
        - impl<T> From<T> for T;
```

That is **four sites workspace-wide**, all fixed with an explicit annotation and no behavior change:

- `homeboy-rig/src/dependency_materialization_cache.rs` — `.map_err(Into::into)` → `.map_err(Error::from)`
- `homeboy-rig/src/local_artifact.rs` — `.map(Ok)` → `.map(Ok::<_, Error>)`
- `homeboy-refactor/src/plan/sources/stages.rs` — annotated the immediately-invoked closure's return type
- `homeboy-upgrade/src/upgrade/helpers.rs` — `Ok(...)` → `Ok::<_, Error>(...)`

Four annotations is not wide breakage, so the impls were kept unscoped.

Adding a public field to `Error` also breaks struct-literal construction. Exactly two exist in the workspace — `homeboy-core`'s `identity_error` and a `homeboy-lab-runner` test fixture — both updated with `source: None`. The one functional-update site (`Error { details, ..base }` in `homeboy-engine-primitives`) needed no change.

## Scope

No repo-wide `.map_err` cleanup. This establishes the mechanism plus the one file that proves it. The other 47 `internal_io(..., None)` sites are follow-up.

## Notes against the issue text

Two details had drifted and are worth correcting for whoever picks up the follow-up:

- The issue says "~12 call sites pass `None`". The real count is **48** passing `None` out of 1500 `internal_io` calls. But only **5** use `|_|` and fully discard the error — and all five are the `provider.rs` ones fixed here. The `None`-passing sites are a much milder problem (missing context) than the `|_|` sites (destroyed evidence).
- The issue notes `Error` "is serialized ... a non-serializable field needs `#[serde(skip)]`". It has no serde derives at all; serialization is a manual per-consumer projection. That made part 2 substantially cheaper than budgeted.

One implementation note: the tests avoid `serde_json::Error::io`, which is `#[doc(hidden)]` and documented in-tree as "Not public API". Io-category `serde_json::Error` values are produced through a failing `std::io::Write`, i.e. the same public path production code takes.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo test -p homeboy-error` — **30 passed, 0 failed** (was 20 before this PR)
- `cargo check --lib` exit 0 on `homeboy-error`, `homeboy-core`, `homeboy-cli`, `homeboy-release`
- `cargo check --tests` exit 0 on `homeboy-release` and `homeboy-lab-runner` (neither has integration test binaries, so this is lib-under-`cfg(test)` only) to validate the test-module edits

Full build and test are left to CI per this host's build constraints.
