### PR TITLE
Modernize release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       verified-release-branch: ${{ steps.attach.outputs['release-branch'] }}
       verified-release-sha: ${{ steps.attach.outputs['release-sha'] }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_tag || github.sha }}
           fetch-depth: 0
@@ -130,7 +130,7 @@ jobs:
       - name: Restore failed release marker
         id: failure-cache
         if: inputs.release_tag == ''
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-last-failed
           key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
@@ -143,7 +143,7 @@ jobs:
       - name: Restore release recovery attempts
         id: recovery-attempts-cache
         if: inputs.release_tag == ''
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-recovery-attempts
           key: release-recovery-attempts-${{ github.ref_name }}-${{ github.run_id }}
@@ -357,7 +357,7 @@ jobs:
     # the oldest consumer runtime so recovery finalizers cannot require a newer GLIBC.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Recovery checks out an older release tag downstream, but the
           # finalizer must include the current recovery contract from main.
@@ -367,7 +367,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -380,7 +380,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: homeboy-binary
           path: target/release/homeboy
@@ -401,13 +401,13 @@ jobs:
     outputs:
       audit-result: ${{ steps.audit.outcome }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_tag || github.sha }}
           fetch-depth: 0
 
       - name: Download homeboy binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: homeboy-binary
           path: .homeboy-bin
@@ -422,7 +422,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
@@ -437,7 +437,6 @@ jobs:
           commands: review audit
           expected-commands: review audit,review lint,review test
           args: ${{ github.event.before && format('--profile=pr --changed-since {0}', github.event.before) || '--profile=pr' }}
-          autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   gate-lint:
@@ -448,13 +447,13 @@ jobs:
     if: needs.check.outputs.should-release == 'true' && needs.check.outputs.recovery-release != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_tag || github.sha }}
           fetch-depth: 0
 
       - name: Download homeboy binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: homeboy-binary
           path: .homeboy-bin
@@ -469,7 +468,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
@@ -481,7 +480,6 @@ jobs:
           commands: review lint
           expected-commands: review audit,review lint,review test
           args: ${{ github.event.before && format('--changed-since {0}', github.event.before) || '' }}
-          autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   gate-test:
@@ -496,13 +494,13 @@ jobs:
     env:
       HOMEBOY_TEST_TIMEOUT_SECONDS: '2700'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_tag || github.sha }}
           fetch-depth: 0
 
       - name: Download homeboy binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: homeboy-binary
           path: .homeboy-bin
@@ -517,7 +515,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
@@ -531,7 +529,6 @@ jobs:
           commands: review test
           expected-commands: review audit,review lint,review test
           args: ${{ github.event.before && format('--skip-lint --changed-since {0}', github.event.before) || '--skip-lint' }}
-          autofix: 'false'
           execution-timeout-seconds: '3000'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
@@ -558,7 +555,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workflow event commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
 
@@ -589,7 +586,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
@@ -598,7 +595,7 @@ jobs:
       # A push-triggered self-recovery has no `inputs.release_tag`, and main has
       # normally moved well past the stranded tag by now. Check out the tag
       # being recovered so every job in the publish chain agrees on the tree.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_tag || (needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag']) || github.sha }}
           fetch-depth: 0
@@ -753,7 +750,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs['release-tag'] }}
           persist-credentials: false
@@ -764,7 +761,7 @@ jobs:
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
 
       - name: Cache dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -869,7 +866,7 @@ jobs:
           fi
 
       - name: Upload dist-manifest.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -893,7 +890,7 @@ jobs:
         run: |
           git config --global core.longpaths true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs['release-tag'] }}
           persist-credentials: false
@@ -911,7 +908,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
 
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -945,7 +942,7 @@ jobs:
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -963,7 +960,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs['release-tag'] }}
           persist-credentials: false
@@ -999,7 +996,7 @@ jobs:
           fi
 
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
@@ -1007,7 +1004,7 @@ jobs:
       - run: chmod +x ~/.cargo/bin/dist
 
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -1032,7 +1029,7 @@ jobs:
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -1058,7 +1055,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs['release-tag'] }}
           fetch-depth: 0
@@ -1071,7 +1068,7 @@ jobs:
       # phase is skipped and this job goes straight to verified adoption.
       - name: Install cached dist
         if: needs.plan.outputs.draft-complete != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
@@ -1081,7 +1078,7 @@ jobs:
 
       - name: Fetch artifacts
         if: needs.plan.outputs.draft-complete != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -1110,14 +1107,14 @@ jobs:
 
       - name: Upload dist-manifest.json
         if: needs.plan.outputs.draft-complete != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-dist-manifest
           path: dist-manifest.json
 
       - name: Download GitHub Artifacts
         if: needs.plan.outputs.draft-complete != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: artifacts
@@ -1129,7 +1126,7 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
 
       - name: Download current Homeboy finalizer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: homeboy-binary
           path: .homeboy-bin
@@ -1391,7 +1388,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -1415,7 +1412,7 @@ jobs:
     if: ${{ always() && github.event_name == 'push' && needs.check.outputs.should-release == 'true' && contains(toJson(needs), '"result":"failure"') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # The SHA marker means "do not re-PREPARE this HEAD". A recovery run
       # never prepares anything — it finishes an already-prepared tag — so
@@ -1427,7 +1424,7 @@ jobs:
 
       - name: Cache failed SHA
         if: needs.check.outputs.recovery-release != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-last-failed
           key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
@@ -1438,7 +1435,7 @@ jobs:
       # MAX_RECOVERY_ATTEMPTS and falls through to a normal fresh release.
       - name: Restore recovery attempts
         if: needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag'] != ''
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-recovery-attempts
           key: release-recovery-attempts-${{ github.ref_name }}-${{ github.run_id }}
@@ -1462,7 +1459,7 @@ jobs:
 
       - name: Cache recovery attempts
         if: needs.check.outputs.recovery-release == 'true' && needs.check.outputs['release-tag'] != ''
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-recovery-attempts
           key: release-recovery-attempts-${{ github.ref_name }}-${{ github.run_id }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -73,21 +73,42 @@ fn release_workflow_has_no_generic_source_autofix() {
         "release workflow must not contain a gate-refactor job"
     );
     assert!(
-        !workflow.contains("autofix: 'true'"),
-        "release workflow must not enable generic source autofix"
-    );
-    assert!(
-        !workflow.contains("autofix-mode: always"),
-        "release workflow must not run autofix in always mode"
-    );
-    assert!(
-        !workflow.contains("autofix-open-pr: 'true'"),
-        "release workflow must not create autofix PRs"
+        !workflow.contains("autofix:"),
+        "release workflow must not pass the removed autofix action input"
     );
     assert!(
         !workflow.contains("refactor --from all"),
         "release workflow must not run a broad refactor --from all sweep"
     );
+}
+
+#[test]
+fn release_workflow_uses_current_direct_actions_without_changing_permissions() {
+    let workflow = release_workflow();
+
+    for (action, major) in [
+        ("actions/checkout", "v6"),
+        ("actions/cache", "v5"),
+        ("actions/cache/restore", "v5"),
+        ("actions/cache/save", "v5"),
+        ("actions/upload-artifact", "v7"),
+        ("actions/download-artifact", "v7"),
+        ("actions/create-github-app-token", "v3"),
+    ] {
+        assert!(
+            workflow.contains(&format!("{action}@{major}")),
+            "release workflow must use {action}@{major}"
+        );
+        assert!(
+            !workflow.contains(&format!("{action}@v4"))
+                && !workflow.contains(&format!("{action}@v1")),
+            "release workflow must not retain deprecated {action} majors"
+        );
+    }
+
+    assert!(workflow.contains(
+        "permissions:\n  actions: write\n  contents: write\n  issues: write\n  pull-requests: write"
+    ));
 }
 
 #[test]
@@ -99,24 +120,18 @@ fn release_workflow_declared_drift_maintenance_is_narrow_not_generic() {
     // (changes_are_only_drift / drift_file_paths), which gates on
     // extension-declared lockfile_paths + the audit baseline (homeboy.json).
     // The release workflow must not widen this into generic source mutation:
-    // every quality gate must run read-only (autofix disabled) so that no
+    // the quality gates must not receive the removed autofix input, so no
     // authored source fix is produced for the transaction to route.
     for job in ["gate-audit", "gate-lint", "gate-test"] {
         let section = job_section(workflow, job);
         assert!(
-            section.contains("autofix: 'false'"),
-            "{job} must run read-only (autofix disabled) so only declared generated drift can be maintained"
+            !section.contains("autofix:"),
+            "{job} must not pass the removed autofix input"
         );
     }
 
-    // The release workflow has no other writable action invocation. Generated
-    // drift remains owned by the core allowlist, rather than a workflow-level
-    // repair action that could stage authored source files.
-    assert_eq!(
-        workflow.matches("autofix:").count(),
-        3,
-        "only the three read-only quality gates may declare autofix behavior"
-    );
+    // Generated drift remains owned by the core allowlist, rather than a
+    // workflow-level repair action that could stage authored source files.
 }
 
 #[test]
@@ -143,7 +158,7 @@ fn release_quality_policy_defaults_to_lint_and_test_blocking() {
 fn release_quality_policy_checks_out_event_commit_before_running_script() {
     let policy = job_section(release_workflow(), "release-quality-policy");
 
-    let checkout_index = policy.find("actions/checkout@v4").expect(
+    let checkout_index = policy.find("actions/checkout@v6").expect(
         "release-quality-policy must check out the repository before running the policy script",
     );
     let script_index = policy
@@ -695,7 +710,7 @@ fn release_artifact_builds_survive_recovery_skips_but_fail_closed_on_required_bu
 fn release_host_checkout_fetches_full_history_for_finalizer_ancestry_validation() {
     let host = job_section(release_workflow(), "host");
     let checkout = host
-        .find("uses: actions/checkout@v4")
+        .find("uses: actions/checkout@v6")
         .expect("host must check out the release tag");
     let finalizer = host
         .find("Finish Homeboy release pipeline at tag")
@@ -1153,7 +1168,7 @@ fn release_recovery_records_control_binary_lineage_against_the_release_target() 
 fn release_recovery_builds_its_control_binary_from_main_not_the_recovered_tag() {
     let workflow = release_workflow();
     let gate_build = job_section(workflow, "gate-build");
-    let checkout = release_step_block(gate_build, "uses: actions/checkout@v4");
+    let checkout = release_step_block(gate_build, "uses: actions/checkout@v6");
 
     assert!(
         checkout.contains("ref: ${{ github.sha }}"),


### PR DESCRIPTION
## Summary

- remove obsolete `autofix` inputs from release quality gates
- upgrade direct release dependencies to Node 24-capable action majors
- lock the action versions, absent input, and unchanged permissions into release contracts

Closes #11217.

## Verification

- `cargo fmt --all --check`
- `cargo test --test release_workflow_test --test release_expected_assets_test` (50 passed)
- `actionlint -ignore 'SC(2086|2129)' .github/workflows/release.yml`\n- `git diff --check`\n\n## AI assistance\n\nOpenCode using `openai/gpt-5.6-sol` traced the warnings, implemented the workflow migration, and verified the release contracts. Chris Huber reviewed the resulting diff and remains responsible for every line.