### PR TITLE
Fix silent binary upgrade no-op regression

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -100,8 +100,15 @@ pub(crate) fn execute_upgrade(
     explicit_source_path: bool,
     force: bool,
     previous_build_identity: Option<&str>,
+    selected_binary_version: Option<&str>,
 ) -> Result<(bool, Option<String>, Option<String>, Option<String>)> {
     let defaults = defaults::load_defaults();
+    // The binary installer replaces `command -v homeboy`. Capture that path
+    // before its shell runs so verification proves the intended PATH target was
+    // replaced rather than merely finding some other Homeboy afterward.
+    let binary_destination = (method == InstallMethod::Binary)
+        .then(active_binary_path)
+        .transpose()?;
     let output = match method {
         InstallMethod::Homebrew => {
             let cmd = &defaults.install_methods.homebrew.upgrade_command;
@@ -199,19 +206,42 @@ pub(crate) fn execute_upgrade(
     // false-negative `upgraded: false` / `new_version: null` on a successful
     // upgrade. Retry the read-back until it reports a verifiable version before
     // giving up. See issue #3463.
-    let (success, active_binary) = verify_upgrade_with_retry(
-        method,
-        force,
-        current_version(),
-        previous_build_identity,
-        VERIFY_READBACK_ATTEMPTS,
-        VERIFY_READBACK_DELAY,
-        || active_binary_info().ok().flatten(),
-        std::thread::sleep,
-    );
+    let (success, active_binary) = if let Some(selected_version) = selected_binary_version {
+        let destination = binary_destination
+            .as_deref()
+            .expect("binary upgrades capture a PATH destination");
+        verify_binary_upgrade_with_retry(
+            destination,
+            selected_version,
+            VERIFY_READBACK_ATTEMPTS,
+            VERIFY_READBACK_DELAY,
+            std::thread::sleep,
+        )
+    } else {
+        verify_upgrade_with_retry(
+            method,
+            force,
+            current_version(),
+            previous_build_identity,
+            VERIFY_READBACK_ATTEMPTS,
+            VERIFY_READBACK_DELAY,
+            || active_binary_info().ok().flatten(),
+            std::thread::sleep,
+        )
+    };
 
     let new_version = active_binary.as_ref().and_then(|info| info.version.clone());
-    let new_build_identity = active_binary.and_then(|info| info.build_identity);
+    let new_build_identity = active_binary
+        .as_ref()
+        .and_then(|info| info.build_identity.clone());
+
+    if method == InstallMethod::Binary && !success {
+        return Err(binary_swap_failure(
+            selected_binary_version.expect("binary upgrades select a release version"),
+            binary_destination.as_deref(),
+            active_binary.as_ref(),
+        ));
+    }
 
     // A source upgrade's command is responsible for swapping the freshly built
     // artifact into the active binary on disk. When that command exits 0 but the
@@ -222,6 +252,31 @@ pub(crate) fn execute_upgrade(
     // believe the roll-forward succeeded. Fail loudly with an actionable reason
     // so urgent source fixes are not silently dropped (#5772).
     Ok((success, new_version, new_build_identity, None))
+}
+
+fn binary_swap_failure(
+    selected_version: &str,
+    destination: Option<&Path>,
+    observed: Option<&ActiveBinaryInfo>,
+) -> Error {
+    let destination = destination
+        .map(display_path)
+        .unwrap_or_else(|| "unresolved".to_string());
+    let observed_version = observed
+        .and_then(|info| info.version.as_deref())
+        .unwrap_or("unverifiable");
+
+    Error::internal_unexpected(format!(
+        "binary upgrade did not activate the selected release {selected_version} at {destination} (observed {observed_version})"
+    ))
+    .with_hint(format!(
+        "The PATH-active destination was not verified after the installer exited: {destination}"
+    ))
+    .with_hint(format!(
+        "Expected `{destination} --version` to report {selected_version}, but it reported {observed_version}."
+    ))
+    .with_hint("Inspect PATH shadowing with: type -a homeboy")
+    .with_hint("Retry explicitly after correcting the active destination: homeboy upgrade --force --method binary")
 }
 
 fn complete_source_upgrade(
@@ -674,6 +729,83 @@ where
 
         // Hold onto the most informative read so the caller can still report a
         // version even if verification never flips to success.
+        if active_binary
+            .as_ref()
+            .and_then(|info| info.version.as_deref())
+            .is_some()
+            || last_seen.is_none()
+        {
+            last_seen = active_binary;
+        }
+
+        if attempt + 1 < attempts {
+            sleep(delay);
+        }
+    }
+
+    (false, last_seen)
+}
+
+fn verify_binary_upgrade_with_retry<S>(
+    destination: &Path,
+    selected_version: &str,
+    attempts: u32,
+    delay: Duration,
+    sleep: S,
+) -> (bool, Option<ActiveBinaryInfo>)
+where
+    S: FnMut(Duration),
+{
+    verify_binary_upgrade_with_retry_reader(
+        selected_version,
+        attempts,
+        delay,
+        || active_binary_info_at(destination).ok().flatten(),
+        sleep,
+    )
+}
+
+fn verify_binary_upgrade_with_retry_reader<R, S>(
+    selected_version: &str,
+    attempts: u32,
+    delay: Duration,
+    read_active: R,
+    sleep: S,
+) -> (bool, Option<ActiveBinaryInfo>)
+where
+    R: FnMut() -> Option<ActiveBinaryInfo>,
+    S: FnMut(Duration),
+{
+    verify_with_retry(
+        attempts,
+        delay,
+        read_active,
+        |info| info.version.as_deref() == Some(selected_version),
+        sleep,
+    )
+}
+
+fn verify_with_retry<R, V, S>(
+    attempts: u32,
+    delay: Duration,
+    mut read_active: R,
+    mut verified: V,
+    mut sleep: S,
+) -> (bool, Option<ActiveBinaryInfo>)
+where
+    R: FnMut() -> Option<ActiveBinaryInfo>,
+    V: FnMut(&ActiveBinaryInfo) -> bool,
+    S: FnMut(Duration),
+{
+    let attempts = attempts.max(1);
+    let mut last_seen: Option<ActiveBinaryInfo> = None;
+
+    for attempt in 0..attempts {
+        let active_binary = read_active();
+        if active_binary.as_ref().is_some_and(|info| verified(info)) {
+            return (true, active_binary);
+        }
+
         if active_binary
             .as_ref()
             .and_then(|info| info.version.as_deref())

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
@@ -29,6 +29,103 @@ fn test_verify_upgrade_with_retry() {
 }
 
 #[test]
+fn explicit_binary_upgrade_requires_the_selected_release_version() {
+    // #11152: a successful installer process is insufficient when it leaves a
+    // stale or shadowed executable on PATH. Explicit binary mode must verify
+    // the release selected before the swap, not just any newer version.
+    let reads = std::cell::RefCell::new(vec![
+        Some(ActiveBinaryInfo {
+            version: Some("0.326.1".to_string()),
+            build_identity: Some("homeboy 0.326.1".to_string()),
+        }),
+        Some(ActiveBinaryInfo {
+            version: Some("0.326.1".to_string()),
+            build_identity: Some("homeboy 0.326.1".to_string()),
+        }),
+    ]);
+
+    let (success, observed) = verify_binary_upgrade_with_retry_reader(
+        "0.326.2",
+        2,
+        Duration::ZERO,
+        || reads.borrow_mut().remove(0),
+        |_| {},
+    );
+
+    assert!(!success, "a different release must not verify as success");
+    assert_eq!(
+        observed.and_then(|info| info.version).as_deref(),
+        Some("0.326.1")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn explicit_binary_upgrade_reads_the_captured_destination_not_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // #11152: the installer replaces `command -v homeboy` before this process
+    // returns. Verification must execute that captured path, even when another
+    // Homeboy binary shadows it later on PATH.
+    let directory = tempfile::tempdir().expect("tempdir");
+    let destination = directory.path().join("homeboy");
+    std::fs::write(&destination, "#!/bin/sh\nprintf 'homeboy 0.326.0\\n'\n").expect("stale binary");
+    std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o755))
+        .expect("make stale binary executable");
+
+    let (success, observed) =
+        verify_binary_upgrade_with_retry(&destination, "0.326.1", 1, Duration::ZERO, |_| {});
+
+    assert!(!success, "the stale captured target must fail verification");
+    assert_eq!(
+        observed.and_then(|info| info.version).as_deref(),
+        Some("0.326.0")
+    );
+}
+
+#[test]
+fn explicit_binary_upgrade_accepts_the_selected_release_version() {
+    let (success, observed) = verify_binary_upgrade_with_retry_reader(
+        "0.326.1",
+        1,
+        Duration::ZERO,
+        || {
+            Some(ActiveBinaryInfo {
+                version: Some("0.326.1".to_string()),
+                build_identity: Some("homeboy 0.326.1".to_string()),
+            })
+        },
+        |_| {},
+    );
+
+    assert!(success);
+    assert_eq!(
+        observed.and_then(|info| info.version).as_deref(),
+        Some("0.326.1")
+    );
+}
+
+#[test]
+fn binary_swap_failure_identifies_the_target_and_observed_destination() {
+    let err = binary_swap_failure(
+        "0.326.1",
+        Some(Path::new("/Users/chubes/.cargo/bin/homeboy")),
+        Some(&ActiveBinaryInfo {
+            version: Some("0.326.0".to_string()),
+            build_identity: Some("homeboy 0.326.0".to_string()),
+        }),
+    );
+
+    assert!(err.message.contains("0.326.1"));
+    assert!(err.message.contains("/Users/chubes/.cargo/bin/homeboy"));
+    assert!(err.message.contains("observed 0.326.0"));
+    assert!(err
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("type -a homeboy")));
+}
+
+#[test]
 fn source_swap_failure_errors_when_active_binary_unchanged() {
     // Issue #5772: the source upgrade command exited 0 but the read-back
     // proves the active binary was not replaced — fail loudly instead of a

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -232,7 +232,7 @@ pub fn run_upgrade_with_method(
 
     // Check if a release update is available unless an explicit source target
     // has already been approved for controller replacement.
-    if !replacement_approved {
+    let release_target = if !replacement_approved {
         let check = check_for_updates()?;
         if !controller_replacement_proceeds(force, source_upgrade_decision, check.update_available)
         {
@@ -309,7 +309,22 @@ pub fn run_upgrade_with_method(
                 services_pending_restart: Vec::new(),
             });
         }
-    }
+        check.latest_version
+    } else {
+        None
+    };
+
+    // Binary upgrades install GitHub's latest release asset. Resolve that
+    // release before mutation so post-swap verification can prove the PATH
+    // destination runs the exact release selected for this operation.
+    let selected_binary_version = if install_method == InstallMethod::Binary {
+        match release_target {
+            Some(version) => Some(version),
+            None => Some(fetch_latest_version(InstallMethod::Binary)?),
+        }
+    } else {
+        None
+    };
 
     // Execute the upgrade
     promotion_lease.assert_generation()?;
@@ -319,6 +334,7 @@ pub fn run_upgrade_with_method(
         source_path.is_some(),
         force,
         previous_build_identity.as_deref(),
+        selected_binary_version.as_deref(),
     )?;
     let upgrade_completed = should_sync_after_upgrade(new_version.as_deref());
     if upgrade_completed {


### PR DESCRIPTION
Closes #11152.

## Summary

- resolve the selected binary release before mutation
- capture the PATH-active Homeboy destination before invoking the installer
- verify that exact executable reports the selected release after the swap
- fail closed with destination, observed version, PATH-shadowing diagnostics, and a recovery command when activation cannot be proven
- add regression coverage for stale/shadowed destinations, release mismatch, successful activation, and actionable diagnostics

## Verification

- `cargo test -p homeboy-upgrade` (127 passed)
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Process evidence

The canonical Cook path was attempted first. It was blocked by pre-dispatch runner reconciliation (#11156), disconnected Lab, and then a local provider timeout (#11081/#11077). Chris explicitly approved bypassing Homeboy and implementing the issue directly. Follow-up ergonomics were filed as #11225 and #11226.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol reproduced and diagnosed the upgrade failure, searched and filed related Homeboy issues, implemented the post-swap verification and regression tests, ran the focused verification gates, and drafted this PR. Chris Huber remains responsible for every line.