### PR TITLE
fix(daemon): execute the computed repair plan, and dispatch daemon recovery

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -35,6 +35,28 @@ enum DaemonCommand {
         #[arg(long)]
         replacement_operation_id: Option<String>,
     },
+    /// Resolve and run the right daemon recovery from the current status report
+    ///
+    /// Reads `homeboy daemon status` once, matches its stale reason code, and
+    /// fills every argument the resolved recovery needs from that report. The
+    /// explicit subcommands below stay available as escape hatches for the
+    /// cases this cannot resolve.
+    Recover {
+        /// Print the resolved plan without running it. This is the default.
+        #[arg(long)]
+        dry_run: bool,
+        /// Run the resolved plan.
+        #[arg(long, conflicts_with = "dry_run")]
+        yes: bool,
+        /// Required only when the resolved plan reconciles PID-less durable
+        /// jobs. Unverifiable by design, so it is never supplied automatically:
+        /// the daemon died before persisting any child identity, leaving no PID
+        /// for anything in process to check.
+        #[arg(long)]
+        confirm_workload_processes_absent: bool,
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
     /// Explicitly replace one proven-dead daemon lease and reconcile its durable jobs
     AdoptOrphan {
         /// Exact lease ID reported by `homeboy daemon status`
@@ -207,6 +229,7 @@ pub struct DaemonArtifactGetArgs {
 pub enum DaemonOutput {
     Start(DaemonStartResult),
     EnsureRunning(DaemonStartResult),
+    Recover(DaemonRecoverOutput),
     AdoptOrphan(DaemonOrphanAdoptionResult),
     ReconcileDeadLeaseOrphans(DaemonExactOrphanRecoveryResult),
     RecoverMissingChildIdentity(homeboy::core::api_jobs::Job),
@@ -217,6 +240,32 @@ pub enum DaemonOutput {
     Status(DaemonStatus),
     BrokerConfig(BrokerConfig),
     ArtifactGet(DaemonArtifactGetOutput),
+}
+
+/// The resolved recovery, and what was done about it.
+///
+/// `plan` is the whole point: every argument in it was filled from the status
+/// read in this same invocation, so an operator never transcribes a lease id, a
+/// PID, an endpoint, or a `/proc` start-tick value between two commands.
+#[derive(Debug, Serialize)]
+pub struct DaemonRecoverOutput {
+    pub command: &'static str,
+    /// `false` for a dry run, which is the default.
+    pub executed: bool,
+    pub fresh: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason_code: Option<daemon::DaemonStaleReasonCode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lease_id: Option<String>,
+    pub active_jobs: usize,
+    pub plan: daemon::recovery_actions::DaemonRecoveryPlan,
+    /// The steps actually run, in order. Empty on a dry run.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub applied_steps: Vec<String>,
+    /// Why execution stopped short, when it did.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_on: Option<String>,
+    pub next_command: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -247,6 +296,18 @@ pub fn run(args: DaemonArgs) -> CmdResult<DaemonOutput> {
             )?),
             0,
         )),
+        DaemonCommand::Recover {
+            dry_run,
+            yes,
+            confirm_workload_processes_absent,
+            addr,
+        } => recover(
+            // Dry run is the default: an unasked-for recovery is a mutation of
+            // the daemon that owns the caller's durable jobs.
+            !yes || dry_run,
+            confirm_workload_processes_absent,
+            &addr,
+        ),
         DaemonCommand::AdoptOrphan {
             lease_id,
             // Deprecated no-op: adoption proves PID death itself, under the lock.
@@ -394,6 +455,168 @@ pub fn run(args: DaemonArgs) -> CmdResult<DaemonOutput> {
         )),
         DaemonCommand::ArtifactGet(args) => artifact_get(args),
     }
+}
+
+/// Resolve the recovery for the local daemon and either print it or run it.
+///
+/// One `read_status()` read supplies every argument. Dispatch is on the typed
+/// step code, never on the rendered command string (#11105).
+fn recover(
+    dry_run: bool,
+    confirm_workload_processes_absent: bool,
+    addr: &str,
+) -> CmdResult<DaemonOutput> {
+    use daemon::recovery_actions as actions;
+
+    let status = daemon::read_status()?;
+    let plan = actions::plan_recovery(&status);
+    let lease_id = status.freshness.lease_id.clone();
+    let job_ids: Vec<Uuid> = status
+        .active_job_recovery_evidence
+        .iter()
+        .map(|evidence| evidence.job_id)
+        .collect();
+
+    let mut output = DaemonRecoverOutput {
+        command: "daemon.recover",
+        executed: false,
+        fresh: status.fresh,
+        stale_reason_code: status.freshness.stale_reason_code,
+        lease_id: lease_id.clone(),
+        active_jobs: status.freshness.active_jobs,
+        applied_steps: Vec::new(),
+        blocked_on: None,
+        next_command: String::new(),
+        plan,
+    };
+
+    if output.plan.steps.is_empty() {
+        output.next_command = "homeboy daemon status".to_string();
+        return Ok((DaemonOutput::Recover(output), 0));
+    }
+    if !output.plan.executable {
+        // A read-only diagnosis, or evidence that authorizes nothing. The plan
+        // and its reason are the answer; running it would be a guess.
+        output.blocked_on = Some(output.plan.reason.clone());
+        output.next_command = rendered_plan(&output.plan);
+        return Ok((DaemonOutput::Recover(output), 0));
+    }
+
+    // Confirmations an operator has to make are surfaced, never synthesized.
+    let missing = unmet_confirmations(&output.plan, confirm_workload_processes_absent);
+    if !missing.is_empty() {
+        output.blocked_on = Some(format!(
+            "this recovery requires operator attestation that no report can supply: {}",
+            missing
+                .iter()
+                .map(|confirmation| format!("--{confirmation}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        output.next_command = format!(
+            "{} --{}",
+            rendered_plan(&output.plan),
+            actions::CONFIRM_WORKLOAD_PROCESSES_ABSENT
+        );
+        return Ok((DaemonOutput::Recover(output), 0));
+    }
+
+    if dry_run {
+        output.next_command = "homeboy daemon recover --yes".to_string();
+        return Ok((DaemonOutput::Recover(output), 0));
+    }
+
+    for step in &output.plan.steps {
+        match step.code.as_str() {
+            // A lease-bound stop refuses to kill a daemon other than the exact
+            // one the report described, which is why the lease is carried here
+            // rather than left to a bare `homeboy daemon stop`.
+            code if code == actions::DAEMON_STOP => match lease_id.as_deref() {
+                Some(lease_id) => {
+                    daemon::stop_for_lease(lease_id)?;
+                }
+                None => {
+                    daemon::stop()?;
+                }
+            },
+            code if code == actions::DAEMON_START => {
+                daemon::start_background(addr)?;
+            }
+            code if code == actions::DAEMON_ADOPT_ORPHAN => {
+                let lease_id = lease_id.as_deref().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "lease_id",
+                        "the status report named an orphan adoption but carried no lease id",
+                        None,
+                        None,
+                    )
+                })?;
+                daemon::adopt_orphaned_lease(lease_id, &[], addr)?;
+            }
+            code if code == actions::DAEMON_RECONCILE_LEASELESS_ORPHANS => {
+                daemon::reconcile_leaseless_orphans(addr, None)?;
+            }
+            code if code == actions::DAEMON_RECONCILE_DEAD_LEASE_ORPHANS => {
+                let lease_id = lease_id.as_deref().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "lease_id",
+                        "the status report named a dead-lease reconciliation but carried no lease id",
+                        None,
+                        None,
+                    )
+                })?;
+                daemon::reconcile_dead_lease_orphans(
+                    lease_id,
+                    &job_ids,
+                    confirm_workload_processes_absent,
+                    addr,
+                )?;
+            }
+            code => {
+                return Err(Error::validation_invalid_argument(
+                    "recovery_step",
+                    format!("resolved recovery step `{code}` has no dispatcher"),
+                    Some(code.to_string()),
+                    Some(vec![
+                        "Run `homeboy daemon status` and use the explicit recovery subcommand for this case.".to_string(),
+                    ]),
+                ));
+            }
+        }
+        output.applied_steps.push(step.code.clone());
+    }
+
+    output.executed = true;
+    output.next_command = "homeboy daemon status".to_string();
+    Ok((DaemonOutput::Recover(output), 0))
+}
+
+/// Attestations the resolved plan needs and the operator has not made.
+///
+/// The dispatcher fills arguments from the report; it does not fill in claims
+/// about the world. `--confirm-workload-processes-absent` is the one input on
+/// this surface that no report can contain — `core/daemon/control.rs` documents
+/// why — so it is reported back as a blocker rather than assumed.
+fn unmet_confirmations(
+    plan: &daemon::recovery_actions::DaemonRecoveryPlan,
+    confirm_workload_processes_absent: bool,
+) -> Vec<String> {
+    plan.required_confirmations
+        .iter()
+        .filter(|confirmation| {
+            confirmation.as_str() != daemon::recovery_actions::CONFIRM_WORKLOAD_PROCESSES_ABSENT
+                || !confirm_workload_processes_absent
+        })
+        .cloned()
+        .collect()
+}
+
+fn rendered_plan(plan: &daemon::recovery_actions::DaemonRecoveryPlan) -> String {
+    plan.steps
+        .iter()
+        .map(|step| step.command.as_str())
+        .collect::<Vec<_>>()
+        .join(" && ")
 }
 
 fn legacy_child_recovery_migration_error() -> Error {
@@ -745,6 +968,105 @@ mod tests {
         assert!(
             declared.iter().any(|option| option == "--confirm-no-daemon-owner"),
             "--confirm-no-daemon-owner must render as a bare long option or controllers refuse remote lease-less recovery; declared={declared:?} help={help}"
+        );
+    }
+
+    /// #11105: five recovery subcommands existed and nothing chose between
+    /// them. The dispatcher parses with no arguments at all — every value it
+    /// needs comes from the status report it reads.
+    #[test]
+    fn the_recovery_dispatcher_needs_no_transcribed_arguments() {
+        assert!(Cli::try_parse_from(["homeboy", "daemon", "recover"]).is_ok());
+        assert!(Cli::try_parse_from(["homeboy", "daemon", "recover", "--dry-run"]).is_ok());
+        assert!(Cli::try_parse_from(["homeboy", "daemon", "recover", "--yes"]).is_ok());
+        assert!(
+            Cli::try_parse_from(["homeboy", "daemon", "recover", "--yes", "--dry-run"]).is_err(),
+            "a dry run and an execution are not the same request"
+        );
+    }
+
+    /// Dry run is the default. Recovery mutates the daemon that owns the
+    /// caller's durable jobs, so it may not happen because someone ran the
+    /// obvious command to find out what it would do.
+    #[test]
+    fn recovery_is_a_dry_run_unless_execution_is_asked_for() {
+        with_isolated_home(|_| {
+            let cli = Cli::try_parse_from(["homeboy", "daemon", "recover"])
+                .expect("the dispatcher parses bare");
+            let Commands::Daemon(args) = cli.command else {
+                panic!("expected daemon command");
+            };
+
+            let (output, exit_code) = run(args).expect("an isolated home still resolves a plan");
+
+            assert_eq!(exit_code, 0);
+            let DaemonOutput::Recover(output) = output else {
+                panic!("expected recovery output");
+            };
+            assert!(!output.executed, "a bare recover must not mutate anything");
+            assert_eq!(output.command, "daemon.recover");
+        });
+    }
+
+    /// The one confirmation on this surface that is not ceremony must stay
+    /// operator-supplied. `core/daemon/control.rs` documents why: the daemon
+    /// died before persisting any child identity, so nothing in process can
+    /// observe whether the workloads are still running. A dispatcher that
+    /// filled it in from a report would be fabricating evidence.
+    #[test]
+    fn the_dispatcher_never_synthesizes_the_workload_attestation() {
+        use daemon::recovery_actions as actions;
+
+        let job_ids = [Uuid::nil()];
+        let plan = actions::DaemonRecoveryPlan {
+            steps: vec![daemon::DaemonRepairStep::executable(
+                actions::DAEMON_RECONCILE_DEAD_LEASE_ORPHANS,
+                actions::reconcile_dead_lease_orphans("lease-dead", &job_ids),
+            )],
+            reason: "dead lease with PID-less durable jobs".to_string(),
+            required_confirmations: vec![actions::CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()],
+            executable: true,
+        };
+
+        assert_eq!(
+            unmet_confirmations(&plan, false),
+            vec![actions::CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()],
+            "a plan needing the attestation must block until the operator makes it"
+        );
+        assert!(
+            unmet_confirmations(&plan, true).is_empty(),
+            "the operator must still be able to supply it"
+        );
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "daemon",
+            "recover",
+            "--yes",
+            "--confirm-workload-processes-absent",
+        ])
+        .is_ok());
+    }
+
+    /// Every value the dispatcher fills comes from the report. A restart plan
+    /// needs no attestation, so it must not be gated behind one.
+    #[test]
+    fn a_plan_needing_no_attestation_is_not_gated_on_one() {
+        use daemon::recovery_actions as actions;
+
+        let plan = actions::DaemonRecoveryPlan {
+            steps: vec![
+                daemon::DaemonRepairStep::executable(actions::DAEMON_STOP, actions::stop()),
+                daemon::DaemonRepairStep::executable(actions::DAEMON_START, actions::start()),
+            ],
+            reason: "version mismatch".to_string(),
+            required_confirmations: Vec::new(),
+            executable: true,
+        };
+
+        assert!(unmet_confirmations(&plan, false).is_empty());
+        assert_eq!(
+            rendered_plan(&plan),
+            "homeboy daemon stop && homeboy daemon start"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -10,7 +10,8 @@ use homeboy::agents::agent_tasks::provider::{
 use homeboy::core::engine::shell;
 use homeboy::core::server::{self, Server, SshClient};
 use homeboy::runner::runners::{
-    self as runner, Runner, RunnerKind, RunnerToolRegistry, RunnerToolSpec, RunnerTunnelMode,
+    self as runner, daemon_repair_codes, Runner, RunnerKind, RunnerToolRegistry, RunnerToolSpec,
+    RunnerTunnelMode,
 };
 use serde::Serialize;
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -57,6 +57,14 @@ pub fn apply(
 
     repair_managed_sources(client, report);
 
+    // The report already carries a lease-specific, controller-frame plan.
+    // Executing it is the whole point of `--repair`; the fixed
+    // disconnect/connect pair below is the fallback for a connected daemon whose
+    // exec probe failed without any typed plan behind it (#11103).
+    if apply_daemon_repair_plan(id, report) {
+        return;
+    }
+
     let daemon_failed = report
         .checks
         .iter()
@@ -132,6 +140,206 @@ pub fn apply(
             });
         }
     }
+}
+
+/// What an executor should do about one typed repair step.
+///
+/// Dispatch is a pure function of the step's code plus typed evidence from the
+/// report, so the decision is testable without a runner, an SSH transport, or a
+/// daemon. The rendered `step.command` is never parsed back into arguments —
+/// that is the drift the codes exist to prevent (#11103).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum DaemonRepairDispatch {
+    Disconnect,
+    Connect,
+    AdoptOrphanLease {
+        lease_id: String,
+    },
+    ReconcileLeaselessOrphans,
+    RefreshHomeboy {
+        git_ref: Option<String>,
+        allow_downgrade: bool,
+    },
+    /// Nothing may be executed for this step, and the reason is explicit.
+    NotAutomatable {
+        reason: String,
+    },
+}
+
+pub(super) fn dispatch_for(
+    step: &homeboy::core::daemon::DaemonRepairStep,
+    lease_id: Option<&str>,
+) -> DaemonRepairDispatch {
+    match step.code.as_str() {
+        code if code == daemon_repair_codes::RUNNER_DISCONNECT => DaemonRepairDispatch::Disconnect,
+        code if code == daemon_repair_codes::RUNNER_CONNECT => DaemonRepairDispatch::Connect,
+        code if code == daemon_repair_codes::RUNNER_ADOPT_ORPHAN_LEASE => {
+            // The lease is read off the report, never scraped out of the
+            // rendered command. Without one there is nothing to adopt.
+            match lease_id {
+                Some(lease_id) => DaemonRepairDispatch::AdoptOrphanLease {
+                    lease_id: lease_id.to_string(),
+                },
+                None => DaemonRepairDispatch::NotAutomatable {
+                    reason: "the report named an orphan-lease adoption but carried no lease id"
+                        .to_string(),
+                },
+            }
+        }
+        code if code == daemon_repair_codes::RUNNER_RECONCILE_LEASELESS_ORPHANS => {
+            DaemonRepairDispatch::ReconcileLeaselessOrphans
+        }
+        code if code == daemon_repair_codes::RUNNER_REFRESH_HOMEBOY => match step.action.as_ref() {
+            // The recovery ref is a property of the plan rather than of the
+            // daemon's lease, so it is the one value taken from the step's argv.
+            Some(action) => DaemonRepairDispatch::RefreshHomeboy {
+                git_ref: action
+                    .args
+                    .iter()
+                    .position(|arg| arg == "--ref")
+                    .and_then(|index| action.args.get(index + 1))
+                    .cloned(),
+                allow_downgrade: action.args.iter().any(|arg| arg == "--allow-downgrade"),
+            },
+            None => DaemonRepairDispatch::NotAutomatable {
+                reason: "the refresh step carried no executable arguments".to_string(),
+            },
+        },
+        code if code == daemon_repair_codes::RUNNER_DIAGNOSE => {
+            DaemonRepairDispatch::NotAutomatable {
+                reason: "the report authorizes no mutation; the diagnostic step is for the operator to run".to_string(),
+            }
+        }
+        code => DaemonRepairDispatch::NotAutomatable {
+            reason: format!("repair step `{code}` carries no executable dispatch"),
+        },
+    }
+}
+
+/// Execute the typed repair plan the freshness report already computed.
+///
+/// Returns `false` when there is no plan to act on, so the caller falls through
+/// to its own probe-driven recovery.
+fn apply_daemon_repair_plan(runner_id: &str, report: &mut RunnerDoctorOutput) -> bool {
+    let Some(recovery) = report.daemon_recovery.as_ref() else {
+        return false;
+    };
+    if recovery.repair_plan.is_empty() {
+        return false;
+    }
+
+    let plan = recovery.repair_plan.clone();
+    let lease_id = recovery.lease_id.clone();
+    let commands: Vec<String> = plan.iter().map(|step| step.command.clone()).collect();
+
+    let mut applied = 0usize;
+    for step in &plan {
+        let outcome = match dispatch_for(step, lease_id.as_deref()) {
+            DaemonRepairDispatch::Disconnect => runner::disconnect(runner_id)
+                .map(|_| ())
+                .map_err(|error| error.message),
+            DaemonRepairDispatch::Connect => connect_outcome(runner::connect(runner_id)),
+            DaemonRepairDispatch::AdoptOrphanLease { lease_id } => {
+                connect_outcome(runner::connect_with_orphan_adoption(
+                    runner_id,
+                    Some(&lease_id),
+                    &[],
+                    false,
+                    None,
+                    None,
+                    None,
+                ))
+            }
+            DaemonRepairDispatch::ReconcileLeaselessOrphans => connect_outcome(
+                runner::connect_with_orphan_adoption(runner_id, None, &[], true, None, None, None),
+            ),
+            DaemonRepairDispatch::RefreshHomeboy {
+                git_ref,
+                allow_downgrade,
+            } => refresh_outcome(runner_id, git_ref, allow_downgrade),
+            // A read-only diagnosis, or a recovery command a runner advertised
+            // as text with no argv behind it. The operator gets the plan and an
+            // explicit reason instead of silence.
+            DaemonRepairDispatch::NotAutomatable { reason } => {
+                report.repairs.push(RunnerRepair {
+                    id: "repair.daemon".to_string(),
+                    status: RunnerDoctorStatus::Warning,
+                    message: format!(
+                        "No automatic repair was applied for daemon repair step `{}`: {reason}. Run the reported commands to repair it explicitly.",
+                        step.code
+                    ),
+                    commands: commands.clone(),
+                });
+                return true;
+            }
+        };
+
+        if let Err(message) = outcome {
+            report.repairs.push(RunnerRepair {
+                id: "repair.daemon".to_string(),
+                status: RunnerDoctorStatus::Error,
+                message: format!(
+                    "Could not apply daemon repair step `{}` (step {} of {}): {message}",
+                    step.code,
+                    applied + 1,
+                    plan.len()
+                ),
+                commands,
+            });
+            return true;
+        }
+        applied += 1;
+    }
+
+    report.checks.retain(|check| check.id != "daemon.exec");
+    report.repairs.push(RunnerRepair {
+        id: "repair.daemon".to_string(),
+        status: RunnerDoctorStatus::Ok,
+        message: format!(
+            "Applied the reported daemon repair plan ({applied} step(s): {})",
+            plan.iter()
+                .map(|step| step.code.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        commands,
+    });
+    true
+}
+
+fn connect_outcome(
+    result: homeboy::core::Result<(runner::RunnerConnectReport, i32)>,
+) -> Result<(), String> {
+    match result {
+        Ok((_, 0)) => Ok(()),
+        Ok((connect_report, exit_code)) => Err(connect_report
+            .failure_message
+            .unwrap_or_else(|| format!("runner connect exited with code {exit_code}"))),
+        Err(error) => Err(error.message),
+    }
+}
+
+fn refresh_outcome(
+    runner_id: &str,
+    git_ref: Option<String>,
+    allow_downgrade: bool,
+) -> Result<(), String> {
+    runner::refresh_homeboy_binary(runner::HomeboyBinaryRefreshOptions {
+        runner_id: runner_id.to_string(),
+        mode: runner::HomeboyBinaryRefreshMode::Materialize,
+        source: None,
+        git_ref,
+        target_dir: None,
+        reconnect: true,
+        force: false,
+        allow_downgrade,
+        dry_run: false,
+    })
+    .map_err(|error| error.message)
+    .and_then(|(_, exit_code)| match exit_code {
+        0 => Ok(()),
+        code => Err(format!("runner refresh-homeboy exited with code {code}")),
+    })
 }
 
 fn repair_managed_sources(client: &SshClient, report: &mut RunnerDoctorOutput) {

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -214,3 +214,171 @@ fn disconnected_lab_doctor_reuses_daemon_recovery_envelope() {
     );
     assert_eq!(report.daemon_recovery.expect("recovery").active_jobs, 1);
 }
+
+/// #11103: the repair plan was computed everywhere and executed nowhere.
+/// `--repair` refused most scopes outright and, for the one scope it handled,
+/// emitted a fixed disconnect/connect pair regardless of what the report said.
+/// These pin the dispatch itself: code in, typed action out, no shell parsing.
+mod repair_dispatch {
+    use super::super::super::repair::{dispatch_for, DaemonRepairDispatch};
+    use homeboy::core::daemon::DaemonRepairStep;
+    use homeboy::core::error::{ActionSafety, ExecutableAction};
+    use homeboy::runner::runners::daemon_repair_codes;
+
+    fn action(args: &[&str]) -> ExecutableAction {
+        ExecutableAction::new(
+            "runner.refresh_homeboy",
+            "refresh",
+            "homeboy",
+            args.iter().map(|arg| arg.to_string()),
+            ActionSafety::Mutating,
+        )
+    }
+
+    /// The live reproduction on the machine that motivated this fix: a
+    /// reachable daemon whose build identity no longer matches the binary. It
+    /// must reach the binary refresh, not a session reconnect that would
+    /// reproduce the same mismatch.
+    #[test]
+    fn a_version_mismatch_step_dispatches_to_a_binary_refresh() {
+        let step = DaemonRepairStep::executable(
+            daemon_repair_codes::RUNNER_REFRESH_HOMEBOY,
+            action(&["runner", "refresh-homeboy", "lab", "--reconnect"]),
+        );
+
+        assert_eq!(
+            dispatch_for(&step, Some("lease-live")),
+            DaemonRepairDispatch::RefreshHomeboy {
+                git_ref: None,
+                allow_downgrade: false,
+            }
+        );
+    }
+
+    /// The recovery ref and the downgrade allowance come from the step's argv,
+    /// which is the authoritative form. Nothing re-parses the rendered command.
+    #[test]
+    fn refresh_arguments_are_read_from_argv_not_from_the_rendered_command() {
+        let step = DaemonRepairStep::executable(
+            daemon_repair_codes::RUNNER_REFRESH_HOMEBOY,
+            action(&[
+                "runner",
+                "refresh-homeboy",
+                "lab",
+                "--ref",
+                "abc123",
+                "--reconnect",
+                "--allow-downgrade",
+            ]),
+        );
+
+        assert_eq!(
+            dispatch_for(&step, None),
+            DaemonRepairDispatch::RefreshHomeboy {
+                git_ref: Some("abc123".to_string()),
+                allow_downgrade: true,
+            }
+        );
+    }
+
+    /// The lease comes from the report's typed evidence, never from the text.
+    #[test]
+    fn an_adoption_step_takes_its_lease_from_the_report() {
+        let step = DaemonRepairStep::text(
+            daemon_repair_codes::RUNNER_ADOPT_ORPHAN_LEASE,
+            "homeboy runner connect lab --adopt-orphan-lease lease-in-text --confirm-pid-dead",
+        );
+
+        assert_eq!(
+            dispatch_for(&step, Some("lease-from-report")),
+            DaemonRepairDispatch::AdoptOrphanLease {
+                lease_id: "lease-from-report".to_string(),
+            },
+            "the lease must come from typed evidence, not from the command string"
+        );
+    }
+
+    #[test]
+    fn an_adoption_step_without_a_lease_refuses_rather_than_guessing() {
+        let step = DaemonRepairStep::text(
+            daemon_repair_codes::RUNNER_ADOPT_ORPHAN_LEASE,
+            "homeboy runner connect lab --adopt-orphan-lease lease-in-text --confirm-pid-dead",
+        );
+
+        let DaemonRepairDispatch::NotAutomatable { reason } = dispatch_for(&step, None) else {
+            panic!("an adoption with no lease must not be executed");
+        };
+        assert!(reason.contains("no lease id"), "{reason}");
+    }
+
+    /// The empty-plan case. A report matching no repair branch now yields a
+    /// read-only diagnosis, and the executor must surface it with an explicit
+    /// reason instead of either running it as a repair or saying nothing.
+    #[test]
+    fn an_unmatched_report_yields_an_explicit_refusal_not_silence() {
+        let step = DaemonRepairStep::text(
+            daemon_repair_codes::RUNNER_DIAGNOSE,
+            "homeboy runner doctor lab --scope lab-offload",
+        );
+
+        let DaemonRepairDispatch::NotAutomatable { reason } =
+            dispatch_for(&step, Some("lease-live"))
+        else {
+            panic!("a read-only diagnosis is not a repair to apply");
+        };
+        assert!(reason.contains("authorizes no mutation"), "{reason}");
+        assert!(!reason.is_empty());
+    }
+
+    /// A recovery command a runner advertised as text has no argv behind it, so
+    /// it is reported rather than executed. It must not fall through silently.
+    #[test]
+    fn an_untyped_recovery_command_is_reported_rather_than_executed() {
+        let step = DaemonRepairStep::text(
+            daemon_repair_codes::STALE_DAEMON_RECOVERY,
+            "homeboy runner refresh-homeboy lab --ref abc123 --reconnect",
+        );
+
+        let DaemonRepairDispatch::NotAutomatable { reason } = dispatch_for(&step, None) else {
+            panic!("an untyped step must never be shell-parsed into an execution");
+        };
+        assert!(
+            reason.contains(daemon_repair_codes::STALE_DAEMON_RECOVERY),
+            "{reason}"
+        );
+    }
+
+    #[test]
+    fn the_generic_reconnect_plan_still_dispatches_step_by_step() {
+        assert_eq!(
+            dispatch_for(
+                &DaemonRepairStep::text(
+                    daemon_repair_codes::RUNNER_DISCONNECT,
+                    "homeboy runner disconnect lab"
+                ),
+                None
+            ),
+            DaemonRepairDispatch::Disconnect
+        );
+        assert_eq!(
+            dispatch_for(
+                &DaemonRepairStep::text(
+                    daemon_repair_codes::RUNNER_CONNECT,
+                    "homeboy runner connect lab"
+                ),
+                None
+            ),
+            DaemonRepairDispatch::Connect
+        );
+        assert_eq!(
+            dispatch_for(
+                &DaemonRepairStep::text(
+                    daemon_repair_codes::RUNNER_RECONCILE_LEASELESS_ORPHANS,
+                    "homeboy runner connect lab --reconcile-leaseless-orphans --confirm-no-daemon-owner"
+                ),
+                None
+            ),
+            DaemonRepairDispatch::ReconcileLeaselessOrphans
+        );
+    }
+}

--- a/crates/homeboy-core/src/daemon/daemon_lease.rs
+++ b/crates/homeboy-core/src/daemon/daemon_lease.rs
@@ -16,11 +16,10 @@ use std::path::Path;
 use sha2::{Digest, Sha256};
 
 use super::{
-    current_binary_sha256, read_termination_evidence, runtime_path_fingerprint,
+    current_binary_sha256, read_termination_evidence, recovery_actions, runtime_path_fingerprint,
     DaemonFreshnessReport, DaemonRecoveryEvidence, DaemonRepairStep, DaemonRuntimeSnapshot,
     DaemonStaleReasonCode, DaemonState, DAEMON_LEASE_SCHEMA,
 };
-use crate::engine::shell;
 use crate::process::pid_is_running;
 use crate::{build_identity, Error, Result};
 
@@ -230,41 +229,42 @@ pub(crate) fn freshness_report_from_validation(
         ));
     }
 
-    let adoption_command = if proven_dead {
-        Some(format!(
-            "homeboy daemon adopt-orphan --lease-id {} --confirm-pid-dead",
-            shell::quote_arg(lease_id.as_deref().expect("proven dead lease"))
+    // One definition of each recovery invocation, as argv. The adoption command
+    // and the repair step are the same action in two shapes, so both are
+    // rendered from the action rather than written out twice.
+    let adoption_action = if proven_dead {
+        Some(recovery_actions::adopt_orphan(
+            lease_id.as_deref().expect("proven dead lease"),
         ))
     } else if leaseless_reconciliation_available {
-        Some("homeboy daemon reconcile-leaseless-orphans --confirm-no-daemon-owner".to_string())
+        Some(recovery_actions::reconcile_leaseless_orphans())
     } else {
         None
     };
+    let adoption_command = adoption_action
+        .as_ref()
+        .map(crate::error::ExecutableAction::render_command);
 
     // A restartable lease has nothing durable to protect, so a plain stop/start
     // is the whole repair. Otherwise the repair is exactly the explicit
-    // reconciliation the evidence authorizes; anything else would be prose.
+    // reconciliation the evidence authorizes; anything else would be prose. The
+    // last case is deliberately empty here: a local report that authorizes no
+    // mutation is completed by the dispatcher, which owns the diagnostic step.
     let repair_plan = if restartable {
         vec![
-            DaemonRepairStep {
-                code: "daemon_stop".to_string(),
-                command: "homeboy daemon stop".to_string(),
-            },
-            DaemonRepairStep {
-                code: "daemon_start".to_string(),
-                command: "homeboy daemon start".to_string(),
-            },
+            DaemonRepairStep::executable(recovery_actions::DAEMON_STOP, recovery_actions::stop()),
+            DaemonRepairStep::executable(recovery_actions::DAEMON_START, recovery_actions::start()),
         ]
     } else if proven_dead {
-        vec![DaemonRepairStep {
-            code: "daemon_adopt_orphan".to_string(),
-            command: adoption_command.clone().expect("proven dead adoption"),
-        }]
+        vec![DaemonRepairStep::executable(
+            recovery_actions::DAEMON_ADOPT_ORPHAN,
+            adoption_action.clone().expect("proven dead adoption"),
+        )]
     } else if leaseless_reconciliation_available {
-        vec![DaemonRepairStep {
-            code: "daemon_reconcile_leaseless_orphans".to_string(),
-            command: adoption_command.clone().expect("leaseless adoption"),
-        }]
+        vec![DaemonRepairStep::executable(
+            recovery_actions::DAEMON_RECONCILE_LEASELESS_ORPHANS,
+            adoption_action.clone().expect("leaseless adoption"),
+        )]
     } else {
         Vec::new()
     };

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -16,7 +16,7 @@ use crate::api_jobs::{
     RunnerJobLifecycleMetadata,
 };
 use crate::build_identity;
-use crate::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
+use crate::error::{Error, ExecutableAction, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::lab_contract::LabRunnerWorkload;
 use crate::paths;
@@ -33,6 +33,7 @@ mod control;
 pub mod controller_job_driver;
 mod daemon_lease;
 mod patch_capture;
+pub mod recovery_actions;
 mod remote_runner;
 pub mod runner_exec_driver;
 mod runner_files;
@@ -529,10 +530,42 @@ pub enum DaemonRecoveryEvidence {
     Unavailable,
 }
 
+/// One step of a repair a caller may execute.
+///
+/// `action` is the contract; `command` is presentation. A step built through
+/// [`DaemonRepairStep::executable`] renders its own text from the argv, so an
+/// executor never has to parse the string back into arguments and the two can
+/// never drift. Steps whose text came from an untyped upstream source (a remote
+/// runner's advertised recovery command, for instance) carry `None` and are
+/// surfaced to the operator rather than executed.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonRepairStep {
     pub code: String,
+    /// Presentation only whenever `action` is present.
     pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<ExecutableAction>,
+}
+
+impl DaemonRepairStep {
+    /// A step known only as operator prose. Nothing may execute it implicitly.
+    pub fn text(code: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            command: command.into(),
+            action: None,
+        }
+    }
+
+    /// A step whose argv is authoritative. The rendered command is derived, so
+    /// the text an operator reads is exactly what an executor would run.
+    pub fn executable(code: impl Into<String>, action: ExecutableAction) -> Self {
+        Self {
+            code: code.into(),
+            command: action.render_command(),
+            action: Some(action),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/daemon/recovery_actions.rs
+++ b/crates/homeboy-core/src/daemon/recovery_actions.rs
@@ -11,8 +11,10 @@
 //! be restated in controller frame first — running `homeboy daemon stop` on the
 //! controller stops the controller's daemon, not the runner's.
 
+use serde::Serialize;
 use uuid::Uuid;
 
+use super::{DaemonRepairStep, DaemonStatus};
 use crate::error::{ActionSafety, ExecutableAction};
 
 /// Stop the daemon recorded in the local state file.
@@ -132,6 +134,124 @@ pub fn diagnose() -> ExecutableAction {
     )
 }
 
+/// The recovery a dispatcher resolved from one `homeboy daemon status` read.
+///
+/// Every argument in `steps` is already filled in from that report. The point
+/// of the type is that an operator never transcribes a lease id, a PID, an
+/// endpoint, or a job id out of a prior status output by hand (#11105).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonRecoveryPlan {
+    pub steps: Vec<DaemonRepairStep>,
+    /// Why this plan, in the evidence's own terms. Non-empty even when there
+    /// are no steps, so "nothing to do" and "nothing is authorized" are
+    /// distinguishable.
+    pub reason: String,
+    /// Attestations only an operator can make. A dispatcher surfaces these and
+    /// refuses to execute until they are supplied; it never synthesizes them.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub required_confirmations: Vec<String>,
+    /// Whether every step is a mutation the plan can carry out on its own.
+    pub executable: bool,
+}
+
+impl DaemonRecoveryPlan {
+    fn nothing(reason: impl Into<String>) -> Self {
+        Self {
+            steps: Vec::new(),
+            reason: reason.into(),
+            required_confirmations: Vec::new(),
+            executable: false,
+        }
+    }
+}
+
+/// Resolve the recovery for one daemon status report.
+///
+/// The freshness report already computes the local-frame repair for every case
+/// it can authorize, so this dispatches to that plan rather than restating the
+/// table. It adds the two cases the freshness report deliberately leaves empty:
+/// an exact PID-less job set behind a dead lease, which needs an operator
+/// attestation, and the unauthorized remainder, which gets an explicit reason
+/// and a read-only step instead of nothing at all.
+pub fn plan_recovery(status: &DaemonStatus) -> DaemonRecoveryPlan {
+    let freshness = &status.freshness;
+    if freshness.fresh && freshness.stale_reason_code.is_none() {
+        return DaemonRecoveryPlan::nothing(
+            "daemon lease is fresh; there is nothing to recover".to_string(),
+        );
+    }
+
+    if !freshness.repair_plan.is_empty() {
+        let reason = match freshness.stale_reason_code {
+            Some(code) => format!(
+                "daemon is stale ({code:?}) with {} active job(s); the freshness report authorizes this repair",
+                freshness.active_jobs
+            ),
+            None => "daemon reported a repair plan without a stale reason code".to_string(),
+        };
+        let required_confirmations = freshness
+            .repair_plan
+            .iter()
+            .filter_map(|step| step.action.as_ref())
+            .flat_map(|action| action.required_confirmations.iter().cloned())
+            .collect();
+        return DaemonRecoveryPlan {
+            steps: freshness.repair_plan.clone(),
+            reason,
+            required_confirmations,
+            executable: true,
+        };
+    }
+
+    // The lease named a daemon that is gone and durable jobs outlived it, but
+    // the daemon died before persisting any child identity, so the store holds
+    // no PID to check. The exact job set is a compare-and-swap over the
+    // destructive scope, and the store refuses any mismatch — so the ids can be
+    // filled from the report, while the workload attestation cannot be.
+    let job_ids: Vec<Uuid> = status
+        .active_job_recovery_evidence
+        .iter()
+        .map(|evidence| evidence.job_id)
+        .collect();
+    if let Some(lease_id) = freshness.lease_id.as_deref() {
+        if !job_ids.is_empty() {
+            let action = reconcile_dead_lease_orphans(lease_id, &job_ids);
+            let required_confirmations = action.required_confirmations.clone();
+            return DaemonRecoveryPlan {
+                steps: vec![DaemonRepairStep::executable(
+                    DAEMON_RECONCILE_DEAD_LEASE_ORPHANS,
+                    action,
+                )],
+                reason: format!(
+                    "lease `{lease_id}` is gone and {} durable job(s) have no recorded child identity; the exact job set is named from the report, but workload absence is unverifiable in process",
+                    job_ids.len()
+                ),
+                required_confirmations,
+                executable: true,
+            };
+        }
+    }
+
+    // Nothing is authorized. Say so, and hand back the read-only step that
+    // produces the evidence a later pass would need, rather than an empty plan.
+    let reason = match freshness.stale_reason_code {
+        Some(code) => format!(
+            "daemon is stale ({code:?}) but the evidence authorizes no automatic recovery: {}",
+            freshness
+                .ownership_evidence
+                .as_deref()
+                .unwrap_or("no ownership evidence was recorded")
+        ),
+        None => "daemon is not fresh and recorded no stale reason code".to_string(),
+    };
+    DaemonRecoveryPlan {
+        steps: vec![DaemonRepairStep::executable(DAEMON_DIAGNOSE, diagnose())],
+        reason,
+        required_confirmations: Vec::new(),
+        executable: false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,6 +303,169 @@ mod tests {
             vec![CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()]
         );
         assert!(stop().required_confirmations.is_empty());
+    }
+
+    fn status(
+        stale_reason_code: Option<super::super::DaemonStaleReasonCode>,
+        repair_plan: Vec<DaemonRepairStep>,
+        active_jobs: usize,
+    ) -> DaemonStatus {
+        DaemonStatus {
+            running: false,
+            fresh: stale_reason_code.is_none(),
+            reachable: true,
+            freshness: super::super::DaemonFreshnessReport {
+                fresh: stale_reason_code.is_none(),
+                stale_reason_code,
+                restartable: true,
+                lease_id: Some("661f731f-99c7-436a-aadc-24dee908fd8b".to_string()),
+                pid: Some(3_572_046),
+                recovery_evidence: None,
+                ownership_evidence: Some("daemon lease evidence is inconclusive".to_string()),
+                adoption_command: None,
+                binary_hash: None,
+                daemon_version: Some("0.326.1".to_string()),
+                daemon_build_identity: Some("homeboy 0.326.1+8755ba48288f".to_string()),
+                runtime_paths: None,
+                active_jobs,
+                termination_evidence: None,
+                repair_plan,
+            },
+            stale_reason: None,
+            state: None,
+            state_path: "/root/.config/homeboy/daemon/state.json".to_string(),
+            state_identity: "identity".to_string(),
+            process_candidates: Vec::new(),
+            active_job_recovery_evidence: Vec::new(),
+            termination_evidence: None,
+        }
+    }
+
+    /// The live reproduction this fix was written against: a reachable daemon
+    /// whose build identity no longer matches the current binary, zero active
+    /// jobs, restartable. The dispatcher must resolve the stop/start pair with
+    /// every argument already filled in.
+    #[test]
+    fn a_version_mismatch_report_resolves_the_restart_plan() {
+        let status = status(
+            Some(super::super::DaemonStaleReasonCode::VersionMismatch),
+            vec![
+                DaemonRepairStep::executable(DAEMON_STOP, stop()),
+                DaemonRepairStep::executable(DAEMON_START, start()),
+            ],
+            0,
+        );
+
+        let plan = plan_recovery(&status);
+
+        assert!(plan.executable);
+        assert!(plan.required_confirmations.is_empty());
+        assert_eq!(
+            plan.steps
+                .iter()
+                .map(|step| (step.code.as_str(), step.command.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (DAEMON_STOP, "homeboy daemon stop"),
+                (DAEMON_START, "homeboy daemon start"),
+            ]
+        );
+        assert!(plan.reason.contains("VersionMismatch"), "{}", plan.reason);
+        for step in &plan.steps {
+            assert!(step.action.is_some(), "{} carries no argv", step.code);
+        }
+    }
+
+    #[test]
+    fn a_fresh_report_plans_nothing_and_says_why() {
+        let plan = plan_recovery(&status(None, Vec::new(), 0));
+
+        assert!(plan.steps.is_empty());
+        assert!(!plan.executable);
+        assert!(plan.reason.contains("fresh"), "{}", plan.reason);
+    }
+
+    /// #11105: a report the freshness table authorizes nothing for used to
+    /// leave an operator with no subcommand to run and no statement of why.
+    #[test]
+    fn a_report_matching_no_branch_still_yields_a_step_and_a_reason() {
+        let plan = plan_recovery(&status(
+            Some(super::super::DaemonStaleReasonCode::TransportUnreachable),
+            Vec::new(),
+            0,
+        ));
+
+        assert_eq!(plan.steps.len(), 1, "an unmatched report is never empty");
+        assert_eq!(plan.steps[0].code, DAEMON_DIAGNOSE);
+        assert_eq!(plan.steps[0].command, "homeboy daemon status");
+        assert!(
+            !plan.executable,
+            "a read-only diagnosis is not a repair to apply"
+        );
+        assert!(
+            plan.reason.contains("authorizes no automatic recovery"),
+            "{}",
+            plan.reason
+        );
+        assert!(
+            plan.reason
+                .contains("daemon lease evidence is inconclusive"),
+            "the refusal must quote the evidence it refused on: {}",
+            plan.reason
+        );
+    }
+
+    /// Every `--job-id` is filled from the report; only the attestation that no
+    /// report can contain is demanded from the operator.
+    #[test]
+    fn a_pidless_job_set_is_filled_from_the_report_but_still_demands_the_attestation() {
+        let mut status = status(
+            Some(super::super::DaemonStaleReasonCode::LeaseCorrupt),
+            Vec::new(),
+            2,
+        );
+        status.active_job_recovery_evidence = vec![
+            recovery_evidence(Uuid::from_u128(1)),
+            recovery_evidence(Uuid::from_u128(2)),
+        ];
+
+        let plan = plan_recovery(&status);
+
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].code, DAEMON_RECONCILE_DEAD_LEASE_ORPHANS);
+        let args = &plan.steps[0].action.as_ref().expect("argv").args;
+        assert_eq!(
+            args.iter().filter(|arg| *arg == "--job-id").count(),
+            2,
+            "every durable job id is named: {args:?}"
+        );
+        assert!(args.contains(&Uuid::from_u128(1).to_string()));
+        assert!(args.contains(&"661f731f-99c7-436a-aadc-24dee908fd8b".to_string()));
+        assert_eq!(
+            plan.required_confirmations,
+            vec![CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()],
+            "workload absence is unverifiable and stays operator-supplied"
+        );
+    }
+
+    fn recovery_evidence(job_id: Uuid) -> crate::api_jobs::DaemonActiveJobRecoveryEvidence {
+        crate::api_jobs::DaemonActiveJobRecoveryEvidence {
+            job_id,
+            operation: "exec".to_string(),
+            status: crate::api_jobs::JobStatus::Running,
+            daemon_lease_id: Some("661f731f-99c7-436a-aadc-24dee908fd8b".to_string()),
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            started_at_ms: None,
+            terminal_evidence: None,
+            child_pid: None,
+            child_started_at: None,
+            linked_durable_run_id: None,
+            linked_durable_run_state: None,
+            linked_durable_run_terminal_status: None,
+            disposition:
+                crate::api_jobs::DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable,
+        }
     }
 
     #[test]

--- a/crates/homeboy-core/src/daemon/recovery_actions.rs
+++ b/crates/homeboy-core/src/daemon/recovery_actions.rs
@@ -1,0 +1,200 @@
+//! Local-frame daemon recovery actions.
+//!
+//! Every `homeboy daemon *` recovery invocation is defined here exactly once,
+//! as argv. `DaemonFreshnessReport::repair_plan` renders its operator text from
+//! these builders and `homeboy daemon recover` dispatches on the same codes, so
+//! the plan an operator reads and the plan the dispatcher executes cannot drift
+//! apart, and no executor ever has to parse a rendered command back into
+//! arguments (#11103, #11105).
+//!
+//! These are the *local* frame. A report that has crossed an SSH boundary must
+//! be restated in controller frame first — running `homeboy daemon stop` on the
+//! controller stops the controller's daemon, not the runner's.
+
+use uuid::Uuid;
+
+use crate::error::{ActionSafety, ExecutableAction};
+
+/// Stop the daemon recorded in the local state file.
+pub const DAEMON_STOP: &str = "daemon_stop";
+/// Start a replacement daemon.
+pub const DAEMON_START: &str = "daemon_start";
+/// Adopt one proven-dead lease and reconcile the jobs it owned.
+pub const DAEMON_ADOPT_ORPHAN: &str = "daemon_adopt_orphan";
+/// Reconcile durable jobs that outlived the lease that owned them.
+pub const DAEMON_RECONCILE_LEASELESS_ORPHANS: &str = "daemon_reconcile_leaseless_orphans";
+/// Reconcile an exact PID-less job set after a proven unexpected daemon exit.
+pub const DAEMON_RECONCILE_DEAD_LEASE_ORPHANS: &str = "daemon_reconcile_dead_lease_orphans";
+/// Re-read daemon evidence. The step emitted when nothing else is authorized.
+pub const DAEMON_DIAGNOSE: &str = "daemon_diagnose";
+
+/// The operator attestation that cannot be synthesized from any report.
+///
+/// `reconcile-dead-lease-orphans` exists precisely because the daemon died
+/// before persisting any child identity, so the store holds no PID to inspect
+/// and nothing in-process can observe whether the workloads are still running.
+/// A dispatcher must surface this as a required confirmation, never supply it.
+pub const CONFIRM_WORKLOAD_PROCESSES_ABSENT: &str = "confirm-workload-processes-absent";
+
+fn action(
+    id: &str,
+    label: String,
+    args: impl IntoIterator<Item = String>,
+    safety: ActionSafety,
+) -> ExecutableAction {
+    ExecutableAction::new(id, label, "homeboy", args, safety)
+}
+
+pub fn stop() -> ExecutableAction {
+    action(
+        "daemon.stop",
+        "stop the local daemon".to_string(),
+        ["daemon".to_string(), "stop".to_string()],
+        ActionSafety::Mutating,
+    )
+}
+
+pub fn start() -> ExecutableAction {
+    action(
+        "daemon.start",
+        "start a replacement local daemon".to_string(),
+        ["daemon".to_string(), "start".to_string()],
+        ActionSafety::Mutating,
+    )
+}
+
+pub fn adopt_orphan(lease_id: &str) -> ExecutableAction {
+    action(
+        "daemon.adopt_orphan",
+        format!("adopt proven-dead daemon lease {lease_id}"),
+        [
+            "daemon".to_string(),
+            "adopt-orphan".to_string(),
+            "--lease-id".to_string(),
+            lease_id.to_string(),
+            // Released spelling. The flag is a no-op — adoption proves PID death
+            // itself, under the lifecycle lock — but it is retained so the
+            // rendered command stays copy-pasteable against a released binary.
+            "--confirm-pid-dead".to_string(),
+        ],
+        ActionSafety::Mutating,
+    )
+}
+
+pub fn reconcile_leaseless_orphans() -> ExecutableAction {
+    action(
+        "daemon.reconcile_leaseless_orphans",
+        "reconcile durable jobs with no owning daemon lease".to_string(),
+        [
+            "daemon".to_string(),
+            "reconcile-leaseless-orphans".to_string(),
+            "--confirm-no-daemon-owner".to_string(),
+        ],
+        ActionSafety::Mutating,
+    )
+}
+
+/// The exact PID-less job set is a compare-and-swap over the destructive scope,
+/// so every job id is named. The store recomputes the active set and refuses any
+/// mismatch; a dispatcher may therefore fill the ids from the report it read.
+pub fn reconcile_dead_lease_orphans(lease_id: &str, job_ids: &[Uuid]) -> ExecutableAction {
+    let mut args = vec![
+        "daemon".to_string(),
+        "reconcile-dead-lease-orphans".to_string(),
+        "--lease-id".to_string(),
+        lease_id.to_string(),
+    ];
+    for job_id in job_ids {
+        args.push("--job-id".to_string());
+        args.push(job_id.to_string());
+    }
+    args.push(format!("--{CONFIRM_WORKLOAD_PROCESSES_ABSENT}"));
+    action(
+        "daemon.reconcile_dead_lease_orphans",
+        format!(
+            "reconcile {} PID-less durable job(s) owned by dead lease {lease_id}",
+            job_ids.len()
+        ),
+        args,
+        ActionSafety::Mutating,
+    )
+    .requiring_confirmation(CONFIRM_WORKLOAD_PROCESSES_ABSENT)
+}
+
+/// Read-only. Emitted when the evidence authorizes no mutation, so that a
+/// report matching no recovery branch still hands back something to run.
+pub fn diagnose() -> ExecutableAction {
+    action(
+        "daemon.status",
+        "re-read daemon lease, process, and durable job evidence".to_string(),
+        ["daemon".to_string(), "status".to_string()],
+        ActionSafety::ReadOnly,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendered_text_is_derived_from_argv() {
+        assert_eq!(stop().render_command(), "homeboy daemon stop");
+        assert_eq!(start().render_command(), "homeboy daemon start");
+        assert_eq!(
+            adopt_orphan("lease-dead").render_command(),
+            "homeboy daemon adopt-orphan --lease-id lease-dead --confirm-pid-dead"
+        );
+        assert_eq!(
+            reconcile_leaseless_orphans().render_command(),
+            "homeboy daemon reconcile-leaseless-orphans --confirm-no-daemon-owner"
+        );
+        assert_eq!(diagnose().render_command(), "homeboy daemon status");
+    }
+
+    #[test]
+    fn an_exact_job_set_is_named_argument_by_argument() {
+        let first = Uuid::nil();
+        let second = Uuid::from_u128(2);
+        let action = reconcile_dead_lease_orphans("lease-dead", &[first, second]);
+
+        assert_eq!(
+            action.args,
+            vec![
+                "daemon",
+                "reconcile-dead-lease-orphans",
+                "--lease-id",
+                "lease-dead",
+                "--job-id",
+                &first.to_string(),
+                "--job-id",
+                &second.to_string(),
+                "--confirm-workload-processes-absent",
+            ]
+        );
+    }
+
+    /// The workload attestation is unverifiable by construction, so it must
+    /// travel as a declared confirmation an operator has to supply rather than
+    /// as an argument a dispatcher can fill in from a report.
+    #[test]
+    fn the_workload_attestation_is_declared_as_an_operator_confirmation() {
+        assert_eq!(
+            reconcile_dead_lease_orphans("lease-dead", &[Uuid::nil()]).required_confirmations,
+            vec![CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()]
+        );
+        assert!(stop().required_confirmations.is_empty());
+    }
+
+    #[test]
+    fn diagnosis_is_the_only_read_only_action() {
+        assert_eq!(diagnose().safety, ActionSafety::ReadOnly);
+        for action in [
+            stop(),
+            start(),
+            adopt_orphan("lease"),
+            reconcile_leaseless_orphans(),
+        ] {
+            assert_eq!(action.safety, ActionSafety::Mutating, "{}", action.id);
+        }
+    }
+}

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -517,22 +517,22 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
     // and falling back to generic reconnect prose discards the evidence the SSH
     // probe just paid for (#10302).
     let repair_step = if proven_dead && adoption_eligible {
-        Some(daemon_repair::step(
+        Some(daemon_repair::action_step(
             daemon_repair::RUNNER_ADOPT_ORPHAN_LEASE,
-            daemon_repair::adopt_orphan_lease_command(
+            daemon_repair::adopt_orphan_lease_action(
                 runner_id,
                 lease_id.as_deref().expect("proven dead lease"),
             ),
         ))
     } else if leaseless_reconciliation_available {
-        Some(daemon_repair::step(
+        Some(daemon_repair::action_step(
             daemon_repair::RUNNER_RECONCILE_LEASELESS_ORPHANS,
-            daemon_repair::reconcile_leaseless_orphans_command(runner_id),
+            daemon_repair::reconcile_leaseless_orphans_action(runner_id),
         ))
     } else if recoverable_fresh_idle {
-        Some(daemon_repair::step(
+        Some(daemon_repair::action_step(
             daemon_repair::RUNNER_CONNECT,
-            daemon_repair::connect_command(runner_id),
+            daemon_repair::connect_action(runner_id),
         ))
     } else {
         None

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -491,9 +491,10 @@ fn into_controller_frame(
     report.repair_plan = daemon_repair::controller_frame_plan(runner_id, &report);
     // An adoption command is one explicit, operator-confirmed action. A
     // multi-step restart sequence is a plan, not an adoption, so it is exposed
-    // only as steps.
+    // only as steps, and the read-only fallback is a diagnosis rather than an
+    // adoption an operator could mistake for one.
     report.adoption_command = match report.repair_plan.as_slice() {
-        [step] => Some(step.command.clone()),
+        [step] if step.code != daemon_repair::RUNNER_DIAGNOSE => Some(step.command.clone()),
         _ => None,
     };
     report

--- a/crates/homeboy-lab-runner/src/daemon_repair.rs
+++ b/crates/homeboy-lab-runner/src/daemon_repair.rs
@@ -8,59 +8,181 @@
 //! emits is therefore restated here in controller-side `homeboy runner`
 //! commands bound to an explicit runner id.
 //!
-//! These builders are the single definition of each command string, so the
-//! `adoption_command` a report carries and the `repair_plan` step that executes
-//! it can never drift apart.
+//! Each builder produces an [`ExecutableAction`] — argv, not text. The command
+//! string a report carries is rendered from that argv, so the `adoption_command`
+//! a report advertises, the `repair_plan` step an operator reads, and the
+//! arguments an executor would run can never drift apart, and no consumer has to
+//! parse a rendered shell command back into arguments to act on it (#11103).
 
 use homeboy_core::daemon::{DaemonFreshnessReport, DaemonRepairStep, DaemonStaleReasonCode};
-use homeboy_core::engine::shell;
+use homeboy_core::error::{ActionSafety, ExecutableAction};
 
-pub(crate) const RUNNER_DISCONNECT: &str = "runner_disconnect";
-pub(crate) const RUNNER_CONNECT: &str = "runner_connect";
-pub(crate) const RUNNER_REFRESH_HOMEBOY: &str = "runner_refresh_homeboy";
-pub(crate) const RUNNER_ADOPT_ORPHAN_LEASE: &str = "runner_adopt_orphan_lease";
-pub(crate) const RUNNER_RECONCILE_LEASELESS_ORPHANS: &str = "runner_reconcile_leaseless_orphans";
-pub(crate) const STALE_DAEMON_RECOVERY: &str = "stale_daemon_recovery";
+/// The step codes a repair executor dispatches on.
+///
+/// Public because dispatch crosses a crate boundary: `homeboy runner doctor
+/// --repair` lives in the CLI and executes the plan this crate composed. The
+/// code is the contract — an executor matches on it and supplies typed values
+/// from the report, and never parses the rendered command string (#11103).
+pub mod codes {
+    pub const RUNNER_DISCONNECT: &str = "runner_disconnect";
+    pub const RUNNER_CONNECT: &str = "runner_connect";
+    pub const RUNNER_REFRESH_HOMEBOY: &str = "runner_refresh_homeboy";
+    pub const RUNNER_ADOPT_ORPHAN_LEASE: &str = "runner_adopt_orphan_lease";
+    pub const RUNNER_RECONCILE_LEASELESS_ORPHANS: &str = "runner_reconcile_leaseless_orphans";
+    /// A recovery command a runner advertised as text. It has no argv behind it,
+    /// so it is surfaced to the operator rather than executed.
+    pub const STALE_DAEMON_RECOVERY: &str = "stale_daemon_recovery";
+    /// The read-only step emitted when the evidence authorizes no mutation. A
+    /// report matching no repair branch must still hand back something to run.
+    pub const RUNNER_DIAGNOSE: &str = "runner_diagnose";
+}
 
+pub(crate) use codes::{
+    RUNNER_ADOPT_ORPHAN_LEASE, RUNNER_CONNECT, RUNNER_DIAGNOSE, RUNNER_DISCONNECT,
+    RUNNER_RECONCILE_LEASELESS_ORPHANS, RUNNER_REFRESH_HOMEBOY, STALE_DAEMON_RECOVERY,
+};
+
+/// A step known only as text. Nothing may execute it implicitly.
 pub(crate) fn step(code: &str, command: String) -> DaemonRepairStep {
-    DaemonRepairStep {
-        code: code.to_string(),
-        command,
-    }
+    DaemonRepairStep::text(code, command)
+}
+
+/// A step whose argv is authoritative; its text is rendered from the action.
+pub(crate) fn action_step(code: &str, action: ExecutableAction) -> DaemonRepairStep {
+    DaemonRepairStep::executable(code, action)
+}
+
+fn runner_action(
+    id: &str,
+    label: String,
+    args: impl IntoIterator<Item = String>,
+    safety: ActionSafety,
+) -> ExecutableAction {
+    ExecutableAction::new(id, label, "homeboy", args, safety)
 }
 
 /// `homeboy runner disconnect <id>`.
-pub(crate) fn disconnect_command(runner_id: &str) -> String {
-    format!("homeboy runner disconnect {}", shell::quote_arg(runner_id))
+pub(crate) fn disconnect_action(runner_id: &str) -> ExecutableAction {
+    runner_action(
+        "runner.disconnect",
+        format!("disconnect runner {runner_id}"),
+        [
+            "runner".to_string(),
+            "disconnect".to_string(),
+            runner_id.to_string(),
+        ],
+        ActionSafety::Mutating,
+    )
 }
 
 /// `homeboy runner connect <id>`.
-pub(crate) fn connect_command(runner_id: &str) -> String {
-    format!("homeboy runner connect {}", shell::quote_arg(runner_id))
+pub(crate) fn connect_action(runner_id: &str) -> ExecutableAction {
+    runner_action(
+        "runner.connect",
+        format!("connect runner {runner_id}"),
+        [
+            "runner".to_string(),
+            "connect".to_string(),
+            runner_id.to_string(),
+        ],
+        ActionSafety::Mutating,
+    )
 }
 
 /// `homeboy runner connect <id> --adopt-orphan-lease <lease> --confirm-pid-dead`.
-pub(crate) fn adopt_orphan_lease_command(runner_id: &str, lease_id: &str) -> String {
-    format!(
-        "homeboy runner connect {} --adopt-orphan-lease {} --confirm-pid-dead",
-        shell::quote_arg(runner_id),
-        shell::quote_arg(lease_id)
+pub(crate) fn adopt_orphan_lease_action(runner_id: &str, lease_id: &str) -> ExecutableAction {
+    runner_action(
+        "runner.adopt_orphan_lease",
+        format!("adopt proven-dead lease {lease_id} on runner {runner_id}"),
+        [
+            "runner".to_string(),
+            "connect".to_string(),
+            runner_id.to_string(),
+            "--adopt-orphan-lease".to_string(),
+            lease_id.to_string(),
+            "--confirm-pid-dead".to_string(),
+        ],
+        ActionSafety::Mutating,
     )
 }
 
 /// `homeboy runner connect <id> --reconcile-leaseless-orphans --confirm-no-daemon-owner`.
-pub(crate) fn reconcile_leaseless_orphans_command(runner_id: &str) -> String {
-    format!(
-        "homeboy runner connect {} --reconcile-leaseless-orphans --confirm-no-daemon-owner",
-        shell::quote_arg(runner_id)
+pub(crate) fn reconcile_leaseless_orphans_action(runner_id: &str) -> ExecutableAction {
+    runner_action(
+        "runner.reconcile_leaseless_orphans",
+        format!("reconcile lease-less durable jobs on runner {runner_id}"),
+        [
+            "runner".to_string(),
+            "connect".to_string(),
+            runner_id.to_string(),
+            "--reconcile-leaseless-orphans".to_string(),
+            "--confirm-no-daemon-owner".to_string(),
+        ],
+        ActionSafety::Mutating,
     )
 }
 
 /// `homeboy runner refresh-homeboy <id> --reconnect`.
-pub(crate) fn refresh_homeboy_command(runner_id: &str) -> String {
-    format!(
-        "homeboy runner refresh-homeboy {} --reconnect",
-        shell::quote_arg(runner_id)
+pub(crate) fn refresh_homeboy_action(runner_id: &str) -> ExecutableAction {
+    refresh_homeboy_action_for_ref(runner_id, None)
+}
+
+/// `homeboy runner refresh-homeboy <id> [--ref <ref>] --reconnect`.
+///
+/// The recovery ref, when one is known, names the exact commit the runner's
+/// configured job binary should be rebuilt at. Reconnecting the same drifted
+/// binary would only reproduce the mismatch.
+pub(crate) fn refresh_homeboy_action_for_ref(
+    runner_id: &str,
+    recovery_ref: Option<&str>,
+) -> ExecutableAction {
+    let mut args = vec![
+        "runner".to_string(),
+        "refresh-homeboy".to_string(),
+        runner_id.to_string(),
+    ];
+    if let Some(recovery_ref) = recovery_ref {
+        args.push("--ref".to_string());
+        args.push(recovery_ref.to_string());
+    }
+    args.push("--reconnect".to_string());
+    runner_action(
+        "runner.refresh_homeboy",
+        format!("refresh runner {runner_id}"),
+        args,
+        ActionSafety::Mutating,
+    )
+}
+
+/// `homeboy runner refresh-homeboy <id> --ref <commit> --reconnect --allow-downgrade`.
+///
+/// Controller convergence can require moving the runner *back* to the
+/// controller's commit, which the ordinary refresh refuses.
+pub(crate) fn refresh_homeboy_downgrade_action(
+    runner_id: &str,
+    controller_commit: &str,
+) -> ExecutableAction {
+    let mut action = refresh_homeboy_action_for_ref(runner_id, Some(controller_commit));
+    action.args.push("--allow-downgrade".to_string());
+    action
+}
+
+/// `homeboy runner doctor <id> --scope lab-offload`.
+///
+/// Read-only, and deliberately not a repair: it is what an operator (or an
+/// automated repairer) should run when the report authorizes no mutation.
+pub(crate) fn diagnose_action(runner_id: &str) -> ExecutableAction {
+    runner_action(
+        "runner.doctor",
+        format!("re-probe runner {runner_id} daemon evidence"),
+        [
+            "runner".to_string(),
+            "doctor".to_string(),
+            runner_id.to_string(),
+            "--scope".to_string(),
+            "lab-offload".to_string(),
+        ],
+        ActionSafety::ReadOnly,
     )
 }
 
@@ -70,8 +192,8 @@ pub(crate) fn refresh_homeboy_command(runner_id: &str) -> String {
 /// daemon, so it stays deliberately generic.
 pub(crate) fn reconnect_plan(runner_id: &str) -> Vec<DaemonRepairStep> {
     vec![
-        step(RUNNER_DISCONNECT, disconnect_command(runner_id)),
-        step(RUNNER_CONNECT, connect_command(runner_id)),
+        action_step(RUNNER_DISCONNECT, disconnect_action(runner_id)),
+        action_step(RUNNER_CONNECT, connect_action(runner_id)),
     ]
 }
 
@@ -96,9 +218,9 @@ pub(crate) fn controller_frame_plan(
         && report.adoption_command.is_some()
     {
         if let Some(lease_id) = report.lease_id.as_deref().filter(|_| report.pid.is_some()) {
-            return vec![step(
+            return vec![action_step(
                 RUNNER_ADOPT_ORPHAN_LEASE,
-                adopt_orphan_lease_command(runner_id, lease_id),
+                adopt_orphan_lease_action(runner_id, lease_id),
             )];
         }
     }
@@ -115,9 +237,9 @@ pub(crate) fn controller_frame_plan(
             )
         )
     {
-        return vec![step(
+        return vec![action_step(
             RUNNER_RECONCILE_LEASELESS_ORPHANS,
-            reconcile_leaseless_orphans_command(runner_id),
+            reconcile_leaseless_orphans_action(runner_id),
         )];
     }
     // An identity drift is a binary problem, not a lease problem: reconnecting
@@ -130,15 +252,19 @@ pub(crate) fn controller_frame_plan(
                 | DaemonStaleReasonCode::BinaryHashMismatch
         )
     ) {
-        return vec![step(
+        return vec![action_step(
             RUNNER_REFRESH_HOMEBOY,
-            refresh_homeboy_command(runner_id),
+            refresh_homeboy_action(runner_id),
         )];
     }
     if report.restartable {
         return reconnect_plan(runner_id);
     }
-    Vec::new()
+    // A stale report that matched no branch above named a real problem and no
+    // authorized mutation. Returning an empty plan hands the operator nothing
+    // at all, so the honest answer is the read-only re-probe: the evidence that
+    // would let a later pass match a branch (#11103).
+    vec![action_step(RUNNER_DIAGNOSE, diagnose_action(runner_id))]
 }
 
 /// Render a plan as the `&&`-joined shell text used in operator prose.
@@ -214,7 +340,11 @@ mod tests {
 
     #[test]
     fn a_dead_lease_with_conflicting_candidates_does_not_rebuild_adoption() {
-        assert!(plan(&report(Some(DaemonStaleReasonCode::PidDead), 0, false)).is_empty());
+        assert!(
+            plan(&report(Some(DaemonStaleReasonCode::PidDead), 0, false))
+                .iter()
+                .all(|(code, _)| code != RUNNER_ADOPT_ORPHAN_LEASE)
+        );
     }
 
     #[test]
@@ -262,6 +392,67 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    /// #11103: a report that matches no repair branch used to return an empty
+    /// plan, so the operator was handed a stale daemon and nothing to do about
+    /// it. The fallback is read-only rather than a guessed mutation.
+    #[test]
+    fn a_report_matching_no_branch_still_produces_an_actionable_step() {
+        let plan = controller_frame_plan(
+            "homeboy-lab",
+            &report(Some(DaemonStaleReasonCode::TransportUnreachable), 0, false),
+        );
+
+        assert_eq!(plan.len(), 1, "an unmatched stale report is never empty");
+        assert_eq!(plan[0].code, RUNNER_DIAGNOSE);
+        assert_eq!(
+            plan[0].command,
+            "homeboy runner doctor homeboy-lab --scope lab-offload"
+        );
+        let action = plan[0].action.as_ref().expect("fallback carries argv");
+        assert_eq!(action.safety, ActionSafety::ReadOnly);
+        assert_eq!(action.args[0], "runner");
+        assert_eq!(action.args[1], "doctor");
+    }
+
+    /// Every branch must carry argv, or the executor is back to shell-parsing
+    /// the rendered text it was handed.
+    #[test]
+    fn every_controller_frame_step_carries_executable_argv() {
+        for code in [
+            DaemonStaleReasonCode::PidDead,
+            DaemonStaleReasonCode::LeaseMissing,
+            DaemonStaleReasonCode::LeaseCorrupt,
+            DaemonStaleReasonCode::VersionMismatch,
+            DaemonStaleReasonCode::BuildIdentityMismatch,
+            DaemonStaleReasonCode::BinaryHashMismatch,
+            DaemonStaleReasonCode::RuntimePathsDrift,
+            DaemonStaleReasonCode::TransportUnreachable,
+            DaemonStaleReasonCode::LeaseSchemaMismatch,
+        ] {
+            for restartable in [true, false] {
+                for active_jobs in [0, 1] {
+                    let mut report = report(Some(code), active_jobs, restartable);
+                    report.adoption_command = Some("daemon-authored".to_string());
+                    let plan = controller_frame_plan("homeboy-lab", &report);
+                    assert!(!plan.is_empty(), "{code:?} produced no step at all");
+                    for step in plan {
+                        let action = step.action.as_ref().unwrap_or_else(|| {
+                            panic!("{code:?} step {} carries no argv", step.code)
+                        });
+                        assert_eq!(
+                            step.command,
+                            action.render_command(),
+                            "{code:?} step {} rendered text drifted from its argv",
+                            step.code
+                        );
+                        assert_eq!(action.program, "homeboy");
+                        assert_eq!(action.args.first().map(String::as_str), Some("runner"));
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2834,6 +2834,7 @@ mod tests {
             changed_runtime_paths: Vec::new(),
             message: "daemon is stale".to_string(),
             recovery_commands: Vec::new(),
+            recovery_actions: Vec::new(),
         });
 
         let error = require_available_lab_runner("homeboy-lab", &status, None, "cook")

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -693,18 +693,25 @@ fn daemon_repair_steps(runner_id: &str, status: &RunnerStatusReport) -> Vec<Daem
     {
         return report.repair_plan.clone();
     }
-    let stale_commands = status
-        .stale_daemon
-        .as_ref()
-        .map(|warning| warning.recovery_commands.as_slice())
-        .unwrap_or_default();
-    if !stale_commands.is_empty() {
-        return stale_commands
-            .iter()
-            .map(|command| {
-                daemon_repair::step(daemon_repair::STALE_DAEMON_RECOVERY, command.clone())
+    if let Some(warning) = status.stale_daemon.as_ref() {
+        // The warning renders its own text from argv, so a step keeps the
+        // action alongside the string instead of forcing a consumer to
+        // reconstruct one from the other. A recovery with no typed form (an
+        // older warning, or one whose command came from the runner rather than
+        // from a builder) degrades to text and is surfaced, not executed.
+        let steps: Vec<_> = warning
+            .recovery_steps()
+            .into_iter()
+            .map(|(command, action)| match action {
+                Some(action) => {
+                    daemon_repair::action_step(daemon_repair::STALE_DAEMON_RECOVERY, action)
+                }
+                None => daemon_repair::step(daemon_repair::STALE_DAEMON_RECOVERY, command),
             })
             .collect();
+        if !steps.is_empty() {
+            return steps;
+        }
     }
     daemon_repair::reconnect_plan(runner_id)
 }
@@ -713,38 +720,34 @@ fn daemon_repair_command(runner_id: &str, status: &RunnerStatusReport) -> String
     daemon_repair::render(&daemon_repair_steps(runner_id, status))
 }
 
+/// The one repair a caller may execute directly, when there is exactly one.
+///
+/// #11104: this used to rebuild a `refresh-homeboy` action from scratch and
+/// then lift it only if it rendered to a byte-identical string to the plan's
+/// sole command. Five producers emit five different commands, so the equality
+/// guard threw away the argv the plan had already computed for four of them.
+/// Now the plan carries the action, so the action is simply read off the step.
+/// A multi-step plan is a plan, not one action, and still yields `None`; so
+/// does a step with no typed form, and so does the read-only diagnosis, which
+/// must not be presented as a repair the caller can apply.
 fn daemon_repair_action(runner_id: &str, status: &RunnerStatusReport) -> Option<ExecutableAction> {
     let steps = daemon_repair_steps(runner_id, status);
     let recovery_plan: Vec<&str> = steps.iter().map(|step| step.command.as_str()).collect();
-    let recovery_ref = match status.stale_daemon.as_ref() {
-        Some(warning) => warning.recovery_ref()?,
-        None => homeboy_product_identity::build_identity()
-            .git_commit
-            .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version())),
+    let [step] = steps.as_slice() else {
+        return None;
     };
-    let action = ExecutableAction::new(
-        "runner.refresh_homeboy",
-        format!("refresh runner {runner_id}"),
-        "homeboy",
-        [
-            "runner",
-            "refresh-homeboy",
-            runner_id,
-            "--ref",
-            &recovery_ref,
-            "--reconnect",
-        ],
-        ActionSafety::Mutating,
+    let action = step.action.clone()?;
+    if action.safety != ActionSafety::Mutating {
+        return None;
+    }
+    Some(
+        action
+            .requiring_confirmation("operator")
+            .with_evidence(serde_json::json!({
+                "runner_id": runner_id,
+                "recovery_plan": recovery_plan,
+            })),
     )
-    .requiring_confirmation("operator")
-    .with_evidence(serde_json::json!({
-        "runner_id": runner_id,
-        "recovery_plan": recovery_plan,
-    }));
-
-    // The report exposes shell text, not argv. Only lift a single command that
-    // exactly matches this explicit action; never parse or approximate a plan.
-    (recovery_plan.len() == 1 && recovery_plan[0] == action.render_command()).then_some(action)
 }
 
 pub(super) fn resolve_lab_runner_selection(
@@ -1037,9 +1040,9 @@ mod daemon_repair_step_tests {
         // values to it instead of re-parsing `&&`-joined shell text.
         let report = status_report(
             "homeboy-lab",
-            Some(freshness_with_plan(vec![daemon_repair::step(
+            Some(freshness_with_plan(vec![daemon_repair::action_step(
                 daemon_repair::RUNNER_ADOPT_ORPHAN_LEASE,
-                daemon_repair::adopt_orphan_lease_command("homeboy-lab", "lease-dead"),
+                daemon_repair::adopt_orphan_lease_action("homeboy-lab", "lease-dead"),
             )])),
             None,
         );

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -39,6 +39,7 @@ mod daemon_exec_driver;
 mod daemon_health;
 mod daemon_http_get;
 mod daemon_repair;
+pub use daemon_repair::codes as daemon_repair_codes;
 mod evidence;
 mod execution;
 mod execution_bundle;

--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -15,6 +15,7 @@
 // Stable top-level contracts
 // ----------------------------------------------------------------------------
 
+pub use crate::daemon_repair_codes;
 pub use crate::runner_capability_inventory;
 pub use crate::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -6,6 +6,7 @@ use homeboy_core::daemon::{
 };
 
 use homeboy_core::engine::shell;
+use homeboy_core::error::{ActionSafety, ExecutableAction};
 use homeboy_core::redaction::redact_argv_shell_display;
 
 use homeboy_core::api_jobs::{ActiveRunnerJobSummary, Job, JobArtifactMetadata, JobStatus};
@@ -938,6 +939,7 @@ mod status_serialization_tests {
             changed_runtime_paths: Vec::new(),
             message: "stale".to_string(),
             recovery_commands: Vec::new(),
+            recovery_actions: Vec::new(),
         });
         let summary = report.admission_summary(0);
         assert!(!summary.daemon_fresh);
@@ -964,22 +966,35 @@ mod status_serialization_tests {
             display: "homeboy 0.323.1+6899aabbccdd".to_string(),
         };
 
+        let actions = recovery_action(
+            "homeboy-lab",
+            Some("homeboy 0.323.1+c8a6673b6abc"),
+            &initiating,
+        );
+
+        // The rendered text is derived from the argv, so asserting on both
+        // pins that a consumer executing this recovery runs exactly what the
+        // operator was shown (#11104).
         assert_eq!(
-            recovery_command(
-                "homeboy-lab",
-                Some("homeboy 0.323.1+c8a6673b6abc"),
-                &initiating,
-            ),
+            rendered_commands(&actions),
             ["homeboy runner refresh-homeboy homeboy-lab --ref c8a6673b6abc --reconnect"]
+        );
+        assert_eq!(
+            actions[0].args,
+            [
+                "runner",
+                "refresh-homeboy",
+                "homeboy-lab",
+                "--ref",
+                "c8a6673b6abc",
+                "--reconnect"
+            ]
         );
         for configured in [
             "homeboy 0.323.1+c8a6673b6abc-dirty",
             "homeboy not-a-version",
         ] {
-            assert_eq!(
-                recovery_command("homeboy-lab", Some(configured), &initiating),
-                Vec::<String>::new(),
-            );
+            assert!(recovery_action("homeboy-lab", Some(configured), &initiating).is_empty());
         }
     }
 
@@ -1045,6 +1060,16 @@ pub struct RunnerStaleDaemonWarning {
     pub changed_runtime_paths: Vec<RunnerChangedRuntimePath>,
     pub message: String,
     pub recovery_commands: Vec<String>,
+    /// Argv for `recovery_commands`, in the same order.
+    ///
+    /// Deliberately not serialized: the wire contract stays the string list.
+    /// This is how an in-process consumer executes a recovery without parsing
+    /// that list back into arguments (#11104). It is written only through
+    /// [`RunnerStaleDaemonWarning::set_recovery`], which renders the strings
+    /// from the argv, so the two can never disagree. It is empty exactly when
+    /// the recovery has no typed form.
+    #[serde(skip)]
+    pub(crate) recovery_actions: Vec<ExecutableAction>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -1072,11 +1097,12 @@ impl RunnerStaleDaemonWarning {
         session_homeboy_build_identity: Option<String>,
         current_homeboy_build_identity: Option<String>,
     ) -> Self {
-        let recovery_commands = recovery_command(
+        let recovery_actions = recovery_action(
             runner_id,
             current_homeboy_build_identity.as_deref(),
             &homeboy_product_identity::build_identity(),
         );
+        let recovery_commands = rendered_commands(&recovery_actions);
         let message = if !same_homeboy_version(&session_homeboy_version, &current_homeboy_version) {
             format!(
                 "connected runner daemon control plane version `{session_homeboy_version}` differs from configured job command binary version `{current_homeboy_version}`; run recovery_commands in order when runner active jobs are drained"
@@ -1109,7 +1135,19 @@ impl RunnerStaleDaemonWarning {
             stale_runtime_paths: Vec::new(),
             changed_runtime_paths: Vec::new(),
             recovery_commands,
+            recovery_actions,
         }
+    }
+
+    /// The one place a recovery is assigned.
+    ///
+    /// Argv in, text out: `recovery_commands` and `refresh_command` are both
+    /// rendered from the actions, so a consumer can execute the recovery
+    /// directly and still read exactly what it would run.
+    fn set_recovery(&mut self, actions: Vec<ExecutableAction>) {
+        self.recovery_commands = rendered_commands(&actions);
+        self.refresh_command = self.recovery_commands.join(" && ");
+        self.recovery_actions = actions;
     }
 
     pub fn with_controller_compatibility(
@@ -1131,8 +1169,13 @@ impl RunnerStaleDaemonWarning {
                     .as_deref()
                     .unwrap_or(&self.job_command_binary_version),
             );
-            self.recovery_commands = vec!["homeboy upgrade --force".to_string()];
-            self.refresh_command = self.recovery_commands.join(" && ");
+            self.set_recovery(vec![ExecutableAction::new(
+                "upgrade.force",
+                "rebuild the controller binary".to_string(),
+                "homeboy",
+                ["upgrade".to_string(), "--force".to_string()],
+                ActionSafety::Mutating,
+            )]);
         } else if daemon_matches_configured {
             self.compatibility_reason = Some(if controller_version_matches {
                 "controller_configured_identity_skew"
@@ -1153,15 +1196,28 @@ impl RunnerStaleDaemonWarning {
                     .filter(|identity| identity.git_dirty != Some(true))
                     .and_then(|identity| identity.git_commit)
                 {
-                    self.recovery_commands = vec![format!(
-                        "homeboy runner refresh-homeboy {} --ref {controller_commit} --reconnect --allow-downgrade",
-                        shell::quote_arg(runner_id),
-                    )];
-                    self.refresh_command = self.recovery_commands.join(" && ");
+                    self.set_recovery(vec![
+                        crate::daemon_repair::refresh_homeboy_downgrade_action(
+                            runner_id,
+                            &controller_commit,
+                        ),
+                    ]);
                 }
             }
         }
         self
+    }
+
+    /// Each recovery command paired with its argv, in order.
+    ///
+    /// The argv is `None` only when this warning's recovery has no typed form,
+    /// which is the one case a consumer must surface rather than execute.
+    pub(crate) fn recovery_steps(&self) -> Vec<(String, Option<ExecutableAction>)> {
+        self.recovery_commands
+            .iter()
+            .enumerate()
+            .map(|(index, command)| (command.clone(), self.recovery_actions.get(index).cloned()))
+            .collect()
     }
 
     pub(crate) fn recovery_ref(&self) -> Option<String> {
@@ -1225,19 +1281,26 @@ impl RunnerStaleDaemonWarning {
     }
 }
 
-fn recovery_command(
+/// The recovery for an identity-drifted runner daemon, as argv.
+///
+/// A rendered string is derived from this; nothing derives argv from a string.
+fn recovery_action(
     runner_id: &str,
     configured_identity: Option<&str>,
     initiating_identity: &homeboy_product_identity::BuildIdentity,
-) -> Vec<String> {
+) -> Vec<ExecutableAction> {
     recovery_ref(configured_identity, initiating_identity)
         .map(|recovery_ref| {
-            format!(
-                "homeboy runner refresh-homeboy {} --ref {recovery_ref} --reconnect",
-                shell::quote_arg(runner_id),
-            )
+            crate::daemon_repair::refresh_homeboy_action_for_ref(runner_id, Some(&recovery_ref))
         })
         .into_iter()
+        .collect()
+}
+
+fn rendered_commands(actions: &[ExecutableAction]) -> Vec<String> {
+    actions
+        .iter()
+        .map(ExecutableAction::render_command)
         .collect()
 }
 

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -14,7 +14,43 @@ homeboy daemon <COMMAND>
 - `serve` — run the daemon in the foreground
 - `stop` — gracefully stop the background daemon recorded in the state file
 - `status` — show daemon state, active-job recovery evidence, and selected local address
+- `recover` — resolve and run the right recovery from the current status report
 - `broker-config` — render a deployable reverse-runner broker service recipe
+
+## Recovery dispatch
+
+`homeboy daemon status` already computes the repair its own evidence
+authorizes and reports it as `freshness.repair_plan`. `homeboy daemon recover`
+is the dispatcher for that plan: it reads status once, resolves the matching
+recovery, and **fills every argument from the report it just read**. Nothing is
+transcribed by hand between two commands.
+
+```sh
+homeboy daemon recover            # resolve and print the plan (default)
+homeboy daemon recover --yes      # resolve and run it
+```
+
+Dry run is the default because recovery mutates the daemon that owns the
+caller's durable jobs. The output carries the resolved `plan` (each step with
+its code, its rendered command, and its argv), the `stale_reason_code` it
+matched, and `next_command`.
+
+A report the evidence authorizes nothing for does not produce an empty plan. It
+produces the read-only `daemon_diagnose` step and `blocked_on`, stating in the
+evidence's own words why no mutation was resolved.
+
+The explicit subcommands below remain available as escape hatches for cases the
+dispatcher cannot resolve — notably `recover-missing-lease-state` and
+`recover-missing-child-identity`, whose required values (a recorded endpoint, a
+`/proc` child start-tick) are precisely the ones that no longer exist in any
+report by the time they are needed.
+
+`--confirm-workload-processes-absent` is never supplied automatically. When the
+resolved plan is a dead-lease reconciliation, `recover` reports it under
+`blocked_on` and refuses to execute until the operator passes it. See the
+reasoning in the dead-lease recovery section below: the attestation is
+unverifiable in process by construction, so a dispatcher supplying it would be
+fabricating evidence.
 
 ## Local HTTP API
 


### PR DESCRIPTION
## Motivating evidence

This machine's local daemon was, at the time of writing, sitting in exactly the state both issues describe. `homeboy daemon status`:

```json
{ "fresh": false, "running": false, "reachable": true,
  "stale_reason": "daemon build identity does not match current Homeboy binary",
  "freshness": {
    "daemon_build_identity": "homeboy 0.326.1+8755ba48288f",
    "daemon_version": "0.326.1",
    "pid": 3572046,
    "lease_id": "661f731f-99c7-436a-aadc-24dee908fd8b",
    "active_jobs": 0,
    "restartable": true,
    "recovery_evidence": "unavailable",
    "stale_reason_code": "version_mismatch",
    "repair_plan": [
      { "code": "daemon_stop",  "command": "homeboy daemon stop" },
      { "code": "daemon_start", "command": "homeboy daemon start" }
    ],
    "ownership_evidence": "daemon lease evidence is inconclusive; 0 active job(s) are protected from implicit replacement; ..."
  } }
```

Homeboy knew the stale reason code, the lease, the PID, the job count, and the exact two-step repair. It rendered that repair to a string and handed it to a human. `homeboy daemon recover` did not exist (`error: unrecognized subcommand 'recover'`), and `runner doctor --repair` would not have looked at `repair_plan` if it had.

## #11103 — the plan was computed everywhere and executed nowhere

`daemon_repair.rs` builds `Vec<DaemonRepairStep { code, command }>`, `connection_daemon.rs` threads it into `RunnerStatusReport.daemon_freshness.repair_plan`, `lab_selection.rs` reads it back — and `daemon_repair::render` joins it with `" && "`. The only repair executor, `runner/doctor/repair.rs`, never touched `repair_plan`: it refused outright for most scopes and, for `--scope lab-offload`, emitted a fixed `runner disconnect {id}` / `runner connect {id}` pair regardless of what the report said.

- `runner doctor --repair` now reads `daemon_recovery.repair_plan` and dispatches on `step.code` against the `daemon_repair_codes::RUNNER_*` contract, to `runner::connect`, `runner::disconnect`, `runner::connect_with_orphan_adoption`, and `refresh_homeboy_binary`.
- **`step.command` is never parsed.** Dispatch is on the typed code, and values come from typed evidence — the lease id is read off `daemon_recovery.lease_id`, not scraped out of the rendered string. `dispatch_for` is a pure function of `(step, lease_id)`, so it is tested without a runner, an SSH transport, or a daemon.
- `DaemonRepairStep` gained `action: Option<ExecutableAction>`. **Argv is authoritative; the string is rendered from it**, so a step's text and its arguments cannot drift, and `adoption_command` is now derived from the same action instead of being written out a second time. A step whose text came from an untyped upstream source (a runner's advertised recovery command) carries `None` and is surfaced rather than executed.
- **The empty-plan case is closed.** `controller_frame_plan` returned an empty `Vec` for a non-restartable report matching no branch, so the operator got a stale daemon and nothing at all. It now emits a read-only `runner_diagnose` step, and the executor reports it with an explicit reason. The diagnosis is excluded from `adoption_command` so it cannot be mistaken for a repair to apply.

## #11104 — the guard came out

`daemon_repair_action` rebuilt a `refresh-homeboy` action from scratch and lifted it only if `recovery_plan[0] == action.render_command()` exactly. Five producers emit five different strings, so for four of them the argv the plan had already computed was discarded. The action is now read off the step and the equality guard is gone.

To keep that honest, `RunnerStaleDaemonWarning` gained a non-serialized `recovery_actions` (wire contract unchanged) written only through a new `set_recovery`, which renders `recovery_commands` and `refresh_command` *from* the argv. One definition, no comparison. It removed cleanly.

## #11105 — daemon recovery has a dispatcher

Five subcommands existed and nothing chose between them. The worst requires `--lease-id`, `--recorded-daemon-pid`, `--recorded-daemon-endpoint`, `--job-id`, `--child-pid` and `--child-starttime-ticks` — a `/proc` value — each transcribed by hand from a prior `daemon status`, hard-failing on any transcription error.

```sh
homeboy daemon recover          # resolve and print the plan (the default)
homeboy daemon recover --yes    # run it
```

It reads `read_status()` once, matches `stale_reason_code`, and **fills every argument from that report**. Dry run is the default because recovery mutates the daemon that owns the caller's durable jobs.

`plan_recovery` dispatches to the plan the freshness report already computes rather than restating the table, and adds the two cases that report deliberately leaves empty:

- an exact PID-less job set behind a dead lease, where every `--job-id` is filled from `active_job_recovery_evidence` (the store recomputes the active set and refuses any mismatch, so the repeated flag is a compare-and-swap over the destructive scope, not a fact assertion);
- the unauthorized remainder, which gets a read-only step plus a reason **quoting the evidence it refused on**, instead of an empty plan.

### What stays operator-supplied, and why

`--confirm-workload-processes-absent` is never synthesized. `core/daemon/control.rs` documents why it is genuinely unverifiable: that command exists *because* the daemon died before persisting any child identity, so the store holds no PID for the named jobs and nothing in process can observe whether their workloads are still running. `recover` surfaces it under `blocked_on` and refuses to execute until the operator passes it. The dispatcher fills in arguments; it does not make claims about the world.

`--confirm-no-daemon-owner` is untouched — controllers negotiate the lease-less recovery contract by matching that bare long option in remote `--help` output, and removing it makes every controller refuse remote lease-less recovery. Tracked separately as #11102.

## A finding worth recording

While exercising the live daemon above, the report's own advertised plan **did not work against the state that produced it**. `homeboy daemon stop` returned `"stopped": false` (the lease was stale, not live) and `homeboy daemon start` then refused with `daemon_unleased_process_conflict`, because PID 3572046 was still alive and unattributable. Recovery required the documented lease-bound force stop:

```sh
homeboy daemon stop --force --lease-id 661f731f-99c7-436a-aadc-24dee908fd8b
```

That is a separate defect in the plan *content* for `version_mismatch` + a live unattributable PID, and this PR does not claim to fix it. It does make the failure legible: `recover --yes` executes the plan the report authored and reports the refusal as a structured error against the named step, instead of leaving an operator to discover it by hand. Worth its own issue.

## Tests

Hermetic, no daemon or transport required:

- `daemon_repair`: a `version_mismatch` report resolves to the binary refresh rather than a reconnect; a report matching no branch produces a non-empty read-only step; **every** branch across all nine stale reason codes × restartable × active-jobs carries argv whose render equals the step's text.
- `recovery_actions`: the live `version_mismatch` shape resolves the stop/start plan; an unmatched report yields a step *and* a reason quoting its ownership evidence; a PID-less job set names every id from the report while still demanding the attestation.
- `doctor/repair`: adoption takes its lease from typed evidence even when the rendered command contains a *different* lease; an adoption with no lease refuses rather than guessing; an untyped step is reported, never shell-parsed into an execution.
- `daemon`: the dispatcher parses with no arguments at all; a bare `recover` does not mutate; the attestation gate blocks and unblocks correctly.

## Verification

`cargo fmt --check` clean and `cargo check --lib` exit 0 on `homeboy-core`, `homeboy-lab-runner`, `homeboy-cli`; `--lib --tests` also compiles clean on all three. Full build and test left to CI.

Found during the 2026-08-01 consolidation investigation (#11151).

Closes #11103
Closes #11104
Closes #11105
