### PR TITLE
fix: skip the guaranteed draft 404 (#11145); make the Lab help-visibility table testable (#11141)

### DIFF
--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -2,6 +2,50 @@
 //!
 //! This intentionally uses only argv so it can run before extension discovery,
 //! configuration hydration, or any mutation coordination.
+//!
+//! ## Why this is not `command_safety_manifest_from(...).find_path(argv).mutates`
+//!
+//! #11141 proposed replacing this classifier with a lookup into the command
+//! safety manifest, on the theory that it duplicates `CommandSpec.safety`. The
+//! ordering objection this module states does NOT block that: the manifest
+//! derives from `COMMAND_SPECS` (static consts) plus `Cli::command()` (clap
+//! derive metadata), and `registered_command` is a linear scan over a static
+//! array — neither reads config nor discovers extensions. Verified 2026-08-01.
+//!
+//! The conversion is blocked by something else. The two tables answer different
+//! questions:
+//!
+//! - `CommandSafetyEntry.mutates` is ONE bool per command PATH, feeding a
+//!   documentation/audit projection that deliberately under-declares —
+//!   `command_safety_manifest_audit` is `report_only: true`, and a path with no
+//!   registry declaration resolves to `read_only()` by default.
+//! - `CommandCapability` is a per-INVOCATION runtime gate that must fail closed,
+//!   because `Mutation` is what authorizes `reconcile_terminal_runner_exec_runs`
+//!   (recovering completed runner-exec evidence before a mutating command can
+//!   evict it) and the deferred-workload worker restart.
+//!
+//! A per-path lookup cannot express the argument-conditional rows here at all:
+//! `status` is read-only until `--refresh`, and `project`/`rig`/`server` are
+//! read-only only when bare or `list`. Worse, the registry's silence is not
+//! evidence of read-only-ness. Every one of these resolves `mutates: false`
+//! today while this classifier correctly answers `Mutation`:
+//!
+//! - `status --refresh` — `ops_command_spec!(status)` is a bare `command_spec`,
+//!   so the manifest has no `--refresh` distinction and no subcommand table
+//! - `daemon start` — `ops_command_spec!(daemon)` likewise declares nothing
+//! - `runtime promotion-takeover` — `RUNTIME_SUBCOMMAND_SAFETY` declares only
+//!   `refresh`
+//! - `agent-task retry <run> --run` — `AGENT_TASK_SUBCOMMAND_SAFETY` declares no
+//!   `retry` row
+//!
+//! Converting would silently reclassify all four as `ReadOnly` and skip their
+//! startup recovery. `classifies_actions_as_mutations_by_default` below pins
+//! exactly that. The `_ => Mutation` fail-closed default the issue asks for is
+//! already in place.
+//!
+//! The duplication is real; the fix is not a per-path lookup. It would need the
+//! registry to carry a mutation-inducing-flag axis, and every silent path to be
+//! declared rather than defaulted.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandCapability {

--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -70,69 +70,103 @@ fn scope_lab_cli_arguments_at_path(
 /// Command paths that expose the Lab execution placement/runner flags in their
 /// `--help`, mirroring the Lab-portable command surface. Kept explicit so the
 /// help surface is deterministic and reviewable.
+///
+/// Declared as DATA rather than a `matches!` arm chain (#11141). This table is
+/// a second source of truth for "is this path Lab-portable", parallel to each
+/// command's `lab_contract()`, and while it was control flow nothing could
+/// enumerate it — so nothing could assert the two agreed, and nothing could
+/// catch a path spelling that clap does not expose (the #10313 failure mode,
+/// which here would silently hide the placement flags forever). The tests
+/// below now assert both.
+///
+/// The coarse dimension — which top-level commands are Lab-supported at all —
+/// is NOT restated here; `lab_cli_arguments_are_visible_for_path` reads it from
+/// `COMMAND_SPECS`, so this table only refines a registry fact instead of
+/// re-declaring one.
+const LAB_VISIBLE_COMMAND_PATHS: &[&[&str]] = &[
+    &["agent-task", "cook"],
+    &["agent-task", "run-plan"],
+    &["agent-task", "run"],
+    &["agent-task", "run-next"],
+    &["agent-task", "status"],
+    &["agent-task", "list"],
+    &["agent-task", "active"],
+    &["agent-task", "latest"],
+    &["agent-task", "logs"],
+    &["agent-task", "artifacts"],
+    &["agent-task", "evidence"],
+    &["agent-task", "review"],
+    &["agent-task", "retry"],
+    &["agent-task", "promote"],
+    &["agent-task", "providers"],
+    &["agent-task", "fanout", "submit-batch"],
+    &["agent-task", "fanout", "status"],
+    &["agent-task", "fanout", "artifacts"],
+    // The fanout coordinator is controller-owned, but split placement hands
+    // each child attempt to the selected runner, so the placement arguments are
+    // load-bearing here and must stay discoverable.
+    &["agent-task", "fanout", "cook-batch"],
+    &["agent-task", "fanout", "run-plan"],
+    &["agent-task", "auth", "status"],
+    &["agent-task", "controller", "from-spec"],
+    &["agent-task", "controller", "run-from-spec"],
+    &["agent-task", "controller", "materialize"],
+    &["agent-task", "controller", "resume"],
+    &["bench"],
+    &["bench", "matrix"],
+    &["fuzz"],
+    &["fuzz", "run"],
+    &["fuzz", "run-campaign"],
+    &["fuzz", "list"],
+    &["fuzz", "plan"],
+    &["fuzz", "doctor"],
+    &["review"],
+    &["review", "audit"],
+    &["review", "lint"],
+    &["review", "test"],
+    &["trace"],
+    &["refactor"],
+    &["rig", "check"],
+    &["rig", "run"],
+    &["runtime", "refresh"],
+    &["worktree", "cleanup"],
+    &["extension", "update"],
+    &["extension", "refresh"],
+    &["extension", "dev-run"],
+    &["extension", "show"],
+    &["tunnel", "preview-consumer", "run"],
+    &["tunnel", "service", "expose"],
+    &["tunnel", "service", "start"],
+];
+
 fn lab_cli_arguments_are_visible_for_path(path: &[String]) -> bool {
-    matches!(
-        path.iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .as_slice(),
-        ["agent-task", "cook"]
-            | ["agent-task", "run-plan"]
-            | ["agent-task", "run"]
-            | ["agent-task", "run-next"]
-            | ["agent-task", "status"]
-            | ["agent-task", "list"]
-            | ["agent-task", "active"]
-            | ["agent-task", "latest"]
-            | ["agent-task", "logs"]
-            | ["agent-task", "artifacts"]
-            | ["agent-task", "evidence"]
-            | ["agent-task", "review"]
-            | ["agent-task", "retry"]
-            | ["agent-task", "promote"]
-            | ["agent-task", "providers"]
-            | ["agent-task", "fanout", "submit-batch"]
-            | ["agent-task", "fanout", "status"]
-            | ["agent-task", "fanout", "artifacts"]
-            // The fanout coordinator is controller-owned, but split placement
-            // hands each child attempt to the selected runner, so the placement
-            // arguments are load-bearing here and must stay discoverable.
-            | ["agent-task", "fanout", "cook-batch"]
-            | ["agent-task", "fanout", "run-plan"]
-            | ["agent-task", "auth", "status"]
-            | ["agent-task", "controller", "from-spec"]
-            | ["agent-task", "controller", "run-from-spec"]
-            | ["agent-task", "controller", "materialize"]
-            | ["agent-task", "controller", "resume"]
-            | ["bench"]
-            | ["bench", "matrix"]
-            | ["fuzz"]
-            | ["fuzz", "run"]
-            | ["fuzz", "run-campaign"]
-            | ["fuzz", "list"]
-            | ["fuzz", "plan"]
-            | ["fuzz", "doctor"]
-            | ["review"]
-            | ["review", "audit"]
-            | ["review", "lint"]
-            | ["review", "test"]
-            | ["trace"]
-            | ["refactor"]
-            | ["rig", "check"]
-            | ["rig", "run"]
-            | ["runtime", "refresh"]
-            | ["worktree", "cleanup"]
-            | ["extension", "update"]
-            | ["extension", "refresh"]
-            | ["extension", "dev-run"]
-            | ["extension", "show"]
-            | ["tunnel", "preview-consumer", "run"]
-            | ["tunnel", "service", "expose"]
-            | ["tunnel", "service", "start"]
-    )
+    let path = path.iter().map(String::as_str).collect::<Vec<_>>();
+
+    // `CommandSpec.lab_supported` already answers "does this command family
+    // route to Lab at all". Gate on it so a path table entry can only ever
+    // NARROW a registry fact, never invent one: adding a Lab-visible path under
+    // a command the registry does not declare Lab-supported now shows nothing
+    // and fails the agreement test below, instead of quietly advertising
+    // placement flags on a command that cannot honour them.
+    if !path
+        .first()
+        .copied()
+        .is_some_and(top_level_command_is_lab_supported)
+    {
+        return false;
+    }
+
+    LAB_VISIBLE_COMMAND_PATHS.contains(&path.as_slice())
+}
+
+fn top_level_command_is_lab_supported(name: &str) -> bool {
+    crate::command_contract::registered_command(name).is_some_and(|spec| spec.lab_supported)
 }
 
 mod support;
+
+#[cfg(test)]
+mod tests;
 
 // The lab contract types (workload / handoff / typed identifiers) and the
 // lab-runnable command labels now live in the homeboy-lab-contract crate.

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -1,0 +1,266 @@
+//! Guards for the Lab help-visibility path table (#11141).
+//!
+//! `LAB_VISIBLE_COMMAND_PATHS` decides which subcommands advertise the Lab
+//! placement/runner flags in `--help`. That is a second source of truth for "is
+//! this path Lab-portable", parallel to each command's `lab_contract()`, and
+//! until now NOTHING asserted the two agreed — the table was a `matches!` arm
+//! chain, so it could not even be enumerated.
+//!
+//! Drift between the two is not cosmetic. A path missing from the table hides
+//! `--placement`/`--runner` on a command that honours them, so the capability
+//! is undiscoverable; a path present in the table with no contract advertises
+//! flags that silently do nothing. The comparable class of bug in the safety
+//! registry (#10313) was a declared path spelling clap does not expose, which
+//! is likewise unobservable here without a test.
+
+use super::{lab_cli_arguments_are_visible_for_path, LAB_VISIBLE_COMMAND_PATHS};
+use crate::cli_surface::{current_command_surface, Cli, CommandSurfaceEntry};
+use clap::{CommandFactory, FromArgMatches};
+
+/// A parseable invocation at each Lab-visible path.
+///
+/// Help visibility is per-PATH; a Lab contract is resolved per-INVOCATION.
+/// Several commands only carry a contract for a particular argument shape
+/// (`retry --run`, `controller from-spec --resume`, `refactor --all`,
+/// `fuzz list --remote-discovery`), which is precisely why the flags are
+/// advertised on the path: the operator needs them discoverable in order to
+/// reach that shape. So the claim under test is "there exists an invocation at
+/// this path with a Lab contract", and these are those invocations.
+///
+/// Required arguments below are the ones clap actually demands; a path whose
+/// required arguments change fails here loudly rather than skipping silently.
+const REPRESENTATIVE_INVOCATIONS: &[&[&str]] = &[
+    &["agent-task", "cook", "--to-worktree", "repo@slug"],
+    &["agent-task", "run-plan", "--plan", "-"],
+    &["agent-task", "run", "run-1"],
+    &["agent-task", "run-next"],
+    &["agent-task", "status", "run-1"],
+    &["agent-task", "list"],
+    &["agent-task", "active"],
+    &["agent-task", "latest"],
+    &["agent-task", "logs", "run-1"],
+    &["agent-task", "artifacts", "run-1"],
+    &["agent-task", "evidence", "run-1"],
+    &["agent-task", "review", "run-1"],
+    // Only `--run` executes; the bare form is local retry bookkeeping.
+    &["agent-task", "retry", "run-1", "--run"],
+    &[
+        "agent-task",
+        "promote",
+        "--to-worktree",
+        "repo@slug",
+        "candidate.patch",
+    ],
+    &["agent-task", "providers"],
+    &["agent-task", "fanout", "submit-batch", "--input", "{}"],
+    &["agent-task", "fanout", "status", "batch-1"],
+    &["agent-task", "fanout", "artifacts", "batch-1"],
+    &[
+        "agent-task",
+        "fanout",
+        "cook-batch",
+        "--repo",
+        "owner/repo",
+        "https://example.test/issues/1",
+    ],
+    &["agent-task", "fanout", "run-plan", "--input", "{}"],
+    &["agent-task", "auth", "status"],
+    // #9375-adjacent: only `--resume` materializes, and only that shape has a
+    // portable contract.
+    &["agent-task", "controller", "from-spec", "--resume", "spec"],
+    &[
+        "agent-task",
+        "controller",
+        "run-from-spec",
+        "--max-actions",
+        "1",
+        "spec",
+    ],
+    &["agent-task", "controller", "materialize", "spec"],
+    &["agent-task", "controller", "resume", "loop-1"],
+    &["bench"],
+    &["bench", "matrix"],
+    &["fuzz"],
+    &["fuzz", "run"],
+    &["fuzz", "run-campaign"],
+    // Listing is local metadata discovery until a runner is queried.
+    &["fuzz", "list", "--remote-discovery"],
+    &["fuzz", "plan"],
+    &["fuzz", "doctor", "--extension", "rust"],
+    &["review"],
+    &["review", "audit"],
+    &["review", "lint"],
+    &["review", "test"],
+    &["trace"],
+    // A bare `refactor` is not a hot resource command; `--all` is the shape
+    // that offloads.
+    &["refactor", "--all"],
+    &["rig", "check", "target"],
+    &["rig", "run", "--profile", "profile", "rig-1"],
+    &["runtime", "refresh", "--source", "source", "runtime-1"],
+    &["worktree", "cleanup"],
+    &["extension", "update"],
+    &["extension", "refresh", "source"],
+    &[
+        "extension",
+        "dev-run",
+        "--source",
+        "source",
+        "--runner",
+        "runner-1",
+        "extension-1",
+        "command",
+    ],
+    &["extension", "show", "extension-1"],
+    &["tunnel", "preview-consumer", "run", "--config", "config"],
+    // `--server` is `required_unless_present = "runner_local"`, so it does not
+    // appear in the usage line but clap still demands one of the pair.
+    &[
+        "tunnel",
+        "service",
+        "expose",
+        "--server",
+        "server-1",
+        "--remote-host",
+        "host",
+        "--remote-port",
+        "8080",
+        "--auth-mode",
+        "ssh-only",
+        "service-1",
+    ],
+    &[
+        "tunnel",
+        "service",
+        "start",
+        "--command",
+        "sleep",
+        "service-1",
+    ],
+];
+
+fn owned(path: &[&str]) -> Vec<String> {
+    path.iter().map(|segment| segment.to_string()).collect()
+}
+
+/// The declared table is what `lab_cli_arguments_are_visible_for_path` answers
+/// with. Without this the tests below could pass against a table the help
+/// surface never consults.
+#[test]
+fn every_declared_path_is_visible_and_undeclared_paths_are_not() {
+    for path in LAB_VISIBLE_COMMAND_PATHS {
+        assert!(
+            lab_cli_arguments_are_visible_for_path(&owned(path)),
+            "declared Lab-visible path `{}` is not visible",
+            path.join(" ")
+        );
+    }
+
+    // The root has no path, and `contract manifest` is the non-portable
+    // subcommand a previous refactor wrongly advertised these flags on.
+    for path in [vec![], vec!["contract"], vec!["contract", "manifest"]] {
+        assert!(
+            !lab_cli_arguments_are_visible_for_path(&owned(&path)),
+            "`{}` must not advertise Lab placement flags",
+            path.join(" ")
+        );
+    }
+}
+
+/// Every Lab-visible path must resolve to a real node in the clap-derived
+/// command surface.
+///
+/// This is the #10313 guard applied to help visibility: a declared path that
+/// clap does not expose can never match, so the placement flags are hidden
+/// forever on a command that supports them, with no error anywhere.
+#[test]
+fn every_lab_visible_path_resolves_to_a_clap_surface_node() {
+    fn resolves(entries: &[CommandSurfaceEntry], path: &[&str]) -> bool {
+        let Some((first, rest)) = path.split_first() else {
+            return true;
+        };
+
+        entries
+            .iter()
+            .find(|entry| entry.name == *first)
+            .is_some_and(|entry| resolves(&entry.subcommands, rest))
+    }
+
+    let surface = current_command_surface();
+
+    for path in LAB_VISIBLE_COMMAND_PATHS {
+        assert!(
+            resolves(&surface.commands, path),
+            "Lab-visible path `{}` is not a path in the clap command surface",
+            path.join(" ")
+        );
+    }
+}
+
+/// The path table may only refine the registry, never contradict it.
+///
+/// `CommandSpec.lab_supported` is the declared answer to "does this command
+/// family route to Lab at all". A Lab-visible path under a command the registry
+/// does not declare Lab-supported is one table disagreeing with another — the
+/// exact shape of #8025/#9375/#9428/#9763, where a private copy of one
+/// workload's taxonomy drifted from the copy that governed behavior.
+#[test]
+fn lab_visible_paths_stay_within_the_registry_lab_supported_commands() {
+    let declared = LAB_VISIBLE_COMMAND_PATHS
+        .iter()
+        .filter_map(|path| path.first().copied())
+        .collect::<std::collections::BTreeSet<_>>();
+    let registered = crate::command_contract::COMMAND_SPECS
+        .iter()
+        .filter(|spec| spec.lab_supported)
+        .map(|spec| spec.name)
+        .collect::<std::collections::BTreeSet<_>>();
+
+    assert_eq!(
+        declared, registered,
+        "the Lab help-visibility table and `CommandSpec.lab_supported` must describe the same command families"
+    );
+}
+
+/// The agreement the issue says nothing asserts (#11141).
+///
+/// Help visibility is per-path; a Lab contract is per-invocation. The honest
+/// claim is that SOME invocation at each Lab-visible path carries a Lab
+/// contract — if none does, the flags are pure noise in `--help`.
+#[test]
+fn every_lab_visible_path_has_an_invocation_with_a_lab_contract() {
+    assert_eq!(
+        REPRESENTATIVE_INVOCATIONS.len(),
+        LAB_VISIBLE_COMMAND_PATHS.len(),
+        "every Lab-visible path needs a representative invocation"
+    );
+
+    for (path, invocation) in LAB_VISIBLE_COMMAND_PATHS
+        .iter()
+        .zip(REPRESENTATIVE_INVOCATIONS)
+    {
+        assert!(
+            invocation.starts_with(path),
+            "representative invocation `{}` is not an invocation of `{}`",
+            invocation.join(" "),
+            path.join(" ")
+        );
+
+        let argv = std::iter::once("homeboy")
+            .chain(invocation.iter().copied())
+            .collect::<Vec<_>>();
+        let matches = Cli::command()
+            .try_get_matches_from(&argv)
+            .unwrap_or_else(|error| panic!("`{}` should parse: {error}", argv.join(" ")));
+        let command = Cli::from_arg_matches(&matches)
+            .expect("validated arguments should parse")
+            .command;
+
+        assert!(
+            command.portability_contract().lab_command().is_some(),
+            "`{}` advertises the Lab placement flags in --help but `{}` resolves no Lab contract",
+            path.join(" "),
+            argv.join(" ")
+        );
+    }
+}

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -6,6 +6,35 @@
 //! `hot_command` composes them to short-circuit commands that are controller-
 //! local coordination, planning-only, read-only, or lightweight registry
 //! management, and to recognize the Lab-offloadable fanout coordinator.
+//!
+//! ## Why this is not a `CommandPathSafetySpec` lookup
+//!
+//! #11141 proposed folding this table into the command registry as a
+//! per-resolved-path `resource_behavior`, alongside the Lab help-visibility
+//! table (converted) and `command_capability` (see that module's note).
+//!
+//! It does not fit. `CommandPathSafetySpec` keys on a command PATH; seven rows
+//! here key on parsed ARGUMENT VALUES at a single path, and flip classification
+//! across the admission boundary when they do:
+//!
+//! - `cook --queue-only` — `LocalControl`, otherwise `AdmittedWorkload`
+//! - `retry --run` — `AdmittedWorkload`, otherwise `LocalControl`
+//! - `active --reconcile` — `AdmittedWorkload`, otherwise `BoundedMetadataRead`
+//! - `reconcile --apply` — `AdmittedWorkload`, otherwise `BoundedMetadataRead`
+//! - `loop define --resume` — `AdmittedWorkload`, otherwise `LocalControl`
+//! - `controller from-spec --resume` — `AdmittedWorkload`, otherwise
+//!   `LocalControl`
+//! - `fanout cook-batch --dry-run` — `is_plan_only_command` below
+//!
+//! `path_safety` resolves one entry per path, so each of these pairs would
+//! collapse to a single behavior. Choosing either side is a real incident:
+//! collapsing to `AdmittedWorkload` puts controller-local bookkeeping behind
+//! warm/hot refusal (the #9428 failure), and collapsing to `LocalControl`
+//! refuses a validated batch a ready runner could serve (the #9375 failure).
+//!
+//! The Lab help-visibility table WAS convertible because help visibility is
+//! genuinely per-path. This one is per-invocation. Folding it into the registry
+//! needs the registry to gain an argument-predicate axis first.
 
 use crate::cli_surface::Commands;
 use crate::commands::agent_task;

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -582,40 +582,58 @@ pub(crate) fn github_release_upload_timeout() -> Duration {
         .unwrap_or_else(|| Duration::from_secs(DEFAULT_GITHUB_RELEASE_UPLOAD_TIMEOUT_SECS))
 }
 
+/// Resolve release metadata for `tag`.
+///
+/// `expect_draft` states what the caller already knows about the release. The
+/// readback after `gh release create --draft` KNOWS the release is a draft, and
+/// `releases/tags/{tag}` 404s for drafts by design (see below), so attempting
+/// that endpoint there is a guaranteed-failing round trip whose only lasting
+/// effect is putting an expected, irrelevant 404 at the front of any composed
+/// error message (#11145). Callers that do not know the publication state --
+/// the retry boundary reading a pre-existing release, the post-upload
+/// verification -- pass `false` and keep the tag lookup as the fast path.
 pub(crate) fn gh_release_metadata(
     github: &GitHubRepo,
     config: &GithubConfig,
     tag: &str,
     repo_flag: &str,
+    expect_draft: bool,
 ) -> Result<GitHubReleaseMetadata, GitHubReleaseMetadataError> {
     // `gh release view --json` uses GraphQL, whose release asset shape omits
     // the REST digest field. Recovery authority requires that digest, including
     // for drafts, so read the REST API directly.
     let endpoint = format!("repos/{repo_flag}/releases/tags/{tag}");
-    let output = run_gh_command(
-        gh_command(github, config, &["api", &endpoint]),
-        github_release_upload_timeout(),
-    );
-    if !output.timed_out && output.exit_code == Some(0) {
-        return serde_json::from_str(&output.stdout).map_err(|error| GitHubReleaseMetadataError {
-            message: format!("GitHub REST release metadata was invalid: {error}"),
-            diagnostics: vec![gh_failure_diagnostic(
-                "gh api release metadata",
-                &endpoint,
-                &output,
-            )],
-        });
-    }
-    if output.timed_out {
-        return Err(GitHubReleaseMetadataError {
-            message: gh_failure_detail("gh api release metadata", &output),
-            diagnostics: vec![gh_failure_diagnostic(
-                "gh api release metadata",
-                &endpoint,
-                &output,
-            )],
-        });
-    }
+    let by_tag = if expect_draft {
+        None
+    } else {
+        let output = run_gh_command(
+            gh_command(github, config, &["api", &endpoint]),
+            github_release_upload_timeout(),
+        );
+        if !output.timed_out && output.exit_code == Some(0) {
+            return serde_json::from_str(&output.stdout).map_err(|error| {
+                GitHubReleaseMetadataError {
+                    message: format!("GitHub REST release metadata was invalid: {error}"),
+                    diagnostics: vec![gh_failure_diagnostic(
+                        "gh api release metadata",
+                        &endpoint,
+                        &output,
+                    )],
+                }
+            });
+        }
+        if output.timed_out {
+            return Err(GitHubReleaseMetadataError {
+                message: gh_failure_detail("gh api release metadata", &output),
+                diagnostics: vec![gh_failure_diagnostic(
+                    "gh api release metadata",
+                    &endpoint,
+                    &output,
+                )],
+            });
+        }
+        Some(output)
+    };
 
     // `releases/tags/{tag}` resolves published releases only -- GitHub returns
     // 404 for a draft, because a draft has no tag association on that endpoint.
@@ -648,7 +666,13 @@ pub(crate) fn gh_release_metadata(
         Ok(metadata) => Ok(metadata),
         Err(by_id_error) => {
             gh_draft_release_metadata(github, config, tag, repo_flag).map_err(|draft_error| {
-                metadata_fallback_error(&endpoint, &output, by_id_error.join(draft_error))
+                let resolved = by_id_error.join(draft_error);
+                // When the tag lookup was skipped there is no 404 to report,
+                // and the by-id/list failures ARE the whole story (#11145).
+                match by_tag.as_ref() {
+                    Some(output) => metadata_fallback_error(&endpoint, output, resolved),
+                    None => resolved,
+                }
             })
         }
     }
@@ -732,22 +756,31 @@ fn gh_release_metadata_by_id(
     })
 }
 
+/// Compose the tag-lookup failure with the failures that actually explain a
+/// stranded release.
+///
+/// Both survive (#10441), but the ORDER matters: `releases/tags/{tag}` returns
+/// 404 for every draft by design, so leading with it put an expected,
+/// irrelevant "exited with status 1" in front of the real cause on every
+/// failure an operator ever had to read (#11145). The causal failures lead; the
+/// tag lookup trails, annotated as the expected outcome it usually is.
+/// Diagnostics are ordered to match the message.
 fn metadata_fallback_error(
     endpoint: &str,
     output: &GhCommandOutput,
     draft_error: GitHubReleaseMetadataError,
 ) -> GitHubReleaseMetadataError {
-    let mut diagnostics = vec![gh_failure_diagnostic(
+    let mut diagnostics = draft_error.diagnostics;
+    diagnostics.push(gh_failure_diagnostic(
         "gh api release metadata",
         endpoint,
         output,
-    )];
-    diagnostics.extend(draft_error.diagnostics);
+    ));
     GitHubReleaseMetadataError {
         message: format!(
-            "{}; the draft fallback also failed: {}",
-            gh_failure_detail("gh api release metadata", output),
-            draft_error.message
+            "{}; the release lookup by tag also failed (expected for a draft): {}",
+            draft_error.message,
+            gh_failure_detail("gh api release metadata", output)
         ),
         diagnostics,
     }
@@ -1926,10 +1959,103 @@ mod tests {
 
         let error = metadata_fallback_error("repos/example/repo/releases/tags/v1", &primary, draft);
 
-        assert!(error.message.contains("draft fallback also failed"));
+        assert!(error
+            .message
+            .contains("gh api releases list exited with status 1"));
+        assert!(error
+            .message
+            .contains("the release lookup by tag also failed"));
         assert_eq!(error.diagnostics.len(), 2);
-        assert_eq!(error.diagnostics[0].http_status, Some(404));
-        assert_eq!(error.diagnostics[1].http_status, Some(403));
+        // #11145: the causal failure leads; the by-design 404 trails.
+        assert_eq!(error.diagnostics[0].http_status, Some(403));
+        assert_eq!(error.diagnostics[1].http_status, Some(404));
+    }
+
+    /// #11145: a 404 that is expected must not be the first thing an operator
+    /// reads.
+    ///
+    /// `releases/tags/{tag}` returns 404 for every draft by design, so the
+    /// composed message led with "gh api release metadata exited with status 1"
+    /// on every failure this error type has ever described -- burying the cause
+    /// that actually stranded the release behind a line that carries no
+    /// information at all.
+    #[test]
+    fn the_composed_message_leads_with_the_cause_not_the_by_design_404() {
+        let primary = failed_output("", "HTTP 404: Not Found", Some(1), false);
+        let draft = GitHubReleaseMetadataError {
+            message: "gh release view databaseId exited with status 1".to_string(),
+            diagnostics: Vec::new(),
+        };
+
+        let error = metadata_fallback_error("repos/example/repo/releases/tags/v1", &primary, draft);
+
+        let cause = error
+            .message
+            .find("gh release view databaseId")
+            .expect("the causal failure must survive");
+        let expected_404 = error
+            .message
+            .find("the release lookup by tag also failed")
+            .expect("the tag lookup failure must survive");
+        assert!(
+            cause < expected_404,
+            "operator diagnosis reads top-down; the cause must precede the expected 404: {}",
+            error.message
+        );
+    }
+
+    /// #11145: the post-create readback knows the release is a draft, so it
+    /// must not pay a round trip to an endpoint that 404s for drafts by design.
+    ///
+    /// Asserted structurally because the alternative is a live `gh` call. The
+    /// tag endpoint may only be built inside the `expect_draft` guard.
+    #[test]
+    fn an_expected_draft_skips_the_tag_endpoint_that_404s_by_design() {
+        let source = include_str!("gh_cli.rs");
+        let body = source
+            .split("pub(crate) fn gh_release_metadata(")
+            .nth(1)
+            .expect("gh_release_metadata should exist");
+        let signature_end = body.find(')').expect("the signature must terminate");
+        assert!(
+            body[..signature_end].contains("expect_draft: bool"),
+            "callers must be able to state that the release is a draft"
+        );
+
+        let guard = body
+            .find("if expect_draft {")
+            .expect("the tag lookup must be gated on what the caller knows");
+        let tag_request = body
+            .find("&[\"api\", &endpoint]")
+            .expect("the tag lookup must still exist for callers that need it");
+        assert!(
+            guard < tag_request,
+            "the tag lookup must sit inside the expect_draft guard, not before it"
+        );
+    }
+
+    /// #11145: the readback after `gh release create --draft` is the one call
+    /// site that KNOWS it is reading a draft. If it ever reverts to `false` the
+    /// guaranteed 404 comes straight back, silently -- the release still
+    /// resolves via the id lookup, so nothing fails, it just costs a round trip
+    /// and corrupts every error message on that path.
+    #[test]
+    fn the_post_create_readback_declares_that_it_expects_a_draft() {
+        let source = include_str!("run.rs");
+        let after_create = source
+            .split("\"--draft\",")
+            .nth(1)
+            .expect("the create call must still pass --draft");
+        let readback = after_create
+            .find("gh_release_metadata(")
+            .expect("the create path must read the release back");
+        let call = &after_create[readback..];
+        let call_end = call.find(')').expect("the call must terminate");
+        assert!(
+            call[..call_end].contains("true"),
+            "the post-create readback must pass expect_draft: true, got: {}",
+            &call[..call_end]
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -159,7 +159,13 @@ pub(crate) fn run_github_release(
         // ships nothing. This step is the pipeline's last chance to close that
         // window, so "a release object exists" is not sufficient to report
         // success; it must also be published.
-        let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
+        let metadata = match gh_release_metadata(
+            &github,
+            &component.github,
+            &tag,
+            &repo_flag,
+            false,
+        ) {
             Ok(metadata) => metadata,
             Err(error) => {
                 let repair = repair_commands(None, None);
@@ -207,7 +213,13 @@ pub(crate) fn run_github_release(
                     Error::validation_invalid_argument("release assets", error, None, None)
                 })?;
             // Re-read immediately before un-drafting so a concurrent asset edit cannot race validation.
-            let current = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
+            let current = match gh_release_metadata(
+                &github,
+                &component.github,
+                &tag,
+                &repo_flag,
+                false,
+            ) {
                 Ok(metadata) => metadata,
                 Err(error) => {
                     let repair = repair_commands(None, None);
@@ -469,23 +481,24 @@ pub(crate) fn run_github_release(
             ));
         }
 
-        let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                let diagnostics = error.diagnostics;
-                return Ok(upload_failed_result(
-                    &tag,
-                    &github,
-                    String::new(),
-                    error.message,
-                    None,
-                    false,
-                    artifact_paths.len(),
-                    repair_commands(None, None),
-                    &diagnostics,
-                ));
-            }
-        };
+        let metadata =
+            match gh_release_metadata(&github, &component.github, &tag, &repo_flag, false) {
+                Ok(metadata) => metadata,
+                Err(error) => {
+                    let diagnostics = error.diagnostics;
+                    return Ok(upload_failed_result(
+                        &tag,
+                        &github,
+                        String::new(),
+                        error.message,
+                        None,
+                        false,
+                        artifact_paths.len(),
+                        repair_commands(None, None),
+                        &diagnostics,
+                    ));
+                }
+            };
         if let Err(error) = verify_release_publications(
             &publications,
             &metadata.assets,
@@ -636,7 +649,11 @@ pub(crate) fn run_github_release(
         ));
     }
 
-    let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag) {
+    // `expect_draft: true` — the release was created with `--draft` a few lines
+    // above, and `releases/tags/{tag}` 404s for drafts by design. Attempting it
+    // here is a guaranteed-failing round trip that only succeeds at pushing an
+    // irrelevant 404 to the front of the error message (#11145).
+    let metadata = match gh_release_metadata(&github, &component.github, &tag, &repo_flag, true) {
         Ok(metadata) => metadata,
         Err(error) => {
             let diagnostics = error.diagnostics;


### PR DESCRIPTION
Found during the 2026-08-01 consolidation investigation (#11151).

Two issues. The small one lands whole; the large one lands one third and explains the other two thirds.

## #11145 — the release readback pays a guaranteed 404

`gh_release_metadata` resolved a release in three tiers, the first being `repos/{repo}/releases/tags/{tag}` — which returns **404 for a draft by design**. The readback in `run.rs` fires immediately after `gh release create --draft`, so on that path tier 1 is guaranteed to fail. Every successful release paid a wasted round trip, and every failure composed a message that led with the irrelevant 404:

```
gh api release metadata exited with status 1; the draft fallback also failed: <the actual cause>
```

The operator's eye lands on the expected failure first.

`gh_release_metadata` now takes `expect_draft`. The post-create readback passes `true` and goes straight to the id lookup. The three call sites that genuinely do not know the publication state — the retry boundary, the pre-publish re-read, the post-upload verification — pass `false` and keep the tag lookup as their fast path.

`metadata_fallback_error` now leads with the causal failure and trails the tag lookup, annotated as the expected outcome it usually is. Diagnostics reorder to match. Both failures still survive (#10441); only the order changed. When the tag lookup was skipped there is no 404 to report and the by-id/list failures are returned unwrapped.

The stranded-release bug class itself was already fixed. This is the residual.

## #11141 — three hardcoded taxonomies

The issue reads three hardcoded `agent-task` taxonomies as three projections of one per-path fact, to be folded into `CommandPathSafetySpec`. **One of the three is. Two are not**, and the difference is load-bearing.

### Converted — Table 2, help visibility (`command_contract/lab.rs`)

`lab_cli_arguments_are_visible_for_path` was a ~50-entry `matches!` arm chain deciding which subcommands advertise the Lab placement/runner flags in `--help`. It is a second source of truth for "is this path Lab-portable", parallel to each command's `lab_contract()`, and because it was *control flow rather than data*, nothing could enumerate it — so nothing could assert the two agreed, and nothing could catch a path spelling clap does not expose (the #10313 failure mode, which here silently hides the flags forever on a command that supports them).

The arms become `LAB_VISIBLE_COMMAND_PATHS`, and the coarse dimension — which command families route to Lab at all — is no longer restated: the lookup now gates on `CommandSpec.lab_supported` first, so the table can only **narrow** a registry fact, never invent one. The two incident comments (`fanout cook-batch` split placement; `agent-task cook`'s hidden `queue_only`) carry across verbatim.

Behavior is unchanged: the 11 families the table names are exactly the 11 the registry declares `lab_supported`.

Four guards, none of which existed:

1. the declared table is what the help surface actually consults, and `contract manifest` still does not advertise the flags
2. every Lab-visible path resolves to a real clap surface node — the #10313 guard, applied to help visibility
3. the table stays inside the registry's `lab_supported` command set
4. **every Lab-visible path has a parseable invocation that resolves a Lab contract** — the agreement the issue says nothing asserts

On (4): help visibility is per-**path**; a Lab contract is resolved per-**invocation**. Several paths only carry a contract for a particular argument shape — `retry --run`, `controller from-spec --resume`, `refactor --all`, `fuzz list --remote-discovery` — which is exactly *why* the flags are advertised on the path: the operator needs them discoverable in order to reach that shape. So the testable claim is "there exists an invocation at this path with a Lab contract", and the 50 representative invocations encode it. They use each path's real required arguments, so a path whose required arguments change fails loudly rather than skipping silently.

### Refused — Table 1, resource admission (`resource_policy/classification.rs`)

`CommandPathSafetySpec` keys on a command path. **Seven rows here key on parsed argument values at a single path**, and flip classification across the admission boundary when they do:

| row | with flag | without |
|---|---|---|
| `cook --queue-only` | `LocalControl` | `AdmittedWorkload` |
| `retry --run` | `AdmittedWorkload` | `LocalControl` |
| `active --reconcile` | `AdmittedWorkload` | `BoundedMetadataRead` |
| `reconcile --apply` | `AdmittedWorkload` | `BoundedMetadataRead` |
| `loop define --resume` | `AdmittedWorkload` | `LocalControl` |
| `controller from-spec --resume` | `AdmittedWorkload` | `LocalControl` |
| `fanout cook-batch --dry-run` | plan-only | coordinator |

`CommandSpec::path_safety` resolves one entry per path, so each pair collapses to a single behavior — and **either choice is an incident that already happened**. Collapsing to `AdmittedWorkload` puts controller-local bookkeeping behind warm/hot refusal: that is #9428. Collapsing to `LocalControl` refuses a validated batch a ready runner could serve: that is #9375.

### Refused — Table 3, mutation classification (`command_capability.rs`)

**The "runs before extension discovery, configuration hydration" justification does hold as stated, and it is not what blocks the conversion.** Verified: `classify` runs at `cli_runtime.rs:349`, before `register_startup_providers_before_reconcile`, before `load_config`, and before `parse_matches`. But the proposed replacement would not violate it either — the manifest derives from `COMMAND_SPECS` (static consts) plus `Cli::command()` (clap derive metadata), and `registered_command` is a linear scan over a static array. Nothing there reads config or discovers extensions.

What blocks it is that the two tables answer different questions:

- `CommandSafetyEntry.mutates` is one bool per path feeding a **documentation/audit** projection that deliberately under-declares — `command_safety_manifest_audit` is `report_only: true`, and a path with no registry declaration resolves to `read_only()` by default.
- `CommandCapability` is a per-invocation **runtime gate that must fail closed**, because `Mutation` is what authorizes `reconcile_terminal_runner_exec_runs` (recovering completed runner-exec evidence before a mutating command can evict it) and the deferred-workload worker restart.

The registry's silence is not evidence of read-only-ness. Four commands resolve `mutates: false` in the manifest **today** while the classifier correctly answers `Mutation`:

| argv | why the manifest says `false` |
|---|---|
| `status --refresh` | `ops_command_spec!(status)` is a bare `command_spec` — no flag axis, no subcommand table |
| `daemon start` | `ops_command_spec!(daemon)` likewise declares nothing |
| `runtime promotion-takeover` | `RUNTIME_SUBCOMMAND_SAFETY` declares only `refresh` |
| `agent-task retry <run> --run` | `AGENT_TASK_SUBCOMMAND_SAFETY` has no `retry` row |

Converting would silently reclassify all four as `ReadOnly` and skip their startup recovery. `classifies_actions_as_mutations_by_default` pins all four, so the change would fail — but that means the fix as specified is *wrong*, not merely risky. Separately, the `Mutation` fail-closed default the issue asks for **is already in place** (`_ => CommandCapability::Mutation`).

Both refusals are recorded as module-level notes in the files themselves, with the incident numbers, so the next attempt does not re-derive the analysis.

## Incident numbers preserved

`#8025`, `#9375`, `#9428`, `#9763` (Table 1 rows, untouched), `#10313` (now guarded for help visibility too), `#10441` (both metadata failures still survive), `#9279`, `#10519`.

## Verification

`cargo fmt`; `cargo check -p homeboy-release --lib`, `cargo check -p homeboy-cli --lib`, and `cargo check -p homeboy-cli --lib --tests` all exit 0. Per the VPS build constraint no test binary was linked locally — the new tests are left to CI. The 50 representative invocations were each validated against the real required-argument shapes in source (including `tunnel service expose`'s `required_unless_present = "runner_local"`, which does not appear in the usage line).

`Closes #11145`
`Refs #11141` — Table 2 converted; Tables 1 and 3 refused with reasons above and recorded in-tree.
