### PR TITLE
Use GitHub App client IDs in workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # actionlint v1.7.12 bundles the pre-v3.1.0 input schema.
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@'

--- a/.github/workflows/audit-debt.yml
+++ b/.github/workflows/audit-debt.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: ./.homeboy-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: ./.homeboy-action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - name: Run advisory audit
@@ -471,7 +471,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: Extra-Chill/homeboy-action@v2
@@ -518,7 +518,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: Extra-Chill/homeboy-action@v2
@@ -589,7 +589,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       # A push-triggered self-recovery has no `inputs.release_tag`, and main has


### PR DESCRIPTION
## Summary

- replace deprecated `app-id` inputs with canonical `client-id` across owned workflows
- preserve the existing secret values and workflow permissions
- narrowly suppress actionlint v1.7.12 stale-schema false positives documented in rhysd/actionlint#669

Closes #11217.

## Verification

- `actionlint -ignore 'SC(2086|2129)' .github/workflows/ci.yml .github/workflows/audit-debt.yml .github/workflows/release.yml`\n- `cargo test --test release_workflow_test --test release_expected_assets_test` (50 passed)\n- `git diff --check`\n- live `actions/create-github-app-token@v3/action.yml` confirms `client-id` is canonical and `app-id` is deprecated\n\n## AI assistance\n\nOpenCode using `openai/gpt-5.6-sol` traced the post-upgrade runtime warning, verified upstream action metadata, and implemented the migration. Chris Huber reviewed the resulting diff and remains responsible for every line.