### PR TITLE
fix(defaults): document the two-layer defaults contract, fail safe on a malformed override

### DIFF
--- a/crates/homeboy-core/src/defaults/builtins.rs
+++ b/crates/homeboy-core/src/defaults/builtins.rs
@@ -7,6 +7,28 @@ use serde::Deserialize;
 use std::fs;
 use std::sync::OnceLock;
 
+/// Defaults that an ecosystem extension may supply, with a generic fallback
+/// compiled into core.
+///
+/// Two documents implement this same schema, and they are deliberately NOT
+/// copies of each other (#11099):
+///
+/// * The bundled asset under this crate's `assets/defaults/` is core's
+///   fallback. It is framework-agnostic on purpose (#2240): only generic
+///   dev-tool manifests, a generic source layout, and no presupposed file
+///   extension. Four tests at the bottom of this file pin that agnosticism.
+/// * The document owned by the extensions repository is an ecosystem
+///   *override*, loaded at runtime via the `EXTENSION_DEFAULTS_PATH`
+///   environment variable. It intentionally carries the extra
+///   framework-specific candidates, source directories, and file extensions
+///   that core must not bake in.
+///
+/// So a field-by-field difference between the two is the design working, not
+/// drift. The one field where they must agree is
+/// `install_methods.source.upgrade_command`, which describes how *Homeboy
+/// itself* is rebuilt and has nothing to do with any ecosystem; the override
+/// copy is currently stale there and is tracked for a follow-up in the
+/// extensions repository.
 #[derive(Debug, Clone, Deserialize)]
 struct ExtensionProvidedDefaults {
     install_methods: InstallMethodsConfig,
@@ -21,6 +43,19 @@ fn extension_provided_defaults() -> &'static ExtensionProvidedDefaults {
     DEFAULTS.get_or_init(load_extension_provided_defaults)
 }
 
+/// Resolve the active defaults: an operator-supplied override when one is
+/// configured, otherwise the compiled-in bundled asset.
+///
+/// The bundled asset is load-bearing and cannot be reduced to an empty
+/// `Default` the way the detector profile was. `install_methods` drives
+/// `detect_install_method_from_exe_path`, which matches the running
+/// executable's path against `path_patterns`. With empty defaults every
+/// pattern list is empty, detection returns `InstallMethod::Unknown`, and
+/// `homeboy upgrade` fails outright with "Cannot upgrade: unknown
+/// installation method". Nothing sets `EXTENSION_DEFAULTS_PATH`
+/// automatically, so an install with no override configured would have no
+/// other source for these values — self-upgrade is a bootstrap path and must
+/// keep working with zero extensions installed.
 fn load_extension_provided_defaults() -> ExtensionProvidedDefaults {
     if let Some(defaults) = load_external_extension_provided_defaults() {
         return defaults;

--- a/crates/homeboy-core/src/defaults/builtins.rs
+++ b/crates/homeboy-core/src/defaults/builtins.rs
@@ -67,15 +67,33 @@ fn load_extension_provided_defaults() -> ExtensionProvidedDefaults {
     )))
 }
 
+/// Load an operator-supplied defaults override, or `None` to fall back to the
+/// bundled asset.
+///
+/// Every failure mode here is operator input, so all of them fall back rather
+/// than abort: an unset variable, an unreadable file, and a file that does not
+/// parse as a defaults document. The parse case previously panicked through
+/// `expect`, which made a single malformed override file take down every
+/// command that touches defaults — including the `upgrade` path that would
+/// otherwise repair the install.
 fn load_external_extension_provided_defaults() -> Option<ExtensionProvidedDefaults> {
     let path =
         std::env::var(crate::product_identity::PRODUCT_IDENTITY.env_var("EXTENSION_DEFAULTS_PATH"))
             .ok()?;
     let content = fs::read_to_string(path).ok()?;
 
-    Some(parse_extension_provided_defaults(&content))
+    try_parse_extension_provided_defaults(&content)
 }
 
+/// Parse a defaults document supplied at runtime, returning `None` when it is
+/// not a valid defaults contract.
+fn try_parse_extension_provided_defaults(content: &str) -> Option<ExtensionProvidedDefaults> {
+    serde_json::from_str(content).ok()
+}
+
+/// Parse a defaults document that is expected to be well-formed, panicking if
+/// it is not. Reserved for the compiled-in bundled asset, where a parse failure
+/// is a build defect rather than bad operator input and should stay loud.
 fn parse_extension_provided_defaults(content: &str) -> ExtensionProvidedDefaults {
     serde_json::from_str(content).expect("extension-provided defaults asset should parse")
 }
@@ -211,6 +229,38 @@ mod tests {
         assert!(suffixes.contains(&".test.js".to_string()));
         assert!(suffixes.contains(&".spec.tsx".to_string()));
         assert!(suffixes.contains(&"_test.rs".to_string()));
+    }
+
+    #[test]
+    fn malformed_runtime_defaults_document_falls_back_to_bundled_asset() {
+        // An override file is untrusted operator input. A document that does
+        // not parse must yield None so the bundled asset stays in effect,
+        // rather than aborting every command that reads defaults — including
+        // the upgrade path that would otherwise repair the install.
+        assert!(try_parse_extension_provided_defaults("not a defaults document").is_none());
+        assert!(try_parse_extension_provided_defaults("{}").is_none());
+    }
+
+    #[test]
+    fn well_formed_runtime_defaults_document_overrides_bundled_asset() {
+        let defaults = try_parse_extension_provided_defaults(
+            r#"{
+                "install_methods": {},
+                "version_candidates": [],
+                "test_drift": {
+                    "source_dirs": ["lib"],
+                    "test_dirs": ["spec"],
+                    "file_extensions": ["rb"],
+                    "inline_tests": true
+                },
+                "direct_test_file_suffixes": ["_spec.rb"]
+            }"#,
+        )
+        .expect("well-formed defaults document parses");
+
+        assert_eq!(defaults.test_drift.source_dirs, ["lib"]);
+        assert_eq!(defaults.test_drift.test_dirs, ["spec"]);
+        assert_eq!(defaults.direct_test_file_suffixes, ["_spec.rb"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

#11099 reports that `extension-provided-defaults.json` exists twice and has drifted. I diffed the two copies and traced their history. **Four of the five differences are deliberate design, not drift** — and the proposed fix (converge the copies, then replace the `include_str!` fallback with an empty `Default`) would break four live tests, re-hardcode ecosystem literals into core, and take `homeboy upgrade` offline for every install.

This PR lands the safe part: it documents the two-layer relationship so the "drift" reading does not recur, and fixes a genuine robustness defect found in the same loader. **Step 3 is deferred with findings below.**

## 1. The complete diff

`crates/homeboy-core/assets/defaults/extension-provided-defaults.json` (54 lines) vs `homeboy-extensions/defaults/extension-provided-defaults.json` (63 lines):

| Key | core copy | extensions copy | verdict |
|---|---|---|---|
| `install_methods.source.upgrade_command` | 644-char hardened script (detached-HEAD-safe `git pull --ff-only`, `cargo build --release`, tmp-swap `install -m 0755`, `--version` verify) | 66-char `git pull && . "$HOME/.cargo/env" && cargo install --path . --force` | **real drift** — core is correct |
| `version_candidates` | `Cargo.toml`, `package.json` | + `composer.json`, `style.css` | intentional |
| `test_drift.source_dirs` | `["src"]` | `["src","inc","lib"]` | intentional |
| `test_drift.file_extensions` | `[]` | `["php"]` | intentional |
| `direct_test_file_suffixes` | 12 entries | 13 entries, adds `Test.php` | intentional (**not in the issue's table**) |

Top-level keys and `install_methods` keys are otherwise identical (`homebrew`/`cargo`/`source`/`binary`).

## 2. Why they differ — the four are deliberate

`005e08bd8` ("code_audit: de-hardcode WP/Automattic literals from core") **removed** `composer.json`, `style.css`, `inc`/`lib`, `php`, and `Test.php` from core's copy on purpose, to enforce the language-agnostic core rule (#2240). Its message is explicit: *"Make the in-binary defaults asset's language fallbacks generic … The WP/PHP profile is supplied by the extension override path."*

These are not two copies of one file. They are two layers:

* **core's bundled asset** = the framework-agnostic compiled-in fallback
* **the extensions document** = an ecosystem *override*, loaded at runtime via `HOMEBOY_EXTENSION_DEFAULTS_PATH`

**Converging core onto the extensions copy would fail four live tests** in `crates/homeboy-core/src/defaults/builtins.rs`:

* `core_version_candidate_defaults_are_framework_agnostic` — asserts `== ["Cargo.toml", "package.json"]` exactly
* `core_test_drift_fallback_is_framework_agnostic` — asserts `source_dirs == ["src"]`, `file_extensions` empty
* `core_direct_test_suffix_fallback_is_framework_agnostic` — asserts `Test.php` is absent
* `source_upgrade_installs_active_binary` — asserts the upgrade command contains `cargo build --release` and **not** `cargo install --path`, which the extensions copy would violate on all four assertions

So I did **not** converge them. Instead the two-layer contract is now documented on the type itself, which is the durable fix for the misreading.

**The one real drift** is `install_methods.source.upgrade_command`. That field describes how Homeboy *itself* is rebuilt and has nothing to do with any ecosystem, so the two should agree. Core's is correct and newer (`58efc319a` hardened it with a tmp-swap install and `--version` verification; `1f15b706d` made it safe on detached checkouts). The extensions copy still has the old `cargo install --path . --force` and has not been touched since `5d8548d8` (#1381, 2026-06-19). **This needs a companion PR in `homeboy-extensions` — see below.**

## 3. Bootstrap safety — step 3 must NOT ship

**Step 3 is a bootstrap regression. Confirmed by tracing, not assumed.**

`install_methods` is consumed by `detect_install_method_from_exe_path` (`crates/homeboy-upgrade/src/upgrade/helpers.rs:86-118`), which matches the running executable's path against each method's `path_patterns`. With an empty `Default`:

1. All four `path_patterns` vectors are empty → all four loops no-op.
2. The `homebrew.list_command` fallback is `None` → skipped.
3. Returns `InstallMethod::Unknown`.
4. `execute_upgrade` (`execution.rs:163+`) hits the `Unknown` arm → hard error: **"Cannot upgrade: unknown installation method"**.

Even if detection somehow succeeded, `upgrade_command` would be `""` and `sh -c ""` exits 0 — reporting a successful upgrade that did nothing, which is worse than failing.

**Is `homeboy upgrade` reachable with zero extensions?** Yes, and the replacement path does not exist:

* **Nothing sets `HOMEBOY_EXTENSION_DEFAULTS_PATH`.** Grepping `crates/`, `src/`, and `.github/` finds only *readers* (`builtins.rs:37`, `detector_profile.rs:227`). No setter anywhere in core.
* **Nothing in `homeboy-extensions` references the file either.** `defaults/` contains that one orphaned document, and no manifest, script, or workflow in the repo mentions `extension-provided-defaults` or `defaults/`. It is dead weight from #1381, never wired to a loader.

So the extensions copy does **not** currently "ship to users" in any automatic sense. Removing core's bundled asset would leave **every** install with no defaults at all — not just zero-extension ones. Step 3 as written breaks self-upgrade globally.

The `detector_profile` precedent does not transfer: an empty detector profile degrades gracefully (fewer audit findings). An empty `install_methods` degrades to a broken `homeboy upgrade`.

## 4. What this PR changes

**`docs(defaults)`** — documents the two-layer relationship on `ExtensionProvidedDefaults` and the bootstrap constraint on `load_extension_provided_defaults`, so the next reader does not re-file this as drift or re-attempt the empty default.

**`fix(defaults)`** — `load_external_extension_provided_defaults` already treats operator input as fallible (unset var and unreadable file both return `None` and fall back). The parse step did not follow that contract: it went through `expect`, so **a single malformed override file panicked every command that touches defaults** — including the upgrade path that would otherwise repair the install. Split into a fallible `try_parse_extension_provided_defaults` for the runtime override path, keeping the panicking variant for the compiled-in asset where a parse failure is a build defect and should stay loud. Two regression tests added.

## 5. What remains

* **`homeboy-extensions` companion PR needed** — sync `install_methods.source.upgrade_command` to match core's hardened script, or delete the orphaned `defaults/` document outright given nothing loads it. I could not edit that repo from this worktree.
* **Decide whether the extensions document should be wired at all.** Nothing sets `HOMEBOY_EXTENSION_DEFAULTS_PATH`, so the ecosystem override is inert today. Either wire it during extension install or drop it. That decision is what actually unblocks a future step 3.
* **Step 3 stays deferred** until the override path is real and a zero-extension install has a working self-upgrade source. Not `Closes`.
* **Latent hazard, not fixed here:** `load_external_extension_provided_defaults` runs inside `OnceLock::get_or_init`, and `InstallMethodsConfig::deserialize` falls back to `builtins::default_*_config()` for any missing key — which re-enters `extension_provided_defaults()`. An override file omitting an `install_methods` key would re-enter the same `OnceLock` initializer. Not triggered today because the extensions document supplies all four keys. Worth a separate issue.
* The `bundled_core_defaults_stay_product_agnostic` guard test that used to pin this invariant at the asset level was deleted by `ccb9642de` ("delete tombstone, absence, and shape-matrix tests", 4643 lines). That looked like a deliberate policy decision, so I did not restore it rather than route around it. The four value-level tests in `builtins.rs` still cover the same ground from the positive direction.

## Verification

`cargo fmt -p homeboy-core`, `cargo check -p homeboy-core --lib --tests`, `cargo check -p homeboy-cli --lib` all exit 0. No `homeboy.json` changes (sibling PRs own that file).

Found during the 2026-08-01 consolidation investigation (#11151).

Refs #11099
